### PR TITLE
fix(jq): yq mode's 3-arg sub ignores args past the pattern (#1122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,9 +299,11 @@ printf 'a:\n  x: 1\nb:\n  x: 2\n  y: 3\n' | succinctly yq '.a *=n .b'  # a: {x: 
 
 `null` acts as an empty container on either side of a yq-mode merge (jq mode has no such exception -- every `null`-involving `*` pairing errors there, #1175): a null/absent *left* operand merges as if starting from `{}`/`[]` (`.a *=n .b` on `a: null` writes the full `.b` in; `.a *=? .b` on an absent `.a` leaves `a: {}`, blocked field-by-field rather than staying `null`), and a null *right* operand is always a no-op (`.a *= null` leaves `.a` untouched).
 
-### `sub`/`gsub` divergence (yq mode only)
+### `sub` divergence (yq mode only) — `gsub`/`scan`/`splits` aren't real yq builtins at all
 
-Real yq's bare, 2-arg `sub(re; s)` replaces *every* match, not just the first — jq's `sub` = first match only, `gsub` = all matches; yq's bare `sub` behaves like jq's `gsub` unconditionally (`"aaa" | sub("a";"X")` => `"XXX"` in yq, `"Xaa"` in jq, confirmed against yq v4.53.3). `gsub` itself, and the 3-arg `sub(re;s;flags)` form, are unaffected by this and keep matching jq's model — the 3-arg form's real-yq semantics don't fit any hypothesis tried so far (#1122).
+Real yq's bare, 2-arg `sub(re; s)` replaces *every* match, not just the first — jq's `sub` = first match only, `gsub` = all matches; yq's bare `sub` behaves like jq's `gsub` unconditionally (`"aaa" | sub("a";"X")` => `"XXX"` in yq, `"Xaa"` in jq, confirmed against yq v4.53.3). `gsub` is not a real yq builtin at any arity — its lexer rejects `gsub(...)` outright, same as `scan`/`splits` (confirmed live against yq v4.53.3, #1436) — so there's no jq-model "match" to speak of for succinctly's own `gsub` in yq mode; it's an unopposed succinctly behavior, not a verified divergence.
+
+Real yq's 3-arg `sub(re; replacement; flags)` never evaluates `replacement` or `flags` at all — it always performs a global replace-with-empty-string using only the pattern (near-certainly an upstream Go bug reading its replacement from a fixed AST slot that's empty once arity exceeds 2, not a designed feature; confirmed live that an `error(...)` in either position never fires). Per ADR-0018 rule 3, succinctly reproduces this bug-for-bug rather than "fixing" it into jq's model (`"aaa" | sub("a";"X";"g")` => `""` in both yq and succinctly yq mode; flags like `"i"` are silently ignored, and a 4th+ argument is accepted and discarded, matching real yq's own parser leniency — #1122).
 
 ### Anchor/alias preservation and its soundness rule (yq mode only)
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -218,23 +218,40 @@ Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/44
 deliberately made output *preserve* duplicate keys. They stand for yq mode; ADR-0018 rules 2
 and 3 revise them for jq mode only.
 
-### 3-argument `sub(re; s; flags)`, and a `split(re; flags)` sibling mystery
+### `gsub`, `scan`, `splits` are not real yq builtins at all
 
-The bare 2-arg form matches (see the next section). The 3-arg form does not, and real yq's
-own behaviour here has resisted every hypothesis tried
-([#1122](https://github.com/rust-works/succinctly/issues/1122)) — it returns an empty string
-for a `"g"` flag and ignores `"i"` entirely, and its `gsub` does not accept a third argument
-at all — indeed does not exist as a builtin at all, along with `scan`/`splits`
-([#1436](https://github.com/rust-works/succinctly/issues/1436), found during #1426's own
-investigation below):
+Confirmed via the pinned binary's lexer rejecting all three outright, at any arity
+([#1436](https://github.com/rust-works/succinctly/issues/1436)) — this isn't "3-arg `gsub`
+diverges," it's that yq's grammar has no `gsub`/`scan`/`splits` token at all:
+
+```bash
+$ echo '"aaa"' | yq 'gsub("a";"X")'      # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\")"
+$ echo '"aaa"' | yq 'gsub("a";"X";"g")'  # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\";\"g\"..."
+$ echo '"aaa"' | yq 'scan("a")'          # Error: 1:1: lexer: invalid input text "scan(\"a\")"
+```
 
 | Filter on `"aaa"` | real yq | succinctly |
 |---|---|---|
-| `sub("a";"X";"g")` | `""` | `"XXX"` |
-| `sub("A";"X";"i")` | `"aaa"` | `"Xaa"` |
 | `gsub("a";"X";"g")` | `Error: 1:1: lexer: invalid input text` | `"XXX"` |
 
-`split`'s 2-arg `split(re; flags)` form has an unrelated, equally unexplained mystery of its
+### 3-argument `sub(re; s; flags)` — resolved, real yq ignores everything past the pattern
+
+[#1122](https://github.com/rust-works/succinctly/issues/1122) resolved what had looked like an
+inconsistent mystery: real yq's `sub(re; replacement; flags)` never evaluates `replacement` or
+`flags` at all (near-certainly an upstream Go implementation bug reading its replacement from a
+fixed AST slot that's empty once arity exceeds 2, not a designed feature) — it always performs a
+global replace-with-empty-string using only the pattern. Confirmed live: an `error(...)` placed
+in either `replacement` or `flags` never fires. Per [ADR-0018](../../adrs/adr-0018.md) rule 3,
+succinctly now reproduces this bug-for-bug rather than "fixing" it into jq's model:
+
+```bash
+$ echo '"aaa"' | yq            'sub("a";"X";"g")'   # ""   (global match, empty replace)
+$ echo '"aaa"' | succinctly yq 'sub("a";"X";"g")'   # ""   (matches)
+$ echo '"aaa"' | yq            'sub("A";"X";"i")'   # "aaa" (flags never read, no match)
+$ echo '"aaa"' | succinctly yq 'sub("A";"X";"i")'   # "aaa" (matches)
+```
+
+`split`'s 2-arg `split(re; flags)` form has an unrelated, still-unresolved mystery of its
 own ([#1439](https://github.com/rust-works/succinctly/issues/1439)) — it doesn't do a regex
 split at all:
 
@@ -243,7 +260,7 @@ $ echo '"a1b2c"' | yq            -o=json 'split("[0-9]";"g")'   # ["a","1","b","
 $ echo '"a1b2c"' | succinctly yq -o=json 'split("[0-9]";"g")'   # ["a","b","c"] -- jq-modeled regex split
 ```
 
-### Regex flag grammar — `test`/`match`/`capture` fixed, three siblings still open
+### Regex flag grammar — `test`/`match`/`capture` fixed, `split` still open
 
 **Fixed by [#1426](https://github.com/rust-works/succinctly/issues/1426):** real yq doesn't
 use jq's flag grammar at all for `test`/`match`/`capture` — only `g` is a real flag; every
@@ -263,8 +280,12 @@ ordering against a simultaneously-invalid pattern type (`test(1;"z")` reports th
 error, matching real yq, not `succinctly`'s own "number (1) is not a string").
 
 Deliberately **not** extended to:
-- `sub`/`split` (see the mysteries just above — applying this rule there without first
-  understanding their actual argument semantics would be a new, unverified guess).
+- `sub` — moot rather than unverified now that #1122 resolved its mystery: 3-arg `sub`
+  never evaluates its `flags` argument at all, so there is no flags *grammar* to check in
+  the first place, valid or garbage.
+- `split` — its own mystery (#1439, above) is still genuinely unresolved; applying this
+  rule there without first understanding its actual argument semantics would be a new,
+  unverified guess.
 - `gsub`/`scan`/`splits` (not real yq builtins at all, per #1436 — flag validation is moot
   for a call real yq would reject before ever reaching it).
 - The array-unpack form (`test(["abc","i"])`, no explicit flags argument) — real yq's own

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -246,11 +246,22 @@ echo '"aaa"' | succinctly yq 'gsub("a"; "X")'
 # "XXX" — same result; gsub is effectively a synonym for bare sub in yq mode
 ```
 
-**Known gap:** the 3-arg `sub(re; s; flags)` form's real-yq semantics don't
-fit jq's model, yq's own bare-`sub` model, or a couple of other hypotheses
-tried so far — see #1122. succinctly's 3-arg form currently matches jq's
-model (global only when the flags string contains `"g"`), which is not
-confirmed to match real yq.
+`gsub` (any arity), `scan`, and `splits` are not real yq builtins at all — real yq's own
+lexer rejects them outright (confirmed live against yq v4.53.3, #1436). succinctly's `gsub`
+support in yq mode is therefore a succinctly-only convenience, not a verified match against
+an oracle that has nothing to compare against.
+
+**Resolved (#1122):** the 3-arg `sub(re; s; flags)` form doesn't fit jq's
+model or yq's own bare-`sub` model — real yq never evaluates `replacement`
+or `flags` at all, and always does a global replace with the empty string
+using only the pattern (near-certainly an upstream Go bug, not a designed
+feature). succinctly now reproduces this bug-for-bug per
+[ADR-0018](../adrs/adr-0018.md) rule 3:
+
+```bash
+echo '"aaa"' | succinctly yq 'sub("a"; "X"; "g")'
+# "" — replacement and flags are never read; every match is deleted
+```
 
 ### Date/Time Extensions
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10049,10 +10049,8 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    if S::TAG == EvalTag::Yq {
-        if let Some(_flags_expr) = flags_expr {
-            return yq_sub_arity3_empty_replace::<W, S>(re_expr, value, optional);
-        }
+    if S::TAG == EvalTag::Yq && flags_expr.is_some() {
+        return yq_sub_arity3_empty_replace::<W, S>(re_expr, value, optional);
     }
 
     let (pattern, flags) = match eval_regex_pattern_and_flags::<W, S>(
@@ -10089,8 +10087,12 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `"abc" | sub("b"; error("boom"); "g")` prints `"ac"` in real yq, not
 /// an error, so this isn't "evaluate and discard" (which would still
 /// propagate `error(...)`), it's "never reached." Only `re_expr` is
-/// evaluated and type-checked, so `sub("[";"X";"g")` still raises the
-/// genuine regex-compile error real yq gives for an invalid pattern.
+/// evaluated, so `sub("[";"X";"g")` still raises the genuine
+/// regex-compile error real yq gives for an invalid pattern. A
+/// *non-string* pattern (e.g. `sub(1;"X";"g")`) is a separate, pre-existing
+/// divergence shared by `test`/`match`/`capture`/2-arg `sub` in yq mode
+/// (real yq coerces it to a string; succinctly errors) -- not specific to
+/// this arity-3 path and not fixed here, see #1443.
 ///
 /// The result is a genuine global replace with a constant `""`, not
 /// "always returns `""`" -- confirmed live: `"abc" | sub("b";"X";"g")`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10114,6 +10114,16 @@ fn yq_sub_arity3_empty_replace<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err(escape) => return escape.into(),
     };
 
+    // The three `if optional` guards below mirror every sibling builtin's own
+    // `_ if optional => QueryResult::None` arm (see `format_base64` above)
+    // for consistency, but are very likely unreachable dead code post-#693:
+    // `Expr::Optional` forces the inner evaluation's ambient `optional` to
+    // `false` and catches the resulting `Error` itself, rather than letting
+    // a builtin's own internal `optional` flag see `true`. Confirmed via
+    // `cargo llvm-cov`: `sub(...; ...; ...)?` on a non-string input or an
+    // invalid pattern still returns empty output (proving `?` itself works),
+    // but does so via the outer wrapper catching the arms below that ignore
+    // `optional`, not via these guards.
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10037,6 +10037,10 @@ fn builtin_sub_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// for their side effects before either is type-checked, so a flags-side
 /// `error()` still wins over an ordinary pattern-side type mismatch —
 /// see `eval_regex_pattern_and_flags`'s doc comment.
+///
+/// yq mode diverges entirely for the 3-arg form (`flags_expr.is_some()`)
+/// -- see [`yq_sub_arity3_empty_replace`]'s own doc comment for the
+/// oracle-verified rule (#1122).
 #[cfg(feature = "regex")]
 fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     re_expr: &Expr,
@@ -10045,6 +10049,12 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    if S::TAG == EvalTag::Yq {
+        if let Some(_flags_expr) = flags_expr {
+            return yq_sub_arity3_empty_replace::<W, S>(re_expr, value, optional);
+        }
+    }
+
     let (pattern, flags) = match eval_regex_pattern_and_flags::<W, S>(
         re_expr,
         flags_expr,
@@ -10063,6 +10073,76 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         value,
         optional,
     )
+}
+
+/// yq mode's `sub(re; replacement; flags)` (arity >= 3): real yq
+/// **ignores every argument after the first** and replaces every match
+/// with the empty string -- confirmed live against yq v4.53.3 (#1122),
+/// near-certainly an upstream bug (yq's own `substitute` reading its
+/// replacement from a fixed AST slot that's empty once arity exceeds 2),
+/// not a designed feature, but this repo pins oracle behaviour rather
+/// than upstream intent (ADR-0018 rule 3: bug-for-bug fidelity by
+/// default, including the reference's own internal inconsistencies).
+///
+/// `replacement_expr`/`flags_expr` are **not evaluated at all** -- neither
+/// their side effects nor their errors are observable, confirmed live:
+/// `"abc" | sub("b"; error("boom"); "g")` prints `"ac"` in real yq, not
+/// an error, so this isn't "evaluate and discard" (which would still
+/// propagate `error(...)`), it's "never reached." Only `re_expr` is
+/// evaluated and type-checked, so `sub("[";"X";"g")` still raises the
+/// genuine regex-compile error real yq gives for an invalid pattern.
+///
+/// The result is a genuine global replace with a constant `""`, not
+/// "always returns `""`" -- confirmed live: `"abc" | sub("b";"X";"g")`
+/// is `"ac"` (only the matched `"b"` is removed), and every probed
+/// variant (non-string replacement, non-string/junk/`i` flags, 4+ args,
+/// a capture-referencing replacement) gives the identical answer, since
+/// none of those arguments are ever read. Flags are not honoured either
+/// -- `"AAA" | sub("a";"X";"i")` stays `"AAA"`, matching `re_expr`
+/// case-sensitively regardless of what a flags argument requested.
+#[cfg(feature = "regex")]
+fn yq_sub_arity3_empty_replace<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    re_expr: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    let pattern = match result_to_owned(eval_single::<W, S>(re_expr, value.clone(), optional)) {
+        Ok(OwnedValue::String(s)) => s,
+        Ok(v) => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+        Err(escape) => return escape.into(),
+    };
+
+    let input = match &value {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => cow.into_owned(),
+            Err(_) if optional => return QueryResult::None,
+            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+        },
+        _ if optional => return QueryResult::None,
+        _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
+    };
+
+    let re = match build_regex(&pattern, None) {
+        Ok(r) => r,
+        Err(_e) if optional => return QueryResult::None,
+        Err(e) => return e.into(),
+    };
+
+    let matches = global_captures(&re, &input);
+    if matches.is_empty() {
+        return QueryResult::Owned(OwnedValue::String(input));
+    }
+    let mut out = String::with_capacity(input.len());
+    let mut last_end = 0;
+    for caps in &matches {
+        let m = caps
+            .get(0)
+            .expect("capture group 0 is always present on a match");
+        out.push_str(&input[last_end..m.start()]);
+        last_end = m.end();
+    }
+    out.push_str(&input[last_end..]);
+    QueryResult::Owned(OwnedValue::String(out))
 }
 
 /// The rest of `sub`/`gsub`'s work once the pattern string and flags string
@@ -37681,41 +37761,38 @@ mod tests {
     }
 
     /// Pins that the 3-arg `sub(re; s; flags)` form's *own* code path is
-    /// untouched by #1069's `flags.is_none()` gate -- **not** a claim that
-    /// these values match real yq. They don't: real yq's actual 3-arg
-    /// behavior is itself a separate, still-unresolved mystery (filed as
-    /// #1122 rather than guessed at here) -- live-probing found real yq
-    /// gives an *empty string* for both `sub("a";"X";"g")` and
-    /// `sub("a";"X";"")` on `"aaa"` whenever the pattern matches, not
-    /// `"XXX"`/`"Xaa"`. This test exists only to catch a *future* change
-    /// accidentally routing the 3-arg form through the new bare-2-arg
-    /// global-replace gate (it shouldn't, per the doc comment on `global`
-    /// above) -- it is a regression pin on succinctly's own current (and
-    /// separately tracked as incorrect) output, not an oracle-verified
-    /// baseline.
+    /// untouched by #1069's `flags.is_none()` gate -- that gate identifies
+    /// the bare 2-arg shape specifically (`flags == None`), and the 3-arg
+    /// form always arrives with `flags == Some(_)`, so it can't
+    /// accidentally widen onto #1069's bare-2-arg global-replace rule.
+    ///
+    /// The values asserted here *do* now match real yq (#1122, fixed):
+    /// yq's 3-arg `sub` ignores every argument after the pattern and
+    /// replaces every match with the empty string, regardless of what the
+    /// flags expression evaluates to -- `"g"`, `""`, and `null` all give
+    /// the identical `""` for `"aaa"`, confirmed live against yq v4.53.3
+    /// for all three. This was a genuine, separately-filed mystery before
+    /// #1122's fix (`yq_sub_arity3_empty_replace`, gated on `S::TAG ==
+    /// EvalTag::Yq && flags_expr.is_some()` in `builtin_sub_with_flags`,
+    /// *before* this bare-2-arg `global` gate is ever reached) -- this test
+    /// now exercises that fix's own dispatch, not just confirms it stays
+    /// off a different one.
     #[cfg(feature = "regex")]
     #[test]
-    fn test_regex_sub_flags_yq_mode_unaffected_by_1069() {
+    fn test_regex_sub_flags_yq_mode_matches_oracle_1122() {
         yq_query!(br#""aaa""#, r#"sub("a"; "X"; "g")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "XXX");
+                assert_eq!(s, "");
             }
         );
         yq_query!(br#""aaa""#, r#"sub("a"; "X"; "")"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "Xaa");
+                assert_eq!(s, "");
             }
         );
-
-        // `sub(re; s; null)` specifically: `validate_regex_flags` maps a
-        // `null` flags expression to `Some(String::new())`, not `None`
-        // (confirmed at its call site above `sub_with_resolved_pattern`),
-        // so this shape also stays off the new global-replace gate --
-        // exercising the exact case the doc comment on `global` reasons
-        // through but that nothing previously asserted directly.
         yq_query!(br#""aaa""#, r#"sub("a"; "X"; null)"#,
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "Xaa");
+                assert_eq!(s, "");
             }
         );
     }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2639,6 +2639,23 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
+                // yq mode accepts (and ignores) any further `; expr`
+                // arguments -- confirmed live against yq v4.53.3: arity 4+
+                // parses and behaves identically to arity 3 (#1122), unlike
+                // jq, where `sub/4` is a hard "not defined" compile error.
+                // Parsed and discarded here, not evaluated at all --
+                // `yq_sub_arity3_empty_replace` already never reads
+                // `replacement`/`flags` either, so a discarded 4th+ argument
+                // is consistent with that same "ignored past the first"
+                // rule, not a separate carve-out for it.
+                if self.mode == ParserMode::Yq {
+                    while self.peek() == Some(';') {
+                        self.next();
+                        self.skip_ws();
+                        self.parse_expr()?;
+                        self.skip_ws();
+                    }
+                }
                 self.expect(')')?;
                 return Ok(Some(Builtin::SubFlags(
                     Box::new(re),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14028,6 +14028,127 @@ fn test_sub_yq_mode_non_string_replacement_exits_zero_1052() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// #1122: real yq's 3-arg `sub(re; replacement; flags)` ignores every
+// argument after the pattern and replaces every match with the empty
+// string -- confirmed live against yq v4.53.3, near-certainly an upstream
+// bug (ADR-0018 rule 3: bug-for-bug fidelity by default, including the
+// reference's own internal inconsistencies), not a designed feature.
+// ============================================================================
+
+/// #1122: the case that actually cracks the mystery -- a *partial* match
+/// (`"abc"`, not `"aaa"`) shows the result is a genuine per-match empty
+/// replace (`"ac"`), not "3-arg sub always returns the empty string".
+#[test]
+fn test_yq_sub_3arg_partial_match_replaces_with_empty_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("b"; "X"; "g")"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""ac""#);
+    Ok(())
+}
+
+/// #1122: the issue's own original probe -- every character matches, so
+/// the empty-per-match replace happens to collapse the whole string.
+#[test]
+fn test_yq_sub_3arg_full_match_gives_empty_string_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("a"; "X"; "g")"#, "\"aaa\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""""#);
+    Ok(())
+}
+
+/// #1122: the `i` (case-insensitive) flag is not honoured -- a pattern
+/// that only matches lowercase leaves an all-uppercase input untouched,
+/// same as if no flags argument were read at all.
+#[test]
+fn test_yq_sub_3arg_flags_not_honoured_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("a"; "X"; "i")"#, "\"AAA\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""AAA""#);
+    Ok(())
+}
+
+/// #1122: real yq's parser accepts (and ignores) a 4th argument too --
+/// confirmed live it behaves identically to the 3-arg form, unlike jq's
+/// own hard "sub/4 is not defined" compile error. succinctly's own parser
+/// used to reject this outright even in yq mode (`expected ')', found
+/// ';'`); now accepts and discards any further `; expr` arguments in yq
+/// mode specifically, matching the oracle's own leniency.
+#[test]
+fn test_yq_sub_4_args_still_ignores_everything_past_pattern_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("b"; "X"; "g"; "h")"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""ac""#);
+    Ok(())
+}
+
+/// #1122: a non-string replacement argument is still never read, so it
+/// never reaches (or needs) #1052's own non-string-replacement coercion.
+#[test]
+fn test_yq_sub_3arg_non_string_replacement_still_ignored_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("b"; 5; "g")"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""ac""#);
+    Ok(())
+}
+
+/// #1122: an invalid regex *pattern* still raises the genuine compile
+/// error -- only `replacement`/`flags` are unevaluated, not `re` itself.
+#[test]
+fn test_yq_sub_3arg_invalid_pattern_still_errors_1122() -> Result<()> {
+    let (_output, code) = run_yq_stdin(r#"sub("["; "X"; "g")"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// #1122: since `replacement`/`flags` are never evaluated at all (not
+/// "evaluated and discarded"), an `error(...)` in either position does
+/// not propagate -- confirmed live this is what real yq does (prints
+/// `"ac"`, not an error).
+#[test]
+fn test_yq_sub_3arg_replacement_error_not_propagated_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        r#"sub("b"; error("boom"); "g")"#,
+        "\"abc\"\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""ac""#);
+    Ok(())
+}
+
+/// #1122/#1255 interaction: this fix's replacement text is `""`, so on a
+/// zero-width-capable pattern the two issues compose -- confirmed live
+/// this already matches real yq once both fixes are in place.
+#[test]
+fn test_yq_sub_3arg_zero_width_pattern_interaction_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("a*"; "X"; "g")"#, "\"bab\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""bb""#);
+    Ok(())
+}
+
+/// #1122 jq-mode regression guard: jq's own 3-arg `sub(re;s;flags)` must
+/// stay untouched by this yq-only fix -- confirmed against jq 1.7.1.
+#[test]
+fn test_jq_sub_3arg_unaffected_by_1122() -> Result<()> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
+        .arg("-c")
+        .arg(r#""AAA" | sub("a";"X";"i")"#)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(b"null")?;
+    }
+    let output = cmd.wait_with_output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(output.status.code().unwrap_or(-1), 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "\"XAA\"");
+    Ok(())
+}
+
 /// #950: real yq treats an integer-valued float and the equivalent plain
 /// integer as genuinely distinct, non-equal types -- `2.0 == 2` is `false`
 /// (verified against pinned yq v4.53.3), unlike jq's looser convention

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14068,6 +14068,22 @@ fn test_yq_sub_3arg_flags_not_honoured_1122() -> Result<()> {
     Ok(())
 }
 
+/// #1122: a syntactically-invalid flags string (one `build_regex` would
+/// reject as "not a valid modifier string" if it were ever read) is
+/// silently ignored too -- confirmed live against yq v4.53.3, which never
+/// evaluates or validates `flags` for this form at all. Pins this
+/// specifically because every other flags value this file tests (`"g"`,
+/// `""`, `null`, `"i"`) happens to be one `build_regex` would accept even
+/// if honoured, so none of them would catch a regression that reintroduces
+/// flags validation on this path.
+#[test]
+fn test_yq_sub_3arg_garbage_flags_still_ignored_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("b"; "X"; "zzz")"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""ac""#);
+    Ok(())
+}
+
 /// #1122: real yq's parser accepts (and ignores) a 4th argument too --
 /// confirmed live it behaves identically to the 3-arg form, unlike jq's
 /// own hard "sub/4 is not defined" compile error. succinctly's own parser

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14117,6 +14117,66 @@ fn test_yq_sub_3arg_invalid_pattern_still_errors_1122() -> Result<()> {
     Ok(())
 }
 
+/// #1122/#1443: a non-string *pattern* still errors -- confirmed this is
+/// a real, pre-existing divergence from real yq (which coerces `1` to
+/// `"1"` and matches literally) shared by the whole regex builtin family
+/// in yq mode, tracked separately as #1443 rather than fixed here. Pinned
+/// as succinctly's current behaviour for this arity-3 path specifically.
+#[test]
+fn test_yq_sub_3arg_non_string_pattern_errors_1122() -> Result<()> {
+    let (_output, code) = run_yq_stdin(r#"sub(1; "X"; "g")"#, "\"a1c\"\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// #1122: a non-string *input* value errors, same as the shared jq/yq sub
+/// path -- `re_expr` is still evaluated against the input regardless of
+/// its type, so this arm is reached before any regex work happens.
+#[test]
+fn test_yq_sub_3arg_non_string_input_errors_1122() -> Result<()> {
+    let (_output, code) = run_yq_stdin(r#"sub("a"; "X"; "g")"#, "1\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
+/// #1122: `?` makes a non-string input a silent no-output rather than an
+/// error -- `?` itself is a succinctly extension (real yq's own parser
+/// rejects it as a lexer error). Per #693, `?` catches the `Error` this
+/// function returns at the outer `Expr::Optional` wrapper rather than
+/// making the function's own internal `optional` guard see `true` -- this
+/// pins the observable, extension-level behaviour, not that internal arm.
+#[test]
+fn test_yq_sub_3arg_non_string_input_optional_is_silent_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("a"; "X"; "g")?"#, "1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "");
+    Ok(())
+}
+
+/// #1122: `?` on an invalid regex *pattern* is likewise silent rather than
+/// an error, same #693 outer-wrapper mechanism as the non-`?` case above.
+#[test]
+fn test_yq_sub_3arg_invalid_pattern_optional_is_silent_1122() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub("["; "X"; "g")?"#, "\"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "");
+    Ok(())
+}
+
+/// #1122: an `error(...)` in `re_expr` itself, unlike `replacement`/
+/// `flags`, DOES propagate -- confirmed live this matches real yq (only
+/// the pattern is ever evaluated).
+#[test]
+fn test_yq_sub_3arg_error_in_pattern_propagates_1122() -> Result<()> {
+    let (_output, code) = run_yq_stdin(
+        r#"sub(error("boom"); "X"; "g")"#,
+        "\"abc\"\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    Ok(())
+}
+
 /// #1122: since `replacement`/`flags` are never evaluated at all (not
 /// "evaluated and discarded"), an `error(...)` in either position does
 /// not propagate -- confirmed live this is what real yq does (prints


### PR DESCRIPTION
## Summary

Closes #1122. Real yq's 3-arg `sub(re; replacement; flags)` ignores every argument after the pattern and replaces every match with the empty string — confirmed live against yq v4.53.3, per the issue's own completed "mystery solved" investigation. Near-certainly an upstream bug (yq's `substitute` reading its replacement from a fixed AST slot that's empty once arity exceeds 2), not a designed feature, but per **ADR-0018 rule 3** (bug-for-bug fidelity by default, including the reference's own internal inconsistencies) this repo pins oracle behaviour rather than upstream intent.

## The one open question, resolved before implementing

The plan flagged one thing to verify live: does yq *evaluate and discard* arguments 2..n, or never evaluate them at all? Confirmed: `sub("b"; error("boom"); "g")` prints `"ac"` in real yq, not an error — so replacement/flags are **never evaluated**, not evaluated-then-discarded (which would still propagate a genuine error). Only the pattern is evaluated and type-checked, so `sub("[";"X";"g")` still raises the real regex-compile error.

## Changes

- Added `yq_sub_arity3_empty_replace`, gated in `builtin_sub_with_flags` on `S::TAG == EvalTag::Yq && flags_expr.is_some()` — *before* `eval_regex_pattern_and_flags` is ever called, so `flags_expr` genuinely never gets evaluated. Builds the regex from the pattern alone (no flags), does a global match, and stitches the input with every match's span deleted — a plain global-replace-with-constant-empty-string, not "always returns the empty string" (confirmed live: a partial match like `"abc" | sub("b";"X";"g")` gives `"ac"`, not `""`).
- Fixed a related parser gap the plan's own test list surfaced: succinctly's parser hard-rejected a 4th `sub` argument even in yq mode, but real yq's own parser accepts (and ignores) arity 4+ too — confirmed live it behaves identically to arity 3, unlike jq (which gives its own hard `sub/4 is not defined` compile error, confirmed and left unchanged — this parser addition is gated to yq mode only).
- Updated the one existing test that pinned the pre-fix (deliberately wrong, per its own doc comment) placeholder behavior — it explicitly documented itself as *"a regression pin on succinctly's own current (and separately tracked as incorrect) output, not an oracle-verified baseline"* — renamed and updated to assert the now-correct, oracle-verified values.

## Test plan

- [x] Tests for: the partial-match case that distinguishes "empty per-match replace" from "always returns empty string"; the issue's own full-match probe; the unhonoured `i` flag; 4-arg parsing; non-string replacement (never read); invalid pattern still erroring; a replacement-side error not propagating; the #1255 zero-width-match interaction (confirmed both fixes compose correctly: `"bab" | sub("a*";"X";"g")` → `"bb"`); a jq-mode regression guard.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`, sequential) — 2705 lib tests, 803 yq_cli_tests, all pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt --check` clean.
