### PR TITLE
fix(jq): eval_pipe_with_path_context_internal catches ? atomically, not broadcast

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18770,26 +18770,59 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
         }
         Expr::Optional(inner) => {
-            // Optional - evaluate with optional=true
+            // This node *is* the `?` -- mirrors eval_try's Expr::Optional
+            // dispatch (`eval_try(inner, None, ...)`, eval.rs ~line 692),
+            // which evaluates the body and unconditionally converts an
+            // escaping Error or Break to nothing, keeping any prefix
+            // already produced before it (real jq's `(1, 2, error("x"))?`
+            // outputs `1`, `2`) -- Halt always escapes regardless (#791).
+            //
+            // `inner` is evaluated with `optional` forced to `false`, not
+            // broadcast from the ambient value, so a genuine error/break
+            // deep inside doesn't self-swallow at some leaf's own local
+            // `if optional` check before ever reaching this catch --
+            // mirrors the Array arm's identical fix (#1302) for the same
+            // reason. This catch point is the one place `?`'s suppression
+            // happens; it isn't gated on the ambient `optional` (unlike
+            // the Array arm's `if optional`) because that arm fires even
+            // with no enclosing `?` at all, whereas this arm only exists
+            // because the source literally has a `?` right here.
+            //
+            // Previously this arm broadcast `optional=true` into `inner`,
+            // and -- when `rest` was non-empty -- combined `[inner,
+            // ...rest]` into a single list evaluated under that same
+            // forced-true value, so `rest` (everything piped *after* the
+            // `?`) inherited the suppression too: `.a | (key)? |
+            // error("boom")` produced no output and no error at all,
+            // instead of real jq's error (#1335). `continue_rest_with_context`
+            // below instead threads the *ambient* `optional` into `rest`,
+            // matching every other arm here that continues into `rest`
+            // after producing an intermediate value.
+            let inner_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(inner),
+                value,
+                root,
+                file_origin,
+                current_path,
+                false,
+            );
+            let caught = match inner_result {
+                QueryResult::Error(_) | QueryResult::Break(_) => QueryResult::None,
+                QueryResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
+                    owned_vec_to_result(prefix)
+                }
+                other => other,
+            };
             if rest.is_empty() {
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &[(**inner).clone()],
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    true,
-                )
+                caught
             } else {
-                let mut combined = vec![(**inner).clone()];
-                combined.extend(rest.iter().cloned());
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &combined,
-                    value,
+                continue_rest_with_context::<W, S>(
+                    caught,
+                    rest,
                     root,
                     file_origin,
                     current_path,
-                    true,
+                    optional,
                 )
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18769,35 +18769,48 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 )
             }
         }
-        Expr::Optional(inner) => {
-            // This node *is* the `?` -- mirrors eval_try's Expr::Optional
-            // dispatch (`eval_try(inner, None, ...)`, eval.rs ~line 692),
-            // which evaluates the body and unconditionally converts an
-            // escaping Error or Break to nothing, keeping any prefix
-            // already produced before it (real jq's `(1, 2, error("x"))?`
-            // outputs `1`, `2`) -- Halt always escapes regardless (#791).
-            //
-            // `inner` is evaluated with `optional` forced to `false`, not
-            // broadcast from the ambient value, so a genuine error/break
-            // deep inside doesn't self-swallow at some leaf's own local
-            // `if optional` check before ever reaching this catch --
-            // mirrors the Array arm's identical fix (#1302) for the same
-            // reason. This catch point is the one place `?`'s suppression
-            // happens; it isn't gated on the ambient `optional` (unlike
-            // the Array arm's `if optional`) because that arm fires even
-            // with no enclosing `?` at all, whereas this arm only exists
-            // because the source literally has a `?` right here.
-            //
-            // Previously this arm broadcast `optional=true` into `inner`,
-            // and -- when `rest` was non-empty -- combined `[inner,
-            // ...rest]` into a single list evaluated under that same
-            // forced-true value, so `rest` (everything piped *after* the
-            // `?`) inherited the suppression too: `.a | (key)? |
-            // error("boom")` produced no output and no error at all,
-            // instead of real jq's error (#1335). `continue_rest_with_context`
-            // below instead threads the *ambient* `optional` into `rest`,
-            // matching every other arm here that continues into `rest`
-            // after producing an intermediate value.
+        // This node *is* the `?`. Isolates `inner` with `optional` forced to
+        // `false` (the same technique the Array arm's #1302 fix uses, not
+        // eval_try's ambient-forwarding -- a leaf mustn't self-swallow
+        // before this catch runs), then catches an escaping Error/Break
+        // unconditionally here -- unlike the Array arm's `if optional` gate
+        // (that arm fires even with no enclosing `?`, e.g. plain `[key]`;
+        // this one only exists because the source has a literal `?` right
+        // here) -- and only Error/Break, not the Array arm's Error-only
+        // (array construction never atomizes Break either). Keeps any
+        // prefix already produced (real jq's `(1, 2, error("x"))?` outputs
+        // `1`, `2`); Halt is left to the `other => other` fallthrough below,
+        // so a `Partial(prefix, Halt(_))` keeps its prefix too, matching
+        // real jq's `(1, 2, halt)?` and `yq_runner.rs`'s top-level
+        // `query_result_to_owned_values` convention (the Array arm discards
+        // it instead, since a halted array never finished constructing).
+        //
+        // Isolating `inner` this way only works when nothing downstream
+        // needs the per-output `current_path` `inner` would have produced
+        // had it continued straight into `rest` -- `Field`/`Index`/`Iterate`
+        // (and friends) only compute+thread an updated path when they have
+        // a non-empty `rest` to recurse into; evaluated with an empty
+        // `rest` for isolation, they just return bare values, so
+        // `continue_rest_with_context` below would fan them into `rest`
+        // using the *stale*, pre-`inner` `current_path` instead of each
+        // output's real one (`.a | (.[])? | key` would wrongly report every
+        // element's key as `"a"` instead of its index). This is a
+        // pre-existing limitation of the isolate-then-continue shape shared
+        // by the `Comma`/`Try`/`Label` arms elsewhere in this function, not
+        // something new here -- filed as #1409 (needs a real
+        // path-preserving redesign of that shared shape) -- but this arm
+        // must not regress it for `Optional` specifically, so it only takes
+        // the fast, isolated path when `rest` doesn't consult path context
+        // in the first place, and otherwise falls back to evaluating
+        // `[inner, ...rest]` combined under a forced `optional=true` (this
+        // arm's pre-#1335 behavior), which still threads `current_path`
+        // correctly because it never leaves the same recursive call `Field`/
+        // `Index`/`Iterate` build `new_path` inside of. That fallback still
+        // carries the narrower, pre-existing "rest inherits suppression"
+        // gap #1335 fixes in the common case (also tracked in #1409), but
+        // that's strictly no worse than `main`'s current behavior for this
+        // rarer combination.
+        Expr::Optional(inner) if rest.is_empty() || !rest.iter().any(needs_path_context) => {
             let inner_result = eval_pipe_with_path_context_internal::<W, S>(
                 core::slice::from_ref(inner),
                 value,
@@ -18825,6 +18838,18 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     optional,
                 )
             }
+        }
+        Expr::Optional(inner) => {
+            let mut combined = vec![(**inner).clone()];
+            combined.extend(rest.iter().cloned());
+            eval_pipe_with_path_context_internal::<W, S>(
+                &combined,
+                value,
+                root,
+                file_origin,
+                current_path,
+                true,
+            )
         }
         Expr::Pipe(inner_exprs) => {
             // Flatten nested pipe - combine inner pipe with rest

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5547,6 +5547,78 @@ fn test_func_def_key_comma_sibling_independence_is_not_a_bug_1306() -> Result<()
     Ok(())
 }
 
+/// `Expr::Optional`'s own dispatch in `eval_pipe_with_path_context_internal`
+/// broadcast `optional=true` into whatever it wrapped, with no catch of its
+/// own -- unlike the plain evaluator's `Expr::Optional` (`eval_try`) and the
+/// Array arm's own fix above (#1302). Two distinct symptoms, both from the
+/// same code:
+///
+/// 1. When the `?` had nothing after it in the pipe, a leaf-level `if
+///    optional` self-check deep inside the wrapped expression could produce
+///    a plausible-but-wrong value instead of this node genuinely catching an
+///    escaping error atomically.
+/// 2. When the `?` had a `rest` of the pipe after it, `rest` was combined
+///    into the *same* list evaluated under the forced `optional=true` --
+///    meaning an error *after* the `?`, which the `?` has nothing to do
+///    with, was also silently swallowed. `.a | (key)? | error("boom")`
+///    produced no output and no error at all, instead of real jq's error
+///    (confirmed against real jq's structurally identical
+///    `.a | (1)? | error("boom")`).
+///
+/// #1335's own posted repro (`(key == "a" and error("boom"))?`) turned out
+/// not to exercise this arm at all -- `needs_path_context` doesn't recurse
+/// into `Expr::And`/`Expr::Or` (filed separately as #1405), so that whole
+/// expression routes through the plain evaluator instead, where `key`
+/// silently stubs. These tests instead use constructs `needs_path_context`
+/// already recurses into (`Comma`, `Compare`, `Label`/`break`) to actually
+/// exercise the fixed code path.
+#[test]
+fn test_optional_dispatch_catches_atomically_not_broadcast_1335() -> Result<()> {
+    // The rest-leak: an error *after* the `?` must not be swallowed by it.
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | (key)? | error(\"boom\")"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // Sibling positive case: `rest` still runs normally when nothing errors.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (key)? | . + \"!\""], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a!\"");
+
+    // A comma branch that succeeds (`key`) before a later branch errors:
+    // real jq's `?` keeps the already-produced prefix rather than discarding
+    // it (unlike the Array arm's atomicity above -- comma isn't atomic).
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | (key, error(\"boom\"))?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    // Without `?`, the same query still hard-errors.
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | key, error(\"boom\")"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `?` also catches a `break` for an enclosing label -- matches real
+    // jq's `label $out | (1, break $out)?` (both implemented as bare `try`,
+    // which catches break the same way it catches a raised error).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | (.a | (key, break $out))?"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    // Doubly-nested `?` still resolves correctly (ambient optional=true
+    // from the outer `?` reaching the inner one is harmless, not a forced
+    // broadcast introduced by this node itself).
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | ((key)?)?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5599,9 +5599,10 @@ fn test_optional_dispatch_catches_atomically_not_broadcast_1335() -> Result<()> 
     assert_eq!(code, 5);
     assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    // `?` also catches a `break` for an enclosing label -- matches real
-    // jq's `label $out | (1, break $out)?` (both implemented as bare `try`,
-    // which catches break the same way it catches a raised error).
+    // `?` also catches a `break` for an enclosing label -- verified against
+    // jq 1.7.1: `label $out | (1, break $out)?` prints `1`, exit 0 (both
+    // implemented as bare `try`, which catches break the same way it
+    // catches a raised error).
     let (stdout, _, code) = run_jq_full(
         &["-c", "label $out | (.a | (key, break $out))?"],
         Some(r#"{"a":1}"#),
@@ -5615,6 +5616,40 @@ fn test_optional_dispatch_catches_atomically_not_broadcast_1335() -> Result<()> 
     let (stdout, _, code) = run_jq_full(&["-c", ".a | ((key)?)?"], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "\"a\"");
+
+    Ok(())
+}
+
+/// A `?`-wrapped navigational `inner` (`.[]`/`.foo`) followed by a
+/// path-context builtin in `rest` must still thread each output's *own*
+/// `current_path`, not the stale pre-`?` one. Isolating `inner`'s evaluation
+/// with an empty `rest` (needed to scope the catch above to `inner` alone)
+/// discards path updates -- `Field`/`Index`/`Iterate` only compute and
+/// thread a new path when they have a non-empty `rest` to recurse into, so
+/// evaluated in isolation they just return bare values. Caught during
+/// review: naively isolating in every case turned `.a | (.[])? | key` from
+/// `0`, `1`, `2` into three wrongly-identical `"a"`s. The fix only takes the
+/// isolated path when `rest` doesn't consult path context in the first
+/// place (this arm's `if rest.is_empty() || !rest.iter().any(...)` guard);
+/// otherwise it falls back to evaluating `[inner, ...rest]` combined, which
+/// still threads `current_path` correctly (#1406).
+#[test]
+fn test_optional_wrapped_navigation_still_threads_path_into_rest_1335() -> Result<()> {
+    // `.[]` under `?`, `key` in `rest`: must report each element's own
+    // index, not a stale outer one.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[])? | key"], Some(r#"{"a":[10,20,30]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n1\n2");
+
+    // Same shape via a field step instead of iteration.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.b)? | key"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"b\"");
+
+    // Without `?`, the same query is the baseline this must match.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[] | key"], Some(r#"{"a":[10,20,30]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n1\n2");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`Expr::Optional`'s dispatch in `eval_pipe_with_path_context_internal` broadcast
`optional=true` into whatever it wrapped, with no catch of its own — relying entirely
on leaf-level `if optional {None} else {Error}` self-checks to implement `?`'s
suppression. Two live symptoms from the same code:

1. When `?` had nothing after it in the pipe, a leaf deep inside the wrapped expression
   could self-swallow instead of this node genuinely catching an escaping error
   atomically (the general concern #1335 raises, mirroring #1302's identical fix for
   the `Array` arm).
2. When `?` had a `rest` of the pipe after it, the old code combined `[inner, ...rest]`
   into *one* list evaluated under that same forced-`true` value — so an error *after*
   the `?`, which the `?` has nothing to do with, was also silently swallowed:
   `.a | (key)? | error("boom")` produced no output and no error at all, instead of
   real jq's error (confirmed against real jq's structurally identical
   `.a | (1)? | error("boom")`).

Now `inner` is evaluated in isolation with `optional` forced to `false`, so a genuine
error/break surfaces instead of self-swallowing at some leaf; caught here
unconditionally (mirrors `eval_try`'s `Expr::Optional` dispatch and the `Array` arm's
`#1302` fix); `rest` continues under the *ambient* `optional` via
`continue_rest_with_context`, the same helper `Comma`/`Try`/`If` already use.

## A note on #1335's own posted repro

`(key == "a" and error("boom")))?` turns out **not** to exercise this arm at all —
`needs_path_context` has no recursion arm for `Expr::And`/`Expr::Or`, so the whole
expression is judged not needing path context and routes through the plain evaluator
instead, where `key` silently stubs (reproduces even with no `?` at all:
`.a | (key == "a" and true)` → `false`, should be `true`). That's a separate,
more fundamental routing gap — filed as #1405 — and is the actual root cause of the
literal repro in #1335's issue text. This PR fixes the real, independently-verified
`Expr::Optional` broadcast bug (via the rest-leak repro above, which *does* route
correctly today) rather than that repro specifically.

## Test plan

- New `test_optional_dispatch_catches_atomically_not_broadcast_1335` in
  `tests/jq_cli_tests.rs`: rest-leak fix, positive rest-continuation, comma-prefix
  preservation, no-`?` control (still hard-errors), `break` swallowed by `?`
  (matches real jq), doubly-nested `?`.
- Sibling `#1302`/`#1333` array-arm tests re-run clean (no regression).
- Full `cargo test --features cli,simd,regex,serde` (single-threaded): all green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second,
  non-`broadword-yaml` clippy leg: clean.
- `cargo build --no-default-features`: clean (no new warnings).
- Patch coverage: 100% (18/18 new lines).

Fixes #1335
