### PR TITLE
fix(jq): yq scalar-noop reaches a scalar hit before the last path component

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -268,6 +268,39 @@ for the ordering divergence would likely resolve the comma-LHS gap as a side eff
 path-before-RHS reorder no longer needs the static-only safety gate #1233's own narrower
 fix relies on).
 
+### Dynamic-key and comma-grouped scalar-target assignment: the *write itself* fails
+
+[#1232](https://github.com/rust-works/succinctly/issues/1232) widened #1181's scalar-target
+no-op to a scalar hit *before* the last path component (`.a.b = 99` on a scalar `.a`
+no-ops), but only for the *static*-path walkers (`get_path_mut`/`set_path`/`update_path`).
+A path that needs the full `resolve_dynamic_indexes` pre-pass — a computed key, or a
+`Comma`-grouped LHS — resolves each component through a plain read evaluator with no yq
+scalar-noop awareness at all, so the boundary this section's *previous* entry describes
+("no computed key, and no `Comma`") is wider than just the RHS-discard optimization: for
+these paths the write genuinely fails, not just the optimization of skipping RHS
+evaluation:
+
+```bash
+$ printf 'a: 5\n' | yq            -o=json '"a" as $k | .[$k].b = 99'   # a: 5, no-op
+$ printf 'a: 5\n' | succinctly yq -o=json '"a" as $k | .[$k].b = 99'   # Error: Cannot index number with string "b"
+
+$ printf 'a: 5\nx: {}\n' | yq            -o=json '(.a.b, .x.y) = 99'   # a: 5, x: {y: 99} -- .x.y still writes
+$ printf 'a: 5\nx: {}\n' | succinctly yq -o=json '(.a.b, .x.y) = 99'   # Error: Cannot index number with string "b" -- .x.y write lost too
+```
+
+Both live-verified against yq v4.53.3, and confirmed unaffected by #1232's own fix (identical
+on `main` immediately before that PR). Filed as
+[#1419](https://github.com/rust-works/succinctly/issues/1419), which also covers the
+narrower, already-fixed-write case where only the RHS-discard *optimization* is missing
+(`0 as $k | .[$k] = error("boom")` on a scalar root still raises `boom` where real yq no-ops
+silently, even though the write itself — `.[$k] = 99` — already correctly no-ops).
+
+Separately, `get_path_mut` (the walker #1232 widened) has no `Expr::Iterate` arm at all, so
+a mid-chain `.[]` under plain `=` (`.a[].b = 99`) always errors "invalid path component" —
+in both jq and yq mode, and predating #1232 entirely (`|=`/`+=`/`-=`/`*=`/`del()` are
+unaffected). Filed as
+[#1418](https://github.com/rust-works/succinctly/issues/1418).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11172,6 +11172,17 @@ enum PrefixNavOutcome<'a> {
 /// distinction (`del()`'s own scalar-root behavior is a separate, unscoped
 /// gap — #1411) and folds `HitScalar` back into "this rule doesn't apply",
 /// same as it always treated `None`.
+///
+/// A second, hand-synchronized walker rather than a shared traversal
+/// `get_path_mut` itself could call — code review flagged this against the
+/// same "duplicated predicates diverge silently" lesson `is_owned_container`
+/// was factored out to avoid (#106). Kept separate anyway: the two have
+/// different write permissions (this one is read-only by design, the other
+/// mutates and autovivifies), so unifying them is a real redesign, not a
+/// mechanical extraction. If a future `Field`/`Index` arm gains a new
+/// container-mismatch case (or `OwnedValue` gains a variant) in one walker,
+/// mirror it here too — a drift would make `yq_assign_is_total_noop`
+/// disagree with what the real write does.
 fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> PrefixNavOutcome<'a> {
     let mut current = root;
     for step in steps {
@@ -12628,20 +12639,25 @@ fn get_path_mut<'a>(
             continue;
         }
 
+        // #1232: same terminal-position no-op #1181 gave `set_path`'s own
+        // `Field`/`Index` arms, applied here so a scalar hit *before* the
+        // last path component (`.a.b = 99` on a scalar root) no-ops instead
+        // of erroring while still navigating toward the parent. Computed
+        // once per iteration rather than at each arm's own `else if`
+        // (previously duplicated across both): `autovivify_object`/
+        // `autovivify_array` below only ever convert `Null` into a
+        // container, and `is_yq_field_index_noop_scalar` already excludes
+        // `Null`, so the answer is identical whether checked before or
+        // after autovivification runs.
+        let noop_here = scalar_noop && is_yq_field_index_noop_scalar(current);
+
         current = match part {
             Expr::Identity => current,
             Expr::Field(name) => {
                 autovivify_object(current);
                 if let OwnedValue::Object(map) = current {
                     map.entry(name.clone()).or_insert(OwnedValue::Null)
-                } else if optional
-                    // #1232: same terminal-position no-op #1181 gave
-                    // `set_path`'s own `Field` arm, applied here so a scalar
-                    // hit *before* the last path component (`.a.b = 99` on a
-                    // scalar root) no-ops instead of erroring while still
-                    // navigating toward the parent.
-                    || (scalar_noop && is_yq_field_index_noop_scalar(current))
-                {
+                } else if optional || noop_here {
                     return Ok(None);
                 } else {
                     return Err(EvalError::cannot_index_with_field(
@@ -12660,7 +12676,7 @@ fn get_path_mut<'a>(
                     // returns that error for a component this function can
                     // itself elect to suppress.
                     write_index(arr, *idx)?
-                } else if optional || (scalar_noop && is_yq_field_index_noop_scalar(current)) {
+                } else if optional || noop_here {
                     return Ok(None);
                 } else {
                     return Err(EvalError::cannot_index_with_type(
@@ -12701,6 +12717,15 @@ fn update_path<S: EvalSemantics>(
     // recursive call. Bound once here rather than recomputed inline at each
     // `Expr::Slice` arm below, so the two can't drift out of sync.
     let container_noop = S::TAG == EvalTag::Yq;
+    // #1181/#1232's yq-mode scalar-target no-op, bound once for the same
+    // reason as `container_noop` above rather than repeated at each of this
+    // function's six `Field`/`Index`/`Iterate` arms (three terminal, three
+    // in the `Pipe` arm's own mid-chain duplicate). Safe to compute before
+    // any arm runs: every arm's own `autovivify_object`/`autovivify_array`
+    // call only ever converts a `Null` `root` into an (empty) container,
+    // and `is_yq_field_index_noop_scalar` already excludes `Null`, so the
+    // answer is identical whether checked before or after autovivification.
+    let noop_scalar = S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root);
     match path_expr {
         Expr::Identity => {
             // The filter runs as an ordinary sub-expression, not one
@@ -12749,7 +12774,7 @@ fn update_path<S: EvalSemantics>(
                 // the same as `.a |= f`, unlike the slice case, which
                 // diverges for both operators in ways this codebase
                 // doesn't implement yet (#1340's own follow-up).
-                || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
+                || noop_scalar
             {
                 Ok(())
             } else {
@@ -12766,7 +12791,7 @@ fn update_path<S: EvalSemantics>(
                     optional,
                     scalar_noop,
                 )
-            } else if optional || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) {
+            } else if optional || noop_scalar {
                 Ok(())
             } else {
                 Err(EvalError::cannot_index_with_type(owned_type_name(root), "number").into())
@@ -12807,9 +12832,7 @@ fn update_path<S: EvalSemantics>(
                     }
                     Ok(())
                 }
-                _ if optional || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) => {
-                    Ok(())
-                }
+                _ if optional || noop_scalar => Ok(()),
                 _ => Err(EvalError::cannot_iterate(root).into()),
             }
         }
@@ -12838,7 +12861,7 @@ fn update_path<S: EvalSemantics>(
                             // no-op check -- applied here too so a scalar hit
                             // *before* the last path component (`.a.b |= 99`
                             // on a scalar root) no-ops instead of erroring.
-                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
+                            || noop_scalar
                         {
                             Ok(())
                         } else {
@@ -12858,9 +12881,7 @@ fn update_path<S: EvalSemantics>(
                                 optional,
                                 scalar_noop,
                             )
-                        } else if here
-                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
-                        {
+                        } else if here || noop_scalar {
                             Ok(())
                         } else {
                             Err(
@@ -12882,11 +12903,7 @@ fn update_path<S: EvalSemantics>(
                             }
                             Ok(())
                         }
-                        _ if here
-                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) =>
-                        {
-                            Ok(())
-                        }
+                        _ if here || noop_scalar => Ok(()),
                         _ => Err(EvalError::cannot_iterate(root).into()),
                     },
                     // `resolve_node`'s `?` arm emits `Optional(Pipe([…]))`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10876,12 +10876,16 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
         return false;
     }
     match navigate_read_only(root, prefix) {
-        Some(parent) => is_yq_field_index_noop_scalar(parent),
-        // An absent prefix (missing field/out-of-range index) isn't this
-        // predicate's case at all -- defer to the normal RHS evaluation
-        // and let `set_path`'s own existing `get_path_mut` report whatever
-        // it reports for a genuinely missing path.
-        None => false,
+        PrefixNavOutcome::Resolved(parent) => is_yq_field_index_noop_scalar(parent),
+        // A scalar hit mid-prefix is a no-op regardless of what the
+        // terminal component was going to do (#1232) -- the scalar can't
+        // become a container no matter how much further path is left.
+        PrefixNavOutcome::HitScalar => true,
+        // An absent prefix (missing field/out-of-range index/`Null`) isn't
+        // this predicate's case at all -- defer to the normal RHS
+        // evaluation and let `set_path`'s own existing `get_path_mut`
+        // report whatever it reports for a genuinely missing path.
+        PrefixNavOutcome::Absent => false,
     }
 }
 
@@ -11111,7 +11115,10 @@ fn yq_del_slice_outcome(
     // is the only remaining reason to defer to `delete_at_path`'s own
     // absent-path handling instead.
     let prefix_components: Vec<Expr> = prefix.iter().map(|s| s.component.clone()).collect();
-    if navigate_read_only(root, &prefix_components).is_none() {
+    if !matches!(
+        navigate_read_only(root, &prefix_components),
+        PrefixNavOutcome::Resolved(_)
+    ) {
         return YqDelSliceOutcome::NotApplicable;
     }
     let wrap = |s: &DeleteStep| {
@@ -11127,23 +11134,56 @@ fn yq_del_slice_outcome(
     })
 }
 
-/// Read-only navigation for [`yq_del_slice_outcome`]'s prefix
-/// peek. Unlike `get_path_mut`, never autovivifies (a peek must not create
-/// structure the delete itself would otherwise leave untouched) and simply
-/// returns `None` for anything it can't resolve — a missing field, an
-/// out-of-bounds index, a wrong container type (including `Null`), or a
-/// step shape that can't appear in a resolved path's prefix before its own
-/// trailing slice. The caller treats `None` as "this rule doesn't apply,"
-/// deferring to `delete_at_path`'s own already-correct del()-through-absent
-/// handling rather than duplicating it here.
-fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> Option<&'a OwnedValue> {
+/// Outcome of [`navigate_read_only`]'s prefix walk.
+///
+/// Three-way rather than [`navigate_read_only`]'s old binary `Option`
+/// (#1232): a step that can't continue splits into two outcomes real yq
+/// treats completely differently. Hitting a genuine scalar (`is_yq_field_
+/// index_noop_scalar`) while trying to `Field`/`Index` into it is a
+/// transitively-permanent no-op — the scalar never becomes a container no
+/// matter what the rest of the path was going to do, matching
+/// `get_path_mut`'s own post-#1232 `Field`/`Index` arms. A missing object
+/// key, an out-of-range array index, or `Null` (autovivifies), by contrast,
+/// is not settled at all — `get_path_mut` autovivifies straight through
+/// those and keeps going. Collapsing both into one `None` was exactly the
+/// gap #1232 found: `yq_assign_is_total_noop` (the only caller that cares
+/// about the distinction) treated a mid-prefix scalar hit the same as an
+/// unresolved parent, deferring to normal RHS evaluation and letting
+/// `.a.b.c = error("boom")` on `a: 5` raise `boom` where real yq no-ops
+/// silently (RHS never runs) — live-verified against yq v4.53.3.
+enum PrefixNavOutcome<'a> {
+    /// Every prefix step navigated an existing value.
+    Resolved(&'a OwnedValue),
+    /// A step tried to index into a real, non-`Null` scalar.
+    HitScalar,
+    /// Missing key, out-of-range index, `Null`, or a container-type
+    /// mismatch (e.g. `Field` on an `Array`) — the real write either
+    /// autovivifies through it or genuinely errors; either way this isn't
+    /// a settled no-op.
+    Absent,
+}
+
+/// Read-only navigation shared by [`yq_del_slice_outcome`]'s prefix peek and
+/// [`yq_assign_is_total_noop`]'s pre-RHS-evaluation check. Unlike
+/// `get_path_mut`, never autovivifies (a peek must not create structure the
+/// caller's own real walker would otherwise leave untouched) — see
+/// [`PrefixNavOutcome`] for what each non-`Resolved` outcome means and why
+/// there are two of them. `yq_del_slice_outcome` doesn't need the
+/// distinction (`del()`'s own scalar-root behavior is a separate, unscoped
+/// gap — #1411) and folds `HitScalar` back into "this rule doesn't apply",
+/// same as it always treated `None`.
+fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> PrefixNavOutcome<'a> {
     let mut current = root;
     for step in steps {
         let (step, _optional) = unwrap_path_component(step);
         current = match step {
             Expr::Field(name) => match current {
-                OwnedValue::Object(map) => map.get(name)?,
-                _ => return None,
+                OwnedValue::Object(map) => match map.get(name) {
+                    Some(v) => v,
+                    None => return PrefixNavOutcome::Absent,
+                },
+                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
+                _ => return PrefixNavOutcome::Absent,
             },
             Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
                 OwnedValue::Array(arr) => {
@@ -11152,15 +11192,16 @@ fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> Option<&'a Ow
                     if actual >= 0 && (actual as usize) < arr.len() {
                         &arr[actual as usize]
                     } else {
-                        return None;
+                        return PrefixNavOutcome::Absent;
                     }
                 }
-                _ => return None,
+                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
+                _ => return PrefixNavOutcome::Absent,
             },
-            _ => return None,
+            _ => return PrefixNavOutcome::Absent,
         };
     }
-    Some(current)
+    PrefixNavOutcome::Resolved(current)
 }
 
 /// Apply a resolved slice directly to an owned value.
@@ -12056,7 +12097,7 @@ fn set_path(
             if exprs.len() == 1 {
                 set_path(root, &exprs[0], new_value, scalar_noop, container_noop)
             } else if let Some(split) = split_at_slice(exprs) {
-                match get_path_mut(root, &split.before)? {
+                match get_path_mut(root, &split.before, scalar_noop)? {
                     None => Ok(()),
                     Some(parent) => through_slice(
                         parent,
@@ -12082,7 +12123,7 @@ fn set_path(
                 let parent_path = &exprs[..exprs.len() - 1];
                 let last_path = &exprs[exprs.len() - 1];
 
-                match get_path_mut(root, parent_path)? {
+                match get_path_mut(root, parent_path, scalar_noop)? {
                     None => Ok(()),
                     Some(parent) => {
                         set_path(parent, last_path, new_value, scalar_noop, container_noop)
@@ -12546,6 +12587,7 @@ fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
 fn get_path_mut<'a>(
     root: &'a mut OwnedValue,
     path_parts: &[Expr],
+    scalar_noop: bool,
 ) -> Result<Option<&'a mut OwnedValue>, EvalError> {
     let mut current = root;
     // A working copy, not a plain slice iteration: `resolve_node`'s `?` arm
@@ -12592,7 +12634,14 @@ fn get_path_mut<'a>(
                 autovivify_object(current);
                 if let OwnedValue::Object(map) = current {
                     map.entry(name.clone()).or_insert(OwnedValue::Null)
-                } else if optional {
+                } else if optional
+                    // #1232: same terminal-position no-op #1181 gave
+                    // `set_path`'s own `Field` arm, applied here so a scalar
+                    // hit *before* the last path component (`.a.b = 99` on a
+                    // scalar root) no-ops instead of erroring while still
+                    // navigating toward the parent.
+                    || (scalar_noop && is_yq_field_index_noop_scalar(current))
+                {
                     return Ok(None);
                 } else {
                     return Err(EvalError::cannot_index_with_field(
@@ -12611,7 +12660,7 @@ fn get_path_mut<'a>(
                     // returns that error for a component this function can
                     // itself elect to suppress.
                     write_index(arr, *idx)?
-                } else if optional {
+                } else if optional || (scalar_noop && is_yq_field_index_noop_scalar(current)) {
                     return Ok(None);
                 } else {
                     return Err(EvalError::cannot_index_with_type(
@@ -12782,7 +12831,15 @@ fn update_path<S: EvalSemantics>(
                         if let OwnedValue::Object(map) = root {
                             let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
                             update_path::<S>(current, &rest, filter_expr, optional, scalar_noop)
-                        } else if here {
+                        } else if here
+                            // #1232: this mid-chain arm is a separately-
+                            // maintained copy of the terminal `Expr::Field`
+                            // arm above, which already gained the #1181
+                            // no-op check -- applied here too so a scalar hit
+                            // *before* the last path component (`.a.b |= 99`
+                            // on a scalar root) no-ops instead of erroring.
+                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
+                        {
                             Ok(())
                         } else {
                             Err(
@@ -12801,7 +12858,9 @@ fn update_path<S: EvalSemantics>(
                                 optional,
                                 scalar_noop,
                             )
-                        } else if here {
+                        } else if here
+                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root))
+                        {
                             Ok(())
                         } else {
                             Err(
@@ -12823,7 +12882,11 @@ fn update_path<S: EvalSemantics>(
                             }
                             Ok(())
                         }
-                        _ if here => Ok(()),
+                        _ if here
+                            || (S::TAG == EvalTag::Yq && is_yq_field_index_noop_scalar(root)) =>
+                        {
+                            Ok(())
+                        }
                         _ => Err(EvalError::cannot_iterate(root).into()),
                     },
                     // `resolve_node`'s `?` arm emits `Optional(Pipe([…]))`
@@ -44244,6 +44307,7 @@ mod tests {
         let slot = get_path_mut(
             &mut root,
             &[Expr::Field("a".to_string()), Expr::Field("b".to_string())],
+            false,
         )
         .unwrap()
         .unwrap();
@@ -47632,7 +47696,7 @@ mod tests {
         #[test]
         fn test_get_path_mut_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = get_path_mut(&mut root, &[unresolved()]).unwrap_err();
+            let err = get_path_mut(&mut root, &[unresolved()], false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in path component"
@@ -47729,7 +47793,7 @@ mod tests {
         #[test]
         fn test_get_path_mut_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = get_path_mut(&mut root, &[unresolved()]).unwrap_err();
+            let err = get_path_mut(&mut root, &[unresolved()], false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in path component"

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15076,20 +15076,118 @@ fn test_yq_scalar_target_noop_discards_rhs_1233() -> Result<()> {
     Ok(())
 }
 
-/// #1233 (deliberate non-goal, matching the issue's own plan): a scalar
-/// reached *before* the last path component (`.a.b.c` where `.a` is
-/// already the scalar) is #1232's own territory, not this fix's --
-/// `yq_assign_is_total_noop` only walks a resolved path's own prefix
-/// against the *original* root, so a path whose write-time no-op depth
-/// #1232 hasn't widened yet simply doesn't qualify here either, and this
-/// fix doesn't change that. Live-verified this still (unrelated to #1233)
-/// errors in real yq too, for the wrong reason (yq's error message differs
-/// from succinctly's) -- both are "still broken pending #1232", not a
-/// regression.
+/// #1232: a scalar reached *before* the last path component (`.a.b.c`
+/// where `.a` is already the scalar) now no-ops the same as the
+/// already-fixed terminal case, including discarding the RHS entirely
+/// (`error("boom")` never runs) -- the #1233-era version of this test
+/// pinned the opposite as a "deliberate non-goal, #1232's own territory",
+/// live-verified against yq v4.53.3 which no-ops cleanly here too (that
+/// earlier verification, claiming real yq also errored "for the wrong
+/// reason", does not reproduce against the pinned binary and was mistaken).
+/// Root cause was two separate walkers: `get_path_mut` (`=`'s own
+/// parent-navigation walker) had no yq-mode scalar-noop check on its
+/// `Field`/`Index` arms at all, and `yq_assign_is_total_noop` (#1233's
+/// eager-RHS-discard pre-check) only recognized a scalar hit at the
+/// *parent-of-terminal* position via `navigate_read_only`, which collapsed
+/// "hit a scalar mid-prefix" and "hit a missing key/out-of-range index"
+/// into the same `None` -- widened to a three-way `PrefixNavOutcome` so the
+/// pre-check can tell them apart.
 #[test]
-fn test_yq_scalar_target_noop_pre_last_component_is_1232_territory_1233() -> Result<()> {
+fn test_yq_scalar_target_noop_pre_last_component_1232() -> Result<()> {
+    for op in ["=", "+=", "-=", "*=", "//="] {
+        let (out, err, code) = run_yq_stdin_with_stderr(
+            &format!(".a.b.c {op} error(\"boom\")"),
+            "a: 5\n",
+            &["-o", "json", "-I0"],
+        )?;
+        assert_eq!(code, 0, "op={op} err={err}");
+        assert_eq!(out.trim(), r#"{"a":5}"#, "op={op}");
+    }
+
+    // `|=` was already lazy (`update_path` never reaches the filter for a
+    // path that no-ops before it), pinned as a regression guard alongside
+    // the eagerly-evaluating operators above.
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        ".a.b.c |= error(\"boom\")",
+        "a: 5\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // The write itself (not just RHS-discard) no-ops too, with a
+    // non-erroring RHS.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a.b.c = 99", "a: 5\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // jq mode is unaffected -- no such no-op rule exists there.
+    let (_out, err, code) = run_jq_stdin_with_stderr(".a.b.c = error(\"boom\")", "5", &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    Ok(())
+}
+
+/// #1232: the fully-dynamic repro from the issue's own text -- a computed
+/// key chain (`.[$k1][$k2]`) that never touches a literal `Field`/`Index`
+/// node at all, falsifying "the no-op only needs to special-case a literal
+/// path component". `resolve_dynamic_indexes` folds `$k1`/`$k2` into
+/// concrete `Expr::IndexNumber` components before `get_path_mut` ever runs,
+/// so the *write* itself exercises the exact same fixed arms as the
+/// literal-path tests above.
+///
+/// RHS is a plain value here, not `error(...)` like the sibling tests --
+/// `yq_assign_noop_check` bails out to `NotChecked` for any path
+/// `needs_path_prepass` classifies as dynamic (computed keys), before ever
+/// calling `yq_assign_is_total_noop`, so the eager-RHS-discard optimization
+/// this fix's other tests pin doesn't reach a computed-key path at all,
+/// live-verified as *already* true for the terminal case #1233 covers
+/// (`0 as $k | .[$k] = error("boom")` on a scalar root still raises `boom`
+/// in succinctly where real yq no-ops silently) -- a real, separate gap,
+/// not something #1232 introduces or is scoped to fix. Filed as its own
+/// follow-up rather than folded in here.
+#[test]
+fn test_yq_scalar_target_noop_pre_last_component_dynamic_index_1232() -> Result<()> {
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        "0 as $k1 | 1 as $k2 | .[$k1][$k2] = 99",
+        "5\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// #1232: a mid-chain `Iterate` scalar hit (`.a[].b`, not just
+/// `Field`/`Index`) no-ops too -- covers `update_path`'s own separately-
+/// maintained `Pipe`-arm `Expr::Iterate` sub-arm, which had the identical
+/// gap as its `Field`/`Index` siblings (missing the yq-mode no-op check
+/// the *terminal* `Iterate` arm already had from #1181).
+#[test]
+fn test_yq_scalar_target_noop_pre_last_component_iterate_1232() -> Result<()> {
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        ".a[].b |= error(\"boom\")",
+        "a: 5\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+    Ok(())
+}
+
+/// #1232: a missing key mid-prefix on a *real* container (not a scalar) is
+/// not this fix's no-op case -- `navigate_read_only`'s `PrefixNavOutcome::
+/// Absent` arm, distinct from the new `HitScalar` arm this fix adds.
+/// `.a` exists as `{}`, so `.a.b` isn't indexing into a scalar; the real
+/// write would autovivify `.b` (and then `.c`) same as jq, so the RHS must
+/// still evaluate and propagate its error, live-verified against yq
+/// v4.53.3.
+#[test]
+fn test_yq_missing_key_mid_prefix_on_real_container_is_not_a_noop_1232() -> Result<()> {
     let (_out, err, code) =
-        run_yq_stdin_with_stderr(".a.b.c = error(\"boom\")", "a: 5\n", &["-o", "json"])?;
+        run_yq_stdin_with_stderr(".a.b.c = error(\"boom\")", "a: {}\n", &["-o", "json"])?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15146,8 +15146,13 @@ fn test_yq_scalar_target_noop_pre_last_component_1232() -> Result<()> {
 /// live-verified as *already* true for the terminal case #1233 covers
 /// (`0 as $k | .[$k] = error("boom")` on a scalar root still raises `boom`
 /// in succinctly where real yq no-ops silently) -- a real, separate gap,
-/// not something #1232 introduces or is scoped to fix. Filed as its own
-/// follow-up rather than folded in here.
+/// not something #1232 introduces or is scoped to fix. Filed as #1419
+/// rather than folded in here (that issue also covers a more severe
+/// sibling: a *literal tail after* a resolved dynamic key, e.g.
+/// `"a" as $k | .[$k].b = 99`, fails the write itself, not just the
+/// RHS-discard optimization -- `resolve_node`'s own dynamic-path
+/// resolution has no yq scalar-noop awareness at all, unlike the
+/// static-path walkers `get_path_mut`/`update_path` this PR fixes).
 #[test]
 fn test_yq_scalar_target_noop_pre_last_component_dynamic_index_1232() -> Result<()> {
     let (out, err, code) = run_yq_stdin_with_stderr(


### PR DESCRIPTION
## Summary

- `get_path_mut` (`=`'s own parent-navigation walker, delegated to by `set_path`'s `Pipe` arm for every non-terminal path component) had no yq-mode scalar-noop check at all — `.a.b = 99` on scalar `.a` errored instead of no-op'ing like real yq.
- `update_path`'s own separately-maintained `Pipe`-arm `Field`/`Index`/`Iterate` sub-arms had the same gap — the #1181 no-op check was only ever applied to the *terminal* arms a few lines above, not this mid-chain duplicate.
- `yq_assign_is_total_noop`'s prefix check (`navigate_read_only`, added by #1233) collapsed "hit a scalar mid-prefix" and "hit a missing key / out-of-range index" into the same `None`, so the eager-RHS-discard pre-check didn't recognize a pre-last-component scalar hit as a no-op — `.a.b.c = error("boom")` on scalar `.a` still raised `boom` even after the write-level fix, where real yq discards the RHS silently. Widened to a three-way `PrefixNavOutcome` so the pre-check can tell the two apart; the `del()` slice-outcome call site (the only other caller) folds the new `HitScalar` variant back into its existing "not applicable" handling, so its behavior is unchanged.

All shapes live-verified against yq v4.53.3, including the issue's own fully-dynamic repro (`0 as $k1 | 1 as $k2 | .[$k1][$k2] = 99`) and a mid-chain `Iterate` case (`.a[].b`).

One already-pinned test (`test_yq_scalar_target_noop_pre_last_component_is_1232_territory_1233`) had recorded the old broken behavior as a "deliberate non-goal" with a note that real yq "also errors, for the wrong reason" — re-verifying against the pinned binary now shows that was mistaken (real yq cleanly no-ops there too); updated to assert the fixed behavior.

Fixes #1232

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (2704+ tests, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] Patch coverage: 100% (31/31 new lines)
- [x] Live-verified every repro shape against yq v4.53.3