### PR TITLE
fix(jq): first(a, b) stops at the first sibling that yields, in eval_generic (#820 Stage 2b)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3125,6 +3125,16 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     want_last: bool,
 ) -> GenericResult<V> {
+    // `first` over a comma stops at the first sibling that yields an output,
+    // so later siblings are never evaluated (#820 Stage 2b). `last` cannot
+    // short-circuit -- it does not know a value is the last until the stream
+    // is exhausted -- so it keeps the eager path below.
+    if !want_last {
+        if let Some(result) = first_over_comma_generic::<S, V>(inner, &value, optional, cursor) {
+            return result;
+        }
+    }
+
     let result = eval_single::<S, V>(inner, value, optional, cursor);
     if want_last {
         match result {
@@ -3169,43 +3179,88 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),
         }
     } else {
-        match result {
-            GenericResult::One(v) => GenericResult::One(v),
-            GenericResult::OneCursor(c) => GenericResult::OneCursor(c),
-            GenericResult::Many(vs) => match vs.into_iter().next() {
-                Some(v) => GenericResult::One(v),
-                None => GenericResult::None,
-            },
-            GenericResult::ManyCursor(cs) => match cs.into_iter().next() {
-                Some(c) => GenericResult::OneCursor(c),
-                None => GenericResult::None,
-            },
-            GenericResult::Owned(v) => GenericResult::Owned(v),
-            GenericResult::ManyOwned(vs) => match vs.into_iter().next() {
-                Some(v) => GenericResult::Owned(v),
-                None => GenericResult::None,
-            },
-            // Same forwarding as the `want_last` branch above.
-            GenericResult::LazyKeys { fields, sorted } => {
-                GenericResult::LazyKeys { fields, sorted }
-            }
-            GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
-            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
-            GenericResult::None => GenericResult::None,
-            GenericResult::Error(e) => GenericResult::Error(e),
-            GenericResult::Break(label) => GenericResult::Break(label),
-            GenericResult::Halt(code) => GenericResult::Halt(code),
-            // jq's generator-based `first` never asks for values past the
-            // first (verified: `first(1,2,error("x"))` is `1`, exit 0 -- the
-            // error is never reached), so a non-empty prefix always
-            // satisfies it and the trailing control is dropped. `Partial`'s
-            // prefix is never empty by construction (matches
-            // `eval::eval_first_expr`).
-            GenericResult::Partial(vs, _control) => {
-                GenericResult::Owned(vs.into_iter().next().expect("Partial prefix non-empty"))
-            }
+        take_first_generic(result).unwrap_or(GenericResult::None)
+    }
+}
+
+/// The first output of `result`, or `None` if it produced none.
+///
+/// Extracted from `eval_first_or_last_generic`'s own `first` branch so that
+/// [`first_over_comma_generic`] can reuse it per comma sibling. `None` means
+/// "this stream was empty" — which for a bare `first(f)` is `GenericResult::None`,
+/// but for one sibling of `first(a, b)` means "try `b`".
+fn take_first_generic<V: DocumentValue>(result: GenericResult<V>) -> Option<GenericResult<V>> {
+    match result {
+        GenericResult::One(v) => Some(GenericResult::One(v)),
+        GenericResult::OneCursor(c) => Some(GenericResult::OneCursor(c)),
+        GenericResult::Many(vs) => vs.into_iter().next().map(GenericResult::One),
+        GenericResult::ManyCursor(cs) => cs.into_iter().next().map(GenericResult::OneCursor),
+        GenericResult::Owned(v) => Some(GenericResult::Owned(v)),
+        GenericResult::ManyOwned(vs) => vs.into_iter().next().map(GenericResult::Owned),
+        // Each of these is exactly one output of `inner`'s stream, forwarded
+        // unchanged so laziness survives `first(...)`; `first` only needs to
+        // know *which* output this is, never to inspect it.
+        GenericResult::LazyKeys { fields, sorted } => {
+            Some(GenericResult::LazyKeys { fields, sorted })
+        }
+        GenericResult::LazyIndexRange(len) => Some(GenericResult::LazyIndexRange(len)),
+        GenericResult::LazySeq(seq) => Some(GenericResult::LazySeq(seq)),
+        GenericResult::None => None,
+        GenericResult::Error(e) => Some(GenericResult::Error(e)),
+        GenericResult::Break(label) => Some(GenericResult::Break(label)),
+        GenericResult::Halt(code) => Some(GenericResult::Halt(code)),
+        // jq's generator-based `first` never asks for values past the first
+        // (verified: `first(1,2,error("x"))` is `1`, exit 0 -- the error is
+        // never reached), so a non-empty prefix always satisfies it and the
+        // trailing control is dropped. `Partial`'s prefix is never empty by
+        // construction (matches `eval::eval_first_expr`).
+        GenericResult::Partial(vs, _control) => Some(GenericResult::Owned(
+            vs.into_iter().next().expect("Partial prefix non-empty"),
+        )),
+    }
+}
+
+/// `first(a, b, ...)` evaluated one comma sibling at a time, stopping at the
+/// first that yields an output — #820 Stage 2b.
+///
+/// Returns `None` when `inner` is not a comma, leaving the caller on its
+/// existing eager path.
+///
+/// **Why this exists at all.** Stage 2 made `eval::eval_first_expr` lazy, but
+/// the CLI never reaches it for a bare `first(...)`: `jq_runner` enters
+/// `eval_generic::eval_with_cursor`, and `Expr::FirstExpr` has a native arm
+/// here (kept cursor-preserving for #607), so the subtree never crosses into
+/// `eval.rs`. `limit`/`nth`/`isempty` have no native arm and do bounce, which
+/// is exactly why Stage 2 fixed them and left `first` leaking.
+///
+/// This is deliberately the *narrow* fix the design's Stage 2b names as option
+/// (b): it closes `first(1, stderr)` and — the reason it is not merely
+/// cosmetic — `first(1, input)`, where the discarded branch was **consuming a
+/// document** the CLI's driver loop then never processed. It does **not**
+/// close `first(.[] | stderr)`, which is a `Pipe` and needs real per-output
+/// backtracking; that is option (c), mirroring `Demand`/`Item`/`Flow` into
+/// this module, filed as a follow-up.
+fn first_over_comma_generic<S: EvalSemantics, V: DocumentValue>(
+    inner: &Expr,
+    value: &V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> Option<GenericResult<V>> {
+    let Expr::Comma(exprs) = unwrap_paren(inner) else {
+        return None;
+    };
+    for e in exprs {
+        // Each sibling is evaluated only once the previous one has been shown
+        // to produce nothing -- so a side-effecting or input-consuming sibling
+        // past the answer is never reached, matching jq's `label $out | (f,
+        // break $out)`.
+        let result = eval_single::<S, V>(e, value.clone(), optional, cursor);
+        if let Some(first) = take_first_generic(result) {
+            return Some(first);
         }
     }
+    // Every sibling was empty, so the comma as a whole produced nothing.
+    Some(GenericResult::None)
 }
 
 /// Apply one resolved key to one target value.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15621,6 +15621,10 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
         ),
         (&["-cn", r#"limit(1; 1, ("B"|stderr))"#], None, "1\n", "", 0),
         (&["-cn", r#"nth(0; 1, ("B"|stderr))"#], None, "1\n", "", 0),
+        // Closed by Stage 2b: `first` over a comma now stops at the first
+        // sibling that yields, inside `eval_generic`'s own native arm.
+        (&["-cn", r#"first(1, ("B"|stderr))"#], None, "1\n", "", 0),
+        (&["-cn", r#"first((1, ("B"|stderr)))"#], None, "1\n", "", 0),
         // Reached through a subtree that has already bounced into `eval.rs`,
         // so `eval_first_expr`'s own rewrite is what closes this one -- unlike
         // a bare `first(...)`, which `eval_generic` still intercepts natively
@@ -15710,14 +15714,10 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // `first(f)` has a NATIVE arm in `eval_generic.rs`
-        // (`eval_first_or_last_generic`, kept cursor-preserving for #607), and
-        // the CLI always enters `eval_generic` first -- so an `eval.rs`-only
-        // fix never reaches it. `limit`/`nth`/`isempty` have no generic arm
-        // and bounce to `eval.rs`, which is why they are fixed in the test
-        // above while these two are not. Closed by Stage 2b. jq: no stderr.
-        (&["-cn", r#"first(1, ("B"|stderr))"#], None, "1\n", "B", 0),
-        // jq writes exactly one `1`; the generic Comma arm runs both.
+        // `first(.[] | stderr)` is a *Pipe*, not a Comma, so Stage 2b's
+        // sibling walk does not reach it -- it needs real per-output
+        // backtracking inside `eval_generic` (design option (c), mirroring
+        // Demand/Item/Flow into that module). jq writes exactly one `1`.
         (
             &["-c", "first(.[] | stderr)"],
             Some("[1,2]"),
@@ -15820,15 +15820,15 @@ fn test_discarded_generator_branch_consumes_input_documents_820() -> Result<()> 
         "every document must still be processed"
     );
 
-    // STILL divergent until Stage 2b: `first(f)` is intercepted by
-    // `eval_generic`'s own native arm (kept cursor-preserving for #607), so it
-    // never reaches `eval.rs`'s now-lazy `eval_first_expr`.
-    // jq: [1,1] [1,2] [1,3] [1,4].
+    // FIXED by Stage 2b: `first` over a comma stops at the first sibling that
+    // yields, inside `eval_generic`'s own native arm -- so the discarded
+    // `input` branch is never evaluated here either. With this, every
+    // document-consuming shape #820 exposed matches jq.
     let (stdout, _, code) = run_jq_full(&["-c", "[first(1, input), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0);
     assert_eq!(
-        (stdout.as_str(), code),
-        ("[1,1]\n[1,3]\n", 0),
-        "documents 2 and 4 are still consumed -- Stage 2b"
+        stdout, "[1,1]\n[1,2]\n[1,3]\n[1,4]\n",
+        "every document must still be processed"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

**Stage 2b** of [`docs/plan/jq-lazy-generator-consumers.md`](https://github.com/rust-works/succinctly/blob/main/docs/plan/jq-lazy-generator-consumers.md). Closes **#1434** — and with it **the last document-consuming shape #820 exposed**.

## Why Stage 2 didn't already fix this

Stage 2 made `eval::eval_first_expr` lazy, but **the CLI never reaches it for a bare
`first(...)`**. `jq_runner` enters `eval_generic::eval_with_cursor`, and `Expr::FirstExpr` has a
native arm there (`eval_first_or_last_generic`, kept cursor-preserving for #607), so the subtree
never crosses into `eval.rs`. `limit`/`nth`/`isempty` have no native generic arm and *do* bounce
— which is exactly why Stage 2 fixed those and left `first` leaking:

```
$ succinctly jq -cn 'limit(1; 1, stderr)'    1     (no stderr)   <- fixed by Stage 2
$ succinctly jq -cn 'first(1, stderr)'       1     stderr: null  <- still leaked
```

And it was destroying data:

```
$ printf '{"id":1} {"id":2} {"id":3} {"id":4}' | jq -c '[first(1, input), .id]'
[1,1] [1,2] [1,3] [1,4]
before: [1,1] [1,3]                # documents 2 and 4 consumed by the discarded branch
after:  [1,1] [1,2] [1,3] [1,4]    # == jq
```

## What this does

The design's **option (b)**: walk `first(a, b, ...)` one comma sibling at a time
(paren-unwrapping), stopping at the first that yields an output. The existing eager path and the
new walk now share an extracted `take_first_generic` helper, rather than duplicating the
twelve-arm `GenericResult` match.

**Rejected — option (a)**, narrowing the native arm by a syntactic "contains
`stderr`/`halt_error`" predicate. Such a predicate rots, and it would not catch `input` at all,
which is the half that destroys data.

**Deferred — option (c)**, mirroring `Demand`/`Item`/`Flow` into `eval_generic.rs` for
`Comma`/`Pipe`/`Paren` (~150 lines). That is the principled endgame and the only option that also
closes `first(.[] | stderr)`, which is a `Pipe` and needs real per-output backtracking. Filed as
a follow-up; that shape stays pinned as still-divergent in
`test_short_circuit_side_effect_leaks_820_932_987`.

## Invariants held

- **`last` stays eager.** It cannot short-circuit — it does not know a value is the last until
  the stream is exhausted.
- **#607's cursor preservation is intact.** `[{"a":1,"a":2}] | first(.[])` still returns the
  cursor-backed value with both keys. It diverges from jq there, but that is the pre-existing
  #1385 (duplicate keys survive to output in jq mode), not this change — verified identical
  before and after.
- `first(empty, ("B"|stderr))` still writes `B`, `first(stderr, 1)` still writes `null`,
  `first(1,2,error("x"))` is still `1` exit 0, `[first(empty)]` is still `[]`.

## Verification

Full `ci.yml`-derived gate: `fmt --check`, both clippy invocations, `no_std`, `cargo test` — all
clean. Suites: `jq_cli_tests` **788 passed**, `jq_error_message_tests` **1017 passed** (both
evaluators), plus `yq_cli_tests`, `jq_golden_tests`, `yq_golden_tests`,
`jq_evaluator_parity_tests`, `yq_path_consistency_tests` — 0 failures.

One note for anyone reading the CI logs: a combined suite run on this machine produced six
spurious failures, all with `Blocking waiting for file lock on package cache` and exit `-1` —
cargo build-lock contention from concurrent work, in tests that shell out via `cargo run`. Re-run
in isolation, all 788 pass. Not a property of this change.

Refs #820. Closes #1434.
