### PR TITLE
fix(jq): non-terminal Iterate in a plain = assignment path fans out

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -295,11 +295,28 @@ narrower, already-fixed-write case where only the RHS-discard *optimization* is 
 (`0 as $k | .[$k] = error("boom")` on a scalar root still raises `boom` where real yq no-ops
 silently, even though the write itself — `.[$k] = 99` — already correctly no-ops).
 
-Separately, `get_path_mut` (the walker #1232 widened) has no `Expr::Iterate` arm at all, so
-a mid-chain `.[]` under plain `=` (`.a[].b = 99`) always errors "invalid path component" —
-in both jq and yq mode, and predating #1232 entirely (`|=`/`+=`/`-=`/`*=`/`del()` are
-unaffected). Filed as
-[#1418](https://github.com/rust-works/succinctly/issues/1418).
+**Fixed by [#1298](https://github.com/rust-works/succinctly/issues/1298):** `get_path_mut`
+(the walker #1232 widened) used to have no `Expr::Iterate` arm at all, so a mid-chain `.[]`
+under plain `=` (`.a[].b = 99`) always errored "invalid path component" — in both jq and yq
+mode, and predating #1232 entirely (`|=`/`+=`/`-=`/`*=`/`del()` were unaffected, their own
+recursive-descent walkers already supported fan-out). #1298 added `split_at_iterate`/
+`set_path_through_iterate` so `=` fans out per element like every other operator, and gave
+`navigate_read_only`'s prefix walk (`yq_assign_is_total_noop`'s own eager-RHS-discard
+pre-check, #1232's `PrefixNavOutcome`) an `Expr::Iterate` arm too — but only for the
+narrowest case, `.a` itself being a genuine scalar (`.a[].b = error("boom")` on `a: 5` now
+no-ops silently, RHS never evaluated, matching real yq).
+
+**Still open ([#1432](https://github.com/rust-works/succinctly/issues/1432)):** real yq's
+actual RHS-discard rule for a mid-chain `Iterate` is broader — a real container whose own
+elements *all* individually no-op also discards the RHS, and so does an empty or
+null-autovivified container (vacuously). The underlying *write* already gets all of these
+right (verified against real yq); only the RHS-discard optimization is narrower than real
+yq's own rule:
+
+```bash
+$ printf 'a: [1, 2]\n' | yq            -o=json '.a[].b = error("boom")'   # {"a":[1,2]}, no-op
+$ printf 'a: [1, 2]\n' | succinctly yq -o=json '.a[].b = error("boom")'   # Error: boom
+```
 
 ### Other categories
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12109,6 +12109,18 @@ fn set_path(
             // For chained paths like .a.b.c, navigate to parent and set at last element
             if exprs.len() == 1 {
                 set_path(root, &exprs[0], new_value, scalar_noop, container_noop)
+            } else if let Some(split) = split_at_iterate(exprs) {
+                match get_path_mut(root, &split.before, scalar_noop)? {
+                    None => Ok(()),
+                    Some(target) => set_path_through_iterate(
+                        target,
+                        split.optional,
+                        &split.tail,
+                        new_value,
+                        scalar_noop,
+                        container_noop,
+                    ),
+                }
             } else if let Some(split) = split_at_slice(exprs) {
                 match get_path_mut(root, &split.before, scalar_noop)? {
                     None => Ok(()),
@@ -12573,6 +12585,129 @@ fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
             Expr::Pipe(rest)
         },
     })
+}
+
+/// Where a chained path crosses a *non-terminal* `Iterate` (`.[]`), as
+/// [`split_at_iterate`] found it.
+struct IterateSplit {
+    /// The components to navigate before reaching the `Iterate`.
+    before: Vec<Expr>,
+    /// Whether the `Iterate` itself carried a `?` (`.a[]?[0] = 9`).
+    optional: bool,
+    /// Everything left to apply to *each* fanned-out element, as one
+    /// expression.
+    tail: Expr,
+}
+
+/// Split a chained path at its first *non-terminal* `Iterate`, if it has
+/// one.
+///
+/// `.[]` names every element/value in a container, not one slot, so
+/// `get_path_mut` cannot navigate through it the way it does a `Field`/
+/// `Index` — `.a[][0] = 9` has to fan out and apply `[0] = 9` independently
+/// to each of `.a`'s own elements, not find one shared parent slot to hand
+/// back (#1298). A *terminal* `Iterate` (`.a[] = 9`, nothing left after it)
+/// needs none of this: it already reaches `set_path`'s own top-level
+/// `Iterate` arm correctly via the ordinary `parent_path`/`last_path`
+/// split, so this function deliberately returns `None` for that shape —
+/// `at == flat.len() - 1` below is exactly that check.
+///
+/// Checked *before* [`split_at_slice`] in `set_path`'s `Pipe` arm: an
+/// `Iterate` fans out into independent per-element writes, each of which
+/// then re-resolves whatever slice/index/field remains in its own
+/// recursive `set_path` call — including a slice that comes *after* the
+/// `Iterate` in the chain (`.a[][0:2] = v`). A slice that comes *before*
+/// the `Iterate` is the opposite ordering, and is deliberately left to
+/// `split_at_slice` instead: this function bails (`None`) whenever a slice
+/// exists earlier in the flattened chain than the `Iterate` it would
+/// otherwise split on, so `split_at_slice` runs first, hands the residual
+/// `Iterate` to `through_slice`'s own closure as part of its `tail`, and
+/// this function gets a fresh, slice-free look at it on the next
+/// recursive `set_path` call. Without that check, this function's own
+/// `before` could itself contain the earlier slice — a component
+/// `get_path_mut` (which this function's caller navigates `before` with)
+/// cannot walk through any more than it can walk through an `Iterate`.
+///
+/// Flattens via [`push_path_components`] first, same as `split_at_slice`,
+/// so a `.[]` nested inside a parenthesized sub-path (`(.a[])[0] = 9`) is
+/// still found.
+fn split_at_iterate(exprs: &[Expr]) -> Option<IterateSplit> {
+    // Cheap common-case guard, mirroring `split_at_slice`'s own: skip the
+    // flatten entirely when nothing here could possibly hide an `Iterate`.
+    if exprs.iter().all(|e| {
+        let component = unwrap_path_component(e).0;
+        !matches!(component, Expr::Iterate | Expr::Pipe(_))
+    }) {
+        return None;
+    }
+    let mut flat = Vec::with_capacity(exprs.len());
+    for e in exprs {
+        push_path_components(&mut flat, e);
+    }
+    let at = flat
+        .iter()
+        .position(|e| matches!(unwrap_path_component(e).0, Expr::Iterate))?;
+    if at == flat.len() - 1 {
+        // Terminal position -- not this function's case.
+        return None;
+    }
+    if flat[..at]
+        .iter()
+        .any(|e| unwrap_path_component(e).0.is_slice())
+    {
+        // An earlier slice takes precedence -- see the doc comment above.
+        return None;
+    }
+    let (_, optional) = unwrap_path_component(&flat[at]);
+    let rest = flat.split_off(at + 1);
+    flat.truncate(at);
+    Some(IterateSplit {
+        before: flat,
+        optional,
+        // `rest` can never be empty here: the terminal-position check above
+        // already excluded `at == flat.len() - 1`, so there is always at
+        // least one component left after the `Iterate`.
+        tail: Expr::Pipe(rest),
+    })
+}
+
+/// Fan a `=` write out over every element/value of `target` — the
+/// non-terminal `Iterate` case [`split_at_iterate`] found (#1298).
+/// `get_path_mut` can only ever return one mutable slot, so a mid-chain
+/// `.[]` can't reuse its loop the way `Field`/`Index` do; each element
+/// instead gets its own independent recursive `set_path` call against
+/// `split.tail`. Mirrors `set_path`'s own top-level `Expr::Iterate` arm
+/// (the terminal-position case, #1181) for the yq-only null-to-`[]`
+/// autovivify and the scalar-target no-op — deliberately the same rules, a
+/// mid-chain `.[]` isn't semantically different from a terminal one, just
+/// followed by more path.
+fn set_path_through_iterate(
+    target: &mut OwnedValue,
+    optional: bool,
+    tail: &Expr,
+    new_value: OwnedValue,
+    scalar_noop: bool,
+    container_noop: bool,
+) -> Result<(), EvalError> {
+    if scalar_noop {
+        autovivify_array(target);
+    }
+    match target {
+        OwnedValue::Array(arr) => {
+            for elem in arr.iter_mut() {
+                set_path(elem, tail, new_value.clone(), scalar_noop, container_noop)?;
+            }
+            Ok(())
+        }
+        OwnedValue::Object(map) => {
+            for (_, elem) in map.iter_mut() {
+                set_path(elem, tail, new_value.clone(), scalar_noop, container_noop)?;
+            }
+            Ok(())
+        }
+        _ if optional || (scalar_noop && is_yq_field_index_noop_scalar(target)) => Ok(()),
+        _ => Err(EvalError::cannot_iterate(target)),
+    }
 }
 
 /// Get a mutable reference to the parent named by `path_parts`, or `None` if

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11211,6 +11211,37 @@ fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> PrefixNavOutc
                 _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
                 _ => return PrefixNavOutcome::Absent,
             },
+            // #1298: `Iterate` fans out into every element/value of a real
+            // container -- unlike `Field`/`Index`, there is no single next
+            // `current` to continue this loop with, so a real container
+            // here can only ever mean "give up and defer" (`Absent`), same
+            // as this function already does for a component it can't
+            // interpret at all. A genuine scalar, though, is exactly
+            // `set_path_through_iterate`'s own no-op fallback (`.a[].b = v`
+            // on scalar `.a` no-ops the whole write, transitively, whatever
+            // the rest of the path was going to do) -- so that case still
+            // reports `HitScalar`, closing the gap where `yq_assign_is_
+            // total_noop` used to fall through this arm's old absence to
+            // the generic catch-all below and eagerly evaluate an RHS the
+            // real write was always going to discard.
+            //
+            // Deliberately incomplete, not just conservative: live-verified
+            // that real yq's actual rule is broader than "the iterated
+            // value is itself a scalar" -- `a: [1, 2]` (a real container
+            // whose own elements are *all* scalars `.b` would no-op into)
+            // also discards the RHS, and so does an empty or
+            // null-autovivified container (vacuously -- zero elements to
+            // check). Reporting `HitScalar` for those too would need
+            // recursively checking every element against the *rest* of the
+            // path, not just this one step -- effectively a read-only dry
+            // run of `set_path_through_iterate` itself. Left as `Absent`
+            // (correct, just not optimal) rather than attempted here; see
+            // #1432.
+            Expr::Iterate => match current {
+                OwnedValue::Array(_) | OwnedValue::Object(_) => return PrefixNavOutcome::Absent,
+                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
+                _ => return PrefixNavOutcome::Absent,
+            },
             _ => return PrefixNavOutcome::Absent,
         };
     }
@@ -12511,14 +12542,26 @@ struct SliceSplit {
     tail: Expr,
 }
 
+/// Flatten `exprs` via [`push_path_components`] — shared by [`split_at_slice`]
+/// and [`split_at_iterate`], which both need the identical flatten before
+/// their own scan (the first for the first `Slice`, the second for the
+/// first non-terminal `Iterate`).
+fn flatten_path_components(exprs: &[Expr]) -> Vec<Expr> {
+    let mut flat = Vec::with_capacity(exprs.len());
+    for e in exprs {
+        push_path_components(&mut flat, e);
+    }
+    flat
+}
+
 /// Split a chained path at its first slice, if it has one.
 ///
 /// A slice names a *range*, not a slot, so `get_path_mut` cannot navigate
 /// through one — `.a[1:2][0] = 9` would fail on the middle component — and the
 /// walker has to hand off to [`through_slice`] there instead.
 ///
-/// Flattens via [`push_path_components`] before scanning, so a slice nested
-/// inside a parenthesized sub-path that is itself only one of several
+/// Flattens via [`flatten_path_components`] before scanning, so a slice
+/// nested inside a parenthesized sub-path that is itself only one of several
 /// top-level components — `(.a[0:1])[0] = 9`, where `(.a[0:1])` arrives as a
 /// single `Expr::Pipe([Field("a"), Slice{..}])` slot — is still found (#1292).
 /// A single-element Pipe never reaches here: `set_path`'s own `Paren`/`Pipe`
@@ -12557,10 +12600,7 @@ fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
     }) {
         return None;
     }
-    let mut flat = Vec::with_capacity(exprs.len());
-    for e in exprs {
-        push_path_components(&mut flat, e);
-    }
+    let mut flat = flatten_path_components(exprs);
     let at = flat
         .iter()
         .position(|e| unwrap_path_component(e).0.is_slice())?;
@@ -12628,7 +12668,7 @@ struct IterateSplit {
 /// `get_path_mut` (which this function's caller navigates `before` with)
 /// cannot walk through any more than it can walk through an `Iterate`.
 ///
-/// Flattens via [`push_path_components`] first, same as `split_at_slice`,
+/// Flattens via [`flatten_path_components`] first, same as `split_at_slice`,
 /// so a `.[]` nested inside a parenthesized sub-path (`(.a[])[0] = 9`) is
 /// still found.
 fn split_at_iterate(exprs: &[Expr]) -> Option<IterateSplit> {
@@ -12640,10 +12680,7 @@ fn split_at_iterate(exprs: &[Expr]) -> Option<IterateSplit> {
     }) {
         return None;
     }
-    let mut flat = Vec::with_capacity(exprs.len());
-    for e in exprs {
-        push_path_components(&mut flat, e);
-    }
+    let mut flat = flatten_path_components(exprs);
     let at = flat
         .iter()
         .position(|e| matches!(unwrap_path_component(e).0, Expr::Iterate))?;
@@ -12661,12 +12698,17 @@ fn split_at_iterate(exprs: &[Expr]) -> Option<IterateSplit> {
     let (_, optional) = unwrap_path_component(&flat[at]);
     let rest = flat.split_off(at + 1);
     flat.truncate(at);
+    // `rest` can never be empty here: the terminal-position check above
+    // already excluded `at == flat.len() - 1`, so there is always at least
+    // one component left after the `Iterate` -- self-checking rather than
+    // relying on a reader trusting this comment, since `SliceSplit`'s own
+    // `tail` (two structs above) visibly branches on an empty `rest`
+    // instead and it would be an easy, silently-wrong "fix" to copy that
+    // branch here by analogy.
+    debug_assert!(!rest.is_empty());
     Some(IterateSplit {
         before: flat,
         optional,
-        // `rest` can never be empty here: the terminal-position check above
-        // already excluded `at == flat.len() - 1`, so there is always at
-        // least one component left after the `Iterate`.
         tail: Expr::Pipe(rest),
     })
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15843,3 +15843,108 @@ fn test_long_pipe_and_comma_chains_evaluate_without_overflowing() -> Result<()> 
 
     Ok(())
 }
+
+/// #1298: a non-terminal `Iterate` (`.[]` with more path after it) in a
+/// plain `=` assignment target fans out and writes into every element,
+/// matching jq -- previously `invalid path component`, since `get_path_mut`
+/// (the walker `=`'s `Pipe` arm delegates non-terminal navigation to) can
+/// only ever return one mutable slot, and had no way to represent "apply
+/// the rest of the path independently to each of N elements". `|=`/`del()`
+/// already handled this correctly (their own recursive-descent walkers
+/// naturally support fan-out); this is `=`/`set_path`'s own gap, split off
+/// from #1292 (which fixed the sibling `Slice` case). Every shape
+/// live-verified against pinned jq 1.7.1.
+#[test]
+fn test_jq_nonterminal_iterate_in_assign_path_fans_out_1298() -> Result<()> {
+    // The issue's own repro: a parenthesized `.[]` ahead of an index.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(.a[])[0] = 9"], Some(r#"{"a":[[1,2],[3,4]]}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":[[9,2],[9,4]]}\n");
+
+    // No parens needed -- the gap is `get_path_mut`'s, not paren-specific.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a[].b = 99"], Some(r#"{"a":[{"b":1},{"b":2}]}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":[{\"b\":99},{\"b\":99}]}\n");
+
+    // Fans out over object values too, not just array elements.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a[].b = 9"],
+        Some(r#"{"a":{"x":{"b":1},"y":{"b":2}}}"#),
+    )?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":{\"x\":{\"b\":9},\"y\":{\"b\":9}}}\n");
+
+    // `.[]?` on the Iterate itself still suppresses a non-iterable target,
+    // same as the terminal-position `.a[]? = v` already does.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a[]?.b = 9"], Some(r#"{"a":5}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":5}\n");
+
+    // Without `?`, the same non-iterable target still errors -- this fix
+    // must not accidentally suppress that.
+    let (_stdout, stderr, code) = run_jq_full(&["-c", ".a[].b = 9"], Some(r#"{"a":5}"#))?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot iterate"), "stderr={stderr}");
+
+    Ok(())
+}
+
+/// #1298: an `Iterate` interleaved with a `Slice` on either side of it must
+/// resolve in the order jq itself does -- a `Slice` before the `Iterate`
+/// slices first and fans the `Iterate` out over *that* sub-range only; a
+/// `Slice` after the `Iterate` re-resolves independently inside each
+/// fanned-out element. `split_at_iterate` deliberately defers to
+/// `split_at_slice` when a slice sits earlier in the chain (its own doc
+/// comment explains why): without that ordering check, `.a[0:2][][0] = 9`
+/// would have handed `get_path_mut` a `before` list that still contained
+/// the earlier slice, which it cannot navigate through either.
+#[test]
+fn test_jq_iterate_slice_ordering_in_assign_path_1298() -> Result<()> {
+    // Slice before Iterate: slice first, fan out over the sliced range.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a[0:2][][0] = 9"],
+        Some(r#"{"a":[[1,2],[3,4],[5,6]]}"#),
+    )?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":[[9,2],[9,4],[5,6]]}\n");
+
+    // Iterate before slice: fan out first, each element resolves its own
+    // slice independently.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a[][0:2] = [9,9]"],
+        Some(r#"{"a":[[1,2,3],[4,5,6]]}"#),
+    )?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":[[9,9,3],[9,9,6]]}\n");
+
+    Ok(())
+}
+
+/// #1298: an `Iterate` that genuinely *is* the last path component must
+/// still reach `set_path`'s own top-level `Iterate` arm (#1181's original,
+/// unaffected implementation) rather than this fix's new mid-chain
+/// fan-out — `split_at_iterate` returns `None` for that shape precisely so
+/// this stays a regression guard, not new coverage.
+#[test]
+fn test_jq_terminal_iterate_in_assign_path_unaffected_by_1298() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a[] = 9"], Some(r#"{"a":[1,2]}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "{\"a\":[9,9]}\n");
+    Ok(())
+}
+
+/// #1298: a `?` earlier in the chain than the non-terminal `Iterate` — not
+/// on the `Iterate` itself — suppresses the whole write when *that*
+/// component fails to navigate, exercising `get_path_mut`'s `Ok(None)`
+/// return from `split.before`'s own walk (`set_path`'s `Ok(())` fallback
+/// for it, distinct from `set_path_through_iterate`'s own fan-out logic,
+/// which never runs at all here).
+#[test]
+fn test_jq_optional_component_before_iterate_suppresses_whole_write_1298() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a?.b[].c = 9"], Some("5"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "5\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18689,3 +18689,62 @@ fn test_yq_nonterminal_iterate_in_assign_path_fans_out_1298() -> Result<()> {
 
     Ok(())
 }
+
+/// #1298 (code review): the write-level no-op above isn't the whole story
+/// -- `yq_assign_is_total_noop`'s own pre-check (`navigate_read_only`,
+/// #1232's `PrefixNavOutcome`) had no `Expr::Iterate` arm at all, so a
+/// mid-chain `.[]` never reached the eager-RHS-discard optimization
+/// `.a.b.c = error(...)`-shaped paths already get: the write correctly
+/// no-op'd, but the RHS still evaluated for real and any error it raised
+/// still surfaced. `.a[].b = error("boom")` on `a: 5` now no-ops silently
+/// (RHS never runs), matching real yq exactly (live-verified against
+/// v4.53.3).
+///
+/// This only closes the narrowest case -- `current` (`.a` itself) being a
+/// genuine scalar. Real yq's actual rule turned out broader once
+/// live-probed further: `a: [1, 2]` (a real *container*, but every one of
+/// its own elements is itself a scalar `.b` would no-op into) *also*
+/// discards the RHS in real yq, and so does an empty/null-autovivified
+/// container (vacuously -- zero elements to check). Neither of those is
+/// implemented here; `navigate_read_only`'s new `Iterate` arm deliberately
+/// reports `Absent` (defer to normal evaluation) for *any* real
+/// `Array`/`Object`, so those broader cases still eagerly evaluate the
+/// RHS where real yq wouldn't -- filed as #1432 rather than expanded here.
+/// The second case below (`a: [1, {}]`, a genuinely *mixed* target where
+/// one element really does write) is the regression guard for what this
+/// fix must *not* accidentally suppress.
+#[test]
+fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: 5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": 5\n}");
+
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        ".a[].b = error(\"boom\")",
+        "a:\n  - 1\n  - {}\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    Ok(())
+}
+
+/// #1298 (code review, #1432): a `Null` target for the `Iterate` -- neither
+/// a real container nor a genuine scalar -- falls to `navigate_read_only`'s
+/// `Iterate` arm's final `_ => Absent` catch-all, so the RHS still
+/// evaluates here even though real yq's own null-autovivify-to-`[]`
+/// behavior means the fan-out ends up empty and real yq discards the RHS
+/// too (`a: null` becomes `a: []` there, with the RHS never running --
+/// live-verified against yq v4.53.3). This is the exact gap #1432 tracks;
+/// pinned here as a known-divergent case, not a regression to fix in this
+/// PR.
+#[test]
+fn test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: null\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18662,3 +18662,30 @@ fn test_yq_reduce_foreach_accept_full_pattern_1201() -> Result<()> {
     assert_eq!(output.lines().collect::<Vec<_>>(), ["3", "10"]);
     Ok(())
 }
+
+/// #1298: yq-mode coverage for the same non-terminal `Iterate` fan-out
+/// fixed in jq mode (`tests/jq_cli_tests.rs`'s
+/// `test_jq_nonterminal_iterate_in_assign_path_fans_out_1298`) --
+/// `get_path_mut` (the shared, non-generic walker both modes' `=` routes
+/// through) had no mode-specific behavior in its old `invalid path
+/// component` failure, so this confirms the fix reaches yq mode too,
+/// including yq's own scalar-target no-op (#1181) for the non-iterable
+/// case, live-verified against yq v4.53.3.
+#[test]
+fn test_yq_nonterminal_iterate_in_assign_path_fans_out_1298() -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(
+        ".a[].b = 99",
+        "a:\n  - b: 1\n  - b: 2\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#"{"a":[{"b":99},{"b":99}]}"#);
+
+    // yq's own scalar-target no-op applies here too, matching the
+    // terminal-position case #1181/#1232 already cover.
+    let (output, exit_code) = run_yq_stdin(".a[].b = 9", "a: 5\n", &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "a: 5");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`get_path_mut` (`=`'s own parent-navigation walker, delegated to by `set_path`'s `Pipe` arm for every non-terminal path component) can only ever return one mutable slot. A non-terminal `Iterate` (`.[]` with more path after it, e.g. `(.a[])[0] = 9`) has no single parent to hand back — it fans out over every element/value in a container — so it fell through to the generic `invalid path component` catch-all instead of performing jq's per-element write. `|=`/`del()` already handle this correctly (their own recursive-descent walkers naturally support fan-out); only `=`/`set_path` had the gap.

Split off from #1292 (which fixed the sibling `Slice` case with a mechanical flatten-then-hand-off fix). `Iterate` doesn't have an equivalent single hand-off point, so this needed a structurally different approach:

- `split_at_iterate` (mirroring the existing `split_at_slice`) flattens the chain and finds the first *non-terminal* `Iterate` — a terminal one (`.a[] = 9`, nothing after it) already reaches `set_path`'s own top-level `Iterate` arm correctly and is left alone.
- `set_path_through_iterate` fans the write out over the found target's elements/values, applying the remaining path (`split.tail`) independently to each via a recursive `set_path` call — mirroring `set_path`'s own terminal `Iterate` arm for the yq-only null-to-`[]` autovivify and the yq scalar-target no-op (#1181).
- Checked *before* `split_at_slice` in `set_path`'s `Pipe` arm, but deliberately defers back to it when an earlier slice precedes the found `Iterate` (`split_at_iterate` bails to `None` in that case) — otherwise its own `before` list could itself contain the earlier slice, which `get_path_mut` can't navigate through either. This composes correctly via ordinary recursion for both orderings (`.a[0:2][][0] = 9` and `.a[][0:2] = v`), verified live.

All shapes live-verified against pinned jq 1.7.1 and yq v4.53.3, including `?`-transparency on the `Iterate` itself, an earlier optional component suppressing the whole write, object-value fan-out (not just arrays), and both interleaving orders with a slice.

Fixes #1298 (closes duplicate #1418, filed independently before spotting this issue already existed)

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (2704+ tests, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] Patch coverage: 100% (67/67 new lines)
- [x] Live-verified every repro shape against jq 1.7.1 and yq v4.53.3