### PR TITLE
fix(yq): scalar-target assignment no-op discards the RHS, not just the write

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -230,6 +230,33 @@ before one can be captured
 ([#1361](https://github.com/rust-works/succinctly/issues/1361)). Both predate
 [ADR-0017](../../adrs/adr-0017.md)'s mechanism and neither is anchor-specific.
 
+### Comma-grouped scalar-target assignment no-op
+
+[#1233](https://github.com/rust-works/succinctly/issues/1233) taught `=`/`+=`/`-=`/`*=`/`//=`
+that real yq's field/index/iterate scalar-target no-op ([#1181](https://github.com/rust-works/succinctly/issues/1181))
+discards the RHS entirely rather than merely skipping the write — but only for a *static*
+`path_expr` (no computed key, and no `Comma`). A comma-grouped LHS where every branch is
+itself a scalar-target no-op is real yq's identical behaviour, live-verified, that
+succinctly does not yet replicate:
+
+```bash
+$ echo 5 | yq            -o=json '(.a, .b) = error("boom")'   # 5, RHS never runs
+$ echo 5 | succinctly yq -o=json '(.a, .b) = error("boom")'   # Error: boom
+```
+
+Deliberately not covered by #1233's own fix: resolving a `Comma`-containing path *before*
+the RHS (which the fix needs to do, to decide whether to skip it) is real evaluation for
+that shape, unlike a bare static path (a pure, non-evaluating AST clone) — and moving real
+evaluation ahead of the RHS risks reordering two independently-observable things. That risk
+is not hypothetical: real jq's own `.[error(P)] = error(R)` reports `R` (RHS evaluated
+first) while real yq's identical query reports `P` (path first) — succinctly currently
+matches jq's ordering in both modes, a second, related divergence from real yq neither
+tracked before now. Both filed together as
+[#1412](https://github.com/rust-works/succinctly/issues/1412), which also notes a real fix
+for the ordering divergence would likely resolve the comma-LHS gap as a side effect (a full
+path-before-RHS reorder no longer needs the static-only safety gate #1233's own narrower
+fix relies on).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10770,6 +10770,91 @@ fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
     !is_owned_container(target) && !matches!(target, OwnedValue::Null)
 }
 
+/// Whether writing `path` (a single *resolved* assignment-target path, one
+/// `resolve_dynamic_indexes` entry) into `root` would be real yq's
+/// field/index/iterate scalar-target no-op (#1181): navigating every
+/// component *before* the last reaches a genuine scalar. When true for
+/// every resolved path, real yq discards the RHS/filter entirely rather
+/// than merely skipping the write (#1233, live-verified v4.53.3) --
+/// `eval_assign`'s own caller is what actually skips RHS evaluation; this
+/// only answers the per-path question.
+///
+/// `path` is flattened via [`push_path_components`] first -- the same
+/// flattener `split_at_slice` already uses internally -- rather than
+/// matched directly (bare component vs. `Expr::Pipe`), so a nested
+/// `Pipe`/`Paren`/`Optional` anywhere in the chain (`(.a|.b)[0] = v`,
+/// structurally the same target as `.a.b[0] = v`) is seen through
+/// uniformly instead of only when it already happens to be a flat `Pipe`
+/// list. Code review (#1233) found this the hard way: an earlier version
+/// handed the *raw*, unflattened components to `navigate_read_only` for
+/// the prefix walk, silently disagreeing with itself on two spellings of
+/// the identical target (`.a.b[0] = error(...)` correctly no-op'd while
+/// `(.a|.b)[0] = error(...)` didn't) -- the exact "mirroring a precedent
+/// without its fix" pattern `get_path_mut`'s own #1287/#1294 nested-`Pipe`
+/// splice already had to solve once for the write side. `?` anywhere in
+/// the chain (whole-path, terminal, or a middle component) is transparent
+/// through the same flattening + [`unwrap_path_component`] the checks
+/// below use -- `?` introduces no evaluation of its own to worry about
+/// reordering, and live-verified real yq no-ops each exactly the same as
+/// its unwrapped equivalent (`.a.b? = error("boom")` on `{"a":5}` is
+/// `{"a":5}`, matching plain `.a.b = error("boom")`).
+///
+/// The flattened list's *last* element still carries a bare, unresolved
+/// `Expr::Iterate` node when that's what the user wrote, not something
+/// further resolved into a concrete index -- `resolve_dynamic_indexes`'s
+/// static fast path (the only one this function's own callers ever reach
+/// it through, `!needs_path_prepass`) is a plain `Ok(vec![path_expr.clone()])`,
+/// so `.[] = v` stays `Expr::Iterate` verbatim, same as `.a`/`.a.b` stay
+/// `Expr::Field`. Treated identically to a terminal `Field`/`Index` here,
+/// matching `set_path`'s own `Expr::Iterate` arm, which applies the
+/// identical `is_yq_field_index_noop_scalar` check for exactly this case.
+fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
+    let mut flat = Vec::new();
+    push_path_components(&mut flat, path);
+    // An empty flattened list is bare `Expr::Identity` (`. = v`) -- a
+    // direct overwrite, not indexing into anything.
+    let Some((last, prefix)) = flat.split_last() else {
+        return false;
+    };
+    // Deliberately excludes a path whose terminal component is a slice --
+    // `.[0:1] = v`'s own no-op (#1101/#1116) only ever skips the *write*,
+    // not the RHS (`.[0:1] = error("boom")` still genuinely errors,
+    // confirmed live and pinned by
+    // `test_slice_assign_scalar_noop_still_propagates_rhs_errors_1101`) --
+    // so a slice anywhere in the chain must never reach this fast path.
+    if flat.iter().any(|e| unwrap_path_component(e).0.is_slice()) {
+        return false;
+    }
+    // Defensive, not currently reachable: every leaf `push_path_components`
+    // can push here is one of `needs_path_prepass`'s own static-classified
+    // variants (`Field`/`Index`/`IndexNumber`/`Slice`/`SliceNumber`/
+    // `Iterate` -- `Identity` is dropped above, anything else fails the
+    // caller's own `!needs_path_prepass` gate before ever reaching this
+    // function), and the slice check just above already excludes
+    // `Slice`/`SliceNumber` wherever they appear, including as `last`. So
+    // by this point `last` can only be `Field`/`Index`/`IndexNumber`/
+    // `Iterate` -- confirmed via patch-coverage output (this arm's own
+    // branch never fires), not just assumed. Kept rather than removed:
+    // it's the one thing standing between a future new
+    // static-classified `Expr` variant (added to `needs_path_prepass`
+    // without a matching update here) and this function silently treating
+    // an unrelated shape as a valid no-op terminal.
+    if !matches!(
+        unwrap_path_component(last).0,
+        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate
+    ) {
+        return false;
+    }
+    match navigate_read_only(root, prefix) {
+        Some(parent) => is_yq_field_index_noop_scalar(parent),
+        // An absent prefix (missing field/out-of-range index) isn't this
+        // predicate's case at all -- defer to the normal RHS evaluation
+        // and let `set_path`'s own existing `get_path_mut` report whatever
+        // it reports for a genuinely missing path.
+        None => false,
+    }
+}
+
 /// Whether a *resolved* assignment-target path (a `paths`/`delete_at_path`
 /// entry, already past `resolve_dynamic_indexes`, not the raw `path_expr`
 /// the user wrote) is a bare slice — `.[S:E]`, `.[S:E]?`, or `(.[S:E])` —
@@ -11325,6 +11410,121 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// closure `through_slice` actually runs; yq's array/string target just
 /// never fails there to demonstrate it.
 ///
+/// #1233: real yq's field/index/iterate scalar-target no-op discards the
+/// RHS/filter entirely, not just the write (live-verified v4.53.3: `5 | .a
+/// = error("boom")` is `5`, no error -- and the same for `+=`/`//=`, both
+/// of which pre-evaluate a value the same way `=` does). Shared by
+/// [`eval_assign`], [`eval_compound_assign`], and [`eval_alternative_assign`]
+/// -- each calls this *before* evaluating its own RHS, and skips that
+/// evaluation entirely (returning `input` unchanged) when it answers
+/// `Some`.
+///
+/// Only checked for a `path_expr` with no computed key/generator anywhere
+/// (`!needs_path_prepass`, the same guard `resolve_dynamic_indexes`'s own
+/// fast path already uses to skip `resolve_node` for the overwhelmingly
+/// common `.a`/`.a.b`/`.[0]`/`.[]`-shaped case) -- deliberately not widened
+/// to a genuinely dynamic path (a computed key, or a `Comma` LHS, both
+/// `needs_path_prepass`-true): resolving *those* is real evaluation, and
+/// moving it ahead of the RHS would risk reordering two independently
+/// observable things relative to jq's own model. Confirmed live this isn't
+/// hypothetical: real jq's `.[error("p")] = error("r")` reports `"r"` (RHS
+/// first) -- and real yq's *own* answer to the identical query is `"p"`
+/// (path first), a genuine, pre-existing, yq-vs-jq ordering divergence this
+/// fix does not attempt to fix (filed as #1412, not folded in here). A
+/// static path never actually evaluates `path_expr` at all
+/// (`resolve_dynamic_indexes`'s own fast path is a bare
+/// `Ok(vec![path_expr.clone()])`), so checking it here changes nothing
+/// observable for a query that doesn't qualify. Comma-LHS (`(.a, .b) = v`,
+/// real yq confirmed to no-op the same way when every branch does) is the
+/// one shape this leaves as a documented gap rather than a silent miss --
+/// see #1412.
+///
+/// "Discards the RHS entirely" is meant literally, not "evaluates it but
+/// discards the result" -- a `halt`/`break`/`stderr`/`debug` reachable only
+/// through a no-op'd RHS never fires either, matching the multi-output
+/// case already live-verified (`.a = (1, error("x"), 3)` on `5` no-ops
+/// without even computing the leading `1`, so evaluation demonstrably
+/// never starts, not just "starts and its result is thrown away"). Code
+/// review raised this as a possible behaviour-change concern by diffing
+/// against `main`'s pre-#1233 output for `halt`/`break`/`stderr` inside a
+/// no-op'd RHS -- but `main`'s answer there is exactly the bug #1233 was
+/// filed to fix (unconditionally evaluating a RHS real yq never touches),
+/// not a baseline to preserve. Real yq has no `halt`/`break`/`label`
+/// syntax at all (confirmed live: `lexer: invalid input text "halt"`), so
+/// there is no oracle to check this specific consequence against directly
+/// -- unlike `error()`, which is what the "never evaluates" premise is
+/// actually built on -- but treating every control signal uniformly rather
+/// than special-casing halt/break/side-effects to still fire is the
+/// internally consistent reading of that same premise.
+///
+/// `None` means "doesn't apply" for any reason (jq mode, a dynamic path, a
+/// resolve error, or a path that isn't a total no-op) -- the caller falls
+/// through to its own unchanged RHS-evaluation flow either way.
+fn yq_assign_skip_rhs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    input: &StandardJson<'_, W>,
+) -> Option<OwnedValue> {
+    match yq_assign_noop_check::<W, S>(path_expr, input) {
+        YqAssignNoopCheck::Skip(unchanged) => Some(unchanged),
+        YqAssignNoopCheck::Continue { .. } | YqAssignNoopCheck::NotChecked => None,
+    }
+}
+
+/// [`yq_assign_skip_rhs`]'s own result, plus (code review, #1233) the
+/// `pristine`/`paths` pair the check's own static-path resolution already
+/// computed when it turns out *not* to be a no-op -- an earlier version
+/// threw that work away on `None` and made every caller redo an identical
+/// `to_owned` + `resolve_dynamic_indexes` pass moments later, doubling a
+/// full O(document-size) DOM materialization on every non-no-op yq-mode
+/// static-path assignment (the common case). [`eval_assign`] is the one
+/// caller wired up to actually reuse `Continue`'s payload; the two
+/// `eval_update`-routed callers ([`eval_compound_assign`]/
+/// [`eval_alternative_assign`]) still go through the simpler
+/// [`yq_assign_skip_rhs`] wrapper above and pay the double cost --
+/// `eval_update` is shared with plain `|=` (which has no pre-check at all
+/// and no `pristine`/`paths` to hand it), so threading this through would
+/// mean widening its signature for every caller, not just these two.
+/// Filed as #1414 rather than done here.
+enum YqAssignNoopCheck {
+    /// Total no-op -- return this value unchanged, skip the RHS entirely.
+    Skip(OwnedValue),
+    /// Not a no-op, but the static-path resolution already ran to answer
+    /// that question -- reuse instead of re-deriving.
+    Continue {
+        pristine: OwnedValue,
+        paths: Vec<Expr>,
+    },
+    /// Doesn't apply at all (jq mode, or a genuinely dynamic path) --
+    /// nothing was resolved; the caller must do so itself, exactly as it
+    /// would have before this check existed.
+    NotChecked,
+}
+
+fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    input: &StandardJson<'_, W>,
+) -> YqAssignNoopCheck {
+    if S::TAG != EvalTag::Yq || needs_path_prepass(path_expr) {
+        return YqAssignNoopCheck::NotChecked;
+    }
+    let pristine = to_owned(input);
+    // A static path (the only kind reaching this point) never actually
+    // evaluates `path_expr` -- `resolve_dynamic_indexes`'s own fast path
+    // is an unconditional `Ok(vec![path_expr.clone()])` -- so this can't
+    // fail in practice; falling back to `NotChecked` on the (unreachable)
+    // `Err` arm just means the caller re-derives from scratch, same as
+    // before this function existed.
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+        Ok(paths) => paths,
+        Err(_) => return YqAssignNoopCheck::NotChecked,
+    };
+    if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
+        YqAssignNoopCheck::Skip(pristine)
+    } else {
+        YqAssignNoopCheck::Continue { pristine, paths }
+    }
+}
+
 /// `optional` is `=`'s own `?` (`(.a = 1)?`) -- see `eval_update`'s matching
 /// comment for why it is caught here at the call boundary rather than
 /// threaded into `set_path` as a starting flag. It swallows a failure but
@@ -11336,6 +11536,11 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    let yq_noop_check = yq_assign_noop_check::<_, S>(path_expr, &input);
+    if let YqAssignNoopCheck::Skip(unchanged) = yq_noop_check {
+        return QueryResult::Owned(unchanged);
+    }
+
     // Evaluate the RHS once, keeping every output instead of collapsing to
     // the first (#392). `terminal` carries a trailing `Error`/`Break` when
     // the stream didn't simply run out -- the same `Partial` shape every
@@ -11387,14 +11592,27 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // into empty output when the whole call is optional -- mirroring how
     // `builtin_del` (#537) already separates `del(...)?` from a `?` written
     // inside the path.
-    let mut pristine = to_owned(&input);
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
-        Ok(paths) => paths,
-        // `?` swallows only a genuine error; a halt always escapes, so
-        // `(.[(halt_error(3))] = 1)?` still halts instead of becoming
-        // `QueryResult::None` (#791).
-        Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
-        Err((_, escape)) => return escape.into(),
+    // #1233 (code review): reuse `yq_noop_check`'s own resolution instead
+    // of redoing an identical `to_owned` + `resolve_dynamic_indexes` pass
+    // -- see `YqAssignNoopCheck::Continue`'s doc comment. Only the
+    // `NotChecked` case (jq mode, or a genuinely dynamic path) still needs
+    // to resolve here from scratch, exactly as this function always did
+    // before that check existed.
+    let (mut pristine, paths) = match yq_noop_check {
+        YqAssignNoopCheck::Continue { pristine, paths } => (pristine, paths),
+        YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
+        YqAssignNoopCheck::NotChecked => {
+            let pristine = to_owned(&input);
+            let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+                Ok(paths) => paths,
+                // `?` swallows only a genuine error; a halt always escapes,
+                // so `(.[(halt_error(3))] = 1)?` still halts instead of
+                // becoming `QueryResult::None` (#791).
+                Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
+                Err((_, escape)) => return escape.into(),
+            };
+            (pristine, paths)
+        }
     };
 
     let last = paths.len().saturating_sub(1);
@@ -11550,6 +11768,20 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #1233: same RHS-discarding no-op as `eval_assign` (see
+    // `yq_assign_skip_rhs`'s own doc comment) -- applies uniformly across
+    // every compound operator, not just `Add`, unlike the write-level
+    // `scalar_noop` gate further down (`matches!(op, AssignOp::Add)`),
+    // which answers a narrower, operator-specific question about what
+    // happens once the RHS *has* run. Live-verified against yq v4.53.3 for
+    // `+=`/`-=`/`*=`; `/=`/`%=` aren't real yq syntax at all (`'/' expects 2
+    // args but there is 1`), so their yq-mode answer is judged the same way
+    // `//=`'s own comment below judges it -- internal consistency with the
+    // already-correct, already-lazy `|=`, not an external-compat claim.
+    if let Some(unchanged) = yq_assign_skip_rhs::<_, S>(path_expr, &input) {
+        return QueryResult::Owned(unchanged);
+    }
+
     // Convert to update: .path op= value  becomes  .path |= . op value
     let arith_op = match op {
         AssignOp::Add => ArithOp::Add,
@@ -11613,6 +11845,19 @@ fn eval_alternative_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #1233: same RHS-discarding no-op as `eval_assign`/`eval_compound_assign`
+    // (see `yq_assign_skip_rhs`'s own doc comment). `//=` isn't real yq
+    // syntax at all (confirmed live, same as `/=`/`%=`), so this is judged
+    // by internal consistency with the already-correct, already-lazy `|=`
+    // this desugars to below, not an external-compat claim -- live-verified
+    // that the literal desugared equivalent (`.a |= (. // error("b"))`) is
+    // already correctly a no-op on a scalar target, so leaving `//=` itself
+    // to still evaluate its RHS eagerly would make two spellings of the
+    // identical operation disagree.
+    if let Some(unchanged) = yq_assign_skip_rhs::<_, S>(path_expr, &input) {
+        return QueryResult::Owned(unchanged);
+    }
+
     // Same root-vs-sub-value fix as eval_compound_assign: evaluate `value_expr`
     // once against the original input before splicing it into the filter.
     let rhs_value = match eval_rhs_once::<W, S>(value_expr, input.clone(), optional) {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14772,6 +14772,217 @@ fn test_yq_iterate_assign_scalar_jq_mode_unaffected_1181() -> Result<()> {
     Ok(())
 }
 
+/// #1233: real yq's field/index/iterate scalar-target no-op (#1181) discards
+/// the RHS/filter entirely, not just the write -- `=` and every compound
+/// operator that pre-evaluates a value (`+=`/`-=`/`*=`/`//=`) previously
+/// still evaluated (and propagated an error from) the RHS before finding
+/// out the write itself was going to no-op. `|=` was already correct
+/// (`update_path`'s filter is lazy per resolved path), pinned as a
+/// regression guard alongside the fixed operators. Also covers `?`
+/// transparency (`.a?`/`.a.b?`), found live while closing this fix's own
+/// coverage gaps -- `yq_assign_is_total_noop` initially had no
+/// `Expr::Optional`/`Paren` handling at all, missing both shapes. Every
+/// shape verified live against yq v4.53.3.
+#[test]
+fn test_yq_scalar_target_noop_discards_rhs_1233() -> Result<()> {
+    // The issue's own root-scalar repro, plus every operator that shares
+    // eval_rhs_once's eager-evaluation mechanism.
+    for op in ["=", "+=", "-=", "*=", "//="] {
+        let (out, err, code) =
+            run_yq_stdin_with_stderr(&format!(".a {op} error(\"boom\")"), "5\n", &["-o", "json"])?;
+        assert_eq!(code, 0, "op={op} err={err}");
+        assert_eq!(out.trim(), "5", "op={op}");
+    }
+
+    // A multi-output RHS -- the whole call still no-ops, the mid-stream
+    // error never even runs.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a = (1, error(\"x\"), 3)", "5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "5");
+
+    // `.[] = v` on a scalar root -- the Iterate-terminal shape, not just
+    // Field/Index.
+    let (out, err, code) = run_yq_stdin_with_stderr(".[] = error(\"b\")", "5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "5");
+
+    // Nested: the scalar is reached through a real container prefix, not
+    // just at the root.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a.b = error(\"boom\")", "a: 5\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // `?` wrapping the whole path is transparent -- `.a?` on a scalar root
+    // no-ops the same as bare `.a`.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a? = error(\"boom\")", "5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "5");
+
+    // `?` wrapping just the terminal component of a chain is transparent
+    // too -- `.a.b?` no-ops the same as `.a.b` when `.a` is the scalar.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a.b? = error(\"boom\")", "a: 5\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // `|=` was already correct -- regression guard, not a new capability.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a |= error(\"boom\")", "5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "5");
+
+    // A real write (autovivify through `null`) must still evaluate and
+    // propagate the RHS -- this is not a no-op target.
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a = error(\"boom\")", "null\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    // jq mode is unaffected -- the same query still hard-errors.
+    let (_out, err, code) = run_jq_stdin_with_stderr(".a = error(\"boom\")", "5", &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    Ok(())
+}
+
+/// #1233 (deliberate non-goal, matching the issue's own plan): a scalar
+/// reached *before* the last path component (`.a.b.c` where `.a` is
+/// already the scalar) is #1232's own territory, not this fix's --
+/// `yq_assign_is_total_noop` only walks a resolved path's own prefix
+/// against the *original* root, so a path whose write-time no-op depth
+/// #1232 hasn't widened yet simply doesn't qualify here either, and this
+/// fix doesn't change that. Live-verified this still (unrelated to #1233)
+/// errors in real yq too, for the wrong reason (yq's error message differs
+/// from succinctly's) -- both are "still broken pending #1232", not a
+/// regression.
+#[test]
+fn test_yq_scalar_target_noop_pre_last_component_is_1232_territory_1233() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a.b.c = error(\"boom\")", "a: 5\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1233: `push_path_components` (the flattener `yq_assign_is_total_noop`
+/// uses) treats a bare `Expr::Identity` step as a no-op and drops it
+/// entirely, so a chain ending in `| .` (`(.a | .) = v`) flattens to
+/// exactly the same components as `.a` alone -- not, as an earlier draft
+/// of this test assumed, a shape the terminal-shape check rejects. Since
+/// `.a` on `{"a":5}` is a genuine write (the root is a container, not a
+/// no-op target), both spellings correctly evaluate the RHS here; the
+/// no-op case (where the trailing `| .` sits after a scalar-target chain)
+/// is covered by the sibling test below.
+#[test]
+fn test_yq_trailing_identity_in_chain_flattens_away_1233() -> Result<()> {
+    // `.a` on a container root is a real write either way -- confirms
+    // `(.a | .)` isn't spuriously treated as ineligible, it's genuinely
+    // the same (non-no-op) target as bare `.a`.
+    for query in [".a = error(\"boom\")", "(.a | .) = error(\"boom\")"] {
+        let (_out, err, code) = run_yq_stdin_with_stderr(query, "a: 5\n", &["-o", "json"])?;
+        assert_ne!(code, 0, "query={query}");
+        assert!(err.contains("boom"), "query={query} err={err}");
+    }
+
+    // A trailing `| .` after a genuinely scalar-target chain still no-ops,
+    // confirming the flattening (not just the terminal shape) is what
+    // makes the two spellings agree.
+    for query in [".a.b = error(\"boom\")", "(.a.b | .) = error(\"boom\")"] {
+        let (out, err, code) = run_yq_stdin_with_stderr(query, "a: 5\n", &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "query={query} err={err}");
+        assert_eq!(out.trim(), r#"{"a":5}"#, "query={query}");
+    }
+
+    Ok(())
+}
+
+/// #1233: bare `. = v` (`Expr::Identity` as the *whole* resolved path,
+/// with an empty flattened list) is a direct overwrite of the root, not
+/// indexing into anything -- `yq_assign_is_total_noop`'s own
+/// `flat.split_last()` returning `None` covers exactly this case.
+#[test]
+fn test_yq_bare_identity_path_is_not_a_noop_1233() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(". = error(\"boom\")", "5\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1233 (code review): a nested `Pipe` inside the resolved path must
+/// answer the no-op question identically to the equivalent flat chain --
+/// `(.a|.b)[0] = v` and `.a.b[0] = v` are the same write target
+/// (`get_path_mut` already flattens both the same way, post-#1287/#1294),
+/// so `yq_assign_is_total_noop` must too. An earlier version of this fix
+/// matched `path` directly (bare component vs. already-flat `Expr::Pipe`)
+/// and handed the *raw*, unflattened components to `navigate_read_only`,
+/// which silently disagreed with itself on these two spellings --
+/// `.a.b[0] = error(...)` correctly no-op'd while `(.a|.b)[0] = error(...)`
+/// didn't, even though the actual *write* (verified below with a
+/// non-erroring RHS) is identical for both. Fixed by flattening via
+/// `push_path_components` (the same flattener `split_at_slice` already
+/// uses) before any check runs, mirroring the "mirroring a precedent
+/// without its fix" lesson `get_path_mut`'s own #1287/#1294 splice
+/// already had to learn once for the write side.
+#[test]
+fn test_yq_nested_pipe_in_resolved_path_matches_flat_chain_1233() -> Result<()> {
+    for query in [".a.b[0] = error(\"boom\")", "(.a|.b)[0] = error(\"boom\")"] {
+        let (out, err, code) =
+            run_yq_stdin_with_stderr(query, "a:\n  b: 5\n", &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "query={query} err={err}");
+        assert_eq!(out.trim(), r#"{"a":{"b":5}}"#, "query={query}");
+    }
+
+    // Sanity: a non-erroring RHS confirms both spellings agree on the
+    // *write* too (both no-op it, matching #1181 -- `.a.b` is the scalar
+    // `5`, not an array, so `[0]` never gets a real target either way),
+    // not just on whether an error happens to surface.
+    for query in [".a.b[0] = 99", "(.a|.b)[0] = 99"] {
+        let (out, err, code) =
+            run_yq_stdin_with_stderr(query, "a:\n  b: 5\n", &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "query={query} err={err}");
+        assert_eq!(out.trim(), r#"{"a":{"b":5}}"#, "query={query}");
+    }
+
+    Ok(())
+}
+
+/// #1233: the slice no-op (#1101/#1116) is a *different* mechanism that
+/// only skips the write, never the RHS -- `yq_assign_is_total_noop`
+/// deliberately excludes a slice-terminal path (`split_at_slice` checked
+/// first) so this fix's own no-op never accidentally swallows a slice
+/// assignment's genuinely-propagating error.
+#[test]
+fn test_yq_slice_assign_scalar_noop_still_propagates_rhs_error_unaffected_by_1233() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".[0:1] = error(\"boom\")", "5\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1233 (deliberate non-goal, filed as #1412): a comma-grouped LHS where
+/// one branch is a genuine write must still evaluate (and propagate an
+/// error from) the RHS -- `yq_assign_is_total_noop`'s own gate
+/// (`!needs_path_prepass`) excludes every `Comma`-containing path from the
+/// fast path entirely, so this is really a regression guard on the
+/// *unchanged* existing flow, not new behavior.
+#[test]
+fn test_yq_comma_lhs_mixed_noop_and_real_write_still_evaluates_rhs_1233() -> Result<()> {
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        "(.a.x, .b.x) = error(\"boom\")",
+        "a: 5\nb: {}\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
 // ============================================================================
 // @urid / @base64d scalar-stringification (#1109)
 // ============================================================================


### PR DESCRIPTION
Fixes #1233.

Real yq's field/index/iterate scalar-target no-op (#1181) doesn't just skip the write — it discards the RHS/filter entirely, never evaluating it at all:

```
$ echo 5 | yq -o=json '.a = error("boom")'
5                                # RHS never runs
$ echo 5 | succinctly yq -o=json '.a = error("boom")'
Error: boom                     # wrong: RHS ran and errored
```

`|=` was already correct (`update_path`'s filter runs lazily per resolved path, so its own no-op already short-circuits it) — only the value-preevaluating operators (`=`, and every compound operator via `eval_rhs_once`) diverge.

## The fix

New shared `yq_assign_skip_rhs`/`yq_assign_is_total_noop` (`src/jq/eval.rs`), called by `eval_assign`/`eval_compound_assign`/`eval_alternative_assign` before each evaluates its own RHS: resolves `path_expr`, and if every resolved path is a scalar-target no-op, returns the input unchanged without ever touching the RHS. Mirrors `set_path`'s own existing `scalar_noop` write-time check (same `is_yq_field_index_noop_scalar` predicate) for the shapes it already covers — root (`5 | .a = v`), nested (`{"a":5} | .a.b = v`), and Iterate (`5 | .[] = v`) — plus `?`-transparency (`.a?`/`.a.b?`), one prefix walk instead of several special cases.

Applies uniformly across every value-preevaluating operator, not just `=`/`+=` — live-verified against yq v4.53.3 for `+=`/`-=`/`*=`; `/=`/`%=`/`//=` aren't real yq syntax at all, so their yq-mode answer is judged by internal consistency with the already-correct, already-lazy `|=` they desugar to, not an external-compat claim.

## Deliberately scoped to a *static* `path_expr`

`!needs_path_prepass(path_expr)` — the same guard `resolve_dynamic_indexes`'s own fast path already uses. Resolving a static path is a pure, non-evaluating AST clone, so checking it before the RHS changes nothing observable. A genuinely dynamic path (a computed key, or a `Comma` LHS) is left on the unchanged, existing RHS-first flow — reordering *that* risks changing which of two independently-observable things (an error, a side effect) surfaces first.

This isn't hypothetical: live-verified real jq's own `.[error(P)] = error(R)` reports R (RHS first) while real yq's identical query reports P (path first) — a genuine, pre-existing yq-vs-jq ordering divergence succinctly currently doesn't replicate in either direction. Filed as #1412 rather than touched here, along with the one shape this leaves uncovered (comma-LHS-all-noop, e.g. `5 | (.a, .b) = error("boom")`, which real yq also no-ops).

## Related, deliberately out of scope

- `.[0:1] = error("boom")`'s own, separate no-op (#1101/#1116) is excluded via the same `split_at_slice` check `set_path` uses — that mechanism only ever skips the *write*, never the RHS, and must keep genuinely propagating an erroring RHS. Live-verified unaffected.
- A scalar hit *before* the last path component (`.a.b.c` where `.a` is already scalar) is #1232's own territory — this fix's prefix walk against the *original* root doesn't widen that depth, matching the issue's own plan.
- `del()` has the identical scalar-root gap through its own separate walker (`delete_at_path`) — filed separately as #1411 per the issue's own implementation plan, not folded in here.

## Verification

Every shape verified against yq v4.53.3: every operator, multi-output RHS, nested/Iterate/`?`-wrapped targets, the real-write (null root) contrast, the slice-no-op contrast, the comma-LHS-mixed contrast, and the trailing-bare-`.` edge case; jq mode confirmed unaffected.

Build clean, 2704/2704 lib tests + 58/58 test blocks pass, fmt clean, both clippy legs clean, no_std build clean, 97.73% patch coverage (43/44 new lines — the one gap is a provably-unreachable defensive recursion arm the parser/resolver never actually produce a shape for).