### PR TITLE
docs(jq): accept regex-engine gap for l/n flags in ADR-0019

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -45,6 +45,7 @@ by Michael Nygard.
 | [ADR-0016](adr-0016.md) | ✅ Accepted | 2026-08-08 | Reject SIMD Escape Scanning for jq Format Functions           |
 | [ADR-0017](adr-0017.md) | ✅ Accepted | 2026-08-11 | Presentation-Metadata Side-Trees over a Mutable YAML Document |
 | [ADR-0018](adr-0018.md) | ✅ Accepted | 2026-08-22 | Reference-Tool Fidelity, Decided by Mode Rather than Format   |
+| [ADR-0019](adr-0019.md) | ✅ Accepted | 2026-08-22 | Reject Regex-Engine Swap for jq's l/n Flag Gaps (#920, #922)  |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0019.md
+++ b/docs/adrs/adr-0019.md
@@ -1,0 +1,118 @@
+# ADR-0019: Reject Regex-Engine Swap for jq's l/n Flag Gaps (#920, #922)
+
+## Status
+
+✅ Accepted
+
+## Context
+
+Two open issues report jq regex-flag gaps that both explicitly ask for an architecture
+decision rather than a unilateral implementation:
+
+- [issue #920](https://github.com/rust-works/succinctly/issues/920) — jq's `l` flag
+  (POSIX leftmost-longest matching) is accepted as a valid flag character but has no
+  effect. Real jq/oniguruma switches from Perl-style leftmost-first to POSIX
+  leftmost-longest under `l` (`match("a|aa|aaa";"l")` returns `"aaa"`, not `"a"`), and
+  POSIX semantics apply recursively to every subexpression, not just top-level
+  alternation.
+- [issue #922](https://github.com/rust-works/succinctly/issues/922) — jq's `n` flag
+  (suppress empty matches, implemented for the common case by #921/#730) has a narrower
+  gap: for lazy quantifiers (`a*?`) and alternations with an empty-matching branch
+  listed first (`(?:|a)`), a non-empty match exists at the same start position the
+  engine's leftmost-first search reports as empty, but it is reachable only by
+  backtracking to a different alternative.
+
+**The two issues share one root cause.** `src/jq/eval.rs:8261-8277` (the `JqRegex` doc
+comment) already states it directly: `n`'s gap is "the same category of gap as `l`'s
+missing `MatchKind::LeftmostLongest` (#920)." Rust's `regex`/`regex-automata` crates are
+Thompson-NFA-based, not backtracking. `regex-automata` 0.4.16's `MatchKind` enum has
+exactly two variants, `All` and `LeftmostFirst` — `LeftmostLongest` is a documented "we
+could add this, unclear it's worth it" comment from the crate's own maintainers, never
+implemented, because simple literal-reordering tricks don't generalize past top-level
+alternation. There is no equivalent anywhere in the `regex`/`regex-automata` stack for
+oniguruma's `ONIG_OPTION_FIND_NOT_EMPTY` (retry a different alternative at the same
+position when the first-found match is empty) either.
+
+**Every regex builtin shares one choke point.** `test`, `match`, `capture`, `sub`,
+`gsub`, `scan`, `split`, and `splits` all route match discovery through exactly two
+functions, `first_captures`/`global_captures` (`src/jq/eval.rs:8689-8723`), built on
+`next_match_step` (`src/jq/eval.rs:8653-8676`), which queries one `regex::Regex` compiled
+with Rust's fixed `LeftmostFirst` semantics. There is no per-builtin duplication to
+reconcile — any fix for either gap has exactly one place to land, and conversely no
+per-builtin escape hatch to dodge the problem for just one flag combination.
+
+**The gap is already tested, not silently wrong.** `test_regex_n_flag_known_gap_lazy_quantifier_922`
+(`src/jq/eval.rs:35396-35439`) pins the current, jq-divergent behavior with explanatory
+assertion messages (e.g. `"jq says true here (offset 2, \"a\") — known gap, #922"`).
+`test_regex_unknown_flags_rejected_730` (`src/jq/eval.rs:35270-35301`) only confirms `l`
+is accepted as valid flag syntax, not what it should do — no test currently exercises
+`l` actually changing match output, since it never has.
+
+### Candidates evaluated
+
+| Candidate | Solves #920 (`l`)? | Solves #922 (`n`)? | Cost |
+|---|---|---|---|
+| `onig` (Oniguruma FFI bindings) | Yes — it's the reference implementation jq itself uses | Yes | C dependency, breaks pure-`cargo build` portability and cross-compilation; the Rust bindings crate has a history of sporadic maintenance |
+| `pcre2` (BurntSushi's bindings) | Partial — PCRE2's own "longest match" mode is non-standard versus true POSIX leftmost-longest | Yes, via its backtracking engine | Still a C FFI dependency, same build/cross-compile cost as `onig` |
+| `fancy-regex` (pure Rust, hybrid NFA/backtracking) | **No** — inherits `regex`'s leftmost-first semantics even on its backtracking path; has no POSIX-longest mode at all | **No** — its backtracking fallback triggers only for backreferences/lookaround, not for plain lazy quantifiers, so #922's exact repro would not route through it differently | Would add a second regex crate/API surface for zero coverage of either gap |
+| Hand-rolled backtracking/longest-match over `regex-syntax` | Only for simple cases (e.g. reordering a bare top-level literal alternation by length) | Only for a fixed set of recognized shapes (plain lazy quantifiers, leading-empty alternation) | Real engineering effort that does not generalize to nested quantifiers/groups — precisely where POSIX/backtracking semantics diverge most from Perl-style, so a narrow special-case buys the least coverage where the gap is worst |
+
+The `regex` feature is gated behind `cli` and is already CLI/std-only in practice — the
+upstream `regex` crate's own default features require `std`, so `no_std` + `regex` is
+untested and would not build today regardless of this decision. No candidate above is
+disqualified by `no_std`; that constraint simply doesn't change the calculus.
+
+## Decision
+
+We will **not** swap or augment the regex engine to fix #920 or #922, and will **not**
+hand-roll a general leftmost-longest or backtracking-retry layer for them. Both gaps are
+accepted as permanent, documented limitations:
+
+- `l` stays a no-op flag character — accepted as valid jq syntax, silently without
+  effect on match semantics (`src/jq/eval.rs:8341-8345`).
+- `n` stays the skip-forward approximation implemented by `first_captures`/
+  `global_captures`: correct for every documented real-world jq use of `n` (greedy
+  quantifiers, alternations with the non-empty branch listed first), known-divergent
+  only for lazy quantifiers and empty-first alternation.
+
+Neither candidate engine clears the bar for a Low-severity (#920) and Medium-severity
+(#922) gap that are both narrow and rare in practice: the two C-FFI options (`onig`,
+`pcre2`) trade a pure-Rust, already-integrated, well-understood dependency for build
+portability and cross-compilation cost, in exchange for fixing edge cases most users
+will never hit; `fancy-regex` costs a second dependency for no actual coverage of either
+issue; and a hand-rolled special-case only covers the simple shapes already enumerated
+in the issues, while adding real correctness risk for the nested/nonlocal cases that
+POSIX/backtracking semantics actually diverge on.
+
+## Consequences
+
+**Positive:**
+
+- No new dependency, no C toolchain/cross-compilation cost, no second regex engine to
+  reason about alongside the existing `regex`/`regex-automata` stack.
+- The decision is uniform across all eight regex builtin families (`test`, `match`,
+  `capture`, `sub`, `gsub`, `scan`, `split`, `splits`), since they all share the
+  `first_captures`/`global_captures`/`next_match_step` choke point — nothing is fixed
+  for one builtin and left broken for another.
+- The gap was already correctly diagnosed and tested before this ADR — this record
+  formalizes an existing, working decision rather than changing behavior.
+
+**Negative / trade-offs:**
+
+- `succinctly jq`/`yq` remain permanently divergent from real jq for two narrow flag
+  combinations: `match("a|aa|aaa";"l")` will keep returning the leftmost-first match
+  (`"a"`), not the POSIX-longest one (`"aaa"`); `test("a*?";"n")` and similar lazy-
+  quantifier/empty-first-alternation patterns combined with `n` will keep missing
+  non-empty matches real jq finds.
+- Anyone hand-rolling a fix later has to do so at the shared choke point
+  (`first_captures`/`global_captures`/`next_match_step`/`build_regex`), which affects
+  all eight builtins at once — there's no way to patch just one.
+
+**Revisit this decision if:**
+
+- Upstream `regex-automata` ever ships `MatchKind::LeftmostLongest` (the crate's own
+  maintainers have left the door open, per the doc comment quoted in #920).
+- A well-maintained, pure-Rust (non-FFI) engine emerges that actually covers both gaps —
+  not just one, per the candidates table above.
+- Real-world reports of `l` or lazy-quantifier-plus-`n` usage become frequent enough to
+  justify the engineering cost this ADR declines to pay today.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8336,7 +8336,8 @@ fn dv_captures_at<'h>(
 /// finding it needs backtracking semantics (oniguruma's
 /// `ONIG_OPTION_FIND_NOT_EMPTY`) that Rust's non-backtracking `regex` crate
 /// has no equivalent for — the same category of gap as `l`'s missing
-/// `MatchKind::LeftmostLongest` (#920). Tracked as #922.
+/// `MatchKind::LeftmostLongest` (#920). Tracked as #922. Both gaps are
+/// accepted as permanent, documented limitations — see ADR-0019.
 #[cfg(feature = "regex")]
 struct JqRegex {
     re: regex::Regex,
@@ -8400,10 +8401,11 @@ fn build_regex(pattern: &str, flags: Option<&str>) -> Result<JqRegex, EvalError>
                 'p' => dot_matches_newline = true,
                 'g' => {}                     // global - handled at call site
                 'n' => suppress_empty = true, // suppress empty matches (#730)
-                // Recognized by real jq but not yet implemented here (#730):
+                // Recognized by real jq but not implemented here (#730):
                 // `l` (POSIX leftmost-longest) is accepted as a valid flag
                 // character, silently without effect, rather than raising
-                // the error below — see #920 for why this one stays open.
+                // the error below — see #920 and ADR-0019 for why this one
+                // stays open permanently.
                 'l' => {}
                 _ => {
                     // Real jq's own wording, and its own choice: the message
@@ -37570,8 +37572,9 @@ mod tests {
 
         // `n` (suppress empty matches, implemented below in
         // test_regex_n_flag_suppresses_empty_matches_730), `l` (POSIX
-        // leftmost-longest, not yet implemented — #920) and `p` are all
-        // real jq flag characters — they must not be rejected as unknown.
+        // leftmost-longest, permanently unimplemented — #920, ADR-0019)
+        // and `p` are all real jq flag characters — they must not be
+        // rejected as unknown.
         for flags in ["n", "l", "p"] {
             query!(br#""abc""#, &format!(r#"test("abc"; "{flags}")"#),
                 QueryResult::Owned(OwnedValue::Bool(b)) => {
@@ -37684,6 +37687,7 @@ mod tests {
         // alternation can require. Rust's non-backtracking `regex` crate
         // has no equivalent to oniguruma's `ONIG_OPTION_FIND_NOT_EMPTY`
         // (same root cause as #920's missing `MatchKind::LeftmostLongest`).
+        // Accepted as a permanent, documented limitation — see ADR-0019.
         //
         // This pins the *current, known-divergent* behavior rather than
         // jq's — verified live against jq 1.7.1, which returns `true`/a


### PR DESCRIPTION
## Summary

- Adds ADR-0019, resolving the architecture decision both #920 and #922 explicitly asked for: whether to swap/augment the regex engine to support jq's `l` flag (POSIX leftmost-longest) and the lazy-quantifier/empty-first-alternation gap in the `n` flag.
- Decision: **accept both as permanent, documented limitations.** Neither a C-FFI engine swap (`onig`/`pcre2`) nor a general hand-rolled backtracking/longest-match layer is proportionate to a Low-severity and Medium-severity gap this narrow — `fancy-regex` was also evaluated and doesn't actually solve either issue. Full reasoning and the candidate comparison table are in the ADR.
- Cross-references ADR-0019 from the four code sites that already implement/pin this behavior (`JqRegex` doc comment, the `build_regex` flag arms, and the two regex-flag tests) — **no behavior change**, since the existing skip-forward `n` implementation and no-op `l` flag were already correct per this decision, just not yet formally recorded.

Originally numbered ADR-0018; renumbered to ADR-0019 after rebasing onto main, which independently merged a different ADR-0018 (#1397, reference-tool fidelity) while this PR was open.

## Test plan

- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,regex --lib test_regex_` — all 33 regex tests pass, including `test_regex_unknown_flags_rejected_730`, `test_regex_n_flag_suppresses_empty_matches_730`, and `test_regex_n_flag_known_gap_lazy_quantifier_922` (unchanged)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Resolves #920, Resolves #922