### PR TITLE
docs(adr): record ADR-0018, the jq/yq fidelity rule and the mode axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,25 @@ echo '{"a": {"x": 1}, "b": {"x": 2, "y": 3}}' | succinctly jq '.a *= .b'  # {"a"
 printf 'a: [1, 2]\nb: [3, 4]\n' | succinctly yq '.a *= .b'               # a: [3, 4]
 ```
 
+### The rule the divergence sections below are exceptions to
+
+**`succinctly jq` follows jq; `succinctly yq` follows yq — and the *mode* decides, never the
+input format.** Bug-for-bug fidelity is the default, a reference tool's own inconsistencies
+included. Divergence is permitted only where the reference emits output it cannot itself read
+back, where matching would corrupt data or discard a write, or where matching would take the
+host process down — and every divergence must be recorded in
+[docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md) or
+[docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md). Behavioural rules
+therefore belong on `EvalSemantics` (per-mode), not on per-format traits like
+`DocumentFields`.
+
+Never state a jq/yq behaviour from memory — capture it from the pinned binary (`/usr/bin/jq`
+1.7.1, Homebrew `yq` v4.53.3). That applies to "neither tool has this" as much as to any
+other claim: `--front-matter`, `--split-exp` and cross-file evaluation all look like
+succinctly extensions and are all real yq features (#715). Calling reference surface an
+extension is the costly direction of that mistake, because extensions are exempt from the
+divergence rule above. See [docs/adrs/adr-0018.md](docs/adrs/adr-0018.md).
+
 ### yq Merge-Flag Suffixes on `*`/`*=` (yq mode only)
 
 Real yq extends `*`/`*=` with combinable flag suffixes that control merge semantics. They go directly after `*` for the plain (non-assign) form, or after `*=` for the in-place form — never between `*` and `=` (`.a *+= .b` is not valid; the flags belong after the `=`):
@@ -310,8 +329,12 @@ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)'          # b: *x   <- no &x anywhere; y
 printf 'a: &x 1\nb: *x\n' | succinctly yq 'del(.a)'   # b: 1
 ```
 
-`--sort-keys` diverges the same way when sorting would move an alias above its
-declaration. The equal-value rule also contains a real gap rather than papering over it:
+Real yq's `sort_keys` diverges the same way when sorting would move an alias above its
+declaration — and succinctly's own `--sort-keys` currently *reproduces* that unsound output,
+because the soundness pass doesn't reach the streaming path (#1350). That is a bug against
+the rule, not a second exception to it, so the "never" above is the intent and #1350 is the
+one place it does not hold. The equal-value rule also contains a real gap rather than
+papering over it:
 succinctly's alias sync is one-directional (anchor → aliases), so a write *through* an
 alias (`.b.p = 9`) updates only `.b`, where yq mutates the shared node. Emitting `b: *x`
 there would silently discard the write, so the mark is dropped and the computed value

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -44,6 +44,7 @@ by Michael Nygard.
 | [ADR-0015](adr-0015.md) | ✅ Accepted | 2026-08-05 | Keep BitVec, RankDirectory, and SelectIndex As-Is             |
 | [ADR-0016](adr-0016.md) | ✅ Accepted | 2026-08-08 | Reject SIMD Escape Scanning for jq Format Functions           |
 | [ADR-0017](adr-0017.md) | ✅ Accepted | 2026-08-11 | Presentation-Metadata Side-Trees over a Mutable YAML Document |
+| [ADR-0018](adr-0018.md) | ✅ Accepted | 2026-08-22 | Reference-Tool Fidelity, Decided by Mode Rather than Format   |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -1,0 +1,362 @@
+# ADR-0018: Reference-Tool Fidelity, Decided by Mode Rather than Format
+
+## Status
+
+✅ Accepted
+
+## Context
+
+The most load-bearing rule in this codebase has never been written down:
+
+> `succinctly jq` should behave like `jq`, and `succinctly yq` should behave like
+> `mikefarah/yq`.
+
+It governs dozens of decisions already, but it exists nowhere as a normative statement.
+Today it surfaces only as a passing claim in one [CLAUDE.md](../../CLAUDE.md) line
+(*"`succinctly yq` is now a drop-in replacement for `yq` for supported arguments"*) and as
+prose in [benchmarks/yq.md](../benchmarks/yq.md). Nothing states it as the rule that
+adjudicates a conflict, and nothing states what to do when it is under-determined. So every
+case gets re-argued from scratch, and at least one has been decided wrong.
+
+**The rule is already implemented — under a name that does not say so.**
+`EvalSemantics` ([src/jq/eval.rs](../../src/jq/eval.rs)) is a trait over two zero-sized
+marker types, `JqSemantics` and `YqSemantics`, carrying eleven behavioural constants plus a
+runtime identity tag. Every one of the eleven is a place the two reference tools disagree,
+and every one carries a doc comment recording the live verification behind it — integer
+overflow, division by zero, `has()`/`in()` on negative indices, float `%`, array `*` and
+`+`, `null` as an empty container in a merge, `halt_error`'s exit code, strict int/float
+equality, and `+`/`-`'s asymmetric `null` identities. That trait *is* this ADR's decision,
+expressed in code and applied eleven times without ever being stated as a principle.
+
+### The bare sentence does not adjudicate
+
+Scoping [#1385](https://github.com/rust-works/succinctly/issues/1385) (duplicate object
+keys) showed the sentence alone settles nothing. Four corollaries have to travel with it,
+and each has already cost concrete work.
+
+**1. When the two references disagree, which axis decides?**
+`DocumentFields::keys_dedup()` ([src/jq/document.rs](../../src/jq/document.rs)) gates
+duplicate-key collapse on **input format** — JSON `true`, YAML `false`. But that is not the
+axis the reference tools use. Real `yq` preserves duplicate keys when reading *JSON* too:
+
+```bash
+$ printf '{"b":1,"a":2,"b":3}' > dup.json
+$ printf 'b: 1\na: 2\nb: 3\n'   > dup.yaml
+
+$ jq -c 'length' dup.json                          # 2  — jq collapses
+$ yq -o=json -I=0 'length' dup.json                # 3  — yq preserves, reading JSON
+$ yq -o=json -I=0 'length' dup.yaml                # 3  — and reading YAML
+
+$ succinctly yq -o=json -I=0 'length' dup.json     # 2  <- wrong
+$ succinctly yq -o=json -I=0 'length' dup.yaml     # 3
+```
+
+A trait keyed on format cannot see which tool is running, so `syq` reading JSON silently
+inherits jq's rule. Stating only "be compatible" does not catch this; naming the axis does.
+
+**2. When a reference tool contradicts itself, do we copy the contradiction?**
+Real `yq` does, on this very document — and the inconsistency is narrower than it first
+looks:
+
+```bash
+$ yq -o=json -I=0 'length'            dup.yaml     # 3
+$ yq -o=json -I=0 'keys'              dup.yaml     # ["b","a","b"]
+$ yq -o=json -I=0 'to_entries|length' dup.yaml     # 3
+$ yq -o=json -I=0 '[.[]]'             dup.yaml     # [3,2]     <- iteration dedups
+```
+
+Probing the rest of the surface, `.[]` is the *only* outlier: `keys`, `length`,
+`to_entries`, `from_entries`, `with_entries`, `map_values` and `del` all preserve, while
+iteration alone collapses — using jq's exact first-position/last-value rule. So this is one
+nameable defect in the reference, not a diffuse mess, which is what makes it decidable
+rather than merely deferrable.
+
+**3. When may we deliberately diverge?**
+One carve-out is already accepted but justified only case-by-case: **succinctly never emits
+YAML it cannot read back**, where real `yq` does
+([#763](https://github.com/rust-works/succinctly/issues/763),
+`enforce_anchor_soundness`). Real `yq` demonstrates the problem against itself:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)'
+b: *x
+$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)' | yq '.'
+Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
+```
+
+**4. Where does a divergence get recorded?**
+[compliance/jq/limitations.md](../compliance/jq/limitations.md) exists. There was no
+`docs/compliance/yq/` — only `docs/compliance/yaml/`, which covers YAML 1.2 *spec*
+conformance, not `yq` *behavioural* fidelity. yq-mode divergences therefore had no home,
+which is part of why the same family keeps being rediscovered
+([#1342](https://github.com/rust-works/succinctly/issues/1342),
+[#1343](https://github.com/rust-works/succinctly/issues/1343),
+[#1344](https://github.com/rust-works/succinctly/issues/1344)).
+
+### The precedents already pull in four directions
+
+| Precedent | What it establishes |
+|---|---|
+| `sub`/`gsub` in yq mode ([#1122](https://github.com/rust-works/succinctly/issues/1122)) — bare 2-arg `sub` replaces *every* match | **Bug-for-bug fidelity**: reproduce a yq behaviour that contradicts jq's, and document it |
+| Anchor soundness ([#763](https://github.com/rust-works/succinctly/issues/763)) | **Deliberate divergence**, with a stated justification |
+| `@uri`/`@base64` on containers ([#1096](https://github.com/rust-works/succinctly/issues/1096)) | The two modes **deliberately differ from each other**: jq mode JSON-encodes first, yq mode errors |
+| `leaf_paths` ([#771](https://github.com/rust-works/succinctly/issues/771)) | A succinctly **extension** — neither reference defines it; a third category |
+
+All four re-verified against the pinned binaries while writing this record.
+
+### Worked example: duplicate object keys (#1385)
+
+Measured on `dup.json` / `dup.yaml` above, against **jq 1.7.1**
+([`tests/data/jq-golden/JQ_VERSION`](../../tests/data/jq-golden/JQ_VERSION)) and **yq
+v4.53.3** ([`tests/data/yq-golden/YQ_VERSION`](../../tests/data/yq-golden/YQ_VERSION)).
+Real `yq` answers identically on both inputs, so it gets one column; `succinctly yq` does
+not, so it gets two:
+
+| Filter | real jq | real yq (JSON *and* YAML) | `sjq` | `syq` ← JSON | `syq` ← YAML |
+|---|---|---|---|---|---|
+| `.` | `{"b":3,"a":2}` | `{"b":1,"a":2,"b":3}` | preserve ✗ | preserve ✓ | preserve ✓ |
+| `length` | `2` | `3` | `3` ✗ | `2` ✗ | `3` ✓ |
+| `keys` | `["a","b"]` | `["b","a","b"]` | `["a","b","b"]` ✗ | `["b","a","b"]` ✓ | `["b","a","b"]` ✓ |
+| `to_entries` | collapse | preserve | collapse ✓ | collapse ✗ | preserve ✓ |
+| `map_values(.)` | collapse | preserve | collapse ✓ | collapse ✗ | collapse ✗ |
+| `[.[]]` | `[3,2]` | `[3,2]` | `[1,2,3]` ✗ | `[3,2]` ✓ | `[1,2,3]` ✗ |
+| `.b` | `3` (last) | `3` (last) | `3` ✓ | `3` ✓ | `3` ✓ |
+
+Both modes diverge from their own reference, in opposite directions — and `syq`'s answer
+changes with the *input format* on three of seven filters, which is corollary 1 made
+visible.
+
+Three closed decisions already sit on this axis, pulling the other way.
+[#442](https://github.com/rust-works/succinctly/issues/442) and
+[#478](https://github.com/rust-works/succinctly/issues/478) — both filed `yq/jq:`, i.e.
+against **both** modes — deliberately changed JSON output to *preserve* duplicate mapping
+keys, treating the collapse as the bug; [#868](https://github.com/rust-works/succinctly/issues/868)
+did the same for `paths` in yq mode. Preserving is right for yq mode and wrong for jq mode,
+so a decision taken across both at once was always going to land wrong on one of them —
+which is corollary 1 again, reached from the opposite direction. Rules 2 and 3 below revise
+those decisions **in jq mode only**; they stand unchanged for yq.
+
+## Decision
+
+We will treat reference-tool fidelity as a normative rule, decided on the mode axis, with
+named exceptions that must be recorded. Six rules:
+
+**1. Each mode has exactly one reference, pinned by version.** `succinctly jq` targets
+`jq` at [`tests/data/jq-golden/JQ_VERSION`](../../tests/data/jq-golden/JQ_VERSION);
+`succinctly yq` targets `mikefarah/yq` at
+[`tests/data/yq-golden/YQ_VERSION`](../../tests/data/yq-golden/YQ_VERSION). A behavioural
+claim about either tool is only admissible if it was **captured from that binary**, with the
+command shown — never recalled, and never inferred from succinctly's own output. Inferring
+the intended rule from succinctly's behaviour is exactly how `keys_dedup()` came to gate on
+the wrong axis.
+
+**2. The mode decides, not the input format.** `succinctly yq` reading JSON follows yq's
+rules; `succinctly jq` reading DSV follows jq's. Therefore **behavioural rules belong on
+`EvalSemantics`**, which is parameterised by mode, and **not** on per-format traits such as
+`DocumentFields`/`DocumentCursor`, which are parameterised by format. A per-format trait may
+answer only questions genuinely about the format (how bytes are scanned, what a cursor
+navigates); the moment its answer is "because jq does X", it is on the wrong trait.
+`keys_dedup()` is the identified violation; correcting it is
+[#1385](https://github.com/rust-works/succinctly/issues/1385), not this ADR.
+
+This also names a standing hazard the codebase has hit repeatedly: a builtin generic over
+`S: EvalSemantics` is shared by *both* modes, so rewriting it to fix one mode can silently
+regress the other. Any change to a shared builtin must be verified in both modes.
+
+**3. Bug-for-bug fidelity is the default, including a reference's internal
+inconsistencies.** Where a reference tool contradicts itself, we reproduce the contradiction
+rather than "fixing" it into self-consistency. The reference's observable behaviour *is* the
+specification a user of a drop-in replacement is relying on; a self-consistency repair is an
+unrequested divergence with no user demand behind it, and it silently breaks anyone who
+depended on the real tool's actual answer. This resolves corollary 2 for real yq's `.[]`:
+succinctly should collapse duplicate keys under iteration and preserve them everywhere else,
+because that is what yq does. `sub`/`gsub`
+([#1122](https://github.com/rust-works/succinctly/issues/1122)) is this rule already applied.
+
+Note the scope. [#1385](https://github.com/rust-works/succinctly/issues/1385) is filed
+against **jq mode**, and names #1342/#1343/#1344 as its yq-side continuation — so neither it
+nor they currently own the two things this record found: `succinctly yq` collapsing when the
+same document arrived as JSON, and yq mode's missing `.[]` collapse. Rule 6 binds this ADR
+as much as any other change, so both are enumerated in
+[compliance/yq/limitations.md](../compliance/yq/limitations.md) and filed as
+[#1398](https://github.com/rust-works/succinctly/issues/1398).
+
+The rule is not unbounded: where a reference's inconsistency would fall under rule 4 — output
+it cannot re-read, data corruption, a process death — rule 4 wins. Fidelity yields to
+soundness, never to taste.
+
+**4. Divergence is permitted only under three named conditions**, and must be justified in
+writing against one of them:
+
+- **(a) The reference emits output it cannot itself consume.** Anchor soundness
+  ([#763](https://github.com/rust-works/succinctly/issues/763)) is the case: real `yq`
+  prints `b: *x` with no `&x` anywhere and then rejects its own output.
+- **(b) Matching would corrupt a document or silently discard a write.** The remaining half
+  of the anchor rule is this: succinctly's alias sync is one-directional, so emitting `*x`
+  after a write *through* the alias would discard the write; it prints the computed value
+  instead.
+- **(c) Matching would take the host process down.** succinctly is a library as well as a
+  CLI, so a crash is a caller's crash. `null | setpath([1e30]; 9)` gets jq killed on the
+  allocation; succinctly refuses with `Cannot grow array to <n> elements` — see
+  [compliance/jq/limitations.md](../compliance/jq/limitations.md#refusing-an-allocation-jq-does-not-survive).
+
+Nothing else qualifies. In particular, "the reference's behaviour is surprising", "our
+architecture makes it awkward", and "the other mode does it differently" are not
+justifications.
+
+Rule 4 governs *evaluator and CLI behaviour*. A divergence originating in which inputs the
+parser accepts, or in how a plain scalar's type resolves against a published spec, is not a
+rule-4 case at all: it is settled by the spec succinctly targets and recorded on the
+relevant `compliance/` spec page. succinctly's YAML 1.2 core-schema reading of `1_000` and
+`0X2A`, where real yq applies YAML 1.1, is the example — see
+[compliance/yq/limitations.md](../compliance/yq/limitations.md) § Input-spec divergences.
+This is a scope boundary, not a fourth carve-out: it reaches only spec-level input
+questions, and an evaluator behaviour may not be reframed as one to escape rule 4.
+
+Applying this list retroactively already finds one divergence out of policy and one gap in
+the flagship carve-out, and both are recorded rather than grandfathered:
+
+- The yq merge-flag combination `*+d` diverges from real yq (`[3,4,3,4]` there, `[1,2,3,4]`
+  here) on the stated grounds that real yq's behaviour is surprising and untested upstream.
+  That is not one of the three conditions, so it stands as a divergence to be fixed or
+  re-justified, not a settled decision.
+- Rule 4(a)'s own exemplar has a hole: `enforce_anchor_soundness` is not reached on the
+  cursor-streaming path, so `succinctly yq --sort-keys` still emits an alias above its
+  anchor — output succinctly itself refuses to parse
+  ([#1350](https://github.com/rust-works/succinctly/issues/1350)). The carve-out is the
+  intent; that path is a bug against it, not a second exception.
+
+Both are enumerated in
+[compliance/yq/limitations.md](../compliance/yq/limitations.md), which is what rule 6 is for.
+
+**5. Extensions are a third category, and must not perturb the first two.** A succinctly
+extension adds a capability neither reference has — `leaf_paths`
+([#771](https://github.com/rust-works/succinctly/issues/771)), `at_offset`/`at_position`,
+`@dsv`. An extension is permitted where it is **marked as an extension** in user-facing
+documentation, and where it **changes the behaviour of no filter the reference also
+accepts**. An extension is not a divergence and does not need a carve-out under rule 4;
+conversely, a carve-out may not be relabelled an extension to avoid being recorded.
+
+"Neither reference has it" is itself a claim about the reference, so rule 1 governs it:
+read `jq --help` / `yq --help` before adding to that list. A draft of this record listed
+`--front-matter` and `--split-exp` as extensions; both are real `yq` flags (`-f` and `-s`),
+and [#715](https://github.com/rust-works/succinctly/issues/715) — *"yq: missing
+--front-matter, real --split-exp (collides with -s), and eval-all/fileIndex"* — had already
+filed all three, cross-file evaluation included, as yq surface to implement. This is the
+more dangerous direction of a rule-5 error: because rule 5 exempts extensions from rule 4,
+mislabelling a reference feature as an extension retires a fidelity obligation rather than
+merely inventing a spurious one.
+
+**6. Every divergence is recorded on the mode's compliance page.** jq-mode divergences go in
+[compliance/jq/limitations.md](../compliance/jq/limitations.md); yq-mode divergences go in
+[compliance/yq/limitations.md](../compliance/yq/limitations.md), created alongside this ADR
+for that purpose. Both pages enumerate exceptions to *this* rule and link back here. A
+divergence that is not written down does not exist as a decision — it is a bug that has not
+been found yet.
+
+## Consequences
+
+**Positive:**
+
+- The whole duplicate-key axis becomes decidable without re-litigating first principles:
+  rule 2 says the format gate is wrong, rule 3 says match yq's `.[]` collapse rather than
+  smoothing it out, rule 6 says record whatever remains.
+  [#1385](https://github.com/rust-works/succinctly/issues/1385) can then be settled on its
+  jq-mode half without the yq half being re-argued from scratch.
+- The yq duplicate-key family (#1342/#1343/#1344) and every future yq divergence gets a
+  single home instead of being scattered across issue threads and `CLAUDE.md` sections.
+- `EvalSemantics` gains a stated purpose. Its eleven constants stop looking like accumulated
+  special cases and read as eleven applications of one rule, which makes the twelfth
+  obvious to place.
+- The shared-builtin hazard in rule 2 is named once, in a citable place, rather than
+  rediscovered per incident.
+
+**Negative / trade-offs:**
+
+- **We will knowingly ship behaviour that is wrong on its own terms.** Rule 3 commits us to
+  reproducing real yq's `.[]` dedup and its `sub`/`gsub` oddity. Anyone reading succinctly's
+  source in isolation will find these indefensible; the compliance pages are the only thing
+  that makes them legible.
+- **The yq compliance page is hand-maintained.** The jq side has a probe corpus
+  (`tests/data/jq-error-probes.tsv`) with a two-sided manifest check, so it cannot silently
+  drift. The yq side has golden fixtures and a `yq-drift` CI job but no equivalent
+  divergence manifest, so rule 6 relies on discipline rather than a gate. Building one is
+  worth a future issue.
+- **Pinning the reference makes a version bump a behaviour change.** Fidelity is to a
+  version, not to "jq" in the abstract; upgrading either pin is a deliberate, reviewed
+  change with its own churn, not routine maintenance.
+- Rule 4's carve-outs are deliberately narrow, so some real divergences will have to be
+  fixed rather than argued for.
+
+**Neutral:**
+
+- No `src/` change lands with this ADR. It records a rule already in force and names the
+  violations found while writing it — `keys_dedup()`'s format gate, the `*+d` merge flags,
+  [#1350](https://github.com/rust-works/succinctly/issues/1350)'s streaming anchor path, and
+  the two divergences that became
+  [#1398](https://github.com/rust-works/succinctly/issues/1398) — each scoped elsewhere for
+  correction.
+- Rule 5 does not restrict succinctly's extension surface; it only requires extensions be
+  labelled and inert with respect to reference-defined filters.
+- Rule 4's list of conditions is closed *by this record*, not permanently. A fourth condition
+  is reachable — by superseding or amending this ADR with the case that motivates it, which is
+  a deliberate, reviewed act rather than a one-off justification in a pull request. That is
+  the intended path for revisiting any of the six rules.
+
+## Alternatives considered and rejected
+
+- **Self-consistency over fidelity** — where a reference contradicts itself, pick the
+  coherent reading and apply it everywhere. Rejected: it makes succinctly's behaviour a
+  function of our judgement rather than of an observable binary, which is untestable against
+  an oracle and unpredictable for a user who chose a drop-in replacement. It also has no
+  stopping rule — every awkward reference behaviour becomes a candidate for repair.
+- **Gate behaviour on input format** (the status quo `keys_dedup()` encodes). Rejected by
+  measurement, not taste: real `yq` gives identical answers on JSON and YAML input across
+  every filter probed, so format is demonstrably not the axis the references use.
+- **Track differences ad hoc at each call site**, without a designated home. Rejected: this
+  is what produced the drift `EvalSemantics` was introduced to end, and the same pathology
+  the jq error-message work found when one sentence had three inlined copies.
+- **Leave the rule unwritten** and keep deciding case by case. Rejected: it is what produced
+  the `keys_dedup()` error, and it makes the divergence sections in `CLAUDE.md` a list of
+  exceptions to a rule that is stated nowhere.
+- **One merged compliance page for both modes.** Rejected: the two have different evidence
+  bases (a probe corpus versus golden fixtures) and different audiences, and rule 2's whole
+  point is that the two modes are separately adjudicated. One page per mode keeps the axis
+  visible in the file layout.
+- **Defer corollary 2 to a named owner-decision** (permitted by #1396's own framing).
+  Rejected: the precedent already exists in `sub`/`gsub`, and the inconsistency turned out
+  to be a single identifiable outlier rather than an open-ended mess — deferring would have
+  left this ADR unable to adjudicate the case that motivated it.
+
+## Related
+
+- [ADR-0000](adr-0000.md) — the ADR format this record follows.
+- [ADR-0017](adr-0017.md) — presentation-metadata side-trees; its #763 amendment records the
+  anchor-soundness divergence that rule 4(a) generalises.
+- [compliance/jq/limitations.md](../compliance/jq/limitations.md) — jq-mode divergences.
+- [compliance/yq/limitations.md](../compliance/yq/limitations.md) — yq-mode divergences.
+- [reference/jq-language.md](../reference/jq-language.md),
+  [reference/yq-language.md](../reference/yq-language.md) — feature coverage per mode.
+- [#1396](https://github.com/rust-works/succinctly/issues/1396) — this record.
+- [#1385](https://github.com/rust-works/succinctly/issues/1385) — duplicate object keys; the
+  worked example, and the case that surfaced the gap.
+- [#1122](https://github.com/rust-works/succinctly/issues/1122) — `sub`/`gsub`; bug-for-bug
+  precedent. [#763](https://github.com/rust-works/succinctly/issues/763) — anchor soundness;
+  deliberate-divergence precedent.
+  [#1096](https://github.com/rust-works/succinctly/issues/1096) — the two modes deliberately
+  differing. [#771](https://github.com/rust-works/succinctly/issues/771) — `leaf_paths`; the
+  extension category.
+- [#1342](https://github.com/rust-works/succinctly/issues/1342),
+  [#1343](https://github.com/rust-works/succinctly/issues/1343),
+  [#1344](https://github.com/rust-works/succinctly/issues/1344) — yq duplicate-key issues
+  that rule 6's page would have collected rather than scattered.
+- [#1398](https://github.com/rust-works/succinctly/issues/1398) — the yq-mode duplicate-key
+  divergences this record found: the input-format leak and the missing `.[]` collapse.
+- [#442](https://github.com/rust-works/succinctly/issues/442),
+  [#478](https://github.com/rust-works/succinctly/issues/478),
+  [#868](https://github.com/rust-works/succinctly/issues/868) — the closed decisions that
+  made output preserve duplicate keys across both modes; rules 2 and 3 revise them for jq
+  mode only.
+- [#715](https://github.com/rust-works/succinctly/issues/715) — `--front-matter`,
+  `--split-exp` and cross-file evaluation as *missing yq features*, which is why rule 5 does
+  not list them as extensions.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3,7 +3,11 @@
 [Home](../../../) > [Docs](../../) > [Compliance](../) > jq Limitations
 
 This page records how closely succinctly's evaluator reproduces jq's *error messages*,
-measured against the pinned `jq` binary rather than asserted. Since
+measured against the pinned `jq` binary rather than asserted. It is one of the two pages
+[ADR-0018](../../adrs/adr-0018.md) obliges: that record makes jq-fidelity the rule for jq
+mode, permits divergence only under three named conditions, and requires every divergence to
+be written down — so **this page is the enumeration of exceptions to ADR-0018** for jq mode,
+as [yq Limitations](../yq/limitations.md) is for yq mode. Since
 [#158](https://github.com/rust-works/succinctly/issues/158) bound the raised value as
 `catch`'s input, the message text is readable from a filter — `try f catch (if
 test("Cannot index") then … else … end)` is a real jq idiom — so the wording is part of
@@ -577,8 +581,10 @@ diff.
 
 ## Depends On
 
+- [ADR-0018](../../adrs/adr-0018.md) - the fidelity rule this page enumerates exceptions to
 - [jq Evaluator](../../reference/jq-evaluator.md) - the evaluator raising these errors
 - [jq Language Support](../../reference/jq-language.md) - feature coverage matrix
+- [yq Limitations](../yq/limitations.md) - the yq-mode counterpart to this page
 
 ## Used By
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1,0 +1,346 @@
+# yq Behavioural Conformance and Known Divergences
+
+[Home](../../../) > [Docs](../../) > [Compliance](../) > yq Limitations
+
+This page records where `succinctly yq` behaves differently from `mikefarah/yq`, and why.
+It is the yq-mode counterpart to
+[jq Error Message Conformance](../jq/limitations.md), and it exists because
+[ADR-0018](../../adrs/adr-0018.md) requires it: that record makes yq-fidelity the rule for
+yq mode, permits divergence only under three named conditions, and obliges every divergence
+to be written down. **This page is the enumeration of exceptions to ADR-0018.** A divergence
+that is not recorded here is not a decision — it is a bug nobody has found yet.
+
+Everything below was captured from the pinned binary at
+[`tests/data/yq-golden/YQ_VERSION`](../../../tests/data/yq-golden/YQ_VERSION) (**v4.53.3**),
+with the command shown. Per ADR-0018's rule 1, a claim about real yq's behaviour is
+inadmissible here unless it came from that binary — never from recall, and never from
+succinctly's own output.
+
+```bash
+./scripts/sync-yq-golden.sh          # recapture the golden fixtures from the pinned yq
+./scripts/sync-yq-golden.sh --check  # verify they have not drifted
+cargo test --features cli --test yq_golden_tests --test yq_cli_tests
+```
+
+For YAML *spec* conformance rather than yq behavioural fidelity, see
+[YAML Test Suite Conformance](../yaml/limitations.md) and
+[YAML 1.2 Compliance](../yaml/1.2.md). For feature coverage and the yq-only surface, see
+[yq Query Language Reference](../../reference/yq-language.md).
+
+## Scope note: this page is narrative, not a manifest
+
+The jq page is backed by a probe corpus
+([`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv)) with a
+two-sided manifest check, so it cannot silently drift. **The yq side has no equivalent.**
+Golden fixtures and the `yq-drift` CI job pin the cases that *are* captured, but nothing
+enumerates the divergences the fixtures do not cover. This page is therefore maintained by
+discipline, and it records categories with representative live-verified examples rather than
+claiming to be exhaustive. The full current list of known yq-mode gaps is the open issue set
+whose titles begin `yq:` — forty-five at the time of writing. Building a yq divergence
+manifest to close this hole is worth its own issue.
+
+## Deliberate divergences (ADR-0018 rule 4)
+
+These are the cases where succinctly knowingly does not match real yq. Each is measured
+against the three permitted conditions — including the one below that fails them, which is
+labelled as such rather than grandfathered.
+
+### Anchor soundness: never emit YAML we cannot read back — rule 4(a)
+
+Real yq emits YAML that real yq then refuses to parse. Two ordinary cases:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)'
+b: *x
+$ printf 'a: &x 1\nb: *x\n' | yq 'del(.a)' | yq '.'
+Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
+
+$ printf 'b: &x 1\na: *x\n' | yq 'sort_keys(.)'
+a: *x
+b: &x 1
+$ printf 'b: &x 1\na: *x\n' | yq 'sort_keys(.)' | yq '.'
+Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
+```
+
+succinctly refuses to produce that output. `enforce_anchor_soundness`
+([src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs), from
+[#763](https://github.com/rust-works/succinctly/issues/763)) emits a `*name` only when a
+matching `&name` exists, is emitted **earlier**, and holds an **equal** value; otherwise the
+mark is dropped and the value printed:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | succinctly yq 'del(.a)'
+b: 1
+```
+
+The equal-value clause also covers a genuine gap rather than papering over it: succinctly's
+alias sync is one-directional (anchor → aliases), so a write *through* an alias (`.b.p = 9`)
+updates only that position where real yq mutates the shared node. Emitting `*x` there would
+silently discard the write, so the mark is dropped and the computed value printed — rule
+4(b). True alias node identity remains unimplemented
+([#1351](https://github.com/rust-works/succinctly/issues/1351)).
+
+**Known gap in this rule.** `enforce_anchor_soundness` takes a `sort_keys` argument and
+handles it correctly — but only on the DOM path. The cursor-streaming path never calls it,
+so succinctly currently reproduces the unsound output it is supposed to prevent. The two
+paths disagree on the same document, which is what makes the gap unambiguous:
+
+```bash
+$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.'        # streaming
+a: *x
+b: &x 1
+$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys -P '.'     # DOM-forced (-P)
+a: 1
+b: &x 1
+
+$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.' | succinctly yq '.'
+Error: YAML parse error: unknown anchor 'x' referenced at offset 3
+```
+
+That is [#1350](https://github.com/rust-works/succinctly/issues/1350) — a bug against this
+carve-out, not a second carve-out. Related open items in the same family:
+[#1359](https://github.com/rust-works/succinctly/issues/1359) (a write that changes a node's
+kind drops its `&anchor`, where real yq keeps it),
+[#1360](https://github.com/rust-works/succinctly/issues/1360) (NaN false-positives the
+equal-value rule), [#1352](https://github.com/rust-works/succinctly/issues/1352) and
+[#1353](https://github.com/rust-works/succinctly/issues/1353).
+
+### Merge-flag `+` and `d` combined — **no carve-out; this one is out of policy**
+
+Real yq's `*+d` applies the deep-merge *and* the append, doubling the right operand.
+succinctly gives `+` clean priority instead:
+
+```bash
+$ printf 'a: [1, 2]\nb: [3, 4]\n' > arr.yaml
+$ yq         -o=json -I=0 '.a *=+d .b | .a' arr.yaml    # [3,4,3,4]
+$ succinctly yq -o=json -I=0 '.a *=+d .b | .a' arr.yaml # [1,2,3,4]
+```
+
+This was accepted as a "documented simplification" of behaviour that is surprising and
+untested upstream. Under ADR-0018 rule 4 that is **not** a valid justification — the output
+is readable, no data is corrupted and no process dies, so none of the three conditions
+applies. It is recorded here as a divergence to be either fixed or re-justified, not as a
+settled decision. The plain (non-combined) flags all match real yq:
+
+| Filter | real yq | succinctly |
+|---|---|---|
+| `.a *= .b` | `[3,4]` | `[3,4]` ✓ |
+| `.a *=+ .b` | `[1,2,3,4]` | `[1,2,3,4]` ✓ |
+| `.a *=d .b` | `[3,4]` | `[3,4]` ✓ |
+| `.a *=+d .b` | `[3,4,3,4]` | `[1,2,3,4]` ✗ |
+
+## Input-spec divergences (below ADR-0018's scope)
+
+ADR-0018 adjudicates *evaluator and CLI behaviour*. A divergence originating in which inputs
+the parser accepts, or in how a plain scalar's type resolves against a published spec, sits
+below that line: it is settled by the spec succinctly targets and recorded on the relevant
+spec page, not by a rule-4 carve-out. This section exists so the case is not mistaken for one.
+
+### YAML 1.1 legacy numeric forms
+
+succinctly resolves plain scalars per the YAML **1.2** core schema
+([src/yaml/scalar.rs](../../../src/yaml/scalar.rs)); real yq still accepts several YAML 1.1
+numeric spellings:
+
+```bash
+$ for v in 1_000 0X2A 0o17 0b101 +0x1A; do printf "a: $v\n" | yq -o=json -I=0 '.a'; done
+1000
+42
+15
+Error: json: error calling MarshalJSON for type *yqlib.CandidateNode: … parsing "0b101": invalid syntax
+Error: json: error calling MarshalJSON for type *yqlib.CandidateNode: … parsing "+0x1A": invalid syntax
+```
+
+succinctly answers `"1_000"`, `"0X2A"`, `15`, `"0b101"`, `"+0x1A"` — the 1.2 reading, with
+the non-1.2 spellings staying strings. So it agrees with real yq on `0o17` and diverges on
+the other four. The full table lives in
+[YAML 1.2 Compliance § Differences from System yq](../yaml/1.2.md#differences-from-system-yq);
+it is cross-referenced rather than duplicated here.
+
+An earlier draft filed this under rule 4(a), which was wrong twice over: 4(a) is about output
+the reference cannot re-read, and an *error* is not such output; and even read generously it
+would cover only the last two spellings, leaving `1_000` → `1000` and `0X2A` → `42` —
+perfectly consumable output that succinctly simply declines to match — with no justification
+at all. The justification is the spec target, which is why the case belongs here.
+
+## Open divergences (bugs, not decisions)
+
+Representative cases, each live-verified. These are gaps to close, listed here so they are
+not rediscovered from scratch.
+
+### Duplicate mapping keys
+
+The subject of [ADR-0018](../../adrs/adr-0018.md)'s worked example. Real yq preserves
+duplicate keys almost everywhere but collapses them under iteration, and succinctly matches
+neither side consistently — and, worse, answers differently depending on whether the same
+logical document arrived as JSON or YAML:
+
+```bash
+$ printf '{"b":1,"a":2,"b":3}' > dup.json
+$ printf 'b: 1\na: 2\nb: 3\n'   > dup.yaml
+
+$ yq            -o=json -I=0 'length' dup.json   # 3
+$ succinctly yq -o=json -I=0 'length' dup.json   # 2   <- format leaking into behaviour
+$ succinctly yq -o=json -I=0 'length' dup.yaml   # 3
+
+$ yq            -o=json -I=0 '[.[]]' dup.yaml    # [3,2]   — iteration collapses
+$ succinctly yq -o=json -I=0 '[.[]]' dup.yaml    # [1,2,3]
+```
+
+ADR-0018 rule 2 identifies the cause — `DocumentFields::keys_dedup()`
+([src/jq/document.rs](../../../src/jq/document.rs)) gates on input *format* where the
+reference tools decide on *mode*.
+
+**Both divergences above are [#1398](https://github.com/rust-works/succinctly/issues/1398).**
+[#1385](https://github.com/rust-works/succinctly/issues/1385) is scoped to **jq mode** (its
+own body: *"In jq mode, `succinctly jq` emits duplicate JSON object keys verbatim"*) and
+names [#1342](https://github.com/rust-works/succinctly/issues/1342) (`paths(node_filter)`),
+[#1343](https://github.com/rust-works/succinctly/issues/1343) (`-s`/`--eval-all`/`-i` bypass
+the fix) and [#1344](https://github.com/rust-works/succinctly/issues/1344)
+(`tostream`/`walk`/`recurse`) as the yq-side continuation. None of the four covers the format
+leak or the missing `.[]` collapse, which is why #1398 exists — recording them here is the
+first half of ADR-0018 rule 6, and filing them is the second.
+
+Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
+[#478](https://github.com/rust-works/succinctly/issues/478) and
+[#868](https://github.com/rust-works/succinctly/issues/868) are closed decisions that
+deliberately made output *preserve* duplicate keys. They stand for yq mode; ADR-0018 rules 2
+and 3 revise them for jq mode only.
+
+### 3-argument `sub(re; s; flags)`
+
+The bare 2-arg form matches (see the next section). The 3-arg form does not, and real yq's
+own behaviour here has resisted every hypothesis tried
+([#1122](https://github.com/rust-works/succinctly/issues/1122)) — it returns an empty string
+for a `"g"` flag and ignores `"i"` entirely, and its `gsub` does not accept a third argument
+at all:
+
+| Filter on `"aaa"` | real yq | succinctly |
+|---|---|---|
+| `sub("a";"X";"g")` | `""` | `"XXX"` |
+| `sub("A";"X";"i")` | `"aaa"` | `"Xaa"` |
+| `gsub("a";"X";"g")` | `Error: 1:1: lexer: invalid input text` | `"XXX"` |
+
+### Presentation metadata lost on two whole output routes
+
+Neither route builds a `CommentTree`, so both drop comments, style **and** anchors together:
+`--inplace` never builds one ([#1349](https://github.com/rust-works/succinctly/issues/1349)),
+and any filter yielding multiple results — anything containing a comma — loses its cursor
+before one can be captured
+([#1361](https://github.com/rust-works/succinctly/issues/1361)). Both predate
+[ADR-0017](../../adrs/adr-0017.md)'s mechanism and neither is anchor-specific.
+
+### Other categories
+
+Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),
+[#1129](https://github.com/rust-works/succinctly/issues/1129),
+[#1356](https://github.com/rust-works/succinctly/issues/1356),
+[#1358](https://github.com/rust-works/succinctly/issues/1358)), error-message rendering
+(succinctly's previews format via jq's rules rather than yq's verbatim echo —
+[#1055](https://github.com/rust-works/succinctly/issues/1055)), comment placement
+([#1079](https://github.com/rust-works/succinctly/issues/1079),
+[#1080](https://github.com/rust-works/succinctly/issues/1080),
+[#1085](https://github.com/rust-works/succinctly/issues/1085)), and the regex engine's
+zero-width-match handling
+([#1255](https://github.com/rust-works/succinctly/issues/1255) — real yq uses Go's
+`regexp`). Also see
+[yq Query Language Reference § Known Limitations](../../reference/yq-language.md#known-limitations)
+for the feature-level gaps (`*`/`+` are not cartesian generators; position builtins after DOM
+conversion).
+
+## Where the two modes deliberately differ from each other
+
+Not divergences — these are ADR-0018 rule 2 working correctly. The same filter text means
+different things in `sjq` and `syq` because the two reference tools disagree, and succinctly
+follows each one in its own mode. The behavioural axis is `EvalSemantics`
+([src/jq/eval.rs](../../../src/jq/eval.rs)) — eleven `const`s plus an `EvalTag` identity tag
+— together with a handful of `S::TAG` tests at individual call sites:
+
+| Behaviour | `succinctly jq` (jq 1.7.1) | `succinctly yq` (yq v4.53.3) |
+|---|---|---|
+| Bare 2-arg `sub(re; s)` | first match only (`"aaa"` → `"Xaa"`) | **every** match (`"aaa"` → `"XXX"`) |
+| `@uri`/`@base64`/`@html` on a container | JSON-encodes first (`[1,2]` → `"%5B1%2C2%5D"`) | errors, as real yq does |
+| `keys` | sorted | document order (yq's `keys` *is* `keys_unsorted`) |
+| Integer overflow | converts to float | wraps |
+| Division by zero | errors | infinity |
+| `%` on floats | truncates operands | float modulo |
+| `has()`/`in()` on a negative index | `false`; type mismatch errors | `true` unconditionally; type mismatch is `false` |
+| `array * array` | type error | replaces (plus the merge-flag suffixes) |
+| `array + non-array` | type error | appends as one element |
+| `null` in a `*` merge | every pairing errors | acts as an empty container |
+| `2.0 == 2` | `true` | `false` (strict int/float distinction) |
+| Bare `halt_error` exit code | `5` | `1` |
+| `7 + null` / `null - 7` | `7` / error | error / `7` |
+
+Ten of these rows are `EvalSemantics` constants, each carrying its live-verification note in
+the trait's doc comments — `7 + null` / `null - 7` is one row over two constants,
+`ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE` and `SUB_LEFT_NULL_IS_IDENTITY`. **Three are not.**
+Bare `sub` and container `@uri`/`@base64` are `S::TAG == EvalTag::Yq` tests at their call
+sites in [src/jq/eval.rs](../../../src/jq/eval.rs), and `keys` is rewritten to
+`KeysUnsorted` at parse time under `ParserMode::Yq`
+([src/jq/parser.rs](../../../src/jq/parser.rs)). More than forty `S::TAG` sites exist in
+`src/` in total.
+
+That split is the debt ADR-0018 rule 2 is aimed at, not a counterexample to it: a constant is
+discoverable from the trait definition, whereas a call-site test is discoverable only by
+grep — which is how a mode difference ends up re-derived instead of looked up. Prefer a
+constant for a new row, and lift a branch to one when you are already editing it. Either way,
+because a builtin generic over `S: EvalSemantics` is shared by both modes, any change to one
+must be verified in the other (ADR-0018 rule 2).
+
+## Extensions
+
+succinctly adds capabilities neither reference has — `at_offset`/`at_position`,
+`leaf_paths`, `@dsv`. Under ADR-0018 rule 5 these are a third category: permitted where
+marked as extensions and where they change the behaviour of no filter the reference also
+accepts. They are documented in
+[yq Query Language Reference](../../reference/yq-language.md) and in
+[CLAUDE.md](../../../CLAUDE.md), not here — an extension is not a divergence.
+
+**Not extensions, though a draft of this page listed them as such:** `--front-matter`,
+`--split-exp`, and cross-file evaluation. All three are real yq surface —
+`yq --help` lists `-f, --front-matter` and `-s, --split-exp`, and yq evaluates across
+multiple files under `eval-all` — and
+[#715](https://github.com/rust-works/succinctly/issues/715) filed all three together as
+*missing* yq features, not as succinctly inventions. They therefore carry an ordinary
+fidelity obligation. succinctly's `--split-exp` is long-only because its `-s` is already
+`--slurp`, which is a spelling divergence and belongs above, not here.
+
+Getting this backwards is worse than it looks: rule 5 exempts extensions from rule 4, so
+labelling reference surface an "extension" silently retires a fidelity obligation. Check
+`yq --help` before adding to the list above.
+
+## Provenance
+
+| Artifact | Path |
+|---|---|
+| Version pin | [`tests/data/yq-golden/YQ_VERSION`](../../../tests/data/yq-golden/YQ_VERSION) |
+| Golden fixtures | [`tests/data/yq-golden/cases/`](../../../tests/data/yq-golden/cases/) |
+| Golden harness | [`tests/yq_golden_tests.rs`](../../../tests/yq_golden_tests.rs) |
+| CLI behaviour tests | [`tests/yq_cli_tests.rs`](../../../tests/yq_cli_tests.rs) |
+| Sync script | [`scripts/sync-yq-golden.sh`](../../../scripts/sync-yq-golden.sh) |
+| Drift detector | `yq-drift` job in [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) |
+| Mode-behaviour axis | [`src/jq/eval.rs`](../../../src/jq/eval.rs) (`EvalSemantics`) |
+
+The goldens are committed, so `cargo test` runs hermetically with no `yq` on PATH; the
+`yq-drift` job re-checks them against the pinned binary, so a yq upgrade surfaces as fixture
+churn rather than a silent mismatch.
+
+## Depends On
+
+- [ADR-0018](../../adrs/adr-0018.md) - the fidelity rule this page enumerates exceptions to
+- [ADR-0017](../../adrs/adr-0017.md) - presentation-metadata side-trees (anchors, comments, style)
+- [yq Query Language Reference](../../reference/yq-language.md) - feature coverage
+- [YAML 1.2 Compliance](../yaml/1.2.md) - scalar type resolution, incl. the 1.1 numeric forms
+
+## Used By
+
+- [yq benchmarks](../../benchmarks/yq.md) - comparison against `yq`
+
+## Source & Docs
+
+- [`src/jq/eval.rs`](../../../src/jq/eval.rs) - `EvalSemantics`, the per-mode behaviour axis
+- [`src/bin/succinctly/yq_runner.rs`](../../../src/bin/succinctly/yq_runner.rs) - `enforce_anchor_soundness`
+- [`src/jq/document.rs`](../../../src/jq/document.rs) - `DocumentFields`, incl. the `keys_dedup()` violation
+- [jq Limitations](../jq/limitations.md) - the jq-mode counterpart to this page
+- [mikefarah/yq](https://github.com/mikefarah/yq) - upstream reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,10 +100,12 @@ Key lesson: Micro-benchmark wins often don't translate to end-to-end improvement
 
 ## Specification Compliance
 
-Where the parsers diverge from their specifications, the divergence is measured and recorded
-rather than asserted:
+Where the parsers diverge from their specifications — or the CLIs from the reference tools they
+reproduce ([ADR-0018](adrs/adr-0018.md)) — the divergence is measured and recorded rather than
+asserted:
 
 - [compliance/jq/limitations.md](compliance/jq/limitations.md) — jq error-message conformance measured against pinned jq, and the behaviour gaps behind the probes that do not match
+- [compliance/yq/limitations.md](compliance/yq/limitations.md) — yq behavioural conformance measured against pinned yq: the deliberate divergences, the open ones, and where the two modes differ on purpose
 - [compliance/yaml/limitations.md](compliance/yaml/limitations.md) — YAML Test Suite conformance (402 cases), unsupported features, and why validation is opt-in
 - [compliance/yaml/1.2.md](compliance/yaml/1.2.md) — YAML 1.2 scalar type resolution: the Norway problem, booleans, quoted numbers
 - [guides/cli.md](guides/cli.md) — strict validation for both formats: JSON's RFC 8259 (`json validate`, `sjq --validate`) and YAML's opt-in validator (`yaml validate`, `syq --validate`)


### PR DESCRIPTION
Closes #1396.

Records the project's most load-bearing unwritten rule — **`succinctly jq` follows jq, `succinctly yq` follows yq** — and the four corollaries the bare sentence leaves unresolved.

The rule already exists in code: `EvalSemantics` (`src/jq/eval.rs`) carries eleven behavioural constants, each a live-verified point where the two references disagree. It just existed nowhere as the principle that adjudicates a conflict.

## The decision, as six rules

1. One pinned reference per mode; a behavioural claim is inadmissible unless captured from that binary with the command shown.
2. **The mode decides, never the input format.** Behavioural rules belong on `EvalSemantics`; per-format traits like `DocumentFields` may only answer format questions. `keys_dedup()` is the identified violation — fix owned by #1385.
3. Bug-for-bug fidelity by default, a reference's own inconsistencies included.
4. Divergence only where the reference emits output it cannot re-read, where matching corrupts data or discards a write, or where matching kills the host process.
5. Extensions are a labelled third category that must not perturb reference-defined filters.
6. Every divergence is recorded on the mode's compliance page.

## Corollary 2 is resolved, not deferred

The issue permitted either. Probing the pinned yq showed its duplicate-key inconsistency is a **single outlier** rather than a diffuse mess — `.[]` collapses using jq's exact first-position/last-value rule, while `keys`, `length`, `to_entries`, `from_entries`, `with_entries`, `map_values` and `del` all preserve. That makes it decidable under rule 3.

## Measuring against the oracles changed the worked example

Every claim was captured from jq 1.7.1 (`/usr/bin/jq`) and yq v4.53.3, per the acceptance criteria. Real yq answers **identically on JSON and YAML input for all seven filters**, while `succinctly yq` flips its answer with the input format on three of them — a sharper statement of the mode-not-format axis than the issue's own table, which merged the two input columns and hid it.

## Two findings recorded rather than grandfathered

Applying rule 4 retroactively immediately found problems, and the ADR names both:

- The merge-flag `*+d` divergence (`[3,4,3,4]` in real yq, `[1,2,3,4]` here) was justified as "upstream is surprising and untested" — not one of the three carve-outs. It stands as a divergence to fix or re-justify.
- **Rule 4(a)'s own exemplar has a hole.** `enforce_anchor_soundness` takes a `sort_keys` argument and handles it correctly — but only on the DOM path. The cursor-streaming path never calls it, so the two paths disagree on the same document:

  ```console
  $ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.'       # streaming
  a: *x
  b: &x 1
  $ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys -P '.'    # DOM-forced
  a: 1
  b: &x 1
  ```

  The streaming output is YAML succinctly itself refuses to parse. Already filed as #1350 — no duplicate opened. It does make CLAUDE.md's absolute *"succinctly never emits YAML it cannot read back"* false, so that sentence is corrected to name the exception.

## Also

`docs/compliance/yq/limitations.md` is new — the counterpart to the jq page that yq-mode divergences previously had no home for (part of why #1342/#1343/#1344 kept being rediscovered). Both compliance pages now cross-link to the ADR as the rule they enumerate exceptions to.

## Verification

- Reviewed with the `review-adr` skill; it found the three gaps above, all fixed in-branch before commit.
- Inventory row added via the `update-adr-inventory` skill, not by hand.
- All relative links and cross-file heading anchors resolve locally (lychee gates any `.md` change).
- `cargo test --features cli,regex --test jq_error_message_tests` — 3/3 pass; that suite parses the jq page this PR edits.

**No `src/` changes.**