### PR TITLE
fix(jq): dedupe pattern bindings per real jq's array/object asymmetry (#1366)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27184,7 +27184,17 @@ fn extract_pattern_bindings(
                 let sub_bindings = extract_pattern_bindings(&entry.pattern, &field_value)?;
                 bindings.extend(sub_bindings);
             }
-            Ok(bindings)
+            // #1366: an object pattern binding the same variable name from
+            // more than one field (`{x:$a,y:$a}`) keeps the *first* field's
+            // value in real jq, regardless of the object's own key order --
+            // confirmed live (jq 1.7.1): `{"x":1,"y":2} | . as {y:$a,x:$a} |
+            // $a` is `2` (y's value, since y is listed first in the
+            // pattern) on both `{"x":1,"y":2}` and the differently-ordered
+            // `{"y":2,"x":1}`, so this is the *pattern's* field order, not
+            // the value's. Opposite of the Array arm below -- see
+            // `dedup_keep_first_binding`'s doc comment for why the two
+            // container kinds disagree.
+            Ok(dedup_keep_first_binding(bindings))
         }
         Pattern::Array(patterns) => {
             // Same `null`-absorbs-further-access tolerance as the Object arm
@@ -27211,9 +27221,63 @@ fn extract_pattern_bindings(
                 let sub_bindings = extract_pattern_bindings(pat, &elem_value)?;
                 bindings.extend(sub_bindings);
             }
-            Ok(bindings)
+            // #1366: an array pattern binding the same variable name at more
+            // than one position (`[$a,$a]`) keeps the *last* position's
+            // value in real jq -- confirmed live: `[1,2] | . as [$a,$a] |
+            // $a` is `2`. Opposite of the Object arm above; see
+            // `dedup_keep_last_binding`'s doc comment for why.
+            Ok(dedup_keep_last_binding(bindings))
         }
     }
+}
+
+/// Drop every binding after the first for each repeated variable name,
+/// preserving first-seen order -- the rule real jq's object-pattern
+/// destructuring uses for a name bound by more than one field of the
+/// *same* object pattern (#1366). Confirmed live (jq 1.7.1) this tracks the
+/// *pattern's* field order, not the underlying object's own key order:
+/// `{"x":1,"y":2} | . as {y:$a,x:$a} | $a` is `2` (y's value, y being
+/// listed first in the pattern) on both `{"x":1,"y":2}` and the
+/// differently-ordered `{"y":2,"x":1}` value. Also confirmed via a
+/// computed-key probe (`{("x"|debug):$a,("y"|debug):$a}`) that both
+/// fields' key expressions still evaluate in textual order -- only the
+/// *binding* silently keeps the earlier one, later same-name fields are
+/// not skipped as dead code, their bind is just a no-op.
+///
+/// This is the opposite of [`dedup_keep_last_binding`], which applies to
+/// array-position duplicates instead -- real jq's `. as [$a,$a] | $a`
+/// keeps the *last* position, not the first. Both were verified
+/// independently; nothing about `extract_pattern_bindings`'s own recursive
+/// structure predicts one direction from the other, so each is pinned by
+/// its own oracle-verified doc comment rather than inferred.
+fn dedup_keep_first_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, OwnedValue)> {
+    let mut seen = BTreeSet::new();
+    bindings
+        .into_iter()
+        .filter(|(name, _)| seen.insert(name.clone()))
+        .collect()
+}
+
+/// Drop every binding *before* the last for each repeated variable name,
+/// preserving last-seen relative order -- the rule real jq's array-pattern
+/// destructuring uses for a name bound at more than one position of the
+/// *same* array pattern (#1366). Confirmed live (jq 1.7.1): `[1,2] | . as
+/// [$a,$a] | $a` is `2`; `[1,2,3] | . as [$a,$b,$a] | $a` is `3`.
+///
+/// See [`dedup_keep_first_binding`]'s doc comment for the object-pattern
+/// counterpart, which keeps the *first* occurrence instead -- the two
+/// container kinds are independently verified, not derived from one
+/// shared mechanism.
+fn dedup_keep_last_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, OwnedValue)> {
+    let mut seen = BTreeSet::new();
+    bindings
+        .into_iter()
+        .rev()
+        .filter(|(name, _)| seen.insert(name.clone()))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
 }
 
 /// Evaluate function definition: `def name(params): body; then`.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17493,7 +17493,10 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // for the whole input stream, same as `eval_reduce`.
     let bindings_per_element: Vec<Result<Vec<(String, OwnedValue)>, EvalError>> = input_values
         .iter()
-        .map(|v| extract_pattern_bindings(pattern, v))
+        // `false`: reduce/foreach's own pattern never supports `?//` (#1201
+        // has no analogue for it), so this is always the ordinary,
+        // non-alternation dedup rule.
+        .map(|v| extract_pattern_bindings(pattern, v, false))
         .collect();
     let substituted_updates: Vec<Result<Expr, EvalError>> = bindings_per_element
         .iter()
@@ -26998,11 +27001,19 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> Result<(Vec<OwnedValue>, Option<Control>), EvalError> {
     let last_idx = patterns.len() - 1;
     let mut carried: Vec<OwnedValue> = Vec::new();
+    // #1366 code review: a genuine `?//`-chain (2+ patterns) inverts real
+    // jq's duplicate-binding dedup rule relative to a bare, non-`?//`
+    // pattern -- `patterns.len() > 1` is the actual test, not "did this call
+    // come through `try_pattern_alternatives`", since `eval_as_pattern`
+    // routes a bare pattern through here too as a one-element list. See
+    // `extract_pattern_bindings`'s own doc comment for the live-verified
+    // evidence.
+    let invert_dedup = patterns.len() > 1;
 
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_pattern_bindings(pattern, bound_val) {
+        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
             Ok(b) => b,
             Err(e) => {
                 if is_last {
@@ -27134,7 +27145,9 @@ fn substitute_pattern(
     pattern: &Pattern,
     input_val: &OwnedValue,
 ) -> Result<Expr, EvalError> {
-    let bindings = extract_pattern_bindings(pattern, input_val)?;
+    // `false`: this pattern never supports `?//` (its own caller is
+    // `eval_foreach`, per this function's own doc comment above).
+    let bindings = extract_pattern_bindings(pattern, input_val, false)?;
     Ok(substitute_bindings(expr, &bindings))
 }
 
@@ -27150,9 +27163,28 @@ fn substitute_bindings(expr: &Expr, bindings: &[(String, OwnedValue)]) -> Expr {
 }
 
 /// Extract variable bindings from a pattern matching an OwnedValue.
+/// `invert` is `false` for an ordinary, single pattern (`. as PATTERN`,
+/// `reduce`/`foreach`'s own pattern -- neither supports `?//` at all) and
+/// `true` when called for one alternative of a genuine `?// `-chain (#1366
+/// code review: `patterns.len() > 1` in `try_pattern_alternatives`, *not*
+/// "which function called this" -- `eval_as_pattern` degrades a bare,
+/// non-`?//` pattern to a one-element alternatives list and still reaches
+/// `try_pattern_alternatives`, so the caller alone can't distinguish the
+/// two cases). Real jq's own duplicate-binding rule flips depending on
+/// this, for *both* container kinds and at *every* nesting depth --
+/// confirmed live (jq 1.7.1): `[1,2] | . as [$a,$a] | $a` is `2` (last
+/// wins) but `[1,2] | . as [$a,$a] ?// [$a,$a] | $a` is `1` (first wins,
+/// same pattern, only a trivial self-alternative added); symmetrically
+/// `{"x":1,"y":2} | . as {x:$a,y:$a} | $a` is `1` (first wins) but
+/// `... ?// $z | $a` is `2` (last wins). Also confirmed at a nested
+/// depth -- `{"x":[1,2]} | . as {x:[$a,$a]} ?// $z | $a` is `1`, still
+/// inverted for the *inner* array sub-pattern too, not just the outermost
+/// container -- so `invert` threads through every recursive call
+/// unchanged, it is not computed once and only applied at the top.
 fn extract_pattern_bindings(
     pattern: &Pattern,
     value: &OwnedValue,
+    invert: bool,
 ) -> Result<Vec<(String, OwnedValue)>, EvalError> {
     match pattern {
         Pattern::Var(name) => Ok(vec![(name.clone(), value.clone())]),
@@ -27161,10 +27193,17 @@ fn extract_pattern_bindings(
             // way plain `.foo` on `null` does (`null | .foo` is `null`) --
             // every variable this pattern (and anything nested inside it)
             // would bind resolves to `null` instead of hard-erroring (#1239).
+            // Every entry binds the same `Null` value here regardless of
+            // `invert`, but still routed through the same dedup call (#1366
+            // code review) so this path upholds the same "no duplicate
+            // names in the result" invariant every other path does, rather
+            // than relying on "every value happens to be Null anyway" to
+            // paper over a skipped step.
             if matches!(value, OwnedValue::Null) {
                 let mut names = Vec::new();
                 collect_pattern_var_names(pattern, &mut names);
-                return Ok(names.into_iter().map(|n| (n, OwnedValue::Null)).collect());
+                let bindings = names.into_iter().map(|n| (n, OwnedValue::Null)).collect();
+                return Ok(dedup_object_bindings(bindings, invert));
             }
             let mut bindings = Vec::new();
             for entry in entries {
@@ -27181,7 +27220,7 @@ fn extract_pattern_bindings(
                     }
                 };
                 let field_value = obj.get(&entry.key).cloned().unwrap_or(OwnedValue::Null);
-                let sub_bindings = extract_pattern_bindings(&entry.pattern, &field_value)?;
+                let sub_bindings = extract_pattern_bindings(&entry.pattern, &field_value, invert)?;
                 bindings.extend(sub_bindings);
             }
             // #1366: an object pattern binding the same variable name from
@@ -27191,18 +27230,20 @@ fn extract_pattern_bindings(
             // $a` is `2` (y's value, since y is listed first in the
             // pattern) on both `{"x":1,"y":2}` and the differently-ordered
             // `{"y":2,"x":1}`, so this is the *pattern's* field order, not
-            // the value's. Opposite of the Array arm below -- see
-            // `dedup_keep_first_binding`'s doc comment for why the two
-            // container kinds disagree.
-            Ok(dedup_keep_first_binding(bindings))
+            // the value's. Opposite of the Array arm below, and inverted
+            // again under `?//` -- see `extract_pattern_bindings`'s own doc
+            // comment and `dedup_object_bindings`'s for why.
+            Ok(dedup_object_bindings(bindings, invert))
         }
         Pattern::Array(patterns) => {
             // Same `null`-absorbs-further-access tolerance as the Object arm
-            // above, for array-shaped destructuring (#1239).
+            // above, for array-shaped destructuring (#1239); same "route
+            // through the real dedup step anyway" reasoning too.
             if matches!(value, OwnedValue::Null) {
                 let mut names = Vec::new();
                 collect_pattern_var_names(pattern, &mut names);
-                return Ok(names.into_iter().map(|n| (n, OwnedValue::Null)).collect());
+                let bindings = names.into_iter().map(|n| (n, OwnedValue::Null)).collect();
+                return Ok(dedup_array_bindings(bindings, invert));
             }
             let mut bindings = Vec::new();
             for (i, pat) in patterns.iter().enumerate() {
@@ -27218,65 +27259,73 @@ fn extract_pattern_bindings(
                     }
                 };
                 let elem_value = arr.get(i).cloned().unwrap_or(OwnedValue::Null);
-                let sub_bindings = extract_pattern_bindings(pat, &elem_value)?;
+                let sub_bindings = extract_pattern_bindings(pat, &elem_value, invert)?;
                 bindings.extend(sub_bindings);
             }
             // #1366: an array pattern binding the same variable name at more
             // than one position (`[$a,$a]`) keeps the *last* position's
             // value in real jq -- confirmed live: `[1,2] | . as [$a,$a] |
-            // $a` is `2`. Opposite of the Object arm above; see
-            // `dedup_keep_last_binding`'s doc comment for why.
-            Ok(dedup_keep_last_binding(bindings))
+            // $a` is `2`. Opposite of the Object arm above, and inverted
+            // again under `?//`.
+            Ok(dedup_array_bindings(bindings, invert))
         }
     }
 }
 
-/// Drop every binding after the first for each repeated variable name,
-/// preserving first-seen order -- the rule real jq's object-pattern
-/// destructuring uses for a name bound by more than one field of the
-/// *same* object pattern (#1366). Confirmed live (jq 1.7.1) this tracks the
-/// *pattern's* field order, not the underlying object's own key order:
-/// `{"x":1,"y":2} | . as {y:$a,x:$a} | $a` is `2` (y's value, y being
-/// listed first in the pattern) on both `{"x":1,"y":2}` and the
-/// differently-ordered `{"y":2,"x":1}` value. Also confirmed via a
-/// computed-key probe (`{("x"|debug):$a,("y"|debug):$a}`) that both
-/// fields' key expressions still evaluate in textual order -- only the
-/// *binding* silently keeps the earlier one, later same-name fields are
-/// not skipped as dead code, their bind is just a no-op.
-///
-/// This is the opposite of [`dedup_keep_last_binding`], which applies to
-/// array-position duplicates instead -- real jq's `. as [$a,$a] | $a`
-/// keeps the *last* position, not the first. Both were verified
-/// independently; nothing about `extract_pattern_bindings`'s own recursive
-/// structure predicts one direction from the other, so each is pinned by
-/// its own oracle-verified doc comment rather than inferred.
-fn dedup_keep_first_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, OwnedValue)> {
-    let mut seen = BTreeSet::new();
-    bindings
-        .into_iter()
-        .filter(|(name, _)| seen.insert(name.clone()))
-        .collect()
+/// Object-pattern dedup: keep-first when `invert` is `false` (the ordinary,
+/// non-`?//` rule), keep-last when `true` (real jq's `?//`-alternative
+/// rule, confirmed the opposite -- see `extract_pattern_bindings`'s own doc
+/// comment for the live-verified evidence).
+fn dedup_object_bindings(
+    bindings: Vec<(String, OwnedValue)>,
+    invert: bool,
+) -> Vec<(String, OwnedValue)> {
+    if invert {
+        dedup_keep_last_binding(bindings)
+    } else {
+        dedup_keep_first_binding(bindings)
+    }
 }
 
-/// Drop every binding *before* the last for each repeated variable name,
-/// preserving last-seen relative order -- the rule real jq's array-pattern
-/// destructuring uses for a name bound at more than one position of the
-/// *same* array pattern (#1366). Confirmed live (jq 1.7.1): `[1,2] | . as
-/// [$a,$a] | $a` is `2`; `[1,2,3] | . as [$a,$b,$a] | $a` is `3`.
-///
-/// See [`dedup_keep_first_binding`]'s doc comment for the object-pattern
-/// counterpart, which keeps the *first* occurrence instead -- the two
-/// container kinds are independently verified, not derived from one
-/// shared mechanism.
+/// Array-pattern dedup: keep-last when `invert` is `false` (the ordinary,
+/// non-`?//` rule), keep-first when `true` (real jq's `?//`-alternative
+/// rule) -- the mirror image of [`dedup_object_bindings`].
+fn dedup_array_bindings(
+    bindings: Vec<(String, OwnedValue)>,
+    invert: bool,
+) -> Vec<(String, OwnedValue)> {
+    if invert {
+        dedup_keep_first_binding(bindings)
+    } else {
+        dedup_keep_last_binding(bindings)
+    }
+}
+
+/// Drop every binding after the first for each repeated variable name,
+/// keeping first-insertion order -- `IndexMap::entry().or_insert()` only
+/// writes a key's value the first time it's seen, exactly this rule, so
+/// this needs no bespoke seen-set bookkeeping (#1366 code review; mirrors
+/// `build_object_entries`'s own use of `IndexMap` for jq's analogous
+/// duplicate-*object-key* rule elsewhere in this file).
+fn dedup_keep_first_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, OwnedValue)> {
+    let mut map = IndexMap::new();
+    for (name, value) in bindings {
+        map.entry(name).or_insert(value);
+    }
+    map.into_iter().collect()
+}
+
+/// Drop every binding before the last for each repeated variable name --
+/// collecting into an `IndexMap` already gives "last value wins, first
+/// insertion position kept" for a repeated key (#1366 code review; the
+/// same `IndexMap` behavior `build_object_entries` documents for jq's
+/// duplicate-object-key rule), so this needs no explicit reverse/re-reverse
+/// pass either.
 fn dedup_keep_last_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, OwnedValue)> {
-    let mut seen = BTreeSet::new();
     bindings
         .into_iter()
-        .rev()
-        .filter(|(name, _)| seen.insert(name.clone()))
-        .collect::<Vec<_>>()
+        .collect::<IndexMap<_, _>>()
         .into_iter()
-        .rev()
         .collect()
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11125,6 +11125,99 @@ fn test_as_pattern_no_alt_unaffected_720() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// #1366: a pattern binding the same variable name more than once used to
+// always keep the *first* occurrence -- an artifact of `substitute_bindings`
+// folding `substitute_var` (which replaces every remaining occurrence of a
+// name) over the raw, undeduped binding list in pattern order, so only the
+// first bind ever found anything left to replace. Real jq's actual rule is
+// asymmetric between the two container kinds, confirmed live against jq
+// 1.7.1 (not inferred, per CLAUDE.md's #1120 lesson that a fix matching
+// only one repro shape can encode the wrong general rule): an **array**
+// pattern keeps the *last* position's value; an **object** pattern keeps
+// the *first* field's value, tracking the pattern's own field order rather
+// than the underlying object's key order.
+// ============================================================================
+
+/// #1366: array pattern, own repro plus a 3-position variant with a
+/// distinct variable in between (confirms this isn't specific to two
+/// *adjacent* duplicate positions).
+#[test]
+fn test_array_pattern_duplicate_var_keeps_last_position_1366() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ". as [$a,$a] | $a"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ". as [$a,$b,$a] | $a"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "3");
+    Ok(())
+}
+
+/// #1366: object pattern keeps the *first* field's value, and -- the
+/// non-obvious half -- this tracks the pattern's own field order, not the
+/// object's key order. Both `{"x":1,"y":2}` and the differently-ordered
+/// `{"y":2,"x":1}` (confirmed via `keys_unsorted` to actually differ in
+/// jq's own eyes) give the same two answers for the two pattern
+/// orderings, so the object's key order is not what decides this.
+#[test]
+fn test_object_pattern_duplicate_var_keeps_first_field_by_pattern_order_1366() -> Result<()> {
+    for input in ["{\"x\":1,\"y\":2}", "{\"y\":2,\"x\":1}"] {
+        let (stdout, _stderr, code) = run_jq_full(&["-c", ". as {x:$a,y:$a} | $a"], Some(input))?;
+        assert_eq!(code, 0, "input: {input}");
+        assert_eq!(stdout.trim_end(), "1", "input: {input}");
+
+        let (stdout, _stderr, code) = run_jq_full(&["-c", ". as {y:$a,x:$a} | $a"], Some(input))?;
+        assert_eq!(code, 0, "input: {input}");
+        assert_eq!(stdout.trim_end(), "2", "input: {input}");
+    }
+    Ok(())
+}
+
+/// #1366: a nested pattern combining both container kinds -- the array
+/// sub-pattern's own last-wins resolution (`[$a,$a]` on `[1,2]` -> `2`)
+/// becomes field `x`'s single contribution to the outer object pattern,
+/// which then keeps *that* (the first field, `x`) over the second field
+/// `y`'s own `$a` binding -- confirming the two rules compose per
+/// container level rather than being flattened into one global rule.
+#[test]
+fn test_nested_pattern_duplicate_var_composes_per_container_1366() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {x:[$a,$a],y:$a} | $a"],
+        Some(r#"{"x":[1,2],"y":3}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #1366: the issue's own `reduce` repro -- `#1201`'s `substitute_bindings`
+/// call site shares the same `extract_pattern_bindings` fix, so `reduce`
+/// (and by the same code path, `foreach`) must resolve this identically
+/// to plain `. as PATTERN`.
+#[test]
+fn test_reduce_array_pattern_duplicate_var_keeps_last_position_1366() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "reduce .[] as [$a,$a] (0; $a)"], Some("[[1,2]]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #1366 regression check: an ordinary pattern with no repeated variable
+/// name must still bind each name to its own, independent value --
+/// confirms the dedup step doesn't accidentally touch distinct names.
+#[test]
+fn test_object_pattern_distinct_vars_unaffected_1366() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {x:$p,y:$q} | [$p,$q]"],
+        Some(r#"{"x":100,"y":200}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[100,200]");
+    Ok(())
+}
+
 /// yq mode does not support `?//` at all -- real yq's own parser rejects
 /// it ("lexer: invalid input text", confirmed live against yq v4.53.3) --
 /// so succinctly's shared jq/yq parser must keep erroring on it in yq mode

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11204,6 +11204,59 @@ fn test_reduce_array_pattern_duplicate_var_keeps_last_position_1366() -> Result<
     Ok(())
 }
 
+/// #1366 code review: the previous test's own doc comment claims `foreach`
+/// shares the same code path "by the same code path" as `reduce` -- this
+/// pins that claim directly instead of leaving it asserted-but-untested,
+/// for both container kinds (`reduce`'s own sibling test above only
+/// covers the array case).
+#[test]
+fn test_foreach_and_reduce_object_pattern_duplicate_var_keeps_first_field_1366() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "foreach .[] as [$a,$a] (0; $a)"], Some("[[1,2]]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", "foreach .[] as {x:$a,y:$a} (0; $a)"],
+        Some(r#"[{"x":1,"y":2}]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", "reduce .[] as {x:$a,y:$a} (0; $a)"],
+        Some(r#"[{"x":1,"y":2}]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #1366 code review: `{$a: Pattern}` (#1204's key-shorthand pattern)
+/// desugars into two `PatternEntry`s sharing the key `"a"` -- an implicit
+/// whole-field bind (`{key:"a", pattern:Var("a")}`) followed by whatever
+/// the user's own nested `Pattern` does. When that nested pattern also
+/// binds `$a`, this is a same-name collision baked into one syntactic
+/// construct rather than two explicit fields, and it happens to already
+/// resolve correctly (the auto-bind is the object pattern's *first* field
+/// textually, so it wins under the plain, non-`?//` rule) -- pinned here
+/// since none of the tests above exercise this desugaring path.
+#[test]
+fn test_key_shorthand_pattern_duplicate_var_1366() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", ". as {$a: {x:$a}} | $a"], Some(r#"{"a":{"x":99}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "{\"x\":99}");
+
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {$a: [$b,$a]} | [$a,$b]"],
+        Some(r#"{"a":[10,20]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[[10,20],10]");
+    Ok(())
+}
+
 /// #1366 regression check: an ordinary pattern with no repeated variable
 /// name must still bind each name to its own, independent value --
 /// confirms the dedup step doesn't accidentally touch distinct names.
@@ -11215,6 +11268,116 @@ fn test_object_pattern_distinct_vars_unaffected_1366() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[100,200]");
+    Ok(())
+}
+
+/// #1366 code review: a genuine `?//`-chain (2+ alternatives) *inverts*
+/// real jq's duplicate-binding dedup rule relative to a bare, non-`?//`
+/// pattern of the identical shape -- confirmed live against jq 1.7.1 and
+/// 1.8.2. This is not "which code path handles it": `eval_as_pattern`
+/// routes a bare pattern through the same `try_pattern_alternatives` as a
+/// one-element list, so `patterns.len() > 1` (a real `?//`) is the only
+/// thing that actually distinguishes the two cases, and it flips the
+/// answer for *both* container kinds.
+#[test]
+fn test_array_pattern_duplicate_var_inverts_under_alternation_1366() -> Result<()> {
+    // Bare: last position wins (`2`).
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ". as [$a,$a] | $a"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+
+    // Same pattern, trivially `?//`-chained with itself: first position
+    // wins instead (`1`).
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", ". as [$a,$a] ?// [$a,$a] | $a"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    // Holds for a 3-position pattern too, not just the 2-position case.
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as [$a,$b,$a] ?// [$a,$b,$a] | $a"],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #1366 code review: the object-pattern counterpart of the array
+/// inversion above -- bare keeps the *first* field, `?//` keeps the
+/// *last*.
+#[test]
+fn test_object_pattern_duplicate_var_inverts_under_alternation_1366() -> Result<()> {
+    // Bare: first field wins (`1`, x's value).
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", ". as {x:$a,y:$a} | $a"], Some(r#"{"x":1,"y":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    // Same pattern via `?//` (second alternative never taken, just needs
+    // to exist): last field wins instead (`2`, y's value).
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {x:$a,y:$a} ?// $z | $a"],
+        Some(r#"{"x":1,"y":2}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+
+    // Holds for a 3-field pattern too.
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {z:$a,x:$a,y:$a} ?// $w | $a"],
+        Some(r#"{"x":1,"y":2,"z":3}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #1366 code review: the `?//` inversion isn't limited to the outermost
+/// container -- a nested sub-pattern's own duplicate-binding rule inverts
+/// too, at any depth, since `invert` threads unchanged through every
+/// recursive call rather than being computed once at the top.
+#[test]
+fn test_nested_pattern_duplicate_var_inverts_under_alternation_1366() -> Result<()> {
+    // Array nested inside an object, bare vs. `?//`.
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", ". as {x:[$a,$a]} | $a"], Some(r#"{"x":[1,2]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as {x:[$a,$a]} ?// $z | $a"],
+        Some(r#"{"x":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    // Object nested inside an array, bare vs. `?//`.
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as [{x:$a,y:$a}] | $a"],
+        Some(r#"[{"x":1,"y":2}]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", ". as [{x:$a,y:$a}] ?// $z | $a"],
+        Some(r#"[{"x":1,"y":2}]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #1366 code review: the inversion holds even when the duplicate-bound
+/// alternative is reached via a genuine fallback (the first alternative's
+/// own pattern fails to match), not just a trivial self-`?//`.
+#[test]
+fn test_pattern_duplicate_var_inverts_via_genuine_fallback_1366() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", ". as {x:$a} ?// [$a,$a] | $a"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #1366. A pattern binding the same variable name more than once (`. as [$a,$a]`, `. as {x:$a,y:$a}`) always kept the *first* occurrence — an artifact of `substitute_bindings` folding `substitute_var` (which replaces every remaining occurrence of a name) over the raw, undeduped binding list `extract_pattern_bindings` built in pattern order, so only the first bind ever found anything left to replace.

## The actual rule (live-verified, not inferred)

Per CLAUDE.md's #1120 lesson ("a fix matching only the issue's own repro can encode the wrong general rule and still pass"), and per ADR-0018's rule 1 (a behavioral claim is only admissible if captured live from the pinned reference), I probed this thoroughly against jq 1.7.1 rather than trusting the tier-review comment's own guess about the object-pattern case (which turned out to be wrong — see below). The real rule is **asymmetric** between the two container kinds:

- **Array pattern**: the *last* position wins. `[1,2] | . as [$a,$a] | $a` → `2`; `[1,2,3] | . as [$a,$b,$a] | $a` → `3`.
- **Object pattern**: the *first* field wins — and, the non-obvious half, this tracks the **pattern's own field order**, not the underlying object's key order (the tier-review comment guessed the opposite). Confirmed by running the same two pattern orderings against two differently-key-ordered objects (verified distinct via `keys_unsorted`): both `{"x":1,"y":2}` and `{"y":2,"x":1}` give the same two answers for `{x:$a,y:$a}` (→1) vs `{y:$a,x:$a}` (→2) — the object's own key order never matters. Also confirmed via a computed-key probe (`{("x"|debug):$a,("y"|debug):$a}`) that both fields' key expressions still evaluate in textual order — only the *binding* silently keeps the earlier one; a later same-name field's bind is a no-op, not dead code.
- The two rules **compose per container level** when patterns nest, not as one flattened global rule: `{x:[$a,$a],y:$a}` on `{"x":[1,2],"y":3}` gives `2` — the array sub-pattern's own last-wins resolution becomes field `x`'s single contribution, which the outer object then keeps over field `y`'s own binding, since `x` is listed first in the object pattern.

## Changes

Added `dedup_keep_first_binding`/`dedup_keep_last_binding`, applied at the Object/Array arms of `extract_pattern_bindings` respectively — the one place #1201's `reduce`/`foreach` and `try_pattern_alternatives`'s `?//` handling already share with plain `. as PATTERN`, per the issue's own suggested fix location.

## Test plan

- [x] 5 new tests: the array-pattern repro plus a 3-position variant; the object-pattern first-field rule across both key orderings of the underlying object; the nested per-container composition case; the `reduce` form; and a regression check that ordinary (non-duplicate) pattern bindings are unaffected.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`, sequential) — 2704 lib tests, 793 jq_cli_tests, all pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt --check` clean.


## Round 2 (/code-review, 6 finder agents)

No correctness bugs in the dedup mechanism itself, but a major finding confirmed independently by three separate agents plus my own live re-verification against both jq 1.7.1 and 1.8.2: **the first commit's fixed dedup direction per container kind is correct for bare `. as PATTERN` but wrong for `PATTERN ?// PATTERN2`** — real jq's rule *inverts* between the two contexts, for both container kinds and at every nesting depth.

Confirmed live: `[1,2] | . as [$a,$a] | $a` is `2` (last wins) but `[1,2] | . as [$a,$a] ?// [$a,$a] | $a` is `1` (first wins) — same pattern, only a trivial self-alternative added. Symmetrically for objects, inverted the other way. This is not "which function calls `extract_pattern_bindings`" — `eval_as_pattern` routes a bare, non-`?//` pattern through `try_pattern_alternatives` as a one-element list too, so `patterns.len() > 1` is the actual (and only) distinguishing test.

**Fixed** by threading a new `invert: bool` parameter through `extract_pattern_bindings`'s entire recursion (nested sub-patterns need it too — confirmed live at multiple nesting depths), computed once in `try_pattern_alternatives` as `patterns.len() > 1`; `reduce`/`foreach` (no `?//` support at all) and plain `. as PATTERN`'s other call site always pass `false`.

Also fixed, per two more findings:
- The `#1239` null-absorption early-return paths bypassed the new dedup entirely (invisible today since every binding there is `Null`, but a latent invariant violation) — now routed through the same dedup helpers.
- `dedup_keep_first_binding`/`dedup_keep_last_binding` reimplemented a `BTreeSet`-based seen-filter that this same file already solves via `IndexMap` for jq's analogous duplicate-object-key rule — simplified to use `IndexMap`'s own `entry().or_insert()` / `collect::<IndexMap<_,_>>()` behavior instead, no clones.

Added tests for the `?//` inversion (array/object, 2/3-element, nested at depth, genuine-fallback-not-just-trivial-self-alt), `foreach`+`reduce` with an object pattern (a coverage gap in the first commit's own test comment claiming parity), and the `{$a: Pattern}` (#1204) key-shorthand desugaring's same-name-collision shape.

(A sweep finding about stale line citations in `docs/adrs/adr-0019.md` was investigated and confirmed unrelated to this PR — that file isn't part of this PR's diff at all; `gh pr diff --name-only` shows only `src/jq/eval.rs`/`tests/jq_cli_tests.rs`. The reviewing agent's own worktree had picked up main's already-merged history during a rebase, not anything this PR introduces.)

Re-ran the full local verification suite — all clean.
