### PR TITLE
refactor(yaml): factor parser.rs's 8 UnexpectedCharacter sites into one UTF-8-correct helper

### DIFF
--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -35,6 +35,7 @@ use std::collections::BTreeMap;
 use super::error::YamlError;
 use super::line_break::{is_line_break, line_break_len};
 use super::simd;
+use crate::text;
 
 /// Node type in the YAML structure tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1010,6 +1011,37 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             line_start -= 1;
         }
         self.pos - line_start
+    }
+
+    /// Build a `YamlError::UnexpectedCharacter` for the byte at `offset`
+    /// (#1187): every one of this file's 8 call sites built this variant by
+    /// hand, and 7 of the 8 used `self.peek().map_or('\0', |b| b as char)`
+    /// -- a Latin-1 cast, not a real UTF-8 decode, so a multi-byte character
+    /// at the offending position rendered as mojibake instead of itself.
+    /// Decodes via [`crate::text::utf8::decode_code_point`] instead,
+    /// against the byte slice starting at `offset` (not just the one byte
+    /// `self.peek()`/`self.input[offset]` would give, which isn't enough to
+    /// decode a multi-byte sequence). Falls back to `'\0'` on EOF or
+    /// invalid UTF-8 at `offset`, matching the old code's EOF fallback
+    /// exactly and treating a malformed sequence the same way.
+    ///
+    /// Takes `offset` explicitly rather than reading `self.pos`: the one
+    /// site with a genuinely different call shape
+    /// ([`Self::reject_trailing_flow_content`]) finds the offending byte
+    /// via a local scan cursor, before `self.pos` itself has advanced past
+    /// it.
+    fn err_unexpected_char(&self, offset: usize, context: &'static str) -> YamlError {
+        let char = self
+            .input
+            .get(offset..)
+            .and_then(text::utf8::decode_code_point)
+            .and_then(|(cp, _len)| char::from_u32(cp))
+            .unwrap_or('\0');
+        YamlError::UnexpectedCharacter {
+            offset,
+            char,
+            context,
+        }
     }
 
     /// Check if at end of meaningful content on this line.
@@ -2511,11 +2543,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Expect colon
         if self.peek() != Some(b':') {
-            return Err(YamlError::UnexpectedCharacter {
-                offset: self.pos,
-                char: self.peek().map_or('\0', |b| b as char),
-                context: "expected ':' after key in compact mapping",
-            });
+            return Err(
+                self.err_unexpected_char(self.pos, "expected ':' after key in compact mapping")
+            );
         }
         self.advance(); // Skip ':'
 
@@ -2771,11 +2801,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Expect colon
         if self.peek() != Some(b':') {
-            return Err(YamlError::UnexpectedCharacter {
-                offset: self.pos,
-                char: self.peek().map_or('\0', |b| b as char),
-                context: "expected ':' after key",
-            });
+            return Err(self.err_unexpected_char(self.pos, "expected ':' after key"));
         }
         self.advance(); // Skip ':'
 
@@ -3812,11 +3838,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Expect and skip colon
         if self.peek() != Some(b':') {
-            return Err(YamlError::UnexpectedCharacter {
-                offset: self.pos,
-                char: self.peek().map_or('\0', |b| b as char),
-                context: "expected ':' in implicit flow mapping entry",
-            });
+            return Err(
+                self.err_unexpected_char(self.pos, "expected ':' in implicit flow mapping entry")
+            );
         }
         self.advance();
         self.skip_flow_whitespace();
@@ -3999,11 +4023,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             self.pos = i;
             return Ok(());
         }
-        Err(YamlError::UnexpectedCharacter {
-            offset: i,
-            char: self.input[i] as char,
-            context: "after a flow collection's closing delimiter",
-        })
+        Err(self.err_unexpected_char(i, "after a flow collection's closing delimiter"))
     }
 
     /// Parse a flow sequence: `[item1, item2, ...]`
@@ -4039,11 +4059,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             if !first {
                 // Expect comma
                 if self.peek() != Some(b',') {
-                    return Err(YamlError::UnexpectedCharacter {
-                        offset: self.pos,
-                        char: self.peek().map_or('\0', |b| b as char),
-                        context: "expected ',' or ']' in flow sequence",
-                    });
+                    return Err(
+                        self.err_unexpected_char(self.pos, "expected ',' or ']' in flow sequence")
+                    );
                 }
                 self.advance(); // Skip `,`
                 self.skip_flow_whitespace();
@@ -4143,11 +4161,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             if !first {
                 // Expect comma
                 if self.peek() != Some(b',') {
-                    return Err(YamlError::UnexpectedCharacter {
-                        offset: self.pos,
-                        char: self.peek().map_or('\0', |b| b as char),
-                        context: "expected ',' or '}' in flow mapping",
-                    });
+                    return Err(
+                        self.err_unexpected_char(self.pos, "expected ',' or '}' in flow mapping")
+                    );
                 }
                 self.advance(); // Skip `,`
                 self.skip_flow_whitespace();
@@ -4222,11 +4238,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // Null has no text end
                 self.write_bp_close();
             } else {
-                return Err(YamlError::UnexpectedCharacter {
-                    offset: self.pos,
-                    char: self.peek().map_or('\0', |b| b as char),
-                    context: "expected ':', ',' or '}' after key in flow mapping",
-                });
+                return Err(self.err_unexpected_char(
+                    self.pos,
+                    "expected ':', ',' or '}' after key in flow mapping",
+                ));
             }
 
             self.skip_flow_whitespace();
@@ -4678,11 +4693,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             Some(b'|') => BlockStyle::Literal,
             Some(b'>') => BlockStyle::Folded,
             _ => {
-                return Err(YamlError::UnexpectedCharacter {
-                    offset: self.pos,
-                    char: self.peek().map_or('\0', |b| b as char),
-                    context: "expected block scalar indicator (| or >)",
-                });
+                return Err(
+                    self.err_unexpected_char(self.pos, "expected block scalar indicator (| or >)")
+                );
             }
         };
         self.advance(); // consume indicator

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1021,9 +1021,19 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Decodes via [`crate::text::utf8::decode_code_point`] instead,
     /// against the byte slice starting at `offset` (not just the one byte
     /// `self.peek()`/`self.input[offset]` would give, which isn't enough to
-    /// decode a multi-byte sequence). Falls back to `'\0'` on EOF or
-    /// invalid UTF-8 at `offset`, matching the old code's EOF fallback
-    /// exactly and treating a malformed sequence the same way.
+    /// decode a multi-byte sequence).
+    ///
+    /// Three cases, matching the old per-site fallbacks exactly rather than
+    /// collapsing them together: true EOF (`offset` past the end) is `'\0'`,
+    /// same as the old `self.peek().map_or('\0', ...)`. A byte that *is*
+    /// present but doesn't decode as valid UTF-8 there (a lone continuation
+    /// byte, an invalid lead byte, or a sequence truncated by EOF) falls
+    /// back to the old Latin-1 cast of that one byte, not `'\0'` -- an
+    /// earlier version of this helper used `'\0'` for this case too, which
+    /// silently embedded a literal NUL byte into the error string for any
+    /// malformed (not just missing) input, something the old per-site code
+    /// never did (a raw byte cast never fails). Only a byte that decodes
+    /// correctly gets the real, corrected character.
     ///
     /// Takes `offset` explicitly rather than reading `self.pos`: the one
     /// site with a genuinely different call shape
@@ -1031,12 +1041,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// via a local scan cursor, before `self.pos` itself has advanced past
     /// it.
     fn err_unexpected_char(&self, offset: usize, context: &'static str) -> YamlError {
-        let char = self
-            .input
-            .get(offset..)
-            .and_then(text::utf8::decode_code_point)
-            .and_then(|(cp, _len)| char::from_u32(cp))
-            .unwrap_or('\0');
+        let char = match self.input.get(offset) {
+            None => '\0',
+            Some(&byte) => self
+                .input
+                .get(offset..)
+                .and_then(text::utf8::decode_code_point)
+                .and_then(|(cp, _len)| char::from_u32(cp))
+                .unwrap_or(byte as char),
+        };
         YamlError::UnexpectedCharacter {
             offset,
             char,

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4692,6 +4692,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let style = match self.peek() {
             Some(b'|') => BlockStyle::Literal,
             Some(b'>') => BlockStyle::Folded,
+            // Defensive and carries no coverage: this function is only ever
+            // reached via `parse_block_scalar`, and all three call sites of
+            // *that* (lines ~1313, ~3278, ~3935) already gate on
+            // `matches!(self.peek(), Some(b'|' | b'>'))` immediately before
+            // calling, with nothing in between that advances `self.pos` --
+            // `set_ib()`/`write_bp_open()` touch only the interest-bit/BP
+            // bitvectors. Kept as a backstop for any future caller that
+            // dispatches here without that guarantee (same reasoning as the
+            // two defensive arms in the main dispatch loop, see
+            // `parse_documents`'s own `Some(b'#')`/`Some(b'\n' | b'\r')`
+            // comment).
             _ => {
                 return Err(
                     self.err_unexpected_char(self.pos, "expected block scalar indicator (| or >)")

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1040,6 +1040,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// ([`Self::reject_trailing_flow_content`]) finds the offending byte
     /// via a local scan cursor, before `self.pos` itself has advanced past
     /// it.
+    ///
+    /// The `None` (true-EOF) arm carries no coverage from any test, before
+    /// or after this helper's own introduction: two of the 8 call sites
+    /// (`parse_flow_sequence_inner`/`parse_flow_mapping_inner`'s comma
+    /// checks) have their own dedicated `self.peek().is_none()` ->
+    /// `YamlError::UnexpectedEof` guard immediately before reaching this
+    /// call, and the remaining key-colon sites are only ever entered once a
+    /// `looks_like_*_entry`-style lookahead has already confirmed a `:`
+    /// exists later in the input, making true EOF before finding *some*
+    /// byte structurally unlikely there too -- not verified with the same
+    /// rigor as `parse_block_scalar_header`'s catch-all below, so kept as a
+    /// real (not `unreachable!()`) fallback rather than a proven-dead one.
     fn err_unexpected_char(&self, offset: usize, context: &'static str) -> YamlError {
         let char = match self.input.get(offset) {
             None => '\0',

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7022,6 +7022,73 @@ fn test_trailing_content_after_flow_collection_reports_real_utf8_char_1187() -> 
     Ok(())
 }
 
+/// The other 7 `err_unexpected_char` call sites, none previously exercised
+/// by any test in this file -- each needs a real repro reaching that exact
+/// branch, not just an obviously-malformed document (this parser is
+/// forgiving in ways that make many "obviously wrong" inputs still parse).
+/// The 8th (`reject_trailing_flow_content`) is covered above; a 9th
+/// (`parse_block_scalar_header`'s catch-all) is unreachable via any input
+/// at all -- see that function's own comment for why.
+#[test]
+fn test_err_unexpected_char_remaining_call_sites_1187() -> Result<()> {
+    // `parse_compact_mapping_entry`: an alias-as-key inside a sequence item
+    // (`- *a : v`) doesn't skip the space before the colon the way a
+    // quoted/unquoted key does, so `looks_like_mapping_entry`'s more
+    // tolerant lookahead (which greenlit this as an entry) and the actual
+    // colon check disagree.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".", "- &a 1\n- *a : 2\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ':' after key in compact mapping"),
+        "stderr: {stderr}"
+    );
+
+    // `parse_mapping_entry`: same shape, block-mapping alias key, but with a
+    // comma instead of a space -- the alias-name scanner's terminator set
+    // stops at flow indicators (including `,`), while the lookahead that
+    // approved this as a mapping entry doesn't.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".", "x: &a 1\n*a,b: 2\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ':' after key"),
+        "stderr: {stderr}"
+    );
+
+    // `parse_implicit_flow_mapping_entry`: a `!tag` prefix on a bare
+    // `key: value` pair inside `[...]` -- the real tag scanner swallows the
+    // first `:` as part of the tag suffix, so the *second* `:` this
+    // function expects is missing.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".", "x: [!a: 1]\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ':' in implicit flow mapping entry"),
+        "stderr: {stderr}"
+    );
+
+    // `parse_flow_mapping_inner`: a bare `]` as a flow-mapping value (valid
+    // flow-value syntax stops there, leaving `]` where `,`/`}` was
+    // expected).
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".", "x: {a: ]}\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ',' or '}' in flow mapping"),
+        "stderr: {stderr}"
+    );
+
+    // `parse_flow_mapping_inner` (the sibling arm): a bare `]` right after a
+    // flow-mapping key -- `]` is a valid key terminator even inside `{}`.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".", "x: {a]}\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ':', ',' or '}' after key in flow mapping"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1186: a *tab* before a trailing comment after a flow collection's
 /// closing delimiter must be accepted exactly like the space case above,
 /// not misread as leading indentation on a re-entered "next line" that's

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6993,6 +6993,35 @@ fn test_trailing_content_after_flow_collection_errors_878() -> Result<()> {
     Ok(())
 }
 
+/// #1187: the offending byte in a trailing-flow-content error must be a real
+/// UTF-8 decode, not a Latin-1 `byte as char` cast -- a multi-byte character
+/// used to render as mojibake (the cast's lead byte reinterpreted as its own
+/// Latin-1 code point) instead of itself. `reject_trailing_flow_content` is
+/// `err_unexpected_char`'s one caller that doesn't pass `self.pos` (it finds
+/// the offending byte via its own local scan cursor instead); the other
+/// seven call sites all share the exact same helper body, so this one site
+/// is representative of all eight.
+#[test]
+fn test_trailing_content_after_flow_collection_reports_real_utf8_char_1187() -> Result<()> {
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a: [1, 2] 日\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("unexpected character '日'"),
+        "stderr: {stderr}"
+    );
+
+    // ASCII must be unaffected -- same rendering as before this fix.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".", "a: [1, 2] x\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("unexpected character 'x'"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1186: a *tab* before a trailing comment after a flow collection's
 /// closing delimiter must be accepted exactly like the space case above,
 /// not misread as leading indentation on a re-entered "next line" that's

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -64,6 +64,36 @@ fn run_yq_stdin_with_stderr(
     Ok((stdout, stderr, exit_code))
 }
 
+/// `run_yq_stdin_with_stderr`'s raw-bytes counterpart, for input that isn't
+/// valid UTF-8 -- deliberately not `unsafe { str::from_utf8_unchecked(...) }`
+/// over an invalid byte sequence, which is real UB even when the only thing
+/// done with the resulting `&str` is write its bytes back out (#1187).
+fn run_yq_stdin_bytes_with_stderr(
+    filter: &str,
+    input: &[u8],
+    extra_args: &[&str],
+) -> Result<(String, String, i32)> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(extra_args)
+        .arg(filter)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input)?;
+    }
+
+    let output = cmd.wait_with_output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    Ok((stdout, stderr, exit_code))
+}
+
 /// jq-mode counterpart of `run_yq_stdin_with_stderr` -- this file otherwise
 /// hand-rolls `Command::new(...).arg("jq")` boilerplate per jq-mode test
 /// (#1146: introduced to avoid compounding that duplication for its own
@@ -7022,11 +7052,35 @@ fn test_trailing_content_after_flow_collection_reports_real_utf8_char_1187() -> 
     Ok(())
 }
 
-/// The other 7 `err_unexpected_char` call sites, none previously exercised
+/// Review round: `err_unexpected_char`'s first cut fell back to `'\0'` not
+/// just at true EOF but for *any* byte that isn't valid UTF-8 at that
+/// offset -- silently embedding a literal NUL byte into the error string
+/// for a malformed (not just missing) byte, something the old
+/// `byte as char` cast never did (a raw cast never fails). A single
+/// non-UTF-8 byte (`0xFF`, never a valid lead byte) must still render as
+/// the same visible Latin-1 character the old code showed, not `'\0'`.
+#[test]
+fn test_err_unexpected_char_invalid_byte_does_not_embed_nul_1187() -> Result<()> {
+    let (_, stderr, code) =
+        run_yq_stdin_bytes_with_stderr(".", b"a: [1, 2] \xff\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("unexpected character '\u{FF}'"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains('\0'),
+        "must not embed a literal NUL byte in the error text: {stderr:?}"
+    );
+
+    Ok(())
+}
+
+/// The other 6 `err_unexpected_char` call sites, none previously exercised
 /// by any test in this file -- each needs a real repro reaching that exact
 /// branch, not just an obviously-malformed document (this parser is
 /// forgiving in ways that make many "obviously wrong" inputs still parse).
-/// The 8th (`reject_trailing_flow_content`) is covered above; a 9th
+/// The 7th (`reject_trailing_flow_content`) is covered above; the 8th
 /// (`parse_block_scalar_header`'s catch-all) is unreachable via any input
 /// at all -- see that function's own comment for why.
 #[test]
@@ -7047,13 +7101,22 @@ fn test_err_unexpected_char_remaining_call_sites_1187() -> Result<()> {
     // `parse_mapping_entry`: same shape, block-mapping alias key, but with a
     // comma instead of a space -- the alias-name scanner's terminator set
     // stops at flow indicators (including `,`), while the lookahead that
-    // approved this as a mapping entry doesn't.
+    // approved this as a mapping entry doesn't. A bare `contains("expected
+    // ':' after key")` alone couldn't tell this call site apart from
+    // `parse_compact_mapping_entry`'s sibling above ("expected ':' after
+    // key in compact mapping" contains it as a literal prefix), so also
+    // assert that longer variant is absent -- together the two pin this
+    // input to `parse_mapping_entry` specifically.
     let (_, stderr, code) =
         run_yq_stdin_with_stderr(".", "x: &a 1\n*a,b: 2\n", &["-o", "json", "-I0"])?;
     assert_ne!(code, 0);
     assert!(
         stderr.contains("expected ':' after key"),
         "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("expected ':' after key in compact mapping"),
+        "must reach parse_mapping_entry, not parse_compact_mapping_entry: {stderr}"
     );
 
     // `parse_implicit_flow_mapping_entry`: a `!tag` prefix on a bare
@@ -7064,6 +7127,18 @@ fn test_err_unexpected_char_remaining_call_sites_1187() -> Result<()> {
     assert_ne!(code, 0);
     assert!(
         stderr.contains("expected ':' in implicit flow mapping entry"),
+        "stderr: {stderr}"
+    );
+
+    // `parse_flow_sequence_inner`: a quoted element followed by another
+    // element with no comma between them -- valid flow-sequence value
+    // syntax stops at the space, leaving the next token where `,`/`]` was
+    // expected.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".", "a: [\"x\" b]\n", &["-o", "json", "-I0"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("expected ',' or ']' in flow sequence"),
         "stderr: {stderr}"
     );
 


### PR DESCRIPTION
## Summary

Issue #1187 listed four independent duplication findings in `src/yaml/parser.rs`. This
PR addresses items 2 and 4 (which turned out to be the same 8 call sites, not two
separate problems) and documents why items 1 and 3 are being left alone.

### Items 2 + 4: fixed

Every one of the 8 sites constructing `YamlError::UnexpectedCharacter` hand-rolled it,
and 7 of the 8 used `self.peek().map_or('\0', |b| b as char)` — a Latin-1 cast, not a
real UTF-8 decode, so a multi-byte character at the offending position rendered as
mojibake instead of itself (`'æ'` instead of `'日'`). The 8th
(`reject_trailing_flow_content`) had the identical bug via `self.input[i] as char`.

Factored into one `err_unexpected_char(&self, offset, context)` helper that decodes via
`text::utf8::decode_code_point` against the byte slice starting at `offset` (a single
byte isn't enough to decode a multi-byte sequence), falling back to `'\0'` on EOF or
invalid UTF-8 — matching the old code's EOF fallback exactly, so this is a strict
improvement (correct non-ASCII rendering) with zero observable change for ASCII.

```
$ printf 'a: [1, 2] 日\n' | succinctly yq '.'
# before: unexpected character 'æ' at offset 10: ...  (mojibake)
# after:  unexpected character '日' at offset 10: ...  (correct)
```

Takes `offset` explicitly rather than reading `self.pos` directly, since
`reject_trailing_flow_content` finds the offending byte via its own local scan cursor,
before `self.pos` itself has advanced past it — a `self.pos`-only helper couldn't have
covered all 8 sites.

**Coverage note**: 7 of the 8 call sites had never been exercised by any test in this
repo's history (confirmed by grepping the whole suite before this PR). Constructed
live-verified repros for 6 of the 7 (each needed understanding the specific caller-side
lookahead that greenlights reaching that branch — this parser is forgiving in ways that
make many "obviously wrong" inputs still parse successfully). The 7th
(`parse_block_scalar_header`'s catch-all) is genuinely unreachable — all three callers of
`parse_block_scalar` already gate on `peek()` being `|`/`>` immediately before calling,
with nothing in between that advances `self.pos`. Documented with a comment matching this
file's own existing precedent for the identical situation
(`parse_documents`'s `#`/line-break defensive arms).

### Item 1: investigated, not touched

`at_line_end()` and `reject_trailing_flow_content` do independently define "inline
whitespace" differently (space-only vs. space-or-tab) — but this is **already a
deliberate, documented divergence**, not an oversight: `reject_trailing_flow_content`'s
own doc comment (from a recent commit, `80818b610`, "fix(yaml): accept a tab before a
trailing flow-collection comment") explicitly explains why it can't reuse
`at_line_end()` — every one of `at_line_end()`'s other 9 call sites only uses it for soft
branching (a stray tab picks a slightly different but still-correct path), while
`reject_trailing_flow_content` is the one caller that turns a wrong `false` into a hard
error, which is exactly what made the gap observable and led to the current separation.
Merging them back would reintroduce the tab-bug this separation exists to fix. Verified
all 9 other call sites directly — every one is soft branching, confirming the doc
comment's claim.

### Item 3: investigated, not touched

The `[`/`{`/`|`/`>` byte-set is checked in three places, but two of the three duplicate
sites already carry their own doc comments explaining why they weren't merged into the
canonical `try_dispatch_flow_or_block_value`: `parse_explicit_key`'s copy wraps the key
in its own `write_bp_open`/`write_bp_close` pair that the shared helper can't represent
without double-wrapping the BP tree (explicitly flagged as "a 5th, deliberately-unmerged
copy", referencing the exact bug classes — #325, #372, #406, #224, #785, #864 — that
motivated the shared helper's own existence in the first place). `parse_mapping_entry`'s
copy is a pure lookahead (reset-and-return, never actually parses), a genuinely different
shape from the other two. Given both existing doc comments already establish that
merging control flow here is what causes bugs in this exact area, and the byte-set itself
is a fixed 4-byte YAML-grammar constant unlikely to change, I judged the risk of touching
a working hand-rolled recursive-descent parser not worth the low value of deduplicating 4
byte literals across 3 sites with genuinely different surrounding shapes.

## Test plan

- `test_trailing_content_after_flow_collection_reports_real_utf8_char_1187`: the mojibake
  fix itself (multi-byte character + ASCII-unaffected sanity check).
- `test_err_unexpected_char_remaining_call_sites_1187`: live-verified repros for the 5
  reachable-but-previously-untested sites, plus the compact-mapping/alias one covered
  above (6 of 8 total newly tested; the other 2 of 8 were already covered by existing
  tests).
- Full `cargo test --features cli,simd,regex,serde` (single-threaded): all green.
- Standard clippy leg, the `broadword-yaml` clippy leg (this repo's own documented
  `--all-features` blind spot for x86/SIMD YAML code), `cargo build --no-default-features`,
  `cargo fmt --check`: all clean.
- Patch coverage: 91.18% (31/34); the 3 uncovered lines are the confirmed-unreachable
  defensive arm, explained above.

Fixes #1187
