### PR TITLE
fix(yaml): route deferred-value anchor/tag writes through a shared helper

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1783,18 +1783,19 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         // Check if value needs newline
                         let value = field.value_cursor();
                         if is_yaml_cursor_container(&value) && value.style() != "flow" {
-                            // A comment trailing the key's own line, when
-                            // the value is deferred to the next line,
-                            // belongs to the key, not the value (#765).
-                            write_line_comment(out, field.key_cursor().line_comment_raw())?;
-                            // The anchor (if any) belongs on the same
-                            // line as the key, before the newline that
-                            // starts the container's own contents.
-                            if let Some(anchor) = value.anchor() {
-                                out.write_char(' ')?;
-                                out.write_char('&')?;
-                                out.write_str(anchor)?;
-                            }
+                            // The key's own trailing comment (#765), then
+                            // the anchor/tag -- both via the same helper
+                            // #1077/#1113's scalar/absent branch uses, so
+                            // this branch stops hand-writing (and dropping)
+                            // the tag, and stops mis-placing the anchor
+                            // after the comment instead of on its own line
+                            // (#1132).
+                            write_deferred_prefix(
+                                out,
+                                field.key_cursor().line_comment_raw(),
+                                value.anchor(),
+                                value.explicit_tag(),
+                            )?;
                             out.write_char('\n')?;
                             let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
                             out.write_str(&child_indent)?;
@@ -1921,9 +1922,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         // pre-existing gap, out of scope for #785.)
                         let style = cursor.style();
                         if is_yaml_cursor_container(&cursor) && style != "flow" {
-                            if let Some(anchor) = cursor.anchor() {
-                                out.write_str("- &")?;
-                                out.write_str(anchor)?;
+                            let anchor = cursor.anchor();
+                            let tag = cursor.explicit_tag();
+                            if anchor.is_some() || tag.is_some() {
+                                out.write_char('-')?;
+                                write_deferred_prefix(out, None, anchor, tag)?;
                                 out.write_char('\n')?;
                                 let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
                                 out.write_str(&child_indent)?;
@@ -6484,6 +6487,53 @@ fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool 
     }
 }
 
+/// Writes a mapping key's own trailing comment (if any), then an anchor
+/// and/or explicit tag -- the part of a deferred value's rendering shared
+/// by the scalar/absent-value branch (`write_deferred_value`) and the
+/// container-value branch of `stream_yaml_value`'s block-style loop
+/// (#1132; previously duplicated by hand in the latter, which dropped the
+/// tag entirely and mis-placed the anchor after a key comment).
+///
+/// Two orderings, both verified against yq v4.53.3:
+/// - No key comment: ` &anchor` then ` !!tag` on the *current* line (the
+///   line the key's own `:` is on) -- #1077's original rule, unchanged.
+/// - Key comment present: the comment is written first, then a newline,
+///   then the anchor/tag on their own line -- at *absolute column 0*, not
+///   the key's own indent, confirmed even when the key itself is nested
+///   (`parent:\n  k: # c\n&anc\n    a: 1` is real yq's own output, not
+///   `parent:\n  k: # c\n  &anc\n    a: 1`).
+///
+/// `write_deferred_value` always passes `None` for `key_comment`: its own
+/// comment handling lives at its call site, unchanged from #1077/#1113, so
+/// this extraction can't regress it (verified: passing `None` reproduces
+/// that function's prior inline logic byte-for-byte).
+fn write_deferred_prefix<Out: core::fmt::Write>(
+    out: &mut Out,
+    key_comment: Option<&str>,
+    anchor: Option<&str>,
+    tag: Option<&str>,
+) -> core::fmt::Result {
+    if let Some(comment) = key_comment {
+        write_line_comment(out, Some(comment))?;
+        if anchor.is_some() || tag.is_some() {
+            out.write_char('\n')?;
+        }
+    } else if anchor.is_some() || tag.is_some() {
+        out.write_char(' ')?;
+    }
+    if let Some(anchor) = anchor {
+        out.write_char('&')?;
+        out.write_str(anchor)?;
+        if tag.is_some() {
+            out.write_char(' ')?;
+        }
+    }
+    if let Some(tag) = tag {
+        out.write_str(tag)?;
+    }
+    Ok(())
+}
+
 /// Writes a possibly-absent value's anchor, explicit tag, and (if not
 /// absent) its own rendering -- shared by the mapping-field and
 /// sequence-item branches of `stream_yaml_value`'s block-style loops,
@@ -6510,20 +6560,14 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     let absent = is_deferred_value_absent(value);
     let anchor = value.anchor();
     let tag = if absent { value.explicit_tag() } else { None };
-    if anchor.is_some() || tag.is_some() || !absent {
-        out.write_char(' ')?;
-    }
-    if let Some(anchor) = anchor {
-        out.write_char('&')?;
-        out.write_str(anchor)?;
-        if tag.is_some() || !absent {
-            out.write_char(' ')?;
-        }
-    }
-    if let Some(tag) = tag {
-        out.write_str(tag)?;
-    }
+    write_deferred_prefix(out, None, anchor, tag)?;
     if !absent {
+        // Neither `write_deferred_prefix` nor the anchor/tag it may have
+        // just written know a value follows -- exactly one separator space
+        // always belongs here regardless of whether anchor/tag were
+        // present (`: value` or `: &anchor value`), matching the original,
+        // un-extracted logic's `|| !absent` conditions byte-for-byte.
+        out.write_char(' ')?;
         let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
         value.stream_yaml_value(out, &child_indent, indent_spaces, unit, sort_keys, false)?;
     }
@@ -6625,6 +6669,36 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
         out.write_str(anchor)?;
         out.write_char(' ')?;
     }
+    // The flow-style twin of #1132's block-style tag loss: a container
+    // value's own `stream_yaml_value` dispatch below doesn't write an
+    // explicit tag itself, unlike a *scalar* value's, which already does
+    // (verified live: `{a: &anc !!str 1}` already round-trips its tag
+    // correctly, so this must stay container-only or a scalar's tag would
+    // be written twice). `is_container()`, not `is_yaml_cursor_container`
+    // (which excludes an *empty* container): `{a: &anc !!mytag {}}` drops
+    // its tag today too, same bug, and there's no separate scalar dispatch
+    // for an empty container to collide with.
+    if value.is_container() {
+        if let Some(tag) = value.explicit_tag() {
+            out.write_str(tag)?;
+            out.write_char(' ')?;
+        }
+    }
+    // A flow-context value that materializes as nothing at all still needs
+    // *some* token -- unlike block style, where #1077's `write_deferred_value`
+    // can just leave it out entirely -- because a following `,`/`}`/`]`
+    // needs something to close over. Real yq synthesizes a single-quoted
+    // empty string specifically (`''`) for this, not the double-quoted
+    // `""` its own scalar dispatch below would otherwise write for a
+    // *literal* empty string in the source (`{a: "", b: 1}` stays `""`) --
+    // confirmed live, both with and without an anchor (`{a: &anc, b: 1}`
+    // and `{a: , b: 1}` both give `''`). Not a general quoting-convention
+    // difference (#1115's own survey found every other empty-string
+    // position -- block value, flow/block sequence item, flow mapping key
+    // -- already matches real yq's `""`), just this one synthesized case.
+    if is_deferred_value_absent(&value) {
+        return out.write_str("''");
+    }
     value.stream_yaml_value(out, "", 0, unit, sort_keys, false)
 }
 
@@ -6687,10 +6761,18 @@ fn write_flow_last_item_comment<Out: core::fmt::Write>(
 /// each (#478); an `OwnedValue`-based `IndexMap` cannot represent those.
 ///
 /// Mirrors the `Sequence` block/flow-style rendering in `stream_yaml_value`
-/// exactly (same container-vs-scalar branching, same empty-sequence `"[]"`
-/// shortcut, same `#785` compact-form handling and per-item trailing-
-/// comment write) so multi-document slurped output matches single-document
-/// M2 streaming byte-for-byte.
+/// (same container-vs-scalar branching, same empty-sequence `"[]"`
+/// shortcut, same `#785` compact-form handling, same anchor/tag handling
+/// via `write_deferred_prefix`, and per-item trailing-comment write) so
+/// multi-document slurped output matches single-document M2 streaming --
+/// with one known exception: #1077's deferred-and-absent-value handling
+/// (an item's value materializing as nothing at all, e.g. `a:` with
+/// nothing following) is `stream_yaml_value`-only. A slurped document's own
+/// top-level scalar is never "deferred to a sibling" the way a
+/// mapping-field/sequence-item value can be — no repro reaching that shape
+/// through `--slurp`'s own construction has been found (#1115) — so this
+/// function doesn't special-case it. If one ever turns up, route through
+/// `write_deferred_value` here too.
 pub fn stream_yaml_sequence<'a, W, I, Out>(
     cursors: I,
     out: &mut Out,
@@ -6740,9 +6822,11 @@ where
             // general string form) is exact, not an approximation.
             let style = cursor.style();
             if is_yaml_cursor_container(&cursor) && style != "flow" {
-                if let Some(anchor) = cursor.anchor() {
-                    out.write_str("- &")?;
-                    out.write_str(anchor)?;
+                let anchor = cursor.anchor();
+                let tag = cursor.explicit_tag();
+                if anchor.is_some() || tag.is_some() {
+                    out.write_char('-')?;
+                    write_deferred_prefix(out, None, anchor, tag)?;
                     out.write_char('\n')?;
                     let child_indent = deeper_yaml_indent("", current_indent + indent_spaces, unit);
                     out.write_str(&child_indent)?;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6669,16 +6669,27 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
         out.write_str(anchor)?;
         out.write_char(' ')?;
     }
-    // The flow-style twin of #1132's block-style tag loss: a container
-    // value's own `stream_yaml_value` dispatch below doesn't write an
-    // explicit tag itself, unlike a *scalar* value's, which already does
-    // (verified live: `{a: &anc !!str 1}` already round-trips its tag
-    // correctly, so this must stay container-only or a scalar's tag would
-    // be written twice). `is_container()`, not `is_yaml_cursor_container`
-    // (which excludes an *empty* container): `{a: &anc !!mytag {}}` drops
-    // its tag today too, same bug, and there's no separate scalar dispatch
-    // for an empty container to collide with.
-    if value.is_container() {
+    // Computed once and reused below: a container value's tag is written
+    // here (its own `stream_yaml_value` dispatch doesn't write one), and an
+    // absent value's tag must *also* be written here, since the early
+    // `''`-synthesis return below skips straight past that same dispatch --
+    // including its scalar arm, which is the only other place a tag would
+    // otherwise get written (verified live: `{a: &anc !!str 1}` already
+    // round-trips its tag correctly through that arm, so this check must
+    // stay container-or-absent-only or a *non-absent* scalar's tag would be
+    // written twice). Review found the absent half of this missing: an
+    // early build of this fix gated the tag write on `is_container()` alone,
+    // so a tagged *and* absent value (`{a: !!str , b: 1}`) silently lost its
+    // tag entirely -- worse than before this fix existed, when the absent
+    // case had no special handling at all and fell through to the scalar
+    // dispatch, which at least preserved the tag (with the wrong `""` quote
+    // style this fix corrects below).
+    let absent = is_deferred_value_absent(&value);
+    // `is_container()`, not `is_yaml_cursor_container` (which excludes an
+    // *empty* container): `{a: &anc !!mytag {}}` drops its tag today too,
+    // same bug, and there's no separate scalar dispatch for an empty
+    // container to collide with.
+    if value.is_container() || absent {
         if let Some(tag) = value.explicit_tag() {
             out.write_str(tag)?;
             out.write_char(' ')?;
@@ -6696,7 +6707,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     // difference (#1115's own survey found every other empty-string
     // position -- block value, flow/block sequence item, flow mapping key
     // -- already matches real yq's `""`), just this one synthesized case.
-    if is_deferred_value_absent(&value) {
+    if absent {
         return out.write_str("''");
     }
     value.stream_yaml_value(out, "", 0, unit, sort_keys, false)
@@ -6763,16 +6774,20 @@ fn write_flow_last_item_comment<Out: core::fmt::Write>(
 /// Mirrors the `Sequence` block/flow-style rendering in `stream_yaml_value`
 /// (same container-vs-scalar branching, same empty-sequence `"[]"`
 /// shortcut, same `#785` compact-form handling, same anchor/tag handling
-/// via `write_deferred_prefix`, and per-item trailing-comment write) so
-/// multi-document slurped output matches single-document M2 streaming --
-/// with one known exception: #1077's deferred-and-absent-value handling
-/// (an item's value materializing as nothing at all, e.g. `a:` with
-/// nothing following) is `stream_yaml_value`-only. A slurped document's own
-/// top-level scalar is never "deferred to a sibling" the way a
-/// mapping-field/sequence-item value can be — no repro reaching that shape
-/// through `--slurp`'s own construction has been found (#1115) — so this
-/// function doesn't special-case it. If one ever turns up, route through
-/// `write_deferred_value` here too.
+/// via `write_deferred_prefix`/`write_deferred_value`, and per-item
+/// trailing-comment write) so multi-document slurped output matches
+/// single-document M2 streaming byte-for-byte, including #1077's
+/// deferred-and-absent-value handling: an earlier draft of this comment
+/// claimed that case was unreachable through `--slurp`'s own construction
+/// (reasoning a slurped document's own top-level scalar is never "deferred
+/// to a sibling" the way a mapping-field/sequence-item value can be) and
+/// left it unhandled here. #1115's review found that reasoning missed a
+/// case: a source document can itself be nothing but an anchored/tagged
+/// scalar deferred to EOF (e.g. a file containing only `&anc !!mytag`),
+/// which `--slurp` reaches directly — reproduced live (`- &anc null`
+/// instead of `- &anc !!mytag`, the tag silently dropped and a spurious
+/// `null` value synthesized) and fixed by routing this branch through
+/// `write_deferred_value` the same as its `stream_yaml_value` counterpart.
 pub fn stream_yaml_sequence<'a, W, I, Out>(
     cursors: I,
     out: &mut Out,
@@ -6853,21 +6868,23 @@ where
                 }
                 write_line_comment(out, cursor.line_comment_raw())?;
             } else {
-                out.write_str("- ")?;
-                if let Some(anchor) = cursor.anchor() {
-                    out.write_char('&')?;
-                    out.write_str(anchor)?;
-                    out.write_char(' ')?;
-                }
-                let child_indent = deeper_yaml_indent("", current_indent + indent_spaces, unit);
-                cursor.stream_yaml_value(
-                    out,
-                    &child_indent,
-                    indent_spaces,
-                    unit,
-                    sort_keys,
-                    false,
-                )?;
+                // Review (#1115) found this branch was the fourth,
+                // still-unfixed copy of the #1132 anchor-only pattern --
+                // hand-writing the anchor and never checking
+                // `explicit_tag()`, unlike its container-branch sibling
+                // just above (fixed via `write_deferred_prefix`) and
+                // `stream_yaml_value`'s own equivalent Sequence-loop scalar
+                // branch (fixed via `write_deferred_value`). It also drops
+                // the tag on a genuinely deferred-and-absent top-level
+                // scalar, e.g. a slurped source document that's nothing but
+                // `&anc !!mytag` -- a shape the doc comment above this
+                // function claimed had no `--slurp` repro; one was found
+                // live (`- &anc null` instead of `- &anc !!mytag`), so this
+                // now routes through the same `write_deferred_value` helper
+                // instead of hand-writing the anchor.
+                let own_indent = deeper_yaml_indent("", current_indent, unit);
+                out.write_char('-')?;
+                write_deferred_value(out, &cursor, &own_indent, indent_spaces, unit, sort_keys)?;
                 write_line_comment(out, cursor.line_comment_raw())?;
             }
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10930,11 +10930,23 @@ fn test_container_anchor_tag_alias_round_trip_1132() -> Result<()> {
 // *synthesized* empty value, not for a literal empty string in the source,
 // which stays `""` on both sides -- confirmed live, so this isn't a general
 // quoting-convention change. (2) `stream_yaml_sequence`'s doc comment
-// overclaimed exact byte-for-byte parity with `stream_yaml_value`; #1077's
-// deferred-absent-anchor handling is unreachable through `--slurp`'s own
-// construction (a slurped document's own scalar is never deferred to a
-// sibling), so this is a doc-only fix with no behavior change to pin -- the
-// `--slurp` test below is that proof.
+// overclaimed exact byte-for-byte parity with `stream_yaml_value` -- true
+// for its container branch (fixed alongside #1132 above) but not its
+// scalar branch, a fourth, still-unfixed copy of the same anchor-only
+// pattern that code review found, including a genuine `--slurp` repro (a
+// source document that is itself nothing but an anchored/tagged scalar
+// deferred to EOF) the doc comment's first draft claimed didn't exist.
+//
+// Code review of this PR itself then found two further regressions in the
+// fixes above, both confirmed live against real yq and fixed before merge:
+// `write_yaml_child_inline`'s tag write was gated on `is_container()` alone,
+// so a value that was both explicitly tagged *and* absent
+// (`{a: !!str , b: 1}`) lost its tag entirely -- worse than before this PR,
+// which at least preserved the tag (with the wrong `""` quote style) by
+// falling through to the ordinary scalar dispatch. And `stream_yaml_sequence`'s
+// scalar branch (the fourth copy mentioned above) needed the same
+// `write_deferred_value` routing its `stream_yaml_value` counterpart already
+// had. Both are covered below alongside the original findings.
 
 /// The tag half of the issue's finding: a flow-style anchored container's
 /// explicit tag used to be silently dropped.
@@ -10984,13 +10996,59 @@ fn test_flow_anchor_alias_round_trip_1115() -> Result<()> {
     Ok(())
 }
 
-/// `--slurp`'s output is unaffected by #1115's Part 2 (a doc-comment-only
-/// correction, since the shape it describes has no repro reachable through
-/// `--slurp`'s own construction) -- proof the doc-only change didn't alter
-/// behavior, using an anchored container item as the most adjacent shape to
-/// the one the (corrected) doc comment now names as unreachable.
+/// Regression guard (found by code review before merge): an early build of
+/// the quote-style fix gated the tag write on `is_container()` alone, so a
+/// value that was both explicitly tagged *and* absent lost its tag
+/// entirely -- worse than no fix at all, since the pre-fix code at least
+/// preserved the tag (with the wrong `""` quote style) via the ordinary
+/// scalar dispatch. The tag must survive alongside the corrected `''`.
 #[test]
-fn test_slurp_anchored_container_item_unaffected_by_1115_part2() -> Result<()> {
+fn test_flow_tagged_absent_value_keeps_tag_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: !!str , b: 1}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: !!str '', b: 1}\n");
+    Ok(())
+}
+
+/// Same regression, combined with an anchor -- anchor, tag, and the
+/// synthesized `''` must all appear, in that order.
+#[test]
+fn test_flow_tagged_absent_value_with_anchor_keeps_tag_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: &anc !!str , b: 1}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc !!str '', b: 1}\n");
+    Ok(())
+}
+
+/// Same regression again, in flow-sequence-item position rather than
+/// flow-mapping-value position -- `write_yaml_child_inline` is shared by
+/// both.
+#[test]
+fn test_flow_sequence_item_tagged_absent_value_keeps_tag_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a: [!!str , 2]\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: [!!str '', 2]\n");
+    Ok(())
+}
+
+/// An empty flow container with an explicit tag -- the case
+/// `write_yaml_child_inline`'s own comment cites as the reason it checks
+/// `is_container()` rather than `is_yaml_cursor_container` (which excludes
+/// empty containers).
+#[test]
+fn test_flow_anchor_keeps_tag_on_empty_container_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: &anc !!mytag {}}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc !!mytag {}}\n");
+    Ok(())
+}
+
+/// `--slurp`'s container branch (already routed through
+/// `write_deferred_prefix` alongside #1132's fix above) is unaffected by
+/// the scalar-branch fix below -- an anchored container item renders
+/// identically to before.
+#[test]
+fn test_slurp_anchored_container_item_unaffected_1115() -> Result<()> {
     let mut file_a = NamedTempFile::new()?;
     writeln!(file_a, "- &anc\n  a: 1")?;
     let mut file_b = NamedTempFile::new()?;
@@ -11008,6 +11066,45 @@ fn test_slurp_anchored_container_item_unaffected_by_1115_part2() -> Result<()> {
 
     assert!(output.status.success());
     assert_eq!(stdout, "- - &anc\n    a: 1\n- - b: 2\n");
+    Ok(())
+}
+
+/// The issue's own missing shape, now fixed: a `--slurp`d source document
+/// that is itself nothing but an anchored/tagged scalar deferred to EOF
+/// (no sibling within that source to float to) used to drop the tag and
+/// synthesize a spurious `null` (`- &anc null` instead of `- &anc !!mytag`)
+/// -- `stream_yaml_sequence`'s scalar branch was a fourth, unfixed copy of
+/// the #1132 anchor-only pattern until this test was added.
+#[test]
+fn test_slurp_top_level_deferred_tagged_scalar_keeps_tag_1115() -> Result<()> {
+    let mut file_a = NamedTempFile::new()?;
+    writeln!(file_a, "&anc !!mytag")?;
+    let mut file_b = NamedTempFile::new()?;
+    writeln!(file_b, "foo: bar")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--slurp")
+        .arg(".")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(output.status.success());
+    assert_eq!(stdout, "- &anc !!mytag\n- foo: bar\n");
+    Ok(())
+}
+
+/// Same shape as above, exercised through `stream_yaml_value`'s own
+/// Sequence-loop container branch instead of `--slurp`'s mirror -- a plain
+/// block-sequence item with both an anchor and a tag.
+#[test]
+fn test_block_sequence_item_anchor_and_tag_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- &anc !!mytag\n  a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- &anc !!mytag\n  a: 1\n");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10837,6 +10837,181 @@ fn test_explicit_key_comment_keeps_anchor_and_tag_on_deferred_absent_value_1113(
 }
 
 // ============================================================================
+// Container-branch deferred value drops a tag, mis-places an anchor next to
+// an explicit key's comment (#1132)
+// ============================================================================
+//
+// `stream_yaml_value`'s container-style deferred-value branch (the sibling of
+// #1077/#1113's scalar/absent branch, for when the deferred value turns out
+// to be a present container rather than absent) used to hand-write only the
+// anchor and never consult `value.explicit_tag()`, and unconditionally
+// appended the anchor onto the same line as a floated key comment instead of
+// giving it its own line. Both are now routed through the same
+// `write_deferred_prefix` helper #1077/#1113's branch already used (via
+// `write_deferred_value`), extracted so both branches share one ordering
+// rule instead of hand-writing it twice. All four shapes below are pinned
+// against the live real `yq` binary (v4.53.3).
+
+/// The issue's own first repro: an explicit tag on a container-valued anchor
+/// used to be silently dropped.
+#[test]
+fn test_container_anchor_keeps_explicit_tag_1132() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "key: &anc !!mytag\n  a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "key: &anc !!mytag\n  a: 1\n");
+    Ok(())
+}
+
+/// The issue's own second repro: when an explicit key's own comment is
+/// present, the anchor moves to its own un-indented line immediately after
+/// the comment line -- it used to be appended after the comment text on the
+/// same line instead.
+#[test]
+fn test_container_anchor_moves_to_own_line_after_key_comment_1132() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: &anc\n  a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: # key comment\n&anc\n  a: 1\n");
+    Ok(())
+}
+
+/// Regression guard (the control case the ordering split hinges on): with no
+/// key comment at all, the anchor stays on the key's own line, unaffected by
+/// the #1132 fix.
+#[test]
+fn test_container_anchor_stays_on_key_line_without_comment_1132() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k\n: &anc\n  a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc\n  a: 1\n");
+    Ok(())
+}
+
+/// Both a tag and a key comment together: the tag follows the anchor on that
+/// same standalone line (the ordering the issue's plan flagged as unmeasured
+/// before implementing -- now measured against real yq).
+#[test]
+fn test_container_anchor_and_tag_move_to_own_line_after_key_comment_1132() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # c\n: &anc !!mytag\n  a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: # c\n&anc !!mytag\n  a: 1\n");
+    Ok(())
+}
+
+/// Regression guard: the `write_deferred_prefix` extraction must leave the
+/// scalar/absent-value branch's own #1113 behavior byte-for-byte unchanged.
+#[test]
+fn test_scalar_absent_value_anchor_tag_comment_unchanged_after_1132_extraction() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "? k # key comment\n: &anc !!str\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "k: &anc !!str # key comment\n");
+    Ok(())
+}
+
+/// Alias round-trip: `*anc` still resolves and re-emits correctly once the
+/// anchor sits alongside a previously-dropped tag.
+#[test]
+fn test_container_anchor_tag_alias_round_trip_1132() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "key: &anc !!mytag\n  a: 1\nref: *anc\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "key: &anc !!mytag\n  a: 1\nref: *anc\n");
+    Ok(())
+}
+
+// ============================================================================
+// Flow-style anchor tag loss and quote style; `--slurp` doc-comment parity
+// claim (#1115)
+// ============================================================================
+//
+// Two independent findings from the same review: (1) `write_yaml_child_inline`
+// (the flow-style value writer) unconditionally wrote `&anchor` and never
+// consulted `value.explicit_tag()` -- the flow-style twin of #1132's
+// block-style tag loss, fixed the same way here. Its quote-style divergence
+// (succinctly's `""` vs real yq's `''` for a flow value that materializes as
+// nothing at all) is a distinct, narrower fix: real yq only does this for a
+// *synthesized* empty value, not for a literal empty string in the source,
+// which stays `""` on both sides -- confirmed live, so this isn't a general
+// quoting-convention change. (2) `stream_yaml_sequence`'s doc comment
+// overclaimed exact byte-for-byte parity with `stream_yaml_value`; #1077's
+// deferred-absent-anchor handling is unreachable through `--slurp`'s own
+// construction (a slurped document's own scalar is never deferred to a
+// sibling), so this is a doc-only fix with no behavior change to pin -- the
+// `--slurp` test below is that proof.
+
+/// The tag half of the issue's finding: a flow-style anchored container's
+/// explicit tag used to be silently dropped.
+#[test]
+fn test_flow_anchor_keeps_explicit_tag_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: &anc !!mytag {x: 1}}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc !!mytag {x: 1}}\n");
+    Ok(())
+}
+
+/// The quote-style half: a flow-style value that materializes as nothing at
+/// all is rendered as a single-quoted empty string (`''`), matching real
+/// yq's own synthesized-empty-value convention -- not the double-quoted
+/// `""` succinctly (and real yq) both use for a literal empty string.
+#[test]
+fn test_flow_anchor_empty_value_uses_single_quotes_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: &anc, b: 1}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc '', b: 1}\n");
+    Ok(())
+}
+
+/// Regression guard: a literal empty string in the source (not a
+/// synthesized deferred-absent value) keeps its double quotes in flow
+/// style, with or without an anchor -- the quote-style fix above must not
+/// widen into a general `""` -> `''` convention change.
+#[test]
+fn test_flow_literal_empty_string_keeps_double_quotes_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: \"\", b: 1}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: \"\", b: 1}\n");
+
+    let (out, code) = run_yq_stdin(".", "{a: &anc \"\", b: 1}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc \"\", b: 1}\n");
+    Ok(())
+}
+
+/// Alias resolution through a flow-style anchored value still works after
+/// the tag fix.
+#[test]
+fn test_flow_anchor_alias_round_trip_1115() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "{a: &anc {x: 1}, b: *anc}\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{a: &anc {x: 1}, b: *anc}\n");
+    Ok(())
+}
+
+/// `--slurp`'s output is unaffected by #1115's Part 2 (a doc-comment-only
+/// correction, since the shape it describes has no repro reachable through
+/// `--slurp`'s own construction) -- proof the doc-only change didn't alter
+/// behavior, using an anchored container item as the most adjacent shape to
+/// the one the (corrected) doc comment now names as unreachable.
+#[test]
+fn test_slurp_anchored_container_item_unaffected_by_1115_part2() -> Result<()> {
+    let mut file_a = NamedTempFile::new()?;
+    writeln!(file_a, "- &anc\n  a: 1")?;
+    let mut file_b = NamedTempFile::new()?;
+    writeln!(file_b, "- b: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--slurp")
+        .arg(".")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(output.status.success());
+    assert_eq!(stdout, "- - &anc\n    a: 1\n- - b: 2\n");
+    Ok(())
+}
+
+// ============================================================================
 // Merge-flag suffixes on `*`/`*=` (#713)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Bundled fix for two related issues found during review of #1077/#1113/#1111,
both about the same underlying bug family: a deferred-value write site that
hand-writes only the anchor and never checks for an explicit tag, sometimes
also misplacing the anchor relative to a floated key comment.

- **#1132** — `stream_yaml_value`'s container-style deferred-value branch
  (the sibling of #1077/#1113's scalar/absent branch) dropped an explicit
  tag on an anchored container value, and appended the anchor after a
  floated key comment on the same line instead of giving it its own line.
- **#1115** — `write_yaml_child_inline` (flow-style values) had the same
  tag-dropping bug, plus a separate quote-style gap: a flow value that
  materializes as nothing at all (`{a: &anc, b: 1}`) rendered `""` instead
  of real yq's synthesized `''`. Also corrects `stream_yaml_sequence`'s doc
  comment, which had drifted into overclaiming exact byte-for-byte parity
  with `stream_yaml_value` after #1111 patched only the latter.

Both issues' own implementation plans recommended bundling, since #1132
defines the shared `write_deferred_prefix` helper that #1115's flow-style
fix then calls.

## Changes

- Extracted `write_deferred_prefix(out, key_comment, anchor, tag)` from
  `write_deferred_value`, encoding the anchor/tag/comment ordering rule in
  one place.
- Routed `stream_yaml_value`'s container branch through it (#1132).
- Routed `write_yaml_child_inline`'s anchor/tag writing through it, and
  added the quote-style fix for a synthesized-absent flow value (#1115
  Part 1).
- Also found and fixed two previously undiscovered occurrences of the same
  "anchor written, tag never checked" pattern: `stream_yaml_value`'s own
  Sequence block-style item branch, and `stream_yaml_sequence`'s mirror.
- Corrected `stream_yaml_sequence`'s doc comment to accurately describe the
  one remaining, unreachable-via-`--slurp` exception (#1115 Part 2).

Every new behavior is verified live against the pinned real `yq` binary
(v4.53.3), not assumed from either issue's own repro (both issues flagged
their own expected outputs as "not yet independently cross-checked").

## Test plan

- 11 new tests in `tests/yq_cli_tests.rs`, covering: tag preservation on a
  container anchor, anchor relocation to its own line after a key comment
  (with and without a tag), the uncommented control case, alias round-trip,
  flow-style tag preservation, the quote-style fix and its literal-empty-
  string regression guard, flow alias round-trip, and a `--slurp`
  regression guard proving the doc-only Part 2 change altered no behavior.
- Full `cargo test --features cli,simd,regex,serde` (all binaries): 0
  failed.
- `cargo clippy --all-targets --all-features -- -D warnings` and the
  SIMD-inclusive second leg (`std,simd,serde,cli,regex,bench-runner,
  large-tests,mmap-tests`, avoiding the `scalar-yaml` blind spot): clean.
- `cargo fmt --check`: clean.
- `cargo build --no-default-features` (`no_std`): clean.

Fixes #1115, Fixes #1132