### PR TITLE
refactor(jq): unify resolve_node's Select/If cond-eval fork (#1023)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13393,18 +13393,13 @@ fn resolve_node<'a, S: EvalSemantics>(
         // raising `x`.
         Expr::Builtin(Builtin::Select(cond)) => {
             let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            resolve_cond_fork(cond_outputs, escape, |truthy| {
+            resolve_cond_fork(cond_outputs, escape, |truthy, out| {
                 if truthy {
                     // `select` filters; it never navigates. The value handed
                     // back is the caller's own, so its trackability is too.
-                    Ok(vec![PathBranch::new(
-                        Vec::new(),
-                        Cow::Borrowed(value),
-                        trackable,
-                    )])
-                } else {
-                    Ok(Vec::new())
+                    out.push(PathBranch::new(Vec::new(), Cow::Borrowed(value), trackable));
                 }
+                None
             })
         }
         Expr::Builtin(
@@ -13466,9 +13461,18 @@ fn resolve_node<'a, S: EvalSemantics>(
             else_branch,
         } => {
             let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            resolve_cond_fork(cond_outputs, escape, |truthy| {
+            resolve_cond_fork(cond_outputs, escape, |truthy, out| {
                 let branch = if truthy { then_branch } else { else_branch };
-                resolve_node::<S>(branch, value, trackable)
+                match resolve_node::<S>(branch, value, trackable) {
+                    Ok(branches) => {
+                        out.extend(branches);
+                        None
+                    }
+                    Err((prefix, e)) => {
+                        out.extend(prefix);
+                        Some(e)
+                    }
+                }
             })
         }
 
@@ -14262,35 +14266,39 @@ fn eval_recurse_cond<S: EvalSemantics>(
 /// position (#1023): both arms already evaluate `cond` via
 /// `eval_owned_multi_keep_partial` themselves (the one line the two of them
 /// share verbatim isn't worth extracting on its own), then hand-rolled the
-/// identical "iterate outputs, dispatch per truthiness, collect branches,
-/// propagate a branch's own error immediately, fall through to the
-/// `cond`-level escape only once the loop drains naturally" loop
-/// independently. `dispatch` receives each output's truthiness and returns
-/// this same [`PathResolveResult`] shape resolve_node itself uses, so
-/// `Select` (which never fails building its own branch) and `If` (which
-/// recurses into `resolve_node` and so genuinely can) both fit without a
-/// bool-parameter thicket.
+/// identical "iterate outputs, dispatch per truthiness into the same
+/// collected-branches buffer, propagate a branch's own error immediately,
+/// fall through to the `cond`-level escape only once the loop drains
+/// naturally" loop independently. `dispatch` receives each output's
+/// truthiness plus the shared `out` buffer to push/extend directly (so
+/// `Select`'s zero-or-one-branch case never allocates a throwaway `Vec` of
+/// its own the way an earlier draft of this helper did) and returns just
+/// the escape, if any -- `Select` (which never fails building its own
+/// branch) and `If` (which recurses into `resolve_node` and so genuinely
+/// can) both fit without a bool-parameter thicket.
+///
+/// The value-position analogue of this same `Select`/`If` unification is
+/// [`eval_fanout`], shared by `eval_if`/`builtin_select` (and mirrored a
+/// third time in `eval_pipe_with_path_context_internal`'s own `Select`
+/// arm) -- if a future fix to the fork-on-cond policy needs applying here,
+/// check whether it also needs applying there.
 ///
 /// Not a retrofit of [`eval_recurse_cond`] just above: that primitive is a
-/// one-way *gate* (push only on truthy, no way to express an `else` side,
-/// no per-output return value) built for `recurse(f; cond)`'s two callers,
-/// which need exactly that and nothing more. `Select`/`If` need genuine
-/// two-way dispatch with a fallible per-branch result, which is a different
-/// enough shape that unifying all four call sites under one signature was
-/// tried and rejected during this issue's own design pass — see #1023.
+/// one-way *gate* (push only on truthy, no way to express an `else` side)
+/// built for `recurse(f; cond)`'s two callers, which need exactly that and
+/// nothing more. `Select`/`If` need genuine two-way dispatch with a
+/// fallible per-branch result, which is a different enough shape that
+/// unifying all four call sites under one signature was tried and
+/// rejected during this issue's own design pass — see #1023.
 fn resolve_cond_fork<'a>(
     cond_outputs: Vec<OwnedValue>,
     cond_escape: Option<EvalEscape>,
-    mut dispatch: impl FnMut(bool) -> PathResolveResult<'a>,
+    dispatch: impl Fn(bool, &mut Vec<PathBranch<'a>>) -> Option<EvalEscape>,
 ) -> PathResolveResult<'a> {
     let mut out = Vec::new();
     for c in cond_outputs {
-        match dispatch(c.is_truthy()) {
-            Ok(branches) => out.extend(branches),
-            Err((prefix, e)) => {
-                out.extend(prefix);
-                return Err((out, e));
-            }
+        if let Some(e) = dispatch(c.is_truthy(), &mut out) {
+            return Err((out, e));
         }
     }
     path_result(out, cond_escape)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13393,14 +13393,19 @@ fn resolve_node<'a, S: EvalSemantics>(
         // raising `x`.
         Expr::Builtin(Builtin::Select(cond)) => {
             let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            let branches: Vec<PathBranch<'a>> = cond_outputs
-                .into_iter()
-                .filter(OwnedValue::is_truthy)
-                // `select` filters; it never navigates. The value handed
-                // back is the caller's own, so its trackability is too.
-                .map(|_| PathBranch::new(Vec::new(), Cow::Borrowed(value), trackable))
-                .collect();
-            path_result(branches, escape)
+            resolve_cond_fork(cond_outputs, escape, |truthy| {
+                if truthy {
+                    // `select` filters; it never navigates. The value handed
+                    // back is the caller's own, so its trackability is too.
+                    Ok(vec![PathBranch::new(
+                        Vec::new(),
+                        Cow::Borrowed(value),
+                        trackable,
+                    )])
+                } else {
+                    Ok(Vec::new())
+                }
+            })
         }
         Expr::Builtin(
             builtin @ (Builtin::Values
@@ -13461,22 +13466,10 @@ fn resolve_node<'a, S: EvalSemantics>(
             else_branch,
         } => {
             let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            let mut out = Vec::new();
-            for c in cond_outputs {
-                let branch = if c.is_truthy() {
-                    then_branch
-                } else {
-                    else_branch
-                };
-                match resolve_node::<S>(branch, value, trackable) {
-                    Ok(branches) => out.extend(branches),
-                    Err((prefix, e)) => {
-                        out.extend(prefix);
-                        return Err((out, e));
-                    }
-                }
-            }
-            path_result(out, escape)
+            resolve_cond_fork(cond_outputs, escape, |truthy| {
+                let branch = if truthy { then_branch } else { else_branch };
+                resolve_node::<S>(branch, value, trackable)
+            })
         }
 
         // `a // b`: resolve `a`, keep only its truthy branches — jq's `//`
@@ -13505,14 +13498,18 @@ fn resolve_node<'a, S: EvalSemantics>(
         // own outcome swallowed a `halt`/`break` the retry surfaced instead
         // of letting it escape, same review round).
         //
-        // Every other shape — a `Comma`-fanned `a` mixing a falsy/non-path
-        // sibling with a path-shaped or truthy one, any non-literal filter
-        // that merely *evaluates* to something falsy, ... — is not handled:
-        // this resolver's `Comma`/`If`/`Select` arms already commit to the
-        // first sibling's own failure eagerly, before `//`'s truthy filter
-        // ever gets a chance to see it, the same "resolve everything up
-        // front, not lazily per output" gap #820 tracks more generally;
-        // filed as #980 rather than solved here.
+        // A `Comma`-fanned `a` mixing a falsy/non-path sibling with a
+        // path-shaped or truthy one used to be the one shape this arm
+        // didn't handle (filed as #980): `Comma` used to commit to a
+        // sibling's own failure eagerly, before `//`'s truthy filter ever
+        // got a chance to see it. #1288's "`Expr::Comma` stops checking a
+        // position too early" fixed this incidentally, not this arm
+        // itself; confirmed live against jq 1.7.1, all eight shapes #980
+        // pinned (`path((.a, false) // .b)`, `path((false, .a) // .b)`,
+        // `path((.a, null) // .b)`, `path((null, false) // .b)`,
+        // `path((.x, .a) // .b)`, `path((false, false) // .b)`,
+        // `path((.a, false, .a) // .b)`, and the genuinely-still-erroring
+        // `path((.a, 1) // .b)`) now match.
         Expr::Alternative(left, right) => {
             if let Expr::Literal(lit) = unwrap_paren(left) {
                 if !literal_to_owned(lit).is_truthy() {
@@ -14259,6 +14256,44 @@ fn eval_recurse_cond<S: EvalSemantics>(
         }
     }
     cond_err
+}
+
+/// Shared `Select`/`If` "fork on cond, dispatch per output" step in path
+/// position (#1023): both arms already evaluate `cond` via
+/// `eval_owned_multi_keep_partial` themselves (the one line the two of them
+/// share verbatim isn't worth extracting on its own), then hand-rolled the
+/// identical "iterate outputs, dispatch per truthiness, collect branches,
+/// propagate a branch's own error immediately, fall through to the
+/// `cond`-level escape only once the loop drains naturally" loop
+/// independently. `dispatch` receives each output's truthiness and returns
+/// this same [`PathResolveResult`] shape resolve_node itself uses, so
+/// `Select` (which never fails building its own branch) and `If` (which
+/// recurses into `resolve_node` and so genuinely can) both fit without a
+/// bool-parameter thicket.
+///
+/// Not a retrofit of [`eval_recurse_cond`] just above: that primitive is a
+/// one-way *gate* (push only on truthy, no way to express an `else` side,
+/// no per-output return value) built for `recurse(f; cond)`'s two callers,
+/// which need exactly that and nothing more. `Select`/`If` need genuine
+/// two-way dispatch with a fallible per-branch result, which is a different
+/// enough shape that unifying all four call sites under one signature was
+/// tried and rejected during this issue's own design pass — see #1023.
+fn resolve_cond_fork<'a>(
+    cond_outputs: Vec<OwnedValue>,
+    cond_escape: Option<EvalEscape>,
+    mut dispatch: impl FnMut(bool) -> PathResolveResult<'a>,
+) -> PathResolveResult<'a> {
+    let mut out = Vec::new();
+    for c in cond_outputs {
+        match dispatch(c.is_truthy()) {
+            Ok(branches) => out.extend(branches),
+            Err((prefix, e)) => {
+                out.extend(prefix);
+                return Err((out, e));
+            }
+        }
+    }
+    path_result(out, cond_escape)
 }
 
 /// Item cap shared by every `recurse`-family explicit-stack walker

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12125,6 +12125,33 @@ fn test_resolve_node_select_keeps_cond_partial_fanout_before_error_1023() -> Res
     Ok(())
 }
 
+/// #1023: `Select`/`If` now share `resolve_cond_fork`'s implementation --
+/// CLAUDE.md's own "duplicated predicates diverge silently" rule asks for
+/// "one definition, plus a test that the call sites agree", not just that
+/// each independently matches jq in isolation (code review). `select(cond)`
+/// and `if cond then . else empty end` are the same operation expressed
+/// two ways, so running the identical partial-fanout-then-error cond
+/// through both and asserting they produce byte-identical output directly
+/// demonstrates the two arms can no longer silently diverge, since they
+/// now run through the same fork loop underneath.
+#[test]
+fn test_select_and_if_cond_fork_agree_with_each_other_1023() -> Result<()> {
+    let (select_stdout, select_stderr, select_code) =
+        run_jq_full(&["-c", r#"path(select(true, error("x")))"#], Some("null"))?;
+    let (if_stdout, if_stderr, if_code) = run_jq_full(
+        &["-c", r#"path(if (true, error("x")) then . else empty end)"#],
+        Some("null"),
+    )?;
+    assert_eq!(
+        select_code, if_code,
+        "select: {select_stderr:?} if: {if_stderr:?}"
+    );
+    assert_eq!(select_stdout, if_stdout);
+    assert!(select_stderr.contains('x'), "stderr: {select_stderr:?}");
+    assert!(if_stderr.contains('x'), "stderr: {if_stderr:?}");
+    Ok(())
+}
+
 // ============================================================================
 // #980: a `Comma`-fanned `//` left operand mixing a falsy/non-path sibling
 // with a path-shaped or truthy one used to raise a spurious error --

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12083,6 +12083,164 @@ fn test_resolve_node_alternative_falsy_literal_interacts_correctly_with_untracke
 }
 
 // ============================================================================
+// #1023: resolve_node's Select/If arms both hand-rolled the identical
+// "evaluate cond via eval_owned_multi_keep_partial, fork per output's
+// truthiness, collect branches, propagate a branch's own error immediately,
+// defer to the cond-level escape once the loop drains" shape. Unified
+// behind a shared resolve_cond_fork helper -- these tests pin that the
+// unification is behavior-preserving for both arms' pre-existing edge
+// cases (multi-output fork, partial-prefix-then-error), not just the
+// common case.
+// ============================================================================
+
+/// #1023: `Select`'s multi-output cond fork -- confirmed against jq 1.7.1,
+/// `path(select(false,false))` (three-arg `select` filters each output
+/// independently) is empty, and `path(select(true,true))` resolves twice
+/// (`[[],[]]`), matching `If`'s own #628 multi-output behavior next to it.
+#[test]
+fn test_resolve_node_select_multi_output_fork_1023() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[path(select(false,false))]"], Some("null"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[]");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[path(select(true,true))]"], Some("null"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[],[]]");
+    Ok(())
+}
+
+/// #1023: `Select`'s own partial-prefix-then-error case (the counterpart
+/// to `test_resolve_node_if_keeps_cond_partial_fanout_before_error_896`
+/// just above, for the sibling arm this issue unifies with it) -- a truthy
+/// output already resolved before a later `cond` output errors must still
+/// surface that resolved branch, not discard it. Confirmed against jq
+/// 1.7.1: `path(select(true, error("x")))` prints `[]` before raising `x`.
+#[test]
+fn test_resolve_node_select_keeps_cond_partial_fanout_before_error_1023() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(select(true, error("x")))"#], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[]");
+    assert!(stderr.contains('x'));
+    Ok(())
+}
+
+// ============================================================================
+// #980: a `Comma`-fanned `//` left operand mixing a falsy/non-path sibling
+// with a path-shaped or truthy one used to raise a spurious error --
+// `Comma` committed to a sibling's own failure eagerly, before `//`'s
+// truthy filter ever got a chance to discard it. Fixed incidentally by
+// #1288's `Expr::Comma` fix, not by the `Alternative` arm itself; pinned
+// here (as its own closing comment asked) since nothing previously guarded
+// it, and #1023's neighboring refactor touches the same machinery cluster.
+// All eight shapes confirmed against jq 1.7.1.
+// ============================================================================
+
+/// #980: earlier falsy sibling, later path-shaped one.
+#[test]
+fn test_resolve_node_alternative_comma_falsy_then_path_sibling_980() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((.a, false) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]");
+    Ok(())
+}
+
+/// #980: earlier path-shaped sibling, later falsy one -- order doesn't
+/// matter.
+#[test]
+fn test_resolve_node_alternative_comma_path_then_falsy_sibling_980() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((false, .a) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]");
+    Ok(())
+}
+
+/// #980: a `null` sibling (falsy, distinct from `false`) is treated the
+/// same way.
+#[test]
+fn test_resolve_node_alternative_comma_path_then_null_sibling_980() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((.a, null) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]");
+    Ok(())
+}
+
+/// #980: every sibling falsy (mixed `null`/`false`) -- `//` falls through
+/// to the right side entirely.
+#[test]
+fn test_resolve_node_alternative_comma_all_falsy_siblings_falls_through_980() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((null, false) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"b\"]");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((false, false) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"b\"]");
+    Ok(())
+}
+
+/// #980: two path-shaped siblings, no falsy one involved at all -- both
+/// survive.
+#[test]
+fn test_resolve_node_alternative_comma_two_path_shaped_siblings_980() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[path((.a, .c) // .b)]"],
+        Some(r#"{"a":10,"c":20}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[\"a\"],[\"c\"]]");
+    Ok(())
+}
+
+/// #980: a *missing* field (`.x`, absent from the input) is falsy (`null`)
+/// exactly like a literal `false` sibling -- discarded the same way, not a
+/// distinct "two path-shaped siblings" case despite `.x` itself being a
+/// navigation step. Confirmed against jq 1.7.1: `path((.x, .a) // .b)`
+/// prints only `["a"]`, the missing-field output never surviving `//`'s
+/// truthy filter.
+#[test]
+fn test_resolve_node_alternative_comma_missing_field_sibling_is_falsy_980() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[path((.x, .a) // .b)]"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[\"a\"]]");
+    Ok(())
+}
+
+/// #980: three siblings, falsy/path/falsy -- the fix must hold across more
+/// than two outputs, not just a pair.
+#[test]
+fn test_resolve_node_alternative_comma_three_siblings_mixed_980() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[path((.a, false, .a) // .b)]"],
+        Some(r#"{"a":10}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[\"a\"],[\"a\"]]");
+    Ok(())
+}
+
+/// #980 boundary: a later sibling that is truthy but *not* path-shaped
+/// still raises -- the fix only lets *falsy* siblings through `//`'s
+/// filter uncontested, it doesn't exempt every non-path-shaped value.
+/// This is #845's own pre-existing behavior, unaffected by #980's fix;
+/// pinned here alongside the other seven shapes so the boundary between
+/// "silently filtered" and "still raises" is guarded in one place.
+#[test]
+fn test_resolve_node_alternative_comma_truthy_non_path_sibling_still_raises_980() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path((.a, 1) // .b)"], Some(r#"{"a":10}"#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]");
+    assert!(stderr.contains("Invalid path expression with result 1"));
+    Ok(())
+}
+
+// ============================================================================
 // #891: resolve_leaf's non-primitive fallback used a bespoke message for a
 // multi-output result (`range(3)` used bare inside `path(...)`) instead of
 // the same "#530" wording its single-output sibling already uses, naming


### PR DESCRIPTION
## Summary

Fixes #1023 (item 1 — the only item remaining after items 2/3 shipped in an earlier PR). `resolve_node`'s `Expr::Builtin(Builtin::Select(cond))` and `Expr::If` arms each hand-rolled the identical "evaluate `cond` via `eval_owned_multi_keep_partial`, iterate its outputs, fork per truthiness, collect resolved branches, propagate a branch's own error immediately, fall through to the `cond`-level escape only once the loop drains naturally" shape — the same duplicated-predicate failure mode `CLAUDE.md` calls out directly, and the same one #897/PR #1022 already fixed for the recurse family via `eval_recurse_cond`.

## Why this needed a new primitive, not a retrofit

`eval_recurse_cond` is a one-way *gate* — push only on truthy, no way to express an `else` side, no per-output return value — built for `recurse(f; cond)`'s two callers. `Select` filters-and-keeps (no "child"/gate concept, discards falsy outputs); `If` needs to dispatch into `then_branch` *or* `else_branch` per output, so both truthy and falsy cases carry real work a one-way gate can't express. The issue's own design pass anticipated this and asked for a "fork on cond, with per-branch dispatch" primitive instead — confirmed correct while implementing.

## Changes

- Added `resolve_cond_fork`: takes the already-evaluated `cond` outputs/escape (both arms still call `eval_owned_multi_keep_partial` themselves — the one shared line isn't worth extracting on its own) and a `dispatch` closure receiving each output's truthiness, returning the same `PathResolveResult` shape `resolve_node` itself uses. `Select`'s dispatch never fails; `If`'s recurses into `resolve_node` and genuinely can — both fit the same signature without a bool-parameter thicket.
- Refactored both `Select` and `If` arms onto it.
- Fixed a stale doc comment on the neighboring `Expr::Alternative` arm that still said the `Comma`-fanned `//` shapes filed as #980 were unhandled — #980 closed months ago, fixed incidentally by #1288's `Expr::Comma` change, not by this arm.
- Added the eight regression shapes #980's own closing comment asked to have pinned (nothing previously guarded that fix, since it was incidental), plus two new tests for `Select`'s own multi-output-fork and partial-prefix-then-error cases (mirroring `If`'s existing #628/#896 tests next to them now that both arms share one code path).
- Re-scoped issue #1023's own body down to this one remaining item and refreshed its stale line citations, per the re-tiering comment's explicit request to whoever picked this up.

## Verification

Verified live against jq 1.7.1 that every existing edge case these arms' own doc comments cite still matches exactly:
- #628's multi-output fork (`path(if (false,false) then . else empty end)` empty; `path(if (true,true) then . else empty end)` → `[[],[]]`)
- #896's partial-prefix-then-error (`path(if (true, error("x")) then . else empty end)` prints `[]` before raising)
- Ordinary `select()`/if-then-else paths (`[path(.[] | select(. > 1))]` on `[1,2,3]` → `[[1],[2]]`, matching jq)
- All eight #980 shapes (`path((.a, false) // .b)`, `path((false, .a) // .b)`, `path((.a, null) // .b)`, `path((null, false) // .b)`, `path((.x, .a) // .b)`, `path((false, false) // .b)`, `path((.a, false, .a) // .b)`, and the genuinely-still-erroring `path((.a, 1) // .b)`)

## Test plan

- [x] Full test suite (`cargo test --features cli,simd,regex,serde`, sequential) — 2692+ lib tests, 763 jq_cli_tests, all pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt --check` clean.


## Round 2 (/code-review, 10 finder agents)

No correctness bugs found in the unification itself (multiple independent traces confirmed byte-for-byte behavior preservation for both arms, plus live oracle verification of every edge case). One real efficiency finding, applied:

**Per-branch Vec allocation**: the initial `resolve_cond_fork` design (`dispatch: impl FnMut(bool) -> PathResolveResult<'a>`) forced `Select`'s own dispatch closure to allocate and immediately discard a throwaway single-element `Vec` for every truthy `cond` output (confirmed via disassembly: an unconditional alloc/dealloc pair per truthy output that didn't exist in the original hand-rolled `filter/map/collect`), and left an `Err` arm in the shared loop `Select`'s own closure can never reach. Redesigned to push directly into the shared accumulator instead: `dispatch: impl Fn(bool, &mut Vec<PathBranch<'a>>) -> Option<EvalEscape>` — `Select`'s closure now pushes 0 or 1 branches directly and always returns `None` (genuinely infallible); `If`'s extends the same buffer and returns just the escape, if any. Also loosened `FnMut` to `Fn`, matching what neither closure actually needs.

Also, per a convention-compliance finding (CLAUDE.md: "duplicated predicates diverge silently — one definition, *plus a test that the call sites agree*"): added a test confirming `select(cond)` and `if cond then . else empty end` — the same operation two ways — produce byte-identical output for an analogous partial-fanout-then-error case, directly demonstrating the two arms can no longer silently diverge. Added a cross-reference to `eval_fanout` (the pre-existing value-position analogue of this same unification) in the new helper's doc comment.

Filed #1393 as a follow-up: `eval_pipe_with_path_context_internal` (a different, path-context-aware evaluator) has the identical Select/If duplication one level up — its `Select` arm already reuses `eval_fanout`, its `If` arm still hand-rolls the same fork loop. Out of this issue's own path-position scope.

One transient `jq_golden_conformance` failure during a full-suite run (known concurrent-test-contention flake on this shared machine, per project history) did not reproduce on an isolated rerun or two subsequent full-suite reruns.

Re-ran the full local verification suite — all clean. Rebased onto latest `main` cleanly.
