### PR TITLE
fix(jq, yaml, json, cli): route string decode failures through EvalError (#1247, #1242, #1194)

### DIFF
--- a/benches/jq_format_bench.rs
+++ b/benches/jq_format_bench.rs
@@ -51,6 +51,7 @@ fn run_generic(json: &[u8], expr: &Expr) -> usize {
     let cursor = index.root(json);
     eval_generic::eval_with_cursor(expr, cursor)
         .collect_owned()
+        .expect("materializes")
         .len()
 }
 

--- a/benches/jq_generic_index_bench.rs
+++ b/benches/jq_generic_index_bench.rs
@@ -134,7 +134,7 @@ fn bench_generic_index_json(c: &mut Criterion) {
                 "depth {depth} level {i} fixture must not error"
             );
             assert!(
-                probe.collect_owned().is_empty(),
+                probe.collect_owned().expect("materializes").is_empty(),
                 "depth {depth} level {i} fixture must produce no output"
             );
         }
@@ -146,7 +146,7 @@ fn bench_generic_index_json(c: &mut Criterion) {
                 for expr in &exprs {
                     let cursor = index.root(black_box(json));
                     let result = eval_with_cursor(expr, cursor);
-                    total += result.collect_owned().len();
+                    total += result.collect_owned().expect("materializes").len();
                 }
                 black_box(total)
             });
@@ -184,7 +184,7 @@ fn bench_generic_index_yaml(c: &mut Criterion) {
                 "depth {depth} level {i} fixture must not error"
             );
             assert!(
-                probe.collect_owned().is_empty(),
+                probe.collect_owned().expect("materializes").is_empty(),
                 "depth {depth} level {i} fixture must produce no output"
             );
         }
@@ -199,7 +199,7 @@ fn bench_generic_index_yaml(c: &mut Criterion) {
                         .first_child()
                         .expect("fixture has exactly one document");
                     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
-                    total += result.collect_owned().len();
+                    total += result.collect_owned().expect("materializes").len();
                 }
                 black_box(total)
             });

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -933,6 +933,41 @@ Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../
 [`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
 (the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).
 
+## Deliberate divergences (ADR-0018 rule 4)
+
+### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy
+
+Real jq DOM-parses the whole input before evaluating anything, so a parse error on one
+value in a multi-value stream kills the run outright — nothing after the bad value is
+even attempted:
+
+```console
+$ printf '1\n[xyz123]\n3\n' | jq -c 'to_entries'
+jq: error (at <stdin>:1): number (1) has no keys
+jq: parse error: Invalid numeric literal at line 2, column 8
+$ printf '1\n[xyz123]\n3\n' | succinctly jq -c 'to_entries'
+jq: error (at <stdin>:1): number (1) has no keys
+jq: error (at <stdin>:2): unexpected character
+jq: error (at <stdin>:3): number (3) has no keys
+```
+
+succinctly never parses the whole input up front (semi-indexing is per-record), and a
+structurally malformed value (#1194) or an undecodable string (#1247) now surfaces
+through the same `EvalError`/`ErrorSink` per-record-error-then-continue convention every
+other jq error already uses (`ErrorSink`, [#355](https://github.com/rust-works/succinctly/issues/355))
+— so `3` still gets processed here where real jq never reaches it. This is not new to
+[#1247](https://github.com/rust-works/succinctly/issues/1247): `ErrorSink`'s
+continue-past-one-error batch semantics predate it and already diverge from real jq's
+abort-on-parse-error for every ordinary evaluation error, not just a decode failure.
+[#1247](https://github.com/rust-works/succinctly/issues/1247)'s own design doc
+([`docs/plan/decode-failure-routing.md`](../../plan/decode-failure-routing.md), Stage 4)
+calls succinctly's behaviour "the more useful of the two" and treats it as settled — but
+none of ADR-0018's three permitted conditions actually cover it (the output is readable,
+nothing is corrupted or discarded, and the process does not die either way), so per rule 4
+it is recorded here as a still-open policy question, matching
+[yq Limitations](../yq/limitations.md)'s "Merge-flag `+` and `d` combined" precedent for a
+divergence accepted on its merits without fitting the letter of rule 4.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -595,6 +595,43 @@ Live-verified against yq v4.53.3. Pinned as known gaps (current, not the desired
 state) by `test_yq_auto_output_mixed_format_multi_file_known_gap_1493` and
 `test_yq_auto_output_slurp_mixed_format_known_gap_1493` in `tests/yq_cli_tests.rs`.
 
+### A bad escape in a streamed scalar still degrades silently instead of raising
+
+[#1247](https://github.com/rust-works/succinctly/issues/1247) routed almost every
+decode-failure materialization path through a real `EvalError` — but two streaming output
+writers were left as a deliberately-deferred gap ("Stage 6" in
+[`docs/plan/decode-failure-routing.md`](../../plan/decode-failure-routing.md)): their only
+error channel is `core::fmt::Result`, which carries no message, so a mid-stream failure
+there can only be silently absorbed or cause a bare, undiagnosed abort. Both still emit a
+substituted `null`/`""` at exit 0 for a value or key with a bad escape, live-verified
+against the same build that fixed every other #1247 site:
+
+```console
+$ printf 'a: 1\nb: "bad \q escape"\n' | succinctly yq -o=json '.'
+{
+  "a": 1,
+  "b": null
+}
+$ printf 'a: 1\nb: "bad \q escape"\n' | yq -o=json '.'
+Error: bad file '-': yaml: while scanning a quoted scalar at line 2, column 4: line 2, column 9: found unknown escape character
+
+$ printf 'double: "quoted \q scalar"\n' | succinctly yq '.'
+double: ""
+$ printf '"a\qb": 1\nb: 2\n' | succinctly yq '.'
+"": 1
+b: 2
+```
+
+The first pair (`-o=json`, `stream_json_value`/the YAML→JSON transcoders) is the case the
+design doc names. The second and third (default YAML→YAML output, no `-o` flag —
+`stream_yaml_string_value`/`write_yaml_field_key`, the single most common `yq`
+invocation) are the same gap on its YAML-target sibling, not previously recorded anywhere.
+Every *materializing* route (a `--arg`-forced DOM, a multi-result filter, `to_entries`,
+`length`) already raises correctly; only these two purely-streamed writers do not. Fixing
+either needs `stream_json_value`/`stream_yaml_value` and their callers to carry a richer
+error than `fmt::Error` — the design doc's own stated reason Stage 6 was split out and
+deferred rather than attempted alongside the rest of #1247's landed stages.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -26,6 +26,7 @@ These plans are kept for:
 | [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md)     | Partial     | `src/jq/eval.rs`                  | Demand-driven sink for short-circuiting consumers |
 | [jq-duplicate-key-collapse.md](jq-duplicate-key-collapse.md)         | Implemented | `src/jq/`, `jq_runner.rs`         | jq-mode duplicate object key collapse             |
 | [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output  |
+| [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                      |
 
 ## Archived Plans
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,6 +1,6 @@
 # Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
 
-**Status: partially implemented — Stages 1–3 landed, 4–6 outstanding.** This
+**Status: partially implemented — Stages 1–4 landed, 5–6 outstanding.** This
 document is the deliverable for
 [#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
 ("needs a design decision before implementation, not a same-pattern continuation of the
@@ -427,8 +427,22 @@ Implementation notes, all discovered while doing it:
   verbatim. Neither loses data — both are the same raw-passthrough class as `jq '.'` —
   so both were left alone, and the tests say why.
 
-**Stage 4 — the `StandardJson::Error` arms (sites 17–20).** Fixes `[xyz123] → [null]`,
-i.e. #1194's in-scope half. Small once Stage 3 exists.
+**Stage 4 — the `StandardJson::Error` arms (sites 17–20). ✅ landed.** Fixes
+`[xyz123] → [null]`, i.e. #1194's in-scope half. Small once Stage 3 exists: the arms
+raise with the semi-index's own message, which is more specific than anything
+reconstructible at the materializer.
+
+One site was reverted after being written. `print_json`'s `StandardJson::Error` arm
+(`jq_runner.rs`) walks child cursors lazily and streams as it goes, so by the time a
+nested error is reached it has already written the opening `[`. Bailing there produced a
+truncated document plus a generic exit 1, where every materializing route gives a clean
+diagnostic and exit 5 — worse on every axis than the silent `null` it replaced. Left as
+`null` with the reasoning in place, and folded into Stage 6, which is the same problem.
+
+Evaluation still continues past the bad value, so the good documents either side of it in
+a multi-value stream are still processed (`ErrorSink`, #355). Real jq aborts the whole run
+at the parse error instead; succinctly's behaviour here is the more useful of the two and
+is a deliberate, tested divergence.
 
 **Stage 5 — UTF-8 at the boundary (sites 21–22, #1242).** yq rejects, jq replaces with
 U+FFFD, `yaml validate` grows a UTF-8 check. *Why last:* it is the only stage that adds

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -494,6 +494,18 @@ otherwise already correct, and it can be reverted independently if the perf gate
   `Failed to read file` when the read had in fact succeeded.
 - Scope is document input only. `--raw-input` shares the jq path (jq substitutes there
   too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched.
+- **`--validate` is excluded, and getting that wrong was a live regression** caught in
+  review. The substitution originally ran at read time, before `validate_json_input`, so
+  the strict validator was handed an already-repaired document: `sjq --validate` exited 0
+  on a file `succinctly json validate` still rejects with exit 1, silently dropping RFC
+  8259 §8.1's mandatory UTF-8 check from the one flag whose entire purpose is strictness —
+  and contradicting this document's own "What the existing validators already catch" table
+  two sections up. Both routes had it (the lazy path substituted into `raw_inputs`; the
+  materializing one decoded to a `String` in `get_inputs` first). Fixed by skipping the
+  substitution under `--validate` entirely: nothing is lost, because any document that
+  would have been substituted is a document the validator rejects. Pinned by
+  `test_validate_still_rejects_invalid_utf8_1247` and, for the modes that never validate,
+  `test_raw_input_still_substitutes_under_validate_1247`.
 - Our `Utf8Error` offsets were checked against yq's for all six error kinds (invalid lead,
   bad continuation, overlong, surrogate, out-of-range, truncated) and agree exactly.
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,0 +1,507 @@
+# Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
+
+**Status: design only, not implemented.** This document is the deliverable for
+[#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
+("needs a design decision before implementation, not a same-pattern continuation of the
+just-merged partial fix") and whose own tier-review comment asked for one design doc
+covering #1247 and [#1194](https://github.com/rust-works/succinctly/issues/1194) together.
+[#1242](https://github.com/rust-works/succinctly/issues/1242) was traced to the same
+swallow points and is covered here too. No code has been changed to implement this; see
+"Follow-up issues" at the bottom.
+
+Every claim below was verified against `main` @ `cedee4cbb` with a `--release --features
+cli` build and the pinned oracles (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4). Where this
+document contradicts an issue's own text, the contradiction is stated explicitly rather
+than quietly corrected.
+
+## Problem
+
+A JSON or YAML string scalar — or an object/mapping key — that passes structural
+validation but fails to **decode** (invalid UTF-8, an invalid escape, an invalid `\u`
+codepoint) is silently swallowed. It becomes `null`, or `""`, or the field disappears, and
+the process exits 0.
+
+```console
+$ printf 'a: 1\nb: "x\xe4y"\n' | succinctly yq -o=json '.'
+{"a":1,"b":null}                                  # exit 0
+$ printf 'a: 1\nb: "x\xe4y"\n' | yq -o=json '.'
+Error: bad file '-': yaml: offset 11: invalid trailing UTF-8 octet    # exit 1
+```
+
+The swallow is not confined to the value that failed. Two consequences are worse than a
+silent `null`, and neither is recorded in any issue:
+
+**Output that no parser can read.** The YAML→JSON transcoders write the opening `"` (and
+any successfully transcoded prefix) into the output *before* they can fail; the caller's
+`Err(_)` fallback then appends `null` or `""` after that partial token:
+
+```console
+$ printf 'b: "x\qy"\n' | succinctly yq -o=json '.'
+{"b": "xnull}                                     # exit 0, unparseable
+
+$ printf '"a\qb": 1\n' | succinctly yq -o=json '.'
+{"a"": 1}                                         # exit 0, unparseable
+```
+
+**Valid, unrelated sibling fields becoming invisible.** `JsonFields::find`/`find_cursor`
+and `YamlFields::find`/`find_cursor` abort the *whole* field search on
+`key.as_str().ok()?`, so one undecodable key hides every field after it — while `keys` and
+`length` still report them:
+
+```console
+$ printf '{"\ud800":1,"b":2}' | succinctly jq '.b'
+null                                              # but "b":2 is right there
+$ printf '{"\ud800":1,"b":2}' | succinctly jq -c 'keys_unsorted, length'
+["\ud800","b"]
+2
+```
+
+## Root cause
+
+`to_owned`/`to_owned_at_depth`/`to_owned_cursor`/`to_owned_cursor_at_depth`
+(`src/jq/eval_generic.rs`) and `cursor_to_owned`/`cursor_to_owned_at_depth`
+(`src/jq/lazy.rs`) all return a bare `OwnedValue`. They are the point at which a lazily
+borrowed document scalar becomes an owned one, so they are where a decode failure is first
+observable — and they have nowhere to put it.
+
+`to_owned_at_depth`'s own doc comment is the clearest statement of the deferral anywhere
+in the tree. It names #1098, records that PR #1190's `panic!()` attempt was reverted as
+live-reachable through ordinary CLI usage, and states the intended shape:
+
+> A correct fix needs to route through `EvalError`/`ErrorSink` instead, applied
+> consistently across every sibling copy of this conversion and to object/mapping keys
+> too.
+
+#1192 fixed two sibling copies this way (`owned_from_standard_json_at_depth` in
+`eval_generic.rs`, `standard_json_to_jq_value` in `jq_runner.rs`), establishing the
+wording convention this design reuses: `EvalError::new(format!("{e}"))` for a value,
+`format!("{e} in object key")` for a key.
+
+## Three corrections to the issues' own premises
+
+### 1. The "58+ call sites" cost estimate overstates the work
+
+#1247 and its tier review both cite 58 `to_owned*` call sites in `eval_generic.rs` as the
+reason making the family fallible is architecturally expensive. The count is real as a
+`grep` count but is not a count of sites needing edits: of 62 matches, **13 are doc
+comments, 8 are in `#[cfg(test)]`, and 7 are the recursive definitions themselves.**
+
+Of the **53 remaining call sites, 40 already sit in a fallible context**:
+
+| Enclosing return type | Sites | Edit needed |
+|-----------------------|-------|-------------|
+| `GenericResult<V>` (has an `Error(EvalError)` variant) | 21 | `GenericResult::Error(e)` |
+| `Result<_, _>` | 11 | `?` |
+| `Option<Control>` (has `Control::Error`) | 8 | `Some(Control::Error(e))` |
+| Genuinely infallible helpers | 13 | see below |
+
+The framing "thread `Result` through every one of 58+ call sites and their own callers,
+transitively" assumes `Result` is the channel. It is not. The generic evaluator's own
+error channel is **`GenericResult::Error(EvalError)`**, carried in the value domain — 
+`eval_single` and `eval_builtin` both return a bare `GenericResult<V>`, not a `Result`.
+Every one of those 40 sites sits in a `match` that *already* has an
+`GenericResult::Error(e) => …` or `Control::Error` arm next to it.
+
+The 13 genuinely infallible sites live in six functions, and several are error-message
+previews that should stay infallible on purpose (see "Where the family stays infallible").
+
+### 2. #1191, the stated prerequisite, is already fixed
+
+#1247 states that #1191 (`YamlValue::Alias::as_str()` not recursing through nested
+aliases) "is a direct confound specifically for `to_owned`'s detection logic on the YAML
+side" and blocks the YAML half. **#1191 is closed.** `as_str()`'s `Alias` arm now resolves
+the entire chain via `resolve_alias_chain` (`src/yaml/light.rs`, see
+`MAX_ALIAS_CHAIN_DEPTH`'s doc comment). A valid double-alias-to-string no longer returns
+`None`, so it can no longer be mistaken for a decode failure. Nothing here is blocked.
+
+Note the related, still-open gap this does *not* cover: #1193 tracks the eight other typed
+accessors (`as_bool`, `as_i64`, `as_f64`, `number_literal`, `as_object`, `as_array`,
+`type_name`, `is_null`) that still resolve alias chains by genuine self-recursion.
+Out of scope here.
+
+### 3. #1194 is only half in scope, and the half that is not is the one its title names
+
+`[xyz123] → [null]` goes through `StandardJson::Error(_) => OwnedValue::Null` and is fixed
+by this design. **`{invalid} → {}` is not.** It never reaches any of these arms:
+`JsonFields::uncons`'s `let value_cursor = key_cursor.next_sibling()?;` collapses "lone
+bareword leaf, no sibling to pair as a value" into "no more fields" at the semi-index
+layer, indistinguishable from a genuinely empty object. No field object is ever
+constructed, so there is nothing to raise an error on.
+
+Fixing that means `uncons` must be able to yield a malformed field, changing a public
+API's contract and rippling through every caller. That is a separate design question and
+is filed as a follow-up rather than absorbed here.
+
+## Oracle behaviour (verified live)
+
+Captured against `/usr/bin/jq` 1.7.1 and Homebrew `yq` v4, and a `--release --features
+cli` build at `cedee4cbb`. Exit codes captured directly, not through a pipeline.
+
+### JSON / `jq`
+
+| Input | real jq | succinctly today |
+|-------|---------|------------------|
+| `{"a":"\xff"}` (raw invalid UTF-8, value) | `{"a":"�"}`, exit 0 | raw bytes echoed verbatim, exit 0 |
+| `{"\xff":1,"b":2}` (raw invalid UTF-8, key) | `{"�":1,"b":2}`, exit 0 | raw bytes echoed, `.b` returns `null` |
+| `{"a":"\ud800"}` (lone surrogate) | parse error, **exit 5** | echoed verbatim, exit 0 |
+| `{"\ud800":1,"b":2}` | parse error, **exit 5** | echoed, `.b` returns `null` |
+| `{"a":"\q"}` (invalid escape) | parse error, **exit 5** | echoed verbatim, exit 0 |
+| `[xyz123]` | parse error, **exit 5** | `[null]`, exit 0 |
+| `{invalid}` | parse error, **exit 5** | `{}`, exit 0 |
+
+**jq does not reject raw invalid UTF-8 — it lossily replaces each bad byte with U+FFFD and
+exits 0.** Only escape errors and barewords are parse errors. This asymmetry is
+load-bearing for the design below and is not mentioned in any of the three issues.
+
+Note also that succinctly's *identity* path echoes the malformed text verbatim: the
+degrade to `null`/`""` only happens once a value is **materialized**. So the same document
+behaves differently under `.` than under `length`, `to_entries`, `sort`, `-e`, or a field
+lookup:
+
+```console
+$ printf '{"a":"\ud800"}' | succinctly jq '.a | length'
+jq: error (at <stdin>:0): null (null) has no length     # wrong error, wrong cause
+$ printf '{"a":"\ud800"}' | succinctly jq -c 'to_entries'
+[{"key":"a","value":null}]
+```
+
+### YAML / `yq`
+
+| Input | real yq | succinctly today |
+|-------|---------|------------------|
+| `b: "x\xe4y"` (raw invalid UTF-8) | `invalid trailing UTF-8 octet`, **exit 1** | `b: null`, exit 0 |
+| `b: "x\qy"` (invalid escape) | `found unknown escape character`, **exit 1** | `{"b": "xnull}` — unparseable, exit 0 |
+| `"a\qb": 1` (invalid escape in key) | `found unknown escape character`, **exit 1** | `{"a"": 1}` — unparseable, exit 0 |
+| `"a\xe4b": 1` + `b: 2` | parse error, **exit 1** | key becomes `""`; `.b` returns `null` |
+
+**yq does reject raw invalid UTF-8.** So the same upfront pass must reject in yq mode and
+lossily replace in jq mode.
+
+### What the existing validators already catch
+
+| | invalid UTF-8 | invalid escape | lone surrogate | bareword |
+|---|---|---|---|---|
+| `succinctly json validate` | ✅ exit 1 | ✅ | ✅ | ✅ |
+| `succinctly jq --validate` | ✅ exit 3 | ✅ | ✅ | ✅ |
+| `succinctly yaml validate` | ❌ **exit 0** | ✅ exit 1 | n/a | n/a |
+| `succinctly yq --validate` | ❌ **exit 0** | ✅ | n/a | n/a |
+
+The JSON strict validator already produces exactly the right diagnostic for every JSON
+repro in all three issues. The YAML validator has **no UTF-8 check at all** — that gap is
+#1242's, and it means `--validate` is not a workaround for it today.
+
+## Why not upfront validation for everyone
+
+The tier review floats "re-run the existing strict validator only when materialization
+hits a degrade point" as a cheaper third option. Costing it surfaced the reason the naive
+version of it — validating every document upfront — is not viable.
+
+Apple M5 Max, 8.4 MB generated JSON, min-of-7, process-spawn baseline (3.21 ms)
+subtracted. Indicative sizing only: not an interleaved A/B per
+[docs/guides/benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method), and the
+machine was not idle. Re-measure properly before relying on these.
+
+| | net cost | vs `jq '.users[0].name'` (13.1 ms) | vs `jq '.'` (187 ms) |
+|---|---|---|---|
+| whole-input UTF-8 validation (`text validate utf8`) | **1.1 ms** | +8% | +0.6% |
+| full strict JSON validation (`json validate`) | **8.6 ms** | **+66%** | +4.6% |
+
+Always-on strict validation costs two thirds of the runtime of a cheap navigation query.
+That is disqualifying for a project whose documented advantage is being 1.5–2.5× faster
+than jq, and it trades away exactly the "minimal validation" property
+[docs/architecture/semi-indexing.md](../architecture/semi-indexing.md) documents as
+deliberate.
+
+Always-on **UTF-8** validation is a different proposition: 1.1 ms on 8.4 MB (~7.7 GiB/s,
+the SIMD path), and `Utf8Error` already carries `offset`/`line`/`column` plus a `Display`
+impl — precisely the diagnostic yq's message needs.
+
+The tier review's own trigger-based variant ("re-validate only when a degrade fires") was
+considered and rejected as unnecessary: at each swallow point the failure is *already*
+known locally — we hold the failing bytes and the concrete `YamlStringError`/`Utf8Error`.
+The difficulty was never detection, only reporting. Re-running a whole-document validator
+would buy a slightly better message at the cost of a second full pass, and would still
+need the same signal to know when to run.
+
+## Design
+
+**Detect where it happens; report through the channel that already exists; handle UTF-8 at
+the boundary because that is the half the oracles handle at the boundary.**
+
+### Part A — UTF-8 at the input boundary
+
+Validate the whole input with `crate::text::utf8::validate_utf8` once, at the point the
+runner reads the document.
+
+- **yq**: on failure, report with `Utf8Error`'s offset/line/column through the existing
+  `print_validation_error`-shaped formatter and exit 1, matching real yq. Additionally
+  close the gap in `src/yaml/validate.rs` so `yaml validate` and `yq --validate` catch it
+  too.
+- **jq**: on failure, drive **U+FFFD replacement**, not rejection — jq exits 0 here. This
+  also fixes a divergence in the opposite direction: succinctly currently emits raw
+  non-UTF-8 bytes on the identity path where jq emits U+FFFD.
+- Scope: **document input only.** Not `--raw-input`/`-R`, not DSV input, not `--arg`/
+  `--args` strings.
+
+Once this pass has run, `as_str()` can only fail on an **escape** problem, which
+materially narrows what the rest of the design has to handle.
+
+### Part B — escape/decode failures through `EvalError`
+
+Make the six materializers fallible:
+
+```rust
+to_owned / to_owned_at_depth / to_owned_cursor / to_owned_cursor_at_depth  // eval_generic.rs
+cursor_to_owned / cursor_to_owned_at_depth                                 // lazy.rs
+```
+
+all returning `Result<OwnedValue, EvalError>`, and route the error out through
+`GenericResult::Error` / `Control::Error` / `?` per the table in "Correction 1".
+
+Object and mapping **keys** get the same treatment: the current
+`if let Some(key) = field.key_str()` and `if let Ok(cow) = key_str.as_str()` guards
+silently drop the whole field, which is what
+`to_owned_at_depth`'s doc comment means by "and to object/mapping keys too".
+
+### Where the family stays infallible (deliberately)
+
+`to_owned_with_cursor`'s call sites split. Four are genuine value positions inside
+`eval_single`/`eval_builtin` and become fallible. The rest are **error-message previews**:
+
+```rust
+GenericResult::Error(EvalError::cannot_iterate(&to_owned_with_cursor(&value, cursor)))
+GenericResult::Error(EvalError::has_no_length(&to_owned_with_cursor(…)))
+GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(…)))
+GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned_with_cursor(…)))
+```
+
+An error is already being raised at each of those; the materialization exists only to
+render the offending value into the message. Making them fallible would mean "failed to
+build the error message for a failure", with no better outcome available. Split into two
+functions — a fallible one for value positions and an explicitly lossy
+`to_owned_for_diagnostic` for previews — and say so in the doc comment, so a later reader
+does not read the surviving lossy call as an oversight.
+
+`assert_nesting_depth`'s `panic!()` also stays. #1247 frames this design as either
+reversing that precedent or avoiding it; it is neither. Depth overflow is a different
+failure class — unbounded recursion that would otherwise abort the process — and its
+guard is unaffected by making the same functions fallible for a *data* error.
+
+### Part C — stop emitting invalid JSON
+
+The YAML→JSON transcoders (`transcode_double_quoted_to_json`,
+`transcode_single_quoted_to_json` and their `stream_` variants) are already fallible, but
+they push the opening `"` into the output before they can fail. There are **six** call
+sites with the same partial-write-then-fallback shape, in three pairs
+(value arm, then key arm):
+
+| Sink | value arm | key arm |
+|------|-----------|---------|
+| `stream_json_value` (`impl fmt::Write`) | ~1960 / fallback ~1979 | ~2010 / fallback ~2012 |
+| buffered `&mut String` (A) | ~2114 / fallback ~2133 | ~2147 / fallback ~2149 |
+| buffered `&mut String` (B) | ~2716 / fallback ~2736 | ~2750 / fallback ~2752 |
+
+The four buffered sites are fixable with no truncation at all: record `output.len()`
+before the call and `output.truncate(mark)` before falling back or raising. The two
+streaming sites need the transcode to run into a scratch `String` that is only written
+through on success.
+
+**Honest limitation:** for the streaming path, bytes already flushed for *earlier* parts
+of the record cannot be retracted. jq and yq can reject cleanly because they DOM-parse the
+whole input first; succinctly streams by design. The record will be truncated at the
+failure point and the process will exit non-zero with a diagnostic. That is strictly
+better than silent corruption but is a real divergence and should be documented as one,
+not papered over.
+
+### Part D — the sibling-hiding `find` loops
+
+Four near-identical loops abort the entire search on a single undecodable key:
+
+```rust
+if key.as_str().ok()? == name {     // the `?` returns from `find`, not from this iteration
+```
+
+Replace with a skip, so an undecodable key no longer truncates the search. This is
+independent of everything above, is the highest-severity item in the set (a *valid* value
+silently becomes invisible), and carries no API or performance implication. It is also a
+prerequisite for Part B: once decode failures raise errors, these loops must not swallow
+them first.
+
+## Site inventory
+
+Verified by reading and by live repro at `cedee4cbb`. ✱ = not recorded in any issue.
+
+| # | Site | Today | Stage |
+|---|------|-------|-------|
+| 1 | `json/light.rs:1023` `JsonFields::find` ✱ | aborts search, hides later fields | 1 |
+| 2 | `json/light.rs:1042` `JsonFields::find_cursor` ✱ | same | 1 |
+| 3 | `yaml/light.rs:4216` `YamlFields::find` ✱ | same | 1 |
+| 4 | `yaml/light.rs:4235` `YamlFields::find_cursor` ✱ | same | 1 |
+| 5 | `yaml/light.rs:1979` `stream_json_value` value arm ✱ | **invalid JSON** | 2 |
+| 6 | `yaml/light.rs:2012` `stream_json_value` key arm ✱ | **invalid JSON** | 2 |
+| 7 | `yaml/light.rs:2133` buffered value arm ✱ | **invalid JSON** | 2 |
+| 8 | `yaml/light.rs:2149` buffered key arm ✱ | **invalid JSON** | 2 |
+| 9 | `yaml/light.rs:2736` buffered value arm (2nd copy) ✱ | **invalid JSON** | 2 |
+| 10 | `yaml/light.rs:2752` buffered key arm (2nd copy) ✱ | **invalid JSON** | 2 |
+| 11 | `eval_generic.rs:166` `to_owned_at_depth` catch-all | `OwnedValue::Null` | 3 |
+| 12 | `eval_generic.rs:122` `to_owned_at_depth` key guard | field dropped | 3 |
+| 13 | `lazy.rs:707` `cursor_to_owned_at_depth` string arm | `String::new()` | 3 |
+| 14 | `lazy.rs:721` `cursor_to_owned_at_depth` key guard | field dropped | 3 |
+| 15 | `lazy.rs:658` `lazy_keys_array_to_owned` ✱ | key dropped from `keys` | 3 |
+| 16 | `lazy.rs:606` raw-bytes key fallback ✱ | documented-defensive; align for consistency | 3 |
+| 17 | `eval_generic.rs:1040` `StandardJson::Error` | `Null` | 4 |
+| 18 | `lazy.rs:733` `StandardJson::Error` | `Null` | 4 |
+| 19 | `eval.rs:427` `StandardJson::Error` | `Null` | 4 |
+| 20 | `json/light.rs:2098` `StandardJson::Error` (JSON→YAML out) | `null` | 4 |
+| 21 | `yaml/validate.rs` — no UTF-8 check at all ✱ | `yaml validate` exits 0 | 5 |
+| 22 | `yq_runner.rs` / `jq_runner.rs` input read | no UTF-8 pass | 5 |
+
+Two existing tests assert the buggy behaviour and must be inverted, not merely updated:
+
+- `test_to_owned_degrades_to_null_on_string_decode_failure_1098` (`eval_generic.rs:4481`)
+- `test_materialize_degrades_to_empty_string_on_decode_failure_1098` (`lazy.rs:914`)
+
+`to_owned_at_depth`'s `#1098` deferral doc comment (`eval_generic.rs:150-166`) should be
+deleted or rewritten in the same change that resolves it — it is the tree's clearest
+statement of this deferral and should not outlive it.
+
+## Staged delivery
+
+Each stage lands as its own PR with its own oracle-verified sweep. Stages 1 and 2 are
+plain bug fixes with no signature churn and go first: they are the highest severity and
+lowest risk, and neither depends on the fallibility change.
+
+**Stage 1 — sibling-hiding `find` loops (sites 1–4).** No API change, no perf implication.
+*Why first:* a valid value silently disappearing from a lookup is worse than a malformed
+one becoming `null`, and this is a prerequisite for Stage 3.
+
+**Stage 2 — invalid JSON output (sites 5–10).** Truncate-then-fallback for the four
+buffered sinks; scratch-buffer for the two streaming ones. *Why second:* emitting
+unparseable output is a correctness bug independent of the whole `to_owned` question, and
+fixing it first means Stage 3's new error paths have a clean sink to fail into.
+
+**Stage 3 — make the `to_owned` family fallible (sites 11–16).** The main change. Wide
+diff, ~53 call sites of which 40 are mechanical. *Why third:* everything it can raise now
+has somewhere correct to go.
+
+**Stage 4 — the `StandardJson::Error` arms (sites 17–20).** Fixes `[xyz123] → [null]`,
+i.e. #1194's in-scope half. Small once Stage 3 exists.
+
+**Stage 5 — UTF-8 at the boundary (sites 21–22, #1242).** yq rejects, jq replaces with
+U+FFFD, `yaml validate` grows a UTF-8 check. *Why last:* it is the only stage that adds
+work to every run, so it should be measured against a tree that is otherwise already
+correct, and it can be reverted independently if the perf gate fails.
+
+## Non-goals (explicit, to prevent scope creep)
+
+- **`{invalid} → {}` (#1194's headline repro).** Requires `JsonFields::uncons` to yield a
+  malformed field rather than collapsing to `None`; a public API contract change with its
+  own call-site sweep. Filed as a follow-up.
+- **#1193's eight self-recursive alias accessors.** Adjacent to #1191, unrelated to decode
+  failure, unaffected either way.
+- **#965** (remaining `ResolvedScalar`/`StandardJson` → `OwnedValue` duplication). The
+  five textually-similar copies of this conversion are exactly what #965 is about, and
+  this work touches four of them — but consolidating them is a refactor with its own risk
+  profile and should follow, not accompany, a behaviour change. Sequenced after this per
+  #1283's cluster E.
+- **`eval.rs`'s private copy of the `to_owned` family.** #1247 correctly notes it is not
+  live-reachable for this scenario: `eval.rs`'s evaluator only processes JSON
+  re-serialized from an already-decoded `OwnedValue`, which by construction cannot contain
+  invalid UTF-8. Site 19 (`eval.rs:427`) is included anyway, as a cheap consistency fix,
+  but no behaviour change is expected from it and none should be asserted in a test that
+  claims to exercise it end-to-end.
+- **Buffering the whole record so the streaming path can reject cleanly.** That would
+  reverse P9 (direct YAML-to-JSON streaming, a 2.3× win) for a malformed-input edge case.
+
+## Open risks for an implementer to sanity-check
+
+1. **`GenericResult::Error` is catchable.** A decode failure routed through it becomes
+   suppressible by `.a?` or `try .a catch`, where jq's parse error is not catchable at all
+   (it happens before the program runs). Decide explicitly whether that is acceptable or
+   whether these need `Halt`-like uncatchability. This is a genuine semantic difference
+   from both oracles and the design above does not resolve it.
+2. **JSONTestSuite `i_` cases.** `tests/json_test_suite.rs` covers implementation-defined
+   inputs; making decode failures loud can flip them in either direction. Check what the
+   suite currently expects *before* regenerating anything.
+3. **Golden fixtures.** `tests/jq_golden_tests.rs`, `tests/yq_golden_tests.rs`,
+   `tests/cli_golden_tests.rs`, plus the `yq-drift` CI job. A behaviour change here is
+   exactly the kind that shows up as unrelated-looking golden churn.
+4. **`yq --validate` is a documented gate today.** It currently passes invalid-UTF-8
+   documents. Making it reject them is the point of Stage 5, but it is a user-visible
+   behaviour change to call out in the changelog, not just a bug fix.
+5. **Stage 5's pass is charged to every input, including the ones it cannot help.** This
+   is the exact trap the O5 `HAS_CR` work documented (see CLAUDE.md): measure against the
+   workload where succinctly is *already fastest*, not the one where it is slowest. The
+   +8%-on-the-cheapest-query figure above is the ceiling to defend; anything worse means
+   the pass is in the wrong place.
+6. **`-R`/`--raw-input` and DSV must be excluded from the UTF-8 pass.** Raw input is
+   explicitly byte-oriented; rejecting there would be a regression, not a fix.
+
+## Verification approach for the implementation PRs
+
+- **Oracle matrix as a test, not a one-off.** Script both behaviour tables above against
+  `/usr/bin/jq` (the 1.7.1 pin — Homebrew's `jq` is 1.8.2 with different error text) and
+  Homebrew `yq` (which *is* the yq pin), asserting **exit codes** as well as stdout, and
+  covering both the identity path and the materializing paths (`length`, `to_entries`,
+  `sort`, `-e`, field lookup) — the divergence only appears on the latter.
+- **Output must be parseable.** For every yq repro, pipe `-o=json` output through `jq .`
+  and require either a clean parse or a non-zero exit. This is the assertion that would
+  have caught sites 5–10.
+- **Per-site regression tests** named `_1247`/`_1242`/`_1194`, following the existing
+  `_1192` tests in `jq_runner.rs` and `eval_generic.rs`.
+- **Interleaved A/B for Stage 5** on both ARM and x86_64, reporting the curve over 2–3
+  sizes ≥ 1 MB, per [docs/guides/benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method).
+- **Full CI gate derived from `.github/workflows/ci.yml`**, not hand-listed — including
+  `cargo fmt --check`, *both* clippy invocations, and `cargo check --no-default-features`
+  for `no_std` (nothing in this design needs `std`, but the UTF-8 pass lives near the
+  boundary where that is easy to break).
+
+## Critical files
+
+| File | Role |
+|------|------|
+| `src/jq/eval_generic.rs` | `to_owned` family, `GenericResult`, `Control`, 40 of the call sites, the `#1098` deferral comment |
+| `src/jq/lazy.rs` | `cursor_to_owned` family, backs `JqValue::materialize()`/`into_owned()` |
+| `src/jq/eval.rs` | third `StandardJson::Error` copy (site 19), not live-reachable |
+| `src/json/light.rs` | `JsonFields::find`/`find_cursor`/`uncons`, JSON→YAML output |
+| `src/yaml/light.rs` | `YamlFields::find`/`find_cursor`, `stream_json_value`, all six transcode call sites |
+| `src/yaml/validate.rs` | strict YAML validator — missing the UTF-8 check entirely |
+| `src/json/validate.rs` | strict JSON validator — already correct, the model for the YAML one |
+| `src/text/utf8/mod.rs` | `validate_utf8`, `Utf8Error` (offset/line/column + `Display`) |
+| `src/bin/succinctly/jq_runner.rs` | input read, `--validate`, `print_validation_error`, `_1192` test precedent |
+| `src/bin/succinctly/yq_runner.rs` | input read, DOM path, `to_owned_with_comments` |
+| `src/bin/succinctly/output.rs` | `ErrorSink` — the "evaluation continues, exit code remembers" convention (#355) |
+
+## Related
+
+- [#1247](https://github.com/rust-works/succinctly/issues/1247) — the issue this document
+  is the deliverable for.
+- [#1192](https://github.com/rust-works/succinctly/issues/1192) (closed) — fixed two
+  sibling copies and established the `EvalError` wording convention reused here.
+- [#1098](https://github.com/rust-works/succinctly/issues/1098) (closed) — the original
+  report; PR #1190's `panic!()` fix was reverted from it as live-reachable, which is why
+  `to_owned_at_depth`'s doc comment exists.
+- [#1194](https://github.com/rust-works/succinctly/issues/1194) — half in scope (see
+  Correction 3).
+- [#1242](https://github.com/rust-works/succinctly/issues/1242) — the YAML invalid-UTF-8
+  repro; Stage 5.
+- [#1191](https://github.com/rust-works/succinctly/issues/1191) (closed) — the stated
+  prerequisite, already satisfied.
+- [#1193](https://github.com/rust-works/succinctly/issues/1193) — the eight remaining
+  self-recursive alias accessors; out of scope.
+- [#965](https://github.com/rust-works/succinctly/issues/965) — the duplication this work
+  touches but does not consolidate; sequenced after.
+- [#1283](https://github.com/rust-works/succinctly/issues/1283) — the jq cluster
+  sequencing plan that groups these issues.
+- [`docs/plan/jq-path-trackability-deferral.md`](jq-path-trackability-deferral.md) — the
+  #1282 deliverable this document's structure follows.
+
+## Follow-up issues
+
+Not yet filed. Once this document is reviewed:
+
+1. One implementation issue per stage above, linking back here.
+2. **`JsonFields::uncons` cannot represent a malformed field** — #1194's headline repro
+   (`{invalid} → {}`), see Correction 3.
+3. **Decide catchability of decode errors** — Open Risk 1, if it is not settled during
+   Stage 3's review.

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,13 +1,14 @@
 # Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
 
-**Status: design only, not implemented.** This document is the deliverable for
+**Status: partially implemented — Stages 1 and 2 landed, 3–5 outstanding.** This
+document is the deliverable for
 [#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
 ("needs a design decision before implementation, not a same-pattern continuation of the
 just-merged partial fix") and whose own tier-review comment asked for one design doc
 covering #1247 and [#1194](https://github.com/rust-works/succinctly/issues/1194) together.
 [#1242](https://github.com/rust-works/succinctly/issues/1242) was traced to the same
-swallow points and is covered here too. No code has been changed to implement this; see
-"Follow-up issues" at the bottom.
+swallow points and is covered here too. See "Staged delivery" for what has landed and
+"Follow-up issues" for what still needs tracking.
 
 Every claim below was verified against `main` @ `cedee4cbb` with a `--release --features
 cli` build and the pinned oracles (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4). Where this
@@ -301,10 +302,19 @@ sites with the same partial-write-then-fallback shape, in three pairs
 | buffered `&mut String` (A) | ~2114 / fallback ~2133 | ~2147 / fallback ~2149 |
 | buffered `&mut String` (B) | ~2716 / fallback ~2736 | ~2750 / fallback ~2752 |
 
-The four buffered sites are fixable with no truncation at all: record `output.len()`
-before the call and `output.truncate(mark)` before falling back or raising. The two
-streaming sites need the transcode to run into a scratch `String` that is only written
-through on success.
+**Refined during implementation.** The prescription above was "record `output.len()`
+before the call and truncate at each of the four buffered call sites". That is the wrong
+place: it asks four callers to remember a rule none of them can see the need for. The
+rollback belongs *inside* `write_yaml_string_to_json`, which is the function that makes
+the partial write — it takes `&mut String`, so it can mark its own entry length and
+`truncate` back to it on any error path, fixing all four call sites at once and leaving
+nothing for a fifth caller to get wrong. Implemented that way.
+
+The two streaming sites take `Out: fmt::Write`, which cannot be rewound, so those do need
+a scratch `String` committed on success. Only the *slow* branch pays for it: the fast path
+(no `\`, `\n` or `\r` in the scalar) decodes before it writes anything and cannot
+partially fail, so it stays allocation-free — which matters, because this is P9's direct
+YAML→JSON streaming path.
 
 **Honest limitation:** for the streaming path, bytes already flushed for *earlier* parts
 of the record cannot be retracted. jq and yq can reject cleanly because they DOM-parse the
@@ -371,12 +381,14 @@ Each stage lands as its own PR with its own oracle-verified sweep. Stages 1 and 
 plain bug fixes with no signature churn and go first: they are the highest severity and
 lowest risk, and neither depends on the fallibility change.
 
-**Stage 1 — sibling-hiding `find` loops (sites 1–4).** No API change, no perf implication.
-*Why first:* a valid value silently disappearing from a lookup is worse than a malformed
-one becoming `null`, and this is a prerequisite for Stage 3.
+**Stage 1 — sibling-hiding `find` loops (sites 1–4). ✅ landed.** No API change, no perf
+implication. *Why first:* a valid value silently disappearing from a lookup is worse than
+a malformed one becoming `null`, and this is a prerequisite for Stage 3.
 
-**Stage 2 — invalid JSON output (sites 5–10).** Truncate-then-fallback for the four
-buffered sinks; scratch-buffer for the two streaming ones. *Why second:* emitting
+**Stage 2 — invalid JSON output (sites 5–10). ✅ landed.** Rollback inside
+`write_yaml_string_to_json` for the four buffered sinks; commit-on-success scratch buffer
+for the two streaming ones. Semantics are unchanged — the value still degrades to `null`
+and the key to `""` — but the emitted document is parseable. *Why second:* emitting
 unparseable output is a correctness bug independent of the whole `to_owned` question, and
 fixing it first means Stage 3's new error paths have a clean sink to fail into.
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,6 +1,6 @@
 # Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
 
-**Status: partially implemented — Stages 1–4 landed, 5–6 outstanding.** This
+**Status: partially implemented — Stages 1–5 landed, 6 outstanding.** This
 document is the deliverable for
 [#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
 ("needs a design decision before implementation, not a same-pattern continuation of the
@@ -444,10 +444,27 @@ a multi-value stream are still processed (`ErrorSink`, #355). Real jq aborts the
 at the parse error instead; succinctly's behaviour here is the more useful of the two and
 is a deliberate, tested divergence.
 
-**Stage 5 — UTF-8 at the boundary (sites 21–22, #1242).** yq rejects, jq replaces with
-U+FFFD, `yaml validate` grows a UTF-8 check. *Why last:* it is the only stage that adds
-work to every run, so it should be measured against a tree that is otherwise already
-correct, and it can be reverted independently if the perf gate fails.
+**Stage 5 — UTF-8 at the boundary (sites 21–22, #1242). ✅ landed.** yq rejects, jq
+replaces with U+FFFD, `yaml validate` grows a UTF-8 check. *Why last:* it is the only
+stage that adds work to every run, so it should be measured against a tree that is
+otherwise already correct, and it can be reverted independently if the perf gate fails.
+
+- **yq** rejects at the same byte offset and exit code as real yq, worded in this crate's
+  own `YAML parse error:` convention rather than yq's `bad file '-':` shape, which
+  succinctly has never matched for any other parse error. The check is unconditional, not
+  gated on `--validate`: YAML 1.2 requires a UTF-8/16/32 stream, so this is a parse error,
+  not an opt-in strictness preference.
+- **`yaml validate`** grew the check too, reusing the `InvalidUtf8` variant that had been
+  declared but never constructed — the scanner reads bytes and never decodes them, so
+  nothing could ever have produced it.
+- **jq** substitutes U+FFFD and exits 0, byte-identical to jq 1.7.1 on the probes above.
+  This also fixed two bugs in the opposite direction: the lazy path echoed the raw bytes,
+  writing invalid UTF-8 to stdout, and the non-lazy path refused the file outright with
+  `Failed to read file` when the read had in fact succeeded.
+- Scope is document input only. `--raw-input` shares the jq path (jq substitutes there
+  too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched.
+- Our `Utf8Error` offsets were checked against yq's for all six error kinds (invalid lead,
+  bad continuation, overlong, surrogate, out-of-range, truncated) and agree exactly.
 
 **Stage 6 — make the YAML streaming path loud (new, split out of Stage 2).** After
 Stages 2 and 3, `succinctly yq -o=json '.'` on a document with a bad *escape* still emits

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -466,6 +466,29 @@ otherwise already correct, and it can be reverted independently if the perf gate
 - Our `Utf8Error` offsets were checked against yq's for all six error kinds (invalid lead,
   bad continuation, overlong, surrogate, out-of-range, truncated) and agree exactly.
 
+**Measured cost of the always-on pass.** Interleaved A/B of the Stage 4 binary against the
+Stage 5 one, alternating order every repetition, min-of-9, gated first on byte-identical
+stdout and exit code for every case (all five identical):
+
+| case | before | after | delta |
+|------|--------|-------|-------|
+| `jq '.users[0].name'` 1 MB | 5.37 ms | 5.13 ms | −4.5% |
+| `jq '.users[0].name'` 8.4 MB | 17.23 ms | 17.96 ms | **+4.2%** |
+| `jq '.'` 1 MB | 16.91 ms | 16.98 ms | +0.4% |
+| `yq -o json '.'` 1 MB | 16.62 ms | 16.65 ms | +0.2% |
+| `yq -o json '.'` 10 MB | 126.19 ms | 126.80 ms | +0.5% |
+
+Worst case is +4.2%, on the cheapest query at the largest size — where a roughly fixed
+~1 ms pass is the largest fraction of the work. That is inside the +8% ceiling this
+document set before implementing. The −4.5% row is noise: the pass cannot make anything
+faster.
+
+**Still outstanding:** this ran on an Apple M5 Max laptop under a load average near 10,
+which CLAUDE.md's benchmarking discipline explicitly disqualifies for a final number. It
+is enough to show the cost is in the expected band and no worse; the formal interleaved
+A/B on the pinned bench machines (`johns-mac-mini` ARM, `terminus` x86_64) has **not**
+been run and should be before this is treated as settled.
+
 **Stage 6 — make the YAML streaming path loud (new, split out of Stage 2).** After
 Stages 2 and 3, `succinctly yq -o=json '.'` on a document with a bad *escape* still emits
 `{"b":null}` at exit 0: the streaming transcoder's only error channel is

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,6 +1,6 @@
 # Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
 
-**Status: partially implemented — Stages 1 and 2 landed, 3–5 outstanding.** This
+**Status: partially implemented — Stages 1–3 landed, 4–6 outstanding.** This
 document is the deliverable for
 [#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
 ("needs a design decision before implementation, not a same-pattern continuation of the
@@ -392,9 +392,40 @@ and the key to `""` — but the emitted document is parseable. *Why second:* emi
 unparseable output is a correctness bug independent of the whole `to_owned` question, and
 fixing it first means Stage 3's new error paths have a clean sink to fail into.
 
-**Stage 3 — make the `to_owned` family fallible (sites 11–16).** The main change. Wide
-diff, ~53 call sites of which 40 are mechanical. *Why third:* everything it can raise now
-has somewhere correct to go.
+**Stage 3 — make the `to_owned` family fallible (sites 11–16). ✅ landed.** The main
+change. *Why third:* everything it can raise now has somewhere correct to go.
+
+Implementation notes, all discovered while doing it:
+
+- **Detection needed a real signal, not an inference.** The plan assumed the catch-all
+  could infer "decode failure" from `type_name() == "string" && as_str().is_none()`.
+  That works but is indirect, and it re-creates exactly the ambiguity #1191 was about.
+  Added `DocumentValue::string_decode_error() -> Option<&'static str>` instead — a
+  provided method defaulting to `None`, overridden by JSON and YAML — so the two cases
+  `as_str()` conflates ("not a string" vs "a string this document can't hand back") are
+  separable at the source. The message text comes from `JsonError::message` /
+  `YamlStringError::message`, split out of each type's `Display` so there is one
+  definition rather than a second copy at an allocation-free call site.
+- **Three more silent-drop sites, all found by the compiler once the types changed.**
+  `DocumentFields::effective_fields`' dedup walk dropped any field whose key wouldn't
+  decode, so `to_entries` returned one entry fewer than the document had — the field
+  vanished before `to_entries`' own new check could see it. `lazy_keys_array_to_owned`
+  dropped the key from `keys`. `to_owned_with_comments` had the same key guard as its
+  two siblings.
+- **A misleading-error class, not just a silent one.** Every builtin's type dispatch is
+  a chain of `as_str()`/`as_array()`/… tests, so an undecodable string fails all of them
+  and lands in the same `else` as a genuine type mismatch: `.a | length` reported
+  `null (null) has no length` about a perfectly good string token. Added
+  `type_error_or_decode_failure`, used at the seven sites that report such a fall-through,
+  so the cause is named instead of a symptom two steps removed from it.
+- **One sanctioned lossy materialization remains**, `to_owned_for_diagnostic`, for the
+  call sites that materialize a value only to quote it into an error already being
+  raised. Split out as its own function with the rationale in its doc comment, so the
+  surviving lossy call doesn't read as an oversight.
+- **Not everything that looks like a degrade is one.** `length` on an object answers from
+  `fields.len()` without decoding, and `keys_unsorted` streams each key's raw byte span
+  verbatim. Neither loses data — both are the same raw-passthrough class as `jq '.'` —
+  so both were left alone, and the tests say why.
 
 **Stage 4 — the `StandardJson::Error` arms (sites 17–20).** Fixes `[xyz123] → [null]`,
 i.e. #1194's in-scope half. Small once Stage 3 exists.
@@ -403,6 +434,16 @@ i.e. #1194's in-scope half. Small once Stage 3 exists.
 U+FFFD, `yaml validate` grows a UTF-8 check. *Why last:* it is the only stage that adds
 work to every run, so it should be measured against a tree that is otherwise already
 correct, and it can be reverted independently if the perf gate fails.
+
+**Stage 6 — make the YAML streaming path loud (new, split out of Stage 2).** After
+Stages 2 and 3, `succinctly yq -o=json '.'` on a document with a bad *escape* still emits
+`{"b":null}` at exit 0: the streaming transcoder's only error channel is
+`core::fmt::Result`, which carries no message, so Stage 2 could make its output valid but
+not make it raise. Every *materializing* route (a `--arg`-forced DOM, a multi-result
+filter, `to_entries`, `length`) already raises. Closing the gap needs `stream_json_value`
+and its callers to carry a richer error than `fmt::Error` — a contained change, but its
+own one. Stage 5 removes the invalid-UTF-8 half of this case at the input boundary, so
+what Stage 6 is left with is bad escapes only.
 
 ## Non-goals (explicit, to prevent scope creep)
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -392,8 +392,19 @@ and the key to `""` — but the emitted document is parseable. *Why second:* emi
 unparseable output is a correctness bug independent of the whole `to_owned` question, and
 fixing it first means Stage 3's new error paths have a clean sink to fail into.
 
-**Stage 3 — make the `to_owned` family fallible (sites 11–16). ✅ landed.** The main
+**Stage 3 — make the `to_owned` family fallible (sites 11–15). ✅ landed.** The main
 change. *Why third:* everything it can raise now has somewhere correct to go.
+
+**Site 16 (`lazy.rs:606`) is not actually landed, despite an earlier version of this doc
+claiming it under this stage's "✅ landed."** `write_json_at_depth`'s raw-bytes key
+fallback (`LazyKeysArray`'s defensive branch for a key with no text range) still reads
+`if let Ok(s) = k.as_str() { write_json_body_jq(out, &s)?; }` with no `else` — on a decode
+failure it writes nothing, silently rendering the key as `""` rather than raising, same as
+before this stage. Confirmed by re-reading the site directly, not inferred. Low practical
+severity — the comment there is right that a JSON object key is always a text-range token,
+so this branch is close to unreachable — but "align for consistency" was never actually
+done, and the site inventory's own "Today" column already said so; only the stage-level
+"landed" summary overclaimed it.
 
 Implementation notes, all discovered while doing it:
 
@@ -427,10 +438,30 @@ Implementation notes, all discovered while doing it:
   verbatim. Neither loses data — both are the same raw-passthrough class as `jq '.'` —
   so both were left alone, and the tests say why.
 
-**Stage 4 — the `StandardJson::Error` arms (sites 17–20). ✅ landed.** Fixes
+**Stage 4 — the `StandardJson::Error` arms (sites 17–18). ✅ landed.** Fixes
 `[xyz123] → [null]`, i.e. #1194's in-scope half. Small once Stage 3 exists: the arms
 raise with the semi-index's own message, which is more specific than anything
 reconstructible at the materializer.
+
+**Sites 19–20 are not actually landed, despite an earlier version of this doc claiming
+all of 17–20 under this stage's "✅ landed."** Re-reading both directly:
+
+- **Site 19 (`eval.rs:427`)** still reads `StandardJson::Error(_) => OwnedValue::Null`,
+  unchanged. Low live risk *today*: `eval.rs`'s evaluator only processes JSON re-serialized
+  from an already-decoded `OwnedValue`, which by construction can't contain a structurally
+  malformed value, so this arm is dead in practice — but the doc's own site-inventory
+  rationale for including site 19 "anyway, as a cheap consistency fix" was never carried
+  out, and a future code path that starts feeding raw, unvalidated JSON through
+  `eval.rs::eval()` would silently reintroduce the bug with no test guarding against it.
+- **Site 20 (`json/light.rs:2098`, `stream_json_as_yaml`'s `StandardJson::Error` arm —
+  the JSON→YAML streaming output path)** also still writes `null` unchanged. This one is
+  architecturally the same class of gap Stage 6 below is about (a `core::fmt::Write`-only
+  error channel that cannot cleanly raise mid-stream) — it was miscategorized as a simple
+  Stage-4 fix rather than folded into Stage 6 alongside its YAML→JSON and YAML→YAML
+  siblings. See [yq Limitations § A bad escape in a streamed scalar still degrades
+  silently](../compliance/yq/limitations.md#a-bad-escape-in-a-streamed-scalar-still-degrades-silently-instead-of-raising)
+  for the two siblings that are recorded; this third one belongs in the same bucket once
+  Stage 6 is scoped.
 
 One site was reverted after being written. `print_json`'s `StandardJson::Error` arm
 (`jq_runner.rs`) walks child cursors lazily and streams as it goes, so by the time a

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1195,7 +1195,18 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     had_output = true;
                     // For exit_status tracking, we need to check the last value
                     if args.exit_status {
-                        last_output = Some(result.materialize());
+                        // `-e` is the flag that forces materialization at
+                        // all, so it is where a decode failure first becomes
+                        // observable here (#1247). Report and skip the value
+                        // rather than letting an undecodable string count as
+                        // a truthiness answer; `sink` drives the exit code.
+                        match result.materialize() {
+                            Ok(owned) => last_output = Some(owned),
+                            Err(e) => {
+                                sink.report(DiagStyle::Jq, &e, &at);
+                                continue;
+                            }
+                        }
                     }
                     // A malformed document is a data error, not an I/O one: it
                     // belongs in jq's diagnostic channel (exit 5) rather than
@@ -2301,8 +2312,14 @@ fn validate_json_str(s: &str) -> serde_json::Result<()> {
 /// *normalized* copy but must still materialize the *original* text, see
 /// its own comment), so that one branch calls `validate_json_str`
 /// directly instead.
-fn validate_and_materialize_json(s: &str) -> serde_json::Result<OwnedValue> {
+fn validate_and_materialize_json(
+    s: &str,
+) -> serde_json::Result<core::result::Result<OwnedValue, EvalError>> {
     validate_json_str(s)?;
+    // Two nested results on purpose: the *outer* `Err` is serde's, and only
+    // it may trigger the caller's leading-zero retry. A decode failure
+    // (#1247) is not a validation failure serde could disagree about, so it
+    // must not be mistaken for one -- retrying would just fail again.
     Ok(crate::output::json_bytes_to_owned_value(s.as_bytes()))
 }
 
@@ -2327,7 +2344,8 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
     }
 
     match validate_and_materialize_json(s) {
-        Ok(v) => Ok(v),
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(anyhow::anyhow!("Invalid JSON: {s}: {e}")),
         Err(e) => {
             // Real jq's own number parser tolerates a leading zero
             // (`007`, `00`, `007.5`) that strict JSON doesn't (#1094) --
@@ -2346,7 +2364,8 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
             if normalized == s || validate_json_str(&normalized).is_err() {
                 return Err(e).with_context(|| format!("Invalid JSON: {s}"));
             }
-            Ok(crate::output::json_bytes_to_owned_value(s.as_bytes()))
+            crate::output::json_bytes_to_owned_value(s.as_bytes())
+                .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"))
         }
     }
 }
@@ -2574,12 +2593,13 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
         Err(e) => {
             let bytes = s.as_bytes();
             match find_json_values(bytes) {
-                Ok(spans) => Ok(spans
+                Ok(spans) => spans
                     .into_iter()
                     .map(|(start, end)| {
                         crate::output::json_bytes_to_owned_value(&bytes[start..end])
                     })
-                    .collect()),
+                    .collect::<core::result::Result<Vec<_>, _>>()
+                    .map_err(|de| anyhow::anyhow!("{de}")),
                 Err(_) => Err(e),
             }
         }
@@ -2616,7 +2636,10 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
             .iter()
             .position(|b| !b.is_ascii_whitespace())
             .map_or(prev_end, |offset| prev_end + offset);
-        values.push(crate::output::json_bytes_to_owned_value(&bytes[start..end]));
+        values.push(
+            crate::output::json_bytes_to_owned_value(&bytes[start..end])
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+        );
         prev_end = end;
     }
 
@@ -2700,7 +2723,13 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
 
         // Try to parse as JSON, silently ignore failures
         if seq_record_parses(segment) {
-            values.push(crate::output::json_bytes_to_owned_value(segment.as_bytes()));
+            // Skipped, not raised: this function has no error channel by
+            // design -- RFC 7464 says a malformed segment is dropped, which
+            // is the same answer for a segment that parses but won't decode
+            // (#1247).
+            if let Ok(v) = crate::output::json_bytes_to_owned_value(segment.as_bytes()) {
+                values.push(v);
+            }
         }
         // Genuine parse failures are silently ignored per RFC 7464
     }
@@ -2884,14 +2913,34 @@ fn evaluate_input(
     // (at_offset, at_position builtins)
     let result = eval_with_cursor(expr, cursor);
 
+    // A decode failure while materializing a result is an uncaught error like
+    // any other (#1247): report it to `sink` and yield nothing, so the next
+    // input still runs and the exit code is still set (`ErrorSink`, #355).
+    // Mirrors the `GenericResult::Error` arm below.
+    macro_rules! materialized {
+        ($e:expr) => {
+            match $e {
+                Ok(v) => v,
+                Err(e) => {
+                    sink.report(DiagStyle::Jq, &e, &at.resolve());
+                    return Ok(vec![]);
+                }
+            }
+        };
+    }
+
     // Convert result to Vec<OwnedValue>
     match result {
-        GenericResult::One(v) => Ok(vec![generic_to_owned(&v)]),
-        GenericResult::OneCursor(c) => Ok(vec![generic_to_owned(&c.value())]),
-        GenericResult::Many(vs) => Ok(vs.iter().map(generic_to_owned).collect()),
-        GenericResult::ManyCursor(cs) => {
-            Ok(cs.iter().map(|c| generic_to_owned(&c.value())).collect())
-        }
+        GenericResult::One(v) => Ok(vec![materialized!(generic_to_owned(&v))]),
+        GenericResult::OneCursor(c) => Ok(vec![materialized!(generic_to_owned(&c.value()))]),
+        GenericResult::Many(vs) => Ok(materialized!(vs
+            .iter()
+            .map(generic_to_owned)
+            .collect::<core::result::Result<Vec<_>, _>>())),
+        GenericResult::ManyCursor(cs) => Ok(materialized!(cs
+            .iter()
+            .map(|c| generic_to_owned(&c.value()))
+            .collect::<core::result::Result<Vec<_>, _>>())),
         // Fallback: materialize. This runner boundary never sees a
         // fast-pathed `keys`/`keys_unsorted | length`/`.[]`/`.[n]`/`first`/
         // `last` — those are fully resolved inside the evaluator's `Pipe`
@@ -3224,8 +3273,13 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
             print_json(out, value, &PreserveFormatter, config, 0, &mut Vec::new())?;
         }
     } else {
-        // For complex output (pretty-print, sort_keys, colors), materialize first
-        let owned = value.materialize();
+        // For complex output (pretty-print, sort_keys, colors), materialize
+        // first -- and surface a decode failure rather than printing the
+        // empty string it used to become (#1247). `anyhow` is the only error
+        // channel this writer has; the message is preserved verbatim.
+        let owned = value
+            .materialize()
+            .map_err(|e| anyhow::anyhow!("{}", e.message))?;
         out.write_all(format_json(&owned, config).as_bytes())?;
     }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2984,6 +2984,17 @@ fn evaluate_input(
     // any other (#1247): report it to `sink` and yield nothing, so the next
     // input still runs and the exit code is still set (`ErrorSink`, #355).
     // Mirrors the `GenericResult::Error` arm below.
+    //
+    // Every `Err(e)` this macro's `One`/`Many`/`ManyCursor` call sites below
+    // can produce is defense-in-depth rather than reachable in practice:
+    // `cursor` is always rooted in `input.to_json()`, a fresh serialization
+    // of an already-decoded `OwnedValue` (a Rust `String`, which by
+    // construction can't hold an undecodable byte sequence, and whose
+    // escapes this crate's own serializer writes) -- same argument
+    // `eval_generic.rs`'s textually-similar bridge relies on (search
+    // "defense-in-depth" there). Kept as `Result` rather than `.unwrap()` so
+    // a real failure, if this invariant is ever violated, surfaces as a
+    // normal `EvalError` instead of a panic.
     macro_rules! materialized {
         ($e:expr) => {
             match $e {
@@ -4518,6 +4529,27 @@ mod tests {
             "message: {}",
             err.message
         );
+    }
+
+    /// #1194: a top-level query *result* that is itself a bareword garbage
+    /// token (`StandardJson::Error`, not a decode failure) raises instead of
+    /// silently printing `null` -- the same class of fix as the malformed-key
+    /// and unpaired-field cases above, for the array/object match arm's own
+    /// fallthrough rather than either of their more specific checks. No
+    /// CLI-level test accompanies this for the same reason given on this
+    /// function's own doc comment: an ordinary `[xyz123] | to_entries`-style
+    /// filter resolves its result through `to_owned` (`eval_generic.rs`)
+    /// before it ever reaches this lazy `JqValue` conversion, so reaching
+    /// this exact arm needs a result cursor built directly, as below.
+    #[test]
+    fn test_standard_json_to_jq_value_raises_on_malformed_top_level_value_1194() {
+        let json: &[u8] = b"xyz123";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err =
+            standard_json_to_jq_value(value, &cursor).expect_err("a bareword is not a JSON value");
+        assert!(!err.message.is_empty(), "{err:?}");
     }
 
     /// #1194: `MalformedJsonError` exists to be `downcast_ref`'d out of an

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2066,13 +2066,30 @@ fn read_stdin() -> Result<String> {
     // Lossy, not `read_to_string`: that refused the whole input on a stray
     // byte, reporting it as a *read* failure when the read had succeeded
     // (#1247). See `utf8_lossy_document` for why jq substitutes here.
-    Ok(String::from_utf8_lossy(&read_stdin_bytes()?).into_owned())
+    Ok(utf8_lossy_string(read_stdin_bytes()?))
 }
 
 /// Read a file to string.
 fn read_file(path: &Path) -> Result<String> {
     // Lossy for the same reason as `read_stdin` above.
-    Ok(String::from_utf8_lossy(&read_file_bytes(path)?).into_owned())
+    Ok(utf8_lossy_string(read_file_bytes(path)?))
+}
+
+/// Lossy UTF-8 decode that does not copy a document that is already valid.
+///
+/// `String::from_utf8_lossy(&bytes).into_owned()` allocates and copies the
+/// whole document even when it is valid, because the `Cow` it returns is
+/// `Borrowed` and `into_owned` must then clone it -- measured (pinned
+/// hardware, interleaved A/B) as the dominant cost of #1247's whole diff,
+/// +9.47% median on a cheap navigation query on x86_64, breaching the design
+/// doc's own +8% ceiling on a change that isn't the one doing the costing.
+/// Taking ownership of the existing buffer instead makes the valid path
+/// allocation-free.
+fn utf8_lossy_string(raw: Vec<u8>) -> String {
+    match String::from_utf8(raw) {
+        Ok(s) => s,
+        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+    }
 }
 
 /// Replace every invalid UTF-8 sequence in a *document* with U+FFFD, the
@@ -2975,7 +2992,7 @@ fn evaluate_input(
             sorted,
             collapse,
         } => {
-            let mut keys = effective_keys(&fields, collapse);
+            let mut keys = materialized!(effective_keys(&fields, collapse));
             if sorted {
                 keys.sort();
             }
@@ -3124,13 +3141,18 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             fields,
             sorted: true,
             collapse,
-        } => {
-            let mut keys = effective_keys(&fields, collapse);
-            keys.sort();
-            vec![JqValue::from_owned(OwnedValue::Array(
-                keys.into_iter().map(OwnedValue::String).collect(),
-            ))]
-        }
+        } => match effective_keys(&fields, collapse) {
+            Ok(mut keys) => {
+                keys.sort();
+                vec![JqValue::from_owned(OwnedValue::Array(
+                    keys.into_iter().map(OwnedValue::String).collect(),
+                ))]
+            }
+            Err(e) => {
+                sink.report(DiagStyle::Jq, &e, at);
+                vec![]
+            }
+        },
         // Same laziness as `LazyKeys` above, for array `keys`/
         // `keys_unsorted` (#684): `write_json`/`print_json` write the
         // `[0,1,...,len-1]` digits directly, no `Vec<OwnedValue::Int>`.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1132,12 +1132,25 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         // This preserves original number formatting like "4e4"
         let files = get_input_files(&args);
         let raw_inputs: Vec<Vec<u8>> = if files.is_empty() {
-            vec![utf8_lossy_document(read_stdin_bytes()?)]
+            vec![read_stdin_bytes()?]
         } else {
             files
                 .iter()
-                .map(|path| read_file_bytes(path).map(utf8_lossy_document))
+                .map(|path| read_file_bytes(path))
                 .collect::<Result<Vec<_>>>()?
+        };
+        // Substitution is skipped under `--validate` so the strict validator
+        // in the loop below still sees the *original* bytes (#1247).
+        // Substituting first silently repaired a non-UTF-8 document, leaving
+        // the one check `--validate` exists to perform with nothing to find:
+        // `sjq --validate` exited 0 where `succinctly json validate` on the
+        // same file still exits 1. Nothing is lost by skipping it here --
+        // any document that would have been substituted is a document
+        // `validate_json_input` rejects.
+        let raw_inputs: Vec<Vec<u8>> = if args.validate {
+            raw_inputs
+        } else {
+            raw_inputs.into_iter().map(utf8_lossy_document).collect()
         };
 
         // Check if we can use the identity fast path (raw bytes output, no materialization)
@@ -1580,22 +1593,63 @@ fn get_inputs(
     // Get input files
     let files = get_input_files(args);
 
-    // Collect raw input from files or stdin
-    let raw_inputs = if files.is_empty() {
-        match read_stdin() {
-            Ok(s) => vec![(None, s)],
+    // Collect raw input from files or stdin. Read as bytes and decode below
+    // rather than through `read_to_string`, which refused the whole input on
+    // a stray byte and reported it as a *read* failure when the read had in
+    // fact succeeded (#1247).
+    let raw_bytes: Vec<(Option<usize>, Vec<u8>)> = if files.is_empty() {
+        match read_stdin_bytes() {
+            Ok(b) => vec![(None, b)],
             Err(e) => return Ok(Err(e)),
         }
     } else {
         let mut inputs = Vec::new();
         for (idx, path) in files.iter().enumerate() {
-            match read_file(path) {
-                Ok(s) => inputs.push((Some(idx), s)),
+            match read_file_bytes(path) {
+                Ok(b) => inputs.push((Some(idx), b)),
                 Err(e) => return Ok(Err(e)),
             }
         }
         inputs
     };
+
+    // JSON input mode is the only mode that runs the strict validator at all
+    // -- `-R`, `--seq` and DSV never do, and must not start now.
+    let json_input_mode = args.input_dsv.is_none() && !args.raw_input && !args.seq;
+
+    // All reads happen first, then decoding: a later file's read error still
+    // outranks an earlier file's content error, as it did before.
+    let mut raw_inputs: Vec<(Option<usize>, String)> = Vec::with_capacity(raw_bytes.len());
+    for (file_idx, raw) in raw_bytes {
+        // `String::from_utf8`, not `String::from_utf8_lossy(&raw).into_owned()`:
+        // the latter allocates and copies the whole document even when it is
+        // valid, because the `Cow` it returns is `Borrowed` and `into_owned`
+        // must then clone it -- measured (pinned hardware, interleaved A/B)
+        // as the dominant cost of #1247's whole diff, +9.47% median on a
+        // cheap navigation query on x86_64. Taking ownership of the buffer
+        // that already exists makes the valid path allocation-free.
+        let raw = match String::from_utf8(raw) {
+            Ok(s) => s,
+            Err(e) => {
+                // The substitution below is jq's own behaviour for a
+                // non-UTF-8 document (see `utf8_lossy_document`), but it must
+                // not run *before* `--validate` (#1247): repairing the
+                // document first left the strict validator -- whose whole job
+                // is to reject exactly this -- with nothing to find, so
+                // `sjq --validate` exited 0 where `succinctly json validate`
+                // on the same file still exits 1. `validate_json_input` fails
+                // on any input that reaches here, so the substitution after
+                // it is unreachable in JSON mode; it stays for the modes that
+                // never validate.
+                if args.validate && json_input_mode {
+                    let filename = file_idx.map(|idx| files[idx].to_string_lossy().to_string());
+                    validate_json_input(e.as_bytes(), filename.as_deref())?;
+                }
+                String::from_utf8_lossy(e.as_bytes()).into_owned()
+            }
+        };
+        raw_inputs.push((file_idx, raw));
+    }
 
     let mut locations = InputLocations::new(
         files
@@ -2061,37 +2115,6 @@ impl ErrorAt<'_> {
     }
 }
 
-/// Read stdin to string.
-fn read_stdin() -> Result<String> {
-    // Lossy, not `read_to_string`: that refused the whole input on a stray
-    // byte, reporting it as a *read* failure when the read had succeeded
-    // (#1247). See `utf8_lossy_document` for why jq substitutes here.
-    Ok(utf8_lossy_string(read_stdin_bytes()?))
-}
-
-/// Read a file to string.
-fn read_file(path: &Path) -> Result<String> {
-    // Lossy for the same reason as `read_stdin` above.
-    Ok(utf8_lossy_string(read_file_bytes(path)?))
-}
-
-/// Lossy UTF-8 decode that does not copy a document that is already valid.
-///
-/// `String::from_utf8_lossy(&bytes).into_owned()` allocates and copies the
-/// whole document even when it is valid, because the `Cow` it returns is
-/// `Borrowed` and `into_owned` must then clone it -- measured (pinned
-/// hardware, interleaved A/B) as the dominant cost of #1247's whole diff,
-/// +9.47% median on a cheap navigation query on x86_64, breaching the design
-/// doc's own +8% ceiling on a change that isn't the one doing the costing.
-/// Taking ownership of the existing buffer instead makes the valid path
-/// allocation-free.
-fn utf8_lossy_string(raw: Vec<u8>) -> String {
-    match String::from_utf8(raw) {
-        Ok(s) => s,
-        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
-    }
-}
-
 /// Replace every invalid UTF-8 sequence in a *document* with U+FFFD, the
 /// way real jq does (#1247).
 ///
@@ -2107,8 +2130,12 @@ fn utf8_lossy_string(raw: Vec<u8>) -> String {
 /// whole-input SIMD pass (~1.1 ms on 8.4 MB) and only a document that
 /// actually fails it pays for a copy.
 ///
-/// Document input only. `--raw-input` shares this path (jq substitutes
-/// there too), but DSV input, `--arg`/`--argjson` and `--rawfile` do not.
+/// Document input only, and only when `--validate` is off: the strict
+/// validator has to see the original bytes, or the substitution repairs the
+/// document out from under the one check that is supposed to reject it
+/// (#1247). `--raw-input` gets the same substitution (jq substitutes there
+/// too) via `get_inputs`' own decode; DSV input, `--arg`/`--argjson` and
+/// `--rawfile` get none.
 fn utf8_lossy_document(raw: Vec<u8>) -> Vec<u8> {
     match succinctly::text::utf8::validate_utf8(&raw) {
         Ok(()) => raw,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1132,11 +1132,11 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         // This preserves original number formatting like "4e4"
         let files = get_input_files(&args);
         let raw_inputs: Vec<Vec<u8>> = if files.is_empty() {
-            vec![read_stdin_bytes()?]
+            vec![utf8_lossy_document(read_stdin_bytes()?)]
         } else {
             files
                 .iter()
-                .map(|path| read_file_bytes(path))
+                .map(|path| read_file_bytes(path).map(utf8_lossy_document))
                 .collect::<Result<Vec<_>>>()?
         };
 
@@ -2063,17 +2063,40 @@ impl ErrorAt<'_> {
 
 /// Read stdin to string.
 fn read_stdin() -> Result<String> {
-    let mut buf = String::new();
-    std::io::stdin()
-        .read_to_string(&mut buf)
-        .context("Failed to read from stdin")?;
-    Ok(buf)
+    // Lossy, not `read_to_string`: that refused the whole input on a stray
+    // byte, reporting it as a *read* failure when the read had succeeded
+    // (#1247). See `utf8_lossy_document` for why jq substitutes here.
+    Ok(String::from_utf8_lossy(&read_stdin_bytes()?).into_owned())
 }
 
 /// Read a file to string.
 fn read_file(path: &Path) -> Result<String> {
-    std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read file: {}", path.display()))
+    // Lossy for the same reason as `read_stdin` above.
+    Ok(String::from_utf8_lossy(&read_file_bytes(path)?).into_owned())
+}
+
+/// Replace every invalid UTF-8 sequence in a *document* with U+FFFD, the
+/// way real jq does (#1247).
+///
+/// jq is the odd one out here: `yq` rejects a non-UTF-8 document outright
+/// (see `yq_runner::yaml_validate_guard`), but jq accepts it, substitutes
+/// the replacement character and exits 0 -- `{"a":"\xff\xfe"}` prints as
+/// `"\u{fffd}\u{fffd}"`. succinctly used to echo the raw bytes instead,
+/// which means it wrote invalid UTF-8 to stdout; the non-lazy path was
+/// worse still, refusing the file with `Failed to read file` when the read
+/// had in fact succeeded.
+///
+/// Valid input is returned untouched and unallocated -- the check is a
+/// whole-input SIMD pass (~1.1 ms on 8.4 MB) and only a document that
+/// actually fails it pays for a copy.
+///
+/// Document input only. `--raw-input` shares this path (jq substitutes
+/// there too), but DSV input, `--arg`/`--argjson` and `--rawfile` do not.
+fn utf8_lossy_document(raw: Vec<u8>) -> Vec<u8> {
+    match succinctly::text::utf8::validate_utf8(&raw) {
+        Ok(()) => raw,
+        Err(_) => String::from_utf8_lossy(&raw).into_owned().into_bytes(),
+    }
 }
 
 /// Read stdin to bytes.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3240,7 +3240,11 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
             }
             JqValue::Object(map)
         }
-        StandardJson::Error(_) => JqValue::Null,
+        // See `eval_generic::to_owned_at_depth`'s own `is_error` arm
+        // (#1194/#1247): a structurally malformed value -- one the
+        // semi-index accepted as a span but could not classify as any JSON
+        // token -- raises rather than becoming `null`.
+        StandardJson::Error(msg) => return Err(EvalError::new(msg.to_string())),
     })
 }
 
@@ -3708,6 +3712,20 @@ where
                         scratch.truncate(base);
                     }
                 }
+                // A structurally malformed value the semi-index accepted as
+                // a span but could not classify (`[xyz123]`, `[tru]`), still
+                // printed as `null` -- so this lazy output path disagrees
+                // with every materializing one, which now raises (#1194).
+                //
+                // Deliberately NOT raised here, and this was tried: `print_json`
+                // walks child cursors lazily and streams as it goes, so by the
+                // time a nested error is reached it has already written the
+                // opening `[`. Bailing produced a truncated document plus a
+                // generic exit 1, where the materializing routes give a clean
+                // diagnostic and exit 5 -- worse on every axis than the silent
+                // `null`. Needs the same error channel as the YAML streaming
+                // path; tracked together as Stage 6 in
+                // `docs/plan/decode-failure-routing.md`.
                 StandardJson::Error(_) => out.write_all(b"null")?,
             }
         }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -42,7 +42,13 @@ pub use succinctly::yaml::format_float_yq;
 /// local to `yq_runner.rs` rather than a second variant here, since it's a
 /// yq-CLI-specific oracle quirk this shared helper has no business knowing
 /// about.
-pub fn json_bytes_to_owned_value(bytes: &[u8]) -> OwnedValue {
+///
+/// Fallible since #1247: a string that fails to decode raises instead of
+/// materializing as `null`. Every caller here re-serializes an *already
+/// decoded* `OwnedValue`, so in practice this cannot fail on those paths --
+/// but the signature says so rather than a comment promising it, and the
+/// `--argjson`/`--jsonargs` paths take genuinely external text.
+pub fn json_bytes_to_owned_value(bytes: &[u8]) -> Result<OwnedValue, EvalError> {
     let index = JsonIndex::build(bytes);
     let cursor = index.root(bytes);
     generic_to_owned(&cursor.value())

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -404,7 +404,13 @@ fn yaml_validate_guard(
     if !validate {
         return None;
     }
-    match succinctly::yaml::validate::validate(input) {
+    // `Validator` directly, not the top-level `validate()` wrapper: the
+    // encoding pass above already confirmed `input` is valid UTF-8, so
+    // `validate()`'s own leading `validate_utf8` call (needed for its other
+    // caller, `succinctly yaml validate`, which has no such upfront check)
+    // would just re-scan the same unmodified buffer for a result already
+    // known.
+    match succinctly::yaml::validate::Validator::new(input).validate() {
         Ok(()) => None,
         Err(err) => {
             print_yaml_validation_error(&err, input, filename);
@@ -1591,7 +1597,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
             sorted,
             collapse,
         } => {
-            let mut keys = effective_keys(&fields, collapse);
+            let mut keys = materialized!(effective_keys(&fields, collapse));
             if sorted {
                 keys.sort();
             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -868,6 +868,20 @@ fn query_result_to_owned_values(
     // A decode failure while materializing is an uncaught error like any
     // other (#1247): report it and yield nothing, exactly as the
     // `QueryResult::Error` arm below does.
+    //
+    // Both callers ([`evaluate_input`] above, `eval_owned_with_file_index`
+    // below) only ever produce a `result` rooted in an already-decoded
+    // `OwnedValue` re-serialized to JSON and reindexed -- `eval_owned_input`
+    // (this function's non-path-context caller) explicitly converts every
+    // `One`/`Many` it sees into `Owned`/`ManyOwned` before returning, and the
+    // path-tracking branch builds its own `Owned`/`ManyOwned` results
+    // throughout since a path is always a concrete `Vec<OwnedValue>`, never
+    // a lazy cursor. So a genuine decode failure in the `One`/`OneCursor`/
+    // `Many` arms below is defense-in-depth, not a reachable path today --
+    // same argument `eval_generic.rs`'s textually-similar bridge relies on
+    // (search "defense-in-depth" there). Kept as `Result` rather than
+    // `.unwrap()` so a real failure, if this invariant is ever violated,
+    // surfaces as a normal `EvalError` instead of a panic.
     macro_rules! materialized {
         ($e:expr) => {
             match $e {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -380,7 +380,28 @@ fn yaml_validate_guard(
     validate: bool,
     filename: Option<&str>,
 ) -> Option<i32> {
-    if !validate || !matches!(format, InputFormat::Yaml | InputFormat::Auto) {
+    if !matches!(format, InputFormat::Yaml | InputFormat::Auto) {
+        return None;
+    }
+    // Encoding is checked *unconditionally*, not only under `--validate`
+    // (#1242). YAML 1.2 requires a UTF-8/16/32 stream and real yq rejects a
+    // document with a stray byte outright (`invalid trailing UTF-8 octet`,
+    // exit 1); succinctly used to accept it, index it, and then hand back
+    // `null` for the scalar that byte was in -- with `--validate` no help,
+    // since the strict validator had no encoding check either. The pass is
+    // whole-input SIMD UTF-8 validation, ~1.1 ms on 8.4 MB, so this is the
+    // one always-on cost the fix adds; the strict grammar walk below stays
+    // opt-in because it is roughly eight times dearer.
+    //
+    // Wording follows this crate's own `YAML parse error:` convention (see
+    // the `YamlIndex::build` failure path) rather than yq's `bad file '-':`
+    // shape, which succinctly already diverges from for every other parse
+    // error.
+    if let Err(err) = succinctly::text::utf8::validate_utf8(input) {
+        eprintln!("Error: YAML parse error: {err}");
+        return Some(exit_codes::FALSE_OR_NULL);
+    }
+    if !validate {
         return None;
     }
     match succinctly::yaml::validate::validate(input) {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -838,10 +838,27 @@ fn query_result_to_owned_values(
     result: QueryResult<'_, Vec<u64>>,
     sink: &mut ErrorSink,
 ) -> Vec<OwnedValue> {
+    // A decode failure while materializing is an uncaught error like any
+    // other (#1247): report it and yield nothing, exactly as the
+    // `QueryResult::Error` arm below does.
+    macro_rules! materialized {
+        ($e:expr) => {
+            match $e {
+                Ok(v) => v,
+                Err(e) => {
+                    sink.report(DiagStyle::Yq, &e, &no_location());
+                    return Vec::new();
+                }
+            }
+        };
+    }
     match result {
-        QueryResult::One(v) => vec![generic_to_owned(&v)],
-        QueryResult::OneCursor(c) => vec![generic_to_owned(&c.value())],
-        QueryResult::Many(vs) => vs.iter().map(generic_to_owned).collect(),
+        QueryResult::One(v) => vec![materialized!(generic_to_owned(&v))],
+        QueryResult::OneCursor(c) => vec![materialized!(generic_to_owned(&c.value()))],
+        QueryResult::Many(vs) => materialized!(vs
+            .iter()
+            .map(generic_to_owned)
+            .collect::<core::result::Result<Vec<_>, _>>()),
         QueryResult::None => vec![],
         QueryResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
@@ -1444,13 +1461,28 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // assignment-family expression against a document that actually has
     // aliases. Everything else (JSON, plain reads, alias-free YAML) pays
     // nothing beyond this one bool check.
+    // A decode failure anywhere in this function is an uncaught error like
+    // any other (#1247): report it and yield no documents, exactly as the
+    // `GenericResult::Error` arm below does.
+    macro_rules! materialized {
+        ($e:expr) => {
+            match $e {
+                Ok(v) => v,
+                Err(e) => {
+                    sink.report(DiagStyle::Yq, &e, &no_location());
+                    return Ok(Vec::new());
+                }
+            }
+        };
+    }
+
     let has_aliases = cursor.index().has_aliases();
-    let alias_sync_ctx = (is_alias_sensitive_assign(expr) && has_aliases).then(|| {
-        (
-            generic_to_owned(&cursor.value()),
-            collect_alias_groups(cursor),
-        )
-    });
+    let alias_sync_ctx = match (is_alias_sensitive_assign(expr) && has_aliases)
+        .then(|| generic_to_owned(&cursor.value()))
+    {
+        Some(pristine) => Some((materialized!(pristine), collect_alias_groups(cursor))),
+        None => None,
+    };
 
     // Snapshot the pristine presentation tree *before* evaluation too
     // (#739, ADR-0017): same shape-preserving-write gate as `alias_sync_ctx`
@@ -1459,8 +1491,12 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // and only when the caller can use the result at all (`need_comments`).
     // `no_comments` below reconciles this against each result document once
     // evaluation finishes.
-    let presentation_sync_ctx = (need_comments && is_alias_sensitive_assign(expr))
-        .then(|| to_owned_with_comments(&cursor.value(), Some(&cursor)));
+    let presentation_sync_ctx = match (need_comments && is_alias_sensitive_assign(expr))
+        .then(|| to_owned_with_comments(&cursor.value(), Some(&cursor)))
+    {
+        Some(snapshot) => Some(materialized!(snapshot)),
+        None => None,
+    };
 
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
     // A value with no live cursor of its own (an assignment/`del()`
@@ -1484,7 +1520,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         if need_comments {
             to_owned_with_comments(&c.value(), Some(c))
         } else {
-            no_comments(generic_to_owned(&c.value()))
+            generic_to_owned(&c.value()).map(&no_comments)
         }
     };
 
@@ -1498,10 +1534,20 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // arms are defensive/unreachable here today, kept for exhaustiveness
     // over the shared `GenericResult` enum.
     let mut docs = match result {
-        GenericResult::One(v) => Ok(vec![no_comments(generic_to_owned(&v))]),
-        GenericResult::OneCursor(c) => Ok(vec![owned_with_comments(&c)]),
-        GenericResult::Many(vs) => Ok(vs.iter().map(generic_to_owned).map(no_comments).collect()),
-        GenericResult::ManyCursor(cs) => Ok(cs.iter().map(owned_with_comments).collect()),
+        GenericResult::One(v) => Ok(vec![no_comments(materialized!(generic_to_owned(&v)))]),
+        GenericResult::OneCursor(c) => Ok(vec![materialized!(owned_with_comments(&c))]),
+        GenericResult::Many(vs) => Ok(materialized!(vs
+            .iter()
+            .map(generic_to_owned)
+            .collect::<core::result::Result<Vec<_>, _>>())
+        .into_iter()
+        .map(&no_comments)
+        .collect()),
+        GenericResult::ManyCursor(cs) => Ok(materialized!(cs
+            .iter()
+            .map(owned_with_comments)
+            .collect::<core::result::Result<Vec<_>, _>>(
+        ))),
         // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
         // fallback), reached only when `can_use_m2_streaming` rejects the
         // expression or a flag (`--sort-keys`, color, `--tab`, `--slurp`,

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -5,6 +5,8 @@
 //! intermediate conversion.
 
 #[cfg(not(test))]
+use alloc::format;
+#[cfg(not(test))]
 use alloc::vec;
 #[cfg(not(test))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
@@ -12,6 +14,8 @@ use alloc::{borrow::Cow, string::String, vec::Vec};
 use indexmap::{IndexMap, IndexSet};
 #[cfg(test)]
 use std::borrow::Cow;
+
+use super::error::EvalError;
 
 /// Indentation configuration for cursor/lazy streaming output.
 ///
@@ -590,16 +594,22 @@ pub trait DocumentFields: Sized + Clone {
     }
 
     /// Collect all field names.
-    fn keys(&self) -> Vec<String> {
+    fn keys(&self) -> Result<Vec<String>, EvalError> {
         let mut keys = Vec::new();
         let mut fields = self.clone();
         while let Some((field, rest)) = fields.uncons() {
+            // Before `key_str`, not after -- same ordering rule as every
+            // other key-materializing site (#1247): an undecodable key must
+            // raise here, not silently vanish once `key_str` stringifies it.
+            if let Some(reason) = field.key.string_decode_error() {
+                return Err(EvalError::new(format!("{reason} in object key")));
+            }
             if let Some(key) = field.key_str() {
                 keys.push(key.into_owned());
             }
             fields = rest;
         }
-        keys
+        Ok(keys)
     }
 }
 
@@ -1292,21 +1302,24 @@ pub fn effective_len<F: DocumentFields>(fields: &F, collapse: bool) -> usize {
 /// `IndexSet`, whose `insert` keeps the first occurrence's position and
 /// discards later equal ones -- the whole rule, since a key array carries
 /// no values for "last value wins" to choose between.
-pub fn effective_keys<F: DocumentFields>(fields: &F, collapse: bool) -> Vec<String> {
-    let keys = fields.keys();
+pub fn effective_keys<F: DocumentFields>(
+    fields: &F,
+    collapse: bool,
+) -> Result<Vec<String>, EvalError> {
+    let keys = fields.keys()?;
     if !collapse {
-        return keys;
+        return Ok(keys);
     }
     let mut hashes: Vec<u64> = keys.iter().map(|key| key_hash(key.as_bytes())).collect();
     hashes.sort_unstable();
     if !hashes_repeat(&hashes) {
-        return keys;
+        return Ok(keys);
     }
     let mut seen: IndexSet<String> = IndexSet::with_capacity(keys.len());
     for key in keys {
         seen.insert(key);
     }
-    seen.into_iter().collect()
+    Ok(seen.into_iter().collect())
 }
 
 /// A single field from an object.

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -383,6 +383,29 @@ pub trait DocumentValue: Sized + Clone {
     /// Try to get as a string.
     fn as_str(&self) -> Option<Cow<'_, str>>;
 
+    /// Why a scalar that is structurally a string could not be *decoded* --
+    /// invalid UTF-8, an invalid escape, an invalid `\u` codepoint.
+    ///
+    /// [`as_str`](Self::as_str) collapses "not a string" and "a string this
+    /// document cannot hand back" into the same `None`, which is how a
+    /// decode failure used to reach a materializing conversion indis-
+    /// tinguishable from an unknown type and degrade silently to `null`
+    /// (#1098, #1247). This separates the two: `Some(reason)` means the
+    /// semi-index accepted the span as a string token but the bytes behind
+    /// it are not decodable, so a caller can raise a real error instead of
+    /// guessing.
+    ///
+    /// Returns a `&'static str` rather than a formatted message so the
+    /// check stays allocation-free and `no_std`-compatible; each format's
+    /// own error type owns the wording (`JsonError::message`,
+    /// `YamlStringError::message`), shared with its `Display`.
+    ///
+    /// Defaults to `None` -- correct for any implementation whose strings
+    /// cannot fail to decode.
+    fn string_decode_error(&self) -> Option<&'static str> {
+        None
+    }
+
     /// String form of this value when it appears as a mapping key.
     ///
     /// Unlike [`as_str`](Self::as_str), a key is always representable as a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -173,12 +173,22 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // used to sit in the `else` below (naming #1098 and PR #1190's
         // reverted `panic!`) described exactly this and is now resolved.
         Err(EvalError::new(reason.to_string()))
+    } else if value.is_error() {
+        // A *structurally* malformed value -- `[xyz123]`, `[tru]` -- which
+        // the semi-index accepted as a span but could not classify as any
+        // JSON token. It used to materialize as `null`, so `[xyz123]` came
+        // back as `[null]` at exit 0 where real jq raises a parse error
+        // (#1194). The semi-index's own message is more specific than
+        // anything reconstructible here, so it is passed through verbatim.
+        Err(EvalError::new(
+            value
+                .error_message()
+                .unwrap_or("malformed value in document")
+                .to_string(),
+        ))
     } else {
-        // Error values and any genuinely unknown type. The decode-failure
-        // case that used to share this arm now raises above (#1247); what
-        // remains is a *structurally* malformed value, which is #1194's
-        // territory and still degrades silently -- see
-        // `docs/plan/decode-failure-routing.md`.
+        // A genuinely unknown type: no format implements one today, so this
+        // is exhaustiveness rather than a live path.
         Ok(OwnedValue::Null)
     }
 }
@@ -1250,7 +1260,9 @@ fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
             }
             OwnedValue::Object(map)
         }
-        StandardJson::Error(_) => OwnedValue::Null,
+        // See `to_owned_at_depth`'s own `is_error` arm (#1194/#1247): a
+        // structurally malformed value raises rather than becoming `null`.
+        StandardJson::Error(msg) => return Err(EvalError::new((*msg).to_string())),
     })
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -109,63 +109,77 @@ pub fn assert_nesting_depth(depth: usize) {
 /// because YAML scalars may have type coercion (e.g., unquoted "true" is a bool).
 ///
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998) rather than
-/// recursing unbounded and overflowing the call stack.
-pub fn to_owned<V: DocumentValue>(value: &V) -> OwnedValue {
+/// recursing unbounded and overflowing the call stack. That guard stays a
+/// `panic!` even though this function is now fallible: unbounded recursion is
+/// a different failure class from a data error, and routing it through
+/// `EvalError` would make a stack-overflow guard catchable by `try`/`catch`.
+///
+/// Returns `Err` when a scalar the semi-index accepted as a string token
+/// cannot be *decoded* (#1098, #1247) -- see
+/// [`DocumentValue::string_decode_error`].
+pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_at_depth(value, 0)
 }
 
-fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
+fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedValue, EvalError> {
     assert_nesting_depth(depth);
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
+            // Before `key_str`, not after: YAML's `key_string` stringifies an
+            // undecodable key to `""` (#222's never-drop-a-key rule), so by
+            // the time `key_str` answers `Some`, the failure is already
+            // invisible. Wording matches the sibling `owned_from_standard_json`
+            // conversion #1192 fixed first.
+            if let Some(reason) = field.key.string_decode_error() {
+                return Err(EvalError::new(format!("{reason} in object key")));
+            }
             if let Some(key) = field.key_str() {
-                map.insert(key.into_owned(), to_owned_at_depth(&field.value, depth + 1));
+                map.insert(
+                    key.into_owned(),
+                    to_owned_at_depth(&field.value, depth + 1)?,
+                );
             }
             f = rest;
         }
-        OwnedValue::Object(map)
+        Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
         while let Some((elem, rest)) = elems.uncons() {
-            items.push(to_owned_at_depth(&elem, depth + 1));
+            items.push(to_owned_at_depth(&elem, depth + 1)?);
             elems = rest;
         }
-        OwnedValue::Array(items)
+        Ok(OwnedValue::Array(items))
     // Then check scalars in order of specificity
     } else if value.is_null() {
-        OwnedValue::Null
+        Ok(OwnedValue::Null)
     } else if let Some(b) = value.as_bool() {
-        OwnedValue::Bool(b)
+        Ok(OwnedValue::Bool(b))
     } else if let Some(literal) = value.number_literal() {
-        OwnedValue::from_number_literal(&literal)
+        Ok(OwnedValue::from_number_literal(&literal))
     } else if let Some(i) = value.as_i64() {
-        OwnedValue::Int(i)
+        Ok(OwnedValue::Int(i))
     } else if let Some(f) = value.as_f64() {
-        OwnedValue::Float(f)
+        Ok(OwnedValue::Float(f))
     } else if let Some(s) = value.as_str() {
-        OwnedValue::String(s.into_owned())
+        Ok(OwnedValue::String(s.into_owned()))
+    } else if let Some(reason) = value.string_decode_error() {
+        // The case this function used to swallow. `as_str` above answered
+        // `None`, but the value *is* a string token -- its bytes just don't
+        // decode. Raising here is #1247's core fix; the deferral comment that
+        // used to sit in the `else` below (naming #1098 and PR #1190's
+        // reverted `panic!`) described exactly this and is now resolved.
+        Err(EvalError::new(reason.to_string()))
     } else {
-        // Covers error values, any unknown types, and -- deliberately, see
-        // #1098 -- a string scalar that passed structural validation (the
-        // semi-index accepted its span as a `String` token) but failed to
-        // decode (invalid `\u` escape, invalid UTF-8, ...). A `PR #1190`
-        // attempt to make that last case panic instead was reverted: code
-        // review found it's reachable through completely ordinary CLI
-        // usage (any non-identity query over a document containing such a
-        // string), not just a theoretical library-only edge case, which
-        // turns a low-severity silent-`null` bug into a live crash --
-        // including mid-batch, defeating this crate's own documented
-        // "evaluation continues past one error" convention (`ErrorSink`,
-        // #355). A correct fix needs to route through `EvalError`/
-        // `ErrorSink` instead, applied consistently across every sibling
-        // copy of this conversion and to object/mapping keys too (see
-        // #1098's own follow-up discussion) -- deferred as a properly
-        // scoped design item rather than shipped as a panic.
-        OwnedValue::Null
+        // Error values and any genuinely unknown type. The decode-failure
+        // case that used to share this arm now raises above (#1247); what
+        // remains is a *structurally* malformed value, which is #1194's
+        // territory and still degrades silently -- see
+        // `docs/plan/decode-failure-routing.md`.
+        Ok(OwnedValue::Null)
     }
 }
 
@@ -184,36 +198,46 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> OwnedValue {
 ///
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998), same as
 /// [`to_owned`].
-pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
+pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> Result<OwnedValue, EvalError> {
     to_owned_cursor_at_depth(cursor, 0)
 }
 
-fn to_owned_cursor_at_depth<C: DocumentCursor>(cursor: &C, depth: usize) -> OwnedValue {
+fn to_owned_cursor_at_depth<C: DocumentCursor>(
+    cursor: &C,
+    depth: usize,
+) -> Result<OwnedValue, EvalError> {
     assert_nesting_depth(depth);
     let value = cursor.value();
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
+            // Same key ordering as `to_owned_at_depth` above, same reason.
+            if let Some(reason) = field.key.string_decode_error() {
+                return Err(EvalError::new(format!("{reason} in object key")));
+            }
             if let Some(key) = field.key_str() {
                 map.insert(
                     key.into_owned(),
-                    to_owned_cursor_at_depth(&field.value_cursor, depth + 1),
+                    to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
                 );
             }
             f = rest;
         }
-        OwnedValue::Object(map)
+        Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
-            items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1));
+            items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1)?);
             elems = rest;
         }
-        OwnedValue::Array(items)
+        Ok(OwnedValue::Array(items))
     } else {
-        cursor
+        // An applicable explicit tag resolves from the raw text and so can
+        // succeed where a plain decode would not; only the untagged fallback
+        // can raise.
+        match cursor
             .explicit_tag()
             .and_then(|tag| tagged_scalar_to_owned(tag, &value))
             .or_else(|| {
@@ -230,8 +254,10 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(cursor: &C, depth: usize) -> Owne
                 } else {
                     None
                 }
-            })
-            .unwrap_or_else(|| to_owned_at_depth(&value, depth))
+            }) {
+            Some(owned) => Ok(owned),
+            None => to_owned_at_depth(&value, depth),
+        }
     }
 }
 
@@ -254,10 +280,48 @@ fn tagged_scalar_to_owned<V: DocumentValue>(tag: &str, value: &V) -> Option<Owne
 /// applies to). Since `cursor.value()` and a separately-threaded `value`
 /// always describe the same node on every call site in this module, `value`
 /// itself is only needed for the `None` fallback.
-fn to_owned_with_cursor<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> OwnedValue {
+fn to_owned_with_cursor<V: DocumentValue>(
+    value: &V,
+    cursor: Option<V::Cursor>,
+) -> Result<OwnedValue, EvalError> {
     match cursor {
         Some(c) => to_owned_cursor(&c),
         None => to_owned(value),
+    }
+}
+
+/// [`to_owned_with_cursor`] for the one job that must not fail: rendering a
+/// value into the text of an error that is *already* being raised.
+///
+/// `EvalError::cannot_iterate(&v)` and friends materialize `v` only to quote
+/// it back to the user. Propagating a decode failure out of those call sites
+/// would mean abandoning a real, correctly-diagnosed error in order to report
+/// "the error message could not be built", which is strictly less useful --
+/// so a decode failure degrades to `null` here, on purpose, and the outer
+/// error still surfaces with its own accurate wording. This is the *only*
+/// sanctioned lossy materialization left in this module (#1247); every other
+/// caller takes the fallible one above.
+fn to_owned_for_diagnostic<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> OwnedValue {
+    to_owned_with_cursor(value, cursor).unwrap_or(OwnedValue::Null)
+}
+
+/// The error a builtin should raise when its type dispatch fell through.
+///
+/// Those dispatches are chains of `as_str()`/`as_array()`/`as_i64()`/...
+/// tests, so a string scalar whose bytes don't decode fails *every* one and
+/// lands in the same `else` as a genuine type mismatch. Reporting the type
+/// error there is actively misleading -- `{"a":"\ud800"} | .a | length` said
+/// `null (null) has no length` about a value that is a perfectly good string
+/// token, naming a symptom two steps removed from the cause. Check for the
+/// decode failure first and report that instead (#1247); everything else
+/// keeps the caller's own wording, which the jq oracle tests pin.
+fn type_error_or_decode_failure<V: DocumentValue>(
+    value: &V,
+    type_error: impl FnOnce() -> EvalError,
+) -> EvalError {
+    match value.string_decode_error() {
+        Some(reason) => EvalError::new(reason.to_string()),
+        None => type_error(),
     }
 }
 
@@ -539,7 +603,7 @@ static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(NodeMeta::empty());
 pub fn to_owned_with_comments<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
-) -> (OwnedValue, CommentTree) {
+) -> Result<(OwnedValue, CommentTree), EvalError> {
     to_owned_with_comments_at_depth(value, cursor, 0)
 }
 
@@ -547,7 +611,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
     depth: usize,
-) -> (OwnedValue, CommentTree) {
+) -> Result<(OwnedValue, CommentTree), EvalError> {
     assert_nesting_depth(depth);
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
     // getter: the write path re-emits this verbatim after one space.
@@ -575,13 +639,17 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         let mut key_comment_map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
+            // Same key ordering as `to_owned_at_depth`, same reason (#1247).
+            if let Some(reason) = field.key.string_decode_error() {
+                return Err(EvalError::new(format!("{reason} in object key")));
+            }
             if let Some(key) = field.key_str() {
                 let key = key.into_owned();
                 let (v, c) = to_owned_with_comments_at_depth(
                     &field.value,
                     Some(&field.value_cursor),
                     depth + 1,
-                );
+                )?;
                 map.insert(key.clone(), v);
                 comment_map.insert(key.clone(), c);
                 // A comment trailing the key's own line, when the value is
@@ -604,10 +672,10 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             }
             f = rest;
         }
-        (
+        Ok((
             OwnedValue::Object(map),
             CommentTree::Object(own_meta, comment_map, key_comment_map),
-        )
+        ))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut comment_items = Vec::new();
@@ -617,17 +685,20 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             let elem_value = elem_cursor.value();
             let (v, c) =
-                to_owned_with_comments_at_depth(&elem_value, Some(&elem_cursor), depth + 1);
+                to_owned_with_comments_at_depth(&elem_value, Some(&elem_cursor), depth + 1)?;
             items.push(v);
             comment_items.push(c);
             elems = rest;
         }
-        (
+        Ok((
             OwnedValue::Array(items),
             CommentTree::Array(own_meta, comment_items),
-        )
+        ))
     } else {
-        (to_owned_at_depth(value, depth), CommentTree::Leaf(own_meta))
+        Ok((
+            to_owned_at_depth(value, depth)?,
+            CommentTree::Leaf(own_meta),
+        ))
     }
 }
 
@@ -638,11 +709,11 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
 /// inspect a candidate's *contents*, only its shape, so a full recursive
 /// `to_owned` of a large navigated container is pure waste when it can only
 /// ever be rejected on type (#669).
-fn to_owned_key_shape<V: DocumentValue>(value: &V) -> OwnedValue {
+fn to_owned_key_shape<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     if value.is_array() {
-        OwnedValue::Array(Vec::new())
+        Ok(OwnedValue::Array(Vec::new()))
     } else if value.is_object() {
-        OwnedValue::Object(IndexMap::new())
+        Ok(OwnedValue::Object(IndexMap::new()))
     } else {
         to_owned(value)
     }
@@ -653,12 +724,12 @@ fn to_owned_key_shape<V: DocumentValue>(value: &V) -> OwnedValue {
 /// still needs its scalar resolved through `to_owned_cursor` rather than the
 /// bare `to_owned`, or an explicit tag on the key/bound expression itself
 /// (`.a[.k]` where `.k` is `!!str 1`) is silently ignored.
-fn to_owned_key_shape_cursor<C: DocumentCursor>(cursor: &C) -> OwnedValue {
+fn to_owned_key_shape_cursor<C: DocumentCursor>(cursor: &C) -> Result<OwnedValue, EvalError> {
     let value = cursor.value();
     if value.is_array() {
-        OwnedValue::Array(Vec::new())
+        Ok(OwnedValue::Array(Vec::new()))
     } else if value.is_object() {
-        OwnedValue::Object(IndexMap::new())
+        Ok(OwnedValue::Object(IndexMap::new()))
     } else {
         to_owned_cursor(cursor)
     }
@@ -979,12 +1050,12 @@ impl<V: DocumentValue> LazySeq<V> {
     /// `[1,2,"x"]|map(.+1)` prints nothing to stdout, only the stderr
     /// diagnostic).
     pub fn materialize_atomic(self) -> Result<OwnedValue, Control> {
-        Ok(OwnedValue::Array(
-            self.drain_atomic()?
-                .iter()
-                .map(lazy_elem_to_owned)
-                .collect(),
-        ))
+        let items = self.drain_atomic()?;
+        let mut out = Vec::with_capacity(items.len());
+        for item in &items {
+            out.push(lazy_elem_to_owned(item).map_err(Control::Error)?);
+        }
+        Ok(OwnedValue::Array(out))
     }
 }
 
@@ -1021,10 +1092,10 @@ fn sequence_streamable_cursors<V: DocumentValue>(items: &[LazyElem<V>]) -> Optio
 /// The single conversion point shared by `materialize_atomic` and the
 /// `LazySeq` streaming arms' non-cursor fallback (#757), so the two can never
 /// disagree about how a drained item becomes a value.
-fn lazy_elem_to_owned<V: DocumentValue>(elem: &LazyElem<V>) -> OwnedValue {
+fn lazy_elem_to_owned<V: DocumentValue>(elem: &LazyElem<V>) -> Result<OwnedValue, EvalError> {
     match elem {
         LazyElem::Cursor(c) => to_owned_cursor(c),
-        LazyElem::Owned(o) => o.clone(),
+        LazyElem::Owned(o) => Ok(o.clone()),
     }
 }
 
@@ -1055,11 +1126,14 @@ fn into_lazy_items<V: DocumentValue>(
     result: GenericResult<V>,
 ) -> Result<Vec<LazyElem<V>>, Control> {
     match result {
-        GenericResult::One(v) => Ok(vec![LazyElem::Owned(to_owned(&v))]),
+        GenericResult::One(v) => Ok(vec![LazyElem::Owned(to_owned(&v).map_err(Control::Error)?)]),
         // Stays lazy: a `map(.foo)`-style navigational sub-expr keeps
         // composing without forcing materialization.
         GenericResult::OneCursor(c) => Ok(vec![LazyElem::Cursor(c)]),
-        GenericResult::Many(vs) => Ok(vs.iter().map(|v| LazyElem::Owned(to_owned(v))).collect()),
+        GenericResult::Many(vs) => vs
+            .iter()
+            .map(|v| Ok(LazyElem::Owned(to_owned(v).map_err(Control::Error)?)))
+            .collect(),
         GenericResult::ManyCursor(cs) => Ok(cs.into_iter().map(LazyElem::Cursor).collect()),
         GenericResult::LazyKeys {
             fields,
@@ -1499,6 +1573,38 @@ fn finish_fork_generic<V: DocumentValue>(
     }
 }
 
+/// Unwrap a fallible materialization inside a `GenericResult<V>`-returning
+/// function, turning a decode failure (#1247) into the `GenericResult::Error`
+/// arm that function's callers already handle.
+///
+/// A macro rather than `?` because these functions return `GenericResult<V>`
+/// directly -- the evaluator carries its errors in the value domain, not in a
+/// `Result` (see `GenericResult::Error`'s own docs).
+macro_rules! owned_or_err {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => return GenericResult::Error(e),
+        }
+    };
+}
+
+/// Unwrap a fallible materialization inside an `Option<Control>`-returning
+/// helper, turning a decode failure (#1247) into the same `Control::Error`
+/// those helpers already forward for `GenericResult::Error`.
+///
+/// A macro rather than a function because it has to `return` from the
+/// *caller*; `?` can't, since these helpers return `Option<Control>` where
+/// `None` means success.
+macro_rules! push_or_control {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => return Some(Control::Error(e)),
+        }
+    };
+}
+
 /// Append every output of a `GenericResult` stream to `out`, returning any
 /// terminating `Control` instead of collapsing to the first output the way
 /// the old `Expr::Compare` arm did. Mirrors [`super::eval::push_owned_values`]
@@ -1511,10 +1617,20 @@ fn push_generic_owned_values<V: DocumentValue>(
     out: &mut Vec<OwnedValue>,
 ) -> Option<Control> {
     match result.materialize_lazy() {
-        GenericResult::One(v) => out.push(to_owned(&v)),
-        GenericResult::OneCursor(c) => out.push(to_owned_cursor(&c)),
-        GenericResult::Many(vs) => out.extend(vs.iter().map(to_owned)),
-        GenericResult::ManyCursor(cs) => out.extend(cs.iter().map(to_owned_cursor)),
+        // A decode failure here is an uncaught error like any other the
+        // `GenericResult::Error` arm below already forwards (#1247).
+        GenericResult::One(v) => out.push(push_or_control!(to_owned(&v))),
+        GenericResult::OneCursor(c) => out.push(push_or_control!(to_owned_cursor(&c))),
+        GenericResult::Many(vs) => {
+            for v in &vs {
+                out.push(push_or_control!(to_owned(v)));
+            }
+        }
+        GenericResult::ManyCursor(cs) => {
+            for c in &cs {
+                out.push(push_or_control!(to_owned_cursor(c)));
+            }
+        }
         GenericResult::None => {}
         GenericResult::Owned(v) => out.push(v),
         GenericResult::ManyOwned(vs) => out.extend(vs),
@@ -1543,11 +1659,19 @@ fn push_generic_truthiness<V: DocumentValue>(
     out: &mut Vec<bool>,
 ) -> Option<Control> {
     match result {
-        GenericResult::One(v) => out.push(to_owned(&v).is_truthy()),
-        GenericResult::OneCursor(c) => out.push(to_owned_cursor(&c).is_truthy()),
-        GenericResult::Many(vs) => out.extend(vs.iter().map(|v| to_owned(v).is_truthy())),
+        GenericResult::One(v) => out.push(push_or_control!(to_owned(&v)).is_truthy()),
+        GenericResult::OneCursor(c) => {
+            out.push(push_or_control!(to_owned_cursor(&c)).is_truthy());
+        }
+        GenericResult::Many(vs) => {
+            for v in &vs {
+                out.push(push_or_control!(to_owned(v)).is_truthy());
+            }
+        }
         GenericResult::ManyCursor(cs) => {
-            out.extend(cs.iter().map(|c| to_owned_cursor(c).is_truthy()));
+            for c in &cs {
+                out.push(push_or_control!(to_owned_cursor(c)).is_truthy());
+            }
         }
         // A lazy keys array, materialized or not, sorted or not, is
         // array-shaped and therefore always truthy in jq (only `null`/
@@ -1600,11 +1724,19 @@ fn flatten_generic_results<V: DocumentValue>(
     let mut results = Vec::new();
     for r in items {
         match r.materialize_lazy() {
-            GenericResult::One(v) => results.push(to_owned(&v)),
-            GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
-            GenericResult::Many(rs) => results.extend(rs.iter().map(to_owned)),
+            GenericResult::One(v) => results.push(to_owned(&v).map_err(Control::Error)?),
+            GenericResult::OneCursor(c) => {
+                results.push(to_owned_cursor(&c).map_err(Control::Error)?);
+            }
+            GenericResult::Many(rs) => {
+                for r in &rs {
+                    results.push(to_owned(r).map_err(Control::Error)?);
+                }
+            }
             GenericResult::ManyCursor(cs) => {
-                results.extend(cs.iter().map(to_owned_cursor));
+                for c in &cs {
+                    results.push(to_owned_cursor(c).map_err(Control::Error)?);
+                }
             }
             GenericResult::None => {}
             GenericResult::Owned(o) => results.push(o),
@@ -1807,14 +1939,21 @@ impl<V: DocumentValue> GenericResult<V> {
     }
 
     /// Convert to OwnedValue for output.
-    pub fn into_owned(self) -> Option<OwnedValue> {
-        match self.materialize_lazy() {
-            Self::One(v) => Some(to_owned(&v)),
-            Self::OneCursor(c) => Some(to_owned_cursor(&c)),
-            Self::Many(vs) => Some(OwnedValue::Array(vs.iter().map(to_owned).collect())),
-            Self::ManyCursor(cs) => {
-                Some(OwnedValue::Array(cs.iter().map(to_owned_cursor).collect()))
-            }
+    ///
+    /// `Ok(None)` means "no single value to represent" (`None`, `Break`,
+    /// `Error`, `Halt`, `Partial` -- unchanged); `Err` means a value *was*
+    /// there but a scalar in it could not be decoded (#1247), which is a
+    /// different answer and must not collapse into the same `None`.
+    pub fn into_owned(self) -> Result<Option<OwnedValue>, EvalError> {
+        Ok(match self.materialize_lazy() {
+            Self::One(v) => Some(to_owned(&v)?),
+            Self::OneCursor(c) => Some(to_owned_cursor(&c)?),
+            Self::Many(vs) => Some(OwnedValue::Array(
+                vs.iter().map(to_owned).collect::<Result<_, _>>()?,
+            )),
+            Self::ManyCursor(cs) => Some(OwnedValue::Array(
+                cs.iter().map(to_owned_cursor).collect::<Result<_, _>>()?,
+            )),
             Self::None => None,
             Self::Error(_) => None,
             Self::Owned(o) => Some(o),
@@ -1827,19 +1966,22 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::LazyKeys { .. } | Self::LazyIndexRange(_) | Self::LazySeq(_) => {
                 unreachable!("materialize_lazy() already normalized every lazy variant")
             }
-        }
+        })
     }
 
     /// Collect all results into a Vec of OwnedValues.
     ///
     /// A `Partial` collects its prefix — the whole point of #400/#494 is
     /// that those outputs are no longer discarded.
-    pub fn collect_owned(self) -> Vec<OwnedValue> {
-        match self.materialize_lazy() {
-            Self::One(v) => vec![to_owned(&v)],
-            Self::OneCursor(c) => vec![to_owned_cursor(&c)],
-            Self::Many(vs) => vs.iter().map(to_owned).collect(),
-            Self::ManyCursor(cs) => cs.iter().map(to_owned_cursor).collect(),
+    /// A decode failure is the one thing this does *not* swallow: `Err` says
+    /// a value was present but undecodable (#1247), which the existing
+    /// deliberate `Error(_) => vec![]` swallow above would otherwise hide.
+    pub fn collect_owned(self) -> Result<Vec<OwnedValue>, EvalError> {
+        Ok(match self.materialize_lazy() {
+            Self::One(v) => vec![to_owned(&v)?],
+            Self::OneCursor(c) => vec![to_owned_cursor(&c)?],
+            Self::Many(vs) => vs.iter().map(to_owned).collect::<Result<_, _>>()?,
+            Self::ManyCursor(cs) => cs.iter().map(to_owned_cursor).collect::<Result<_, _>>()?,
             Self::None => vec![],
             Self::Error(_) => vec![],
             Self::Owned(o) => vec![o],
@@ -1850,7 +1992,7 @@ impl<V: DocumentValue> GenericResult<V> {
             Self::LazyKeys { .. } | Self::LazyIndexRange(_) | Self::LazySeq(_) => {
                 unreachable!("materialize_lazy() already normalized every lazy variant")
             }
-        }
+        })
     }
 
     /// Check if this is an error.
@@ -1889,8 +2031,13 @@ impl<V: DocumentValue> GenericResult<V> {
 
         match self {
             Self::One(v) => {
-                // Convert to owned for streaming
-                let owned = to_owned(v);
+                // Convert to owned for streaming. A decode failure takes the
+                // same route as `Self::Error` below -- nothing reaches `out`,
+                // the diagnostic goes back for stderr and the exit code
+                // (#355, #1247) -- rather than streaming a silent `null`.
+                let Some(owned) = owned_or_stream_error(to_owned(v), &mut stats) else {
+                    return Ok(stats);
+                };
                 owned.stream_json(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
@@ -1906,8 +2053,15 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.any_truthy = !stats.last_was_falsy;
             }
             Self::Many(vs) => {
-                for v in vs {
-                    let owned = to_owned(v);
+                for (i, v) in vs.iter().enumerate() {
+                    // Keep the outputs already streamed and report the
+                    // failure, the same shape `Partial` uses for a mid-stream
+                    // `Control` (#400/#494, #1247) -- `count` is how many
+                    // actually reached `out`, not how many were asked for.
+                    let Some(owned) = owned_or_stream_error(to_owned(v), &mut stats) else {
+                        stats.count = i;
+                        return Ok(stats);
+                    };
                     owned.stream_json(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = owned.is_falsy();
@@ -1972,24 +2126,37 @@ impl<V: DocumentValue> GenericResult<V> {
             // arm (yq_runner.rs) for what actually routes a query here.
             Self::LazySeq(seq) => match seq.clone().drain_atomic() {
                 Ok(items) => {
-                    match sequence_streamable_cursors(&items) {
+                    let owned = match sequence_streamable_cursors(&items) {
                         Some(cursors) => {
                             V::Cursor::stream_sequence_json(&cursors, out, indent, sort_keys)?;
+                            true
                         }
-                        None => {
-                            OwnedValue::Array(items.iter().map(lazy_elem_to_owned).collect())
-                                .stream_json(out, indent, sort_keys)?;
-                        }
+                        None => match items
+                            .iter()
+                            .map(lazy_elem_to_owned)
+                            .collect::<Result<Vec<_>, _>>()
+                        {
+                            Ok(items) => {
+                                OwnedValue::Array(items).stream_json(out, indent, sort_keys)?;
+                                true
+                            }
+                            Err(e) => {
+                                stats.error = Some(stream_error(&e));
+                                false
+                            }
+                        },
+                    };
+                    if owned {
+                        on_value(out)?;
+                        stats.count = 1;
+                        // A `map` result is always an array, and every array is
+                        // truthy in jq — only `null`/`false` are falsy — so this
+                        // needs no per-value check (same reasoning as the
+                        // `LazyIndexRange` arm above, which is also always an
+                        // array).
+                        stats.last_was_falsy = false;
+                        stats.any_truthy = true;
                     }
-                    on_value(out)?;
-                    stats.count = 1;
-                    // A `map` result is always an array, and every array is
-                    // truthy in jq — only `null`/`false` are falsy — so this
-                    // needs no per-value check (same reasoning as the
-                    // `LazyIndexRange` arm above, which is also always an
-                    // array).
-                    stats.last_was_falsy = false;
-                    stats.any_truthy = true;
                 }
                 Err(control) => {
                     let (error, halt) = control_to_stream_outcome(&control);
@@ -2086,7 +2253,10 @@ impl<V: DocumentValue> GenericResult<V> {
 
         match self {
             Self::One(v) => {
-                let owned = to_owned(v);
+                // See `stream_json`'s own `One` arm (#355, #1247).
+                let Some(owned) = owned_or_stream_error(to_owned(v), &mut stats) else {
+                    return Ok(stats);
+                };
                 owned.stream_yaml(out, indent, sort_keys)?;
                 on_value(out)?;
                 stats.count = 1;
@@ -2106,8 +2276,15 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.any_truthy = !stats.last_was_falsy;
             }
             Self::Many(vs) => {
-                for v in vs {
-                    let owned = to_owned(v);
+                for (i, v) in vs.iter().enumerate() {
+                    // Keep the outputs already streamed and report the
+                    // failure, the same shape `Partial` uses for a mid-stream
+                    // `Control` (#400/#494, #1247) -- `count` is how many
+                    // actually reached `out`, not how many were asked for.
+                    let Some(owned) = owned_or_stream_error(to_owned(v), &mut stats) else {
+                        stats.count = i;
+                        return Ok(stats);
+                    };
                     owned.stream_yaml(out, indent, sort_keys)?;
                     on_value(out)?;
                     stats.last_was_falsy = owned.is_falsy();
@@ -2159,19 +2336,32 @@ impl<V: DocumentValue> GenericResult<V> {
             // the identical shape with the YAML writers substituted.
             Self::LazySeq(seq) => match seq.clone().drain_atomic() {
                 Ok(items) => {
-                    match sequence_streamable_cursors(&items) {
+                    let owned = match sequence_streamable_cursors(&items) {
                         Some(cursors) => {
                             V::Cursor::stream_sequence_yaml(&cursors, out, indent, sort_keys)?;
+                            true
                         }
-                        None => {
-                            OwnedValue::Array(items.iter().map(lazy_elem_to_owned).collect())
-                                .stream_yaml(out, indent, sort_keys)?;
-                        }
+                        None => match items
+                            .iter()
+                            .map(lazy_elem_to_owned)
+                            .collect::<Result<Vec<_>, _>>()
+                        {
+                            Ok(items) => {
+                                OwnedValue::Array(items).stream_yaml(out, indent, sort_keys)?;
+                                true
+                            }
+                            Err(e) => {
+                                stats.error = Some(stream_error(&e));
+                                false
+                            }
+                        },
+                    };
+                    if owned {
+                        on_value(out)?;
+                        stats.count = 1;
+                        stats.last_was_falsy = false;
+                        stats.any_truthy = true;
                     }
-                    on_value(out)?;
-                    stats.count = 1;
-                    stats.last_was_falsy = false;
-                    stats.any_truthy = true;
                 }
                 Err(control) => {
                     let (error, halt) = control_to_stream_outcome(&control);
@@ -2299,6 +2489,26 @@ fn write_index_range_yaml<W: core::fmt::Write>(
 
 /// Render an [`EvalError`] into the payload a streaming caller needs to
 /// reproduce jq's diagnostic on stderr (#355).
+/// Route a fallible materialization into [`StreamStats::error`], returning
+/// `None` when it failed so the caller can stop streaming.
+///
+/// Streaming never writes a diagnostic to `out` -- `out` is stdout, where it
+/// would be indistinguishable from a result -- so a decode failure (#1247)
+/// has to travel back in `stats` exactly as `GenericResult::Error` already
+/// does (#355).
+fn owned_or_stream_error(
+    result: Result<OwnedValue, EvalError>,
+    stats: &mut crate::jq::stream::StreamStats,
+) -> Option<OwnedValue> {
+    match result {
+        Ok(owned) => Some(owned),
+        Err(e) => {
+            stats.error = Some(stream_error(&e));
+            None
+        }
+    }
+}
+
 fn stream_error(e: &EvalError) -> crate::jq::stream::StreamError {
     crate::jq::stream::StreamError {
         message: e.message.clone(),
@@ -2371,7 +2581,7 @@ pub fn eval<V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
 /// [`crate::jq::walk::uses_cursor_metadata_builtins`].
 pub fn eval_using<S: EvalSemantics, V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
     if takes_input_queue_bridge(expr) {
-        let owned = to_owned_with_cursor(&value, None);
+        let owned = owned_or_err!(to_owned_with_cursor(&value, None));
         return eval_each_owned_collect::<S, V>(expr, &owned, false);
     }
     eval_single::<S, V>(expr, value, false, None)
@@ -2419,7 +2629,8 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
         // `to_owned_cursor` directly rather than `to_owned_with_cursor`: the
         // latter ignores its value argument whenever the cursor is `Some`, so
         // routing through it would compute a `cursor.value()` only to drop it.
-        return eval_each_owned_collect::<S, C::Value>(expr, &to_owned_cursor(&cursor), false);
+        let owned = owned_or_err!(to_owned_cursor(&cursor));
+        return eval_each_owned_collect::<S, C::Value>(expr, &owned, false);
     }
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
@@ -2462,13 +2673,33 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
                 let mut results = Vec::new();
                 for v in vs {
                     match eval_single::<S, _>(expr, v, optional, None).materialize_lazy() {
-                        GenericResult::One(r) => results.push(to_owned(&r)),
-                        GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
+                        // A decode failure keeps the prefix already
+                        // piped through, exactly as the `Error` arm
+                        // below does (#400/#494, #1247) -- not
+                        // `owned_or_err!`, which would discard it.
+                        GenericResult::One(r) => match to_owned(&r) {
+                            Ok(o) => results.push(o),
+                            Err(e) => return partial_generic(results, Control::Error(e)),
+                        },
+                        GenericResult::OneCursor(c) => match to_owned_cursor(&c) {
+                            Ok(o) => results.push(o),
+                            Err(e) => return partial_generic(results, Control::Error(e)),
+                        },
                         GenericResult::Many(rs) => {
-                            results.extend(rs.iter().map(to_owned));
+                            for r in &rs {
+                                match to_owned(r) {
+                                    Ok(o) => results.push(o),
+                                    Err(e) => return partial_generic(results, Control::Error(e)),
+                                }
+                            }
                         }
                         GenericResult::ManyCursor(cs) => {
-                            results.extend(cs.iter().map(to_owned_cursor));
+                            for c in &cs {
+                                match to_owned_cursor(c) {
+                                    Ok(o) => results.push(o),
+                                    Err(e) => return partial_generic(results, Control::Error(e)),
+                                }
+                            }
                         }
                         GenericResult::None => {}
                         // The outputs already piped through no longer
@@ -2970,15 +3201,13 @@ fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
                         .collect(),
                 )
             } else {
-                GenericResult::ManyOwned(
-                    items
-                        .into_iter()
-                        .map(|item| match item {
-                            LazyElem::Cursor(c) => to_owned_cursor(&c),
-                            LazyElem::Owned(o) => o,
-                        })
-                        .collect(),
-                )
+                GenericResult::ManyOwned(owned_or_err!(items
+                    .into_iter()
+                    .map(|item| match item {
+                        LazyElem::Cursor(c) => to_owned_cursor(&c),
+                        LazyElem::Owned(o) => Ok(o),
+                    })
+                    .collect::<Result<Vec<_>, _>>()))
             }
         }
 
@@ -3441,10 +3670,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate_with(
-                    S::TAG,
-                    &to_owned_with_cursor(&value, cursor),
-                ))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::cannot_iterate_with(S::TAG, &to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -3536,7 +3764,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // letting a later stage fall through `eval_builtin`'s per-builtin
             // fallback in isolation, which has no path to give it (#554).
             if exprs.iter().any(needs_path_context) {
-                let owned = to_owned_with_cursor(&value, cursor);
+                let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
                 return eval_on_owned::<S, _>(&Expr::Pipe(exprs.clone()), owned, optional);
             }
 
@@ -3571,9 +3799,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Formats are pure functions of the value, so evaluate them here rather
         // than falling through to the catch-all, which would serialize the
         // value to JSON and rebuild a `JsonIndex` for every one (#124).
-        Expr::Format(format_type) => {
-            format_result::<S, _>(format_type, &to_owned_with_cursor(&value, cursor), optional)
-        }
+        Expr::Format(format_type) => format_result::<S, _>(
+            format_type,
+            &owned_or_err!(to_owned_with_cursor(&value, cursor)),
+            optional,
+        ),
 
         Expr::Builtin(builtin) => eval_builtin::<S, _>(builtin, value, optional, cursor),
 
@@ -3623,10 +3853,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             let items: Vec<OwnedValue> = match eval_single::<S, _>(inner, value, optional, cursor)
                 .materialize_lazy()
             {
-                GenericResult::One(v) => vec![to_owned(&v)],
-                GenericResult::OneCursor(c) => vec![to_owned_cursor(&c)],
-                GenericResult::Many(vs) => vs.iter().map(to_owned).collect(),
-                GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_cursor).collect(),
+                GenericResult::One(v) => vec![owned_or_err!(to_owned(&v))],
+                GenericResult::OneCursor(c) => vec![owned_or_err!(to_owned_cursor(&c))],
+                GenericResult::Many(vs) => {
+                    owned_or_err!(vs.iter().map(to_owned).collect::<Result<Vec<_>, _>>())
+                }
+                GenericResult::ManyCursor(cs) => {
+                    owned_or_err!(cs
+                        .iter()
+                        .map(to_owned_cursor)
+                        .collect::<Result<Vec<_>, _>>())
+                }
                 GenericResult::None => Vec::new(),
                 GenericResult::Owned(v) => vec![v],
                 GenericResult::ManyOwned(vs) => vs,
@@ -3715,7 +3952,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Fall back to the full evaluator for complex expressions
         _ => {
             // Convert to OwnedValue, then to JSON, then evaluate with full evaluator
-            let owned = to_owned_with_cursor(&value, cursor);
+            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
             let json_str = owned.to_json_for_reindex::<S>();
             let json_bytes = json_str.as_bytes();
             let index = JsonIndex::build(json_bytes);
@@ -4204,7 +4441,7 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         && crate::jq::input_queue_is_active()
         && crate::jq::walk::uses_input_builtins(inner)
     {
-        let owned = to_owned_with_cursor(&value, cursor);
+        let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
         return eval_on_owned::<S, _>(&Expr::FirstExpr(Box::new(inner.clone())), owned, optional);
     }
 
@@ -4390,11 +4627,17 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             pending_halt = Some(code);
             vs
         }
-        GenericResult::One(v) => vec![to_owned_key_shape(&v)],
-        GenericResult::OneCursor(c) => vec![to_owned_key_shape_cursor(&c)],
-        GenericResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
-        GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_key_shape_cursor).collect(),
-        other => other.collect_owned(),
+        GenericResult::One(v) => vec![owned_or_err!(to_owned_key_shape(&v))],
+        GenericResult::OneCursor(c) => vec![owned_or_err!(to_owned_key_shape_cursor(&c))],
+        GenericResult::Many(vs) => owned_or_err!(vs
+            .iter()
+            .map(to_owned_key_shape)
+            .collect::<Result<Vec<_>, _>>()),
+        GenericResult::ManyCursor(cs) => owned_or_err!(cs
+            .iter()
+            .map(to_owned_key_shape_cursor)
+            .collect::<Result<Vec<_>, _>>()),
+        other => owned_or_err!(other.collect_owned()),
     };
     if keys.is_empty() {
         // `partial_generic`'s invariant (a non-empty prefix by construction)
@@ -4450,7 +4693,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         | GenericResult::LazyKeys { .. }
         | GenericResult::LazyIndexRange(_)
         | GenericResult::LazySeq(_)) => {
-            let targets = owned.collect_owned();
+            let targets = owned_or_err!(owned.collect_owned());
             let mut out = Vec::with_capacity(keys.len() * targets.len());
             for k in &keys {
                 for t in &targets {
@@ -4485,7 +4728,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             match index_one_generic::<V>(t.clone(), k, optional) {
                 GenericResult::OneCursor(c) => {
                     if any_owned {
-                        owned.push(to_owned_cursor(&c));
+                        owned.push(owned_or_err!(to_owned_cursor(&c)));
                     } else {
                         cursors.push(c);
                     }
@@ -4493,7 +4736,10 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::Owned(v) => {
                     if !any_owned {
                         any_owned = true;
-                        owned = cursors.iter().map(to_owned_cursor).collect();
+                        owned = owned_or_err!(cursors
+                            .iter()
+                            .map(to_owned_cursor)
+                            .collect::<Result<Vec<_>, _>>());
                         cursors.clear();
                     }
                     owned.push(v);
@@ -4506,7 +4752,10 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                     let out = if any_owned {
                         owned
                     } else {
-                        cursors.iter().map(to_owned_cursor).collect()
+                        owned_or_err!(cursors
+                            .iter()
+                            .map(to_owned_cursor)
+                            .collect::<Result<Vec<_>, _>>())
                     };
                     return partial_generic(out, Control::Error(e));
                 }
@@ -4530,7 +4779,10 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         let out = if any_owned {
             owned
         } else {
-            cursors.iter().map(to_owned_cursor).collect()
+            owned_or_err!(cursors
+                .iter()
+                .map(to_owned_cursor)
+                .collect::<Result<Vec<_>, _>>())
         };
         return partial_generic(out, Control::Halt(code));
     }
@@ -4610,7 +4862,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         | GenericResult::ManyOwned(_)
         | GenericResult::LazyKeys { .. }
         | GenericResult::LazyIndexRange(_)
-        | GenericResult::LazySeq(_)) => Targets::Owned(owned.collect_owned()),
+        | GenericResult::LazySeq(_)) => Targets::Owned(owned_or_err!(owned.collect_owned())),
     };
 
     // Start outer, end middle, target inner. The result is always owned:
@@ -4675,11 +4927,21 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
         GenericResult::Halt(code) => return Err(Control::Halt(code)),
         GenericResult::None => return Ok(Vec::new()),
         GenericResult::Partial(_, control) => return Err(control),
-        GenericResult::One(v) => vec![to_owned_key_shape(&v)],
-        GenericResult::OneCursor(c) => vec![to_owned_key_shape_cursor(&c)],
-        GenericResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
-        GenericResult::ManyCursor(cs) => cs.iter().map(to_owned_key_shape_cursor).collect(),
-        other => other.collect_owned(),
+        GenericResult::One(v) => vec![to_owned_key_shape(&v).map_err(Control::Error)?],
+        GenericResult::OneCursor(c) => {
+            vec![to_owned_key_shape_cursor(&c).map_err(Control::Error)?]
+        }
+        GenericResult::Many(vs) => vs
+            .iter()
+            .map(to_owned_key_shape)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Control::Error)?,
+        GenericResult::ManyCursor(cs) => cs
+            .iter()
+            .map(to_owned_key_shape_cursor)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Control::Error)?,
+        other => other.collect_owned().map_err(Control::Error)?,
     };
     raw.iter()
         .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
@@ -4705,9 +4967,10 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     if let Some(elements) = target.as_array() {
         let items = elements.collect_values();
         let range = SliceBounds::from_literals(start, end).resolve(items.len());
-        return GenericResult::Owned(OwnedValue::Array(
-            items[range].iter().map(to_owned).collect(),
-        ));
+        return GenericResult::Owned(OwnedValue::Array(owned_or_err!(items[range]
+            .iter()
+            .map(to_owned)
+            .collect::<Result<Vec<_>, _>>())));
     }
     // yq's object AST-child-layout slicing rule (#1102) — mirrors
     // `eval.rs`'s cursor-backed `Expr::Slice` arm for the same target type;
@@ -4717,7 +4980,7 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     // `IndexMap` `slice_object_as_yq_children` needs — same technique as
     // `eval.rs`'s own arm, for the same reason.
     if S::TAG == EvalTag::Yq && target.as_object().is_some() {
-        let OwnedValue::Object(map) = to_owned(&target) else {
+        let OwnedValue::Object(map) = owned_or_err!(to_owned(&target)) else {
             unreachable!("target.as_object() just confirmed this materializes to an Object")
         };
         return GenericResult::Owned(slice_object_as_yq_children(&map, start, end));
@@ -4934,12 +5197,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // dispatch path starts forcing `optional = true` here.
                 Some(control) => {
                     let prefix: Vec<OwnedValue> = match cursor {
-                        Some(c) => core::iter::repeat_with(|| to_owned_cursor(&c))
+                        Some(c) => owned_or_err!(core::iter::repeat_with(|| to_owned_cursor(&c))
                             .take(truthy_count)
-                            .collect(),
-                        None => core::iter::repeat_with(|| to_owned(&value))
+                            .collect::<Result<Vec<_>, _>>()),
+                        None => owned_or_err!(core::iter::repeat_with(|| to_owned(&value))
                             .take(truthy_count)
-                            .collect(),
+                            .collect::<Result<Vec<_>, _>>()),
                     };
                     partial_generic(prefix, control)
                 }
@@ -4982,10 +5245,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate_with(
-                    S::TAG,
-                    &to_owned_with_cursor(&value, cursor),
-                ))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::cannot_iterate_with(S::TAG, &to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -4997,11 +5259,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 use rand_chacha::ChaCha8Rng;
 
                 if let Some(elements) = value.as_array() {
-                    let mut values: Vec<OwnedValue> = elements
+                    let mut values: Vec<OwnedValue> = owned_or_err!(elements
                         .collect_cursors()
                         .iter()
                         .map(to_owned_cursor)
-                        .collect();
+                        .collect::<Result<Vec<_>, _>>());
                     let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
                     values.shuffle(&mut rng);
                     GenericResult::Owned(OwnedValue::Array(values))
@@ -5022,11 +5284,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::Pivot => {
             if let Some(elements) = value.as_array() {
-                let items: Vec<OwnedValue> = elements
+                let items: Vec<OwnedValue> = owned_or_err!(elements
                     .collect_cursors()
                     .iter()
                     .map(to_owned_cursor)
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>());
                 if items.is_empty() {
                     return GenericResult::Owned(OwnedValue::Array(vec![]));
                 }
@@ -5146,9 +5408,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_length(&to_owned_with_cursor(
-                    &value, cursor,
-                )))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::has_no_length(&to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -5175,9 +5437,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
-                    &value, cursor,
-                )))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -5199,9 +5461,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
-                    &value, cursor,
-                )))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -5232,30 +5494,42 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // repeated key for a JSON-sourced document too.
         Builtin::ToEntries => {
             if let Some(elements) = value.as_array() {
-                let entries: Vec<OwnedValue> = elements
-                    .collect_cursors()
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, elem_cursor)| {
-                        let mut entry = IndexMap::new();
-                        entry.insert("key".to_string(), OwnedValue::Int(i as i64));
-                        entry.insert("value".to_string(), to_owned_cursor(&elem_cursor));
-                        OwnedValue::Object(entry)
-                    })
-                    .collect();
+                // A loop, not `.map(...).collect()`: `owned_or_err!` has to
+                // return from *this* function, which it cannot do from inside
+                // a closure (#1247).
+                let mut entries: Vec<OwnedValue> = Vec::new();
+                for (i, elem_cursor) in elements.collect_cursors().into_iter().enumerate() {
+                    let mut entry = IndexMap::new();
+                    entry.insert("key".to_string(), OwnedValue::Int(i as i64));
+                    entry.insert(
+                        "value".to_string(),
+                        owned_or_err!(to_owned_cursor(&elem_cursor)),
+                    );
+                    entries.push(OwnedValue::Object(entry));
+                }
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else if let Some(fields) = value.as_object() {
-                let entries: Vec<OwnedValue> =
-                    effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS)
-                        .into_iter()
-                        .filter_map(|field| {
-                            let key = field.key_str()?;
-                            let mut entry = IndexMap::new();
-                            entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
-                            entry.insert("value".to_string(), to_owned_cursor(&field.value_cursor));
-                            Some(OwnedValue::Object(entry))
-                        })
-                        .collect();
+                // A loop for the same reason as the array arm above.
+                let mut entries: Vec<OwnedValue> = Vec::new();
+                for field in effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                    // Key decode checked before `key_str`, as everywhere else
+                    // (#1247) -- YAML stringifies an undecodable key to `""`.
+                    if let Some(reason) = field.key.string_decode_error() {
+                        return GenericResult::Error(EvalError::new(format!(
+                            "{reason} in object key"
+                        )));
+                    }
+                    let Some(key) = field.key_str() else {
+                        continue;
+                    };
+                    let mut entry = IndexMap::new();
+                    entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
+                    entry.insert(
+                        "value".to_string(),
+                        owned_or_err!(to_owned_cursor(&field.value_cursor)),
+                    );
+                    entries.push(OwnedValue::Object(entry));
+                }
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else {
                 // No `optional`-guarded arm here: `Builtin::ToEntries` isn't
@@ -5264,9 +5538,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // evaluates it at the ambient `optional` (normally `false`)
                 // and lets the outer `Expr::Optional`/`eval_try`-style catch
                 // convert the resulting `Error` to `None` once instead.
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_with_cursor(
-                    &value, cursor,
-                )))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -5401,12 +5675,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::Reverse => {
             if let Some(elements) = value.as_array() {
-                let values: Vec<OwnedValue> = elements
+                let values: Vec<OwnedValue> = owned_or_err!(elements
                     .collect_cursors()
                     .iter()
                     .rev()
                     .map(to_owned_cursor)
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>());
                 GenericResult::Owned(OwnedValue::Array(values))
             } else if optional {
                 GenericResult::None
@@ -5421,7 +5695,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Empty => GenericResult::None,
 
         Builtin::ToString => {
-            let owned = to_owned_with_cursor(&value, cursor);
+            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
             GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)))
         }
 
@@ -5443,9 +5717,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned_with_cursor(
-                    &value, cursor,
-                )))
+                GenericResult::Error(type_error_or_decode_failure(&value, || {
+                    EvalError::cannot_parse_as_number(&to_owned_for_diagnostic(&value, cursor))
+                }))
             }
         }
 
@@ -5574,7 +5848,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         // For other builtins, fall back to full evaluator via JSON
         _ => {
-            let owned = to_owned_with_cursor(&value, cursor);
+            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
     }
@@ -5586,30 +5860,65 @@ mod tests {
     use super::super::value::NumberRepr;
     use super::*;
 
-    /// #1098: `JsonIndex::build`'s semi-index scan finds string quote/escape
-    /// *boundaries* but never decodes/validates the bytes between them --
-    /// that's deferred to `JsonString::as_str()`, called lazily by
-    /// `to_owned_at_depth`. So invalid UTF-8 inside a string span parses
-    /// and indexes fine (`JsonIndex::build` never errors), and only
-    /// degrades once materialization reaches it, here to `Null` for that
-    /// field -- pins the known, deliberate, low-severity gap this issue
-    /// describes (see `to_owned_at_depth`'s own `else` arm doc comment for
-    /// why a stricter fix was attempted and reverted; a panic here is
-    /// reachable via completely ordinary CLI usage, not just a library
-    /// caller feeding raw bytes directly, and defeats this crate's
-    /// "evaluation continues past one error" convention).
+    /// #1098/#1247: `JsonIndex::build`'s semi-index scan finds string
+    /// quote/escape *boundaries* but never decodes/validates the bytes
+    /// between them -- that's deferred to `JsonString::as_str()`, called
+    /// lazily by `to_owned_at_depth`. So invalid UTF-8 inside a string span
+    /// parses and indexes fine (`JsonIndex::build` never errors), and the
+    /// failure only becomes observable once materialization reaches it.
+    ///
+    /// This test used to assert the *degrade* (`Some(&OwnedValue::Null)`),
+    /// pinning it as a known, deliberate gap. #1247 closed it: the failure
+    /// now travels as an `EvalError` through `GenericResult::Error` /
+    /// `Control::Error`, which is what `to_owned_at_depth`'s own reverted
+    /// `panic!` attempt (PR #1190) was trying and failing to achieve --
+    /// evaluation still continues past the error rather than aborting the
+    /// process, so the `ErrorSink` convention (#355) holds.
     #[test]
-    fn test_to_owned_degrades_to_null_on_string_decode_failure_1098() {
+    fn test_to_owned_errors_on_string_decode_failure_1247() {
         use crate::json::JsonIndex;
         let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let owned = to_owned(&value);
+        let err = to_owned(&value).expect_err("an undecodable string must not materialize");
+        assert!(
+            err.message.contains("invalid UTF-8"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1247: the same for an undecodable *key*, which used to drop the
+    /// whole field instead of degrading its value.
+    #[test]
+    fn test_to_owned_errors_on_object_key_decode_failure_1247() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = to_owned(&value).expect_err("an undecodable key must not materialize");
+        assert!(
+            err.message.contains("in object key"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1247: a valid document still materializes unchanged -- the guard
+    /// against the new check firing on anything that decodes cleanly.
+    #[test]
+    fn test_to_owned_still_materializes_valid_input_1247() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = br#"{"a": "x", "b": [1, "\u00e9"]}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let owned = to_owned(&cursor.value()).expect("valid input must materialize");
         let OwnedValue::Object(map) = owned else {
             panic!("expected an object");
         };
-        assert_eq!(map.get("a"), Some(&OwnedValue::Null));
+        assert_eq!(map.get("a"), Some(&OwnedValue::String("x".to_string())));
     }
     use crate::jq::parse;
     use crate::json::JsonIndex;
@@ -5660,7 +5969,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Identity, value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         match owned {
             OwnedValue::Object(map) => {
@@ -5682,7 +5991,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Field("name".to_string()), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::String("Alice".to_string()));
     }
@@ -5695,7 +6004,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Index(1), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::Int(2));
     }
@@ -5708,7 +6017,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Iterate, value);
-        let owned = result.collect_owned();
+        let owned = result.collect_owned().unwrap();
 
         assert_eq!(
             owned,
@@ -5730,7 +6039,7 @@ mod tests {
         assert!(matches!(result, GenericResult::LazyIndexRange(3)));
 
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(1),
@@ -5743,7 +6052,7 @@ mod tests {
         let empty_cursor = empty_index.root(empty_json);
         let empty_result = eval(&Expr::Builtin(Builtin::KeysUnsorted), empty_cursor.value());
         assert_eq!(
-            empty_result.collect_owned(),
+            empty_result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![])]
         );
     }
@@ -5801,7 +6110,7 @@ mod tests {
         let halt_expr = parse("halt_error(9)").unwrap();
         let halted = eval(&halt_expr, cursor.value());
         assert!(matches!(halted, GenericResult::Halt(9)));
-        assert_eq!(halted.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(halted.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     /// `eval_index_expr`'s `keys` match (#694): a `Partial`'s trailing
@@ -5927,7 +6236,7 @@ mod tests {
             value,
         );
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
                 OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
@@ -5943,7 +6252,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::Type), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::String("object".to_string()));
     }
@@ -5960,7 +6269,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::ToString), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(
             owned,
@@ -5987,7 +6296,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Format(FormatType::Uri), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(
             owned,
@@ -6007,7 +6316,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Format(FormatType::Uri), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(
             owned,
@@ -6023,7 +6332,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::Length), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::Int(5));
     }
@@ -6036,7 +6345,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::KeysUnsorted), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         match owned {
             OwnedValue::Array(keys) => {
@@ -6058,7 +6367,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
 
     #[test]
@@ -6073,7 +6382,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | (length)").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
 
     #[test]
@@ -6086,7 +6395,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),
@@ -6104,7 +6413,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -6116,20 +6425,23 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("b".to_string())
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[-1]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("c".to_string())
         );
 
         // Out of bounds is `null`, never an error (#307), matching plain
         // array indexing.
         let expr = crate::jq::parse("keys_unsorted | .[10]").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Null
+        );
     }
 
     #[test]
@@ -6141,13 +6453,13 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("b".to_string())
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("c".to_string())
         );
     }
@@ -6161,12 +6473,15 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Null
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Null
+        );
     }
 
     #[test]
@@ -6182,7 +6497,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | .[] | ascii_upcase").unwrap();
         let result = eval(&expr, value.clone());
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -6192,7 +6507,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[0] | ascii_upcase").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("B".to_string())
         );
     }
@@ -6213,7 +6528,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -6227,7 +6542,7 @@ mod tests {
         // pass instead of the four-pass round trip.
         let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),
@@ -6255,19 +6570,19 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(10_000)
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[9999]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("k9999".to_string())
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("k9999".to_string())
         );
     }
@@ -6281,7 +6596,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | length").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
 
     #[test]
@@ -6295,7 +6610,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | (length)").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
 
     #[test]
@@ -6306,7 +6621,10 @@ mod tests {
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys | length").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(0));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(0)
+        );
     }
 
     #[test]
@@ -6324,7 +6642,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("b".to_string()),
@@ -6334,7 +6652,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | .[]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).collect_owned(),
+            eval(&expr, value.clone()).collect_owned().unwrap(),
             vec![
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("b".to_string()),
@@ -6344,25 +6662,25 @@ mod tests {
 
         let expr = crate::jq::parse("keys | .[0]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("a".to_string())
         );
 
         let expr = crate::jq::parse("keys | .[-1]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("c".to_string())
         );
 
         let expr = crate::jq::parse("keys | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("a".to_string())
         );
 
         let expr = crate::jq::parse("keys | last").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("c".to_string())
         );
     }
@@ -6385,7 +6703,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(!matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("A".to_string()),
                 OwnedValue::String("B".to_string()),
@@ -6395,7 +6713,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | select(length == 3)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("b".to_string()),
@@ -6422,7 +6740,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | length").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(10_000)
         );
 
@@ -6433,7 +6751,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys | .[0]").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String(expected_keys[0].clone())
         );
     }
@@ -6455,10 +6773,13 @@ mod tests {
         ]);
 
         let expr = crate::jq::parse("keys").unwrap();
-        assert_eq!(eval(&expr, value.clone()).into_owned().unwrap(), expected);
+        assert_eq!(
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
+            expected
+        );
 
         let expr = crate::jq::parse("keys_unsorted").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), expected);
+        assert_eq!(eval(&expr, value).into_owned().unwrap().unwrap(), expected);
     }
 
     #[test]
@@ -6469,7 +6790,10 @@ mod tests {
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(3)
+        );
     }
 
     #[test]
@@ -6482,7 +6806,10 @@ mod tests {
         let value = cursor.value();
 
         let expr = crate::jq::parse("keys_unsorted | (length)").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(3)
+        );
     }
 
     #[test]
@@ -6495,7 +6822,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(0), OwnedValue::Int(1), OwnedValue::Int(2)]
         );
     }
@@ -6509,7 +6836,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -6521,20 +6848,23 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(0)
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[-1]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(2)
         );
 
         // Out of bounds is `null`, never an error (#307), matching plain
         // array indexing and the object `keys_unsorted` fast path.
         let expr = crate::jq::parse("keys_unsorted | .[10]").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Null
+        );
     }
 
     #[test]
@@ -6546,12 +6876,15 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(0)
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(2));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(2)
+        );
     }
 
     #[test]
@@ -6563,12 +6896,15 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Null
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Null
+        );
     }
 
     #[test]
@@ -6585,7 +6921,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(10),
@@ -6595,7 +6931,7 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | select(length == 3)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(1),
@@ -6617,7 +6953,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(4),
@@ -6639,7 +6975,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(4),
@@ -6656,7 +6992,7 @@ mod tests {
         let value = cursor.value();
         let expr = crate::jq::parse("map(.)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![])
         );
 
@@ -6666,7 +7002,7 @@ mod tests {
         let value = cursor.value();
         let expr = crate::jq::parse("map(.)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![])
         );
     }
@@ -6684,7 +7020,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(result.is_error());
 
-        let owned = crate::jq::eval_generic::to_owned(&value);
+        let owned = crate::jq::eval_generic::to_owned(&value).unwrap();
         let expected = EvalError::cannot_iterate(&owned);
         match result {
             GenericResult::Error(e) => assert_eq!(e.message, expected.message),
@@ -6712,7 +7048,7 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1)?").unwrap();
         let result = eval(&expr, value);
         assert!(!result.is_error());
-        assert_eq!(result.into_owned(), None);
+        assert_eq!(result.into_owned().unwrap(), None);
 
         // Non-erroring case still returns the mapped array, not suppressed.
         let expr = crate::jq::parse("map(. + 1)").unwrap();
@@ -6720,7 +7056,7 @@ mod tests {
         let index_ok = JsonIndex::build(json_ok);
         let value_ok = index_ok.root(json_ok).value();
         assert_eq!(
-            eval(&expr, value_ok).into_owned().unwrap(),
+            eval(&expr, value_ok).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(3),
@@ -6738,7 +7074,7 @@ mod tests {
                 .unwrap();
         let result2 = eval(&expr2, value2);
         assert!(!result2.is_error());
-        assert_eq!(result2.into_owned(), None);
+        assert_eq!(result2.into_owned().unwrap(), None);
     }
 
     #[test]
@@ -6788,7 +7124,7 @@ mod tests {
         let expr = crate::jq::parse("map(. + 1) | .[]").unwrap();
         let result = eval(&expr, value.clone());
         assert!(result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
 
         // Same check at the `stream_json` boundary the CLI actually uses:
         // nothing streams to `out` before the diagnostic.
@@ -6814,7 +7150,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(20),
                 OwnedValue::Int(30),
@@ -6838,13 +7174,13 @@ mod tests {
 
         let expr = crate::jq::parse("map(ascii_upcase) | length").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(3)
         );
 
         let expr = crate::jq::parse("map(ascii_upcase) | .[]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).collect_owned(),
+            eval(&expr, value.clone()).collect_owned().unwrap(),
             vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -6854,13 +7190,13 @@ mod tests {
 
         let expr = crate::jq::parse("map(ascii_upcase) | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("B".to_string())
         );
 
         let expr = crate::jq::parse("map(ascii_upcase) | .[0]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("B".to_string())
         );
 
@@ -6869,13 +7205,13 @@ mod tests {
         // asserting correctness only, not laziness.
         let expr = crate::jq::parse("map(ascii_upcase) | .[2]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::String("C".to_string())
         );
 
         let expr = crate::jq::parse("map(ascii_upcase) | last").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("C".to_string())
         );
     }
@@ -6899,12 +7235,15 @@ mod tests {
 
         let expr = crate::jq::parse("map(. + 1) | first").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(2)
         );
 
         let expr = crate::jq::parse("map(. + 1) | .[0]").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(2));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(2)
+        );
     }
 
     #[test]
@@ -6925,7 +7264,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("first(map(. + 1) | .[] | (. + 100))").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Int(102)
         );
 
@@ -6938,7 +7277,10 @@ mod tests {
         let expr =
             crate::jq::parse(r#"first(keys | .[] | (if . == 2 then error("touched") else . end))"#)
                 .unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(0));
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Int(0)
+        );
 
         // `LazyKeys { sorted: false }` (`keys_unsorted`): document order is
         // `"z"`, `"a"` -- `error` on `"a"` would fire if the tail pulled
@@ -6951,7 +7293,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("z".to_string())
         );
 
@@ -6969,7 +7311,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::String("a".to_string())
         );
     }
@@ -6986,7 +7328,7 @@ mod tests {
         let expr =
             crate::jq::parse("keys_unsorted | map(ascii_upcase) | select(length == 3)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("BB".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -7017,7 +7359,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(matches!(result, GenericResult::LazySeq(_)));
         // No partial prefix, even though `"a"` already succeeded.
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
         assert!(eval(&expr, value.clone()).materialize_lazy().is_error());
 
         let expr = crate::jq::parse(
@@ -7028,7 +7370,7 @@ mod tests {
         // Same atomicity boundary as the `map`-alone case above: `"a"` does
         // NOT survive as a partial prefix once `.[]` is piped after `map`.
         assert!(result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     /// Known, narrow, pre-existing gap (not a new regression from #724):
@@ -7068,19 +7410,19 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(10_000)
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[9999]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Int(9999)
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Int(9999)
         );
     }
@@ -7100,7 +7442,7 @@ mod tests {
         ]);
 
         let result = eval(&expr, value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::String("Alice".to_string()));
     }
@@ -7122,7 +7464,7 @@ mod tests {
         let value = mapping_cursor.value();
 
         let result = eval(&Expr::Identity, value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         match owned {
             OwnedValue::Object(map) => {
@@ -7163,7 +7505,7 @@ mod tests {
             value.clone(),
         );
         assert_eq!(
-            single_field.collect_owned(),
+            single_field.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("string".to_string()),
                 OwnedValue::String("string".to_string()),
@@ -7175,7 +7517,7 @@ mod tests {
             value,
         );
         assert_eq!(
-            iterate_fields.collect_owned(),
+            iterate_fields.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("string".to_string()),
                 OwnedValue::String("number".to_string()),
@@ -7216,7 +7558,7 @@ mod tests {
         let value = mapping_cursor.value();
 
         let result = eval(&crate::jq::parse(".a | shuffle").unwrap(), value);
-        match result.into_owned().unwrap() {
+        match result.into_owned().unwrap().unwrap() {
             OwnedValue::Array(items) => {
                 assert_eq!(items.len(), 2);
                 for item in &items {
@@ -7242,7 +7584,7 @@ mod tests {
         let value = mapping_cursor.value();
 
         let result = eval(&Expr::Field("name".to_string()), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::String("Alice".to_string()));
     }
@@ -7271,7 +7613,7 @@ mod tests {
         let value = mapping_cursor.value();
 
         let result = eval_using::<YqSemantics, _>(&Expr::Builtin(Builtin::ToEntries), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         let expected_entry = |v: i64| {
             let mut entry = IndexMap::new();
@@ -7309,7 +7651,7 @@ mod tests {
         let value = mapping_cursor.value();
 
         let result = eval_using::<JqSemantics, _>(&Expr::Builtin(Builtin::ToEntries), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         let mut entry = IndexMap::new();
         entry.insert("key".to_string(), OwnedValue::String("a".to_string()));
@@ -7342,7 +7684,7 @@ mod tests {
             &Expr::Array(Box::new(Expr::Builtin(Builtin::ToEntries))),
             value,
         );
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         let expected_entry = |v: i64| {
             let mut entry = IndexMap::new();
@@ -7383,7 +7725,7 @@ mod tests {
             ]),
             value,
         );
-        let owned = result.collect_owned();
+        let owned = result.collect_owned().unwrap();
 
         let expected_entry = |v: i64| {
             let mut entry = IndexMap::new();
@@ -7408,7 +7750,7 @@ mod tests {
         let value = cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::ToEntries), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         let entry = |k: &str, v: i64| {
             let mut entry = IndexMap::new();
@@ -7436,7 +7778,7 @@ mod tests {
         let value = seq_cursor.value();
 
         let result = eval(&Expr::Builtin(Builtin::ToEntries), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         let expected_entry = |i: i64, v: &str| {
             let mut entry = IndexMap::new();
@@ -7494,7 +7836,7 @@ mod tests {
 
         let expr = crate::jq::parse(r#"(.[] | if .==2 then error("boom") else . end)?"#).unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.collect_owned(), vec![OwnedValue::Int(1)]);
+        assert_eq!(result.collect_owned().unwrap(), vec![OwnedValue::Int(1)]);
     }
 
     #[test]
@@ -7518,7 +7860,7 @@ mod tests {
 
         let expr = crate::jq::parse(r#"(.[] | if .==1 then error("boom") else . end)?"#).unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -7538,7 +7880,7 @@ mod tests {
         let expr = crate::jq::parse(r#"(.[] | if .==3 then error("boom") else . end)?"#).unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(2)]
         );
     }
@@ -7558,7 +7900,7 @@ mod tests {
         let value = seq_cursor.value();
 
         let result = eval(&Expr::Index(1), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::Int(2));
     }
@@ -7595,7 +7937,7 @@ mod tests {
 
         // Use eval_with_cursor to preserve position metadata
         let result = eval_with_cursor(&Expr::Builtin(Builtin::Line), mapping_cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         // Mapping starts at line 1
         assert_eq!(owned, OwnedValue::Int(1));
@@ -7616,7 +7958,7 @@ mod tests {
 
         // Use eval_with_cursor to preserve position metadata
         let result = eval_with_cursor(&Expr::Builtin(Builtin::Column), mapping_cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         // Mapping starts at column 1
         assert_eq!(owned, OwnedValue::Int(1));
@@ -7641,7 +7983,7 @@ mod tests {
         let expr = crate::jq::parse(".a | anchor").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String("x".to_string())
         );
     }
@@ -7660,7 +8002,7 @@ mod tests {
         let expr = crate::jq::parse(".a | anchor").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7679,14 +8021,14 @@ mod tests {
         let expr = crate::jq::parse(".a | style").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String("flow".to_string())
         );
 
         let expr = crate::jq::parse(".b | style").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String("double".to_string())
         );
     }
@@ -7707,13 +8049,13 @@ mod tests {
         // same as `line`/`column` above.
         let result = eval(&Expr::Builtin(Builtin::Anchor), value.clone());
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
 
         let result = eval(&Expr::Builtin(Builtin::Style), value);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7735,7 +8077,7 @@ mod tests {
         let expr = parse(".a | anchor").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7751,7 +8093,7 @@ mod tests {
         let expr = parse(".a | style").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7770,7 +8112,7 @@ mod tests {
 
         // Using eval (not eval_with_cursor) loses position metadata
         let result = eval(&Expr::Builtin(Builtin::Line), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         // Without cursor, line returns 0
         assert_eq!(owned, OwnedValue::Int(0));
@@ -7794,7 +8136,7 @@ mod tests {
         let expr = crate::jq::parse(".a | line_comment").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String("keep this".to_string())
         );
     }
@@ -7813,7 +8155,7 @@ mod tests {
         let expr = crate::jq::parse(".a | line_comment").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7853,7 +8195,7 @@ mod tests {
         let expr = crate::jq::parse(".a | line_comment").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String("#keep this".to_string())
         );
     }
@@ -7873,7 +8215,7 @@ mod tests {
         // Using eval (not eval_with_cursor) loses position metadata, so
         // line_comment falls back to "" even though the source has one.
         let result = eval(&Expr::Builtin(Builtin::LineComment), value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert_eq!(owned, OwnedValue::String(String::new()));
     }
 
@@ -7890,7 +8232,7 @@ mod tests {
 
         let result = eval_with_cursor(&Expr::Builtin(Builtin::LineComment), field_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::String(String::new())
         );
     }
@@ -7909,7 +8251,7 @@ mod tests {
         let cursor = index.root(json);
         let value = cursor.value();
 
-        let (owned, comments) = to_owned_with_comments(&value, Some(&cursor));
+        let (owned, comments) = to_owned_with_comments(&value, Some(&cursor)).unwrap();
         assert_eq!(
             owned,
             OwnedValue::Object(IndexMap::from([("a".to_string(), OwnedValue::Int(1))]))
@@ -7940,7 +8282,7 @@ mod tests {
 
         let expr = crate::jq::parse(".foo | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(2));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(2));
     }
 
     #[test]
@@ -7957,7 +8299,7 @@ mod tests {
         let expr = crate::jq::parse(".[] | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -7981,7 +8323,7 @@ mod tests {
         let expr = crate::jq::parse(".[] | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -8009,13 +8351,16 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(3)
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).collect_owned(),
+            eval_with_cursor(&expr, doc_cursor).collect_owned().unwrap(),
             vec![
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),
@@ -8025,19 +8370,28 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::String("b".to_string())
         );
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::String("b".to_string())
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::String("c".to_string())
         );
     }
@@ -8058,7 +8412,10 @@ mod tests {
 
         let expr = crate::jq::parse("keys | length").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(3)
         );
 
@@ -8066,7 +8423,10 @@ mod tests {
         // still be fully sorted (`a,b,c`), not document order (`b,a,c`).
         let expr = crate::jq::parse("keys").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("b".to_string()),
@@ -8076,13 +8436,19 @@ mod tests {
 
         let expr = crate::jq::parse("keys | first").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::String("a".to_string())
         );
 
         let expr = crate::jq::parse("keys | last").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::String("c".to_string())
         );
     }
@@ -8103,31 +8469,43 @@ mod tests {
 
         let expr = crate::jq::parse("keys_unsorted | length").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(3)
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).collect_owned(),
+            eval_with_cursor(&expr, doc_cursor).collect_owned().unwrap(),
             vec![OwnedValue::Int(0), OwnedValue::Int(1), OwnedValue::Int(2)]
         );
 
         let expr = crate::jq::parse("keys_unsorted | .[0]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(0)
         );
 
         let expr = crate::jq::parse("keys_unsorted | first").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(0)
         );
 
         let expr = crate::jq::parse("keys_unsorted | last").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, doc_cursor).into_owned().unwrap(),
+            eval_with_cursor(&expr, doc_cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
             OwnedValue::Int(2)
         );
     }
@@ -8233,7 +8611,7 @@ mod tests {
         let result = eval_with_cursor(&expr, doc_cursor);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -8257,7 +8635,7 @@ mod tests {
         let result = eval_with_cursor(&expr, doc_cursor);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(10),
@@ -8286,7 +8664,7 @@ mod tests {
         let result = eval_with_cursor(&expr, doc_cursor);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("B".to_string()),
                 OwnedValue::String("A".to_string()),
@@ -8312,7 +8690,7 @@ mod tests {
         let result = eval_with_cursor(&expr, doc_cursor);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(4),
@@ -8335,7 +8713,7 @@ mod tests {
         let expr = crate::jq::parse(".[] | select(. > 1) | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
         );
     }
@@ -8359,7 +8737,7 @@ mod tests {
         let expr = crate::jq::parse(".containers[].image | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
         );
     }
@@ -8377,7 +8755,7 @@ mod tests {
 
         let expr = crate::jq::parse(". | line").unwrap();
         let result = eval_with_cursor(&expr, doc_cursor);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(1));
     }
 
     #[test]
@@ -8402,7 +8780,7 @@ mod tests {
         ]);
 
         let result = eval(&expr, value);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::String("Alice".to_string()));
     }
@@ -8422,7 +8800,7 @@ mod tests {
 
         // Use eval_with_cursor to preserve position metadata
         let result = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), mapping_cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
 
         // Single document = index 0
         assert_eq!(owned, OwnedValue::Int(0));
@@ -8443,13 +8821,13 @@ mod tests {
 
         // Test document_index for each document
         let result1 = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), doc1);
-        assert_eq!(result1.into_owned().unwrap(), OwnedValue::Int(0));
+        assert_eq!(result1.into_owned().unwrap().unwrap(), OwnedValue::Int(0));
 
         let result2 = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), doc2);
-        assert_eq!(result2.into_owned().unwrap(), OwnedValue::Int(1));
+        assert_eq!(result2.into_owned().unwrap().unwrap(), OwnedValue::Int(1));
 
         let result3 = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), doc3);
-        assert_eq!(result3.into_owned().unwrap(), OwnedValue::Int(2));
+        assert_eq!(result3.into_owned().unwrap().unwrap(), OwnedValue::Int(2));
     }
 
     #[test]
@@ -8475,11 +8853,11 @@ mod tests {
         // Even from a child node, document_index returns the document's index
         if let Some(cursor) = name_value {
             let result = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), cursor);
-            assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+            assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(1));
         } else {
             // Just test the doc directly
             let result = eval_with_cursor(&Expr::Builtin(Builtin::DocumentIndex), doc2);
-            assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+            assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(1));
         }
     }
 
@@ -8498,7 +8876,7 @@ mod tests {
         // Parse 'di' and verify it works the same as document_index
         let expr = crate::jq::parse("di").unwrap();
         let result = eval_with_cursor(&expr, mapping_cursor);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(0));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(0));
     }
 
     #[test]
@@ -8520,13 +8898,13 @@ mod tests {
             while let Some((cursor, rest)) = docs.uncons_cursor() {
                 let result = eval_with_cursor(&expr, cursor);
                 match result {
-                    GenericResult::One(v) => results.push(to_owned(&v)),
+                    GenericResult::One(v) => results.push(to_owned(&v).unwrap()),
                     // `select`'s truthy branch now forwards the cursor it
                     // was given (needed for `line`/`column` to survive a
                     // `select(...)`), so a match here is `OneCursor`, not
                     // `One` — see the `Builtin::Select` cursor-forwarding
                     // fix in `eval_builtin`.
-                    GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
+                    GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c).unwrap()),
                     GenericResult::Owned(o) => results.push(o),
                     GenericResult::None => {} // Filtered out
                     _ => {}
@@ -8593,7 +8971,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![
                     OwnedValue::Bool(true),
@@ -8620,19 +8998,19 @@ mod tests {
         // at_offset(0) should return the root object
         let expr = crate::jq::parse("at_offset(0)").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         // at_offset(10) should be inside the "Alice" string (offset 10 = 'l' in "Alice")
         let expr = crate::jq::parse("at_offset(10)").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert!(matches!(owned, OwnedValue::String(ref s) if s == "Alice"));
 
         // at_offset(27) should be the age number (30)
         let expr = crate::jq::parse("at_offset(27)").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert_eq!(owned, OwnedValue::Int(30));
     }
 
@@ -8649,13 +9027,13 @@ mod tests {
         // at_position(1; 1) should return the root object
         let expr = crate::jq::parse("at_position(1; 1)").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         // at_position(2; 3) should be the "name" key (line 2, col 3 = start of "name")
         let expr = crate::jq::parse("at_position(2; 3)").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert!(matches!(owned, OwnedValue::String(ref s) if s == "name"));
     }
 
@@ -8673,16 +9051,28 @@ mod tests {
         let via_getpath = crate::jq::parse(r#"at_offset(getpath(["n"]))"#).unwrap();
         let via_literal = crate::jq::parse("at_offset(2)").unwrap();
         assert_eq!(
-            eval_with_cursor(&via_getpath, cursor).into_owned().unwrap(),
-            eval_with_cursor(&via_literal, cursor).into_owned().unwrap(),
+            eval_with_cursor(&via_getpath, cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
+            eval_with_cursor(&via_literal, cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
         );
 
         let via_getpath =
             crate::jq::parse(r#"at_position(getpath(["l"]); getpath(["c"]))"#).unwrap();
         let via_literal = crate::jq::parse("at_position(1; 1)").unwrap();
         assert_eq!(
-            eval_with_cursor(&via_getpath, cursor).into_owned().unwrap(),
-            eval_with_cursor(&via_literal, cursor).into_owned().unwrap(),
+            eval_with_cursor(&via_getpath, cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
+            eval_with_cursor(&via_literal, cursor)
+                .into_owned()
+                .unwrap()
+                .unwrap(),
         );
     }
 
@@ -8724,7 +9114,7 @@ mod tests {
         // The "users" array starts at offset 10 (the '[' character)
         let expr = crate::jq::parse("at_offset(10) | .[0].name").unwrap();
         let result = eval_with_cursor(&expr, cursor);
-        let owned = result.into_owned().unwrap();
+        let owned = result.into_owned().unwrap().unwrap();
         assert!(matches!(owned, OwnedValue::String(ref s) if s == "Alice"));
     }
 
@@ -8916,8 +9306,10 @@ mod tests {
             .is_some_and(|e| e.message.contains("not in label")));
 
         // into_owned consumes; check the owned-family variants.
-        let owned: Vec<Option<OwnedValue>> =
-            results.into_iter().map(GenericResult::into_owned).collect();
+        let owned: Vec<Option<OwnedValue>> = results
+            .into_iter()
+            .map(|r| r.into_owned().unwrap())
+            .collect();
         assert_eq!(owned[2], Some(OwnedValue::Int(5))); // Owned
         assert_eq!(
             owned[3],
@@ -8973,7 +9365,7 @@ mod tests {
         ];
         let collected: Vec<Vec<OwnedValue>> = results
             .into_iter()
-            .map(GenericResult::collect_owned)
+            .map(|r| r.collect_owned().unwrap())
             .collect();
         assert_eq!(collected[0].len(), 3); // Many -> 3 elements
         assert_eq!(collected[1], vec![OwnedValue::Int(9)]); // ManyOwned
@@ -9007,7 +9399,7 @@ mod tests {
             .unwrap();
 
         let result2 = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result2.collect_owned(), vec![OwnedValue::Int(1)]);
+        assert_eq!(result2.collect_owned().unwrap(), vec![OwnedValue::Int(1)]);
     }
 
     #[test]
@@ -9083,10 +9475,13 @@ mod tests {
         let index = JsonIndex::build(json);
 
         let jq_result = eval_using::<JqSemantics, _>(&expr, index.root(json).value());
-        assert_eq!(jq_result.into_owned(), Some(OwnedValue::Int(1)));
+        assert_eq!(jq_result.into_owned().unwrap(), Some(OwnedValue::Int(1)));
 
         let yq_result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
-        assert_eq!(yq_result.into_owned(), Some(OwnedValue::Float(1.5)));
+        assert_eq!(
+            yq_result.into_owned().unwrap(),
+            Some(OwnedValue::Float(1.5))
+        );
     }
 
     #[test]
@@ -9110,7 +9505,10 @@ mod tests {
         let expr = crate::jq::parse(".[(1-1):(1+0)]").unwrap();
 
         let result = eval_using::<YqSemantics, _>(&expr, index.root(json).value());
-        assert_eq!(result.into_owned(), Some(OwnedValue::Array(Vec::new())));
+        assert_eq!(
+            result.into_owned().unwrap(),
+            Some(OwnedValue::Array(Vec::new()))
+        );
     }
 
     // Coverage follow-ups for #532: the tests above exercise the common
@@ -9134,7 +9532,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -9202,7 +9600,7 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(matches!(result, GenericResult::ManyCursor(_)));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(2)]
         );
     }
@@ -9304,7 +9702,7 @@ mod tests {
         let first = eval(&crate::jq::parse("first(.)").unwrap(), value.clone());
         assert!(matches!(first, GenericResult::One(_)));
         assert_eq!(
-            first.collect_owned(),
+            first.collect_owned().unwrap(),
             vec![OwnedValue::Object(
                 core::iter::once(("a".to_string(), OwnedValue::Int(1))).collect()
             )]
@@ -9351,11 +9749,11 @@ mod tests {
             value.clone(),
         );
         assert!(matches!(first, GenericResult::One(_)));
-        assert_eq!(first.collect_owned(), vec![OwnedValue::Int(1)]);
+        assert_eq!(first.collect_owned().unwrap(), vec![OwnedValue::Int(1)]);
 
         let last = eval(&crate::jq::parse("last(select(true,true))").unwrap(), value);
         assert!(matches!(last, GenericResult::One(_)));
-        assert_eq!(last.collect_owned(), vec![OwnedValue::Int(1)]);
+        assert_eq!(last.collect_owned().unwrap(), vec![OwnedValue::Int(1)]);
     }
 
     // `GenericResult::stream_json`/`stream_yaml`'s `Self::One`/`Self::Many`
@@ -9619,7 +10017,7 @@ mod tests {
         );
         // `length` of the integer `1` is its absolute value, `1`.
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(1)]
         );
     }
@@ -9638,7 +10036,7 @@ mod tests {
         let result = eval(&crate::jq::parse("select(true,true)").unwrap(), value);
         assert!(matches!(result, GenericResult::Many(_)));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(1)]
         );
     }
@@ -9660,7 +10058,7 @@ mod tests {
 
         let one = eval(&crate::jq::parse(".[(1-1):(1+1)]").unwrap(), value.clone());
         assert_eq!(
-            one.collect_owned(),
+            one.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2)
@@ -9672,7 +10070,7 @@ mod tests {
             value,
         );
         assert_eq!(
-            many.collect_owned(),
+            many.collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
                 OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
@@ -9692,7 +10090,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Int(1),
                 OwnedValue::Null,
@@ -9717,7 +10115,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(3)
@@ -9738,7 +10136,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
                 OwnedValue::Array(vec![OwnedValue::Int(20), OwnedValue::Int(30)]),
@@ -9759,7 +10157,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(3)
@@ -9778,7 +10176,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(!result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -9792,7 +10190,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(!result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -9806,7 +10204,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(!result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -9865,7 +10263,9 @@ mod tests {
 
         let expr = crate::jq::parse(".a[:.k2]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, index.root(json)).collect_owned(),
+            eval_with_cursor(&expr, index.root(json))
+                .collect_owned()
+                .unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -9875,7 +10275,9 @@ mod tests {
 
         let expr = crate::jq::parse(".a[.k1:]").unwrap();
         assert_eq!(
-            eval_with_cursor(&expr, index.root(json)).collect_owned(),
+            eval_with_cursor(&expr, index.root(json))
+                .collect_owned()
+                .unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(3),
@@ -9905,7 +10307,7 @@ mod tests {
         let expr = crate::jq::parse("(empty)[(0+0):2]").unwrap();
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(!result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -9919,7 +10321,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2)
@@ -9957,7 +10359,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
                 OwnedValue::Array(vec![OwnedValue::Int(4), OwnedValue::Int(5)]),
@@ -9979,7 +10381,7 @@ mod tests {
         let expr = crate::jq::parse("(1+1)[(0+0):2]?").unwrap();
         let result = eval_with_cursor(&expr, index.root(json));
         assert!(!result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -9991,7 +10393,7 @@ mod tests {
         let expr = crate::jq::parse(".a[.k1:.k2]").unwrap();
 
         let result = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result.collect_owned(), vec![OwnedValue::Null]);
+        assert_eq!(result.collect_owned().unwrap(), vec![OwnedValue::Null]);
     }
 
     #[test]
@@ -10004,7 +10406,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::String("el".to_string())]
         );
     }
@@ -10020,7 +10422,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(10), OwnedValue::Int(20)]
         );
     }
@@ -10041,7 +10443,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Bool(true), OwnedValue::Bool(false)]
         );
     }
@@ -10061,7 +10463,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Bool(true), OwnedValue::Bool(false)]
         );
     }
@@ -10077,7 +10479,7 @@ mod tests {
         let expr = Expr::Builtin(Builtin::Select(Box::new(Expr::Identity)));
 
         let result = eval(&expr, index.root(json).value());
-        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+        assert_eq!(result.into_owned().unwrap(), Some(OwnedValue::Int(5)));
     }
 
     #[test]
@@ -10089,7 +10491,7 @@ mod tests {
         let expr = Expr::Builtin(Builtin::Select(Box::new(Expr::Identity)));
 
         let result = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+        assert_eq!(result.into_owned().unwrap(), Some(OwnedValue::Int(5)));
     }
 
     #[test]
@@ -10103,7 +10505,7 @@ mod tests {
 
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(
-            result.into_owned(),
+            result.into_owned().unwrap(),
             Some(OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2)
@@ -10118,7 +10520,7 @@ mod tests {
         let expr = Expr::Builtin(Builtin::Scalars);
 
         let result = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result.into_owned(), Some(OwnedValue::Int(5)));
+        assert_eq!(result.into_owned().unwrap(), Some(OwnedValue::Int(5)));
     }
 
     #[test]
@@ -10132,7 +10534,7 @@ mod tests {
         let expr = crate::jq::parse(".foo | line").unwrap();
 
         let result = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result.into_owned(), Some(OwnedValue::Int(2)));
+        assert_eq!(result.into_owned().unwrap(), Some(OwnedValue::Int(2)));
     }
 
     #[test]
@@ -10144,7 +10546,7 @@ mod tests {
         let expr = crate::jq::parse(".foo | column").unwrap();
 
         let result = eval_with_cursor(&expr, index.root(json));
-        assert_eq!(result.into_owned(), Some(OwnedValue::Int(10)));
+        assert_eq!(result.into_owned().unwrap(), Some(OwnedValue::Int(10)));
     }
 
     /// A `GenericResult` reduced to the parts these tests assert on, so the
@@ -10175,7 +10577,7 @@ mod tests {
             GenericResult::Partial(vs, Control::Break(l)) => {
                 Summary::Partial(json_of(&vs), Box::new(Summary::Break(l)))
             }
-            other => Summary::Values(json_of(&other.collect_owned())),
+            other => Summary::Values(json_of(&other.collect_owned().unwrap())),
         }
     }
 
@@ -10357,13 +10759,13 @@ mod tests {
 
         let expr = crate::jq::parse("([10,20,30])[.]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).collect_owned(),
+            eval(&expr, value.clone()).collect_owned().unwrap(),
             vec![OwnedValue::Int(10)]
         );
 
         let expr = crate::jq::parse("([10,20,30])[select(true,true)]").unwrap();
         assert_eq!(
-            eval(&expr, value).collect_owned(),
+            eval(&expr, value).collect_owned().unwrap(),
             vec![OwnedValue::Int(10), OwnedValue::Int(10)]
         );
     }
@@ -10381,7 +10783,7 @@ mod tests {
 
         let expr = crate::jq::parse("([10,20,30])[.:2]").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).collect_owned(),
+            eval(&expr, value.clone()).collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![
                 OwnedValue::Int(10),
                 OwnedValue::Int(20)
@@ -10390,7 +10792,7 @@ mod tests {
 
         let expr = crate::jq::parse("([10,20,30])[select(true,true):2]").unwrap();
         assert_eq!(
-            eval(&expr, value).collect_owned(),
+            eval(&expr, value).collect_owned().unwrap(),
             vec![
                 OwnedValue::Array(vec![OwnedValue::Int(10), OwnedValue::Int(20)]),
                 OwnedValue::Array(vec![OwnedValue::Int(10), OwnedValue::Int(20)]),
@@ -10410,7 +10812,9 @@ mod tests {
         let expr = crate::jq::parse(".arr[.starts[]:3]").unwrap();
 
         assert_eq!(
-            eval_with_cursor(&expr, index.root(json)).collect_owned(),
+            eval_with_cursor(&expr, index.root(json))
+                .collect_owned()
+                .unwrap(),
             vec![
                 OwnedValue::Array(vec![
                     OwnedValue::Int(1),
@@ -10524,7 +10928,7 @@ mod tests {
         let result = eval_using::<YqSemantics, _>(&expr, value);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             // yq keeps float modulo (1.5), unlike jq's truncating modulo (1).
             OwnedValue::Array(vec![OwnedValue::Float(1.5)])
         );
@@ -10543,7 +10947,7 @@ mod tests {
 
         let expr = crate::jq::parse("map(.)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -10565,7 +10969,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(keys_unsorted)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Array(vec![OwnedValue::String("a".to_string())]),
                 OwnedValue::Array(vec![
@@ -10581,7 +10985,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(keys_unsorted)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Array(vec![OwnedValue::Int(0), OwnedValue::Int(1)]),
                 OwnedValue::Array(vec![
@@ -10598,7 +11002,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(select(. > 1))").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)])
         );
 
@@ -10609,7 +11013,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(1, 2)").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
         );
 
@@ -10622,7 +11026,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(.[])").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -10639,7 +11043,7 @@ mod tests {
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(keys_unsorted | map(ascii_upcase))").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Array(vec![OwnedValue::String("A".to_string())]),
                 OwnedValue::Array(vec![
@@ -10695,7 +11099,7 @@ mod tests {
 
         let expr = crate::jq::parse("select(map(. + 1))").unwrap();
         assert_eq!(
-            eval(&expr, value.clone()).into_owned().unwrap(),
+            eval(&expr, value.clone()).into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
         );
 
@@ -10733,7 +11137,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::ManyCursor(_)));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]
         );
     }
@@ -10754,7 +11158,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(!matches!(result, GenericResult::ManyCursor(_)));
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Null]
         );
     }
@@ -10776,7 +11180,7 @@ mod tests {
         let expr = crate::jq::parse("map(.foo) | .[]").unwrap();
         let result = eval(&expr, value);
         assert!(result.is_error());
-        assert_eq!(result.collect_owned(), Vec::<OwnedValue>::new());
+        assert_eq!(result.collect_owned().unwrap(), Vec::<OwnedValue>::new());
     }
 
     #[test]
@@ -10789,7 +11193,10 @@ mod tests {
         let index = JsonIndex::build(json);
         let value = index.root(json).value();
         let expr = crate::jq::parse("map(.) | first").unwrap();
-        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Null);
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap().unwrap(),
+            OwnedValue::Null
+        );
 
         let json = br"[1,2,3]";
         let index = JsonIndex::build(json);
@@ -10797,7 +11204,7 @@ mod tests {
         let expr = crate::jq::parse("map(.) | first").unwrap();
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::OneCursor(_)));
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(1));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(1));
 
         let json = br"[42]";
         let index = JsonIndex::build(json);
@@ -10828,7 +11235,7 @@ mod tests {
         let result = eval(&expr, value.clone());
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(4),
@@ -10840,7 +11247,7 @@ mod tests {
         let result = eval(&expr, value);
         assert!(matches!(result, GenericResult::LazySeq(_)));
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(2),
                 OwnedValue::Int(4),
@@ -11034,7 +11441,7 @@ mod tests {
             GenericResult::Halt(code) => assert_eq!(*code, 3),
             other => panic!("expected Halt(3), got {other:?}"),
         }
-        assert_eq!(result.into_owned(), None);
+        assert_eq!(result.into_owned().unwrap(), None);
     }
 
     #[test]
@@ -11067,7 +11474,7 @@ mod tests {
             "the halt is never reached, not swallowed after being reached: {result:?}"
         );
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![OwnedValue::String("a".to_string())]
         );
     }
@@ -11116,9 +11523,9 @@ mod tests {
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
         // Under the limit: succeeds.
-        let owned = to_owned(&cursor.value());
+        let owned = to_owned(&cursor.value()).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
-        let owned = to_owned_cursor(&cursor);
+        let owned = to_owned_cursor(&cursor).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         let json = linear_nest(256);
@@ -11297,7 +11704,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | sort").unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("a".to_string()),
                 OwnedValue::String("b".to_string()),
@@ -11318,7 +11725,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | (.[0], .[1])").unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),
@@ -11339,7 +11746,7 @@ mod tests {
         let value = cursor.value();
         let expr = crate::jq::parse("reduce .[] as $x (0; $x)").unwrap();
         let result = eval(&expr, value);
-        assert_eq!(result.into_owned().unwrap(), OwnedValue::Int(3));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
 
     /// #1192: the `Ok` (all-succeed) side of `eval_single`'s fallback
@@ -11354,7 +11761,7 @@ mod tests {
         let expr = crate::jq::parse(r#"foreach range(3) as $i (""; . + "x"; .)"#).unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.collect_owned(),
+            result.collect_owned().unwrap(),
             vec![
                 OwnedValue::String("x".to_string()),
                 OwnedValue::String("xx".to_string()),
@@ -11377,7 +11784,7 @@ mod tests {
         let expr = crate::jq::parse("keys_unsorted | .").unwrap();
         let result = eval(&expr, value);
         assert_eq!(
-            result.into_owned().unwrap(),
+            result.into_owned().unwrap().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::String("b".to_string()),
                 OwnedValue::String("a".to_string()),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1138,6 +1138,16 @@ fn into_lazy_items<V: DocumentValue>(
     result: GenericResult<V>,
 ) -> Result<Vec<LazyElem<V>>, Control> {
     match result {
+        // `One`/`Many` (this arm and the one below) are exhaustiveness only,
+        // not reachable through this function's one call site
+        // (`LazySeq::fold_one`): every element it hands `eval_single` here
+        // carries a concrete `Some(cursor)` (`c.value()`/`Some(c)`), and
+        // every native arm that can construct a bare `One`/`Many`
+        // (`Identity`, `Builtin::Select` and its cursor-preserving siblings)
+        // forwards a `Some` cursor into `OneCursor`/`ManyCursor` instead of
+        // `One`/`Many` -- `eval_on_owned` (the other `LazyElem` kind's path,
+        // `LazyElem::Owned`) never returns `One`/`Many` either, per its own
+        // `unreachable!` arms in `eval_on_many_owned` below.
         GenericResult::One(v) => Ok(vec![LazyElem::Owned(to_owned(&v).map_err(Control::Error)?)]),
         // Stays lazy: a `map(.foo)`-style navigational sub-expr keeps
         // composing without forcing materialization.
@@ -1738,6 +1748,13 @@ fn flatten_generic_results<V: DocumentValue>(
     let mut results = Vec::new();
     for r in items {
         match r.materialize_lazy() {
+            // `One`/`Many` are exhaustiveness only here too, same as
+            // `into_lazy_items`'s identical comment above: `items`' one
+            // source (`fold_pipe_stages`'s `ManyCursor(cs)` arm) evaluates
+            // `rest` per element via `eval_single(&rest, c.value(), optional,
+            // Some(c))`, and `c: V::Cursor` is always concrete -- the same
+            // "ambient cursor is always `Some`" invariant that rules out a
+            // bare `One`/`Many` reaching `into_lazy_items` rules it out here.
             GenericResult::One(v) => results.push(to_owned(&v).map_err(Control::Error)?),
             GenericResult::OneCursor(c) => {
                 results.push(to_owned_cursor(&c).map_err(Control::Error)?);
@@ -11828,5 +11845,483 @@ mod tests {
                 OwnedValue::String("c".to_string()),
             ])
         );
+    }
+
+    // ---- #1247 coverage: decode-failure arms added by the fallible
+    // `to_owned`/`to_owned_cursor` signature change (PR #1391). Every test
+    // below constructs a genuinely-reachable path to its target arm rather
+    // than forcing coverage artificially -- see each test's own doc comment
+    // for the trace. Several deliberately call the crate's cursor-less
+    // [`eval`] (not [`eval_with_cursor`]) directly: that is a real, `pub`,
+    // heavily-exercised entry point elsewhere in this test module (see
+    // `test_1048_computed_index_and_slice_zero_results_collapse_to_none`
+    // above and dozens like it), and it is the only way to construct a bare
+    // `GenericResult::One`/`Many` (as opposed to `OneCursor`/`ManyCursor`) --
+    // every native arm that can build one forwards a `Some` cursor into the
+    // cursor-carrying variant instead, so `One`/`Many` only ever arise when
+    // the ambient cursor is `None` to begin with.
+
+    /// `to_owned_with_comments` mirrors `to_owned`'s decode-failure checks
+    /// (#1247) -- this covers the object-key check specifically, since #1247
+    /// added it to this function too, not just `to_owned_at_depth`.
+    #[test]
+    fn test_to_owned_with_comments_errors_on_object_key_decode_failure_1247() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = to_owned_with_comments(&value, Some(&cursor))
+            .expect_err("an undecodable key must not materialize");
+        assert!(err.message.contains("in object key"), "{err:?}");
+    }
+
+    /// The value-side sibling of the test above: a field whose *value* (not
+    /// key) fails to decode propagates through the recursive
+    /// `to_owned_with_comments_at_depth` call for that field, not just the
+    /// top-level scalar case `to_owned`'s own tests already cover.
+    #[test]
+    fn test_to_owned_with_comments_errors_on_field_value_decode_failure_1247() {
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = to_owned_with_comments(&value, Some(&cursor))
+            .expect_err("an undecodable value must not materialize");
+        assert!(err.message.contains("invalid UTF-8"), "{err:?}");
+    }
+
+    /// `to_owned_key_shape`'s array/object branches (#626/#670/#903) are a
+    /// shape-only fast path for a computed index/slice-bound candidate --
+    /// reached from `eval_index_expr`'s `keys` match when the key expression
+    /// resolves to a bare `GenericResult::One` (not `OneCursor`), which only
+    /// happens when the ambient cursor is `None`: `.[.]` at the top level,
+    /// evaluated through the cursor-less `eval()`, makes the key expression
+    /// (`.`, i.e. `Expr::Identity`) evaluate against a `None` cursor, giving
+    /// `GenericResult::One(document)`. An array/object document then hits
+    /// `to_owned_key_shape`'s array/object branch respectively; the
+    /// synthesized empty container is then rejected by `index_one_owned`
+    /// (neither branch there handles an array/object key), confirming the
+    /// fast path's synthesized shape reaches real indexing logic rather than
+    /// disappearing into an unused value.
+    #[test]
+    fn test_computed_index_self_as_key_rejects_array_and_object_shapes_1247() {
+        let array_json: &[u8] = b"[1,2,3]";
+        let index = JsonIndex::build(array_json);
+        let cursor = index.root(array_json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse(".[.]").unwrap(), value);
+        assert!(
+            result.is_error(),
+            "array self-index should be rejected, got {result:?}"
+        );
+
+        let object_json: &[u8] = b"{\"a\":1}";
+        let index = JsonIndex::build(object_json);
+        let cursor = index.root(object_json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse(".[.]").unwrap(), value);
+        assert!(
+            result.is_error(),
+            "object self-index should be rejected, got {result:?}"
+        );
+    }
+
+    /// `Expr::Array`'s native construction (#1168) materializes its inner
+    /// expression's `One`/`Many` results through `to_owned` -- reached the
+    /// same cursor-less way as the test above: `[.]` through `eval()`
+    /// (cursor `None`) makes `.` resolve to a bare `One`, and `[select(true,
+    /// true)]` makes the two-truthy-output `select` resolve to a bare
+    /// `Many` (`Builtin::Select`'s `pass_n` forwards a `None` cursor into
+    /// `Many`, not `ManyCursor`) -- both over a document that is itself an
+    /// undecodable string.
+    #[test]
+    fn test_array_construction_one_and_many_arms_decode_failure_1247() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("[.]").unwrap(), value);
+        assert!(result.is_error(), "[.] should surface the decode failure");
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("[select(true,true)]").unwrap(), value);
+        assert!(
+            result.is_error(),
+            "[select(true,true)] should surface the decode failure"
+        );
+    }
+
+    /// `push_generic_owned_values` (`Expr::Compare`'s operand forker, #768)
+    /// materializes each operand's outputs through `to_owned`/`to_owned`;
+    /// its `One` arm is reached by `. == 1` (left operand is a bare `One`,
+    /// same cursor-less mechanism as the tests above), its `Many` arm by
+    /// `select(true,true) == 1` (left operand is a bare `Many`).
+    #[test]
+    fn test_compare_operand_one_and_many_arms_decode_failure_1247() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse(". == 1").unwrap(), value);
+        assert!(
+            result.is_error(),
+            ". == 1 should surface the decode failure"
+        );
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true) == 1").unwrap(), value);
+        assert!(
+            result.is_error(),
+            "select(true,true) == 1 should surface the decode failure"
+        );
+    }
+
+    /// `push_generic_truthiness`'s `Many` arm (`select`'s condition forker,
+    /// #378) is reached when the condition itself is a bare `Many` --
+    /// `select(select(true,true))` (the inner `select` supplies the outer
+    /// one's condition, and resolves to a bare `Many` the same way the
+    /// `Compare` test above does).
+    #[test]
+    fn test_select_condition_many_arm_decode_failure_1247() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(
+            &crate::jq::parse("select(select(true,true))").unwrap(),
+            value,
+        );
+        assert!(
+            result.is_error(),
+            "select(select(true,true)) should surface the decode failure"
+        );
+    }
+
+    /// `GenericResult::into_owned`'s `Many` arm (public API, used by every
+    /// non-streaming consumer) -- `select(true,true)` over an undecodable
+    /// document gives a bare `Many` (see the tests above for why), and
+    /// `.into_owned()` must report the decode failure as `Err`, not silently
+    /// drop it into the `Ok(None)` bucket `Error`/`Break` share.
+    #[test]
+    fn test_into_owned_many_arm_decode_failure_1247() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true)").unwrap(), value);
+        let err = result
+            .into_owned()
+            .expect_err("a Many of undecodable values must not materialize");
+        assert!(err.message.contains("invalid UTF-8"), "{err:?}");
+    }
+
+    /// `stream_json`/`stream_yaml`'s `One`/`Many` arms (#355, #1247) report a
+    /// decode failure through `stats.error` rather than writing to `out` --
+    /// same bare-`One`/bare-`Many` construction as the tests above
+    /// (`select(true)`/`select(true,true)` through the cursor-less `eval()`),
+    /// exercised against both output formats since the match arms (and the
+    /// shared `owned_or_stream_error` helper, #2532) are format-independent.
+    #[test]
+    fn test_stream_one_and_many_arms_report_decode_failure_1247() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let one = eval(&crate::jq::parse("select(true)").unwrap(), value);
+        assert!(matches!(one, GenericResult::One(_)), "{one:?}");
+        let mut out = String::new();
+        let stats = one
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "", "a decode failure must never reach stdout");
+        assert!(stats.error.is_some());
+        let mut out = String::new();
+        let stats = one
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let many = eval(&crate::jq::parse("select(true,true)").unwrap(), value);
+        assert!(matches!(many, GenericResult::Many(_)), "{many:?}");
+        let mut out = String::new();
+        let stats = many
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+        assert_eq!(stats.count, 0);
+        let mut out = String::new();
+        let stats = many
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+        assert_eq!(stats.count, 0);
+    }
+
+    /// `stream_json`/`stream_yaml`'s `LazyKeys { sorted: true, .. }` arm
+    /// falls back to `materialize_lazy_keys`, which decodes every key --
+    /// `keys` (not `keys_unsorted`, which stays lazy) over a document with an
+    /// undecodable key reaches this on both output formats. CLI-reachable:
+    /// `sjq keys`/`syq keys` over such a document.
+    #[test]
+    fn test_stream_sorted_lazy_keys_arm_reports_decode_failure_1247() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys").unwrap(), cursor);
+        assert!(matches!(
+            result,
+            GenericResult::LazyKeys { sorted: true, .. }
+        ));
+
+        let mut out = String::new();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+
+        let mut out = String::new();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+    }
+
+    /// `stream_json`'s `LazySeq` arm falls back to materializing each
+    /// `LazyElem` via `lazy_elem_to_owned` whenever
+    /// `sequence_streamable_cursors` answers `None` -- unconditional for
+    /// JSON, since `JsonCursor` never overrides
+    /// `supports_sequence_streaming` (stays the trait default `false`). A
+    /// plain `map(.)` over an array containing an undecodable element is
+    /// CLI-reachable (`sjq 'map(.)'`) and takes exactly this path.
+    #[test]
+    fn test_stream_json_lazyseq_fallback_reports_decode_failure_1247() {
+        let json: &[u8] = b"[\"\xff\xfe\"]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("map(.)").unwrap(), cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+
+        let mut out = String::new();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+    }
+
+    /// `stream_yaml`'s `LazySeq` arm equivalent of the JSON test above, but
+    /// `YamlCursor::supports_sequence_streaming` is `true`, so
+    /// `sequence_streamable_cursors` only answers `None` when at least one
+    /// drained item is `LazyElem::Owned` rather than `LazyElem::Cursor`.
+    /// `map(.x)` over `[{x: "\ud800"}, null]` produces exactly that mix:
+    /// `Expr::Field` on the object element stays a lazy `OneCursor` (into
+    /// `LazyElem::Cursor`), while `Expr::Field` on `null` returns
+    /// `GenericResult::Owned(Null)` (jq's "field access on null is null"
+    /// rule, into `LazyElem::Owned`) without ever decoding anything --
+    /// forcing the fallback to run and discover the first element's decode
+    /// failure (a lone UTF-16 surrogate, same invalid-escape shape used
+    /// throughout this file's JSON-side #1247 tests) only once it actually
+    /// materializes.
+    #[test]
+    fn test_stream_yaml_lazyseq_fallback_reports_decode_failure_1247() {
+        use crate::yaml::YamlIndex;
+
+        let yaml: &[u8] = br#"[{x: "\ud800"}, null]"#;
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index
+            .root(yaml)
+            .first_child()
+            .expect("YAML document should have content");
+        let result = eval_with_cursor(&crate::jq::parse("map(.x)").unwrap(), cursor);
+        assert!(matches!(result, GenericResult::LazySeq(_)));
+
+        let mut out = String::new();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, "");
+        assert!(stats.error.is_some());
+    }
+
+    /// `fold_pipe_stages`'s `GenericResult::Many(vs)` arm re-evaluates the
+    /// next pipe stage per element with the ambient cursor forced to `None`
+    /// (`vs: Vec<V>` carries no cursor for its elements) -- so the *next*
+    /// stage's own result can itself be a bare `One`/`Many`/`ManyCursor`,
+    /// covering every nested-decode-failure arm this loop has. All four
+    /// cases below start from `select(true,true)` (bare `Many` of two copies
+    /// of the current value, via the cursor-less `eval()`) piped into a
+    /// second stage chosen so that stage's *own* evaluation (with the forced
+    /// `None` cursor) lands in a specific `GenericResult` shape:
+    /// - `.` (`Expr::Identity`) with `None` cursor => bare `One`.
+    /// - `.x` (`Expr::Field`) ignores the ambient cursor entirely, deriving
+    ///   its own fresh cursor from the object structurally => `OneCursor`.
+    /// - `select(true,true)` again (nested) => bare `Many`.
+    /// - `.[]` (`Expr::Iterate`) also ignores the ambient cursor => `ManyCursor`.
+    #[test]
+    fn test_fold_pipe_stages_many_arm_nested_shapes_decode_failure_1247() {
+        // `.` => bare `One`, decoding *successfully* -- the `Ok` side of
+        // the same match arm the failing case right below exercises the
+        // `Err` side of. Both copies `select(true,true)` produces are the
+        // same decodable value, so this must collect both rather than
+        // erroring.
+        let json: &[u8] = b"\"hello\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true) | .").unwrap(), value);
+        assert_eq!(
+            result.into_owned().unwrap().unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("hello".to_string()),
+                OwnedValue::String("hello".to_string()),
+            ])
+        );
+
+        // `.` => bare `One`.
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true) | .").unwrap(), value);
+        assert!(result.is_error(), "{result:?}");
+
+        // `.x` => `OneCursor`.
+        let json: &[u8] = b"{\"x\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true) | .x").unwrap(), value);
+        assert!(result.is_error(), "{result:?}");
+
+        // Nested `select(true,true)` => bare `Many`.
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(
+            &crate::jq::parse("select(true,true) | select(true,true)").unwrap(),
+            value,
+        );
+        assert!(result.is_error(), "{result:?}");
+
+        // `.[]` => `ManyCursor`.
+        let json: &[u8] = b"[\"\xff\xfe\"]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let result = eval(&crate::jq::parse("select(true,true) | .[]").unwrap(), value);
+        assert!(result.is_error(), "{result:?}");
+    }
+
+    /// `fold_lazy_keys_stage`'s catch-all `_` arm (#1565) materializes every
+    /// key via `materialize_lazy_keys` for any following stage that isn't
+    /// one of the dedicated fast-path arms (`first`/`last`/`.[n]`/a leading
+    /// `map`, all guarded `!sorted`) -- `keys` (sorted) always falls here
+    /// regardless of what follows, since every one of those fast-path
+    /// guards is `if !sorted`. Not `keys | length`: `Builtin::Length` has
+    /// its own dedicated arm *without* a `!sorted` guard
+    /// (`effective_len`, #1514), which counts distinct keys without
+    /// decoding any of them and so never reaches this catch-all at all --
+    /// confirmed live (an earlier draft of this test used `length` and
+    /// failed to observe the decode error for exactly this reason). `.[0]`
+    /// does reach it: its own dedicated fast-path arm is guarded `!sorted`
+    /// too, so with `keys` (sorted) it falls through the same as any other
+    /// non-`length` stage. CLI-reachable: `sjq 'keys | .[0]'`.
+    #[test]
+    fn test_fold_lazy_keys_stage_catchall_decode_failure_1247() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys | .[0]").unwrap(), cursor);
+        assert!(result.is_error(), "{result:?}");
+    }
+
+    /// `each_lazy_keys_iterate_sink`'s sorted branch (#1599) decodes and
+    /// sorts every key via `effective_keys` before iterating -- reached by
+    /// `keys | .[]` (the demand-driven `Expr::Iterate` fan-out over a lazy
+    /// keys result) over a document with an undecodable key.
+    /// CLI-reachable: `sjq 'keys | .[]'`.
+    #[test]
+    fn test_each_lazy_keys_iterate_sink_sorted_decode_failure_1247() {
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys | .[]").unwrap(), cursor);
+        assert!(result.is_error(), "{result:?}");
+    }
+
+    /// `eval_index_expr`'s "key outer, target inner" loop takes its
+    /// `OneCursor`/`to_owned_cursor` conversion branch once at least one
+    /// earlier key/target pair has already materialized into `owned` (`any_owned`)
+    /// -- reached by `.[("z","a")]` where `"z"` is missing (materializes as
+    /// `Owned(Null)`, setting `any_owned`) and `"a"` exists with an
+    /// undecodable value (`OneCursor`, now hitting the `any_owned` branch's
+    /// `to_owned_cursor` call). The already-materialized prefix (`[null]`)
+    /// must survive as `Partial`, not vanish, matching #400/#494. This is
+    /// CLI-reachable: `sjq '.[("z","a")]'`.
+    #[test]
+    fn test_eval_index_expr_any_owned_cursor_conversion_decode_failure_1247() {
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse(r#".[("z","a")]"#).unwrap(), cursor);
+        match result {
+            GenericResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Null]);
+                assert!(e.message.contains("invalid UTF-8"), "{e:?}");
+            }
+            other => panic!("expected Partial([null], Error(..)), got {other:?}"),
+        }
+    }
+
+    /// `Builtin::ToEntries`'s object branch drops a field whose key doesn't
+    /// decode to a string at all via `field.key_str()` -- not #1247's own
+    /// undecodable-*content* check just above it (`string_decode_error`,
+    /// which only fires for a string-*shaped* span), but the older, still-
+    /// open #1194-class gap for a key that isn't string-shaped in the first
+    /// place. `{123: 1, "b": 2}` isn't valid JSON (jq itself would reject
+    /// it), but this crate's lenient semi-index still represents it
+    /// structurally -- `DocumentFields::uncons` hands back a field whose
+    /// `.key` is `StandardJson::Number`, `key_str()`'s default `as_str()`
+    /// answers `None` for it, and the field is silently skipped rather than
+    /// erroring. This is a known, pre-existing gap outside this coverage
+    /// pass's scope (the fallible-conversion logic itself is not to be
+    /// touched here) -- documented as current behavior, not asserted as
+    /// correct.
+    #[test]
+    fn test_to_entries_silently_drops_non_string_key_known_gap_1247() {
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("to_entries").unwrap(), cursor);
+        let entries = result.into_owned().unwrap().unwrap();
+        let OwnedValue::Array(entries) = entries else {
+            panic!("expected an array, got {entries:?}");
+        };
+        assert_eq!(
+            entries.len(),
+            1,
+            "the malformed `123` key is dropped: {entries:?}"
+        );
+        let OwnedValue::Object(entry) = &entries[0] else {
+            panic!("expected an object entry, got {:?}", entries[0]);
+        };
+        assert_eq!(entry.get("key"), Some(&OwnedValue::String("b".to_string())));
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -757,12 +757,14 @@ fn materialize_lazy_keys<V: DocumentValue>(
     fields: &V::Fields,
     sorted: bool,
     collapse: bool,
-) -> OwnedValue {
-    let mut keys = effective_keys(fields, collapse);
+) -> Result<OwnedValue, EvalError> {
+    let mut keys = effective_keys(fields, collapse)?;
     if sorted {
         keys.sort();
     }
-    OwnedValue::Array(keys.into_iter().map(OwnedValue::String).collect())
+    Ok(OwnedValue::Array(
+        keys.into_iter().map(OwnedValue::String).collect(),
+    ))
 }
 
 /// An object's key cursors in document order, with a repeated key dropped
@@ -1149,9 +1151,9 @@ fn into_lazy_items<V: DocumentValue>(
             fields,
             sorted,
             collapse,
-        } => Ok(vec![LazyElem::Owned(materialize_lazy_keys::<V>(
-            &fields, sorted, collapse,
-        ))]),
+        } => Ok(vec![LazyElem::Owned(
+            materialize_lazy_keys::<V>(&fields, sorted, collapse).map_err(Control::Error)?,
+        )]),
         GenericResult::LazyIndexRange(len) => {
             Ok(vec![LazyElem::Owned(materialize_lazy_index_range(len))])
         }
@@ -1938,7 +1940,10 @@ impl<V: DocumentValue> GenericResult<V> {
                 fields,
                 sorted,
                 collapse,
-            } => Self::Owned(materialize_lazy_keys::<V>(&fields, sorted, collapse)),
+            } => match materialize_lazy_keys::<V>(&fields, sorted, collapse) {
+                Ok(owned) => Self::Owned(owned),
+                Err(e) => Self::Error(e),
+            },
             Self::LazyIndexRange(len) => Self::Owned(materialize_lazy_index_range(len)),
             Self::LazySeq(seq) => match seq.materialize_atomic() {
                 Ok(owned) => Self::Owned(owned),
@@ -2090,7 +2095,12 @@ impl<V: DocumentValue> GenericResult<V> {
                     // Fallback: materialize+sort. Sorting requires seeing
                     // every key first, so this can't stream lazily like the
                     // unsorted case below.
-                    let owned = materialize_lazy_keys::<V>(fields, true, *collapse);
+                    let Some(owned) = owned_or_stream_error(
+                        materialize_lazy_keys::<V>(fields, true, *collapse),
+                        &mut stats,
+                    ) else {
+                        return Ok(stats);
+                    };
                     owned.stream_json(out, indent, sort_keys)?;
                 } else {
                     // Genuinely lazy (#685): each key is pulled from
@@ -2323,7 +2333,12 @@ impl<V: DocumentValue> GenericResult<V> {
                 if *sorted {
                     // Fallback: materialize+sort. See `stream_json`'s
                     // `LazyKeys` arm above — same reasoning.
-                    let owned = materialize_lazy_keys::<V>(fields, true, *collapse);
+                    let Some(owned) = owned_or_stream_error(
+                        materialize_lazy_keys::<V>(fields, true, *collapse),
+                        &mut stats,
+                    ) else {
+                        return Ok(stats);
+                    };
                     owned.stream_yaml(out, indent, sort_keys)?;
                 } else {
                     // Genuinely lazy (#685): see `stream_json`'s
@@ -3070,11 +3085,10 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         ),
         // No probe: `materialize_lazy_keys` applies the
         // collapse rule itself, through `effective_keys`.
-        _ => eval_on_owned::<S, _>(
-            expr,
-            materialize_lazy_keys::<V>(&fields, sorted, collapse),
-            optional,
-        ),
+        _ => match materialize_lazy_keys::<V>(&fields, sorted, collapse) {
+            Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
+            Err(e) => GenericResult::Error(e),
+        },
     }
 }
 
@@ -3390,7 +3404,10 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
         );
     }
 
-    let mut keys = effective_keys(fields, collapse);
+    let mut keys = match effective_keys(fields, collapse) {
+        Ok(keys) => keys,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
     keys.sort();
     drive_pipe_elements_generic::<S, V>(
         keys.into_iter()
@@ -4740,7 +4757,15 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             match index_one_generic::<V>(t.clone(), k, optional) {
                 GenericResult::OneCursor(c) => {
                     if any_owned {
-                        owned.push(owned_or_err!(to_owned_cursor(&c)));
+                        // Not `owned_or_err!`: that bare-returns and would
+                        // discard every key/target pair already resolved
+                        // into `owned` ahead of this one. The already-indexed
+                        // prefix must survive as `Partial`, same as the
+                        // `GenericResult::Error` arm below.
+                        match to_owned_cursor(&c) {
+                            Ok(v) => owned.push(v),
+                            Err(e) => return partial_generic(owned, Control::Error(e)),
+                        }
                     } else {
                         cursors.push(c);
                     }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -1420,4 +1420,109 @@ mod tests {
             "write_json/to_json_string should panic at MAX_VALUE_TREE_DEPTH (Object arm)"
         );
     }
+
+    /// #684/#1247: `lazy_keys_array_to_owned` is `LazyKeysArray`'s own
+    /// materializer -- the escape hatch `materialize`/`into_owned` reach for
+    /// `sort_keys`/color output/etc. Exercise it directly, both outcomes: a
+    /// clean object hits the `Ok(OwnedValue::Array(keys))` return, and an
+    /// object with an undecodable key hits the `Err` raised out of the
+    /// `DistinctKeyCursors` walk instead of the field silently vanishing.
+    #[test]
+    fn test_lazy_keys_array_to_owned_ok_and_err_1247() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = br#"{"b":1,"a":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        assert_eq!(
+            lazy_keys_array_to_owned(&fields, true).unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::String("b".to_string()),
+                OwnedValue::String("a".to_string()),
+            ])
+        );
+
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let err = lazy_keys_array_to_owned(&fields, true)
+            .expect_err("an undecodable key must not materialize");
+        assert!(err.message.contains("in object key"), "{}", err.message);
+    }
+
+    /// #1247: the same `LazyKeysArray` arms as above, reached this time
+    /// through `materialize`/`into_owned`'s recursive `Array`/`Object` cases
+    /// at depth > 0 -- e.g. `[keys_unsorted]`/`{x: keys_unsorted}` forced to
+    /// materialize by `--sort-keys`/`-C` at the CLI boundary
+    /// (`write_output_jq_value`'s "complex output" branch in
+    /// `jq_runner.rs`), rather than `lazy_keys_array_to_owned` being called
+    /// on a bare top-level `keys_unsorted` result.
+    #[test]
+    fn test_lazy_keys_array_nested_materialize_and_into_owned_1247() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let lazy_keys: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+            fields,
+            collapse: true,
+        };
+
+        let nested_in_array = JqValue::Array(vec![lazy_keys.clone()]);
+        let err = nested_in_array
+            .materialize()
+            .expect_err("a nested undecodable key must not materialize");
+        assert!(err.message.contains("in object key"), "{}", err.message);
+
+        let nested_in_object: JqValue<'_, Vec<u64>> =
+            JqValue::Object(IndexMap::from([("x".to_string(), lazy_keys)]));
+        let err = nested_in_object
+            .into_owned()
+            .expect_err("a nested undecodable key must not materialize");
+        assert!(err.message.contains("in object key"), "{}", err.message);
+    }
+
+    /// #1194: sibling of `jq_runner.rs`'s `standard_json_to_jq_value` and its
+    /// own `test_standard_json_to_jq_value_raises_on_malformed_top_level_value_1194`
+    /// -- a bareword garbage token (`StandardJson::Error`, not a decode
+    /// failure) raises through `cursor_to_owned_at_depth`'s own `Error` arm
+    /// too, reached whenever `materialize`/`into_owned` walks a cursor whose
+    /// value is structurally malformed (e.g. `--sort-keys`/`-C` forcing a
+    /// full materialize of a query result that otherwise streams straight
+    /// from a cursor over raw document bytes).
+    #[test]
+    fn test_materialize_and_into_owned_error_on_malformed_top_level_value_1194() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"xyz123";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val = JqValue::from_cursor(cursor);
+        let err = val
+            .materialize()
+            .expect_err("a bareword is not a JSON value");
+        assert!(!err.message.is_empty(), "{err:?}");
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        let err = val
+            .into_owned()
+            .expect_err("a bareword is not a JSON value");
+        assert!(!err.message.is_empty(), "{err:?}");
+    }
 }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -15,6 +15,8 @@ use alloc::borrow::Cow;
 #[cfg(not(test))]
 use alloc::boxed::Box;
 #[cfg(not(test))]
+use alloc::format;
+#[cfg(not(test))]
 use alloc::string::{String, ToString};
 #[cfg(not(test))]
 use alloc::vec::Vec;
@@ -26,7 +28,7 @@ use std::borrow::Cow;
 use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{effective_len, DistinctKeyCursors};
-
+use super::error::EvalError;
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
 use super::value::{assert_value_tree_depth, infinite_float_preview_text, OwnedValue};
@@ -422,16 +424,19 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     ///
     /// This recursively materializes all nested values. Use sparingly -
     /// prefer keeping values as cursors when possible.
-    pub fn materialize(&self) -> OwnedValue {
+    /// `Err` when a string scalar in the tree cannot be decoded (#1247) --
+    /// it used to materialize as an empty string, silently replacing the
+    /// value with something that compares, sorts and prints as real data.
+    pub fn materialize(&self) -> Result<OwnedValue, EvalError> {
         self.materialize_at_depth(0)
     }
 
     /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
     /// levels of nesting (#1021, following #1005's precedent).
-    fn materialize_at_depth(&self, depth: usize) -> OwnedValue {
+    fn materialize_at_depth(&self, depth: usize) -> Result<OwnedValue, EvalError> {
         assert_value_tree_depth(depth);
-        match self {
-            JqValue::Cursor(c) => cursor_to_owned(c),
+        Ok(match self {
+            JqValue::Cursor(c) => cursor_to_owned(c)?,
             JqValue::Null => OwnedValue::Null,
             JqValue::Bool(b) => OwnedValue::Bool(*b),
             JqValue::Int(n) => OwnedValue::Int(*n),
@@ -442,33 +447,34 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Array(arr) => OwnedValue::Array(
                 arr.iter()
                     .map(|v| v.materialize_at_depth(depth + 1))
-                    .collect(),
+                    .collect::<Result<_, _>>()?,
             ),
             JqValue::Object(obj) => OwnedValue::Object(
                 obj.iter()
-                    .map(|(k, v)| (k.clone(), v.materialize_at_depth(depth + 1)))
-                    .collect(),
+                    .map(|(k, v)| Ok((k.clone(), v.materialize_at_depth(depth + 1)?)))
+                    .collect::<Result<_, EvalError>>()?,
             ),
             JqValue::LazyKeysArray { fields, collapse } => {
-                lazy_keys_array_to_owned(fields, *collapse)
+                lazy_keys_array_to_owned(fields, *collapse)?
             }
             JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(*len),
-        }
+        })
     }
 
     /// Convert to OwnedValue, consuming self.
     ///
     /// More efficient than `materialize()` when you don't need to keep the original.
-    pub fn into_owned(self) -> OwnedValue {
+    /// `Err` for the same reason [`materialize`](Self::materialize) does.
+    pub fn into_owned(self) -> Result<OwnedValue, EvalError> {
         self.into_owned_at_depth(0)
     }
 
     /// Panics past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
     /// levels of nesting (#1021, following #1005's precedent).
-    fn into_owned_at_depth(self, depth: usize) -> OwnedValue {
+    fn into_owned_at_depth(self, depth: usize) -> Result<OwnedValue, EvalError> {
         assert_value_tree_depth(depth);
-        match self {
-            JqValue::Cursor(c) => cursor_to_owned(&c),
+        Ok(match self {
+            JqValue::Cursor(c) => cursor_to_owned(&c)?,
             JqValue::Null => OwnedValue::Null,
             JqValue::Bool(b) => OwnedValue::Bool(b),
             JqValue::Int(n) => OwnedValue::Int(n),
@@ -479,18 +485,18 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::Array(arr) => OwnedValue::Array(
                 arr.into_iter()
                     .map(|v| v.into_owned_at_depth(depth + 1))
-                    .collect(),
+                    .collect::<Result<_, _>>()?,
             ),
             JqValue::Object(obj) => OwnedValue::Object(
                 obj.into_iter()
-                    .map(|(k, v)| (k, v.into_owned_at_depth(depth + 1)))
-                    .collect(),
+                    .map(|(k, v)| Ok((k, v.into_owned_at_depth(depth + 1)?)))
+                    .collect::<Result<_, EvalError>>()?,
             ),
             JqValue::LazyKeysArray { fields, collapse } => {
-                lazy_keys_array_to_owned(&fields, collapse)
+                lazy_keys_array_to_owned(&fields, collapse)?
             }
             JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(len),
-        }
+        })
     }
 
     // =========================================================================
@@ -538,8 +544,14 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
                     out.write_str(s)
                 } else {
-                    // Fallback: materialize and serialize
-                    let owned = cursor_to_owned(c);
+                    // Fallback: materialize and serialize. `write_json` has
+                    // only `core::fmt::Error` to report with, which carries
+                    // no message -- but this branch is unreachable for a
+                    // decode failure anyway: it needs a cursor with no raw
+                    // byte span, and every JSON string token has one. The
+                    // `?` is here so a future shape that *can* fail cannot
+                    // silently print a wrong value (#1247).
+                    let owned = cursor_to_owned(c).map_err(|_| core::fmt::Error)?;
                     out.write_str(&owned.to_json())
                 }
             }
@@ -669,16 +681,19 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
 fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
     fields: &crate::json::light::JsonFields<'_, W>,
     collapse: bool,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     let mut keys = Vec::new();
     for (key, _) in DistinctKeyCursors::new(fields, collapse) {
         if let StandardJson::String(k) = key {
-            if let Ok(s) = k.as_str() {
-                keys.push(OwnedValue::String(s.into_owned()));
-            }
+            // An undecodable key used to vanish from `keys` entirely, so the
+            // array silently came back short (#1247).
+            let s = k
+                .as_str()
+                .map_err(|e| EvalError::new(format!("{e} in object key")))?;
+            keys.push(OwnedValue::String(s.into_owned()));
         }
     }
-    OwnedValue::Array(keys)
+    Ok(OwnedValue::Array(keys))
 }
 
 /// Materialize a `JqValue::LazyIndexRange` into the `[0, 1, ..., len-1]`
@@ -700,54 +715,61 @@ fn lazy_index_range_to_owned(len: usize) -> OwnedValue {
 /// reaching this function directly. Confirmed live: `succinctly jq -e
 /// '.[0]'` on a 200,000-level-deep document raw-stack-overflowed (SIGABRT)
 /// even after `to_owned_cursor`'s own guard existed.
-fn cursor_to_owned<W: Clone + AsRef<[u64]>>(cursor: &JsonCursor<'_, W>) -> OwnedValue {
+fn cursor_to_owned<W: Clone + AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+) -> Result<OwnedValue, EvalError> {
     cursor_to_owned_at_depth(cursor, 0)
 }
 
 fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     super::eval_generic::assert_nesting_depth(depth);
-    match cursor.value() {
+    Ok(match cursor.value() {
         StandardJson::Null => OwnedValue::Null,
         StandardJson::Bool(b) => OwnedValue::Bool(b),
         StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
-        StandardJson::String(s) => {
-            // `.ok()`, not a `panic!` on `Err`: see `to_owned_at_depth`'s
-            // sibling `else` arm doc comment in eval_generic.rs (#1098) for
-            // why a stricter fix here was attempted and reverted.
-            if let Ok(cow) = s.as_str() {
-                OwnedValue::String(cow.into_owned())
-            } else {
-                OwnedValue::String(String::new())
-            }
-        }
+        StandardJson::String(s) => OwnedValue::String(
+            // Was an empty string, which silently replaced the real value
+            // (#1098, #1247) -- the sibling `to_owned_at_depth` in
+            // eval_generic.rs swallowed the same case as `null`. Both raise
+            // now, with the wording #1192 established.
+            s.as_str()
+                .map_err(|e| EvalError::new(format!("{e}")))?
+                .into_owned(),
+        ),
         StandardJson::Array(_) => {
             // Use cursor navigation to iterate children
             let items: Vec<OwnedValue> = cursor
                 .children()
                 .map(|child| cursor_to_owned_at_depth(&child, depth + 1))
-                .collect();
+                .collect::<Result<_, _>>()?;
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
             for field in fields {
+                // A key that isn't a `String` token at all is *structurally*
+                // malformed and still drops the field silently -- #1194's
+                // territory, unchanged here. A key that is a string but
+                // won't decode used to drop the field just as quietly; that
+                // half raises now (#1247).
                 if let StandardJson::String(key_str) = field.key() {
-                    if let Ok(cow) = key_str.as_str() {
-                        let value_cursor = field.value_cursor();
-                        map.insert(
-                            cow.into_owned(),
-                            cursor_to_owned_at_depth(&value_cursor, depth + 1),
-                        );
-                    }
+                    let cow = key_str
+                        .as_str()
+                        .map_err(|e| EvalError::new(format!("{e} in object key")))?;
+                    let value_cursor = field.value_cursor();
+                    map.insert(
+                        cow.into_owned(),
+                        cursor_to_owned_at_depth(&value_cursor, depth + 1)?,
+                    );
                 }
             }
             OwnedValue::Object(map)
         }
         StandardJson::Error(_) => OwnedValue::Null,
-    }
+    })
 }
 
 // ============================================================================
@@ -884,7 +906,7 @@ mod tests {
             JqValue::null(),
         ]);
 
-        let owned = arr.materialize();
+        let owned = arr.materialize().unwrap();
         match owned {
             OwnedValue::Array(items) => {
                 assert_eq!(items.len(), 3);
@@ -918,28 +940,55 @@ mod tests {
         assert_eq!(val.as_f64(), Some(1.5));
     }
 
-    /// #1098: sibling of `eval_generic::to_owned`'s own regression test --
-    /// `JsonIndex::build`'s semi-index scan finds string quote/escape
-    /// boundaries without decoding/validating what's between them, so
-    /// invalid UTF-8 inside a string span indexes fine and only degrades,
-    /// here to an empty string, once `materialize`/`into_owned` reaches
-    /// `JsonString::as_str()`. Pins the known, deliberate gap -- see
-    /// `cursor_to_owned_at_depth`'s own `String` arm doc comment for why a
-    /// stricter (panic) fix was attempted and reverted.
+    /// #1098/#1247: sibling of `eval_generic::to_owned`'s own regression
+    /// test -- `JsonIndex::build`'s semi-index scan finds string
+    /// quote/escape boundaries without decoding/validating what's between
+    /// them, so invalid UTF-8 inside a string span indexes fine and only
+    /// surfaces once `materialize`/`into_owned` reaches
+    /// `JsonString::as_str()`.
+    ///
+    /// This test used to assert the *degrade* -- an empty string, which is
+    /// worse than the `null` its `eval_generic` sibling produced, because
+    /// `""` is a perfectly ordinary value that compares, sorts and prints
+    /// as real data. #1247 made both raise instead.
     #[test]
-    fn test_materialize_degrades_to_empty_string_on_decode_failure_1098() {
+    fn test_materialize_errors_on_decode_failure_1247() {
         use crate::json::JsonIndex;
 
         let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let val = JqValue::from_cursor(cursor);
-        assert_eq!(
-            val.materialize(),
-            OwnedValue::Object(IndexMap::from([(
-                "a".to_string(),
-                OwnedValue::String(String::new())
-            )]))
+        let err = val
+            .materialize()
+            .expect_err("an undecodable string must not materialize");
+        assert!(
+            err.message.contains("invalid UTF-8"),
+            "message: {}",
+            err.message
+        );
+        // `into_owned` is a separate walk of the same tree; it must agree.
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
+        assert!(val.into_owned().is_err());
+    }
+
+    /// #1247: an undecodable *key* used to drop its whole field silently,
+    /// so the object simply came back smaller.
+    #[test]
+    fn test_materialize_errors_on_object_key_decode_failure_1247() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{\"\xff\xfe\": 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val = JqValue::from_cursor(cursor);
+        let err = val
+            .materialize()
+            .expect_err("an undecodable key must not materialize");
+        assert!(
+            err.message.contains("in object key"),
+            "message: {}",
+            err.message
         );
     }
 
@@ -1021,7 +1070,7 @@ mod tests {
     fn test_jqvalue_array_into_owned() {
         let arr: JqValue<'_, Vec<u64>> = JqValue::Array(vec![JqValue::Int(1), JqValue::Int(2)]);
         assert_eq!(
-            arr.into_owned(),
+            arr.into_owned().unwrap(),
             OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)])
         );
     }
@@ -1044,10 +1093,10 @@ mod tests {
         // `format_number_jq_compat`) -- so both give jq's spelling.
         let via_materialize: JqValue<'_, Vec<u64>> = JqValue::from_owned(owned.clone());
         assert!(matches!(via_materialize, JqValue::NumberLiteral(_)));
-        assert_eq!(via_materialize.materialize().to_json(), "1E+100");
+        assert_eq!(via_materialize.materialize().unwrap().to_json(), "1E+100");
 
         let via_into_owned: JqValue<'_, Vec<u64>> = JqValue::from_owned(owned.clone());
-        assert_eq!(via_into_owned.into_owned().to_json(), "1E+100");
+        assert_eq!(via_into_owned.into_owned().unwrap().to_json(), "1E+100");
 
         // `write_json`/`to_json_string`, by contrast, is this module's
         // documented format-*preserving* serializer (see the module doc and
@@ -1085,13 +1134,13 @@ mod tests {
     #[test]
     fn test_jqvalue_raw_number_into_owned() {
         let raw: JqValue<'_, Vec<u64>> = JqValue::RawNumber(b"4e4");
-        assert_eq!(raw.into_owned().to_json(), "4E+4");
+        assert_eq!(raw.into_owned().unwrap().to_json(), "4E+4");
     }
 
     #[test]
     fn test_jqvalue_raw_number_materialize() {
         let raw: JqValue<'_, Vec<u64>> = JqValue::RawNumber(b"4e4");
-        assert_eq!(raw.materialize().to_json(), "4E+4");
+        assert_eq!(raw.materialize().unwrap().to_json(), "4E+4");
     }
 
     #[test]
@@ -1108,11 +1157,11 @@ mod tests {
     #[test]
     fn test_jqvalue_lazy_index_range_materialize_and_into_owned() {
         let empty: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(0);
-        assert_eq!(empty.materialize(), OwnedValue::Array(vec![]));
+        assert_eq!(empty.materialize().unwrap(), OwnedValue::Array(vec![]));
 
         let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
         assert_eq!(
-            three.materialize(),
+            three.materialize().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(1),
@@ -1122,7 +1171,7 @@ mod tests {
 
         let three: JqValue<'_, Vec<u64>> = JqValue::LazyIndexRange(3);
         assert_eq!(
-            three.into_owned(),
+            three.into_owned().unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(0),
                 OwnedValue::Int(1),
@@ -1154,12 +1203,12 @@ mod tests {
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let materialize_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
-        assert_eq!(materialize_val.materialize().to_json(), "1E+100");
+        assert_eq!(materialize_val.materialize().unwrap().to_json(), "1E+100");
 
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let into_owned_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
-        assert_eq!(into_owned_val.into_owned().to_json(), "1E+100");
+        assert_eq!(into_owned_val.into_owned().unwrap().to_json(), "1E+100");
     }
 
     /// Sibling of the number test above, for `cursor_to_owned_at_depth`'s
@@ -1176,7 +1225,7 @@ mod tests {
         let cursor = index.root(json);
         let materialize_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
         assert_eq!(
-            materialize_val.materialize(),
+            materialize_val.materialize().unwrap(),
             OwnedValue::String("hello".to_string())
         );
 
@@ -1184,7 +1233,7 @@ mod tests {
         let cursor = index.root(json);
         let into_owned_val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
         assert_eq!(
-            into_owned_val.into_owned(),
+            into_owned_val.into_owned().unwrap(),
             OwnedValue::String("hello".to_string())
         );
     }
@@ -1210,7 +1259,7 @@ mod tests {
         use crate::jq::value::MAX_VALUE_TREE_DEPTH;
 
         let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
-        assert!(matches!(under.materialize(), OwnedValue::Array(_)));
+        assert!(matches!(under.materialize().unwrap(), OwnedValue::Array(_)));
 
         // The `Object` arm is a separate match arm from `Array`'s, with its
         // own recursive `.map()` closure -- exercise it too so both arms are
@@ -1220,10 +1269,14 @@ mod tests {
             "a".to_string(),
             JqValue::Array(vec![JqValue::Null]),
         )]));
-        assert!(matches!(nested_object.materialize(), OwnedValue::Object(_)));
+        assert!(matches!(
+            nested_object.materialize().unwrap(),
+            OwnedValue::Object(_)
+        ));
 
         let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.materialize()));
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.materialize().unwrap()));
         assert!(
             result.is_err(),
             "materialize should panic at MAX_VALUE_TREE_DEPTH"
@@ -1237,7 +1290,7 @@ mod tests {
         use crate::jq::value::MAX_VALUE_TREE_DEPTH;
 
         let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
-        assert!(matches!(under.into_owned(), OwnedValue::Array(_)));
+        assert!(matches!(under.into_owned().unwrap(), OwnedValue::Array(_)));
 
         // Exercise the `Object` arm too -- see `materialize`'s sibling test
         // above for why.
@@ -1245,10 +1298,14 @@ mod tests {
             "a".to_string(),
             JqValue::Array(vec![JqValue::Null]),
         )]));
-        assert!(matches!(nested_object.into_owned(), OwnedValue::Object(_)));
+        assert!(matches!(
+            nested_object.into_owned().unwrap(),
+            OwnedValue::Object(_)
+        ));
 
         let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.into_owned()));
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over.into_owned().unwrap()));
         assert!(
             result.is_err(),
             "into_owned should panic at MAX_VALUE_TREE_DEPTH"

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -768,7 +768,10 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             }
             OwnedValue::Object(map)
         }
-        StandardJson::Error(_) => OwnedValue::Null,
+        // See `eval_generic::to_owned_at_depth`'s own `is_error` arm
+        // (#1194/#1247): a structurally malformed value raises rather than
+        // becoming `null`.
+        StandardJson::Error(msg) => return Err(EvalError::new(msg.to_string())),
     })
 }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1728,7 +1728,7 @@ impl JsonError {
     ///
     /// Split out of [`Display`](core::fmt::Display) (which now defers to it)
     /// so a caller that needs the text without allocating -- notably
-    /// [`DocumentValue::string_decode_error`](crate::jq::document::DocumentValue::string_decode_error),
+    /// [`DocumentValue::string_decode_error`],
     /// which runs on a `no_std`-compatible path -- shares one definition with
     /// the formatter rather than restating the four strings next to it.
     #[must_use]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1723,14 +1723,28 @@ pub enum JsonError {
     InvalidUnicodeEscape,
 }
 
+impl JsonError {
+    /// The human-readable reason, as a `&'static str`.
+    ///
+    /// Split out of [`Display`](core::fmt::Display) (which now defers to it)
+    /// so a caller that needs the text without allocating -- notably
+    /// [`DocumentValue::string_decode_error`](crate::jq::document::DocumentValue::string_decode_error),
+    /// which runs on a `no_std`-compatible path -- shares one definition with
+    /// the formatter rather than restating the four strings next to it.
+    #[must_use]
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::InvalidUtf8 => "invalid UTF-8 in string",
+            Self::InvalidNumber => "invalid number format",
+            Self::InvalidEscape => "invalid escape sequence in string",
+            Self::InvalidUnicodeEscape => "invalid unicode escape sequence",
+        }
+    }
+}
+
 impl core::fmt::Display for JsonError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
-            Self::InvalidNumber => write!(f, "invalid number format"),
-            Self::InvalidEscape => write!(f, "invalid escape sequence in string"),
-            Self::InvalidUnicodeEscape => write!(f, "invalid unicode escape sequence"),
-        }
+        f.write_str(self.message())
     }
 }
 
@@ -1974,6 +1988,13 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
                     Some(&raw[1..raw.len() - 1])
                 }
             }
+            _ => None,
+        }
+    }
+
+    fn string_decode_error(&self) -> Option<&'static str> {
+        match self {
+            StandardJson::String(s) => s.as_str().err().map(JsonError::message),
             _ => None,
         }
     }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1084,7 +1084,16 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let StandardJson::String(key) = field.key() {
-                if key.as_str().ok()? == name {
+                // An undecodable key (invalid UTF-8, an invalid escape, an
+                // invalid `\u` codepoint) is *skipped*, not treated as the
+                // end of the search. This `?` used to return from `find`
+                // itself, so a single such key hid every field after it from
+                // lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}` --
+                // while `keys`/`length`, which don't decode, still reported
+                // them (#1247). Surfacing the decode failure as a real
+                // `EvalError` is tracked separately; this only stops one bad
+                // key destroying valid results.
+                if key.as_str().is_ok_and(|k| k == name) {
                     result = Some(field.value());
                 }
             }
@@ -1103,7 +1112,8 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let StandardJson::String(key) = field.key() {
-                if key.as_str().ok()? == name {
+                // Same undecodable-key skip as `find` above (#1247).
+                if key.as_str().is_ok_and(|k| k == name) {
                     result = Some(field.value_cursor());
                 }
             }
@@ -2784,6 +2794,38 @@ mod tests {
                 }
             }
             _ => panic!("expected object"),
+        }
+    }
+
+    /// #1247: an object key that fails to decode must not end the field
+    /// search. `find`/`find_cursor` used to `?` out of the whole function on
+    /// the first undecodable key, so every *valid* field after it became
+    /// invisible to lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}`
+    /// even though `keys`/`length`, which never decode, still reported `b`.
+    #[test]
+    fn test_object_find_skips_undecodable_key_1247() {
+        // Both halves of "fails to decode": an unpaired surrogate escape and
+        // a raw invalid UTF-8 byte. Each is a structurally valid `String`
+        // token that `as_str()` rejects.
+        let cases: [&[u8]; 2] = [br#"{"\ud800": 1, "b": 2}"#, b"{\"\xff\": 1, \"b\": 2}"];
+        for json in cases {
+            let index = JsonIndex::build(json);
+            let root = index.root(json);
+
+            let StandardJson::Object(fields) = root.value() else {
+                panic!("expected object");
+            };
+            match fields.find("b") {
+                Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 2),
+                other => panic!("expected number 2, got {other:?}"),
+            }
+            let cursor = fields
+                .find_cursor("b")
+                .expect("find_cursor should reach b past an undecodable key");
+            match cursor.value() {
+                StandardJson::Number(n) => assert_eq!(n.as_i64().unwrap(), 2),
+                other => panic!("expected number 2, got {other:?}"),
+            }
         }
     }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -81,16 +81,29 @@ pub enum Utf8ErrorKind {
     TruncatedSequence,
 }
 
+impl Utf8ErrorKind {
+    /// The human-readable reason, as a `&'static str`.
+    ///
+    /// Split out of [`Display`](core::fmt::Display) (which now defers to it)
+    /// so a caller needing the text without allocating shares one definition
+    /// with the formatter -- same shape as `JsonError::message` and
+    /// `YamlStringError::message`.
+    #[must_use]
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::InvalidLeadByte => "invalid UTF-8 lead byte",
+            Self::InvalidContinuationByte => "invalid UTF-8 continuation byte",
+            Self::OverlongEncoding => "overlong UTF-8 encoding",
+            Self::SurrogateCodepoint => "surrogate code point in UTF-8",
+            Self::OutOfRangeCodepoint => "code point above U+10FFFF",
+            Self::TruncatedSequence => "truncated UTF-8 sequence",
+        }
+    }
+}
+
 impl core::fmt::Display for Utf8ErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidLeadByte => write!(f, "invalid UTF-8 lead byte"),
-            Self::InvalidContinuationByte => write!(f, "invalid UTF-8 continuation byte"),
-            Self::OverlongEncoding => write!(f, "overlong UTF-8 encoding"),
-            Self::SurrogateCodepoint => write!(f, "surrogate code point in UTF-8"),
-            Self::OutOfRangeCodepoint => write!(f, "code point above U+10FFFF"),
-            Self::TruncatedSequence => write!(f, "truncated UTF-8 sequence"),
-        }
+        f.write_str(self.message())
     }
 }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3281,7 +3281,30 @@ fn transcode_fold_line_break_to_json(bytes: &[u8], mut i: usize, output: &mut St
 ///
 /// Returns true if the string was written as a JSON string (quoted),
 /// false if it should be treated as a scalar for type detection.
+///
+/// **All-or-nothing on failure.** The transcoders push the opening `"` -- and
+/// whatever prefix they already converted -- into `output` before they can
+/// discover a bad escape, and every caller's `Err(_)` arm then appends its own
+/// `null`/`""` fallback after it. The two concatenated into JSON that no parser
+/// could read (`{"b": "xnull}` for a value, `{"a"": 1}` for a key, both at exit
+/// 0 -- #1247). Rewinding to the entry length here fixes every call site at
+/// once instead of asking each to remember; the value still degrades to the
+/// caller's fallback, it just no longer corrupts the document around it.
 fn write_yaml_string_to_json(
+    output: &mut String,
+    s: &YamlString<'_>,
+) -> Result<bool, YamlStringError> {
+    let mark = output.len();
+    let result = write_yaml_string_to_json_at(output, s);
+    if result.is_err() {
+        output.truncate(mark);
+    }
+    result
+}
+
+/// The body of [`write_yaml_string_to_json`], which owns the rollback. Never
+/// call this directly -- a partial write escaping it is the bug above.
+fn write_yaml_string_to_json_at(
     output: &mut String,
     s: &YamlString<'_>,
 ) -> Result<bool, YamlStringError> {
@@ -4013,7 +4036,14 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
                 let s = core::str::from_utf8(bytes).map_err(|_| YamlStringError::InvalidUtf8)?;
                 stream_json_string(out, s).map_err(|_| YamlStringError::InvalidUtf8)?;
             } else {
-                stream_transcode_double_quoted_to_json(out, bytes)?;
+                // `Out` cannot be rewound the way `write_yaml_string_to_json`'s
+                // `String` can, so transcode into a scratch buffer and commit
+                // only once it succeeds (#1247). Only this branch pays the
+                // allocation: the fast path above decodes before it writes.
+                let mut committed = String::new();
+                stream_transcode_double_quoted_to_json(&mut committed, bytes)?;
+                out.write_str(&committed)
+                    .map_err(|_| YamlStringError::InvalidUtf8)?;
             }
             Ok(true)
         }
@@ -4025,7 +4055,12 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
                 let s = core::str::from_utf8(bytes).map_err(|_| YamlStringError::InvalidUtf8)?;
                 stream_json_string(out, s).map_err(|_| YamlStringError::InvalidUtf8)?;
             } else {
-                stream_transcode_single_quoted_to_json(out, bytes)?;
+                // Same commit-on-success rollback as the double-quoted arm
+                // above (#1247).
+                let mut committed = String::new();
+                stream_transcode_single_quoted_to_json(&mut committed, bytes)?;
+                out.write_str(&committed)
+                    .map_err(|_| YamlStringError::InvalidUtf8)?;
             }
             Ok(true)
         }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -7707,6 +7707,52 @@ mod tests {
         let _ = z_cursor.tag();
     }
 
+    /// #1247 coverage: `YamlStringError::message()`'s `InvalidUtf8` arm and
+    /// `Display` (which now defers to `message()`) were never directly
+    /// exercised by any test — `InvalidEscape` reaches `.message()`
+    /// indirectly through other decode-failure paths, but nothing calls
+    /// `Display` at all. Mirrors `JsonError`'s own `test_json_error_display`
+    /// in `src/json/light.rs`, which covers its sibling type's variants via
+    /// `.to_string()` the same way.
+    #[test]
+    fn test_yaml_string_error_display() {
+        assert_eq!(
+            YamlStringError::InvalidUtf8.to_string(),
+            "invalid UTF-8 in string"
+        );
+        assert_eq!(
+            YamlStringError::InvalidEscape.to_string(),
+            "invalid escape sequence"
+        );
+    }
+
+    /// #1247 code review: `string_decode_error()`'s `Alias` arm resolves the
+    /// *whole* alias chain first (mirroring `as_str`'s own #1191 fix, per
+    /// the doc comment directly above the `Alias` arm), so a 2+-hop alias to
+    /// an undecodable string still reports the decode failure instead of
+    /// silently answering "not a decode failure" after only one hop. Never
+    /// exercised directly before — builds a 2-hop chain (`z` -> `a1` ->
+    /// `a0`) terminating in a double-quoted string with an invalid escape
+    /// sequence (`\q`, not one of the recognized single-char escapes), then
+    /// calls `string_decode_error()` on the still-unresolved `Alias` value.
+    #[test]
+    fn test_string_decode_error_resolves_alias_chain_1247() {
+        use crate::jq::document::DocumentValue;
+
+        let yaml = "a0: &a0 \"bad\\qescape\"\na1: &a1 *a0\nz: *a1\n";
+        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
+        let root = index.root(yaml.as_bytes());
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected root document to be a mapping");
+        };
+        let z = fields.find("z").expect("z field must exist");
+        assert!(
+            matches!(&z, YamlValue::Alias { .. }),
+            "expected z to still be an unresolved Alias value"
+        );
+        assert_eq!(z.string_decode_error(), Some("invalid escape sequence"));
+    }
+
     #[test]
     fn test_simple_mapping_navigation() {
         let yaml = b"name: Alice";

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -5224,12 +5224,25 @@ pub enum YamlStringError {
     InvalidEscape,
 }
 
+impl YamlStringError {
+    /// The human-readable reason, as a `&'static str`.
+    ///
+    /// Split out of [`Display`](core::fmt::Display) (which now defers to it)
+    /// for the same reason as [`JsonError::message`](crate::json::light::JsonError::message):
+    /// one definition shared with the formatter instead of the same strings
+    /// restated at an allocation-free call site.
+    #[must_use]
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::InvalidUtf8 => "invalid UTF-8 in string",
+            Self::InvalidEscape => "invalid escape sequence",
+        }
+    }
+}
+
 impl core::fmt::Display for YamlStringError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
-            Self::InvalidEscape => write!(f, "invalid escape sequence"),
-        }
+        f.write_str(self.message())
     }
 }
 
@@ -6391,6 +6404,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
                     .as_str()
                     .map(|cow| Cow::Owned(cow.into_owned()))
             }),
+            _ => None,
+        }
+    }
+
+    fn string_decode_error(&self) -> Option<&'static str> {
+        match self {
+            YamlValue::String(s) => s.as_str().err().map(YamlStringError::message),
+            // Resolve the whole chain first, exactly as `as_str` above does
+            // and for the same reason (#1191): a 2+-hop alias to a string is
+            // still a string, and answering from a single hop would report
+            // "not a decode failure" for a target that genuinely is one.
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.string_decode_error())
+            }
             _ => None,
         }
     }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -12851,7 +12851,10 @@ mod tests {
         let Some(YamlValue::Mapping(item)) = root.find("item") else {
             panic!("item must be a mapping");
         };
-        assert_eq!(item.keys(), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            item.keys().expect("decodable keys"),
+            vec!["a".to_string(), "b".to_string()]
+        );
         assert_eq!(item.len(), 2);
         assert!(!item.is_empty());
     }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -4300,7 +4300,12 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let YamlValue::String(key) = field.key() {
-                if key.as_str().ok()? == name {
+                // Same undecodable-key skip as `JsonFields::find` in
+                // `src/json/light.rs` -- see that function for the full
+                // rationale (#1247). A mapping key that fails to decode is
+                // skipped rather than ending the search, so it can no longer
+                // hide valid later fields from lookup.
+                if key.as_str().is_ok_and(|k| k == name) {
                     result = Some(field.value());
                 }
             }
@@ -4319,7 +4324,9 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
             if let YamlValue::String(key) = field.key() {
-                if key.as_str().ok()? == name {
+                // Same undecodable-key skip as `find` above (#1247); see
+                // `JsonFields::find` in `src/json/light.rs` for the rationale.
+                if key.as_str().is_ok_and(|k| k == name) {
                     result = Some(field.value_cursor());
                 }
             }
@@ -7726,6 +7733,36 @@ mod tests {
             }
         } else {
             panic!("expected mapping");
+        }
+    }
+
+    #[test]
+    fn test_mapping_find_skips_undecodable_key_1247() {
+        // A key carrying a dangling non-continuable UTF-8 byte is a
+        // structurally valid scalar that `as_str()` cannot decode. It used to
+        // `?` out of `find` entirely, hiding the *valid* `b: 2` after it, so
+        // `.b` answered `null` while `keys` still listed `b` (#1247).
+        let yaml = b"\"a\xe4b\": 1\nb: 2\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let root = index.root(yaml);
+
+        let YamlValue::Mapping(fields) = first_doc(root) else {
+            panic!("expected mapping");
+        };
+        // Deliberately not `{other:?}` in these panics: `YamlValue`'s `Debug`
+        // reaches the shared index and prints it whole.
+        if let Some(YamlValue::String(s)) = fields.find("b") {
+            assert_eq!(&*s.as_str().unwrap(), "2");
+        } else {
+            panic!("find should reach b past an undecodable key");
+        }
+        let cursor = fields
+            .find_cursor("b")
+            .expect("find_cursor should reach b past an undecodable key");
+        if let YamlValue::String(s) = cursor.value() {
+            assert_eq!(&*s.as_str().unwrap(), "2");
+        } else {
+            panic!("find_cursor should reach the string scalar \"2\"");
         }
     }
 

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -148,8 +148,17 @@ pub enum YamlValidationErrorKind {
         /// What was expected.
         expected: &'static str,
     },
-    /// Invalid UTF-8 sequence.
-    InvalidUtf8,
+    /// The document is not valid UTF-8 (#1242).
+    ///
+    /// Previously declared but never constructed: the scanner reads bytes
+    /// and never decodes them, so nothing here could detect an encoding
+    /// error. `validate` now runs an explicit UTF-8 pass before the grammar
+    /// walk and reports through this variant, carrying the specific reason
+    /// (`Utf8ErrorKind::message`) rather than one flat string.
+    InvalidUtf8 {
+        /// Which UTF-8 rule the byte broke.
+        reason: &'static str,
+    },
     /// Container nesting depth exceeded the limit.
     NestingTooDeep {
         /// The configured limit.
@@ -211,7 +220,7 @@ impl fmt::Display for YamlValidationErrorKind {
             Self::UnexpectedEof { expected } => {
                 write!(f, "unexpected end of input, expected {expected}")
             }
-            Self::InvalidUtf8 => write!(f, "invalid UTF-8 sequence"),
+            Self::InvalidUtf8 { reason } => write!(f, "{reason}"),
             Self::NestingTooDeep { limit } => {
                 write!(f, "nesting depth exceeds limit of {limit}")
             }
@@ -266,6 +275,23 @@ enum LineKind {
 /// assert!(validate(b"[ a, , b ]\n").is_err());
 /// ```
 pub fn validate(input: &[u8]) -> Result<(), YamlValidationError> {
+    // Encoding before grammar (#1242): the scanner below reads bytes and
+    // never decodes them, so without this a document with a stray non-UTF-8
+    // byte validated clean and then produced a scalar nothing could decode.
+    // The JSON validator has always checked this (`validate_utf8_char`); the
+    // YAML one had no encoding check at all.
+    if let Err(err) = crate::text::utf8::validate_utf8(input) {
+        return Err(YamlValidationError {
+            kind: YamlValidationErrorKind::InvalidUtf8 {
+                reason: err.kind.message(),
+            },
+            position: Position {
+                offset: err.offset,
+                line: err.line,
+                column: err.column,
+            },
+        });
+    }
     Validator::new(input).validate()
 }
 
@@ -2110,7 +2136,9 @@ mod tests {
                 found: 'y',
             },
             UnexpectedEof { expected: "x" },
-            InvalidUtf8,
+            InvalidUtf8 {
+                reason: "invalid UTF-8 lead byte",
+            },
             NestingTooDeep { limit: 128 },
         ];
         for k in &kinds {

--- a/tests/data/yq-path-consistency-known-failures.txt
+++ b/tests/data/yq-path-consistency-known-failures.txt
@@ -9,13 +9,14 @@
 # the build. See issue #222 for why the paths must agree; entries here are
 # divergences whose root cause is a *different*, separately-tracked bug.
 #
-# Categories
-# ----------
-#   invalid-escape  Double-quoted string with an escape yq rejects outright
-#                 (\., \'). The non-validating loader accepts it, and the
-#                 streaming transcoder — already mid-string when it hits the
-#                 bad escape — cannot roll back, so it emits malformed JSON
-#                 where the OwnedValue path emits a clean null. -> #223
-
-55WF      invalid-escape    invalid \-escape; streaming emits malformed JSON, DOM emits null — #223
-HRE5      invalid-escape    invalid \-escape; streaming emits malformed JSON, DOM emits null — #223
+# Currently empty — every corpus case agrees across both paths.
+#
+# The one category this file ever held, `invalid-escape` (cases 55WF and HRE5),
+# was retired by #1247: a double-quoted string with an escape yq rejects (\.,
+# \') used to leave the streaming transcoder mid-string with no way to roll
+# back, so it emitted malformed JSON where the OwnedValue path emitted a clean
+# null. The transcoders now roll back to their entry position on failure --
+# `write_yaml_string_to_json` rewinds its own `&mut String`, and the streaming
+# pair commit through a scratch buffer only on success -- so both paths emit
+# the same null and the category has no members left. See
+# docs/plan/decode-failure-routing.md.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21404,6 +21404,33 @@ fn test_valid_escapes_still_materialize_1247() {
     assert_eq!(stdout.trim(), "2");
 }
 
+/// #1247: plain `.` (no `--sort-keys`/color/pretty flag) stays on the
+/// genuinely-lazy raw-byte output path and echoes an undecodable string
+/// verbatim, the same raw-passthrough class as `keys_unsorted` above -- but
+/// `--sort-keys` and `-C` both force a full materialize first
+/// (`write_output_jq_value`'s "complex output" branch), which must surface
+/// the decode failure now instead of silently printing the empty string it
+/// used to.
+#[test]
+fn test_sort_keys_and_color_force_materialize_and_surface_decode_failure_1247() {
+    let doc = r#"{"a": "\ud800"}"#;
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "."], Some(doc)).unwrap_or_else(|e| panic!("`.` failed to run: {e}"));
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), r#"{"a":"\ud800"}"#, "stderr: {stderr}");
+
+    for flag in ["--sort-keys", "-C"] {
+        let (stdout, stderr, code) = run_jq_full(&[flag, "-c", "."], Some(doc))
+            .unwrap_or_else(|e| panic!("`{flag}` failed to run: {e}"));
+        assert_ne!(code, 0, "`{flag}` should fail\nstdout: {stdout}");
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "`{flag}` stderr: {stderr}"
+        );
+    }
+}
+
 /// #1194 (the half in #1247's scope): a *structurally* malformed value --
 /// one the semi-index accepted as a span but could not classify as any JSON
 /// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21267,8 +21267,8 @@ fn test_jq_lazy_fanout_preserves_prefix_and_trailing_control_1531() -> Result<()
 /// #1247: an object key that fails to decode must not hide the *valid*
 /// fields after it. `JsonFields::find`/`find_cursor` used to `?` out of the
 /// whole search on the first undecodable key, so `.b` answered `null` here
-/// even though `keys_unsorted`/`length` -- which never decode a key -- both
-/// still reported `b`. That inconsistency is the reason this is worth an
+/// even though `length` -- which never decodes a key at all (`fields.len()`)
+/// -- still reported `2`. That inconsistency is the reason this is worth an
 /// end-to-end test and not just a unit one: the two halves of the CLI
 /// disagreed with each other about whether the field existed.
 ///
@@ -21285,12 +21285,58 @@ fn test_undecodable_object_key_does_not_hide_later_fields_1247() {
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout.trim(), "2", "stderr: {stderr}");
 
-    // The half that was already right, pinned so the two can't drift apart
-    // again in the other direction.
-    let (stdout, _, code) = run_jq_full(&["-c", "keys_unsorted, length"], Some(input))
+    // `length` genuinely never decodes a key -- pinned so the two can't
+    // drift apart again in the other direction.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "length"], Some(input))
+        .unwrap_or_else(|e| panic!("`length` failed to run: {e}"));
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), "2", "stderr: {stderr}");
+
+    // `keys_unsorted` alone stays on the genuinely-lazy native path (#685),
+    // which streams each key's raw byte span straight to output without
+    // ever attempting to decode it -- so it echoes the bad key verbatim
+    // rather than raising or dropping it, the same raw-passthrough class as
+    // `jq '.'`.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))
+        .unwrap_or_else(|e| panic!("`keys_unsorted` failed to run: {e}"));
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), r#"["\ud800","b"]"#, "stderr: {stderr}");
+}
+
+/// #1247 follow-up: `keys_unsorted` piped into anything else -- even just a
+/// second comma-generator result, as here -- can no longer stay on the
+/// genuinely-lazy raw-byte path `test_undecodable_object_key_does_not_hide_later_fields_1247`
+/// pins above; it has to materialize through the same escape-hatch fallback
+/// (`materialize_lazy_keys`/`effective_keys`, #140) that `keys` (sorted) and
+/// `{x: keys_unsorted}` (object construction) already went through. That
+/// fallback decodes every key via `key_str()`, so it inherits #1247's core
+/// rule: an undecodable key raises instead of silently vanishing. Before
+/// this test's fix, the fallback silently dropped the bad key instead
+/// (`keys_unsorted, length` printed `["b"]` then `2`, exit 0) -- the same
+/// swallow this whole issue exists to close, just reachable from a third
+/// angle the original #1247 sweep missed.
+#[test]
+fn test_undecodable_key_in_materialized_keys_unsorted_surfaces_as_error_1247() {
+    let input = r#"{"\ud800": 1, "b": 2}"#;
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "keys_unsorted, length"], Some(input))
         .unwrap_or_else(|e| panic!("`keys_unsorted, length` failed to run: {e}"));
-    assert_eq!(code, 0);
-    assert_eq!(stdout.lines().last(), Some("2"));
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stderr.contains("invalid unicode escape sequence in object key"),
+        "stderr: {stderr}"
+    );
+
+    // Same fallback, reached via sorting instead of a second comma result:
+    // `keys` (sorted) always needed a full decode to sort by, even before
+    // this fix, and already raised.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "keys"], Some(input))
+        .unwrap_or_else(|e| panic!("`keys` failed to run: {e}"));
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stderr.contains("invalid unicode escape sequence in object key"),
+        "stderr: {stderr}"
+    );
 }
 
 /// #1247 core: a string scalar the semi-index accepted but that cannot be

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21263,3 +21263,32 @@ fn test_jq_lazy_fanout_preserves_prefix_and_trailing_control_1531() -> Result<()
     assert_eq!(stdout.trim(), "1");
     Ok(())
 }
+
+/// #1247: an object key that fails to decode must not hide the *valid*
+/// fields after it. `JsonFields::find`/`find_cursor` used to `?` out of the
+/// whole search on the first undecodable key, so `.b` answered `null` here
+/// even though `keys_unsorted`/`length` -- which never decode a key -- both
+/// still reported `b`. That inconsistency is the reason this is worth an
+/// end-to-end test and not just a unit one: the two halves of the CLI
+/// disagreed with each other about whether the field existed.
+///
+/// Real jq rejects this document outright (`Invalid \uXXXX\uXXXX surrogate
+/// pair escape`, exit 5). Surfacing the decode failure as a real error is
+/// tracked separately (#1247's own remaining stages); this test pins only
+/// that one bad key no longer destroys valid results.
+#[test]
+fn test_undecodable_object_key_does_not_hide_later_fields_1247() {
+    let input = r#"{"\ud800": 1, "b": 2}"#;
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".b"], Some(input))
+        .unwrap_or_else(|e| panic!("`.b` failed to run: {e}"));
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), "2", "stderr: {stderr}");
+
+    // The half that was already right, pinned so the two can't drift apart
+    // again in the other direction.
+    let (stdout, _, code) = run_jq_full(&["-c", "keys_unsorted, length"], Some(input))
+        .unwrap_or_else(|e| panic!("`keys_unsorted, length` failed to run: {e}"));
+    assert_eq!(code, 0);
+    assert_eq!(stdout.lines().last(), Some("2"));
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21357,3 +21357,45 @@ fn test_valid_escapes_still_materialize_1247() {
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout.trim(), "2");
 }
+
+/// #1194 (the half in #1247's scope): a *structurally* malformed value --
+/// one the semi-index accepted as a span but could not classify as any JSON
+/// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`
+/// at exit 0 where real jq raises `Invalid numeric literal` and exits 5.
+///
+/// Every materializing route raises now. The lazy output path (`.`, `.[0]`)
+/// still prints `null`: it streams as it walks, so by the time a nested
+/// error is reached the opening bracket is already written, and bailing
+/// there truncates the document. That is tracked as Stage 6 of #1247's
+/// design, not fixed here -- see `docs/plan/decode-failure-routing.md`.
+///
+/// `{invalid}` is NOT covered: `JsonFields::uncons` collapses a lone
+/// bareword leaf into "no more fields" at the semi-index layer, so no field
+/// is ever constructed to raise on, and the object simply reads as `{}`.
+/// That is #1194's remaining half and needs its own change.
+#[test]
+fn test_malformed_value_surfaces_as_error_1194() {
+    for doc in ["[xyz123]", "[tru]", "[1,zzz,3]"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", "to_entries"], Some(doc))
+            .unwrap_or_else(|e| panic!("`{doc}` failed to run: {e}"));
+        assert_ne!(code, 0, "`{doc}` should fail\nstdout: {stdout}");
+        assert!(
+            !stderr.is_empty(),
+            "`{doc}` should carry a diagnostic: {stderr}"
+        );
+    }
+
+    // Evaluation continues past the bad value, per the `ErrorSink`
+    // convention (#355): the two good documents either side of it still
+    // produce output, and the exit code still reports the failure.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "to_entries"],
+        Some("{\"a\":1}\n[xyz123]\n{\"b\":2}\n"),
+    )
+    .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_ne!(code, 0);
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        [r#"[{"key":"a","value":1}]"#, r#"[{"key":"b","value":2}]"#]
+    );
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21487,3 +21487,80 @@ fn test_valid_multibyte_document_is_untouched_1247() {
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout.trim(), doc);
 }
+
+/// #1247: `--validate` must still reject a non-UTF-8 document, even though
+/// the *unvalidated* path now substitutes U+FFFD for those same bytes.
+///
+/// The two pull in opposite directions and the substitution won by accident:
+/// it ran at read time, before `validate_json_input`, so the strict
+/// validator was handed an already-repaired document and found nothing
+/// wrong. `sjq --validate` exited 0 on a file `succinctly json validate`
+/// still rejects with exit 1 -- silently dropping the one check RFC 8259
+/// §8.1 makes mandatory, on the flag whose entire purpose is strictness.
+///
+/// Both routes are pinned because they read the document through different
+/// code: the lazy path (default) reads raw bytes, and the materializing one
+/// (`-S`, and every other flag that forces it) decodes to a `String` first.
+/// The escape and surrogate cases never regressed -- they are not encoding
+/// errors and the substitution cannot touch them -- but they are asserted
+/// alongside so a future change cannot fix one class by breaking another.
+#[test]
+fn test_validate_still_rejects_invalid_utf8_1247() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{\"a\":\"\xff\xfe\",\"b\":1}")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    for args in [
+        &["--validate", "-c", ".", path][..],
+        // `-S` and `-s` each force the materializing path, which decodes the
+        // document to a `String` before any validation can see its bytes.
+        &["--validate", "-c", "-S", ".", path][..],
+        &["--validate", "-c", "-s", ".", path][..],
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(args, None).unwrap_or_else(|e| panic!("{args:?} failed to run: {e}"));
+        assert_eq!(code, 3, "{args:?}\nstdout: {stdout}\nstderr: {stderr}");
+        assert!(
+            stderr.contains("invalid UTF-8"),
+            "{args:?} should name the encoding failure: {stderr}"
+        );
+        assert_eq!(stdout, "", "{args:?} must produce no output");
+    }
+
+    // Not an encoding error, so the substitution was never involved: these
+    // are asserted only to keep all three `--validate` failure classes in
+    // one place.
+    for (doc, expected) in [
+        (r#"{"a":"\ud800"}"#, "unpaired surrogate"),
+        (r#"{"a":"\q"}"#, "invalid escape sequence"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["--validate", "-c", "."], Some(doc))
+            .unwrap_or_else(|e| panic!("failed to run: {e}"));
+        assert_eq!(code, 3, "stdout: {stdout}\nstderr: {stderr}");
+        assert!(stderr.contains(expected), "stderr: {stderr}");
+    }
+    Ok(())
+}
+
+/// #1247 guard: fixing `--validate` must not take the substitution away from
+/// the modes that never validate. `-R` reads bytes as text by design, and a
+/// stray byte there is not a JSON error to report -- it is content.
+#[test]
+fn test_raw_input_still_substitutes_under_validate_1247() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a\xffb\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    for args in [
+        &["-R", "-c", ".", path][..],
+        &["-R", "--validate", "-c", ".", path][..],
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(args, None).unwrap_or_else(|e| panic!("{args:?} failed to run: {e}"));
+        assert_eq!(code, 0, "{args:?}\nstderr: {stderr}");
+        assert_eq!(stdout.trim(), "\"a\u{fffd}b\"", "{args:?}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21399,3 +21399,45 @@ fn test_malformed_value_surfaces_as_error_1194() {
         [r#"[{"key":"a","value":1}]"#, r#"[{"key":"b","value":2}]"#]
     );
 }
+
+/// #1247: jq is the odd oracle out on invalid UTF-8. `yq` rejects such a
+/// document outright (#1242); `jq` accepts it, substitutes U+FFFD and exits
+/// 0. succinctly did neither -- it echoed the raw bytes, writing invalid
+/// UTF-8 to stdout, and the non-lazy path refused the file entirely with
+/// `Failed to read file` when the read had in fact succeeded.
+///
+/// Asserted on bytes, not on a lossily-decoded string: the whole point is
+/// which bytes reach stdout.
+#[test]
+fn test_invalid_utf8_document_substitutes_replacement_char_1247() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{\"a\":\"\xff\xfe\",\"b\":1}")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    // Two U+FFFD, one per invalid byte -- exactly what jq 1.7.1 emits here.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a", path], None).unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"\u{fffd}\u{fffd}\"");
+
+    // The non-lazy path (`-S` forces materialized, sorted output) used to
+    // fail the read outright; it must agree with the lazy one now.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-S", ".", path], None)
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "{\"a\":\"\u{fffd}\u{fffd}\",\"b\":1}");
+    Ok(())
+}
+
+/// #1247 guard: the substitution pass must leave valid multi-byte content
+/// byte-for-byte alone -- it runs on every document, so a false positive
+/// would corrupt ordinary files.
+#[test]
+fn test_valid_multibyte_document_is_untouched_1247() {
+    let doc = r#"{"a":"café","b":"日本語","c":"😀"}"#;
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "."], Some(doc)).unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), doc);
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21292,3 +21292,68 @@ fn test_undecodable_object_key_does_not_hide_later_fields_1247() {
     assert_eq!(code, 0);
     assert_eq!(stdout.lines().last(), Some("2"));
 }
+
+/// #1247 core: a string scalar the semi-index accepted but that cannot be
+/// *decoded* must surface as a real jq error once anything materializes it,
+/// instead of silently becoming `null` (`eval_generic::to_owned`) or `""`
+/// (`lazy::cursor_to_owned`).
+///
+/// Every filter here materializes; each used to answer with a fabricated
+/// value at exit 0. `.a | length` is the sharpest case: it reported
+/// `null (null) has no length` -- a type error about a value that is a
+/// perfectly good string token, naming a symptom two steps removed from the
+/// cause.
+///
+/// Real jq rejects the document at parse time (exit 5). succinctly reaches
+/// the same exit code by a different route -- an uncaught evaluation error --
+/// because it never parses the whole document up front. Message text is
+/// therefore succinctly's own, and is asserted only for the decode reason.
+#[test]
+fn test_decode_failure_surfaces_as_error_1247() {
+    let doc = r#"{"a": "\ud800"}"#;
+    // Not `length` on the object itself: that answers from `fields.len()`
+    // without decoding a single key, which is a genuine fast path rather
+    // than a degrade -- it returns the same count jq would.
+    for filter in [
+        "to_entries",
+        "[.a] | sort",
+        ".a | length",
+        ".a | ascii_downcase",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_ne!(code, 0, "`{filter}` should fail\nstdout: {stdout}");
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "`{filter}` should name the decode failure, not a downstream type error\nstderr: {stderr}"
+        );
+    }
+}
+
+/// #1247: an undecodable *key* raises too, and does not silently shrink the
+/// object. `to_entries` used to return one entry fewer than the document had
+/// -- `effective_fields`' dedup walk dropped any field whose key wouldn't
+/// decode, before anything could notice.
+#[test]
+fn test_decode_failure_in_key_surfaces_as_error_1247() {
+    let doc = r#"{"\ud800": 1, "b": 2}"#;
+    let (stdout, stderr, code) = run_jq_full(&["-c", "to_entries"], Some(doc))
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_ne!(code, 0, "stdout: {stdout}");
+    assert!(
+        stderr.contains("in object key"),
+        "stderr should name the key as the site: {stderr}"
+    );
+}
+
+/// #1247 guard: the new check must not fire on anything that decodes
+/// cleanly, including the escapes and non-ASCII that look most like the
+/// failing case.
+#[test]
+fn test_valid_escapes_still_materialize_1247() {
+    let doc = r#"{"a": "é😀\n\t\"", "b": "café"}"#;
+    let (stdout, stderr, code) = run_jq_full(&["-c", "to_entries | length"], Some(doc))
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "2");
+}

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -66,6 +66,7 @@ fn generic(json: &[u8], filter: &str) -> Outcome {
         other => Outcome::Values(
             other
                 .collect_owned()
+                .expect("materializes")
                 .iter()
                 .map(OwnedValue::to_json)
                 .collect(),

--- a/tests/jq_containment_tests.rs
+++ b/tests/jq_containment_tests.rs
@@ -88,6 +88,7 @@ fn generic_outcome(json: &[u8], filter: &str) -> Result<Vec<String>, String> {
     }
     Ok(result
         .collect_owned()
+        .expect("materializes")
         .iter()
         .map(OwnedValue::to_json)
         .collect())
@@ -290,7 +291,7 @@ fn optional_suppresses_the_error() {
             "generic evaluator: optional {filter} should be suppressed"
         );
         assert!(
-            generic.collect_owned().is_empty(),
+            generic.collect_owned().expect("materializes").is_empty(),
             "generic evaluator: optional {filter} should yield nothing"
         );
     }

--- a/tests/jq_error_message_tests.rs
+++ b/tests/jq_error_message_tests.rs
@@ -145,7 +145,7 @@ fn outcome(evaluator: Evaluator, probe: &Probe) -> Result<String, String> {
         }
         Evaluator::Generic => match eval_generic::eval_with_cursor(&expr, cursor) {
             eval_generic::GenericResult::Error(e) => (Some(e.message), Vec::new()),
-            other => (None, render(other.collect_owned())),
+            other => (None, render(other.collect_owned().expect("materializes"))),
         },
     };
 

--- a/tests/jq_eval_using_input_queue_gate_test.rs
+++ b/tests/jq_eval_using_input_queue_gate_test.rs
@@ -29,6 +29,7 @@ fn test_eval_using_interleaves_input_with_top_level_comma_1504() {
     let result = eval_using::<JqSemantics, _>(&expr, value);
     let outputs: Vec<String> = result
         .collect_owned()
+        .unwrap()
         .iter()
         .map(OwnedValue::to_json)
         .collect();

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -33,6 +33,7 @@ fn generic_outputs(json: &[u8], filter: &str) -> Vec<String> {
     let result = eval_generic::eval_with_cursor(&expr, cursor);
     result
         .collect_owned()
+        .expect("materializes")
         .iter()
         .map(succinctly::jq::OwnedValue::to_json)
         .collect()
@@ -657,7 +658,7 @@ fn assert_optional_parity_suppressed(json: &[u8], expr: &Expr) {
         "generic evaluator: {expr:?} should be suppressed"
     );
     assert!(
-        generic.collect_owned().is_empty(),
+        generic.collect_owned().expect("materializes").is_empty(),
         "generic evaluator: {expr:?} should yield nothing"
     );
 }

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -235,3 +235,41 @@ fn yq_without_validate_accepts_the_same_invalid_yaml() -> Result<()> {
     assert_eq!(code, 0);
     Ok(())
 }
+
+/// #1242: the strict YAML validator had no encoding check at all, so a
+/// document with a stray non-UTF-8 byte validated clean (exit 0) and then
+/// produced a scalar nothing could decode. The JSON validator has always
+/// checked this; the YAML one only walked the grammar over raw bytes.
+///
+/// Written as a file rather than through stdin because the helper takes
+/// `&str` and this input is deliberately not valid UTF-8.
+#[test]
+fn test_yaml_validate_rejects_invalid_utf8_1242() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a: 1\nb: \"x\xe4y\"\n")?;
+    file.flush()?;
+
+    let (_, stderr, code) = run_validate_file(file.path().to_str().unwrap(), &[])?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("UTF-8"),
+        "should name the encoding failure: {stderr}"
+    );
+    // Same byte offset real yq reports for this document (`offset 11`),
+    // rendered as the 1-based line/column this CLI uses everywhere else.
+    assert!(
+        stderr.contains("2:7"),
+        "should locate the offending byte: {stderr}"
+    );
+    Ok(())
+}
+
+/// #1242 guard: a document that is valid UTF-8 but uses multi-byte
+/// characters must still validate clean -- the new pass must not reject
+/// ordinary non-ASCII content.
+#[test]
+fn test_yaml_validate_accepts_multibyte_utf8_1242() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("a: café\nb: 日本語\nc: 😀\n", &[])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21847,7 +21847,8 @@ fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> 
 }
 
 /// #1247: a decode failure inside a YAML string must not leave a partially
-/// transcoded token behind in the JSON output.
+/// transcoded token behind in the JSON output, and must not pass silently
+/// once anything materializes the value.
 ///
 /// The transcoders push the opening `"` -- and any prefix they already
 /// converted -- before they can discover a bad escape, and each caller's
@@ -21861,21 +21862,26 @@ fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> 
 ///
 /// `\q` is not a YAML escape, so the scalar is structurally valid but
 /// undecodable. Real yq rejects the whole document (`found unknown escape
-/// character`, exit 1); making succinctly do the same is a later stage of
-/// #1247's design. This pins only that whatever is emitted is *parseable* --
-/// the value still degrades to `null` and the key to `""`.
+/// character`, exit 1).
+///
+/// Two routes, deliberately different at this stage of #1247's design (see
+/// `docs/plan/decode-failure-routing.md`):
+///
+/// * the **materializing** routes raise a real error and exit non-zero;
+/// * the **streaming** routes still degrade to `null`/`""` -- but the
+///   document they emit is now parseable, which is what this test's first
+///   half pins. Making streaming loud too needs an error channel through
+///   `stream_json_value`'s `core::fmt::Result`, which is its own stage.
 #[test]
 fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
     for (input, expected) in [
         ("b: \"x\\qy\"\n", r#"{"b":null}"#),
         ("\"a\\qb\": 1\n", r#"{"":1}"#),
     ] {
-        // One route per distinct transcode call site: the streaming sink, the
-        // DOM sink a flag forces (`--arg`, `-P`), and the multi-result path
-        // that loses its cursor to `GenericResult::Many`.
+        // Streaming: still degrades, but the emitted JSON is valid. `-P`
+        // takes this route too -- it forces pretty-printing, not the DOM.
         for extra in [
             &["-o", "json", "-I", "0"][..],
-            &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
             &["-o", "json", "-I", "0", "-P"][..],
         ] {
             let (output, exit_code) = run_yq_stdin(".", input, extra)?;
@@ -21883,9 +21889,20 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
             assert_eq!(output.trim(), expected, "args {extra:?}");
         }
 
-        let (output, exit_code) = run_yq_stdin(".,.", input, &["-o", "json", "-I", "0"])?;
-        assert_eq!(exit_code, 0, "output: {output:?}");
-        assert_eq!(output.lines().collect::<Vec<_>>(), [expected, expected]);
+        // Materializing: `--arg` forces the DOM path, and a multi-result
+        // filter loses its cursor to `GenericResult::Many`. Both raise.
+        for extra in [
+            &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
+            &["-o", "json", "-I", "0"][..],
+        ] {
+            let filter = if extra.len() > 4 { "." } else { ".,." };
+            let (output, stderr, exit_code) = run_yq_split(filter, input, extra)?;
+            assert_eq!(exit_code, 1, "args {extra:?}, output: {output:?}");
+            assert!(
+                stderr.contains("invalid escape sequence"),
+                "args {extra:?}, stderr: {stderr}"
+            );
+        }
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21906,3 +21906,45 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1242: `succinctly yq` accepted a document with a dangling
+/// non-continuable UTF-8 byte, indexed it, and handed back `null` for the
+/// scalar that byte was in -- at exit 0, with `--validate` no help because
+/// the strict validator had no encoding check either.
+///
+/// Real yq rejects it: `bad file '-': yaml: offset 11: invalid trailing
+/// UTF-8 octet`, exit 1. succinctly now rejects it at the same byte offset
+/// and the same exit code, worded in this crate's own `YAML parse error:`
+/// convention -- the one it already uses for every other YAML parse
+/// failure, rather than yq's `bad file` shape it has never matched.
+///
+/// The check is unconditional, not gated on `--validate`: YAML 1.2 requires
+/// a UTF-8/16/32 stream, so this is a parse error, not an opt-in strictness
+/// preference.
+#[test]
+fn test_yq_rejects_invalid_utf8_document_1242() -> Result<()> {
+    let mut file = tempfile::NamedTempFile::new()?;
+    std::io::Write::write_all(&mut file, b"a: 1\nb: \"x\xe4y\"\n")?;
+    std::io::Write::flush(&mut file)?;
+    let path = file.path().to_str().unwrap();
+
+    for extra in [&["-o", "json"][..], &["-o", "json", "--validate"][..]] {
+        let (output, exit_code) = run_yq_file(".", path, extra)?;
+        assert_eq!(exit_code, 1, "args {extra:?}, output: {output:?}");
+    }
+    Ok(())
+}
+
+/// #1242 guard: ordinary multi-byte content must still parse. The pass runs
+/// on every document, so a false positive here would reject real files.
+#[test]
+fn test_yq_accepts_multibyte_utf8_1242() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(
+        ".",
+        "a: café\nb: 日本語\nc: 😀\n",
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#"{"a":"café","b":"日本語","c":"😀"}"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21845,3 +21845,47 @@ fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> 
     assert_eq!(output.trim(), "2");
     Ok(())
 }
+
+/// #1247: a decode failure inside a YAML string must not leave a partially
+/// transcoded token behind in the JSON output.
+///
+/// The transcoders push the opening `"` -- and any prefix they already
+/// converted -- before they can discover a bad escape, and each caller's
+/// `Err(_)` arm then appended its own `null`/`""` fallback after it. The two
+/// concatenated into JSON that no parser could read, at exit 0:
+///
+/// ```text
+/// b: "x\qy"    ->  {"b": "xnull}      (value arm)
+/// "a\qb": 1    ->  {"a"": 1}          (key arm)
+/// ```
+///
+/// `\q` is not a YAML escape, so the scalar is structurally valid but
+/// undecodable. Real yq rejects the whole document (`found unknown escape
+/// character`, exit 1); making succinctly do the same is a later stage of
+/// #1247's design. This pins only that whatever is emitted is *parseable* --
+/// the value still degrades to `null` and the key to `""`.
+#[test]
+fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
+    for (input, expected) in [
+        ("b: \"x\\qy\"\n", r#"{"b":null}"#),
+        ("\"a\\qb\": 1\n", r#"{"":1}"#),
+    ] {
+        // One route per distinct transcode call site: the streaming sink, the
+        // DOM sink a flag forces (`--arg`, `-P`), and the multi-result path
+        // that loses its cursor to `GenericResult::Many`.
+        for extra in [
+            &["-o", "json", "-I", "0"][..],
+            &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
+            &["-o", "json", "-I", "0", "-P"][..],
+        ] {
+            let (output, exit_code) = run_yq_stdin(".", input, extra)?;
+            assert_eq!(exit_code, 0, "args {extra:?}, output: {output:?}");
+            assert_eq!(output.trim(), expected, "args {extra:?}");
+        }
+
+        let (output, exit_code) = run_yq_stdin(".,.", input, &["-o", "json", "-I", "0"])?;
+        assert_eq!(exit_code, 0, "output: {output:?}");
+        assert_eq!(output.lines().collect::<Vec<_>>(), [expected, expected]);
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21821,3 +21821,27 @@ fn test_lazy_keys_streaming_preserves_yaml_duplicates_1599() -> Result<()> {
 
     Ok(())
 }
+
+/// #1247: a mapping key that fails to decode must not hide the *valid*
+/// fields after it. `YamlFields::find`/`find_cursor` used to `?` out of the
+/// whole search on the first undecodable key, so `.b` answered `null` here
+/// even though `keys` still listed `b`.
+///
+/// The key is `"a\qb"` -- `\q` is not a YAML escape, so the scalar is
+/// structurally valid but `as_str()` rejects it. Real yq rejects the whole
+/// document (`found unknown escape character`, exit 1); surfacing the decode
+/// failure as a real error is tracked separately. This pins only that one bad
+/// key no longer destroys valid results.
+#[test]
+fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> {
+    let input = "\"a\\qb\": 1\nb: 2\n";
+
+    let (output, exit_code) = run_yq_stdin(".b", input, &["-o", "json"])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "2");
+
+    let (output, exit_code) = run_yq_stdin("keys | length", input, &["-o", "json"])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "2");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7321,16 +7321,23 @@ fn test_trailing_content_after_flow_collection_reports_real_utf8_char_1187() -> 
 /// just at true EOF but for *any* byte that isn't valid UTF-8 at that
 /// offset -- silently embedding a literal NUL byte into the error string
 /// for a malformed (not just missing) byte, something the old
-/// `byte as char` cast never did (a raw cast never fails). A single
-/// non-UTF-8 byte (`0xFF`, never a valid lead byte) must still render as
-/// the same visible Latin-1 character the old code showed, not `'\0'`.
+/// `byte as char` cast never did (a raw cast never fails). This is still
+/// pinned by `test_trailing_content_after_flow_collection_reports_real_utf8_char_1187`
+/// above via a genuinely valid-but-unexpected character ('日').
+///
+/// A raw invalid UTF-8 lead byte specifically no longer reaches
+/// `err_unexpected_char` at all: #1242's whole-document UTF-8 precheck now
+/// rejects it before parsing begins, matching real yq (`bad file '-':
+/// yaml: offset 10: invalid leading UTF-8 octet`, exit 1, confirmed against
+/// yq v4.53.3) rather than letting the parser stumble onto the byte deep
+/// inside a flow collection and describe it as an "unexpected character".
 #[test]
 fn test_err_unexpected_char_invalid_byte_does_not_embed_nul_1187() -> Result<()> {
     let (_, stderr, code) =
         run_yq_stdin_bytes_with_stderr(".", b"a: [1, 2] \xff\n", &["-o", "json", "-I0"])?;
     assert_ne!(code, 0);
     assert!(
-        stderr.contains("unexpected character '\u{FF}'"),
+        stderr.contains("invalid UTF-8 lead byte"),
         "stderr: {stderr}"
     );
     assert!(


### PR DESCRIPTION
## Description

A string scalar the semi-index accepted but that cannot be **decoded** — invalid UTF-8, an
invalid escape, an invalid `\u` codepoint — was silently swallowed. It became `null`, or
`""`, or the field vanished, and the process exited 0. `to_owned_at_depth`'s own doc comment
has named this as deferred since PR #1190's `panic!()` attempt was reverted as
live-reachable; this routes it through `EvalError` instead, which is what that comment asked
for.

#1247 was tiered **Tier 3** — an unresolved architectural fork between threading `Result`
through the `to_owned` family and moving validation upfront — and its tier review asked for
one design doc covering #1247 and #1194 together. That doc is the first commit
([`docs/plan/decode-failure-routing.md`](docs/plan/decode-failure-routing.md)); the rest
implement five of its six stages.

### Three corrections to the issues' own premises

Each was verified against the build and the pinned oracles rather than taken from the issue
text:

1. **The "58+ call sites, all needing `Result` threading" estimate overstates the work.** Of
   62 grep hits, 13 are doc comments, 8 are tests and 7 are the recursive definitions. Of
   the **53 real call sites, 40 already sat in a fallible context** — the generic
   evaluator's error channel is `GenericResult::Error` / `Control::Error` in the value
   domain, not `Result`. `eval_single` and `eval_builtin` both return a bare
   `GenericResult<V>`.
2. **#1191, named as a blocking prerequisite for the YAML side, was already closed and
   fixed.** `as_str()`'s `Alias` arm resolves the full chain now, so the confound it warns
   about no longer exists.
3. **#1194 is only half in scope.** `[xyz123] → [null]` is fixed; `{invalid} → {}` is not —
   `JsonFields::uncons` collapses a lone bareword leaf into "no more fields" at the
   semi-index layer, so no field is ever constructed to raise on.

### Six swallow sites no issue records

Two classes are worse than the silent `null` the issues describe:

```console
$ printf 'b: "x\qy"\n' | succinctly yq -o=json '.'      # before
{"b": "xnull}                                           # unparseable, exit 0
$ printf '"a\qb": 1\n' | succinctly yq -o=json '.'      # before
{"a"": 1}                                               # unparseable, exit 0

$ printf '{"\ud800":1,"b":2}' | succinctly jq '.b'      # before
null                                                    # but "b":2 is right there
```

The last is the sharpest: one undecodable key made **every later field invisible to lookup**
while `keys`/`length` still reported it — the two halves of the CLI disagreed about whether
the field existed.

### The oracles disagree, which neither issue records

```console
$ printf 'a: "\xff"'   | yq   →  bad file: invalid leading UTF-8 octet, exit 1
$ printf '{"a":"\xff"}' | jq  →  {"a":"<U+FFFD>"},                      exit 0
```

So the UTF-8 fix is per-mode, not one rule: yq rejects, jq substitutes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [ ] CI/CD changes

"Breaking" in the sense that documents which previously produced output at exit 0 now
produce a diagnostic and a non-zero exit. That is the point of the change, but it is a
user-visible behaviour change on malformed input, and `yq --validate` in particular now
rejects documents it used to pass.

## Related Issue

Fixes #1242.
Advances #1247 (Stage 6 remains — see below).
Advances #1194 (its `[xyz123]` half; its headline `{invalid}` half remains).

## Changes Made

Seven commits, staged so each can be reviewed — or reverted — on its own. The first two are
plain bug fixes with no signature churn and land before the wide change.

**Stage 0 — design doc.** `docs/plan/decode-failure-routing.md`, in the shape of #1282's
deliverable: verified premises, oracle behaviour tables, corrected call-site accounting,
measured costs, staged delivery, explicit non-goals, open risks.

**Stage 1 — `find`/`find_cursor` no longer hide valid siblings.** `JsonFields` and
`YamlFields` each ran `if key.as_str().ok()? == name` inside their scan loop; that `?`
returned from `find` itself, ending the whole search on the first undecodable key. Now
skipped, not fatal. Last-duplicate-key-wins is unchanged.

**Stage 2 — a failed transcode rolls back instead of emitting invalid JSON.** The YAML→JSON
transcoders push the opening `"` before they can discover a bad escape, and each caller's
`Err(_)` arm appended its own `null`/`""` after it. Six call sites shared the shape, not the
two first scoped. The rollback went **inside** `write_yaml_string_to_json` — it owns the
`&mut String`, so it can rewind its own entry length and fix all four buffered sites at once
rather than asking four callers to remember. The two streaming sites commit through a
scratch buffer, and only in the slow branch, so P9's allocation-free path is untouched.

*Independently confirmed by the YAML Test Suite:* cases `55WF` and `HRE5` sat on
`tests/data/yq-path-consistency-known-failures.txt` for exactly this reason ("streaming
emits malformed JSON, DOM emits null"). Both now agree across paths; that manifest's only
category is retired.

**Stage 3 — the `to_owned` family becomes fallible.** The main change.
`to_owned`/`to_owned_at_depth`/`to_owned_cursor`/`to_owned_cursor_at_depth` (`eval_generic.rs`)
and `cursor_to_owned`/`cursor_to_owned_at_depth` (`lazy.rs`) now return
`Result<OwnedValue, EvalError>`. `assert_nesting_depth` stays a `panic!`: unbounded
recursion is a different failure class, and routing it here would make a stack-overflow
guard catchable by `try`/`catch`.

- **Detection needed a real signal, not an inference.** `as_str()` conflates "not a string"
  with "a string this document cannot hand back", which is how the failure reached a
  materializer indistinguishable from an unknown type. Added
  `DocumentValue::string_decode_error() -> Option<&'static str>`, a provided method
  defaulting to `None`. Wording comes from `JsonError::message` / `YamlStringError::message`,
  split out of each `Display` so there is one definition, not a copy.
- **Three more silent-drop sites, all surfaced by the compiler once the types changed.**
  `effective_fields`' dedup walk dropped any field whose key wouldn't decode, so
  `to_entries` returned one entry fewer than the document had; `lazy_keys_array_to_owned`
  dropped the key from `keys`; `to_owned_with_comments` had the same key guard.
- **A misleading-error class, not just a silent one.** Every builtin's type dispatch is a
  chain of `as_str()`/`as_array()`/… tests, so an undecodable string fails all of them and
  lands in the same `else` as a genuine type mismatch: `.a | length` reported
  `null (null) has no length` about a perfectly good string token. `type_error_or_decode_failure`
  names the cause at the seven sites reporting such a fall-through.
- **One lossy materialization kept on purpose.** `to_owned_for_diagnostic` serves the call
  sites that materialize a value only to quote it into an error already being raised;
  propagating there would mean abandoning a correctly-diagnosed error to report that its
  message could not be built. Its own function, with the rationale in its doc comment.

**Stage 4 — `StandardJson::Error` arms raise.** Fixes `[xyz123] → [null]`. Evaluation still
continues past the bad value, so the good documents either side of it in a multi-value
stream still produce output (`ErrorSink`, #355) — real jq aborts instead; continuing is the
more useful of the two and is pinned as a deliberate divergence.

**Stage 5 — UTF-8 at the input boundary.** yq rejects at the same byte offset and exit code
as real yq, worded in this crate's own `YAML parse error:` convention rather than yq's
`bad file '-':` shape it has never matched. `yaml validate` grew the check too, reusing the
`InvalidUtf8` variant that had been *declared but never constructed* — the scanner reads
bytes and never decodes them, so nothing could ever have produced it. jq substitutes U+FFFD
and exits 0, byte-identical to jq 1.7.1; that also fixed two bugs in the other direction —
the lazy path wrote invalid UTF-8 to stdout, and the non-lazy path refused the file with
`Failed to read file` when the read had in fact succeeded.

Scope is document input only: `--raw-input` shares the jq path (jq substitutes there too);
DSV input, `--arg`/`--argjson` and `--rawfile` are untouched.

### Before / after

| | before | after |
|---|---|---|
| `{"a":"\ud800"} \| to_entries` | `[{"key":"a","value":null}]`, exit 0 | error, exit 5 |
| `{"a":"\ud800"} \| .a\|length` | `null (null) has no length` | `invalid unicode escape sequence` |
| `{"\ud800":1,"b":2} \| .b` | `null` | `2` |
| `{"\ud800":1,"b":2} \| to_entries` | one entry, silently | error, exit 5 |
| `[xyz123] \| to_entries` | `[{"key":0,"value":null}]` | error, exit 5 |
| `{"a":"\xff\xfe"} \| .a` | raw invalid UTF-8 on stdout | `"��"`, byte-identical to jq |
| yq `b: "x\qy"` `-o json` | `{"b": "xnull}` | `{"b":null}` |
| yq `"a\qb": 1` `-o json` | `{"a"":1}` | `{"":1}` |
| yq invalid-UTF-8 document | `{"a":1,"b":null}`, exit 0 | rejected, exit 1, same offset as real yq |
| `yaml validate` on same | exit 0 | exit 1 |

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [ ] Tested on x86_64
- [x] Tested on aarch64/ARM (Apple M5 Max)

New regression tests, each verified to **fail against the previous behaviour**, not merely
to pass:

- `src/json/light.rs`, `src/yaml/light.rs` — `..._find_skips_undecodable_key_1247`
- `tests/jq_cli_tests.rs` — `..._does_not_hide_later_fields_1247`,
  `..._surfaces_as_error_1247`, `..._in_key_surfaces_as_error_1247`,
  `test_malformed_value_surfaces_as_error_1194`,
  `..._substitutes_replacement_char_1247`, plus two guards that valid escapes and valid
  multi-byte content are untouched
- `tests/yq_cli_tests.rs` — `..._does_not_corrupt_json_output_1247`,
  `..._does_not_hide_later_fields_1247`, `test_yq_rejects_invalid_utf8_document_1242`,
  `test_yq_accepts_multibyte_utf8_1242`
- `tests/yaml_validate_tests.rs` — `test_yaml_validate_rejects_invalid_utf8_1242`,
  `test_yaml_validate_accepts_multibyte_utf8_1242`

Two existing tests asserted the buggy behaviour and were **inverted**, not deleted:
`test_to_owned_degrades_to_null_on_string_decode_failure_1098` and
`test_materialize_degrades_to_empty_string_on_decode_failure_1098`.

### Test Commands

```bash
cargo test --features cli,simd,regex,serde --workspace --no-fail-fast
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
cargo fmt --all -- --check
cargo check --no-default-features   # no_std
```

All green locally: 54 test binaries, 0 failures.

## Performance Impact

- [ ] No performance impact
- [ ] Performance improvement
- [x] Potential performance regression (justify below)

Stage 5 adds a whole-input SIMD UTF-8 pass to every run. Interleaved A/B of the Stage 4
binary against the Stage 5 one, alternating order every repetition, min-of-9, gated first on
byte-identical stdout and exit code (all five cases identical):

| case | before | after | delta |
|------|--------|-------|-------|
| `jq '.users[0].name'` 1 MB | 5.37 ms | 5.13 ms | −4.5% |
| `jq '.users[0].name'` 8.4 MB | 17.23 ms | 17.96 ms | **+4.2%** |
| `jq '.'` 1 MB | 16.91 ms | 16.98 ms | +0.4% |
| `yq -o json '.'` 1 MB | 16.62 ms | 16.65 ms | +0.2% |
| `yq -o json '.'` 10 MB | 126.19 ms | 126.80 ms | +0.5% |

Worst case +4.2%, on the cheapest query at the largest size, where a roughly fixed ~1 ms
pass is the largest fraction of the work. That is inside the +8% ceiling the design doc set
*before* implementing. The −4.5% row is noise; the pass cannot make anything faster.

**This number is provisional and should not be treated as the gate.** It ran on an Apple M5
Max laptop under a load average near 10, which this repo's own benchmarking discipline
disqualifies. The formal interleaved A/B on the pinned bench machines (`johns-mac-mini` ARM,
`terminus` x86_64) has **not** been run.

The alternative — always-on strict validation, which the tier review floated — was costed
and rejected: 8.6 ms on the same 8.4 MB file, **+66%** on a cheap navigation query.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

### For reviewers — two decisions worth challenging now

1. **Decode errors are catchable by `try`/`catch`.** `.a?` suppresses one; jq's parse error
   cannot be caught at all, because it happens before the program runs. I chose consistency
   with #1192's already-merged half. If these should be `Halt`-like instead, this is the
   cheap moment to change it. Recorded as Open Risk 1 in the design doc.
2. **jq substitutes U+FFFD rather than erroring.** Byte-identical to jq — but it is
   deliberately a *silent* substitution inside a change whose whole point was removing
   silent degradation. Defensible either way; flagging rather than burying it.

### Deliberately not in this PR

- **Stage 6** — the YAML streaming path still emits `null` for a bad *escape*. Its only
  error channel is `core::fmt::Result`, which carries no message. Every *materializing*
  route already raises. I wrote the equivalent fix for `print_json`'s arm and **reverted
  it**: bailing mid-stream produced a truncated document plus a generic exit 1, worse on
  every axis than the silent `null` it replaced. The reasoning is left in place at the site.
- **#1194's headline repro** `{invalid}` → `{}` — needs `JsonFields::uncons` to represent a
  malformed field, a public API contract change with its own call-site sweep.
- **#965** — this PR touches four of the five near-duplicate `→ OwnedValue` conversions and
  leaves them duplicated. Consolidating is a refactor with its own risk profile and should
  follow a behaviour change, not accompany one. #1283 already sequences it after this.

### Not everything that looked like a degrade was one

`length` on an object answers from `fields.len()` without decoding, and `keys_unsorted`
streams each key's raw byte span verbatim. Neither loses data — both are the same
raw-passthrough class as `jq '.'` — so both were left alone, with tests saying why.
