### PR TITLE
feat(jq): yq object slicing follows its own AST child-node layout

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -201,6 +201,17 @@ the fix) and [#1344](https://github.com/rust-works/succinctly/issues/1344)
 leak or the missing `.[]` collapse, which is why #1398 exists — recording them here is the
 first half of ADR-0018 rule 6, and filing them is the second.
 
+Object slicing (`.[S:E]` on an object, [#1102](https://github.com/rust-works/succinctly/issues/1102))
+is another surface this same root cause reaches: it must materialize the target object into
+an `OwnedValue::Object` (an `IndexMap`) to build yq's AST-child-list view before slicing it,
+which silently collapses a genuine duplicate key the same way `to_owned()` does everywhere
+else in this list — `a: 1\nb: 2\na: 3` sliced with `.[0:6]` real yq returns `["a",1,"b",2,"a",3]`
+(6 children, both `a` entries present); succinctly returns `["a",3,"b",2]` (4 elements, the
+first `a`/`1` pair gone). Unlike the other surfaces above, there is no cursor-preserving
+alternative available here — the operation inherently needs to reorder/slice the entries, not
+just stream them — so this one is a real limit of `OwnedValue::Object`'s representation, not
+a missed wiring like #1343/#1344.
+
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478) and
 [#868](https://github.com/rust-works/succinctly/issues/868) are closed decisions that
@@ -267,10 +278,15 @@ Float and number formatting ([#1071](https://github.com/rust-works/succinctly/is
 [#1055](https://github.com/rust-works/succinctly/issues/1055)), comment placement
 ([#1079](https://github.com/rust-works/succinctly/issues/1079),
 [#1080](https://github.com/rust-works/succinctly/issues/1080),
-[#1085](https://github.com/rust-works/succinctly/issues/1085)), and the regex engine's
+[#1085](https://github.com/rust-works/succinctly/issues/1085)), the regex engine's
 zero-width-match handling
 ([#1255](https://github.com/rust-works/succinctly/issues/1255) — real yq uses Go's
-`regexp`). Also see
+`regexp`), and a missing explicit-tag slot: `OwnedValue` has no field for it, so any
+computed/constructed value — including an object-slice result (#1102) — loses the source
+node's `!!map`/`!!seq` tag and quoting style in YAML output (`{"a":1,"b":2} | yq
+'.[0:2]'` is `!!map\n- "a"\n- 1` on real yq, plain `- a\n- 1` on succinctly); `-o=json`
+output is unaffected, since neither appears in JSON
+([#1416](https://github.com/rust-works/succinctly/issues/1416)). Also see
 [yq Query Language Reference § Known Limitations](../../reference/yq-language.md#known-limitations)
 for the feature-level gaps (`*`/`+` are not cartesian generators; position builtins after DOM
 conversion).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -615,14 +615,14 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // across all three) rather than jq's own null-passthrough rule
             // or "not sliceable" error -- checked before the jq-only Null
             // arm below so this wins under yq mode. Object targets are
-            // deliberately excluded: real yq's own slicing there follows
-            // its internal AST child-node layout (`{"a":1,"b":2} | .[0:2]`
-            // -> `["a",1]`, alternating keys and values), not a clean
-            // "empty container" rule, and isn't replicated here (#1102).
-            // Assignment targets are a separate, unverified case -- real
-            // yq's own behavior there is a silent no-op, not this rule
-            // (#1101) -- see `is_yq_slice_empty_container_scalar`'s doc
-            // comment, which this arm mirrors.
+            // deliberately excluded from *this* rule: real yq's own slicing
+            // there follows its internal AST child-node layout instead (not
+            // a clean "empty container" rule) -- see the dedicated
+            // `StandardJson::Object` arm below (#1102). Assignment targets
+            // are a separate, unverified case -- real yq's own behavior
+            // there is a silent no-op, not this rule (#1101) -- see
+            // `is_yq_slice_empty_container_scalar`'s doc comment, which this
+            // arm mirrors.
             StandardJson::Null | StandardJson::Number(_) | StandardJson::Bool(_)
                 if S::TAG == EvalTag::Yq =>
             {
@@ -663,6 +663,18 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
 
                 QueryResult::Owned(OwnedValue::String(slice::slice_str(&s_str, range)))
+            }
+            // An object target reaches this cursor-backed arm before any
+            // `OwnedValue` is ever materialized -- `slice_owned_value_read`
+            // (#1102) only sees an object once one already exists. Route
+            // through the same rule by materializing here rather than
+            // re-deriving key/value-pair iteration against the cursor's own
+            // field type.
+            StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+                let OwnedValue::Object(map) = to_owned(&value) else {
+                    unreachable!("StandardJson::Object always materializes to OwnedValue::Object")
+                };
+                QueryResult::Owned(slice_object_as_yq_children(&map, *start, *end))
             }
             _ if optional => QueryResult::None,
             // jq models `.[a:b]` as indexing with `{"start":a,"end":b}`, so a
@@ -11167,12 +11179,13 @@ pub(crate) fn slice_owned_value(
 }
 
 /// Slice one `OwnedValue` target on the *read* path (`.[S:E]`), applying
-/// yq's empty-container-scalar rule (#1065) before falling back to
-/// `slice_owned_value`. Shared by `eval_slice_expr`'s `Targets::Owned` loop
-/// here and `eval_generic::eval_slice_expr`'s equivalent loop, so the rule
-/// has exactly one call site to keep in sync instead of two hand-copied
-/// ones — the same duplicated-predicate shape this codebase has already
-/// been bitten by once (see the crate's own optimization-lessons doc).
+/// yq's empty-container-scalar rule (#1065) and object AST-child-layout
+/// rule (#1102) before falling back to `slice_owned_value`. Shared by
+/// `eval_slice_expr`'s `Targets::Owned` loop here and
+/// `eval_generic::eval_slice_expr`'s equivalent loop, so both rules have
+/// exactly one call site to keep in sync instead of two hand-copied ones —
+/// the same duplicated-predicate shape this codebase has already been
+/// bitten by once (see the crate's own optimization-lessons doc).
 pub(crate) fn slice_owned_value_read<S: EvalSemantics>(
     target: &OwnedValue,
     start: Option<i64>,
@@ -11182,7 +11195,31 @@ pub(crate) fn slice_owned_value_read<S: EvalSemantics>(
     if S::TAG == EvalTag::Yq && is_yq_slice_empty_container_scalar(target) {
         return Ok(Some(OwnedValue::Array(Vec::new())));
     }
+    if let (EvalTag::Yq, OwnedValue::Object(map)) = (S::TAG, target) {
+        return Ok(Some(slice_object_as_yq_children(map, start, end)));
+    }
     slice_owned_value(target, start, end, optional)
+}
+
+/// yq's own slicing rule for an *object* target (#1102, yq mode only — real
+/// jq has no object-slicing concept at all and keeps erroring). Slices the
+/// object's internal AST child-node list (`[k0, v0, k1, v1, ...]`, keys
+/// emitted as strings) rather than key-value pairs — see
+/// [`SliceBounds::resolve_object_children`] for the exact, oracle-verified
+/// bound-resolution rule. Never errors: yq's own object slicing doesn't,
+/// regardless of how the bounds resolve.
+fn slice_object_as_yq_children(
+    map: &IndexMap<String, OwnedValue>,
+    start: Option<i64>,
+    end: Option<i64>,
+) -> OwnedValue {
+    let mut children = Vec::with_capacity(map.len() * 2);
+    for (k, v) in map {
+        children.push(OwnedValue::String(k.clone()));
+        children.push(v.clone());
+    }
+    let range = SliceBounds::from_literals(start, end).resolve_object_children(map.len());
+    OwnedValue::Array(children[range].to_vec())
 }
 
 /// Get element at index (supports negative indexing).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8170,6 +8170,22 @@ fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 };
                 current = OwnedValue::String(slice::slice_str(s, range));
             }
+            // yq mode only (#1102): completes the `getpath(path(x)) == x`
+            // round trip for an object-slice descriptor -- without this,
+            // `path(.[0:2])` on an object succeeds (the new
+            // `slice_owned_value_read` arm) but the descriptor it returns
+            // was unusable here, a narrower regression than the pre-#1102
+            // all-or-nothing error. Read-only, matching #1102's own scope --
+            // `setpath`/`delpaths` deliberately don't get the same
+            // treatment (#1157's write-side scope, not this one's).
+            (OwnedValue::Object(map), OwnedValue::Object(desc)) if S::TAG == EvalTag::Yq => {
+                let range = match SliceBounds::from_descriptor(desc) {
+                    Ok(bounds) => bounds.resolve_object_children(map.len()),
+                    Err(_) if optional => return QueryResult::None,
+                    Err(e) => return e.into(),
+                };
+                current = slice_object_children_at(map, range);
+            }
             _ if optional => return QueryResult::None,
             _ => {
                 return QueryResult::Error(EvalError::cannot_index(current.type_name(), &segment));
@@ -10737,12 +10753,14 @@ fn is_owned_container(target: &OwnedValue) -> bool {
 /// Whether `target` is one of the scalar shapes real yq treats as an empty
 /// container when it's the target of a *read* slice (`.[S:E]`, #1065) —
 /// null, any number representation, or a boolean. Object is deliberately
-/// excluded: real yq's own slicing there follows its internal AST
-/// child-node layout (`{"a":1,"b":2} | .[0:2]` -> `["a",1]`, alternating
-/// keys and values), not a clean "empty container" rule, and isn't
-/// replicated here (#1102). `Array`/`String` are excluded too — those
-/// already slice meaningfully and never reach this check's call sites for
-/// that reason (see [`slice_owned_value`]'s own `Array`/`String` arms).
+/// excluded from *this* rule: real yq's own slicing there follows its
+/// internal AST child-node layout instead (`{"a":1,"b":2} | .[0:2]` ->
+/// `["a",1]`, alternating keys and values), not a clean "empty container"
+/// rule — implemented separately, see `slice_owned_value_read`'s
+/// `OwnedValue::Object` arm and `slice::SliceBounds::resolve_object_children`
+/// (#1102). `Array`/`String` are excluded too — those already slice
+/// meaningfully and never reach this check's call sites for that reason
+/// (see [`slice_owned_value`]'s own `Array`/`String` arms).
 ///
 /// Deliberately its own free function, not folded into `slice_owned_value`:
 /// that function is *also* used by `resolve_slice_expr` for assignment
@@ -11208,18 +11226,48 @@ pub(crate) fn slice_owned_value_read<S: EvalSemantics>(
 /// [`SliceBounds::resolve_object_children`] for the exact, oracle-verified
 /// bound-resolution rule. Never errors: yq's own object slicing doesn't,
 /// regardless of how the bounds resolve.
-fn slice_object_as_yq_children(
+///
+/// `pub(crate)`: also called from `eval_generic.rs`'s `slice_one_generic`,
+/// the generic (computed-slice-bound) evaluator's own equivalent of this
+/// file's cursor-backed `Expr::Slice` arm — both need the same rule, one
+/// definition.
+pub(crate) fn slice_object_as_yq_children(
     map: &IndexMap<String, OwnedValue>,
     start: Option<i64>,
     end: Option<i64>,
 ) -> OwnedValue {
-    let mut children = Vec::with_capacity(map.len() * 2);
-    for (k, v) in map {
-        children.push(OwnedValue::String(k.clone()));
-        children.push(v.clone());
-    }
     let range = SliceBounds::from_literals(start, end).resolve_object_children(map.len());
-    OwnedValue::Array(children[range].to_vec())
+    slice_object_children_at(map, range)
+}
+
+/// [`slice_object_as_yq_children`]'s shared assembly step: materialize only
+/// the child-node slots `range` actually names, at an already-resolved
+/// `range`, rather than building the object's whole `2N`-length child list
+/// and then discarding everything outside it — `IndexMap::get_index` is
+/// O(1), so each wanted child costs one clone, not `2N` of them regardless
+/// of how narrow the slice is. Split out so [`builtin_getpath`]'s
+/// object-slice-descriptor arm (`{"start":s,"end":e}`, already resolved via
+/// [`SliceBounds::from_descriptor`]) can reuse the exact same logic instead
+/// of hand-copying it — the descriptor there carries bounds as `f64`, not
+/// the `i64` literals [`slice_object_as_yq_children`] itself takes, so it
+/// can't call that function directly.
+fn slice_object_children_at(
+    map: &IndexMap<String, OwnedValue>,
+    range: core::ops::Range<usize>,
+) -> OwnedValue {
+    let children: Vec<OwnedValue> = range
+        .map(|child_idx| {
+            let (k, v) = map
+                .get_index(child_idx / 2)
+                .expect("resolve_object_children never names an out-of-bounds entry");
+            if child_idx % 2 == 0 {
+                OwnedValue::String(k.clone())
+            } else {
+                v.clone()
+            }
+        })
+        .collect();
+    OwnedValue::Array(children)
 }
 
 /// Get element at index (supports negative indexing).

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,9 +27,9 @@ use super::document::{
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, format_owned,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
-    numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_owned_value_read,
-    tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag, JqSemantics, QueryResult,
-    YqSemantics,
+    numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
+    slice_owned_value_read, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag,
+    JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -3633,6 +3633,19 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
         return GenericResult::Owned(OwnedValue::Array(
             items[range].iter().map(to_owned).collect(),
         ));
+    }
+    // yq's object AST-child-layout slicing rule (#1102) — mirrors
+    // `eval.rs`'s cursor-backed `Expr::Slice` arm for the same target type;
+    // see `slice::SliceBounds::resolve_object_children`'s doc comment for
+    // the full, oracle-verified rule. Materializes via `to_owned` since
+    // `DocumentFields` only exposes a cons-list walk (`uncons`), not the
+    // `IndexMap` `slice_object_as_yq_children` needs — same technique as
+    // `eval.rs`'s own arm, for the same reason.
+    if S::TAG == EvalTag::Yq && target.as_object().is_some() {
+        let OwnedValue::Object(map) = to_owned(&target) else {
+            unreachable!("target.as_object() just confirmed this materializes to an Object")
+        };
+        return GenericResult::Owned(slice_object_as_yq_children(&map, start, end));
     }
     // yq's empty-container slicing rule (#1065) — see
     // `is_yq_slice_empty_container_scalar`'s doc comment for the full

--- a/src/jq/slice.rs
+++ b/src/jq/slice.rs
@@ -86,6 +86,28 @@ impl SliceBounds {
         let end = clamp(self.end.map_or(len as f64, f64::ceil), len);
         start..end.max(start)
     }
+
+    /// The child-node range yq's own slicing of an *object* target names,
+    /// mirroring its internal AST layout (`[k0, v0, k1, v1, ..., k(N-1),
+    /// v(N-1)]`, length `2N` for an `N`-entry map) rather than key-value
+    /// pairs (#1102, yq mode only -- jq has no object-slicing concept at
+    /// all).
+    ///
+    /// Not `resolve(2 * n_entries)`: `start` and a *negative* `end` fold and
+    /// clamp against the child count `2N`, same as every other bound, but an
+    /// *omitted* `end` defaults to the entry count `N`, not `2N` --
+    /// verified against real yq v4.53.3 across 20+ probes on 3- and
+    /// 4-entry objects, and near-certainly an upstream bug (yq computing
+    /// the default end from `length`, which is `N` for a map, while
+    /// resolving a negative index against `len(node.Content)`, which is
+    /// `2N`). Reproduced anyway -- this repo pins oracle behaviour,
+    /// including its own inconsistencies.
+    pub(crate) fn resolve_object_children(&self, n_entries: usize) -> Range<usize> {
+        let child_count = n_entries * 2;
+        let start = clamp(self.start.map_or(0.0, f64::floor), child_count);
+        let end = clamp(self.end.map_or(n_entries as f64, f64::ceil), child_count);
+        start..end.max(start)
+    }
 }
 
 /// One `start`/`end` slot of a descriptor.

--- a/src/jq/slice.rs
+++ b/src/jq/slice.rs
@@ -82,9 +82,7 @@ impl SliceBounds {
     /// bounds are an *insertion point* on the write side, not an empty read.
     /// `[1,2,3] | setpath([{"start":2,"end":1}]; ["x"])` is `[1,2,"x",3]`.
     pub(crate) fn resolve(&self, len: usize) -> Range<usize> {
-        let start = clamp(self.start.map_or(0.0, f64::floor), len);
-        let end = clamp(self.end.map_or(len as f64, f64::ceil), len);
-        start..end.max(start)
+        self.resolve_with_end_default(len, len as f64)
     }
 
     /// The child-node range yq's own slicing of an *object* target names,
@@ -103,9 +101,20 @@ impl SliceBounds {
     /// `2N`). Reproduced anyway -- this repo pins oracle behaviour,
     /// including its own inconsistencies.
     pub(crate) fn resolve_object_children(&self, n_entries: usize) -> Range<usize> {
-        let child_count = n_entries * 2;
-        let start = clamp(self.start.map_or(0.0, f64::floor), child_count);
-        let end = clamp(self.end.map_or(n_entries as f64, f64::ceil), child_count);
+        self.resolve_with_end_default(n_entries * 2, n_entries as f64)
+    }
+
+    /// Shared bound-resolution body for [`resolve`](Self::resolve) and
+    /// [`resolve_object_children`](Self::resolve_object_children): both
+    /// clamp `start` and a *given* `end` the same way against `len`, and
+    /// differ only in what an *omitted* `end` defaults to before that same
+    /// clamp runs (`len` itself for a plain container, the entry count for
+    /// an object's child-node layout) -- kept as one body, not two
+    /// near-identical ones, per this crate's own "duplicated predicates
+    /// diverge silently" lesson.
+    fn resolve_with_end_default(&self, len: usize, end_default: f64) -> Range<usize> {
+        let start = clamp(self.start.map_or(0.0, f64::floor), len);
+        let end = clamp(self.end.map_or(end_default, f64::ceil), len);
         start..end.max(start)
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13971,9 +13971,9 @@ fn test_yq_equality_consuming_builtins_agree_with_strict_eq_950() -> Result<()> 
 // it's the target of a read slice (`.[S:E]`) rather than erroring (matching
 // jq's own behavior) or passing null through unchanged. Every case here is
 // pinned against the live real `yq` v4.53.3 binary. Object targets are
-// deliberately excluded (#1065's own follow-up, #1102) -- real yq's own
-// slicing there follows its internal AST child-node layout, not this
-// empty-container rule.
+// excluded from *this* rule -- real yq's own slicing there follows its
+// internal AST child-node layout instead, implemented separately below
+// (#1102).
 
 #[test]
 fn test_slice_number_scalar_is_empty_array_1065() -> Result<()> {
@@ -14060,6 +14060,137 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
 }
 
 // ============================================================================
+// yq slicing an object follows its own AST child-node layout (#1102)
+// ============================================================================
+//
+// Real yq's `.[S:E]` on an *object* target doesn't error, doesn't give `[]`,
+// and doesn't slice by key-insertion-order pairs -- it slices yq's own
+// internal AST child-node list, where a mapping's children alternate
+// key-node, value-node, key-node, value-node (`{"a":1,"b":2,"c":3} |
+// .[0:2]` -> `["a",1]`, the first *two children*, not the first pair).
+// `start`/a negative `end` fold and clamp against the child count `2N`, but
+// an *omitted* `end` defaults to the entry count `N`, not `2N` -- verified
+// against real yq v4.53.3 across 20+ probes on 3- and 4-entry objects (see
+// `SliceBounds::resolve_object_children`'s own doc comment for the full
+// matrix and the near-certain upstream-bug explanation). Real jq has no
+// object-slicing concept at all and keeps erroring -- this is yq mode only.
+
+#[test]
+fn test_object_slice_matches_ast_child_layout_matrix_1102() -> Result<()> {
+    let input = r#"{"a":1,"b":2,"c":3}"#;
+    let cases: &[(&str, &str)] = &[
+        (".[0:2]", r#"["a",1]"#),
+        (".[1:2]", "[1]"),
+        (".[:2]", r#"["a",1]"#),
+        (".[4:6]", r#"["c",3]"#),
+        (".[6:8]", "[]"),
+        (".[3:1]", "[]"),
+        (".[2:]", r#"["b"]"#),
+        (".[1:]", r#"[1,"b"]"#),
+        (".[0:]", r#"["a",1,"b"]"#),
+        (".[5:]", "[]"),
+        (".[0:-1]", r#"["a",1,"b",2,"c"]"#),
+        (".[0:99]", r#"["a",1,"b",2,"c",3]"#),
+        (".[-1:]", "[]"),
+        (".[-2:]", "[]"),
+        (".[-3:]", "[]"),
+        (".[-4:]", r#"["b"]"#),
+        (".[-5:]", r#"[1,"b"]"#),
+        (".[-6:]", r#"["a",1,"b"]"#),
+    ];
+    for (filter, expected) in cases {
+        let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "filter {filter}: out {out:?}");
+        assert_eq!(out.trim(), *expected, "filter {filter}");
+    }
+    Ok(())
+}
+
+/// The `end`-omitted-defaults-to-`N`-not-`2N` asymmetry, guarded against an
+/// "obvious" simplification (`end = 2N` for every omitted bound) on a
+/// 4-entry object so it isn't just a coincidence of `N=3`.
+#[test]
+fn test_object_slice_end_omitted_asymmetry_generalizes_1102() -> Result<()> {
+    let input = r#"{"a":1,"b":2,"c":3,"d":4}"#;
+
+    let (out, code) = run_yq_stdin(".[0:]", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",1,"b",2]"#);
+
+    let (out, code) = run_yq_stdin(".[2:]", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["b",2]"#);
+
+    let (out, code) = run_yq_stdin(".[-2:]", input, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+
+    Ok(())
+}
+
+#[test]
+fn test_object_slice_empty_object_and_nested_value_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:1]", "{}", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+
+    let (out, code) = run_yq_stdin(".[0:2]", r#"{"a":{"z":9},"b":2}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",{"z":9}]"#);
+    Ok(())
+}
+
+/// Mirrors `test_slice_owned_target_scalar_is_empty_array_1065`'s shape (a
+/// bare literal in postfix-slice position, with arithmetic non-folding
+/// bounds) to reach `slice_owned_value_read`'s new `Object` arm via
+/// `eval_slice_expr`'s `Targets::Owned` branch specifically, not just the
+/// cursor-backed `Expr::Slice` arm every `.` -direct case above already
+/// exercises.
+#[test]
+fn test_object_slice_owned_target_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"({"a":1,"b":2})[(1-1):(2+0)]"#,
+        "",
+        &["-n", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",1]"#);
+    Ok(())
+}
+
+/// jq mode must be entirely unaffected -- real jq has no object-slicing
+/// concept and keeps erroring, so the `S::TAG == EvalTag::Yq` gate can't
+/// silently rot.
+#[test]
+fn test_object_slice_jq_mode_still_errors_1102() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_stdin_with_stderr(".[0:2]", r#"{"a":1,"b":2,"c":3}"#, &["-c"])?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+/// Known, deliberate gap: real yq's slice result keeps the source node's
+/// `!!map` tag in YAML output (`{"a":1,"b":2} | yq '.[0:2]'` prints
+/// `!!map\n- "a"\n- 1` on real yq). `OwnedValue` has no tag slot (#1090's
+/// whole subject), so this isn't reachable here -- `-o=json` output (what
+/// every case above exercises, and every realistic use of this operator)
+/// is unaffected, since the tag doesn't appear in JSON. Pinned here so a
+/// future #1090 fix doesn't silently change this without the gap being
+/// deliberately revisited.
+#[test]
+fn test_object_slice_yaml_output_known_tag_gap_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:2]", r#"{"a":1,"b":2,"c":3}"#, &[])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        "- a\n- 1",
+        "missing !!map tag is the known #1090 gap"
+    );
+    Ok(())
+}
+
+// ============================================================================
 // yq assigning through a scalar slice target is a silent no-op (#1101)
 // ============================================================================
 //
@@ -14075,9 +14206,10 @@ fn test_slice_owned_target_scalar_is_empty_array_1065() -> Result<()> {
 // never actually written or serialized). `-=`/`*=` are NOT no-ops for a
 // *scalar* target -- they error instead, with Go-internal-looking messages
 // this crate deliberately does not replicate (not a stable compatibility
-// target). Object is still deliberately unaffected -- see #1157/#1102 for
-// why replicating it needs real yq's own AST-child-layout read rule first
-// -- but array/string targets are *not* unaffected any more: #1142 widened
+// target). Object is still deliberately unaffected -- #1102 (see the new
+// section below) implements the read-side AST-child-layout rule #1157's
+// own write-side follow-up needs, but doesn't itself touch assignment --
+// but array/string targets are *not* unaffected any more: #1142 widened
 // this same no-op to them too (any operator, including `-=`/`*=`, unlike
 // the scalar case), and #1116 (PR #1151) separately widened the *scalar*
 // case here to any chain depth, not just the bare-root shape this section
@@ -16942,61 +17074,48 @@ fn test_1219_bare_slice_sibling_trailing_run_no_longer_crashes_but_still_diverge
     Ok(())
 }
 
-/// #1223 follow-up (found by `/code-review`, filed separately): a comma
+/// #1223 follow-up (found by `/code-review`, filed as #1325 item 2): a comma
 /// branch reaching its trailing slice through an `Expr::Iterate` prefix
-/// (`.arr[][0:1]`) still crashes, because `navigate_read_only` (the prefix
-/// walker `yq_del_slice_outcome` uses to confirm the prefix
-/// actually exists) only understands `Field`/`Index` steps -- an
-/// `Iterate` step returns `None` immediately, so the rewrite silently
-/// declines and the branch reaches `resolve_dynamic_indexes` unrewritten.
-/// Deliberately not attempted here: real yq's rule for *which* parent key
-/// to drop when the prefix fans out over multiple array elements (rather
-/// than naming one) isn't obviously "drop every element," and extending
-/// `navigate_read_only` to `Iterate` needs its own live verification before
-/// committing to an answer -- a separate, more involved fix than this PR's
-/// scope. If this is ever addressed, update this expectation.
+/// (`.arr[][0:1]`) used to crash with `Cannot index object with object`,
+/// because that error came from the *read* side ever attempting to slice an
+/// object at all -- unconditional before #1102 gave yq mode a real
+/// object-slicing rule. #1102 resolves this as a side effect, not by
+/// touching any `del()`-specific machinery: `.arr[][0:1]` now legitimately
+/// evaluates (each array element's own AST-child-list slice, `[0:1)` = the
+/// first child = that element's first key alone), and whatever `del()`
+/// mechanism previously only got a chance to run once navigation stopped
+/// erroring now runs to completion. Live-verified against real yq v4.53.3:
+/// `{"arr":[]}` -- both array elements dropped entirely, not just their
+/// first key -- matches exactly.
 #[test]
-fn test_1223_iterate_prefix_slice_sibling_characterize_preexisting_bug() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+fn test_1223_iterate_prefix_slice_sibling_now_matches_real_yq_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(
         "del(.arr[][0:1], .c)",
         r#"{"arr":[{"x":1,"y":2},{"x":3,"y":4}],"c":9}"#,
-        &[],
+        &["-o=json", "-I=0"],
     )?;
-    assert_ne!(code, 0, "if this now succeeds, update this test");
-    assert!(
-        stderr.contains("Cannot index object with object"),
-        "stderr: {stderr}"
-    );
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"arr":[]}"#);
     Ok(())
 }
 
-/// #1223 follow-up (found by `/code-review`, filed separately): a branch
-/// that itself needs a computed-key prepass (`.[($k)][0:1]`) and *also*
-/// ends in a trailing slice still crashes -- `rewrite_yq_del_comma_
-/// branches` deliberately skips any branch where `needs_path_prepass` is
-/// `true` (the existing, pre-#1223 contract: such a branch resolves through
-/// the normal dynamic-index machinery, and the post-resolution rewrite at
-/// `builtin_del`'s own `paths.len() > 1` branch was expected to catch a
-/// trailing slice in its *resolved* output) -- but here the crash happens
-/// *during* that branch's own resolution, before any resolved output
-/// exists for the post-resolution rewrite to run on. A real fix needs
-/// `resolve_dynamic_indexes`'s own per-branch navigation to defer a
-/// trailing slice the same way the top-level fast path already does for a
-/// non-comma expression, which is `resolve_node`'s `Expr::Comma` arm, not
-/// `builtin_del`'s -- out of scope for this PR. If this is ever addressed,
-/// update this expectation.
+/// #1223 follow-up (found by `/code-review`, filed as #1325 item 3): a
+/// branch that itself needs a computed-key prepass (`.[($k)][0:1]`) and
+/// also ends in a trailing slice used to crash the same way, and for the
+/// same underlying reason, as the `Iterate`-prefix case above -- #1102's
+/// object-slicing rule resolves it as a side effect too, not by touching
+/// `resolve_dynamic_indexes`'s per-branch navigation at all. Live-verified
+/// against real yq v4.53.3 with `k=a yq 'del(.[env(k)][0:1], .c)'`: `{}` --
+/// both `.a` and `.c` dropped entirely -- matches exactly.
 #[test]
-fn test_1223_computed_key_with_trailing_slice_characterize_preexisting_bug() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+fn test_1223_computed_key_with_trailing_slice_now_matches_real_yq_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(
         r"del(.[($k)][0:1], .c)",
         r#"{"a":{"x":1,"y":2},"c":9}"#,
-        &["--arg", "k", "a"],
+        &["--arg", "k", "a", "-o=json", "-I=0"],
     )?;
-    assert_ne!(code, 0, "if this now succeeds, update this test");
-    assert!(
-        stderr.contains("Cannot index object with object"),
-        "stderr: {stderr}"
-    );
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{}");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14211,6 +14211,25 @@ fn test_object_slice_getpath_path_round_trip_1102() -> Result<()> {
     Ok(())
 }
 
+/// A malformed slice descriptor against an object target (a `start`/`end`
+/// that isn't a number or `null`) errors the same way it already does for
+/// `getpath`'s existing `Array`/`String` slice-descriptor arms, rather than
+/// silently accepting garbage bounds.
+#[test]
+fn test_object_slice_getpath_malformed_descriptor_errors_1102() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        r#"getpath([{"start":"bad","end":2}])"#,
+        r#"{"a":1,"b":2}"#,
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("Array/string slice indices must be integers"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 /// Known, deliberate gap: slicing an object with a genuine duplicate YAML
 /// key silently collapses it, the same root cause as this repo's other
 /// duplicate-mapping-key gaps (`OwnedValue::Object`'s `IndexMap`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14158,6 +14158,80 @@ fn test_object_slice_owned_target_1102() -> Result<()> {
     Ok(())
 }
 
+/// Found by review: `eval_generic.rs`'s own `slice_one_generic` (the yq
+/// CLI's native handler for `Expr::SliceExpr`, i.e. *computed*, non-literal
+/// slice bounds) never got the object arm -- only `eval.rs`'s cursor-backed
+/// `Expr::Slice` (literal bounds) and the shared `slice_owned_value_read`
+/// (used by both evaluators' `Targets::Owned` loop) did. Literal bounds
+/// (`.[0:2]`) worked; computed bounds (`.[.from:.to]`) on the exact same
+/// object still errored, an internal inconsistency independent of whether
+/// real yq's own slice syntax supports computed bounds identically --
+/// succinctly's own two syntactic forms of the same operation must behave
+/// the same way once their bounds resolve to the same values, matching
+/// #1065's own established precedent of testing both forms.
+#[test]
+fn test_object_slice_computed_bounds_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".items[] | .data[.from:.to]",
+        r#"{"items":[{"data":{"a":1,"b":2,"c":3},"from":0,"to":2}]}"#,
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",1]"#);
+    Ok(())
+}
+
+/// Found by review: `path(.[S:E])` on an object used to succeed (the new
+/// `slice_owned_value_read` arm) while the descriptor it returned was
+/// unusable by `getpath` (whose own hand-rolled slice-descriptor dispatch
+/// had no `Object` arm) -- a narrower regression than the pre-#1102
+/// all-or-nothing error, breaking `getpath(path(x)) == x` for an object
+/// target specifically. Fixed by giving `builtin_getpath` the matching
+/// `Object`+descriptor arm, read-only (matching #1102's own scope) --
+/// `setpath`/`delpaths` deliberately don't get the same treatment (#1157's
+/// write-side scope, not this one's).
+#[test]
+fn test_object_slice_getpath_path_round_trip_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "getpath(path(.[0:2]))",
+        r#"{"a":1,"b":2,"c":3}"#,
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",1]"#);
+
+    // Same round trip via a computed-bound descriptor, not just a literal.
+    let (out, code) = run_yq_stdin(
+        "getpath(path(.[(1-1):(1+1)]))",
+        r#"{"a":1,"b":2,"c":3}"#,
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["a",1]"#);
+    Ok(())
+}
+
+/// Known, deliberate gap: slicing an object with a genuine duplicate YAML
+/// key silently collapses it, the same root cause as this repo's other
+/// duplicate-mapping-key gaps (`OwnedValue::Object`'s `IndexMap`
+/// representation cannot hold two entries with the same key at all) --
+/// unlike those other surfaces, there's no cursor-preserving alternative
+/// available here, since slicing inherently needs to reorder/subset the
+/// entries, not just stream them. Real yq keeps both `a` entries (verified
+/// live against yq v4.53.3: `["a",1,"b",2,"a",3]`, 6 children); succinctly
+/// silently drops the first one during the materialization slicing needs.
+#[test]
+fn test_object_slice_duplicate_key_known_gap_1102() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0:6]", "a: 1\nb: 2\na: 3\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(
+        out.trim(),
+        r#"["a",3,"b",2]"#,
+        "duplicate key collapse is the known gap -- real yq keeps both a entries"
+    );
+    Ok(())
+}
+
 /// jq mode must be entirely unaffected -- real jq has no object-slicing
 /// concept and keeps erroring, so the `S::TAG == EvalTag::Yq` gate can't
 /// silently rot.
@@ -14171,13 +14245,15 @@ fn test_object_slice_jq_mode_still_errors_1102() -> Result<()> {
 }
 
 /// Known, deliberate gap: real yq's slice result keeps the source node's
-/// `!!map` tag in YAML output (`{"a":1,"b":2} | yq '.[0:2]'` prints
-/// `!!map\n- "a"\n- 1` on real yq). `OwnedValue` has no tag slot (#1090's
-/// whole subject), so this isn't reachable here -- `-o=json` output (what
-/// every case above exercises, and every realistic use of this operator)
-/// is unaffected, since the tag doesn't appear in JSON. Pinned here so a
-/// future #1090 fix doesn't silently change this without the gap being
-/// deliberately revisited.
+/// `!!map` tag in YAML output, and keeps the extracted key double-quoted
+/// (`{"a":1,"b":2} | yq '.[0:2]'` prints `!!map\n- "a"\n- 1` on real yq).
+/// `OwnedValue` has no tag or style slot at all -- not specific to slicing,
+/// every computed/constructed value in this codebase has the same gap --
+/// so neither is reachable here -- `-o=json` output (what every case above
+/// exercises, and every realistic use of this operator) is unaffected,
+/// since neither the tag nor the quoting style appears in JSON. Pinned
+/// here so a future fix doesn't silently change this without the gap being
+/// deliberately revisited. Filed as #1416.
 #[test]
 fn test_object_slice_yaml_output_known_tag_gap_1102() -> Result<()> {
     let (out, code) = run_yq_stdin(".[0:2]", r#"{"a":1,"b":2,"c":3}"#, &[])?;
@@ -14185,7 +14261,7 @@ fn test_object_slice_yaml_output_known_tag_gap_1102() -> Result<()> {
     assert_eq!(
         out.trim(),
         "- a\n- 1",
-        "missing !!map tag is the known #1090 gap"
+        "missing !!map tag and key quoting are the known #1416 gap"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq's `.[S:E]` on an *object* target doesn't error, doesn't give `[]`, and doesn't
slice by key-insertion-order pairs — it slices yq's own internal AST child-node list,
where a mapping's children alternate key-node, value-node, key-node, value-node:

```
$ echo '{"a":1,"b":2,"c":3}' | yq -o=json '.[0:2]'
["a",1]
```

`[0:2]` returns the first *two AST children* (key `"a"`, then value `1`), not the first
key-value pair. succinctly previously gave `Cannot index object with object` here
(matching jq's own "not sliceable" rule, which is correct for jq mode — real jq has no
object-slicing concept at all).

## Implementation

`SliceBounds::resolve_object_children` (`src/jq/slice.rs`) implements the
bound-resolution rule, verified against real yq v4.53.3 across 20+ probes on 3- and
4-entry objects (full matrix in that method's doc comment). The interesting part: `start`
and a *negative* `end` fold/clamp against the child count `2N` like every other slice
bound, but an *omitted* `end` defaults to the entry count `N`, not `2N` — near-certainly
an upstream bug (yq computes the default end from `length`, which is `N` for a map,
while resolving a negative index against `len(node.Content)`, which is `2N`). Reproduced
anyway, per ADR-0018's bug-for-bug fidelity rule, and documented so a future reader
doesn't "fix" the asymmetry.

Wired into `slice_owned_value_read` (shared by both `eval.rs`'s and `eval_generic.rs`'s
`Targets::Owned` loop — one definition, not two) and a new `StandardJson::Object` arm in
`eval.rs`'s cursor-backed `Expr::Slice` dispatch, since an object target reaches that
arm before any `OwnedValue` is ever materialized. Both gated on `S::TAG == EvalTag::Yq`;
jq mode keeps erroring (regression test included).

## Unplanned side effect

Two `del()`-machinery crashes pinned as `*_characterize_preexisting_bug` placeholders
(#1325 items 2 and 3 — `del(.arr[][0:1], .c)` and `del(.[($k)][0:1], .c)`, both crashing
with `Cannot index object with object` purely because that error came from the *read*
side ever attempting to slice an object at all) now legitimately evaluate and match real
yq exactly:

```
$ echo '{"arr":[{"x":1,"y":2},{"x":3,"y":4}],"c":9}' | yq -o=json 'del(.arr[][0:1], .c)'
{"arr":[]}
$ echo '{"a":{"x":1,"y":2},"c":9}' | k=a yq -o=json 'del(.[env(k)][0:1], .c)'
{}
```

Both verified live against real yq and matched exactly by succinctly post-fix. Updated
the two tests in place (renamed, now asserting the correct behavior) rather than leaving
them describing a bug that no longer exists.

- #1325's item 1 (bare-slice-sibling ordering) was already fixed pre-#1102 by #1219 and
  remains a separate, unrelated known divergence — unaffected, still passing.
- #1325's item 4 (a warning that assignment might develop the same premature-navigation
  crash once an object-slice target gets a `del()`-style carve-out) doesn't trigger here
  since this PR is read-only — confirmed live: `.a[0:1] = x` and `.a[0:1].foo = x` both
  still error exactly as before (same message, same exit code).

Will comment on #1325 once this merges, noting items 2/3 resolved and item 1/4 still
open.

## Test plan

- `test_object_slice_matches_ast_child_layout_matrix_1102`: all 18 probe rows from the
  characterization matrix (N=3).
- `test_object_slice_end_omitted_asymmetry_generalizes_1102`: the `end`-omitted-defaults-
  to-`N` asymmetry on a 4-entry object, guarding against an "obvious" `2N` simplification.
- `test_object_slice_empty_object_and_nested_value_1102`: `{}` and a nested-value case.
- `test_object_slice_owned_target_1102`: reaches `slice_owned_value_read`'s new arm via
  `eval_slice_expr`'s `Targets::Owned` branch specifically (mirrors
  `test_slice_owned_target_scalar_is_empty_array_1065`'s shape), not just the cursor arm.
- `test_object_slice_jq_mode_still_errors_1102`: jq mode regression guard.
- `test_object_slice_yaml_output_known_tag_gap_1102`: known, deliberate gap — real yq's
  slice result keeps the source node's `!!map` tag and key quoting in YAML output;
  `OwnedValue` has no tag/style slot at all, so neither is reachable here. `-o=json`
  output (every case above, and every realistic use of this operator) is unaffected.
  Filed as #1416 (see the review-round comment below for why not #1090, which the PR
  originally cited).
- Full `1223`/`1325`-tagged suite re-run clean (11 tests), including the two updated
  ones.
- Full `cargo test --features cli,simd,regex,serde` (single-threaded): all green.
- Both clippy legs, `cargo build --no-default-features`, `cargo fmt --check`: clean.
- Patch coverage: 96.15% (25/26). The one uncovered line is a defensive
  `unreachable!()` for an invariant (`StandardJson::Object` always materializes to
  `OwnedValue::Object`) that genuinely cannot be exercised by a test.

Fixes #1102

