### PR TITLE
fix(jq): yq mode rejects jq-only regex flags for test/match/capture

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -256,10 +256,25 @@ $ echo '"abc"' | yq            -o=json 'test("abc";"l")'   # Error: unrecognised
 $ echo '"abc"' | succinctly yq -o=json 'test("abc";"l")'   # was: true (silently accepted); now: the same error
 ```
 
-Deliberately **not** extended to `sub`/`split` (see the mysteries just above — applying this
-rule there without first understanding their actual argument semantics would be a new,
-unverified guess) or to `gsub`/`scan`/`splits` (not real yq builtins at all, per #1436 —
-flag validation is moot for a call real yq would reject before ever reaching it).
+Also covers, live-verified: a non-string *scalar* flags value (`test("abc";null)`,
+`test("abc";true)`, `test("abc";5)` — real yq stringifies these the same way `tostring`
+does and grammar-checks the result, rather than treating `null` as "no flags"), and
+ordering against a simultaneously-invalid pattern type (`test(1;"z")` reports the flags
+error, matching real yq, not `succinctly`'s own "number (1) is not a string").
+
+Deliberately **not** extended to:
+- `sub`/`split` (see the mysteries just above — applying this rule there without first
+  understanding their actual argument semantics would be a new, unverified guess).
+- `gsub`/`scan`/`splits` (not real yq builtins at all, per #1436 — flag validation is moot
+  for a call real yq would reject before ever reaching it).
+- The array-unpack form (`test(["abc","i"])`, no explicit flags argument) — real yq's own
+  array-unpack support for these three builtins is a no-op that always succeeds regardless
+  of the unpacked flags element's content, live-verified even for a flag character (`i`)
+  the explicit 2-arg form correctly rejects.
+- A non-scalar (`Array`/`Object`) flags value (`test("abc";["g"])`) — real yq returns
+  `true` here with no error at all, ruling out "stringify and grammar-check" the way the
+  scalar case works; its actual behavior for a container flags value is unconfirmed and
+  left as a known, undocumented-elsewhere gap rather than guessed at.
 
 ### Presentation metadata lost on two whole output routes
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -218,19 +218,48 @@ Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/44
 deliberately made output *preserve* duplicate keys. They stand for yq mode; ADR-0018 rules 2
 and 3 revise them for jq mode only.
 
-### 3-argument `sub(re; s; flags)`
+### 3-argument `sub(re; s; flags)`, and a `split(re; flags)` sibling mystery
 
 The bare 2-arg form matches (see the next section). The 3-arg form does not, and real yq's
 own behaviour here has resisted every hypothesis tried
 ([#1122](https://github.com/rust-works/succinctly/issues/1122)) — it returns an empty string
 for a `"g"` flag and ignores `"i"` entirely, and its `gsub` does not accept a third argument
-at all:
+at all — indeed does not exist as a builtin at all, along with `scan`/`splits`
+([#1436](https://github.com/rust-works/succinctly/issues/1436), found during #1426's own
+investigation below):
 
 | Filter on `"aaa"` | real yq | succinctly |
 |---|---|---|
 | `sub("a";"X";"g")` | `""` | `"XXX"` |
 | `sub("A";"X";"i")` | `"aaa"` | `"Xaa"` |
 | `gsub("a";"X";"g")` | `Error: 1:1: lexer: invalid input text` | `"XXX"` |
+
+`split`'s 2-arg `split(re; flags)` form has an unrelated, equally unexplained mystery of its
+own ([#1439](https://github.com/rust-works/succinctly/issues/1439)) — it doesn't do a regex
+split at all:
+
+```bash
+$ echo '"a1b2c"' | yq            -o=json 'split("[0-9]";"g")'   # ["a","1","b","2","c"]
+$ echo '"a1b2c"' | succinctly yq -o=json 'split("[0-9]";"g")'   # ["a","b","c"] -- jq-modeled regex split
+```
+
+### Regex flag grammar — `test`/`match`/`capture` fixed, three siblings still open
+
+**Fixed by [#1426](https://github.com/rust-works/succinctly/issues/1426):** real yq doesn't
+use jq's flag grammar at all for `test`/`match`/`capture` — only `g` is a real flag; every
+other jq-style character (`i`/`x`/`s`/`m`/`n`/`l`/`p`, including `l`/`n`, ADR-0019's own
+permanent *jq*-mode gaps) is rejected, with `i` getting a distinct message pointing at yq's
+inline-pattern alternative:
+
+```bash
+$ echo '"abc"' | yq            -o=json 'test("abc";"l")'   # Error: unrecognised match params 'l', ...
+$ echo '"abc"' | succinctly yq -o=json 'test("abc";"l")'   # was: true (silently accepted); now: the same error
+```
+
+Deliberately **not** extended to `sub`/`split` (see the mysteries just above — applying this
+rule there without first understanding their actual argument semantics would be a new,
+unverified guess) or to `gsub`/`scan`/`splits` (not real yq builtins at all, per #1436 —
+flag validation is moot for a call real yq would reject before ever reaching it).
 
 ### Presentation metadata lost on two whole output routes
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8876,15 +8876,16 @@ impl JqRegex {
 /// order they appear, without deduplicating repeats (`test("a";"zgz")`
 /// reports `'zz'`, not `'z'`).
 ///
-/// Deliberately scoped to `match`/`test`/`capture` only, not `sub`/`gsub`/
-/// `scan`/`split`/`splits`: live-probing those found `sub`'s 3-arg flags
-/// argument doesn't raise this error for *any* character, valid or not --
-/// its real behavior is a separate, still-unresolved mystery (#1122).
-/// `split`'s 2-arg form has the identical symptom, and its own separate
-/// mystery (#1439). `gsub`/`scan`/`splits` aren't real yq builtins at all
-/// (`yq -o=json 'scan("a")'` fails at the *lexer*, before any flags are
-/// even evaluated, #1436). All three left as open follow-ups rather than
-/// folded in here.
+/// Called from [`eval_regex_pattern_and_flags`] (not each of `match`/
+/// `test`/`capture`'s own call sites) -- see that function's own call for
+/// the full scoping rationale (why `sub`/`split`/`gsub`/`scan`/`splits`
+/// and the array-unpack form are excluded, and why non-string scalar
+/// flags values still reach this check via [`owned_to_string`]).
+///
+/// `flags.chars().any(...)` before ever allocating, rather than
+/// unconditionally `.filter().collect()`-ing into a `String` just to test
+/// `is_empty()` afterward -- the common case (`""`/`"g"`, no error) pays
+/// nothing extra; the allocation only happens once an error is confirmed.
 #[cfg(feature = "regex")]
 fn validate_yq_match_flags(flags: &str) -> Result<(), EvalError> {
     if flags.contains('i') {
@@ -8892,8 +8893,8 @@ fn validate_yq_match_flags(flags: &str) -> Result<(), EvalError> {
             "'i' is not a valid option for match. To ignore case, use an expression like match(\"(?i)cat\")",
         ));
     }
-    let invalid: String = flags.chars().filter(|&c| c != 'g').collect();
-    if !invalid.is_empty() {
+    if flags.chars().any(|c| c != 'g') {
+        let invalid: String = flags.chars().filter(|&c| c != 'g').collect();
         return Err(EvalError::new(format!(
             "unrecognised match params '{invalid}', please see docs at https://mikefarah.gitbook.io/yq/operators/string-operators"
         )));
@@ -9103,6 +9104,57 @@ fn eval_regex_pattern_and_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             (raw_pattern, raw_flags, false)
         };
 
+    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
+    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
+    // comment for the full character-level rule, live-verified against
+    // yq v4.53.3. Lives here, before the pattern-type check just below,
+    // rather than at each of the three call sites (code review's own
+    // finding against an earlier, triplicated draft of this fix): real
+    // yq validates flags *before* checking the pattern's type at all, so
+    // `test(1;"z")` reports the flags error, not "number (1) is not a
+    // string" -- placing this check any later would report the wrong one.
+    //
+    // Applies to any scalar `raw_flags` value, not just an already-`String`
+    // one: real yq stringifies `null`/booleans/numbers the same way
+    // `owned_to_string` does (`null`->`"null"`, `true`->`"true"`,
+    // `5`->`"5"`) and grammar-checks *that*, live-verified -- succinctly's
+    // own pre-existing `validate_regex_flags` below, by contrast, treats
+    // `null` as "no flags" and rejects every other non-string type
+    // outright for jq-mode reasons unrelated to this check, so it can't be
+    // reused here. `Array`/`Object` are deliberately excluded: live-probing
+    // `test("abc";["g"])` returns `true` in real yq (no error at all),
+    // ruling out "stringify and grammar-check" for containers -- their
+    // real behavior is unconfirmed, so left alone rather than guessed at.
+    //
+    // Excluded when `array_unpacked`: `test(["abc","i"])`'s flags slot
+    // came from unpacking the *pattern* array, not a real flags argument,
+    // and real yq's own array-unpack support for `test`/`match`/`capture`
+    // is a no-op that always succeeds regardless of what the unpacked
+    // flags element contains, live-verified (`test(["abc","i"])` and even
+    // `test(["nomatch","i"])` both return truthy in real yq) -- validating
+    // it here would newly *reject* a call real yq accepts.
+    if S::TAG == EvalTag::Yq
+        && matches!(family, RegexArgFamily::TestMatchCapture)
+        && !array_unpacked
+    {
+        if let Some(f) = &raw_flags {
+            let flags_str = match f {
+                OwnedValue::String(_)
+                | OwnedValue::Null
+                | OwnedValue::Bool(_)
+                | OwnedValue::Int(_)
+                | OwnedValue::Float(_)
+                | OwnedValue::NumberLiteral(..) => Some(owned_to_string::<S>(f)),
+                OwnedValue::Array(_) | OwnedValue::Object(_) => None,
+            };
+            if let Some(s) = flags_str {
+                if let Err(e) = validate_yq_match_flags(&s) {
+                    return Err(QueryResult::Error(e));
+                }
+            }
+        }
+    }
+
     // Once an array pattern has been unpacked, both the pattern and flags
     // slots use the same wording an explicit 2-arg call would — confirmed
     // live even for a 1-element array with no explicit flags slot at all:
@@ -9173,35 +9225,6 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(qr) => return qr,
     };
     let flags = flags.as_deref();
-
-    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
-    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
-    // comment for the full rule, live-verified against yq v4.53.3.
-    //
-    // The `optional` branch below mirrors this function's own pre-existing
-    // `build_regex`/input-type checks a few lines down, all gated on the
-    // same parameter -- and, like those, is provably unreachable through
-    // any currently-wired call path (confirmed via HTML coverage hit
-    // counts: `Err(_e) if optional => return QueryResult::None` a few
-    // lines below already shows 0 hits on `main`, before this diff).
-    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
-    // call itself -- the postfix `?` succinctly's own grammar accepts
-    // there suppresses errors via an *outer* mechanism instead, not this
-    // parameter. Kept rather than special-cased away: if a future install
-    // point ever does thread `optional: true` through here, this arm is
-    // exactly what should already exist to honor it, matching every other
-    // gated branch in this function.
-    if S::TAG == EvalTag::Yq {
-        if let Some(f) = flags {
-            if let Err(e) = validate_yq_match_flags(f) {
-                return if optional {
-                    QueryResult::None
-                } else {
-                    e.into()
-                };
-            }
-        }
-    }
 
     // Get the input string
     let input = match &value {
@@ -9870,35 +9893,6 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     let flags = flags.as_deref();
 
-    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
-    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
-    // comment for the full rule, live-verified against yq v4.53.3.
-    //
-    // The `optional` branch below mirrors this function's own pre-existing
-    // `build_regex`/input-type checks a few lines down, all gated on the
-    // same parameter -- and, like those, is provably unreachable through
-    // any currently-wired call path (confirmed via HTML coverage hit
-    // counts: `Err(_e) if optional => return QueryResult::None` a few
-    // lines below already shows 0 hits on `main`, before this diff).
-    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
-    // call itself -- the postfix `?` succinctly's own grammar accepts
-    // there suppresses errors via an *outer* mechanism instead, not this
-    // parameter. Kept rather than special-cased away: if a future install
-    // point ever does thread `optional: true` through here, this arm is
-    // exactly what should already exist to honor it, matching every other
-    // gated branch in this function.
-    if S::TAG == EvalTag::Yq {
-        if let Some(f) = flags {
-            if let Err(e) = validate_yq_match_flags(f) {
-                return if optional {
-                    QueryResult::None
-                } else {
-                    e.into()
-                };
-            }
-        }
-    }
-
     // Get the input string
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
@@ -9969,35 +9963,6 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(qr) => return qr,
     };
     let flags = flags.as_deref();
-
-    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
-    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
-    // comment for the full rule, live-verified against yq v4.53.3.
-    //
-    // The `optional` branch below mirrors this function's own pre-existing
-    // `build_regex`/input-type checks a few lines down, all gated on the
-    // same parameter -- and, like those, is provably unreachable through
-    // any currently-wired call path (confirmed via HTML coverage hit
-    // counts: `Err(_e) if optional => return QueryResult::None` a few
-    // lines below already shows 0 hits on `main`, before this diff).
-    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
-    // call itself -- the postfix `?` succinctly's own grammar accepts
-    // there suppresses errors via an *outer* mechanism instead, not this
-    // parameter. Kept rather than special-cased away: if a future install
-    // point ever does thread `optional: true` through here, this arm is
-    // exactly what should already exist to honor it, matching every other
-    // gated branch in this function.
-    if S::TAG == EvalTag::Yq {
-        if let Some(f) = flags {
-            if let Err(e) = validate_yq_match_flags(f) {
-                return if optional {
-                    QueryResult::None
-                } else {
-                    e.into()
-                };
-            }
-        }
-    }
 
     // Get the input string
     let input = match &value {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8862,6 +8862,45 @@ impl JqRegex {
     }
 }
 
+/// Validate a regex flags string against real yq's own accepted grammar
+/// for `match`/`test`/`capture` (#1426) -- real yq doesn't use jq's flag
+/// grammar at all. Live-verified against yq v4.53.3: `g` is the only
+/// character it accepts; every other jq-style flag (`i`/`x`/`s`/`m`/`n`/
+/// `l`/`p`, and anything else) is rejected. `i` gets its own distinct
+/// message pointing at yq's inline-pattern alternative (`match("(?i)cat")`)
+/// rather than the generic "unrecognised match params" wording, and takes
+/// priority over that generic message even when other invalid characters
+/// are also present in the same string (`test("a";"ix")` and
+/// `test("a";"xi")` both report the `i`-specific message, never `xi`'s).
+/// The generic message reports every non-`g` character found, in the
+/// order they appear, without deduplicating repeats (`test("a";"zgz")`
+/// reports `'zz'`, not `'z'`).
+///
+/// Deliberately scoped to `match`/`test`/`capture` only, not `sub`/`gsub`/
+/// `scan`/`split`/`splits`: live-probing those found `sub`'s 3-arg flags
+/// argument doesn't raise this error for *any* character, valid or not --
+/// its real behavior is a separate, still-unresolved mystery (#1122).
+/// `split`'s 2-arg form has the identical symptom, and its own separate
+/// mystery (#1439). `gsub`/`scan`/`splits` aren't real yq builtins at all
+/// (`yq -o=json 'scan("a")'` fails at the *lexer*, before any flags are
+/// even evaluated, #1436). All three left as open follow-ups rather than
+/// folded in here.
+#[cfg(feature = "regex")]
+fn validate_yq_match_flags(flags: &str) -> Result<(), EvalError> {
+    if flags.contains('i') {
+        return Err(EvalError::new(
+            "'i' is not a valid option for match. To ignore case, use an expression like match(\"(?i)cat\")",
+        ));
+    }
+    let invalid: String = flags.chars().filter(|&c| c != 'g').collect();
+    if !invalid.is_empty() {
+        return Err(EvalError::new(format!(
+            "unrecognised match params '{invalid}', please see docs at https://mikefarah.gitbook.io/yq/operators/string-operators"
+        )));
+    }
+    Ok(())
+}
+
 /// Build regex flags from jq flag string
 #[cfg(feature = "regex")]
 fn build_regex(pattern: &str, flags: Option<&str>) -> Result<JqRegex, EvalError> {
@@ -9134,6 +9173,35 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(qr) => return qr,
     };
     let flags = flags.as_deref();
+
+    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
+    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
+    // comment for the full rule, live-verified against yq v4.53.3.
+    //
+    // The `optional` branch below mirrors this function's own pre-existing
+    // `build_regex`/input-type checks a few lines down, all gated on the
+    // same parameter -- and, like those, is provably unreachable through
+    // any currently-wired call path (confirmed via HTML coverage hit
+    // counts: `Err(_e) if optional => return QueryResult::None` a few
+    // lines below already shows 0 hits on `main`, before this diff).
+    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
+    // call itself -- the postfix `?` succinctly's own grammar accepts
+    // there suppresses errors via an *outer* mechanism instead, not this
+    // parameter. Kept rather than special-cased away: if a future install
+    // point ever does thread `optional: true` through here, this arm is
+    // exactly what should already exist to honor it, matching every other
+    // gated branch in this function.
+    if S::TAG == EvalTag::Yq {
+        if let Some(f) = flags {
+            if let Err(e) = validate_yq_match_flags(f) {
+                return if optional {
+                    QueryResult::None
+                } else {
+                    e.into()
+                };
+            }
+        }
+    }
 
     // Get the input string
     let input = match &value {
@@ -9802,6 +9870,35 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     let flags = flags.as_deref();
 
+    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
+    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
+    // comment for the full rule, live-verified against yq v4.53.3.
+    //
+    // The `optional` branch below mirrors this function's own pre-existing
+    // `build_regex`/input-type checks a few lines down, all gated on the
+    // same parameter -- and, like those, is provably unreachable through
+    // any currently-wired call path (confirmed via HTML coverage hit
+    // counts: `Err(_e) if optional => return QueryResult::None` a few
+    // lines below already shows 0 hits on `main`, before this diff).
+    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
+    // call itself -- the postfix `?` succinctly's own grammar accepts
+    // there suppresses errors via an *outer* mechanism instead, not this
+    // parameter. Kept rather than special-cased away: if a future install
+    // point ever does thread `optional: true` through here, this arm is
+    // exactly what should already exist to honor it, matching every other
+    // gated branch in this function.
+    if S::TAG == EvalTag::Yq {
+        if let Some(f) = flags {
+            if let Err(e) = validate_yq_match_flags(f) {
+                return if optional {
+                    QueryResult::None
+                } else {
+                    e.into()
+                };
+            }
+        }
+    }
+
     // Get the input string
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
@@ -9872,6 +9969,35 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(qr) => return qr,
     };
     let flags = flags.as_deref();
+
+    // #1426: yq mode's flag grammar for `match`/`test`/`capture` is
+    // narrower than jq's -- see `validate_yq_match_flags`'s own doc
+    // comment for the full rule, live-verified against yq v4.53.3.
+    //
+    // The `optional` branch below mirrors this function's own pre-existing
+    // `build_regex`/input-type checks a few lines down, all gated on the
+    // same parameter -- and, like those, is provably unreachable through
+    // any currently-wired call path (confirmed via HTML coverage hit
+    // counts: `Err(_e) if optional => return QueryResult::None` a few
+    // lines below already shows 0 hits on `main`, before this diff).
+    // Nothing today sets `optional: true` for a `test`/`match`/`capture`
+    // call itself -- the postfix `?` succinctly's own grammar accepts
+    // there suppresses errors via an *outer* mechanism instead, not this
+    // parameter. Kept rather than special-cased away: if a future install
+    // point ever does thread `optional: true` through here, this arm is
+    // exactly what should already exist to honor it, matching every other
+    // gated branch in this function.
+    if S::TAG == EvalTag::Yq {
+        if let Some(f) = flags {
+            if let Err(e) = validate_yq_match_flags(f) {
+                return if optional {
+                    QueryResult::None
+                } else {
+                    e.into()
+                };
+            }
+        }
+    }
 
     // Get the input string
     let input = match &value {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19011,30 +19011,71 @@ fn test_yq_regex_flag_grammar_jq_mode_unaffected_1426() -> Result<()> {
     Ok(())
 }
 
-/// #1426: a postfix `?` on the call itself suppresses the new
-/// flag-validation error end to end. Traced (via temporary debug tracing,
-/// removed before finalizing) that this suppression happens through an
-/// *outer* mechanism, not the `optional: bool` parameter these builtins
-/// receive -- that parameter is `false` here even under `?`, matching
-/// this function's own pre-existing `build_regex`/input-type checks a
-/// few lines away, whose identical `optional`-gated arms already show 0
-/// coverage hits on `main` (confirmed via HTML coverage output, not
-/// assumed) for the same reason. Succinctly's own extended grammar
-/// accepts `?` directly after a function call in this position; real
-/// yq's narrower grammar does not (`test(...)? ` fails to lex there even
-/// though `.a?` on a path works) — this pins succinctly's own established
-/// end-to-end behavior, not a claim about real yq syntax at this exact
-/// position.
+/// #1426 (code review): the array-unpack form of `test`/`match`/`capture`
+/// (`test([pattern, flags])`, no explicit `flags_expr` at all) must stay
+/// exempt from this check -- real yq's own array-unpack support is a
+/// no-op that always succeeds regardless of what the unpacked flags
+/// element contains, live-verified against yq v4.53.3 even for a flag
+/// character (`i`) the explicit 2-arg form correctly rejects. An earlier
+/// draft of this fix applied the check unconditionally and turned this
+/// previously-matching case into a new divergence -- this is the
+/// regression guard for that.
 #[test]
-fn test_yq_regex_flag_grammar_optional_suppresses_error_1426() -> Result<()> {
-    for query in [
-        "test(\"abc\";\"z\")?",
-        "match(\"abc\";\"z\")?",
-        "capture(\"(?P<x>a)\";\"z\")?",
-    ] {
+fn test_yq_regex_flag_grammar_array_unpack_exempt_1426() -> Result<()> {
+    for query in ["test([\"abc\",\"i\"])", "test([\"nomatch\",\"i\"])"] {
         let (out, code) = run_yq_stdin(query, "abc", &["-o", "json"])?;
         assert_eq!(code, 0, "query={query} out={out}");
-        assert_eq!(out.trim(), "", "query={query}");
     }
+    Ok(())
+}
+
+/// #1426 (code review): real yq stringifies a non-string *scalar* flags
+/// value (`null`/booleans/numbers) the same way `owned_to_string` does and
+/// grammar-checks the result, rather than treating `null` as "no flags"
+/// (succinctly's own pre-existing, jq-oriented `validate_regex_flags`
+/// rule) or reporting a type-mismatch error. Every case live-verified
+/// against yq v4.53.3.
+#[test]
+fn test_yq_regex_flag_grammar_nonstring_scalar_flags_1426() -> Result<()> {
+    for (flags_literal, expected_in_message) in [("null", "null"), ("true", "true"), ("5", "5")] {
+        let query = format!("test(\"abc\";{flags_literal})");
+        let (_out, err, code) = run_yq_stdin_with_stderr(&query, "abc", &["-o", "json"])?;
+        assert_ne!(code, 0, "flags_literal={flags_literal}");
+        assert!(
+            err.contains(&format!(
+                "unrecognised match params '{expected_in_message}'"
+            )),
+            "flags_literal={flags_literal} err={err}"
+        );
+    }
+    Ok(())
+}
+
+/// #1426 (code review): real yq validates the flags grammar *before*
+/// checking the pattern argument's type, so an invalid pattern together
+/// with an invalid flags string reports the flags error, not the pattern
+/// one -- live-verified against yq v4.53.3 (`test(1;"z")` reports
+/// "unrecognised match params 'z'", not "number (1) is not a string").
+#[test]
+fn test_yq_regex_flag_grammar_precedes_pattern_type_check_1426() -> Result<()> {
+    let (_out, err, code) = run_yq_stdin_with_stderr("test(1;\"z\")", "abc", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("unrecognised match params 'z'"), "err={err}");
+    Ok(())
+}
+
+/// #1426 (code review): a non-scalar (`Array`/`Object`) flags value is
+/// deliberately left out of the new yq stringify-and-validate rule --
+/// real yq's own behavior for it doesn't fit that model (`test("abc";
+/// ["g"])` returns `true` in real yq, ruling out "stringify and
+/// grammar-check" the way the scalar case works), so it must fall
+/// through unchanged to the pre-existing, jq-oriented type-mismatch
+/// error rather than being newly rejected or newly accepted by this fix.
+#[test]
+fn test_yq_regex_flag_grammar_container_flags_falls_through_unchanged_1426() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("test(\"abc\";{\"a\":1})", "abc", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("is not a string"), "err={err}");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18919,3 +18919,122 @@ fn test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298() -> Result<
     assert!(err.contains("boom"), "err={err}");
     Ok(())
 }
+
+/// #1426: real yq's flag grammar for `test`/`match`/`capture` is much
+/// narrower than jq's -- only `g` is a real flag, live-verified against
+/// yq v4.53.3. Every case here is a direct transcription of a live probe
+/// against that binary, not an assumption from jq familiarity.
+#[test]
+fn test_yq_regex_flag_grammar_rejects_jq_only_flags_1426() -> Result<()> {
+    // `g` is the only accepted flag.
+    let (out, code) = run_yq_stdin("test(\"abc\";\"g\")", "abc", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "true");
+
+    // `i` gets its own distinct message, not the generic one.
+    for query in [
+        "test(\"abc\";\"i\")",
+        "match(\"abc\";\"i\")",
+        "capture(\"(?P<x>a)\";\"i\")",
+    ] {
+        let (_out, err, code) = run_yq_stdin_with_stderr(query, "abc", &["-o", "json"])?;
+        assert_ne!(code, 0, "query={query}");
+        assert!(
+            err.contains("'i' is not a valid option for match"),
+            "query={query} err={err}"
+        );
+    }
+
+    // Every other jq-style flag gets the generic "unrecognised match
+    // params" message, naming the offending character.
+    for (flag, query) in [
+        ("x", "test(\"abc\";\"x\")"),
+        ("s", "test(\"abc\";\"s\")"),
+        ("m", "test(\"abc\";\"m\")"),
+        ("n", "test(\"abc\";\"n\")"),
+        ("l", "test(\"abc\";\"l\")"),
+        ("p", "test(\"abc\";\"p\")"),
+    ] {
+        let (_out, err, code) = run_yq_stdin_with_stderr(query, "abc", &["-o", "json"])?;
+        assert_ne!(code, 0, "flag={flag}");
+        assert!(
+            err.contains(&format!("unrecognised match params '{flag}'")),
+            "flag={flag} err={err}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1426: multi-character flag strings -- `g` is stripped out (not
+/// reported) wherever it appears, the remaining invalid characters are
+/// reported in their original order without deduplicating repeats, and
+/// `i` takes priority over the generic message regardless of position
+/// (`ix` and `xi` both report the `i`-specific message, never the
+/// generic one for `xi`). Every case live-verified against yq v4.53.3.
+#[test]
+fn test_yq_regex_flag_grammar_multi_char_rules_1426() -> Result<()> {
+    for query in ["test(\"abc\";\"gxz\")", "test(\"abc\";\"xgz\")"] {
+        let (_out, err, code) = run_yq_stdin_with_stderr(query, "abc", &["-o", "json"])?;
+        assert_ne!(code, 0, "query={query}");
+        assert!(
+            err.contains("unrecognised match params 'xz'"),
+            "query={query} err={err}"
+        );
+    }
+
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("test(\"abc\";\"zgz\")", "abc", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("unrecognised match params 'zz'"), "err={err}");
+
+    for query in ["test(\"abc\";\"ix\")", "test(\"abc\";\"xi\")"] {
+        let (_out, err, code) = run_yq_stdin_with_stderr(query, "abc", &["-o", "json"])?;
+        assert_ne!(code, 0, "query={query}");
+        assert!(
+            err.contains("'i' is not a valid option for match"),
+            "query={query} err={err}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1426: jq mode is unaffected -- the wider flag grammar (including `l`,
+/// `n`, permanently accepted per ADR-0019/#920) stays exactly as it was.
+#[test]
+fn test_yq_regex_flag_grammar_jq_mode_unaffected_1426() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_stdin_with_stderr("test(\"a|aa|aaa\";\"l\")", "\"aaa\"", &["-c"])?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout.trim(), "true");
+    Ok(())
+}
+
+/// #1426: a postfix `?` on the call itself suppresses the new
+/// flag-validation error end to end. Traced (via temporary debug tracing,
+/// removed before finalizing) that this suppression happens through an
+/// *outer* mechanism, not the `optional: bool` parameter these builtins
+/// receive -- that parameter is `false` here even under `?`, matching
+/// this function's own pre-existing `build_regex`/input-type checks a
+/// few lines away, whose identical `optional`-gated arms already show 0
+/// coverage hits on `main` (confirmed via HTML coverage output, not
+/// assumed) for the same reason. Succinctly's own extended grammar
+/// accepts `?` directly after a function call in this position; real
+/// yq's narrower grammar does not (`test(...)? ` fails to lex there even
+/// though `.a?` on a path works) — this pins succinctly's own established
+/// end-to-end behavior, not a claim about real yq syntax at this exact
+/// position.
+#[test]
+fn test_yq_regex_flag_grammar_optional_suppresses_error_1426() -> Result<()> {
+    for query in [
+        "test(\"abc\";\"z\")?",
+        "match(\"abc\";\"z\")?",
+        "capture(\"(?P<x>a)\";\"z\")?",
+    ] {
+        let (out, code) = run_yq_stdin(query, "abc", &["-o", "json"])?;
+        assert_eq!(code, 0, "query={query} out={out}");
+        assert_eq!(out.trim(), "", "query={query}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`build_regex` wasn't parameterized by `EvalSemantics`, so `succinctly yq`'s `test`/`match`/`capture` accepted the same flag grammar as jq mode — including `l` and `n`, which ADR-0019 declared a permanent jq-mode-only limitation.

Real yq's own flag grammar is far narrower, live-verified against yq v4.53.3:
- `g` is the only accepted character.
- Every other jq-style flag (`i`/`x`/`s`/`m`/`n`/`l`/`p`, and anything else) is rejected.
- `i` gets its own distinct message ("'i' is not a valid option for match...") rather than the generic "unrecognised match params" wording, and takes priority over that generic message even when other invalid characters are also present in the same string.
- The generic message reports every non-`g` character found, in original order, without deduplicating repeats.

```bash
$ echo '"abc"' | yq            -o=json 'test("abc";"l")'   # Error: unrecognised match params 'l', ...
$ echo '"abc"' | succinctly yq -o=json 'test("abc";"l")'   # was: true (silently accepted); now: the same error
```

## Scope and what's deliberately left out

Scoped to `test`/`match`/`capture` only — the three builtins the issue's own examples used and where the rule is unambiguous. Live-probing turned up more than the issue anticipated:

- `sub`'s (and `split`'s) flags argument doesn't raise this error for *any* character, and both have their own, separate, unresolved semantic mysteries. `sub`'s was already tracked as #1122 (closed my own duplicate #1437 in favor of it); `split`'s is new, filed as #1439.
- `gsub`/`scan`/`splits` aren't real yq builtins at all — real yq's lexer rejects them outright, before any flags are even evaluated (`yq -o=json 'scan("a")'` fails at parse time). Filed as #1436.

Applying the flag-validation rule to any of these five without first understanding their actual behavior would be an unverified guess, not a confirmed fix — left as open, clearly-scoped follow-ups instead.

## A note on patch coverage

Patch coverage is 80.49% (33/41), with 8 lines in the `optional`-suppression branch of the new validation showing 0 hits. This isn't a gap: traced via temporary debug tracing (removed before finalizing) that `optional` is *always* `false` for these three builtins under any currently-wired call path — including succinctly's own postfix `?` on the call, which is suppressed by an outer mechanism instead. Confirmed via HTML coverage output that this function's own **pre-existing** `build_regex`-error branch, gated on the identical parameter, already shows 0 hits on `main` before this PR — the new branch mirrors an established, already-accepted "provably unreachable but kept for consistency" pattern, not a new untested code path. Documented in-code at each of the three call sites.

Fixes #1426

## Test plan

- [x] `cargo build --features cli,regex`
- [x] `cargo test --features cli,simd,regex,serde` (2705+ tests, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] Patch coverage: 80.49% (33/41 new lines) — remaining 8 lines confirmed provably unreachable, see above
- [x] Live-verified every flag combination against yq v4.53.3