### PR TITLE
docs(jq): stop citing line numbers in ADR-0019

### DIFF
--- a/docs/adrs/adr-0019.md
+++ b/docs/adrs/adr-0019.md
@@ -22,8 +22,8 @@ decision rather than a unilateral implementation:
   engine's leftmost-first search reports as empty, but it is reachable only by
   backtracking to a different alternative.
 
-**The two issues share one root cause.** `src/jq/eval.rs:8261-8277` (the `JqRegex` doc
-comment) already states it directly: `n`'s gap is "the same category of gap as `l`'s
+**The two issues share one root cause.** The `JqRegex` doc comment in `src/jq/eval.rs`
+already states it directly: `n`'s gap is "the same category of gap as `l`'s
 missing `MatchKind::LeftmostLongest` (#920)." Rust's `regex`/`regex-automata` crates are
 Thompson-NFA-based, not backtracking. `regex-automata` 0.4.16's `MatchKind` enum has
 exactly two variants, `All` and `LeftmostFirst` — `LeftmostLongest` is a documented "we
@@ -35,16 +35,16 @@ position when the first-found match is empty) either.
 
 **Every regex builtin shares one choke point.** `test`, `match`, `capture`, `sub`,
 `gsub`, `scan`, `split`, and `splits` all route match discovery through exactly two
-functions, `first_captures`/`global_captures` (`src/jq/eval.rs:8689-8723`), built on
-`next_match_step` (`src/jq/eval.rs:8653-8676`), which queries one `regex::Regex` compiled
+functions, `first_captures`/`global_captures`, built on `next_match_step` (all in
+`src/jq/eval.rs`), which queries one `regex::Regex` compiled
 with Rust's fixed `LeftmostFirst` semantics. There is no per-builtin duplication to
 reconcile — any fix for either gap has exactly one place to land, and conversely no
 per-builtin escape hatch to dodge the problem for just one flag combination.
 
 **The gap is already tested, not silently wrong.** `test_regex_n_flag_known_gap_lazy_quantifier_922`
-(`src/jq/eval.rs:35396-35439`) pins the current, jq-divergent behavior with explanatory
+(in `src/jq/eval.rs`) pins the current, jq-divergent behavior with explanatory
 assertion messages (e.g. `"jq says true here (offset 2, \"a\") — known gap, #922"`).
-`test_regex_unknown_flags_rejected_730` (`src/jq/eval.rs:35270-35301`) only confirms `l`
+`test_regex_unknown_flags_rejected_730` (also in `src/jq/eval.rs`) only confirms `l`
 is accepted as valid flag syntax, not what it should do — no test currently exercises
 `l` actually changing match output, since it never has.
 
@@ -69,7 +69,7 @@ hand-roll a general leftmost-longest or backtracking-retry layer for them. Both 
 accepted as permanent, documented limitations:
 
 - `l` stays a no-op flag character — accepted as valid jq syntax, silently without
-  effect on match semantics (`src/jq/eval.rs:8341-8345`).
+  effect on match semantics (`build_regex`, `src/jq/eval.rs`).
 - `n` stays the skip-forward approximation implemented by `first_captures`/
   `global_captures`: correct for every documented real-world jq use of `n` (greedy
   quantifiers, alternations with the non-empty branch listed first), known-divergent


### PR DESCRIPTION
## Summary

- ADR-0019 (regex-engine gap for jq's `l`/`n` flags, #1394) originally cited four
  `src/jq/eval.rs` line ranges. By the time the branch was revisited, unrelated commits
  had already shifted every one of them (e.g. `8261-8277` → `8323-8340`), and the
  merged copy on `main` still carries the stale numbers.
- Per feedback: ADRs should never cite source line numbers, only file paths and stable
  symbol names (function/struct/test names) — line numbers drift, symbol names don't.
  Replaces all four citations accordingly.
- Filed #1446 to add this as a standing rule in `docs/adrs/adr-0000.md` (the ADR
  standard) and the `review-adr` skill's Structural Accuracy checklist, so it's
  enforced going forward without becoming a global always-loaded instruction.

## Test plan

- [x] `cargo build --features cli,regex`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `grep -nE '\.rs:[0-9]+' docs/adrs/adr-0019.md` — no matches