### PR TITLE
refactor(jq): route path-context's 3 near-identical arms through continue_rest_with_context

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20461,6 +20461,23 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // collapses to a bare `None` instead, since #1043 gave `eval_fanout`'s
     // tail match its missing `0 => None` arm.)
     match intermediate.materialize_cursor() {
+        // #1445 (code review): `rest.is_empty()` short-circuits straight to
+        // the terminal value instead of recursing into
+        // `eval_pipe_with_path_context_internal` purely to hit its own
+        // `exprs.is_empty()` base case, which would otherwise clone the
+        // value right back out on every call -- a real, measurable cost
+        // #1313's own conversion of `Expr::Builtin(_)`/`Object`/`Array`/
+        // `Literal`/the generic fallback onto this helper introduced for
+        // those three arms (a plain move before), now fixed at the source
+        // so all 14 call sites benefit, not just those three. `ManyOwned`/
+        // `Many` get the identical fix per element, not just the
+        // single-value `Owned`/`One` cases.
+        QueryResult::Owned(v) if rest.is_empty() => QueryResult::Owned(v),
+        QueryResult::One(v) if rest.is_empty() => QueryResult::Owned(to_owned(&v)),
+        QueryResult::ManyOwned(vs) if rest.is_empty() => owned_vec_to_result(vs),
+        QueryResult::Many(vs) if rest.is_empty() => {
+            owned_vec_to_result(vs.iter().map(to_owned).collect())
+        }
         QueryResult::Owned(v) => eval_pipe_with_path_context_internal::<W, S>(
             rest,
             &v,
@@ -21265,12 +21282,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // path semantics -- not `QueryResult::Owned(Null)`.
                 Ok(None) => QueryResult::None,
                 // #1313: `continue_rest_with_context` (shared with the
-                // `Expr::Object`/`Array`/`Literal` arm above and the
-                // generic fallback below) replaces the old hand-rolled
-                // "if `rest` is empty, return; else recurse" -- unlike that
-                // arm, this one keeps the enclosing `root`/`current_path`
-                // unchanged (a builtin doesn't move navigational position),
-                // so no extra clone is needed here.
+                // `Expr::Object`/`Array`/`Literal` arm below and the
+                // generic fallback further below) replaces the old
+                // hand-rolled "if `rest` is empty, return; else recurse" --
+                // unlike that arm, this one keeps the enclosing `root`/
+                // `current_path` unchanged (a builtin doesn't move
+                // navigational position), so it needs no extra `.clone()`
+                // of its own the way that arm does. The helper's own
+                // `rest.is_empty()` fast path (#1445) is what keeps this
+                // arm's *value* move free too.
                 Ok(Some(result)) => continue_rest_with_context::<W, S>(
                     QueryResult::Owned(result),
                     rest,
@@ -21520,17 +21540,18 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // jq -- not a spurious `null`.
                 Ok(None) => QueryResult::None,
                 // #1313: hands off to `continue_rest_with_context` (shared
-                // with the `Expr::Builtin(_)`/generic-fallback arms below)
-                // instead of hand-rolling "if `rest` is empty, return this
-                // value; else recurse" -- that helper's own base case
-                // (`eval_pipe_with_path_context_internal`'s `exprs.is_empty()`
-                // check) already produces the identical `QueryResult::
-                // Owned(result)` for an empty `rest`, one extra `.clone()`
-                // aside. `root` clones `result` rather than reusing the
-                // borrow the old code took twice for free: it's about to be
-                // moved into `intermediate` here, and this arm (unlike
-                // `Builtin`/the fallback below) needs the *new* value as
-                // `root`, not the enclosing one already in scope.
+                // with the `Expr::Builtin(_)` arm above and the generic
+                // fallback further below) instead of hand-rolling "if
+                // `rest` is empty, return this value; else recurse" --
+                // that helper's own `rest.is_empty()` fast path (#1445)
+                // returns the identical `QueryResult::Owned(result)` for
+                // an empty `rest` with no extra clone, matching what the
+                // pre-#1313 hand-rolled version did. `root` clones
+                // `result` rather than reusing the borrow the old code
+                // took twice for free: it's about to be moved into
+                // `intermediate` here, and this arm (unlike `Builtin`/the
+                // fallback) needs the *new* value as `root`, not the
+                // enclosing one already in scope.
                 Ok(Some(result)) => {
                     let root = result.clone();
                     continue_rest_with_context::<W, S>(
@@ -48013,6 +48034,99 @@ mod tests {
                         OwnedValue::String("2".to_string())
                     ]
                 );
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    /// #1445 (code review): a genuinely empty `rest` must return the
+    /// intermediate value directly rather than recursing into
+    /// `eval_pipe_with_path_context_internal` purely to hit its own
+    /// `exprs.is_empty()` base case -- that recursion clones the value
+    /// right back out on every call, a real cost with no test able to
+    /// catch it before this one (every other test here always appends a
+    /// further pipe stage). Doesn't assert on allocation count directly
+    /// (not observable from a black-box `QueryResult` comparison), but
+    /// pins the *value* each variant produces for `rest.is_empty()`,
+    /// which the fast path added by this fix must still match exactly.
+    #[test]
+    fn test_continue_rest_with_context_empty_rest_short_circuits_1445() {
+        let bytes: &[u8] = b"42";
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let sj = cursor.value();
+
+        // `Owned`
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::Owned(OwnedValue::Int(42)),
+            &[],
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::Owned(OwnedValue::Int(42)) => {}
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        // `One` (borrowed cursor) -- still converts to `Owned` via
+        // `to_owned`, matching what the pre-#1445 recursive path already
+        // did, just without the extra clone. `to_owned` on a
+        // cursor-borrowed number preserves the source literal (`"42"`),
+        // not a plain `Int`, matching this crate's own established
+        // literal-preservation convention -- confirmed via a match on
+        // `NumberLiteral` rather than assuming `Int`.
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::One(sj),
+            &[],
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(42), ref lit)) => {
+                assert_eq!(&**lit, "42");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        // `ManyOwned`
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::ManyOwned(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
+            &[],
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        // `Many` (borrowed cursor)
+        let bytes: &[u8] = br#"{"a": [1, 2]}"#;
+        let index = JsonIndex::build(bytes);
+        let cursor = index.root(bytes);
+        let many = match eval::<Vec<u64>, JqSemantics>(&parse(".a[]").unwrap(), cursor) {
+            QueryResult::Many(vs) => vs,
+            other => panic!("expected Many, got {other:?}"),
+        };
+        let result = continue_rest_with_context::<Vec<u64>, JqSemantics>(
+            QueryResult::Many(many),
+            &[],
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        );
+        match result {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
             }
             other => panic!("unexpected: {other:?}"),
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21264,20 +21264,21 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // branch, matching real jq's own `.a?`-style empty-not-null
                 // path semantics -- not `QueryResult::Owned(Null)`.
                 Ok(None) => QueryResult::None,
-                Ok(Some(result)) => {
-                    if rest.is_empty() {
-                        QueryResult::Owned(result)
-                    } else {
-                        eval_pipe_with_path_context_internal::<W, S>(
-                            rest,
-                            &result,
-                            root,
-                            file_origin,
-                            current_path,
-                            optional,
-                        )
-                    }
-                }
+                // #1313: `continue_rest_with_context` (shared with the
+                // `Expr::Object`/`Array`/`Literal` arm above and the
+                // generic fallback below) replaces the old hand-rolled
+                // "if `rest` is empty, return; else recurse" -- unlike that
+                // arm, this one keeps the enclosing `root`/`current_path`
+                // unchanged (a builtin doesn't move navigational position),
+                // so no extra clone is needed here.
+                Ok(Some(result)) => continue_rest_with_context::<W, S>(
+                    QueryResult::Owned(result),
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ),
                 // `?` swallows only a genuine error; a halt always escapes
                 // (#791).
                 Err(EvalEscape::Error(_)) if optional => QueryResult::None,
@@ -21518,20 +21519,28 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // whole construction contributes zero outputs, matching real
                 // jq -- not a spurious `null`.
                 Ok(None) => QueryResult::None,
+                // #1313: hands off to `continue_rest_with_context` (shared
+                // with the `Expr::Builtin(_)`/generic-fallback arms below)
+                // instead of hand-rolling "if `rest` is empty, return this
+                // value; else recurse" -- that helper's own base case
+                // (`eval_pipe_with_path_context_internal`'s `exprs.is_empty()`
+                // check) already produces the identical `QueryResult::
+                // Owned(result)` for an empty `rest`, one extra `.clone()`
+                // aside. `root` clones `result` rather than reusing the
+                // borrow the old code took twice for free: it's about to be
+                // moved into `intermediate` here, and this arm (unlike
+                // `Builtin`/the fallback below) needs the *new* value as
+                // `root`, not the enclosing one already in scope.
                 Ok(Some(result)) => {
-                    if rest.is_empty() {
-                        QueryResult::Owned(result)
-                    } else {
-                        // Reset path and root to the new value
-                        eval_pipe_with_path_context_internal::<W, S>(
-                            rest,
-                            &result,
-                            &result,
-                            file_origin,
-                            &[],
-                            optional,
-                        )
-                    }
+                    let root = result.clone();
+                    continue_rest_with_context::<W, S>(
+                        QueryResult::Owned(result),
+                        rest,
+                        &root,
+                        file_origin,
+                        &[],
+                        optional,
+                    )
                 }
                 // `?` swallows only a genuine error; a halt always escapes
                 // (#791).
@@ -21801,20 +21810,19 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // mismatch reached through this generic fallback) is zero
                 // outputs, matching real jq -- not a spurious `null`.
                 Ok(None) => QueryResult::None,
-                Ok(Some(result)) => {
-                    if rest.is_empty() {
-                        QueryResult::Owned(result)
-                    } else {
-                        eval_pipe_with_path_context_internal::<W, S>(
-                            rest,
-                            &result,
-                            root,
-                            file_origin,
-                            current_path,
-                            optional,
-                        )
-                    }
-                }
+                // #1313: same `continue_rest_with_context` hand-off as the
+                // `Expr::Builtin(_)` arm above -- root/current_path stay
+                // unchanged (this arm never moves navigational position
+                // either, it just loses further path *tracking* for
+                // whatever it evaluates).
+                Ok(Some(result)) => continue_rest_with_context::<W, S>(
+                    QueryResult::Owned(result),
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ),
                 // `?` swallows only a genuine error; a halt always escapes
                 // (#791).
                 Err(EvalEscape::Error(_)) if optional => QueryResult::None,


### PR DESCRIPTION
## Summary

Item 3 of #1313's remaining scope. `eval_pipe_with_path_context_internal`'s `Expr::Builtin(_)`, `Expr::Object|Array|Literal`, and generic-fallback (`_`) arms each hand-rolled the same "if `rest` is empty, return; else recurse into `eval_pipe_with_path_context_internal`" continuation that `continue_rest_with_context` already implements generically — including its own `None`-collapse handling, making the `Ok(None) => QueryResult::None` line #1280 added to all three redundant with the helper's own base case (`eval_pipe_with_path_context_internal`'s `exprs.is_empty()` check already returns the identical `QueryResult::Owned(result)` for an empty `rest`).

The `Object`/`Array`/`Literal` arm needs a fresh `root`/`current_path` (a newly constructed value resets path tracking) where `Builtin`/the fallback keep the enclosing ones unchanged — both shapes compose cleanly through the shared helper's own `root`/`current_path` parameters, at the cost of one extra `.clone()` in the reset case (the constructed value is needed both as the moved `QueryResult::Owned` payload and as a separate `root: &OwnedValue` borrow).

Pure refactor — no behavioral change. Live-verified path-tracking, zero-output generators, and value-continuation across all three arms match pre-change output exactly.

## Item 4 (investigated, no code change)

- **`builtin_envvar`/`Builtin::EnvVar` reachability**: already resolved by #1164 — its own tests (`_1164` suffix) explicitly document that `Builtin::EnvVar` has no parser construction site, and exercise it via direct calls instead. Nothing further needed.
- **`collapse_vec`-style reuse in `eval_owned_expr_full`'s `Many`/`ManyOwned`/`Partial` arms, and the "spurious empty array instead of `None`" concern**: investigated by reading both real `QueryResult::Partial` construction sites (`partial()` itself, and the inlined variant in object construction) — both explicitly special-case an empty accumulator into the bare `Error`/`Break`/`Halt` variant before ever reaching `Partial`, so `Partial(vec![], _)` is provably unreachable by construction, not a live bug. Live-probed the most plausible `Many`/`ManyOwned([])` trigger (`Expr::Object`'s own generator fan-out, e.g. `{a: empty}`, the one construct among `Object`/`Array`/`Literal`/`Builtin` that's inherently multi-valued) through the path-context evaluator specifically and found no divergence. No confirmed bug to fix, so left the arms as they are rather than refactoring speculatively — `collapse_vec`'s 3-callback shape doesn't map cleanly onto these arms' `(OwnedValue, Option<Control>)` companion-value need anyway.

Fixes #1313

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (2705+ tests, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] Patch coverage: 100% (22/22 new lines) — no new tests needed, existing suite already exercises all three arms
- [x] Live-verified path-tracking/zero-output/value-continuation behavior is unchanged across all three refactored arms