### PR TITLE
fix(jq): a genuinely zero-output RHS/bound now produces no output

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11250,13 +11250,28 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Owned(v) => Ok(v),
         // #1313: a genuinely zero-output RHS (`.a += empty`) makes the
         // *whole* compound/alternative assignment produce zero output in
-        // real jq (`value as $value | ...` never binds), not a synthesized
-        // `null` spliced into the update filter -- `Err(QueryResult::None)`
-        // is this function's own early-return signal, so both callers'
-        // existing `Err(early_return) => return early_return` arm already
-        // does the right thing here with no change on their end.
+        // real jq (`value as $value | ...` never binds -- verified live
+        // against jq 1.7.1, all six operators plus `//=`), not a
+        // synthesized `null` spliced into the update filter --
+        // `Err(QueryResult::None)` is this function's own early-return
+        // signal, so both callers' existing `Err(early_return) => return
+        // early_return` arm already does the right thing here with no
+        // change on their end.
         QueryResult::None => Err(QueryResult::None),
         QueryResult::Error(e) => Err(QueryResult::Error(e)),
+        // `Many`/`ManyOwned` defaulting an *empty* vec to `Null` (instead of
+        // propagating zero-output the way the bare `None` arm above now
+        // does, code review #1313) relies on this crate's own hardened
+        // convention that a `Vec`-to-`QueryResult` collapse never
+        // constructs an empty `Many`/`ManyOwned` in the first place --
+        // `collapse_vec`/`owned_vec_to_result` convert an empty
+        // accumulator to `QueryResult::None` before either variant is ever
+        // built (the exact invariant #1038/#1043/#1048 hardened after each
+        // independently missing it). Live-probed several zero-output RHS
+        // shapes that could plausibly reach here as a nonempty-looking
+        // stream (`(1,2) | select(false)`, `(empty, empty)`) -- all
+        // correctly arrive as the `None` arm above instead, confirming the
+        // invariant holds for every reachable path today.
         QueryResult::Many(vs) => Ok(vs.first().map_or(OwnedValue::Null, to_owned)),
         QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().unwrap_or(OwnedValue::Null)),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
@@ -11269,7 +11284,9 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Same "take the first output, ignore the rest" policy as `ManyOwned`
         // above; the trailing `Error`/`Break` is dropped, consistent with how
         // this function already doesn't fork over a multi-output RHS (#392, a
-        // separate, pre-existing limitation).
+        // separate, pre-existing limitation). Same empty-prefix invariant as
+        // `Many`/`ManyOwned` above applies here too -- a `Partial` prefix is
+        // never empty (see `partial`'s own contract).
         QueryResult::Partial(vs, _control) => Ok(vs.into_iter().next().unwrap_or(OwnedValue::Null)),
     }
 }
@@ -13850,8 +13867,10 @@ fn resolve_limit<'a, S: EvalSemantics>(
     // a genuinely zero-output bound to `Null` by design -- which would fall
     // into the `Null`/`Bool` "unlimited passthrough" arm below instead of
     // jq's own `n as $n | ...` desugaring, where a zero-output `n` never
-    // even reaches `path(paths)` and the whole call produces zero output.
-    // `eval_owned_expr_full` keeps that distinction visible.
+    // even reaches `path(paths)` and the whole call produces zero output
+    // (verified live against jq 1.7.1: `path(limit(empty; .a,.b))` on
+    // `{"a":1,"b":2}` produces nothing, exit 0). `eval_owned_expr_full`
+    // keeps that distinction visible.
     let n_value = match eval_owned_expr_full::<S>(n_expr, value, false) {
         Ok(Some((v, _trailing))) => v,
         Ok(None) => return Ok(Vec::new()),
@@ -13869,6 +13888,16 @@ fn resolve_limit<'a, S: EvalSemantics>(
         | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
         | OwnedValue::Null
         | OwnedValue::Bool(_) => {
+            return resolve_node::<S>(expr, value, trackable);
+        }
+        // Same for a negative float, matching `eval_limit`'s own identical
+        // arm -- missing here before this fix (code review, #1313), so
+        // `path(limit(-1.5; ...))` raised "limit requires non-negative
+        // integer" while plain-value-mode `limit(-1.5; ...)` correctly gave
+        // unlimited passthrough. Verified live against jq 1.7.1: both
+        // modes now agree (`path(limit(-1.5; .a,.b))` on `{"a":1,"b":2}` is
+        // `["a"]` then `["b"]` in both real jq and here).
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
             return resolve_node::<S>(expr, value, trackable);
         }
         _ => {
@@ -16777,10 +16806,12 @@ fn eval_owned_fast_path<S: EvalSemantics>(
 /// caller that must let a `break $label` inside its operand reach its
 /// enclosing `label` (#575) but can't (or, for a caller needing every
 /// output rather than one collapsed value, shouldn't) use
-/// [`eval_owned_expr_fork`] directly. Direct callers today: `resolve_limit`
-/// (a single bound value, not a stream) and `builtin_paths_filter`'s
+/// [`eval_owned_expr_fork`] directly. Direct caller today: `builtin_paths_filter`'s
 /// root-node check (only ever cares whether the root escaped, not what it
-/// produced). `while`/`until`/`repeat`/`reduce`/`foreach`/`walk` all use
+/// produced) -- `resolve_limit` used to be a second caller, but its own
+/// zero-output bound turned out to be exactly the collapsing this function
+/// exists to do, which was the bug (#1313); it now calls
+/// [`eval_owned_expr_full`] directly instead. `while`/`until`/`repeat`/`reduce`/`foreach`/`walk` all use
 /// `eval_owned_expr_fork` directly instead, since each needs the full
 /// `(Vec<OwnedValue>, Option<Control>)` shape to avoid silently dropping a
 /// trailing error/break behind values already produced (#855). Same fix
@@ -17193,27 +17224,35 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1313: `result_to_owned` collapses a genuinely zero-output bound
     // (`limit(empty; ...)`) into `result_to_owned_ctrl`'s own `Err("no
     // value")` -- not real jq's behavior (`n as $n | ...` never binds, so
-    // the whole call produces zero output, not an error). `result_to_owned_full`
+    // the whole call produces zero output, not an error -- verified live
+    // against jq 1.7.1: `limit(empty; .a,.b)` on `{"a":1,"b":2}` produces
+    // nothing, exit 0). `result_to_owned_full`
     // (#1045) keeps that distinction visible; migrated the same way every
     // other #1045-era caller already was (e.g. `builtin_ltrimstr` above).
-    let n = match result_to_owned_full(n_result) {
+    // Unwrap the `(value, trailing)` pair once up front, matching the
+    // house style `resolve_limit` (above) and `builtin_nth` both use for
+    // `result_to_owned_full`/`eval_owned_expr_full` call sites, rather than
+    // repeating `Ok(Some((pattern, _)))` in every arm below (code review,
+    // #1313) -- `trailing` is unused here either way (same drop the old,
+    // pre-#1313 `result_to_owned` already made), just surfaced once instead
+    // of four times.
+    let n_value = match result_to_owned_full(n_result) {
         Ok(None) => return QueryResult::None,
-        Ok(Some((OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _), _)))
-            if i >= 0 =>
-        {
+        Ok(Some((v, _trailing))) => v,
+        Err(e) => return e.into(),
+    };
+    let n = match n_value {
+        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
             i as usize
         }
         // A negative int, `null`, or a bool -- jq's total ordering places
         // all three below every positive number, so each takes the same
         // "no limit at all" branch of jq's own `def limit`, not an error
         // -- verified against jq 1.7.1 (#983).
-        Ok(Some((
-            OwnedValue::Int(_)
-            | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-            | OwnedValue::Null
-            | OwnedValue::Bool(_),
-            _,
-        ))) => {
+        OwnedValue::Int(_)
+        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+        | OwnedValue::Null
+        | OwnedValue::Bool(_) => {
             return eval_single::<W, S>(expr, value, optional);
         }
         // Same for a negative float. A *positive* non-integer float (e.g.
@@ -17221,16 +17260,12 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // foreach-decrement loop bounds it to 2 outputs; succinctly errors
         // instead) left untouched here -- out of #983's scope, which is
         // specifically the negative/null/bool "no limit" branch.
-        Ok(Some((
-            OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _),
-            _,
-        ))) if f < 0.0 => {
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
             return eval_single::<W, S>(expr, value, optional);
         }
-        Ok(Some(_)) => {
+        _ => {
             return QueryResult::Error(EvalError::new("limit requires non-negative integer"));
         }
-        Err(e) => return e.into(),
     };
 
     if n == 0 {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11248,7 +11248,14 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match eval_single::<W, S>(expr, value, optional).materialize_cursor() {
         QueryResult::One(v) => Ok(to_owned(&v)),
         QueryResult::Owned(v) => Ok(v),
-        QueryResult::None => Ok(OwnedValue::Null),
+        // #1313: a genuinely zero-output RHS (`.a += empty`) makes the
+        // *whole* compound/alternative assignment produce zero output in
+        // real jq (`value as $value | ...` never binds), not a synthesized
+        // `null` spliced into the update filter -- `Err(QueryResult::None)`
+        // is this function's own early-return signal, so both callers'
+        // existing `Err(early_return) => return early_return` arm already
+        // does the right thing here with no change on their end.
+        QueryResult::None => Err(QueryResult::None),
         QueryResult::Error(e) => Err(QueryResult::Error(e)),
         QueryResult::Many(vs) => Ok(vs.first().map_or(OwnedValue::Null, to_owned)),
         QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().unwrap_or(OwnedValue::Null)),
@@ -13839,8 +13846,17 @@ fn resolve_limit<'a, S: EvalSemantics>(
     value: &'a OwnedValue,
     trackable: bool,
 ) -> PathResolveResult<'a> {
-    let n_value = eval_owned_expr_ctrl::<S>(n_expr, value, false)
-        .map_err(|control| (Vec::new(), control.into()))?;
+    // #1313: `eval_owned_expr_ctrl` (used elsewhere in this file) collapses
+    // a genuinely zero-output bound to `Null` by design -- which would fall
+    // into the `Null`/`Bool` "unlimited passthrough" arm below instead of
+    // jq's own `n as $n | ...` desugaring, where a zero-output `n` never
+    // even reaches `path(paths)` and the whole call produces zero output.
+    // `eval_owned_expr_full` keeps that distinction visible.
+    let n_value = match eval_owned_expr_full::<S>(n_expr, value, false) {
+        Ok(Some((v, _trailing))) => v,
+        Ok(None) => return Ok(Vec::new()),
+        Err(control) => return Err((Vec::new(), control.into())),
+    };
     let n = match n_value {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
             i as usize
@@ -17174,20 +17190,30 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // not an error (#983; verified against jq 1.7.1: `limit(-1; 1,2,3)`
     // and `limit(null; 1,2,3)` both pass every value through unchanged).
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
-    let n = match result_to_owned(n_result) {
-        Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) if i >= 0 => {
+    // #1313: `result_to_owned` collapses a genuinely zero-output bound
+    // (`limit(empty; ...)`) into `result_to_owned_ctrl`'s own `Err("no
+    // value")` -- not real jq's behavior (`n as $n | ...` never binds, so
+    // the whole call produces zero output, not an error). `result_to_owned_full`
+    // (#1045) keeps that distinction visible; migrated the same way every
+    // other #1045-era caller already was (e.g. `builtin_ltrimstr` above).
+    let n = match result_to_owned_full(n_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _), _)))
+            if i >= 0 =>
+        {
             i as usize
         }
         // A negative int, `null`, or a bool -- jq's total ordering places
         // all three below every positive number, so each takes the same
         // "no limit at all" branch of jq's own `def limit`, not an error
         // -- verified against jq 1.7.1 (#983).
-        Ok(
+        Ok(Some((
             OwnedValue::Int(_)
             | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
             | OwnedValue::Null
             | OwnedValue::Bool(_),
-        ) => {
+            _,
+        ))) => {
             return eval_single::<W, S>(expr, value, optional);
         }
         // Same for a negative float. A *positive* non-integer float (e.g.
@@ -17195,12 +17221,13 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // foreach-decrement loop bounds it to 2 outputs; succinctly errors
         // instead) left untouched here -- out of #983's scope, which is
         // specifically the negative/null/bool "no limit" branch.
-        Ok(OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _))
-            if f < 0.0 =>
-        {
+        Ok(Some((
+            OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _),
+            _,
+        ))) if f < 0.0 => {
             return eval_single::<W, S>(expr, value, optional);
         }
-        Ok(_) => {
+        Ok(Some(_)) => {
             return QueryResult::Error(EvalError::new("limit requires non-negative integer"));
         }
         Err(e) => return e.into(),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14608,6 +14608,81 @@ fn test_path_context_parent_n_argument_wrong_type_errors_1280() -> Result<()> {
     Ok(())
 }
 
+/// #1313: `resolve_limit`'s own `n`-bound evaluation used `eval_owned_expr_ctrl`,
+/// which by design collapses a genuinely zero-output bound to `Null` --
+/// falling into the `Null`/`Bool` "unlimited passthrough" branch instead of
+/// jq's own `n as $n | ...` desugaring, where `n` producing zero outputs
+/// makes the whole call produce zero output. Both `path(...)` mode (this
+/// function) and plain value mode (`eval_limit`, the sibling test below)
+/// had the identical bug via two different collapsing helpers.
+#[test]
+fn test_limit_path_mode_zero_output_bound_produces_no_output_1313() -> Result<()> {
+    let (out, _err, code) = run_jq_full(
+        &["-c", "path(limit(empty; .a,.b))"],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "");
+
+    // Sanity: a normal bound is unaffected.
+    let (out, _err, code) =
+        run_jq_full(&["-c", "path(limit(1; .a,.b))"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[\"a\"]\n");
+
+    Ok(())
+}
+
+/// #1313: the plain value-mode sibling of the fix above -- `eval_limit`
+/// used `result_to_owned`, which collapses a zero-output bound into
+/// `result_to_owned_ctrl`'s own `Err("no value")` instead of the zero-output
+/// case `result_to_owned_full` (#1045) already exists to distinguish (and
+/// every other #1045-migrated caller, e.g. `builtin_ltrimstr`, already
+/// uses).
+#[test]
+fn test_limit_value_mode_zero_output_bound_produces_no_output_1313() -> Result<()> {
+    let (out, _err, code) = run_jq_full(&["-c", "limit(empty; .a,.b)"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "");
+
+    // Sanity: negative/null/bool bounds still take the pre-existing
+    // "unlimited passthrough" branch (#983), unaffected by this fix.
+    let (out, _err, code) = run_jq_full(&["-c", "limit(-1; .a,.b)"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "1\n2\n");
+
+    Ok(())
+}
+
+/// #1313: `eval_rhs_once` (backing `+=`/`-=`/`*=`/`/=`/`%=`/`//=`) collapsed
+/// a genuinely zero-output RHS to `Null` and spliced it into the update
+/// filter (`. op null`), instead of real jq's `value as $value | ...`
+/// desugaring, where `value` producing zero outputs makes the whole
+/// assignment produce zero output. Covers every compound operator, plus
+/// `//=` (whose RHS is unconditional -- it's evaluated regardless of
+/// whether the current value is already truthy, since `//=`'s own
+/// short-circuiting is about which *filter result* wins per resolved path,
+/// not whether the RHS expression itself runs).
+#[test]
+fn test_compound_assign_empty_rhs_produces_no_output_1313() -> Result<()> {
+    for op in ["+=", "-=", "*=", "/=", "%="] {
+        let (out, err, code) = run_jq_full(&["-c", &format!(".a {op} empty")], Some(r#"{"a":2}"#))?;
+        assert_eq!(code, 0, "op={op} err={err}");
+        assert_eq!(out, "", "op={op}");
+    }
+
+    let (out, err, code) = run_jq_full(&["-c", ".a //= empty"], Some(r#"{"a":null}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    // Sanity: a normal RHS is unaffected.
+    let (out, _err, code) = run_jq_full(&["-c", ".a += 5"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":6}"#);
+
+    Ok(())
+}
+
 /// #1045 coverage: `flatten(depth)`'s `Ok(Some(_)) => ...type_error("number",
 /// "non-number")` arm -- a non-number depth argument, unconditional (no
 /// `optional` gate), unlike the negative-depth arm covered by

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14633,6 +14633,26 @@ fn test_limit_path_mode_zero_output_bound_produces_no_output_1313() -> Result<()
     Ok(())
 }
 
+/// #1313 (code review): `resolve_limit`'s n-classification was missing the
+/// negative-float "unlimited passthrough" arm `eval_limit` already had
+/// (#983) -- `path(limit(-1.5; ...))` raised "limit requires non-negative
+/// integer" instead of agreeing with plain-value-mode `limit(-1.5; ...)`,
+/// which already correctly passed everything through. A pre-existing
+/// divergence between the two functions, unrelated to and not introduced by
+/// this issue's own zero-output-bound fix, but caught while both functions
+/// were already being edited for it.
+#[test]
+fn test_limit_path_mode_negative_float_bound_is_unlimited_passthrough_1313() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", "path(limit(-1.5; .a,.b))"],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "[\"a\"]\n[\"b\"]\n");
+
+    Ok(())
+}
+
 /// #1313: the plain value-mode sibling of the fix above -- `eval_limit`
 /// used `result_to_owned`, which collapses a zero-output bound into
 /// `result_to_owned_ctrl`'s own `Err("no value")` instead of the zero-output
@@ -14679,6 +14699,29 @@ fn test_compound_assign_empty_rhs_produces_no_output_1313() -> Result<()> {
     let (out, _err, code) = run_jq_full(&["-c", ".a += 5"], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"{"a":6}"#);
+
+    Ok(())
+}
+
+/// #1313 (code review): an `optional`-swallowed RHS error is a distinct
+/// shape from a genuinely zero-output generator (`empty`, covered above),
+/// but reaches `eval_rhs_once` the same way -- `.a += (1/0)?` swallows the
+/// division error to zero output at `eval_single`'s own `?` handling, then
+/// `eval_rhs_once` sees `QueryResult::None` exactly as it would for `empty`,
+/// and the whole assignment correctly produces zero output rather than
+/// splicing `null` in and evaluating `. + null` (which used to be a type
+/// error, not a silent no-op -- this is a case where the old bug produced a
+/// hard error instead of a wrong value, but still diverged from jq).
+#[test]
+fn test_compound_assign_optional_swallowed_rhs_error_produces_no_output_1313() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ".a += (1/0)?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+
+    // Without `?`, the same division-by-zero still hard-errors.
+    let (_out, err, code) = run_jq_full(&["-c", ".a += (1/0)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(err.contains("divided"), "err={err}");
 
     Ok(())
 }


### PR DESCRIPTION
Addresses items 1 and 2 of #1313 (items 3 and 4 are explicitly scoped by the issue's own tier review as separate follow-up work — not closing the issue from this PR).

Three call sites collapsed "produced nothing" into a synthesized `Null` before a downstream match could tell it apart from a real `null` value — real jq's `value as $value | ...`/`n as $n | ...` desugaring means the whole enclosing expression produces zero output when the generator producing `$value`/`$n` does, not that it proceeds with a fabricated `null`.

## `eval_rhs_once` (item 2: `+=`, `-=`, `*=`, `/=`, `%=`, `//=`)

```
$ echo '{"a":1}' | succinctly jq '.a += empty'
{"a":1}       # should be nothing
$ echo '{"a":1}' | succinctly jq '.a -= empty'
error: number (1) and null (null) cannot be subtracted
```

`QueryResult::None => Ok(OwnedValue::Null)` spliced `null` into the update filter (`. op null`) instead of short-circuiting. Changed to `Err(QueryResult::None)` — the function's own existing early-return signal, since both callers already have `Err(early_return) => return early_return`. No caller change needed.

## `resolve_limit` (item 1: `limit(n; f)` inside `path(...)`)

```
$ echo '{"a":1,"b":2}' | succinctly jq -c 'path(limit(empty; .a,.b))'
["a"]
["b"]         # should be nothing
```

Used `eval_owned_expr_ctrl`, which collapses by design; a zero-output `n` fell into the `Null`/`Bool` "unlimited passthrough" branch. Switched to `eval_owned_expr_full`, which keeps the distinction, with an `Ok(None) => return Ok(Vec::new())` arm.

## `eval_limit` (plain value mode — found live while verifying the path-mode fix, not itself named in #1313's text but the same bug's value-mode sibling)

```
$ echo '{"a":1,"b":2}' | succinctly jq -c 'limit(empty; .a,.b)'
jq: error (at <stdin>:1): no value      # should be nothing, exit 0
```

Used `result_to_owned`, which collapses a zero-output `n` into `result_to_owned_ctrl`'s own `Err("no value")`. Migrated to `result_to_owned_full` (#1045) — the same helper every other #1045-migrated caller (e.g. `builtin_ltrimstr`) already uses for exactly this distinction.

## Checked, not fixed here

- **#1313's own item 3** (a 3-arm `continue_rest_with_context` duplication in `eval_pipe_with_path_context_internal`): explicitly scoped by the tier review as "best done as its own PR."
- **Item 4** (unverified loose ends): needs its own verification pass first, per the issue.
- **#1233's yq-mode RHS-discarding fix** (also `Ready`, touches the same `eval_assign` family): read both code paths to confirm no interaction — #1233's planned fix gates entirely before reaching `eval_rhs_once`, for its own narrow yq-mode scalar-target-no-op case. Safe for #1233 to land after this and rebase cleanly.

## Verification

Every repro verified against jq 1.7.1: all six compound operators' empty RHS, `//=` on a falsy target, `limit(empty; ...)` in both path and value mode, plus sanity checks that a normal (non-empty) RHS/bound, negative/null/bool "unlimited" `limit` bounds, and #983's/#824's/#391's prior fixes in the same functions are unaffected.

Build clean, 2704/2704 lib tests + 54/54 test blocks pass (one spurious failure under this machine's concurrent-session load, confirmed environmental by an immediate clean standalone re-run), fmt clean, both clippy legs clean, no_std build clean, 90.91% patch coverage (10/11 new lines — the one gap is a benign `cargo llvm-cov` line-attribution artifact on a multi-line match-arm guard clause; the arm's own body line shows a hit count of 34 across the existing test suite, confirming it's genuinely exercised).