### PR TITLE
fix(jq): track path() through a variable bound outside path()'s argument

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -419,6 +419,30 @@ Unlike the positive case above, `?` does not suppress this one —
 [#498](https://github.com/rust-works/succinctly/issues/498) — because it is a write-time
 bounds check, not a failure to collect the path.
 
+A variable bound outside `reduce`/`foreach` and referenced from inside `UPDATE` is a third,
+narrower gap, found reviewing [#844](https://github.com/rust-works/succinctly/issues/844):
+
+| Filter                                         | Input     | jq   | succinctly                                    |
+|------------------------------------------------|-----------|------|-----------------------------------------------|
+| `path(. as $x \| reduce (1,2) as $i (0; $x))`  | `{"a":1}` | `[]` | `Invalid path expression with result {"a":1}` |
+| `path(. as $x \| foreach (1,2) as $i (0; $x))` | `{"a":1}` | `[]` | `Invalid path expression with result {"a":1}` |
+
+#844 taught `resolve_node` to recognize `Expr::TrackedVar` (a variable frozen from a
+statically-verified passthrough of `.`, per that issue's own `is_identity_passthrough`) so
+that referencing such a variable inside `path(...)` stays trackable. `resolve_node` has no
+`Expr::Reduce`/`Expr::Foreach` arm of its own, though, so either one reaching `path(...)`'s
+resolver falls to `resolve_leaf`'s catch-all regardless of what its `UPDATE` expression
+does internally — a bare `$x` reference inside `UPDATE`, even a `TrackedVar` one, never gets
+the chance to reach the new arm, because `resolve_node` never descends into `Reduce`/
+`Foreach` at all. Real jq has no such gap because `reduce`/`foreach` are sugar over the same
+primitive `as`-binding/iteration machinery every other construct uses, so their own
+trackability was never a separate case to begin with. This is a read-only, safe divergence
+(succinctly never emits a *wrong* path here, only refuses a filter jq accepts) — not fixed
+here; a proper fix needs `resolve_node` to interleave path resolution with `reduce`/
+`foreach`'s own fold loop (evaluating `UPDATE` against each intermediate accumulator through
+`resolve_node` rather than the ordinary value evaluator), which is new machinery beyond a
+single arm.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/docs/plan/jq-path-trackability-deferral.md
+++ b/docs/plan/jq-path-trackability-deferral.md
@@ -372,6 +372,10 @@ measured slice-by-slice rather than as one combined change.
    carve-outs (the `bare_navigation_primitive` check, the `is_untracked_navigation_error`
    distinction) that a mechanical "just propagate whatever came in" migration could silently
    break — read that arm's own doc comment in full before touching it.
+   `Expr::As`'s own gap (a variable bound *outside* `path(...)`'s argument, or from a source
+   that isn't a syntactic passthrough of `.`, losing trackability across the binding) was closed
+   by #844 — see `is_identity_passthrough` and `resolve_node`'s `Expr::TrackedVar` arm in
+   `src/jq/eval.rs`. The others in this list remain open.
 5. **`del`/assignment write-path semantics**, not just `path()`'s read-only output. #972's own
    revert (on a related but different fix in this same code region) was specifically about
    silent data corruption on the write path once multi-key index/slice fan-outs were involved.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -415,6 +415,7 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
         | Expr::RecursiveDescent
         | Expr::Literal(_)
         | Expr::Var(_)
+        | Expr::TrackedVar(_)
         | Expr::Loc { .. }
         | Expr::Env
         | Expr::Not

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2840,6 +2840,7 @@ fn contains_split_doc(expr: &Expr) -> bool {
         | Expr::Not
         | Expr::Format(_)
         | Expr::Var(_)
+        | Expr::TrackedVar(_)
         | Expr::Loc { .. }
         | Expr::Env
         | Expr::Break(_)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -792,6 +792,11 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // In practice, variables are resolved by eval_as which substitutes them
             QueryResult::Error(EvalError::new(format!("undefined variable: ${name}")))
         }
+        // A frozen variable snapshot from `substitute_var_tracked` (#844).
+        // Outside `path()`/`del()`/assignment resolution this is just an
+        // ordinary bound value -- `resolve_node`'s own `Expr::TrackedVar`
+        // arm is what actually decides path-trackability.
+        Expr::TrackedVar(v) => QueryResult::Owned((**v).clone()),
         Expr::Loc { line } => {
             // $__loc__ returns {"file": "<stdin>", "line": N}
             // where N is the 1-based line number in the jq filter source
@@ -14895,9 +14900,20 @@ fn resolve_node<'a, S: EvalSemantics>(
         // completing — not nothing.
         Expr::As { expr, var, body } => {
             let (bound_values, trailing) = eval_owned_expr_fork::<S>(expr, value, false);
+            // #844: same bind-time gate as `eval_as` -- only a
+            // statically-verified passthrough of `.` is even a candidate
+            // for path()-trackability through this binding. The actual
+            // trackability decision is made lazily by `resolve_node`'s own
+            // `Expr::TrackedVar` arm, at each use site.
+            let wrap_tracked = is_identity_passthrough(expr);
             let mut out = Vec::new();
             for bound in bound_values {
-                match resolve_node::<S>(&substitute_var(body, var, &bound), value, trackable) {
+                let substituted = if wrap_tracked {
+                    substitute_var_tracked(body, var, &bound)
+                } else {
+                    substitute_var(body, var, &bound)
+                };
+                match resolve_node::<S>(&substituted, value, trackable) {
                     Ok(branches) => out.extend(branches),
                     Err((body_prefix, escape)) => {
                         out.extend(body_prefix);
@@ -14918,6 +14934,31 @@ fn resolve_node<'a, S: EvalSemantics>(
                 // `body` resolution, already in `out`) and exits cleanly,
                 // never raising the bogus error this arm used to produce.
                 Some(control) => Err((out, control.into())),
+            }
+        }
+
+        // #844: a frozen variable snapshot from a statically-verified
+        // identity-passthrough `as`-binding (see `is_identity_passthrough`
+        // and the two `substitute_var_tracked` call sites above). The
+        // static gate is only a *candidate* signal; the real trackability
+        // decision happens here, lazily, by re-deriving it fresh against
+        // this exact use site: `.` can change between bind time and here
+        // (intervening navigation elsewhere in the pipe), so trusting the
+        // bind-time proof alone could claim a path that doesn't actually
+        // resolve back to `path()`'s own root. Comparing the snapshot to
+        // the ambient `value` can only ever *under*-approximate real jq's
+        // trackability (fall back to untracked), never emit a wrong path:
+        // `getpath(value, [])` trivially equals `value`, so `path=[]` is a
+        // sound witness whenever the snapshot and the ambient value agree.
+        Expr::TrackedVar(marker_value) => {
+            if trackable && marker_value.as_ref() == value {
+                Ok(vec![PathBranch::new(
+                    Vec::new(),
+                    Cow::Borrowed(value),
+                    true,
+                )])
+            } else {
+                resolve_leaf::<S>(expr, value, trackable)
             }
         }
 
@@ -16930,12 +16971,71 @@ where
     result
 }
 
-/// Substitute a variable in an expression with a value.
-/// Returns a new expression with the variable replaced.
-fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr {
+/// True if `expr` is nothing but `.`, statically -- gates whether an
+/// `as`-bound value is wrapped in `Expr::TrackedVar` at all (#844).
+///
+/// Real jq only ever preserves `path()` trackability through a variable
+/// bound from `.` itself, never from a literal, field access, or any other
+/// computation, regardless of what value it evaluates to (confirmed live:
+/// `0 as $x | path($x)` on input `0` still raises `Invalid path expression`
+/// in real jq, even though the bound value trivially equals `.` there). So
+/// this check is deliberately syntactic, not "does the value happen to
+/// match" -- that runtime check happens separately, in `resolve_node`'s own
+/// `Expr::TrackedVar` arm, once a marker actually reaches a use site.
+///
+/// `Expr::TrackedVar` counts as passthrough too, so a chain of pure
+/// bindings composes: `. as $x | $x as $y | path($y | ...)` still tracks
+/// `$y`, because by the time this predicate sees `$y`'s bind source, it has
+/// already been substituted into a `TrackedVar` from the outer binding.
+fn is_identity_passthrough(expr: &Expr) -> bool {
     match expr {
-        Expr::Var(name) if name == var_name => owned_to_expr(replacement),
+        Expr::Identity | Expr::TrackedVar(_) => true,
+        Expr::Paren(inner) => is_identity_passthrough(inner),
+        _ => false,
+    }
+}
+
+/// Substitute a variable in an expression with a value, without marking the
+/// replacement as path-trackable. This is the form used by destructuring,
+/// `--arg`/`--argjson` splicing, and any `as`-binding whose source isn't a
+/// statically-verified passthrough of `.` (see `is_identity_passthrough`).
+fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr {
+    substitute_var_impl(expr, var_name, replacement, false)
+}
+
+/// Like `substitute_var`, but marks the replacement as an `Expr::TrackedVar`
+/// so `resolve_node` can recognize it as a path()-trackability candidate.
+/// Call only when `is_identity_passthrough` holds for the bind source --
+/// `resolve_node`'s own `Expr::TrackedVar` arm still gates actual
+/// trackability at use time by comparing the frozen value to its own
+/// ambient position, so wrapping here is a necessary but not sufficient
+/// condition for the substituted variable to end up trackable (#844).
+fn substitute_var_tracked(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr {
+    substitute_var_impl(expr, var_name, replacement, true)
+}
+
+/// Substitute a variable in an expression with a value.
+/// Returns a new expression with the variable replaced. `mark_trackable`
+/// selects whether a substituted `$var_name` becomes an `Expr::TrackedVar`
+/// (path()-trackability candidate) or a plain value-construction node --
+/// see `substitute_var`/`substitute_var_tracked` above, the only two
+/// callers that should pass a literal `false`/`true` here.
+fn substitute_var_impl(
+    expr: &Expr,
+    var_name: &str,
+    replacement: &OwnedValue,
+    mark_trackable: bool,
+) -> Expr {
+    match expr {
+        Expr::Var(name) if name == var_name => {
+            if mark_trackable {
+                Expr::TrackedVar(Box::new(replacement.clone()))
+            } else {
+                owned_to_expr(replacement)
+            }
+        }
         Expr::Var(_) => expr.clone(),
+        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
         Expr::Loc { line } => Expr::Loc { line: *line },
         Expr::Env => Expr::Env,
         Expr::Identity => Expr::Identity,
@@ -16964,104 +17064,238 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
         // Must recurse into `key`: variables are resolved by substitution, so
         // skipping it would leave `$k` in `.[$k]` unbound at eval time.
         Expr::IndexExpr { target, key } => Expr::IndexExpr {
-            target: Box::new(substitute_var(target, var_name, replacement)),
-            key: Box::new(substitute_var(key, var_name, replacement)),
+            target: Box::new(substitute_var_impl(
+                target,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            key: Box::new(substitute_var_impl(
+                key,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         // Same reasoning as `IndexExpr`: `$a`/`$b` in `.[$a:$b]` must resolve.
         Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
-            target: Box::new(substitute_var(target, var_name, replacement)),
-            start: start
-                .as_deref()
-                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
-            end: end
-                .as_deref()
-                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
+            target: Box::new(substitute_var_impl(
+                target,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            start: start.as_deref().map(|e| {
+                Box::new(substitute_var_impl(
+                    e,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                ))
+            }),
+            end: end.as_deref().map(|e| {
+                Box::new(substitute_var_impl(
+                    e,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                ))
+            }),
         },
         Expr::RecursiveDescent => Expr::RecursiveDescent,
-        Expr::Optional(e) => Expr::Optional(Box::new(substitute_var(e, var_name, replacement))),
+        Expr::Optional(e) => Expr::Optional(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
-                .map(|e| substitute_var(e, var_name, replacement))
+                .map(|e| substitute_var_impl(e, var_name, replacement, mark_trackable))
                 .collect(),
         ),
         Expr::Comma(exprs) => Expr::Comma(
             exprs
                 .iter()
-                .map(|e| substitute_var(e, var_name, replacement))
+                .map(|e| substitute_var_impl(e, var_name, replacement, mark_trackable))
                 .collect(),
         ),
-        Expr::Array(e) => Expr::Array(Box::new(substitute_var(e, var_name, replacement))),
-        Expr::Object(entries) => Expr::Object(
-            entries
-                .iter()
-                .map(|entry| {
-                    let new_key = match &entry.key {
-                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                        ObjectKey::Expr(e) => {
-                            ObjectKey::Expr(Box::new(substitute_var(e, var_name, replacement)))
+        Expr::Array(e) => Expr::Array(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Expr::Object(entries) => {
+            Expr::Object(
+                entries
+                    .iter()
+                    .map(|entry| {
+                        let new_key =
+                            match &entry.key {
+                                ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
+                                ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(
+                                    substitute_var_impl(e, var_name, replacement, mark_trackable),
+                                )),
+                            };
+                        ObjectEntry {
+                            key: new_key,
+                            value: substitute_var_impl(
+                                &entry.value,
+                                var_name,
+                                replacement,
+                                mark_trackable,
+                            ),
                         }
-                    };
-                    ObjectEntry {
-                        key: new_key,
-                        value: substitute_var(&entry.value, var_name, replacement),
-                    }
-                })
-                .collect(),
-        ),
+                    })
+                    .collect(),
+            )
+        }
         Expr::Literal(lit) => Expr::Literal(lit.clone()),
-        Expr::Paren(e) => Expr::Paren(Box::new(substitute_var(e, var_name, replacement))),
+        Expr::Paren(e) => Expr::Paren(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
             op: *op,
-            left: Box::new(substitute_var(left, var_name, replacement)),
-            right: Box::new(substitute_var(right, var_name, replacement)),
+            left: Box::new(substitute_var_impl(
+                left,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            right: Box::new(substitute_var_impl(
+                right,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
-        Expr::Negate(operand) => {
-            Expr::Negate(Box::new(substitute_var(operand, var_name, replacement)))
-        }
+        Expr::Negate(operand) => Expr::Negate(Box::new(substitute_var_impl(
+            operand,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
-            left: Box::new(substitute_var(left, var_name, replacement)),
-            right: Box::new(substitute_var(right, var_name, replacement)),
+            left: Box::new(substitute_var_impl(
+                left,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            right: Box::new(substitute_var_impl(
+                right,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::And(l, r) => Expr::And(
-            Box::new(substitute_var(l, var_name, replacement)),
-            Box::new(substitute_var(r, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                l,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                r,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Expr::Or(l, r) => Expr::Or(
-            Box::new(substitute_var(l, var_name, replacement)),
-            Box::new(substitute_var(r, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                l,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                r,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Expr::Not => Expr::Not,
         Expr::Alternative(l, r) => Expr::Alternative(
-            Box::new(substitute_var(l, var_name, replacement)),
-            Box::new(substitute_var(r, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                l,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                r,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Expr::If {
             cond,
             then_branch,
             else_branch,
         } => Expr::If {
-            cond: Box::new(substitute_var(cond, var_name, replacement)),
-            then_branch: Box::new(substitute_var(then_branch, var_name, replacement)),
-            else_branch: Box::new(substitute_var(else_branch, var_name, replacement)),
+            cond: Box::new(substitute_var_impl(
+                cond,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            then_branch: Box::new(substitute_var_impl(
+                then_branch,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            else_branch: Box::new(substitute_var_impl(
+                else_branch,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::Try { expr, catch } => Expr::Try {
-            expr: Box::new(substitute_var(expr, var_name, replacement)),
-            catch: catch
-                .as_ref()
-                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
+            expr: Box::new(substitute_var_impl(
+                expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            catch: catch.as_ref().map(|e| {
+                Box::new(substitute_var_impl(
+                    e,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                ))
+            }),
         },
         Expr::Error(msg) => Expr::Error(msg.clone()),
-        Expr::Builtin(b) => Expr::Builtin(substitute_var_in_builtin(b, var_name, replacement)),
+        Expr::Builtin(b) => Expr::Builtin(substitute_var_in_builtin(
+            b,
+            var_name,
+            replacement,
+            mark_trackable,
+        )),
         Expr::StringInterpolation(parts) => Expr::StringInterpolation(
             parts
                 .iter()
                 .map(|p| match p {
                     StringPart::Literal(s) => StringPart::Literal(s.clone()),
-                    StringPart::Expr(e) => {
-                        StringPart::Expr(Box::new(substitute_var(e, var_name, replacement)))
-                    }
+                    StringPart::Expr(e) => StringPart::Expr(Box::new(substitute_var_impl(
+                        e,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    ))),
                 })
                 .collect(),
         ),
@@ -17071,15 +17305,30 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             // Don't substitute if this `as` binds the same variable (shadowing)
             if var == var_name {
                 Expr::As {
-                    expr: Box::new(substitute_var(expr, var_name, replacement)),
+                    expr: Box::new(substitute_var_impl(
+                        expr,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     var: var.clone(),
                     body: body.clone(), // Don't substitute in body - shadowed
                 }
             } else {
                 Expr::As {
-                    expr: Box::new(substitute_var(expr, var_name, replacement)),
+                    expr: Box::new(substitute_var_impl(
+                        expr,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     var: var.clone(),
-                    body: Box::new(substitute_var(body, var_name, replacement)),
+                    body: Box::new(substitute_var_impl(
+                        body,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                 }
             }
         }
@@ -17095,17 +17344,42 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             // case of this same question).
             if pattern_binds_var(pattern, var_name) {
                 Expr::Reduce {
-                    input: Box::new(substitute_var(input, var_name, replacement)),
+                    input: Box::new(substitute_var_impl(
+                        input,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     pattern: pattern.clone(),
-                    init: Box::new(substitute_var(init, var_name, replacement)),
+                    init: Box::new(substitute_var_impl(
+                        init,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     update: update.clone(), // shadowed
                 }
             } else {
                 Expr::Reduce {
-                    input: Box::new(substitute_var(input, var_name, replacement)),
+                    input: Box::new(substitute_var_impl(
+                        input,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     pattern: pattern.clone(),
-                    init: Box::new(substitute_var(init, var_name, replacement)),
-                    update: Box::new(substitute_var(update, var_name, replacement)),
+                    init: Box::new(substitute_var_impl(
+                        init,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
+                    update: Box::new(substitute_var_impl(
+                        update,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                 }
             }
         }
@@ -17118,51 +17392,151 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
         } => {
             if pattern_binds_var(pattern, var_name) {
                 Expr::Foreach {
-                    input: Box::new(substitute_var(input, var_name, replacement)),
+                    input: Box::new(substitute_var_impl(
+                        input,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     pattern: pattern.clone(),
-                    init: Box::new(substitute_var(init, var_name, replacement)),
+                    init: Box::new(substitute_var_impl(
+                        init,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     update: update.clone(),
                     extract: extract.clone(),
                 }
             } else {
                 Expr::Foreach {
-                    input: Box::new(substitute_var(input, var_name, replacement)),
+                    input: Box::new(substitute_var_impl(
+                        input,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                     pattern: pattern.clone(),
-                    init: Box::new(substitute_var(init, var_name, replacement)),
-                    update: Box::new(substitute_var(update, var_name, replacement)),
-                    extract: extract
-                        .as_ref()
-                        .map(|e| Box::new(substitute_var(e, var_name, replacement))),
+                    init: Box::new(substitute_var_impl(
+                        init,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
+                    update: Box::new(substitute_var_impl(
+                        update,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
+                    extract: extract.as_ref().map(|e| {
+                        Box::new(substitute_var_impl(
+                            e,
+                            var_name,
+                            replacement,
+                            mark_trackable,
+                        ))
+                    }),
                 }
             }
         }
         Expr::Limit { n, expr } => Expr::Limit {
-            n: Box::new(substitute_var(n, var_name, replacement)),
-            expr: Box::new(substitute_var(expr, var_name, replacement)),
+            n: Box::new(substitute_var_impl(
+                n,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            expr: Box::new(substitute_var_impl(
+                expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
-        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(substitute_var(e, var_name, replacement))),
-        Expr::LastExpr(e) => Expr::LastExpr(Box::new(substitute_var(e, var_name, replacement))),
+        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Expr::LastExpr(e) => Expr::LastExpr(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Expr::NthExpr { n, expr } => Expr::NthExpr {
-            n: Box::new(substitute_var(n, var_name, replacement)),
-            expr: Box::new(substitute_var(expr, var_name, replacement)),
+            n: Box::new(substitute_var_impl(
+                n,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            expr: Box::new(substitute_var_impl(
+                expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::Until { cond, update } => Expr::Until {
-            cond: Box::new(substitute_var(cond, var_name, replacement)),
-            update: Box::new(substitute_var(update, var_name, replacement)),
+            cond: Box::new(substitute_var_impl(
+                cond,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            update: Box::new(substitute_var_impl(
+                update,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::While { cond, update } => Expr::While {
-            cond: Box::new(substitute_var(cond, var_name, replacement)),
-            update: Box::new(substitute_var(update, var_name, replacement)),
+            cond: Box::new(substitute_var_impl(
+                cond,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            update: Box::new(substitute_var_impl(
+                update,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
-        Expr::Repeat(e) => Expr::Repeat(Box::new(substitute_var(e, var_name, replacement))),
+        Expr::Repeat(e) => Expr::Repeat(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Expr::Range { from, to, step } => Expr::Range {
-            from: Box::new(substitute_var(from, var_name, replacement)),
-            to: to
-                .as_ref()
-                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
-            step: step
-                .as_ref()
-                .map(|e| Box::new(substitute_var(e, var_name, replacement))),
+            from: Box::new(substitute_var_impl(
+                from,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            to: to.as_ref().map(|e| {
+                Box::new(substitute_var_impl(
+                    e,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                ))
+            }),
+            step: step.as_ref().map(|e| {
+                Box::new(substitute_var_impl(
+                    e,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                ))
+            }),
         },
         // Phase 9: Variables & Definitions
         Expr::AsPattern {
@@ -17175,12 +17549,22 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             // alternative it might actually run under (#720).
             let shadowed = patterns.iter().any(|p| pattern_binds_var(p, var_name));
             Expr::AsPattern {
-                expr: Box::new(substitute_var(expr, var_name, replacement)),
+                expr: Box::new(substitute_var_impl(
+                    expr,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                )),
                 patterns: patterns.clone(),
                 body: if shadowed {
                     body.clone()
                 } else {
-                    Box::new(substitute_var(body, var_name, replacement))
+                    Box::new(substitute_var_impl(
+                        body,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    ))
                 },
             }
         }
@@ -17198,16 +17582,26 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
                 body: if shadowed {
                     body.clone()
                 } else {
-                    Box::new(substitute_var(body, var_name, replacement))
+                    Box::new(substitute_var_impl(
+                        body,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    ))
                 },
-                then: Box::new(substitute_var(then, var_name, replacement)),
+                then: Box::new(substitute_var_impl(
+                    then,
+                    var_name,
+                    replacement,
+                    mark_trackable,
+                )),
             }
         }
         Expr::FuncCall { name, args } => Expr::FuncCall {
             name: name.clone(),
             args: args
                 .iter()
-                .map(|a| substitute_var(a, var_name, replacement))
+                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
                 .collect(),
         },
         Expr::NamespacedCall {
@@ -17219,26 +17613,66 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             name: name.clone(),
             args: args
                 .iter()
-                .map(|a| substitute_var(a, var_name, replacement))
+                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
                 .collect(),
         },
         // Assignment operators
         Expr::Assign { path, value } => Expr::Assign {
-            path: Box::new(substitute_var(path, var_name, replacement)),
-            value: Box::new(substitute_var(value, var_name, replacement)),
+            path: Box::new(substitute_var_impl(
+                path,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            value: Box::new(substitute_var_impl(
+                value,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::Update { path, filter } => Expr::Update {
-            path: Box::new(substitute_var(path, var_name, replacement)),
-            filter: Box::new(substitute_var(filter, var_name, replacement)),
+            path: Box::new(substitute_var_impl(
+                path,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            filter: Box::new(substitute_var_impl(
+                filter,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
             op: *op,
-            path: Box::new(substitute_var(path, var_name, replacement)),
-            value: Box::new(substitute_var(value, var_name, replacement)),
+            path: Box::new(substitute_var_impl(
+                path,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            value: Box::new(substitute_var_impl(
+                value,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
         Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
-            path: Box::new(substitute_var(path, var_name, replacement)),
-            value: Box::new(substitute_var(value, var_name, replacement)),
+            path: Box::new(substitute_var_impl(
+                path,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            value: Box::new(substitute_var_impl(
+                value,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         },
 
         // Label-break
@@ -17249,7 +17683,12 @@ fn substitute_var(expr: &Expr, var_name: &str, replacement: &OwnedValue) -> Expr
             } else {
                 Expr::Label {
                     name: name.clone(),
-                    body: Box::new(substitute_var(body, var_name, replacement)),
+                    body: Box::new(substitute_var_impl(
+                        body,
+                        var_name,
+                        replacement,
+                        mark_trackable,
+                    )),
                 }
             }
         }
@@ -17273,6 +17712,7 @@ fn substitute_var_in_builtin(
     builtin: &Builtin,
     var_name: &str,
     replacement: &OwnedValue,
+    mark_trackable: bool,
 ) -> Builtin {
     match builtin {
         Builtin::Type => Builtin::Type,
@@ -17295,180 +17735,533 @@ fn substitute_var_in_builtin(
         Builtin::Utf8ByteLength => Builtin::Utf8ByteLength,
         Builtin::Keys => Builtin::Keys,
         Builtin::KeysUnsorted => Builtin::KeysUnsorted,
-        Builtin::Has(e) => Builtin::Has(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::In(e) => Builtin::In(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::UpperIn(e) => Builtin::UpperIn(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Has(e) => Builtin::Has(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::In(e) => Builtin::In(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::UpperIn(e) => Builtin::UpperIn(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::UpperInSrc(src, s) => Builtin::UpperInSrc(
-            Box::new(substitute_var(src, var_name, replacement)),
-            Box::new(substitute_var(s, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                src,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                s,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Select(e) => Builtin::Select(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Select(e) => Builtin::Select(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Empty => Builtin::Empty,
-        Builtin::Map(e) => Builtin::Map(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::MapValues(e) => {
-            Builtin::MapValues(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::Map(e) => Builtin::Map(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::MapValues(e) => Builtin::MapValues(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Add => Builtin::Add,
         Builtin::Any => Builtin::Any,
-        Builtin::AnyF(e) => Builtin::AnyF(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::AnyF(e) => Builtin::AnyF(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::AnyCond(gen, cond) => Builtin::AnyCond(
-            Box::new(substitute_var(gen, var_name, replacement)),
-            Box::new(substitute_var(cond, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                gen,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                cond,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::All => Builtin::All,
-        Builtin::AllF(e) => Builtin::AllF(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::AllF(e) => Builtin::AllF(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::AllCond(gen, cond) => Builtin::AllCond(
-            Box::new(substitute_var(gen, var_name, replacement)),
-            Box::new(substitute_var(cond, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                gen,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                cond,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::Min => Builtin::Min,
         Builtin::Max => Builtin::Max,
-        Builtin::MinBy(e) => Builtin::MinBy(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::MaxBy(e) => Builtin::MaxBy(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::MinBy(e) => Builtin::MinBy(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::MaxBy(e) => Builtin::MaxBy(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::AsciiDowncase => Builtin::AsciiDowncase,
         Builtin::AsciiUpcase => Builtin::AsciiUpcase,
-        Builtin::Ltrimstr(e) => {
-            Builtin::Ltrimstr(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Rtrimstr(e) => {
-            Builtin::Rtrimstr(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Startswith(e) => {
-            Builtin::Startswith(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Endswith(e) => {
-            Builtin::Endswith(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Split(e) => Builtin::Split(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Join(e) => Builtin::Join(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Contains(e) => {
-            Builtin::Contains(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Inside(e) => Builtin::Inside(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Ltrimstr(e) => Builtin::Ltrimstr(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Rtrimstr(e) => Builtin::Rtrimstr(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Startswith(e) => Builtin::Startswith(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Endswith(e) => Builtin::Endswith(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Split(e) => Builtin::Split(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Join(e) => Builtin::Join(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Contains(e) => Builtin::Contains(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Inside(e) => Builtin::Inside(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::First => Builtin::First,
         Builtin::Last => Builtin::Last,
-        Builtin::Nth(e) => Builtin::Nth(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Nth(e) => Builtin::Nth(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Reverse => Builtin::Reverse,
         Builtin::Flatten => Builtin::Flatten,
-        Builtin::FlattenDepth(e) => {
-            Builtin::FlattenDepth(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::GroupBy(e) => Builtin::GroupBy(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::FlattenDepth(e) => Builtin::FlattenDepth(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::GroupBy(e) => Builtin::GroupBy(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Unique => Builtin::Unique,
-        Builtin::UniqueBy(e) => {
-            Builtin::UniqueBy(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::UniqueBy(e) => Builtin::UniqueBy(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Sort => Builtin::Sort,
-        Builtin::SortBy(e) => Builtin::SortBy(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::SortBy(e) => Builtin::SortBy(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::ToEntries => Builtin::ToEntries,
         Builtin::FromEntries => Builtin::FromEntries,
-        Builtin::WithEntries(e) => {
-            Builtin::WithEntries(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::WithEntries(e) => Builtin::WithEntries(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::ToString => Builtin::ToString,
         Builtin::ToNumber => Builtin::ToNumber,
         Builtin::ToJson => Builtin::ToJson,
         Builtin::FromJson => Builtin::FromJson,
         Builtin::Explode => Builtin::Explode,
         Builtin::Implode => Builtin::Implode,
-        Builtin::Test(e) => Builtin::Test(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Indices(e) => Builtin::Indices(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Index(e) => Builtin::Index(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Rindex(e) => Builtin::Rindex(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::UpperIndex(e) => {
-            Builtin::UpperIndex(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::Test(e) => Builtin::Test(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Indices(e) => Builtin::Indices(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Index(e) => Builtin::Index(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Rindex(e) => Builtin::Rindex(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::UpperIndex(e) => Builtin::UpperIndex(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::UpperIndexStream(stream, idx_expr) => Builtin::UpperIndexStream(
-            Box::new(substitute_var(stream, var_name, replacement)),
-            Box::new(substitute_var(idx_expr, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                stream,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                idx_expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::ToJsonStream => Builtin::ToJsonStream,
         Builtin::FromJsonStream => Builtin::FromJsonStream,
         Builtin::ToStream => Builtin::ToStream,
-        Builtin::FromStream(e) => {
-            Builtin::FromStream(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::TruncateStream(e) => {
-            Builtin::TruncateStream(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::GetPath(e) => Builtin::GetPath(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::FromStream(e) => Builtin::FromStream(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::TruncateStream(e) => Builtin::TruncateStream(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::GetPath(e) => Builtin::GetPath(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         // Phase 16: Regex Functions
         Builtin::TestFlags(re, flags) => Builtin::TestFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Match(re) => Builtin::Match(Box::new(substitute_var(re, var_name, replacement))),
+        Builtin::Match(re) => Builtin::Match(Box::new(substitute_var_impl(
+            re,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::MatchFlags(re, flags) => Builtin::MatchFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Capture(re) => {
-            Builtin::Capture(Box::new(substitute_var(re, var_name, replacement)))
-        }
+        Builtin::Capture(re) => Builtin::Capture(Box::new(substitute_var_impl(
+            re,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::CaptureFlags(re, flags) => Builtin::CaptureFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::Sub(re, repl) => Builtin::Sub(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(repl, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                repl,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::SubFlags(re, repl, flags) => Builtin::SubFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(repl, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                repl,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::Gsub(re, repl) => Builtin::Gsub(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(repl, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                repl,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::GsubFlags(re, repl, flags) => Builtin::GsubFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(repl, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                repl,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Scan(re) => Builtin::Scan(Box::new(substitute_var(re, var_name, replacement))),
+        Builtin::Scan(re) => Builtin::Scan(Box::new(substitute_var_impl(
+            re,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::ScanFlags(re, flags) => Builtin::ScanFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::SplitRegex(re, flags) => Builtin::SplitRegex(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Splits(re) => Builtin::Splits(Box::new(substitute_var(re, var_name, replacement))),
+        Builtin::Splits(re) => Builtin::Splits(Box::new(substitute_var_impl(
+            re,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::SplitsFlags(re, flags) => Builtin::SplitsFlags(
-            Box::new(substitute_var(re, var_name, replacement)),
-            Box::new(substitute_var(flags, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                re,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                flags,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         // Phase 8 builtins
         Builtin::Recurse => Builtin::Recurse,
-        Builtin::RecurseF(f) => {
-            Builtin::RecurseF(Box::new(substitute_var(f, var_name, replacement)))
-        }
+        Builtin::RecurseF(f) => Builtin::RecurseF(Box::new(substitute_var_impl(
+            f,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::RecurseCond(f, c) => Builtin::RecurseCond(
-            Box::new(substitute_var(f, var_name, replacement)),
-            Box::new(substitute_var(c, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                f,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                c,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::Walk(f) => Builtin::Walk(Box::new(substitute_var(f, var_name, replacement))),
-        Builtin::IsValid(e) => Builtin::IsValid(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Walk(f) => Builtin::Walk(Box::new(substitute_var_impl(
+            f,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::IsValid(e) => Builtin::IsValid(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         // Phase 10 builtins
-        Builtin::Path(e) => Builtin::Path(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Path(e) => Builtin::Path(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::PathNoArg => Builtin::PathNoArg,
         Builtin::Parent => Builtin::Parent,
-        Builtin::ParentN(e) => Builtin::ParentN(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::ParentN(e) => Builtin::ParentN(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Paths => Builtin::Paths,
-        Builtin::PathsFilter(e) => {
-            Builtin::PathsFilter(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::PathsFilter(e) => Builtin::PathsFilter(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::LeafPaths => Builtin::LeafPaths,
         Builtin::SetPath(p, v) => Builtin::SetPath(
-            Box::new(substitute_var(p, var_name, replacement)),
-            Box::new(substitute_var(v, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                p,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                v,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::DelPaths(e) => {
-            Builtin::DelPaths(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::DelPaths(e) => Builtin::DelPaths(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Floor => Builtin::Floor,
         Builtin::Ceil => Builtin::Ceil,
         Builtin::Round => Builtin::Round,
@@ -17481,8 +18274,18 @@ fn substitute_var_in_builtin(
         Builtin::Exp10 => Builtin::Exp10,
         Builtin::Exp2 => Builtin::Exp2,
         Builtin::Pow(x, y) => Builtin::Pow(
-            Box::new(substitute_var(x, var_name, replacement)),
-            Box::new(substitute_var(y, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                x,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                y,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::Sin => Builtin::Sin,
         Builtin::Cos => Builtin::Cos,
@@ -17491,8 +18294,18 @@ fn substitute_var_in_builtin(
         Builtin::Acos => Builtin::Acos,
         Builtin::Atan => Builtin::Atan,
         Builtin::Atan2(x, y) => Builtin::Atan2(
-            Box::new(substitute_var(x, var_name, replacement)),
-            Box::new(substitute_var(y, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                x,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                y,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
         Builtin::Sinh => Builtin::Sinh,
         Builtin::Cosh => Builtin::Cosh,
@@ -17507,17 +18320,28 @@ fn substitute_var_in_builtin(
         Builtin::IsNormal => Builtin::IsNormal,
         Builtin::IsFinite => Builtin::IsFinite,
         Builtin::Debug => Builtin::Debug,
-        Builtin::DebugMsg(e) => {
-            Builtin::DebugMsg(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::DebugMsg(e) => Builtin::DebugMsg(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Halt => Builtin::Halt,
         Builtin::Stderr => Builtin::Stderr,
         Builtin::HaltError => Builtin::HaltError,
-        Builtin::HaltErrorCode(e) => {
-            Builtin::HaltErrorCode(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::HaltErrorCode(e) => Builtin::HaltErrorCode(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Env => Builtin::Env,
-        Builtin::EnvVar(e) => Builtin::EnvVar(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::EnvVar(e) => Builtin::EnvVar(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::EnvObject(name) => Builtin::EnvObject(name.clone()),
         Builtin::StrEnv(name) => Builtin::StrEnv(name.clone()),
         Builtin::NullLit => Builtin::NullLit,
@@ -17525,12 +18349,30 @@ fn substitute_var_in_builtin(
         Builtin::Ltrim => Builtin::Ltrim,
         Builtin::Rtrim => Builtin::Rtrim,
         Builtin::Transpose => Builtin::Transpose,
-        Builtin::BSearch(e) => Builtin::BSearch(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::ModuleMeta(e) => {
-            Builtin::ModuleMeta(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Pick(e) => Builtin::Pick(Box::new(substitute_var(e, var_name, replacement))),
-        Builtin::Omit(e) => Builtin::Omit(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::BSearch(e) => Builtin::BSearch(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::ModuleMeta(e) => Builtin::ModuleMeta(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Pick(e) => Builtin::Pick(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Omit(e) => Builtin::Omit(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Tag => Builtin::Tag,
         Builtin::Anchor => Builtin::Anchor,
         Builtin::Style => Builtin::Style,
@@ -17544,7 +18386,12 @@ fn substitute_var_in_builtin(
         Builtin::Shuffle => Builtin::Shuffle,
         Builtin::Pivot => Builtin::Pivot,
         Builtin::SplitDoc => Builtin::SplitDoc,
-        Builtin::Del(e) => Builtin::Del(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Del(e) => Builtin::Del(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         // Phase 12 builtins (no args to substitute)
         Builtin::Now => Builtin::Now,
         Builtin::Input => Builtin::Input,
@@ -17556,32 +18403,69 @@ fn substitute_var_in_builtin(
         Builtin::Finites => Builtin::Finites,
         // Phase 13: Iteration control
         Builtin::Limit(n, e) => Builtin::Limit(
-            Box::new(substitute_var(n, var_name, replacement)),
-            Box::new(substitute_var(e, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                n,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                e,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::FirstStream(e) => {
-            Builtin::FirstStream(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::LastStream(e) => {
-            Builtin::LastStream(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::FirstStream(e) => Builtin::FirstStream(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::LastStream(e) => Builtin::LastStream(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::NthStream(n, e) => Builtin::NthStream(
-            Box::new(substitute_var(n, var_name, replacement)),
-            Box::new(substitute_var(e, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                n,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                e,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
-        Builtin::IsEmpty(e) => Builtin::IsEmpty(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::IsEmpty(e) => Builtin::IsEmpty(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         // Phase 14: Recursive traversal (extends Phase 8)
         Builtin::RecurseDown => Builtin::RecurseDown,
         // Phase 15: Date/Time functions
         Builtin::Gmtime => Builtin::Gmtime,
         Builtin::Localtime => Builtin::Localtime,
         Builtin::Mktime => Builtin::Mktime,
-        Builtin::Strftime(e) => {
-            Builtin::Strftime(Box::new(substitute_var(e, var_name, replacement)))
-        }
-        Builtin::Strptime(e) => {
-            Builtin::Strptime(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::Strftime(e) => Builtin::Strftime(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
+        Builtin::Strptime(e) => Builtin::Strptime(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::Todate => Builtin::Todate,
         Builtin::Fromdate => Builtin::Fromdate,
         Builtin::Todateiso8601 => Builtin::Todateiso8601,
@@ -17589,9 +18473,12 @@ fn substitute_var_in_builtin(
 
         // Phase 17: Combinations
         Builtin::Combinations => Builtin::Combinations,
-        Builtin::CombinationsN(e) => {
-            Builtin::CombinationsN(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::CombinationsN(e) => Builtin::CombinationsN(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
 
         // Phase 18: Additional math functions
         Builtin::Trunc => Builtin::Trunc,
@@ -17601,25 +18488,58 @@ fn substitute_var_in_builtin(
 
         // Phase 20: Iteration control extension
         Builtin::Skip(n, e) => Builtin::Skip(
-            Box::new(substitute_var(n, var_name, replacement)),
-            Box::new(substitute_var(e, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                n,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                e,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
 
         // Phase 21: Extended Date/Time functions (yq)
         Builtin::FromUnix => Builtin::FromUnix,
         Builtin::ToUnix => Builtin::ToUnix,
-        Builtin::Tz(e) => Builtin::Tz(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Tz(e) => Builtin::Tz(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
 
         // Phase 22: File operations (yq)
-        Builtin::Load(e) => Builtin::Load(Box::new(substitute_var(e, var_name, replacement))),
+        Builtin::Load(e) => Builtin::Load(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
 
         // Phase 23: Position-based navigation (succinctly extension)
-        Builtin::AtOffset(e) => {
-            Builtin::AtOffset(Box::new(substitute_var(e, var_name, replacement)))
-        }
+        Builtin::AtOffset(e) => Builtin::AtOffset(Box::new(substitute_var_impl(
+            e,
+            var_name,
+            replacement,
+            mark_trackable,
+        ))),
         Builtin::AtPosition(line, col) => Builtin::AtPosition(
-            Box::new(substitute_var(line, var_name, replacement)),
-            Box::new(substitute_var(col, var_name, replacement)),
+            Box::new(substitute_var_impl(
+                line,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            Box::new(substitute_var_impl(
+                col,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
         ),
     }
 }
@@ -17710,8 +18630,19 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // For each bound value, substitute and evaluate the body
     let mut all_results: Vec<OwnedValue> = Vec::new();
 
+    // #844: only a statically-verified passthrough of `.` is even a
+    // candidate for path()-trackability through this binding -- see
+    // `is_identity_passthrough`'s own doc comment. `resolve_node`'s
+    // `Expr::TrackedVar` arm still gates the actual trackability decision
+    // at use time, so wrapping here never risks emitting a wrong path.
+    let wrap_tracked = is_identity_passthrough(expr);
+
     for bound_val in bound_values {
-        let substituted_body = substitute_var(body, var, &bound_val);
+        let substituted_body = if wrap_tracked {
+            substitute_var_tracked(body, var, &bound_val)
+        } else {
+            substitute_var(body, var, &bound_val)
+        };
         match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
             QueryResult::One(v) => all_results.push(to_owned(&v)),
             QueryResult::OneCursor(_) => unreachable!(),
@@ -28570,6 +29501,10 @@ fn expand_func_calls(
         ),
         Expr::Format(f) => Expr::Format(f.clone()),
         Expr::Var(v) => Expr::Var(v.clone()),
+        // Never produced by the parser or by `def` inlining -- only by
+        // variable substitution during evaluation, which runs after this
+        // pass. Trivial pass-through kept for exhaustiveness (#844).
+        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
         Expr::Loc { line } => Expr::Loc { line: *line },
         Expr::Env => Expr::Env,
         Expr::As {
@@ -28970,6 +29905,10 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         // A variable reference to the parameter becomes the argument expression
         Expr::Var(name) if name == param => arg.clone(),
         Expr::Var(_) => expr.clone(),
+        // Never produced by the parser or by `def` inlining -- only by
+        // variable substitution during evaluation, which runs after this
+        // pass. Trivial pass-through kept for exhaustiveness (#844).
+        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
         Expr::Loc { line } => Expr::Loc { line: *line },
         Expr::Env => Expr::Env,
         Expr::Identity => Expr::Identity,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19,6 +19,11 @@ use alloc::vec::Vec;
 #[cfg(test)]
 use std::borrow::Cow;
 
+#[cfg(not(test))]
+use alloc::rc::Rc;
+#[cfg(test)]
+use std::rc::Rc;
+
 use core::cell::Cell;
 
 use indexmap::{IndexMap, IndexSet};
@@ -14900,19 +14905,9 @@ fn resolve_node<'a, S: EvalSemantics>(
         // completing — not nothing.
         Expr::As { expr, var, body } => {
             let (bound_values, trailing) = eval_owned_expr_fork::<S>(expr, value, false);
-            // #844: same bind-time gate as `eval_as` -- only a
-            // statically-verified passthrough of `.` is even a candidate
-            // for path()-trackability through this binding. The actual
-            // trackability decision is made lazily by `resolve_node`'s own
-            // `Expr::TrackedVar` arm, at each use site.
-            let wrap_tracked = is_identity_passthrough(expr);
             let mut out = Vec::new();
             for bound in bound_values {
-                let substituted = if wrap_tracked {
-                    substitute_var_tracked(body, var, &bound)
-                } else {
-                    substitute_var(body, var, &bound)
-                };
+                let substituted = substitute_bound_var(expr, body, var, &bound);
                 match resolve_node::<S>(&substituted, value, trackable) {
                     Ok(branches) => out.extend(branches),
                     Err((body_prefix, escape)) => {
@@ -16971,26 +16966,61 @@ where
     result
 }
 
-/// True if `expr` is nothing but `.`, statically -- gates whether an
-/// `as`-bound value is wrapped in `Expr::TrackedVar` at all (#844).
+/// True if `expr` is statically guaranteed to evaluate to `.` unchanged, in
+/// every case this function recognizes -- gates whether an `as`-bound value
+/// is wrapped in `Expr::TrackedVar` at all (#844). This check is
+/// deliberately syntactic, not "does the value happen to match" -- that
+/// runtime check happens separately, in `resolve_node`'s own
+/// `Expr::TrackedVar` arm, once a marker actually reaches a use site. So
+/// widening this predicate can never make `resolve_node` emit a *wrong*
+/// path (the runtime check still has the final say); it only changes which
+/// bindings even become trackability *candidates*.
 ///
-/// Real jq only ever preserves `path()` trackability through a variable
-/// bound from `.` itself, never from a literal, field access, or any other
-/// computation, regardless of what value it evaluates to (confirmed live:
-/// `0 as $x | path($x)` on input `0` still raises `Invalid path expression`
-/// in real jq, even though the bound value trivially equals `.` there). So
-/// this check is deliberately syntactic, not "does the value happen to
-/// match" -- that runtime check happens separately, in `resolve_node`'s own
-/// `Expr::TrackedVar` arm, once a marker actually reaches a use site.
+/// Recognizes, confirmed live against jq 1.7.1:
+/// - `Expr::Identity`/`Expr::TrackedVar` (the base cases -- the latter lets
+///   a chain of pure bindings compose: `. as $x | $x as $y | path($y|...)`
+///   still tracks `$y`, since by the time this predicate sees `$y`'s bind
+///   source it has already been substituted into a `TrackedVar` from the
+///   outer binding).
+/// - `Expr::Paren` (peeled via `unwrap_paren`; purely syntactic grouping).
+/// - `if C then A else B end`, when **both** `A` and `B` recognize as
+///   passthrough -- `C` decides which one runs, but either answer is `.`
+///   unchanged, so the branch actually taken doesn't need to be known
+///   statically (`. as $x | (if true then $x else $x end) as $y | ...`).
+///   A branch that *isn't* recognized (e.g. `if c then $x else $y end`
+///   where `$y` was itself bound from real navigation) makes the whole
+///   `if` untracked, even when `c` happens to always pick the recognized
+///   branch -- this predicate does not evaluate `c`.
+/// - `try A catch B`, requiring **only** `A` -- unlike `if`, `B` can be
+///   ignored rather than also required: every expression this predicate
+///   recognizes is built from primitives that cannot themselves raise, so
+///   a recognized `A` provably never reaches `B` at all
+///   (`. as $x | (try $x catch "whatever") as $y | ...` still tracks `$y`
+///   even though `"whatever"` alone would not qualify on its own).
+/// - `A // B`, requiring **only** `A` -- `B` only runs when `A` is
+///   null/false/absent, which a recognized `A` (e.g. bare `.`) can
+///   genuinely be at runtime, so this is a deliberate, safe
+///   under-approximation: `false // $x` tracks in real jq but not here,
+///   because whether `A`'s *value* ends up falsy isn't something this
+///   static check can see. Matches the confirmed case
+///   (`. as $x | ($x // 5) as $y | ...`, where `$x` is truthy and thus
+///   always the value actually used) without over-claiming the reverse.
 ///
-/// `Expr::TrackedVar` counts as passthrough too, so a chain of pure
-/// bindings composes: `. as $x | $x as $y | path($y | ...)` still tracks
-/// `$y`, because by the time this predicate sees `$y`'s bind source, it has
-/// already been substituted into a `TrackedVar` from the outer binding.
+/// Not recognized, deliberately: a plain literal/computation, even one
+/// whose *value* happens to equal `.` at runtime (confirmed live: `0 as $x
+/// | path($x)` on input `0` still raises `Invalid path expression` in real
+/// jq, even though the bound value trivially equals `.` there) -- matching
+/// jq's actual rule takes a syntactic passthrough, not mere value equality.
 fn is_identity_passthrough(expr: &Expr) -> bool {
-    match expr {
+    match unwrap_paren(expr) {
         Expr::Identity | Expr::TrackedVar(_) => true,
-        Expr::Paren(inner) => is_identity_passthrough(inner),
+        Expr::If {
+            then_branch,
+            else_branch,
+            ..
+        } => is_identity_passthrough(then_branch) && is_identity_passthrough(else_branch),
+        Expr::Try { expr, .. } => is_identity_passthrough(expr),
+        Expr::Alternative(left, _) => is_identity_passthrough(left),
         _ => false,
     }
 }
@@ -17014,6 +17044,27 @@ fn substitute_var_tracked(expr: &Expr, var_name: &str, replacement: &OwnedValue)
     substitute_var_impl(expr, var_name, replacement, true)
 }
 
+/// Substitute `bound` for `$var_name` in `body`, choosing between
+/// `substitute_var`/`substitute_var_tracked` based on whether `bind_expr`
+/// (the `as`-binding's own source expression) is a statically-verified
+/// passthrough of `.` (`is_identity_passthrough`).
+///
+/// Shared by `eval_as` (value-position `E as $x | body`) and
+/// `resolve_node`'s `Expr::As` arm (path-position, when the whole binding
+/// sits inside `path(...)`'s own argument) -- the two independent call
+/// sites #844 fixed. Extracted so a future refinement of the gate only has
+/// to change this one place to stay in sync at both; the two arms
+/// duplicating this `if` verbatim was flagged in #844's own review as
+/// exactly the kind of two-call-site asymmetry the issue was filed to fix
+/// in the first place.
+fn substitute_bound_var(bind_expr: &Expr, body: &Expr, var_name: &str, bound: &OwnedValue) -> Expr {
+    if is_identity_passthrough(bind_expr) {
+        substitute_var_tracked(body, var_name, bound)
+    } else {
+        substitute_var(body, var_name, bound)
+    }
+}
+
 /// Substitute a variable in an expression with a value.
 /// Returns a new expression with the variable replaced. `mark_trackable`
 /// selects whether a substituted `$var_name` becomes an `Expr::TrackedVar`
@@ -17029,7 +17080,7 @@ fn substitute_var_impl(
     match expr {
         Expr::Var(name) if name == var_name => {
             if mark_trackable {
-                Expr::TrackedVar(Box::new(replacement.clone()))
+                Expr::TrackedVar(Rc::new(replacement.clone()))
             } else {
                 owned_to_expr(replacement)
             }
@@ -18630,19 +18681,8 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // For each bound value, substitute and evaluate the body
     let mut all_results: Vec<OwnedValue> = Vec::new();
 
-    // #844: only a statically-verified passthrough of `.` is even a
-    // candidate for path()-trackability through this binding -- see
-    // `is_identity_passthrough`'s own doc comment. `resolve_node`'s
-    // `Expr::TrackedVar` arm still gates the actual trackability decision
-    // at use time, so wrapping here never risks emitting a wrong path.
-    let wrap_tracked = is_identity_passthrough(expr);
-
     for bound_val in bound_values {
-        let substituted_body = if wrap_tracked {
-            substitute_var_tracked(body, var, &bound_val)
-        } else {
-            substitute_var(body, var, &bound_val)
-        };
+        let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
         match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
             QueryResult::One(v) => all_results.push(to_owned(&v)),
             QueryResult::OneCursor(_) => unreachable!(),
@@ -29501,9 +29541,15 @@ fn expand_func_calls(
         ),
         Expr::Format(f) => Expr::Format(f.clone()),
         Expr::Var(v) => Expr::Var(v.clone()),
-        // Never produced by the parser or by `def` inlining -- only by
-        // variable substitution during evaluation, which runs after this
-        // pass. Trivial pass-through kept for exhaustiveness (#844).
+        // Genuinely reachable, not just a totality formality: this
+        // function re-runs on every `Expr::FuncDef` *evaluation* (its own
+        // call site inlines `def`s at the point they execute, not once at
+        // parse time), and a `def`'s own body can already contain a
+        // `TrackedVar` from an enclosing `as`-binding -- confirmed live,
+        // `. as $x | def f: $x | .b; path(f)` reaches this arm. `v.clone()`
+        // is an O(1) `Rc` refcount bump, not a deep copy of the frozen
+        // snapshot, so re-inlining a `def` that closes over a large
+        // passthrough-bound value on every call stays cheap (#844).
         Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
         Expr::Loc { line } => Expr::Loc { line: *line },
         Expr::Env => Expr::Env,
@@ -29905,9 +29951,13 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         // A variable reference to the parameter becomes the argument expression
         Expr::Var(name) if name == param => arg.clone(),
         Expr::Var(_) => expr.clone(),
-        // Never produced by the parser or by `def` inlining -- only by
-        // variable substitution during evaluation, which runs after this
-        // pass. Trivial pass-through kept for exhaustiveness (#844).
+        // Genuinely reachable, not just a totality formality: called from
+        // `expand_func_calls` to bind a `def`'s own `$`-parameters at every
+        // call site, and the `def`'s body can already contain a
+        // `TrackedVar` from an enclosing `as`-binding unrelated to `param`
+        // -- see `expand_func_calls`'s own `Expr::TrackedVar` arm for the
+        // confirmed repro. `v.clone()` is an `Rc` refcount bump, not a
+        // deep copy (#844).
         Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
         Expr::Loc { line } => Expr::Loc { line: *line },
         Expr::Env => Expr::Env,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -51547,4 +51547,120 @@ mod tests {
         assert_tag_agrees!(b"[1]", OwnedValue::Array(vec![OwnedValue::Int(1)]));
         assert_tag_agrees!(b"{}", OwnedValue::Object(IndexMap::new()));
     }
+
+    // #844: `path()` losing trackability through an `as`-bound variable
+    // whose source is a pure passthrough of `.` -- see
+    // `is_identity_passthrough` and `resolve_node`'s `Expr::TrackedVar` arm.
+    // All expected outputs below are confirmed against real jq 1.7.1.
+
+    /// The issue's own repro: `$orig` is bound one step *before* `path(...)`
+    /// even starts, from `.` itself. Real jq resolves this as `["b"]` --
+    /// succinctly used to raise "Invalid path expression near attempt to
+    /// access element \"b\" of {...}" instead, because `eval_as` (the
+    /// value-position `as` evaluator, entirely separate from `resolve_node`)
+    /// discarded `$orig`'s provenance before `path(...)` ever started
+    /// resolving.
+    #[test]
+    fn test_path_tracks_variable_bound_from_identity_outside_path_844() {
+        assert_eq!(
+            outputs(br#"{"a":1,"b":2}"#, r". as $orig | path($orig | .b)"),
+            [r#"["b"]"#]
+        );
+    }
+
+    /// Negative control: a variable bound from genuine navigation (`.a`,
+    /// not `.` itself) must keep raising -- real jq does not track it
+    /// either, and uses the same "near attempt" wording this fix must not
+    /// accidentally start suppressing. Confirmed against jq 1.7.1.
+    #[test]
+    fn test_path_does_not_track_variable_bound_from_navigation_844() {
+        query!(br#"{"a":{"c":5}}"#, r".a as $x | path($x | .c)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    r#"Invalid path expression near attempt to access element "c" of {"c":5}"#
+                );
+            }
+        );
+    }
+
+    /// A `Comma` sibling untouched by the untracked variable must keep
+    /// resolving on its own merits -- this is the exact case that sank an
+    /// earlier, released attempt at #844: a naive fix that flips one
+    /// `trackable` flag for the whole substituted `body` would have
+    /// poisoned `.other.o` here too. Per-branch trackability (already
+    /// established by #986/#989) means `Expr::TrackedVar`'s own use-time
+    /// check only ever affects its own branch.
+    #[test]
+    fn test_path_comma_sibling_independent_of_untracked_variable_844() {
+        assert_eq!(
+            outputs(
+                br#"{"other":{"o":1},"a":{"c":5}}"#,
+                r"path(.a as $x | (.other.o, ($x | .c)))"
+            ),
+            [r#"["other","o"]"#]
+        );
+        query!(
+            br#"{"other":{"o":1},"a":{"c":5}}"#,
+            r"path(.a as $x | (.other.o, ($x | .c)))",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["other","o"]"#]);
+                assert_eq!(
+                    e.message,
+                    r#"Invalid path expression near attempt to access element "c" of {"c":5}"#
+                );
+            }
+        );
+    }
+
+    /// The same fix also has to cover a binding made *inside* `path()`'s
+    /// own argument -- `resolve_node`'s own `Expr::As` arm, a second,
+    /// independent call site of the same lossy `substitute_var` machinery
+    /// `eval_as` uses.
+    #[test]
+    fn test_path_tracks_variable_bound_from_identity_inside_path_844() {
+        assert_eq!(
+            outputs(br#"{"a":1,"b":2}"#, r"path(. as $x | $x.b)"),
+            [r#"["b"]"#]
+        );
+    }
+
+    /// Chained passthrough bindings compose: `is_identity_passthrough`
+    /// treats an already-substituted `Expr::TrackedVar` as a passthrough
+    /// too, so `$y` stays trackable even though its own bind source is
+    /// `$x`, not `.` directly.
+    #[test]
+    fn test_path_tracks_chained_passthrough_bindings_844() {
+        assert_eq!(
+            outputs(br#"{"a":1,"b":2}"#, r". as $x | $x as $y | path($y | .b)"),
+            [r#"["b"]"#]
+        );
+    }
+
+    /// The fix isn't `path()`-only: `resolve_dynamic_indexes`/`resolve_node`
+    /// back all four path-consuming entry points, so plain assignment and
+    /// `del()` through a passthrough-bound variable are fixed for free.
+    #[test]
+    fn test_assign_and_del_track_variable_bound_from_identity_844() {
+        assert_eq!(outputs(br#"{"a":1}"#, r". as $x | $x = 5"), ["5"]);
+        assert_eq!(outputs(br#"{"a":1}"#, r". as $x | del($x.a)"), ["{}"]);
+    }
+
+    /// Bind-time gate probe: real jq does *not* track a variable merely
+    /// because its bound value happens to equal the ambient position at
+    /// use time -- the bind *source* itself must be a syntactic passthrough
+    /// of `.`. `0 as $x | path($x)` on input `0` still raises in real jq
+    /// even though `$x`'s value trivially equals `.` -- confirmed live.
+    /// This is exactly what `is_identity_passthrough`'s bind-time gate (as
+    /// opposed to relying solely on `resolve_node`'s use-time
+    /// value-equality check) exists to prevent.
+    #[test]
+    fn test_path_does_not_track_variable_bound_from_literal_844() {
+        query!(b"0", r"0 as $x | path($x)",
+            QueryResult::Error(e) => {
+                assert!(e.is_invalid_path_expression());
+                assert_eq!(e.message, "Invalid path expression with result 0");
+            }
+        );
+    }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -51713,4 +51713,111 @@ mod tests {
             }
         );
     }
+
+    // #844 review: `is_identity_passthrough` originally recognized only a
+    // bare `.` (and a chained `TrackedVar`), missing several shapes real jq
+    // still tracks. These extend the gate to `if`/`try`/`//` -- every case
+    // below is confirmed against jq 1.7.1.
+
+    /// `if C then A else B end` tracks when **both** branches are
+    /// passthrough, regardless of which one `C` actually picks -- this
+    /// predicate never evaluates `C`.
+    #[test]
+    fn test_path_tracks_if_with_both_branches_passthrough_844() {
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r". as $x | (if true then $x else $x end) as $y | path($y.b)"
+            ),
+            [r#"["b"]"#]
+        );
+    }
+
+    /// Negative control: an `if` where only *one* branch is passthrough
+    /// stays untracked even when the taken branch happens to be the
+    /// passthrough one -- the gate is purely syntactic, not evaluated.
+    #[test]
+    fn test_path_does_not_track_if_with_one_non_passthrough_branch_844() {
+        query!(br#"{"a":{"c":5}}"#,
+            r".a as $x | . as $y | (if true then $x else $y end) as $z | path($z.c)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    r#"Invalid path expression near attempt to access element "c" of {"c":5}"#
+                );
+            }
+        );
+    }
+
+    /// `try A catch B` tracks based on `A` alone -- `B` is never required
+    /// to be passthrough, since every expression this predicate recognizes
+    /// is built from primitives that cannot themselves raise, so a
+    /// recognized `A` provably never reaches `B`.
+    #[test]
+    fn test_path_tracks_try_catch_ignoring_catch_shape_844() {
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r#". as $x | (try $x catch "unused") as $y | path($y.b)"#
+            ),
+            [r#"["b"]"#]
+        );
+    }
+
+    /// `A // B` tracks based on `A` alone -- confirmed against the
+    /// asymmetric case: `$x // 5` tracks (`$x` truthy, `5` never used;
+    /// `5` alone would not qualify), but `5 // $x` does not (a literal
+    /// `A`, even though `$x`'s branch is provably never taken either,
+    /// stays untracked -- this predicate does not know `5` is truthy any
+    /// more than it evaluates `if`'s `C`).
+    #[test]
+    fn test_path_tracks_alternative_left_ignoring_right_shape_844() {
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r". as $x | ($x // 5) as $y | path($y.b)"
+            ),
+            [r#"["b"]"#]
+        );
+        query!(br#"{"a":1,"b":2}"#, r". as $x | (5 // $x) as $y | path($y.b)",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    r#"Invalid path expression near attempt to access element "b" of 5"#
+                );
+            }
+        );
+    }
+
+    /// `Expr::TrackedVar` switched from `Box` to `Rc` specifically so that
+    /// re-embedding a passthrough-bound variable into a fresh substituted
+    /// `Expr` tree on every loop iteration is an O(1) refcount bump, not an
+    /// O(document size) deep copy -- a multi-second regression on
+    /// `path(. as $root | .records[] as $rec | $root.root_marker[0])`,
+    /// found in #844's own review. That regression lives specifically in
+    /// `resolve_node`'s own `Expr::As` arm (reached because the *whole*
+    /// filter, including the inner `.records[] as $rec` loop, sits inside
+    /// `path(...)`'s own argument, not in `eval_as`/`eval_single`'s
+    /// ordinary value-position dispatch), so this pins the same shape,
+    /// still inside `path(...)`, at a size where an accidental revert to
+    /// per-iteration deep-cloning would be slow to run under `cargo test`.
+    /// Doesn't re-measure wall-clock time (too flaky for a unit test) --
+    /// just pins that this shape still resolves correctly.
+    #[test]
+    fn test_path_tracks_variable_referenced_in_a_loop_844() {
+        let mut json = String::from(r#"{"root_marker":["hit"],"records":["#);
+        for i in 0..300 {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&i.to_string());
+        }
+        json.push_str("]}");
+        let paths = outputs(
+            json.as_bytes(),
+            r"path(. as $root | .records[] as $rec | $root.root_marker[0])",
+        );
+        assert_eq!(paths.len(), 300);
+        assert!(paths.iter().all(|p| p == r#"["root_marker",0]"#));
+    }
 }

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 #[cfg(test)]
 use std::collections::BTreeMap;
 
-use super::value::NumberRepr;
+use super::value::{NumberRepr, OwnedValue};
 
 /// A jq expression representing a query path.
 #[derive(Debug, Clone, PartialEq)]
@@ -262,6 +262,15 @@ pub enum Expr {
 
     /// Variable reference: `$x`
     Var(String),
+
+    /// A frozen variable snapshot, synthesized only by variable
+    /// substitution (`substitute_var_tracked`/`substitute_var_impl` in
+    /// `eval.rs`) to replace an `Expr::Var` reference whose bind source
+    /// was, at bind time, a pure passthrough of `.` -- never produced by
+    /// the parser. `resolve_node`'s own arm for this variant decides
+    /// path-trackability lazily, by comparing this snapshot against the
+    /// ambient value it holds at the point of use (#844).
+    TrackedVar(Box<OwnedValue>),
 
     /// Location reference: `$__loc__`
     /// Returns `{"file": "<stdin>", "line": N}` where N is the 1-based line number

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -5,11 +5,15 @@ use alloc::boxed::Box;
 #[cfg(not(test))]
 use alloc::collections::BTreeMap;
 #[cfg(not(test))]
+use alloc::rc::Rc;
+#[cfg(not(test))]
 use alloc::string::String;
 #[cfg(not(test))]
 use alloc::vec::Vec;
 #[cfg(test)]
 use std::collections::BTreeMap;
+#[cfg(test)]
+use std::rc::Rc;
 
 use super::value::{NumberRepr, OwnedValue};
 
@@ -270,7 +274,18 @@ pub enum Expr {
     /// the parser. `resolve_node`'s own arm for this variant decides
     /// path-trackability lazily, by comparing this snapshot against the
     /// ambient value it holds at the point of use (#844).
-    TrackedVar(Box<OwnedValue>),
+    ///
+    /// `Rc`, not `Box`: a `$var` bound once outside a loop and referenced
+    /// inside it gets re-embedded into a fresh substituted `Expr` tree on
+    /// every loop iteration (`substitute_var_impl`'s ordinary AST-rebuild),
+    /// and every one of those rebuilds clones this node. A `Box` clone
+    /// deep-copies the whole snapshot -- O(document size) per iteration,
+    /// measured as a genuine multi-second regression on a "bind the root
+    /// once, loop, dereference it" filter (#844 review). `Rc::clone` is an
+    /// O(1) refcount bump, so the snapshot is allocated once at the outer
+    /// binding and shared, not repeatedly re-copied, by every inner
+    /// iteration that re-embeds it.
+    TrackedVar(Rc<OwnedValue>),
 
     /// Location reference: `$__loc__`
     /// Returns `{"file": "<stdin>", "line": N}` where N is the 1-based line number


### PR DESCRIPTION
## Summary

Fixes #844: `. as $orig | path($orig | .b)` raised `Invalid path expression` in succinctly's jq/yq even though real jq resolves it to `["b"]`. `$orig` is bound one step *before* `path(...)` starts, from `.` itself — real jq preserves path-trackability through a variable only when its bind source is a syntactic passthrough of `.`; genuine navigation (`.a as $x | ...`) does not survive either way, and this fix keeps that negative case intact.

Two independent call sites of `substitute_var` (`eval_as` for bindings outside `path()`, `resolve_node`'s own `Expr::As` arm for bindings inside it) discarded a variable's provenance the moment they spliced its bound value into the AST as a plain literal/object/array node, so `resolve_node`'s catch-all always marked it untrackable regardless of where the value actually came from.

- Adds `Expr::TrackedVar`, a parser-unreachable AST marker synthesized only when the bind source is statically verified as a passthrough of `.` (`is_identity_passthrough`).
- `resolve_node`'s new arm for it decides trackability **lazily**, at each use site, by comparing the frozen snapshot to the ambient value — sound even when `.` changes between bind and use (falls back to untracked, never emits a wrong path), and correct with respect to `Comma`-sibling independence (the case that sank an earlier, released attempt at this exact issue).
- `substitute_var` is split into `substitute_var`/`substitute_var_tracked` thin wrappers over a shared `substitute_var_impl`, so none of the ~150 unrelated pre-existing callers (destructuring, `--arg`/`--argjson` splicing, CLI) change behavior.
- The fix isn't `path()`-only — `resolve_dynamic_indexes`/`resolve_node` back all four path-consuming entry points, so `=`/`del()` through a passthrough-bound variable are fixed for free.

## Test plan

- [x] `cargo build` clean under `cli`, `--all-features`, and `--no-default-features` (no_std)
- [x] Both CI clippy legs (`--all-targets --all-features` and the SIMD feature-set leg) clean with `-D warnings`
- [x] 7 new regression tests colocated with the existing #843/#986/#989 trackability tests, covering: the issue's repro, a negative control (navigation-sourced binding must keep erroring), `Comma`-sibling independence, the inner `resolve_node::Expr::As` binding site, chained passthrough bindings, assign/`del` through a passthrough-bound variable, and a bind-time-gate probe (`0 as $x | path($x)` must still error)
- [x] Full oracle differential against real `jq` 1.7.1 for every case above — all match exactly
- [x] Full `cargo test` suite: 0 failures across every test binary