### PR TITLE
docs(jq): note regex l/n flag gaps are permanent, not pending (ADR-0019)

### DIFF
--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -23,11 +23,15 @@ The implementation covers ~95% of jq functionality and is production-ready.
 | Format strings        | Fully implemented   | 100%     |
 | Variable binding      | Fully implemented   | 100%     |
 | User functions        | Fully implemented   | 100%     |
-| Regex functions       | Fully implemented   | 100%     |
+| Regex functions       | Fully implemented*  | 100%     |
 | Module system         | Fully implemented   | 95%      |
 | I/O operations        | Won't implement     | N/A      |
 | Assignment operators  | Fully implemented   | 100%     |
 | Succinctly extensions | Fully implemented   | 100%     |
+
+\* Regex functions: two flag combinations are permanent, documented gaps, not
+"not yet implemented" — see [Partial Implementation Notes](#partial-implementation-notes)
+below and [ADR-0019](../adrs/adr-0019.md).
 
 ---
 
@@ -116,7 +120,7 @@ The implementation covers ~95% of jq functionality and is production-ready.
 - [x] `test(re)` (regex with `regex` feature; substring fallback without)
 
 ### Regular Expressions (with `regex` feature, included in `cli`)
-- [x] `match(re)` / `match(re; flags)`
+- [x] `match(re)` / `match(re; flags)` - the `l`/`n` flags have permanent, documented gaps, see [Partial Implementation Notes](#partial-implementation-notes)
 - [x] `capture(re)`
 - [x] `scan(re)`
 - [x] `splits(re)`
@@ -394,6 +398,14 @@ See [jq Remaining Work](../plan/jq-remaining.md) for incomplete CLI and module s
    the decimal literal. They agree on every value representable exactly as an
    `f64`; beyond that `9007199254740993 == 9007199254740992.0` is `true` here
    and `false` in jq
+6. **Regex `l`/`n` flags** - `l` (POSIX leftmost-longest matching) is accepted
+   as valid flag syntax but has no effect (`match("a|aa|aaa";"l")` returns
+   `"a"`, not real jq's `"aaa"`); `n` (suppress empty matches) has a narrower
+   gap for lazy quantifiers and empty-first alternations, where a non-empty
+   match exists but is only reachable via backtracking a Thompson-NFA-based
+   engine doesn't do. Both are permanent, documented limitations, not pending
+   work — [ADR-0019](../adrs/adr-0019.md) rejected swapping the regex engine
+   to close them (#920, #922)
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/reference/jq-language.md` listed "Regex functions: 100%" and checked off
`match(re)` / `match(re; flags)` under "Fully Implemented Features" with no caveat.
[ADR-0019](https://github.com/rust-works/succinctly/blob/main/docs/adrs/adr-0019.md)
(accepted alongside #920/#922) formalized that this overstates coverage: the `l` flag
(POSIX leftmost-longest matching) is a permanent no-op, and the `n` flag has a permanent
gap for lazy quantifiers / empty-first alternation — both accepted as "permanent,
documented limitations," not "not yet implemented."

## Changes

- Table row: `Regex functions | Fully implemented | 100%` → `Fully implemented*`, with a
  footnote below the table pointing at the new caveat section and ADR-0019.
- New item #6 in the existing "Partial Implementation Notes" list (matching that
  section's established one-item-per-known-divergence format), explaining both flags'
  actual behavior and linking ADR-0019 and #920/#922.
- The `match(re)` / `match(re; flags)` checklist entry itself now notes the gap inline.

Live-verified the `l`-flag claim against the current binary before writing it down (per
this repo's own "never state a jq/yq behaviour from memory" rule — this is a claim about
succinctly's *own* output, not the pinned oracle's, but the same discipline applies):

```
$ echo '"a|aa|aaa"' | succinctly jq -c 'match("a|aa|aaa"; "l") | .string'
"a"
```

## Test plan

Docs-only change, no source touched. `cargo build --features cli` and `cargo fmt --check`
clean (unaffected, run for completeness). Internal links (`../adrs/adr-0019.md`,
`#partial-implementation-notes`) match this file's own established convention, used
identically elsewhere in `docs/reference/environment-variables.md` and
`docs/reference/yq-language.md` — verified the target file exists and the anchor matches
GitHub's lowercase-hyphenated header-to-anchor convention. CI's `Check Links` job (lychee)
will validate them; lychee isn't available to run locally.

Fixes #1427
