### PR TITLE
fix(jq): route string interpolation and def scopes through path context

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -540,6 +540,26 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // `label $out | file_index` silently dropped path context (#715
         // follow-up).
         Expr::Label { body, .. } => needs_path_context(body),
+        // `"...\(key)..."` (#1334): the same reasoning as `Array` above --
+        // a string interpolation slot is still just "evaluate this
+        // expression", so whatever it needs, the surrounding string needs
+        // too. Literal parts obviously never need it.
+        Expr::StringInterpolation(parts) => parts.iter().any(|part| match part {
+            StringPart::Literal(_) => false,
+            StringPart::Expr(inner) => needs_path_context(inner),
+        }),
+        // `def name(params): body; then` (#1306): the def itself doesn't
+        // need path context, but `then` might reference `key`/`parent`/...
+        // directly (`def f: 5; f, key`), and so might `body` if `then`
+        // ever calls `name` (`def f: key; .a | f`) -- recursing into both
+        // is a deliberately cheap, syntax-only approximation (no macro
+        // expansion here) that misses only one narrower case: a
+        // path-context builtin reaching `body` solely through a *call
+        // argument* (`def f(x): x; .a | f(key)`), which needs the actual
+        // substitution to see. Not covered by #1306's own repros, so left
+        // as a known gap rather than paying for a full
+        // `expand_func_calls` just to answer this routing question.
+        Expr::FuncDef { body, then, .. } => needs_path_context(body) || needs_path_context(then),
         _ => false,
     }
 }
@@ -11166,9 +11186,13 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`,
 /// `if`/`then`/`else`, `try`/`catch`, comma, and `label` (the same
 /// capability level `key`/`document_index` already have; an array literal
-/// gained this capability too, #1302 -- object literals, string
-/// interpolation, and user-defined functions remain out of scope, matching
-/// those builtins' own existing limits).
+/// gained this capability too, #1302, and a string interpolation slot and a
+/// `def` scope/function call both gained it in turn, #1334/#1306 -- object
+/// literals remain out of scope (#1332, its own multi-entry generator
+/// design pass), and a path-context builtin reaching a `def` only through a
+/// *call argument* (`def f(x): x; f(file_index)`) is a narrower, documented
+/// gap in `needs_path_context`'s own `FuncDef` arm rather than this
+/// function's limit).
 ///
 /// Routes through the ordinary evaluator, untouched, whenever `expr`
 /// doesn't reference `file_index`/`key`/`parent`/`path` anywhere
@@ -19035,6 +19059,154 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     &result,
                     file_origin,
                     &[],
+                    optional,
+                )
+            }
+        }
+        // `"...\(key)..."` (#1334): the `Array` arm's own reasoning above,
+        // applied to a string interpolation slot instead of an array
+        // element -- whatever a `\(...)` slot needs, the surrounding
+        // string needs too, and the generic fallback below (which builds
+        // the string via the plain, context-less `eval_string_interpolation`
+        // regardless) never gave it a chance to resolve.
+        //
+        // Matches `eval_string_interpolation`'s own existing "embed just
+        // the first output" convention for a multi-valued slot exactly --
+        // real jq instead fans out a `\(...)` slot's generator into one
+        // string per value, a separate, pre-existing, unrelated gap (not
+        // this fix's to close, #1403).
+        //
+        // Each slot's inner evaluation is deliberately run with `optional`
+        // forced to `false`, not the ambient value (#1302's `?`-atomicity
+        // lesson, carried over from the start rather than rediscovered
+        // here): otherwise a genuine error inside a slot could
+        // self-swallow at its own leaf-level `if optional` check before
+        // ever reaching this arm's own construction, corrupting
+        // `"a\(key, error("x"))"?` into a partial string instead of the
+        // whole interpolation being caught atomically. Forcing `false`
+        // lets a genuine error surface as a real `Error`/`Partial(_,
+        // Error)`, caught below using *this* arm's own `optional` -- the
+        // same evaluate-then-catch shape as the `Array` arm above.
+        Expr::StringInterpolation(parts)
+            if parts.iter().any(|part| match part {
+                StringPart::Literal(_) => false,
+                StringPart::Expr(inner) => needs_path_context(inner),
+            }) =>
+        {
+            let mut rendered = String::new();
+            for part in parts {
+                let inner = match part {
+                    StringPart::Literal(s) => {
+                        rendered.push_str(s);
+                        continue;
+                    }
+                    StringPart::Expr(inner) => inner,
+                };
+                let slot = eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(inner),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    false,
+                );
+                let s = match slot {
+                    QueryResult::Owned(v) => owned_to_string::<S>(&v),
+                    QueryResult::ManyOwned(vs) => {
+                        vs.first().map(owned_to_string::<S>).unwrap_or_default()
+                    }
+                    QueryResult::None => String::new(),
+                    QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_))
+                        if optional =>
+                    {
+                        return QueryResult::None;
+                    }
+                    QueryResult::Error(e) => return QueryResult::Error(e),
+                    QueryResult::Break(label) => return QueryResult::Break(label),
+                    QueryResult::Halt(code) => return QueryResult::Halt(code),
+                    QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
+                    QueryResult::Partial(_, Control::Break(label)) => {
+                        return QueryResult::Break(label);
+                    }
+                    QueryResult::Partial(_, Control::Halt(code)) => {
+                        return QueryResult::Halt(code);
+                    }
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                };
+                rendered.push_str(&s);
+            }
+            let result = OwnedValue::String(rendered);
+            if rest.is_empty() {
+                QueryResult::Owned(result)
+            } else {
+                eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &result,
+                    &result,
+                    file_origin,
+                    &[],
+                    optional,
+                )
+            }
+        }
+        // `def name(params): body; then` (#1306): the plain evaluator's own
+        // `eval_func_def` expands every call to `name` within `then` into
+        // `body`, then evaluates the expanded tree via `eval_single` --
+        // unconditionally the *plain* evaluator, dropping path context even
+        // once the outer routing decision (`needs_path_context`'s own new
+        // `FuncDef` arm, above) correctly detects that this `def` needs it.
+        // Doing the identical expansion here, then continuing through
+        // *this* same path-context evaluator instead, is what lets
+        // `key`/`parent`/... resolve when reached through a function call
+        // or in a `then` continuation after one.
+        //
+        // Unconditional, no `needs_path_context` guard: unlike `Array`'s
+        // guarded arm above (whose un-guarded case falls to a *different*,
+        // cheaper generic path), there is no dedicated "doesn't need path
+        // context" fallback for `FuncDef` to preserve -- the alternative is
+        // the fully generic `_` catch-all at the bottom, which would expand
+        // and evaluate through `eval_owned_expr_opt` at identical cost
+        // anyway (it dispatches to `eval_func_def`, the same expansion).
+        // Recursing here instead costs nothing extra when the expansion
+        // turns out not to need path context either: the path-context
+        // evaluator's own generic fallback is exactly what `eval_func_def`
+        // itself would have done.
+        //
+        // No `?`-atomicity forcing needed here, unlike `Array`/
+        // `StringInterpolation` above: a `def` scope doesn't construct or
+        // collect a value of its own the way those do (`expanded_then`'s
+        // result *is* this arm's result, with nothing wrapping it) -- it's
+        // a simple delegation, the same shape as the `Paren` arm above,
+        // which also threads `optional` straight through unchanged.
+        Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } => {
+            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
+            let then_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(&expanded_then),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            if rest.is_empty() {
+                then_result
+            } else {
+                continue_rest_with_context::<W, S>(
+                    then_result,
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
                     optional,
                 )
             }
@@ -45261,29 +45433,31 @@ mod tests {
 
     #[test]
     fn test_file_index_inside_user_defined_function() {
-        // `eval_owned_with_file_index`'s own doc comment: user-defined
-        // functions are out of scope for `--eval-all` path-context
-        // resolution, the same pre-existing limit `key`/`document_index`
-        // already have -- `needs_path_context` doesn't see through a
-        // `FuncCall`, so `.[] | f` never routes through path-context
-        // evaluation and `file_index` inside `f`'s body falls back to its
-        // default (0) rather than resolving per-element. This exercises
-        // `expand_func_calls`'s `FileIndex` arm (hit while inlining `f`'s
-        // body at call time), not per-element resolution --
-        // `test_file_index_continues_pipe_after_itself` covers that.
+        // User-defined functions used to be out of scope for `--eval-all`
+        // path-context resolution -- `needs_path_context` didn't see
+        // through a `FuncDef`, so `.[] | f` never routed through
+        // path-context evaluation and `file_index` inside `f`'s body fell
+        // back to its default (0) instead of resolving per-element. Fixed
+        // by #1306's `needs_path_context`/`eval_pipe_with_path_context_internal`
+        // `FuncDef` arms (added for `key`, but shared by every path-context
+        // builtin including this one): each element now correctly sees its
+        // own origin file (3 and 4) via `expand_func_calls`'s `FileIndex`
+        // arm, hit while inlining `f`'s body at call time -- not
+        // per-element resolution itself, `test_file_index_continues_pipe_after_itself`
+        // covers that.
         assert_eq!(
             eval_all_outputs(b"[10,20]", &[3, 4], "def f: file_index; .[] | f"),
-            vec!["0", "0"]
+            vec!["3", "4"]
         );
     }
 
     #[test]
     fn test_file_index_inside_parameterized_user_defined_function() {
-        // Same scope boundary as above, via `substitute_func_param`'s
+        // Same fix as above (#1306), via `substitute_func_param`'s
         // `FileIndex` arm instead of `expand_func_calls`'s.
         assert_eq!(
             eval_all_outputs(b"[10]", &[9], "def f($x): (file_index, $x); .[] | f(1)"),
-            vec!["0", "1"]
+            vec!["9", "1"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -544,10 +544,7 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // a string interpolation slot is still just "evaluate this
         // expression", so whatever it needs, the surrounding string needs
         // too. Literal parts obviously never need it.
-        Expr::StringInterpolation(parts) => parts.iter().any(|part| match part {
-            StringPart::Literal(_) => false,
-            StringPart::Expr(inner) => needs_path_context(inner),
-        }),
+        Expr::StringInterpolation(parts) => string_interpolation_needs_path_context(parts),
         // `def name(params): body; then` (#1306): the def itself doesn't
         // need path context, but `then` might reference `key`/`parent`/...
         // directly (`def f: 5; f, key`), and so might `body` if `then`
@@ -562,6 +559,21 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::FuncDef { body, then, .. } => needs_path_context(body) || needs_path_context(then),
         _ => false,
     }
+}
+
+/// Whether any `\(...)` slot in a string interpolation needs path context
+/// (#1334) -- one definition shared by [`needs_path_context`]'s own
+/// `StringInterpolation` arm (the routing question: does the *whole* pipe
+/// need path-context evaluation) and `eval_pipe_with_path_context_internal`'s
+/// matching arm's guard (the construction question: once already inside
+/// path-context evaluation, does *this* string need the dedicated arm, or
+/// can it fall to the cheaper generic fallback) -- so the two can't drift
+/// apart (CLAUDE.md: "duplicated predicates diverge silently", #106).
+fn string_interpolation_needs_path_context(parts: &[StringPart]) -> bool {
+    parts.iter().any(|part| match part {
+        StringPart::Literal(_) => false,
+        StringPart::Expr(inner) => needs_path_context(inner),
+    })
 }
 
 /// Evaluate a single expression against a JSON value.
@@ -19087,12 +19099,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // lets a genuine error surface as a real `Error`/`Partial(_,
         // Error)`, caught below using *this* arm's own `optional` -- the
         // same evaluate-then-catch shape as the `Array` arm above.
-        Expr::StringInterpolation(parts)
-            if parts.iter().any(|part| match part {
-                StringPart::Literal(_) => false,
-                StringPart::Expr(inner) => needs_path_context(inner),
-            }) =>
-        {
+        Expr::StringInterpolation(parts) if string_interpolation_needs_path_context(parts) => {
             let mut rendered = String::new();
             for part in parts {
                 let inner = match part {
@@ -19169,13 +19176,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // guarded arm above (whose un-guarded case falls to a *different*,
         // cheaper generic path), there is no dedicated "doesn't need path
         // context" fallback for `FuncDef` to preserve -- the alternative is
-        // the fully generic `_` catch-all at the bottom, which would expand
-        // and evaluate through `eval_owned_expr_opt` at identical cost
-        // anyway (it dispatches to `eval_func_def`, the same expansion).
-        // Recursing here instead costs nothing extra when the expansion
-        // turns out not to need path context either: the path-context
-        // evaluator's own generic fallback is exactly what `eval_func_def`
-        // itself would have done.
+        // the fully generic `_` catch-all at the bottom, which would run
+        // the identical `expand_func_calls` (it dispatches to
+        // `eval_func_def`) and then pay `eval_owned_expr_full`'s
+        // serialize-and-reparse round-trip on top, since `FuncDef` isn't in
+        // `eval_owned_fast_path`'s short list. Recursing here instead costs
+        // no more even when the expansion turns out not to need path
+        // context either -- the path-context evaluator's own generic
+        // fallback still reaches `eval_func_def` the same way, just without
+        // that extra round-trip.
         //
         // No `?`-atomicity forcing needed here, unlike `Array`/
         // `StringInterpolation` above: a `def` scope doesn't construct or

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5281,6 +5281,272 @@ fn test_array_wrapped_path_context_builtin_optional_is_atomic_1302() -> Result<(
     Ok(())
 }
 
+/// `needs_path_context` had no `Expr::StringInterpolation` arm (#1334), the
+/// same gap #1302 fixed for `Expr::Array` -- so `"k=\(key)"` silently
+/// stubbed `key` to `null` inside a `\(...)` slot, even once
+/// `needs_path_context` recursed into the slot correctly. #1302's own
+/// two-part fix (recurse in `needs_path_context`, *and* route the slot's own
+/// evaluation through the path-context evaluator during construction) is
+/// the exact template followed here. Verified live for internal consistency
+/// (`key`/`parent` are succinctly extensions, no oracle).
+#[test]
+fn test_string_interpolation_path_context_builtins_1334() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | \"k=\\(key)\""], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""k=a""#);
+
+    // Multiple slots, plus literal text woven between them.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | \"[\\(key)] parent=\\(parent)\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""[a] parent={\"a\":1}""#);
+
+    // Nested inside a longer pipe: `rest` after the string must see the
+    // newly constructed string as its fresh root (path reset), mirroring
+    // #1302's identical array-literal assertion.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | \"\\(key)\" | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    // A plain string (no path-context builtin inside) takes the original,
+    // unmodified code path and must be entirely unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | \"x\\(1)y\""], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""x1y""#);
+
+    Ok(())
+}
+
+/// Exercises the non-`Owned` arms of the new `StringInterpolation` slot
+/// match -- mirrors #1302's identical `Array`-arm coverage
+/// (`test_array_wrapped_path_context_builtin_control_flow_1302`), one slot
+/// at a time. A slot construction is atomic *per slot*, not across the
+/// whole string: unlike `Array`'s single collection point, each `\(...)`
+/// slot embeds independently, so `break`/`halt`/an uncaught error from any
+/// one slot still aborts the entire surrounding string (nothing partial is
+/// ever embedded), matching `eval_string_interpolation`'s own existing
+/// early-return-on-control-signal behavior for the plain (non-path-context)
+/// case.
+#[test]
+fn test_string_interpolation_path_context_builtin_control_flow_1334() -> Result<()> {
+    // A multi-valued slot (`key, key`, a `Comma` of two path-context
+    // builtins) -- embeds just the *first* output, matching
+    // `eval_string_interpolation`'s own existing convention (the
+    // `QueryResult::ManyOwned` arm).
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | \"[\\(key, key)]\""], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""[a]""#);
+
+    // A bare `break` out of a slot (no prior output within that slot)
+    // aborts the whole string construction and unwinds past it to the
+    // enclosing label -- the comma's second branch ("reached") must never
+    // run.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a | \"\\(key | break $out)\"), \"reached\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(
+        code, 0,
+        "break must unwind to the label, not surface as an error"
+    );
+    assert_eq!(
+        stdout, "",
+        "break must discard the whole string, not emit it"
+    );
+
+    // Same, but with real output already produced within that one slot's
+    // own generator first (`key` succeeds with "a" before `break` fires) --
+    // exercises the `Partial(_, Control::Break(_))` arm rather than the
+    // bare one above.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a | \"\\(key, break $out)\"), \"reached\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // `halt_error(n)` from a slot, as that slot's very first output (no
+    // successful output preceding it within the slot), propagates its own
+    // exit code as a bare halt.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | \"\\(key | halt_error(9))\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+
+    // Same, but with real output already produced within that slot first --
+    // exercises the `Partial(_, Control::Halt(_))` arm rather than the bare
+    // one above.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | \"\\(key, halt_error(9))\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+
+    // A comma-grouped slot where real output is produced before an
+    // uncaught error -- exercises the `Partial(_, Control::Error(_))` arm
+    // (the un-guarded one, `optional == false`) rather than the bare
+    // `Error` arm the atomicity test below already covers.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | \"\\(key, error(\"boom\"))\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    Ok(())
+}
+
+/// `?`-atomicity for the new `StringInterpolation` arm, built in from the
+/// start per #1302's own review lesson (its first cut needed a follow-up,
+/// #1333, to force the inner slot's `optional` to `false` so a genuine
+/// error surfaces for this arm's own catch instead of self-swallowing at
+/// the leaf) rather than left to be independently rediscovered here.
+#[test]
+fn test_string_interpolation_path_context_builtin_optional_is_atomic_1334() -> Result<()> {
+    // A slot that succeeds (`key`) before a later slot errors: `?` must
+    // discard the whole string, not embed a partial one.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | \"k=\\(key)-\\(error(\"boom\"))\"?"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Without `?`, the same query still hard-errors.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | \"k=\\(key)-\\(error(\"boom\"))\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // A genuinely nested `?` *inside* a slot must still work on its own
+    // terms, independent of the interpolation's own (here absent) `?`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | \"k=\\(key)-\\((error(\"boom\"))?)\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""k=a-""#);
+
+    Ok(())
+}
+
+/// `needs_path_context` had no `Expr::FuncDef` arm (#1306), so a `def`
+/// scope's own `then` continuation -- even one as simple as `def f: 5; f,
+/// key` -- never routed into path-context evaluation at all: the whole
+/// pipe fell to the plain evaluator, which has no path tracking, and `key`
+/// stubbed to `null` regardless of what preceded the `def`. Recursing into
+/// `body`/`then` fixes the *routing* decision; a second, dedicated
+/// `eval_pipe_with_path_context_internal` arm was needed too (mirroring
+/// #1302's two-part shape again) because the plain evaluator's own
+/// `eval_func_def` unconditionally evaluates the expanded `then` via
+/// `eval_single`, which would otherwise still drop path context even once
+/// routing correctly entered path-context evaluation.
+#[test]
+fn test_func_def_path_context_builtins_1306() -> Result<()> {
+    // The issue's own repro: `key` as a comma sibling to a call, after a
+    // `def`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | def f: 5; f, key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "5\n\"a\"\n");
+
+    // `key` reached directly through the def's own body, not just a
+    // comma sibling in `then` -- the `needs_path_context(body)` half of
+    // the fix, not just `needs_path_context(then)`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | def f: key; f"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    // Nested `def`s, each calling the next -- confirms the fix's recursive
+    // expansion (`expand_func_calls`, run again on the freshly expanded
+    // tree by this arm re-matching) doesn't stop after one level.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b | def f: key; def g: f; g"],
+        Some(r#"{"a":{"b":2}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""b""#);
+
+    // A plain `def` (no path-context builtin anywhere in body or then)
+    // takes the original, unmodified code path and must be unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | def f: . + 1; f"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+
+    // A parenthesized `def` with a further pipe stage *after* the closing
+    // paren -- `Expr::Paren`'s own arm splices its inner expression (the
+    // `FuncDef`) in front of whatever already followed, so this is the one
+    // real-syntax shape where the new `FuncDef` arm's own `rest` is
+    // non-empty rather than always drained by `then`, exercising its
+    // `continue_rest_with_context` branch.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (def f: 5; f) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    Ok(())
+}
+
+/// Documents a deliberate, narrow gap left open by #1306 rather than
+/// silently missed: `needs_path_context`'s new `FuncDef` arm is a cheap
+/// syntactic scan of `body`/`then` (no macro expansion), so a path-context
+/// builtin reaching the body *only* through a call argument
+/// (`def f(x): x; f(key)`) isn't detected -- the argument `key` never
+/// appears literally in `body` or `then`'s own text, only after
+/// substitution. Not covered by #1306's own repros; pinned here so a
+/// regression (this starting to silently resolve, without the routing
+/// decision being deliberately revisited) is visible rather than an
+/// unnoticed behavior change either way.
+#[test]
+fn test_func_def_path_context_argument_passing_is_a_known_gap_1306() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | def f(x): x; f(key)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    Ok(())
+}
+
+/// Documents the other half of #1306's own repro as *not* a bug, contrary
+/// to the issue's initial expectation: a comma's branches are independent,
+/// each evaluated against the same starting `current_path` the comma
+/// itself received -- not threaded from one sibling's own navigation into
+/// the next, matching real jq's own comma semantics (confirmed live:
+/// `.a.b?, path(.)` on `{"a":{"b":null}}` is `null` then `[]`, not `null`
+/// then `["a","b"]` -- `path(.)` in the second branch reflects *its own*
+/// lack of navigation, unaffected by what the first branch did). succinctly's
+/// own `key` already established and tested this independence
+/// (`test_key_survives_comma_branches`, #715: `.[] | (key, key)` on a
+/// 2-element array is `["0","0","1","1"]`, not `["0","1","0","1"]` or any
+/// other cross-branch-aware shape) before #1306 was filed. `key`/`.a.b?` as
+/// top-level comma siblings with nothing preceding them share the same
+/// root `current_path` (empty) `key` alone at the root already returns
+/// `null` for -- so `null` here is that same, already-correct answer, not
+/// a regression of a real bug. See #1306's own comment thread for the
+/// full oracle comparison.
+#[test]
+fn test_func_def_key_comma_sibling_independence_is_not_a_bug_1306() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a.b?, key"], Some(r#"{"a":{"b":null}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "null\nnull\n");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "key, .a.b?"], Some(r#"{"a":{"b":null}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "null\nnull\n");
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9223,6 +9223,31 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
     Ok(())
 }
 
+/// yq-mode counterpart to `jq_cli_tests.rs`'s
+/// `test_string_interpolation_path_context_builtins_1334`/
+/// `test_func_def_path_context_builtins_1306` -- both new
+/// `needs_path_context`/`eval_pipe_with_path_context_internal` arms
+/// (`StringInterpolation`, `FuncDef`) live on the shared `<S: EvalSemantics>`
+/// evaluator #554's fix above already established this file needs its own
+/// coverage for, not just `jq_cli_tests.rs`'s (a jq-scoped fix to shared
+/// evaluator code can silently regress yq without a dedicated check).
+#[test]
+fn test_string_interpolation_and_func_def_path_context_yq_1334_1306() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#".a | "k=\(key)""#, "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""k=a""#);
+
+    let (output, code) = run_yq_stdin(".a | def f: 5; f, key", "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "5\n\"a\"\n");
+
+    let (output, code) = run_yq_stdin(".a | def f: key; f", "a: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""a""#);
+
+    Ok(())
+}
+
 /// `keys_unsorted` gained a lazy `GenericResult`/evaluator path shared with
 /// `jq` (#140); `yq_runner.rs`'s CLI output boundary now streams it lazily
 /// too, via `can_use_m2_streaming` admitting `Builtin::KeysUnsorted` and


### PR DESCRIPTION
Fixes #1334. Addresses the "def scope" half of #1306 (kept open — see below).

## #1334: string interpolation

`needs_path_context` had no `Expr::StringInterpolation` arm, so `key`/`parent`/`file_index`
stubbed to `null`/`0` inside a `\(...)` slot:

```
$ echo '{"a":1}' | succinctly jq -c '.a | "k=\(key)"'
"k=null"      # should be "k=a"
```

Same two-part shape #1302 established for `Expr::Array`: `needs_path_context` recurses
into each slot, and a new `eval_pipe_with_path_context_internal` arm routes each slot's
own evaluation through the path-context evaluator during construction, instead of the
generic fallback's plain, context-less `eval_string_interpolation`. `?`-atomicity built in
from the start per #1302's own review lesson (its first cut needed a follow-up, #1333, to
force the inner evaluation's `optional` to `false` so a genuine error surfaces for the
arm's own catch instead of self-swallowing at the leaf) — not left to be independently
rediscovered here.

Found and filed, not fixed here (separate, pre-existing, unrelated gap): real jq fans a
multi-valued `\(...)` slot out into one string per value (`"\(1,2)"` → `"1"`, `"2"`);
succinctly's `eval_string_interpolation` always takes just the first value. My new arm
matches that existing convention exactly rather than fixing it as a byproduct. Filed as
#1403.

## #1306: def scope (partial)

The "def scope" repro is a real, same-family bug:

```
$ echo '{"a":1}' | succinctly jq -c '.a | def f: 5; f, key'
5
null          # should be "a"
```

`eval_func_def` macro-expands `then`'s function calls into `body`, then evaluates the
result via `eval_single` unconditionally — so even once `needs_path_context`'s own new
`FuncDef` arm correctly routes the pipe into path-context evaluation, the generic fallback
still called that same plain-evaluator path underneath, silently dropping context again.
Fixed with a dedicated `FuncDef` arm that performs the identical expansion, then continues
through *this* same path-context evaluator instead.

Incidentally fixes the identical gap for `file_index` (the `--eval-all` extension sharing
this plumbing) inside a user-defined function — two existing tests had pinned the old,
documented "out of scope" behavior as an explicit assertion; updated to the new, correct
per-element resolution rather than just patched to compile.

**Known, documented gap left open**: the `needs_path_context` `FuncDef` arm is a cheap
syntactic `needs_path_context(body) || needs_path_context(then)` check, not a full
expand-then-check — correct for #1306's own repro, but misses a path-context builtin
reaching `body` only through a call argument (`def f(x): x; f(key)`), since the argument
text never appears in `body`/`then` verbatim. Pinned by its own test rather than left
silently unclear.

**The other half of #1306's own repro turned out to have a mistaken premise, not a bug**:

```
$ echo '{"a":{"b":null}}' | succinctly jq -c '.a.b?, key'
null
null
```

The issue expected `null` then `"b"` (i.e. `key`'s branch reflecting `.a.b?`'s own
navigation) — but a comma's branches are independent, each evaluated against the *same*
starting `current_path` the comma itself received, not threaded from one sibling into the
next. Confirmed live against real jq's own `path(.)` as the oracle-checkable analog:

```
$ echo '{"a":{"b":null}}' | jq -c '.a.b?, path(.)'
null
[]            # not ["a","b"] -- path(.) in the second branch is unaffected by the first
```

This also matches succinctly's own prior, deliberately-tested independence
(`test_key_survives_comma_branches`, #715: `.[] | (key, key)` on a 2-element array is
`["0","0","1","1"]`, not any cross-branch-aware shape). `null` is the same, already-correct
answer a bare `key` at the root already gives — not a regression. Left as current behavior,
pinned by its own test. Posting this finding as a comment on #1306 and keeping it open
rather than closing it from this PR, since only one of its two repros is addressed.

## Verification

- Build clean, 2701/2701 lib tests + 54/54 test blocks pass, fmt clean, both clippy legs
  clean, no_std build clean.
- 98.63% patch coverage (72/73 new lines) — the one uncovered line is a provably-unreachable
  defensive `unreachable!()` arm, the exact same single-line gap #1302's own PR (#1333)
  accepted for the structurally identical `Array` arm.
- All `key`/`parent`/`file_index` shapes verified live for internal consistency (both are
  succinctly extensions — no oracle); the comma-independence finding verified live against
  real jq 1.7.1's `path(.)`.