### PR TITLE
fix(jq): eval_each_pipe's owned-value arm stays lazy through input/inputs

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1849,48 +1849,6 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
-/// Drain a `QueryResult` produced against a *different*, locally-built
-/// document (so it carries no borrow of `'a`) into an `Item<'a, W>` sink.
-///
-/// `eval_owned_pipe`/`eval_owned_input` normalize every output to
-/// `Owned`/`ManyOwned` precisely because their values borrow from an index
-/// built inside the call, so only the owned-family variants are reachable —
-/// the same assumption `eval_pipe`'s own `Owned` arm already makes.
-fn drain_owned_result<'a, W: Clone + AsRef<[u64]>, W2: Clone + AsRef<[u64]>>(
-    result: QueryResult<'_, W2>,
-    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
-) -> Flow {
-    match result {
-        QueryResult::None => Flow::Exhausted,
-        QueryResult::Owned(v) => match sink(Item::Owned(v)) {
-            Demand::Continue => Flow::Exhausted,
-            Demand::Stop => Flow::Stopped,
-        },
-        QueryResult::ManyOwned(vs) => {
-            for v in vs {
-                if sink(Item::Owned(v)) == Demand::Stop {
-                    return Flow::Stopped;
-                }
-            }
-            Flow::Exhausted
-        }
-        QueryResult::Error(e) => Flow::Escaped(Control::Error(e)),
-        QueryResult::Break(label) => Flow::Escaped(Control::Break(label)),
-        QueryResult::Halt(code) => Flow::Escaped(Control::Halt(code)),
-        QueryResult::Partial(vs, control) => {
-            for v in vs {
-                if sink(Item::Owned(v)) == Demand::Stop {
-                    return Flow::Stopped;
-                }
-            }
-            Flow::Escaped(control)
-        }
-        QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-            unreachable!("owned-input evaluation normalizes to the owned-family variants")
-        }
-    }
-}
-
 /// Push every output of `expr` into `sink`, stopping as soon as `sink` says to.
 ///
 /// Only `Comma`, `Pipe` and `Paren` have native lazy arms; everything else
@@ -1957,19 +1915,23 @@ fn eval_each_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // to stop stage 1 too -- that is the whole point of the lazy `Pipe` arm --
     // but the two cases surface differently to our own caller.
     let mut downstream: Option<Flow> = None;
+    // Built once, outside the driver closure, so an Owned item mid-pipe
+    // doesn't re-clone `rest` per value.
+    let rest_pipe = Expr::Pipe(rest.to_vec());
     let upstream = {
         let mut driver = |item: Item<'a, W>| -> Demand {
             let flow = match item {
                 Item::Borrowed(v) => eval_each_pipe::<W, S>(rest, v, optional, &mut *sink),
-                // Mirrors `eval_pipe`'s own `Owned`/`ManyOwned` arms, which
-                // route through `eval_owned_pipe` -> `eval_owned_input`. Same
-                // serialize-and-reindex bridge, same cost, no behaviour
-                // change; laziness simply stops here, which the fallback
-                // invariant permits.
-                Item::Owned(v) => drain_owned_result::<W, Vec<u64>>(
-                    eval_owned_pipe::<Vec<u64>, S>(rest, v, optional),
-                    &mut *sink,
-                ),
+                // Re-enters `eval_each`'s own `Expr::Pipe` arm on the
+                // reindexed owned value (same serialize-and-reindex bridge as
+                // `eval_owned_pipe`/`eval_owned_input`, same cost), so
+                // laziness -- and thus `input`/`inputs` demand -- continues
+                // through the rest of the pipe instead of stopping here
+                // (#820: an eager fallback here silently drained inputs a
+                // downstream sink never asked for).
+                Item::Owned(v) => {
+                    eval_each_owned::<S>(&rest_pipe, &v, optional, &mut |o| sink(Item::Owned(o)))
+                }
             };
             match flow {
                 Flow::Exhausted => Demand::Continue,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16090,6 +16090,52 @@ fn test_discarded_generator_branch_consumes_input_documents_820() -> Result<()> 
     Ok(())
 }
 
+/// A *computed* pipe stage ahead of the comma must not defeat laziness either.
+///
+/// `eval_each_pipe`'s `Item::Owned` arm (an intermediate pipe value that is no
+/// longer borrowed from the input document -- e.g. anything past an
+/// arithmetic op, `tostring`, or a literal) originally fell back to the old
+/// eager `eval_owned_pipe` and only demand-gated *delivery* afterward, so the
+/// discarded branch's side effect -- including an `input`/`inputs` pop --
+/// still happened before the sink ever got a say. This reopened exactly the
+/// data-loss shape `test_discarded_generator_branch_consumes_input_documents_820`
+/// pins, just gated on the pipe having a computed stage before the comma
+/// (a common shape, not an edge case) -- caught in review after Stage 2/2b
+/// landed, so it is pinned here rather than folded into either stage's own
+/// test. Fixed by routing through `eval_each_owned`, which re-enters
+/// `eval_each`'s own lazy `Expr::Pipe` arm on the reindexed owned value
+/// instead of falling back to the eager evaluator.
+#[test]
+fn test_owned_pipe_stage_ahead_of_comma_stays_lazy() -> Result<()> {
+    const DOCS: &str = r#"{"id":1} {"id":2} {"id":3} {"id":4}"#;
+
+    // Control: every document is processed when nothing consumes the queue.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".id"], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "1\n2\n3\n4\n",
+        "control run must see all 4 documents"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-cn", r#"isempty(1 | (1, ("B"|stderr)))"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n");
+    assert_eq!(stderr, "", "the discarded `stderr` branch must not fire");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[isempty(1|(1,input)), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "[false,1]\n[false,2]\n[false,3]\n[false,4]\n",
+        "every document must still be processed"
+    );
+
+    let (stdout, _, code) = run_jq_full(&["-cn", r#"limit(1; 1 | (1, ("B"|stderr)))"#], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\n");
+
+    Ok(())
+}
+
 /// A long *pipe* driven through the evaluator, not just the parser.
 ///
 /// `MAX_EXPR_DEPTH` deliberately does not charge flat pipe/comma chains


### PR DESCRIPTION
## Summary

Found during a review of #820's merged Stage 2/2b work (PRs #1424, #1435):
`eval_each_pipe`'s `Item::Owned` arm fell back to the eager `eval_owned_pipe`
and only demand-gated *delivery* afterward, so a computed pipe stage ahead of
a side-effecting comma still evaluated the discarded branch — reopening the
original data-loss bug for a pipe shape neither stage's own tests covered.

```
$ jq -cn 'isempty(1 | (1, ("B"|stderr)))'                       false   (no stderr)
$ succinctly jq -cn 'isempty(1 | (1, ("B"|stderr)))'            Bfalse  (leaks, before this fix)

$ printf '{"id":1} {"id":2} {"id":3} {"id":4}' | jq -c '[isempty(1|(1,input)), .id]'
[false,1]
[false,2]
[false,3]
[false,4]
$ printf '{"id":1} {"id":2} {"id":3} {"id":4}' | succinctly jq -c '[isempty(1|(1,input)), .id]'
[false,1]
[false,3]     # documents 2 and 4 silently dropped, before this fix
```

Any pipe stage that produces a *computed* value (arithmetic, `tostring`,
literal construction — not just raw field navigation) ahead of the
side-effecting comma triggered this. The design doc's own pseudocode
(`docs/plan/jq-lazy-generator-consumers.md`) calls for routing this arm
through the lazy `eval_each_owned` primitive; the merged code diverged to the
eager fallback without documenting it as a deferred/known gap.

## Fix

Route `eval_each_pipe`'s `Item::Owned` arm through `eval_each_owned` (already
implemented, used by `any`/`all`/`IN`), which re-enters `eval_each`'s own
lazy `Expr::Pipe` arm on the reindexed owned value instead of falling back to
`eval_owned_pipe`. `drain_owned_result` becomes dead code and is removed.

## Test plan

- [x] `cargo test --features cli,regex` — full suite, 0 failures (including a
      new `test_owned_pipe_stage_ahead_of_comma_stays_lazy` pinning the fix)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] Manually verified against pinned `/usr/bin/jq` 1.7.1 for the repros above