### PR TITLE
fix(jq): three path()-tracking eagerness/gaps (#972, #987, #1440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`jq`: `path()` tracks a variable referenced inside `reduce`/`foreach`'s
+  `UPDATE`/`EXTRACT`** (#1440): `resolve_node` had no `Expr::Reduce`/
+  `Expr::Foreach` arm at all, so `path(. as $x | reduce (1,2) as $i (0; $x))`
+  raised "Invalid path expression" where jq gives `[]`. New
+  `resolve_reduce`/`resolve_foreach` arms model jq's own `(path,
+  value_at_path)` register (derived empirically, since real jq has no
+  fold-specific path machinery — `reduce`/`foreach` are sugar over the same
+  variable-binding primitive every other construct uses): the register
+  resets between source-element iterations of the same fold but carries
+  forward within one fold step from `UPDATE` into `EXTRACT`. Four narrower,
+  safe (refuse-only) divergences remain, documented in
+  `docs/compliance/jq/limitations.md`.
+
+- **`jq`: `path(paths(f))` stops pulling from `f` once `path()` is
+  satisfied** (#987): `resolve_leaf`'s fallback for `path()`'s non-primitive
+  argument fully materialized the whole expression before checking whether
+  the first output was path-shaped, so a later output's side effects
+  (`stderr`, a consumed `input`) or error still fired even though real jq's
+  streaming generator never reaches them. Completes Stage 3 of
+  `docs/plan/jq-lazy-generator-consumers.md`: `builtin_paths_filter` becomes
+  a lazy producer (`each_paths_filter`, including each node's own filter
+  fan-out, not just the outer path loop), and `resolve_leaf` splits into a
+  stop-after-first sink for its general case and an always-continue sink for
+  the four static primitives that still need to distinguish 0/1/many
+  outputs.
+
+- **`jq`: `first()`/`limit()` truncate the keep-partial path resolvers**
+  (#972): `resolve_node`'s `first`/`limit` arms fully resolved their inner
+  expression before truncating to `n` outputs, so an error/break/halt after
+  the `n`th output still surfaced. A prior fix (PR #985) was reverted after
+  review found its core assumption — that a `PathResolveResult`'s `Err`
+  prefix is always exactly jq's pre-escape output — false for
+  `resolve_index_expr`/`resolve_slice_expr`'s key/bound × target cross
+  product. Both now restrict their key/bound loops to a single element once
+  their target has escaped, making the invariant hold, before reinstating
+  `first`/`limit`'s truncation.
+
 - **`yq --front-matter`/`--split-exp`/`--eval-all` correctness fixes found
   reviewing #715 before merge**:
   - `--front-matter=extract --inplace` overwrote the target file with just

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,9 +273,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fold-specific path machinery — `reduce`/`foreach` are sugar over the same
   variable-binding primitive every other construct uses): the register
   resets between source-element iterations of the same fold but carries
-  forward within one fold step from `UPDATE` into `EXTRACT`. Four narrower,
-  safe (refuse-only) divergences remain, documented in
-  `docs/compliance/jq/limitations.md`.
+  forward within one fold step from `UPDATE` into `EXTRACT`. A destructuring
+  loop variable (`as [$i]`, `as {v:$v}`) falls back to the old refusal on
+  purpose — jq refuses every such fold in path position too, even one whose
+  pattern matches cleanly. Three narrower divergences remain, documented in
+  `docs/compliance/jq/limitations.md`; **two are refuse-only, but the third
+  (structural equality standing in for jq's pointer identity, #1466) accepts
+  where jq refuses, so `=`/`|=`/`del()` through it write a document jq leaves
+  untouched.**
 
 - **`jq`: `path(paths(f))` stops pulling from `f` once `path()` is
   satisfied** (#987): `resolve_leaf`'s fallback for `path()`'s non-primitive

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -426,36 +426,55 @@ used to be a third, narrower gap, found reviewing
 `resolve_reduce`/`resolve_foreach` arms to `resolve_node` (`src/jq/eval.rs`) modeling jq's
 own `(path, value_at_path)` register, derived empirically since real jq has no fold-specific
 path machinery at all (`reduce`/`foreach` are sugar over the same variable-binding primitive
-every other construct uses). Four narrower shapes remain open, all safe (refuse only, never
-emit a *wrong* path):
+every other construct uses). Three narrower shapes remain open. **They are not all the
+same kind of divergence, and the difference matters on the write path:** #1 and #2 are
+refuse-only (succinctly declines a filter jq accepts — visible, and no document is
+touched), while #3 is the opposite — succinctly *accepts* a filter jq rejects, so
+`=`/`|=`/`del()` through it mutate a document jq leaves untouched.
 
-1. **Variable-rooted navigation off a mismatched accumulator** —
+1. **Variable-rooted navigation off a mismatched accumulator** (refuse-only) —
    `path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))` on `{"a":{"b":1},"c":2}` is
    `["a","b"]` ×2 in jq; succinctly refuses. Same root cause as the pre-existing, unrelated
    `path(. as $x \| 5 \| $x.a)` on `{"a":1}` (jq `["a"]`, succinctly already refuses today) —
    `resolve_node` conflates "current input" with a variable's own bound position outside any
    fold too, so this isn't specific to #1440's own fix.
-2. **The fold's source expression isn't path-checked** — `path(reduce (keys[]) as $k (.; .))`
-   raises in jq, succinctly accepts. `resolve_leaf`'s catch-all keeps only the *first* of a
-   multi-output untracked source (#986), so routing the source through `resolve_node` instead
-   would silently narrow a generator like `range(3)` to one element — correctness over
-   fidelity here, deliberately not attempted.
-3. **A destructuring pattern in the fold's own loop variable isn't path-checked** —
-   `path(. as $x \| reduce ({v:.a}) as {v:$v} (0; $x))` raises in jq, succinctly accepts.
-   Same class as the missing `Expr::AsPattern` resolver arm outside folds entirely.
-4. **Structural equality vs. jq's pointer identity** —
-   `path(reduce (1) as $i (.; {a:.a}))` on `{"a":1}` raises in jq (jq's own `jv_identical`
-   fails since `{a:.a}` constructs a *new* value), succinctly accepts `[]`. `OwnedValue` has
-   no stable identity to compare, so this resolver already softens the check to structural
-   equality everywhere else (`Expr::TrackedVar`'s own arm) — consistent, not a new gap.
-5. **`?//`-alternatives folds aren't path-tracked at all** —
+2. **`?//`-alternatives folds aren't path-tracked at all** (refuse-only) —
    `path(. as $x \| reduce (1) as $y ?// $z (0; $x))` on `{"a":1}` is `[]` in jq; succinctly
    refuses. [#1365](https://github.com/rust-works/succinctly/issues/1365) (`?//`-alternatives
    support for `reduce`/`foreach`'s own `as` clause) landed after `resolve_reduce`/
    `resolve_foreach` were designed, adding a retry-with-rollback matrix
    (`try_reduce_step_alternatives`/`try_foreach_step_alternatives`) neither function threads
-   path-tracking through; `resolve_node`'s dispatch arm handles only the common
-   `patterns.len() == 1` (no `?//`) case and falls to `resolve_leaf`'s catch-all otherwise.
+   path-tracking through. `resolve_node`'s dispatch arm admits exactly `[Pattern::Var(_)]`
+   and falls to `resolve_leaf`'s catch-all otherwise.
+3. **Structural equality vs. jq's pointer identity** (**accepts where jq refuses, including
+   on the write path**) — `path(reduce (1) as $i (.; {a:.a}))` on `{"a":1}` raises in jq
+   (its own `jv_identical` fails since `{a:.a}` constructs a *new* value), succinctly
+   answers `[]`; `(reduce (1) as $i (.; {a:.a})) = 9` therefore writes `9` where jq raises
+   and leaves the input untouched. `OwnedValue` carries no identity, so jq's exact check is
+   not available and only an approximation is — `FoldRegister`'s value comparison is the
+   over-approximating one. `Expr::TrackedVar`'s own arm softens the same check, but is
+   additionally gated on the node *being* a tracked variable, whereas
+   `FoldRegister::relocate` and `resolve_reduce`'s final emission gate on equality alone, so
+   an object literal or any other reconstruction reaching the same value is promoted too.
+   Tracked as [#1466](https://github.com/rust-works/succinctly/issues/1466); do not read
+   this row as "safe".
+
+The fold's own **loop-variable destructuring pattern** (`as [$i]`, `as {v:$v}`) is *not* a
+behavioural divergence: real jq refuses every such fold in path position, even when the
+pattern matches cleanly (`path(. as $x \| reduce ([1]) as [$i] (0; $x))` raises "near attempt
+to access element 0 of [1]", confirmed against jq 1.7.1, while the bare-`$var` spelling of
+the same fold is `[]`), and `resolve_node`'s `[Pattern::Var(_)]` guard reproduces that
+refusal — same outcome, same exit 5, no document written either side. Only the **wording**
+differs: falling through to `resolve_leaf`'s catch-all names the whole fold's own value
+("Invalid path expression with result `{"a":1}`") rather than the destructuring step jq
+blames. That is the same catch-all wording every unresolvable filter already gets here, and
+is the general message-fidelity gap covered above, not a fold-specific one.
+The fold's **source expression** likewise matches jq for every shape tested but one: jq
+evaluates it with tracking on and fails only where it navigates *through* an untrackable
+value, so `reduce (1,2) / (.a) / (.[]) / (keys) / (range(2)) as $i (0; $x)` all resolve in
+both, and only `reduce (keys[]) as $k (.; .)` diverges (jq raises "near attempt to iterate
+through [\"a\"]", succinctly accepts) — tracked as
+[#1467](https://github.com/rust-works/succinctly/issues/1467).
 
 ## Refusing an allocation jq does not survive
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -419,29 +419,43 @@ Unlike the positive case above, `?` does not suppress this one —
 [#498](https://github.com/rust-works/succinctly/issues/498) — because it is a write-time
 bounds check, not a failure to collect the path.
 
-A variable bound outside `reduce`/`foreach` and referenced from inside `UPDATE` is a third,
-narrower gap, found reviewing [#844](https://github.com/rust-works/succinctly/issues/844):
+A variable bound outside `reduce`/`foreach` and referenced from inside `UPDATE`/`EXTRACT`
+used to be a third, narrower gap, found reviewing
+[#844](https://github.com/rust-works/succinctly/issues/844) — closed by
+[#1440](https://github.com/rust-works/succinctly/issues/1440), which added
+`resolve_reduce`/`resolve_foreach` arms to `resolve_node` (`src/jq/eval.rs`) modeling jq's
+own `(path, value_at_path)` register, derived empirically since real jq has no fold-specific
+path machinery at all (`reduce`/`foreach` are sugar over the same variable-binding primitive
+every other construct uses). Four narrower shapes remain open, all safe (refuse only, never
+emit a *wrong* path):
 
-| Filter                                         | Input     | jq   | succinctly                                    |
-|------------------------------------------------|-----------|------|-----------------------------------------------|
-| `path(. as $x \| reduce (1,2) as $i (0; $x))`  | `{"a":1}` | `[]` | `Invalid path expression with result {"a":1}` |
-| `path(. as $x \| foreach (1,2) as $i (0; $x))` | `{"a":1}` | `[]` | `Invalid path expression with result {"a":1}` |
-
-#844 taught `resolve_node` to recognize `Expr::TrackedVar` (a variable frozen from a
-statically-verified passthrough of `.`, per that issue's own `is_identity_passthrough`) so
-that referencing such a variable inside `path(...)` stays trackable. `resolve_node` has no
-`Expr::Reduce`/`Expr::Foreach` arm of its own, though, so either one reaching `path(...)`'s
-resolver falls to `resolve_leaf`'s catch-all regardless of what its `UPDATE` expression
-does internally — a bare `$x` reference inside `UPDATE`, even a `TrackedVar` one, never gets
-the chance to reach the new arm, because `resolve_node` never descends into `Reduce`/
-`Foreach` at all. Real jq has no such gap because `reduce`/`foreach` are sugar over the same
-primitive `as`-binding/iteration machinery every other construct uses, so their own
-trackability was never a separate case to begin with. This is a read-only, safe divergence
-(succinctly never emits a *wrong* path here, only refuses a filter jq accepts) — not fixed
-here; a proper fix needs `resolve_node` to interleave path resolution with `reduce`/
-`foreach`'s own fold loop (evaluating `UPDATE` against each intermediate accumulator through
-`resolve_node` rather than the ordinary value evaluator), which is new machinery beyond a
-single arm.
+1. **Variable-rooted navigation off a mismatched accumulator** —
+   `path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))` on `{"a":{"b":1},"c":2}` is
+   `["a","b"]` ×2 in jq; succinctly refuses. Same root cause as the pre-existing, unrelated
+   `path(. as $x \| 5 \| $x.a)` on `{"a":1}` (jq `["a"]`, succinctly already refuses today) —
+   `resolve_node` conflates "current input" with a variable's own bound position outside any
+   fold too, so this isn't specific to #1440's own fix.
+2. **The fold's source expression isn't path-checked** — `path(reduce (keys[]) as $k (.; .))`
+   raises in jq, succinctly accepts. `resolve_leaf`'s catch-all keeps only the *first* of a
+   multi-output untracked source (#986), so routing the source through `resolve_node` instead
+   would silently narrow a generator like `range(3)` to one element — correctness over
+   fidelity here, deliberately not attempted.
+3. **A destructuring pattern in the fold's own loop variable isn't path-checked** —
+   `path(. as $x \| reduce ({v:.a}) as {v:$v} (0; $x))` raises in jq, succinctly accepts.
+   Same class as the missing `Expr::AsPattern` resolver arm outside folds entirely.
+4. **Structural equality vs. jq's pointer identity** —
+   `path(reduce (1) as $i (.; {a:.a}))` on `{"a":1}` raises in jq (jq's own `jv_identical`
+   fails since `{a:.a}` constructs a *new* value), succinctly accepts `[]`. `OwnedValue` has
+   no stable identity to compare, so this resolver already softens the check to structural
+   equality everywhere else (`Expr::TrackedVar`'s own arm) — consistent, not a new gap.
+5. **`?//`-alternatives folds aren't path-tracked at all** —
+   `path(. as $x \| reduce (1) as $y ?// $z (0; $x))` on `{"a":1}` is `[]` in jq; succinctly
+   refuses. [#1365](https://github.com/rust-works/succinctly/issues/1365) (`?//`-alternatives
+   support for `reduce`/`foreach`'s own `as` clause) landed after `resolve_reduce`/
+   `resolve_foreach` were designed, adding a retry-with-rollback matrix
+   (`try_reduce_step_alternatives`/`try_foreach_step_alternatives`) neither function threads
+   path-tracking through; `resolve_node`'s dispatch arm handles only the common
+   `patterns.len() == 1` (no `?//`) case and falls to `resolve_leaf`'s catch-all otherwise.
 
 ## Refusing an allocation jq does not survive
 

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -2,13 +2,14 @@
 
 [Home](../../) > [Docs](../) > [Plan](./) > Lazy generator consumers
 
-**Status: design only, not implemented.** This document is the deliverable for
-[#820](https://github.com/rust-works/succinctly/issues/820), which its own tier review
-(2026-08-20) classified Tier 3 — "evaluator-architecture change, design doc first, in the
-shape of #1282". It also scopes the two issues that name #820 as their real fix,
-[#932](https://github.com/rust-works/succinctly/issues/932) and
-[#987](https://github.com/rust-works/succinctly/issues/987). No code has been changed;
-see [Follow-up issues](#follow-up-issues).
+**Status: Stages 1, 2, 2b and 3 implemented; Stages 4-5 open.** This document is the
+deliverable for [#820](https://github.com/rust-works/succinctly/issues/820), which its
+own tier review (2026-08-20) classified Tier 3 — "evaluator-architecture change, design
+doc first, in the shape of #1282". It also scopes the two issues that name #820 as their
+real fix, [#932](https://github.com/rust-works/succinctly/issues/932) (partially closed —
+Stage 4 remains) and [#987](https://github.com/rust-works/succinctly/issues/987) (closed
+by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
+[Follow-up issues](#follow-up-issues).
 
 **Mechanism decision, already made:** an **additive sink/callback path alongside** the
 existing eager `eval_single`, not a rewrite of it. `eval_comma`, `eval_pipe` and
@@ -955,9 +956,18 @@ convention: file one implementation issue per stage once this document is review
 
 1. **Stage 1** — characterization tests. **Filed: #1386. Implemented: PR #1389.**
 2. **Stage 2** — `eval_each` + 10 `eval.rs` consumers. Closes #820, most of #932.
-   Depends on 1.
+   Depends on 1. **Implemented** (commit `a493108fc`).
 3. **Stage 2b** — `eval_generic.rs`'s `first`/`last` arm, option (b). Depends on 2. Files
-   its own follow-up for option (c).
-4. **Stage 3** — `paths(f)` producer + `resolve_leaf` sink. Closes #987. Depends on 2.
+   its own follow-up for option (c). **Implemented** (commit `f78089421`).
+4. **Stage 3** — `paths(f)` producer (`each_paths_filter`) + `resolve_leaf`'s
+   stop-after-first sink. Closes #987. Depends on 2. **Implemented.** `Flow::Stopped`
+   gained back its `pending: Option<Control>` payload as part of this stage, exactly as
+   scoped below — `resolve_leaf` is its one reader, preserving an already-triggered
+   `Halt` from an eager-fallback arm rather than downgrading it into a catchable path
+   error. One residual, documented rather than closed: an un-lazified `eval_each` arm
+   (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a side effect for a
+   node's own filter when that filter's shape isn't one of `Comma`/`Pipe`/`Paren`/
+   `Builtin::PathsFilter` — pinned as a known-remaining row in
+   `test_short_circuit_side_effect_leaks_820_932_987`, left to Stage 5.
 5. **Stage 4** — `Expr::Compare`'s outer loop. Closes the rest of #932. Depends on 2.
 6. **Stage 5** — widen the arm set, one sub-issue per arm. Depends on 2.

--- a/docs/plan/jq-path-trackability-deferral.md
+++ b/docs/plan/jq-path-trackability-deferral.md
@@ -375,7 +375,15 @@ measured slice-by-slice rather than as one combined change.
    `Expr::As`'s own gap (a variable bound *outside* `path(...)`'s argument, or from a source
    that isn't a syntactic passthrough of `.`, losing trackability across the binding) was closed
    by #844 — see `is_identity_passthrough` and `resolve_node`'s `Expr::TrackedVar` arm in
-   `src/jq/eval.rs`. The others in this list remain open.
+   `src/jq/eval.rs`. #1440 closed the sibling gap for `Expr::Reduce`/`Expr::Foreach` (which had
+   no `resolve_node` arm at all, not merely an unaudited one) — see `resolve_reduce`/
+   `resolve_foreach` and the `FoldRegister` type, which model jq's own `(path, value_at_path)`
+   register rather than reusing `Expr::As`'s AST-substitution mechanism: the accumulator has no
+   name (it's `.` inside UPDATE), and empirically the register resets between source-element
+   iterations of the same fold (jq's own "backtracking restores the register to its fork point"
+   rule) but carries forward within one fold step from UPDATE into EXTRACT — a genuinely
+   different shape than a named-variable binding, not just the same mechanism applied to a
+   fold. The others in this list remain open.
 5. **`del`/assignment write-path semantics**, not just `path()`'s read-only output. #972's own
    revert (on a related but different fix in this same code region) was specifically about
    silent data corruption on the write path once multi-key index/slice fan-outs were involved.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1770,18 +1770,20 @@ enum Flow {
     Exhausted,
     /// A sink returned [`Demand::Stop`].
     ///
-    /// Carries no payload. The design (`docs/plan/jq-lazy-generator-consumers.md`)
-    /// specifies a `pending: Option<Control>` here, for a control an *eager
-    /// fallback* had already raised before the stop — reachable only when
+    /// `pending` is `Some(control)` only when an *eager fallback* had
+    /// already raised a control before the stop — reachable only when
     /// [`drain_result`] stops part-way through a `Partial`'s prefix, never
-    /// from a natively-lazy arm, which simply never evaluates that far. Every
-    /// consumer rewired in Stage 2 **drops** that control (oracle-confirmed:
-    /// `first(1, ("BOOM"|halt_error(3)))` is `1`, exit 0), so nothing reads it
-    /// yet and carrying it would be dead weight. `resolve_leaf` is the one
-    /// consumer that must *keep* a `Halt` — its own comment argues at length
-    /// that an already-triggered halt must not be downgraded into a catchable
-    /// error — so Stage 3 reintroduces the payload when the reader arrives.
-    Stopped,
+    /// from a natively-lazy arm, which simply never evaluates that far.
+    /// Every consumer rewired in Stage 2 (`each_take_first`, `each_take_n`,
+    /// `each_take_nth`, `builtin_isempty`, `any_all_gen_cond`,
+    /// `builtin_upper_in`, `eval_limit`/`builtin_limit`) **drops** it —
+    /// oracle-confirmed: `first(1, ("BOOM"|halt_error(3)))` is `1`, exit 0 —
+    /// so those sites match `Flow::Stopped { .. }` without reading the
+    /// field. `resolve_leaf` is the one consumer (Stage 3, #987) that must
+    /// *keep* a `Halt`: its own comment argues at length that an
+    /// already-triggered halt must not be downgraded into a catchable path
+    /// error, which is exactly what discarding `pending` would do for it.
+    Stopped { pending: Option<Control> },
     /// Terminated in a control. Everything produced before it was already
     /// delivered to the sink.
     Escaped(Control),
@@ -1808,16 +1810,16 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
         QueryResult::One(v) => match sink(Item::Borrowed(v)) {
             Demand::Continue => Flow::Exhausted,
-            Demand::Stop => Flow::Stopped,
+            Demand::Stop => Flow::Stopped { pending: None },
         },
         QueryResult::Owned(v) => match sink(Item::Owned(v)) {
             Demand::Continue => Flow::Exhausted,
-            Demand::Stop => Flow::Stopped,
+            Demand::Stop => Flow::Stopped { pending: None },
         },
         QueryResult::Many(vs) => {
             for v in vs {
                 if sink(Item::Borrowed(v)) == Demand::Stop {
-                    return Flow::Stopped;
+                    return Flow::Stopped { pending: None };
                 }
             }
             Flow::Exhausted
@@ -1825,7 +1827,7 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
         QueryResult::ManyOwned(vs) => {
             for v in vs {
                 if sink(Item::Owned(v)) == Demand::Stop {
-                    return Flow::Stopped;
+                    return Flow::Stopped { pending: None };
                 }
             }
             Flow::Exhausted
@@ -1835,13 +1837,21 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
         QueryResult::Halt(code) => Flow::Escaped(Control::Halt(code)),
         // `partial()` guarantees the prefix is produced *before* the control
         // and is never empty, so it is delivered first — exactly as
-        // `push_owned_values` already delivers it. A sink that stops part-way
-        // through drops the control it never reached, which is what every
-        // consumer rewired in Stage 2 wants (see `Flow::Stopped`).
+        // `push_owned_values` already delivers it. A sink that stops
+        // part-way through carries the control it never reached forward as
+        // `pending`, rather than dropping it outright: this is the one
+        // `Flow::Stopped` shape that can carry a real payload (see
+        // `Flow::Stopped`'s own doc comment) — an eager fallback like this
+        // one has already computed/raised `control` by the time the sink
+        // says stop, so `resolve_leaf` (#987) needs it to keep an
+        // already-triggered `Halt` from being downgraded into a catchable
+        // path error. Every other consumer still drops it.
         QueryResult::Partial(vs, control) => {
             for v in vs {
                 if sink(Item::Owned(v)) == Demand::Stop {
-                    return Flow::Stopped;
+                    return Flow::Stopped {
+                        pending: Some(control),
+                    };
                 }
             }
             Flow::Escaped(control)
@@ -1851,11 +1861,12 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
 
 /// Push every output of `expr` into `sink`, stopping as soon as `sink` says to.
 ///
-/// Only `Comma`, `Pipe` and `Paren` have native lazy arms; everything else
-/// falls back to `eval_single` + [`drain_result`]. `Paren` is not optional
-/// cosmetics: `isempty(...)` consumes only its own parentheses, so
-/// `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and without this arm
-/// the fix would be a coin flip on spelling.
+/// Native lazy arms: `Comma`, `Pipe`, `Paren`, and `Builtin::PathsFilter`
+/// (#987, Stage 3). Everything else falls back to `eval_single` +
+/// [`drain_result`]. `Paren` is not optional cosmetics: `isempty(...)`
+/// consumes only its own parentheses, so `isempty((1, stderr))` is
+/// `IsEmpty(Paren(Comma(..)))` and without this arm the fix would be a coin
+/// flip on spelling.
 fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
@@ -1877,6 +1888,9 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
         Expr::Pipe(exprs) => eval_each_pipe::<W, S>(exprs, value, optional, sink),
         Expr::Paren(inner) => eval_each::<W, S>(inner, value, optional, sink),
+        Expr::Builtin(Builtin::PathsFilter(f)) => {
+            each_paths_filter::<W, S>(f, value, optional, sink)
+        }
         _ => drain_result(eval_single::<W, S>(expr, value, optional), sink),
     }
 }
@@ -1903,7 +1917,7 @@ fn eval_each_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let Some((first, rest)) = exprs.split_first() else {
         return match sink(Item::Borrowed(value)) {
             Demand::Continue => Flow::Exhausted,
-            Demand::Stop => Flow::Stopped,
+            Demand::Stop => Flow::Stopped { pending: None },
         };
     };
     if rest.is_empty() {
@@ -1991,7 +2005,7 @@ fn each_take_first<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Demand::Stop
     });
     match flow {
-        Flow::Stopped | Flow::Exhausted => Ok(first),
+        Flow::Stopped { .. } | Flow::Exhausted => Ok(first),
         // The sink always stops on its first item, so an escape can only mean
         // nothing was ever produced. The `Some` guard keeps that reasoning
         // local rather than relying on it from a distance.
@@ -2049,7 +2063,7 @@ fn each_take_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     });
     match flow {
-        Flow::Stopped | Flow::Exhausted => Ok(wanted),
+        Flow::Stopped { .. } | Flow::Exhausted => Ok(wanted),
         Flow::Escaped(control) => match wanted {
             Some(item) => Ok(Some(item)),
             None => Err(control),
@@ -2074,7 +2088,7 @@ fn eval_each_owned<S: EvalSemantics>(
         return match result {
             Ok(Some(v)) => match sink(v) {
                 Demand::Continue => Flow::Exhausted,
-                Demand::Stop => Flow::Stopped,
+                Demand::Stop => Flow::Stopped { pending: None },
             },
             Ok(None) => Flow::Exhausted,
             Err(e) => Flow::Escaped(Control::Error(e)),
@@ -4230,7 +4244,7 @@ fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return QueryResult::Owned(OwnedValue::Bool(true));
     }
     match flow {
-        Flow::Exhausted | Flow::Stopped => QueryResult::Owned(OwnedValue::Bool(false)),
+        Flow::Exhausted | Flow::Stopped { .. } => QueryResult::Owned(OwnedValue::Bool(false)),
         Flow::Escaped(control) => control_to_result(control),
     }
 }
@@ -4682,7 +4696,9 @@ fn any_all_gen_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // returned above, so reaching this arm as `Stopped` is impossible
         // today -- but a defensible identity answer is a better failure mode
         // than a panic if a future sink grows a third stop reason.
-        Flow::Exhausted | Flow::Stopped => QueryResult::Owned(OwnedValue::Bool(!target_truthy)),
+        Flow::Exhausted | Flow::Stopped { .. } => {
+            QueryResult::Owned(OwnedValue::Bool(!target_truthy))
+        }
         // No earlier output matched, so `gen`'s own terminator is the only
         // verdict left -- oracle-verified: `IN(3, error("boom"))` on `2` raises.
         Flow::Escaped(control) => control_to_result(control),
@@ -15364,14 +15380,14 @@ fn reject_if_untracked(branches: Vec<PathBranch<'_>>, trackable: bool) -> PathRe
 ///
 /// `trackable == false` (#843) additionally makes `Field`/`Index`/`Slice`
 /// raise the "near attempt to access element ... of ..." error immediately,
-/// *before* `eval_owned_multi` below ever runs — so this fires even where
-/// the underlying access would merely be an ordinary type error (confirmed
+/// *before* either sink below ever runs — so this fires even where the
+/// underlying access would merely be an ordinary type error (confirmed
 /// live: `path(try (.a, error("oops")) catch .foo)` on a caught *string*
 /// reports "near attempt to access element \"foo\" of \"oops\"", never the
 /// ordinary "Cannot index string with string \"foo\""). `Identity` is
 /// deliberately left out of that early check — it performs no navigation at
 /// all, so it falls through to the same eval-then-check path a non-primitive
-/// filter takes below (via the `trackable &&` guard just past it), which is
+/// filter takes below (via the `is_primitive` guard just past it), which is
 /// exactly what makes a bare `catch .` raise `#530`'s classic "with result"
 /// message instead (confirmed live) rather than the "near attempt" one.
 fn resolve_leaf<'a, S: EvalSemantics>(
@@ -15387,31 +15403,9 @@ fn resolve_leaf<'a, S: EvalSemantics>(
             ));
         }
     }
-    // `eval_owned_multi_keep_partial`, not `eval_owned_multi`: a later output
-    // of `expr` erroring or breaking must not retroactively un-produce an
-    // earlier one it already yielded (#842's precedent for `recurse`'s own
-    // fan-out, applying equally here) — see the "streams as it goes" case
-    // below (#861).
-    let (mut values, trailing) = eval_owned_multi_keep_partial::<S>(expr, value);
-    // Halt is never swallowed, however many outputs `expr` already produced:
-    // it is an unconditional process-termination signal (`EvalEscape::Halt`'s
-    // own doc comment), not an ordinary catchable failure. Break/Error below
-    // are provably safe to fold into an ordinary path error instead —
-    // confirmed live against jq 1.7.1, real jq's own `path(...)` never even
-    // reaches a later output's break/error here (see the `1 =>` arm's
-    // comment below) — but that same "real jq never gets there" argument
-    // does not rescue Halt: a script relying on `halt_error` as a hard,
-    // uncatchable abort must not have it silently downgraded into a
-    // `try`/`catch`-able "Invalid path expression" just because this
-    // resolver's own evaluation of `expr` is eager rather than jq's lazy
-    // per-output generator (unlike jq, `eval_owned_multi_keep_partial`
-    // already ran the candidate that halted, side effects included, by the
-    // time control reaches here — the only question left is whether that
-    // already-triggered halt still takes effect, and it must).
-    if let Some(EvalEscape::Halt(code)) = &trailing {
-        return Err((Vec::new(), EvalEscape::Halt(*code)));
-    }
-    if trackable
+
+    // Purely syntactic, decided before either sink below runs.
+    let is_primitive = trackable
         && matches!(
             expr,
             Expr::Identity
@@ -15420,8 +15414,42 @@ fn resolve_leaf<'a, S: EvalSemantics>(
                 | Expr::IndexNumber { .. }
                 | Expr::Slice { .. }
                 | Expr::SliceNumber { .. }
-        )
-    {
+        );
+
+    if is_primitive {
+        // This arm needs every output, not just the first: `values.len()`
+        // (0 vs 1 vs many) decides which of three different outcomes this
+        // returns below, a distinction a stop-after-first sink would
+        // destroy — so this keeps an always-`Continue` sink. That makes it
+        // provably byte-identical to the eager `eval_owned_multi_keep_partial`
+        // this replaced: `eval_each_owned`/`drain_result` mirror
+        // `eval_owned_input`/`push_owned_values` exactly when the sink never
+        // answers `Stop` (`drain_result`'s own doc comment states that
+        // invariant).
+        let mut values = Vec::new();
+        let flow = eval_each_owned::<S>(expr, value, false, &mut |v| {
+            values.push(v);
+            Demand::Continue
+        });
+        // `Flow::Stopped` cannot actually occur here — this sink never
+        // answers `Stop` — but folded to "no trailing control" rather than
+        // `unreachable!()`, mirroring `any_all_gen_cond`'s own "a defensible
+        // answer beats a panic" precedent for the same shape.
+        let trailing = match flow {
+            Flow::Exhausted | Flow::Stopped { .. } => None,
+            Flow::Escaped(control) => Some(EvalEscape::from(control)),
+        };
+        // Halt is never swallowed, however many outputs `expr` already
+        // produced: it is an unconditional process-termination signal
+        // (`EvalEscape::Halt`'s own doc comment), not an ordinary catchable
+        // failure — a script relying on `halt_error` as a hard, uncatchable
+        // abort must not have it silently downgraded into a `try`/`catch`-able
+        // "Invalid path expression" just because this resolver's own
+        // evaluation of `expr` already ran the candidate that halted, side
+        // effects included, by the time control reaches here.
+        if let Some(EvalEscape::Halt(code)) = &trailing {
+            return Err((Vec::new(), EvalEscape::Halt(*code)));
+        }
         let mut components = Vec::new();
         push_path_components(&mut components, expr);
         return match values.len() {
@@ -15429,7 +15457,7 @@ fn resolve_leaf<'a, S: EvalSemantics>(
             // been one because evaluating `expr` itself broke/errored (Halt
             // excluded, handled above) before producing anything.
             0 => path_result(Vec::new(), trailing),
-            // Guarded by the `trackable &&` on this whole arm.
+            // Guarded by `is_primitive` above.
             1 => Ok(vec![PathBranch::new(
                 components,
                 Cow::Owned(values.pop().expect("len checked")),
@@ -15447,38 +15475,62 @@ fn resolve_leaf<'a, S: EvalSemantics>(
             )),
         };
     }
-    match values.len() {
-        // No output prunes the branch — unless there never would have been
-        // one because evaluating `expr` itself broke/errored (Halt excluded,
-        // handled above) before producing anything. Same rule as the
-        // `trackable`-primitive branch above, for the general non-primitive
-        // case this arm covers.
-        0 => path_result(Vec::new(), trailing),
-        // Real jq's `path(...)` checks each output as it streams: the first
-        // non-path-shaped value raises "Invalid path expression" immediately,
-        // before a later output of the same expression is ever produced —
-        // even one that would itself error or break (confirmed live:
-        // `path(range(3))` raises on `0` alone, never reaching `1`/`2`; #861's
-        // own repro, `path(paths(if type=="string" then break $out else true
-        // end))` on `[1,"x",2]`, raises on `[0]` alone, never reaching the
-        // second candidate where the `break` sits). `values[0]` is that first
-        // output regardless of how many outputs there actually were (#891 —
-        // one arm covers both the single- and multi-output case, since real
-        // jq's own per-output check treats them identically: it never even
-        // learns whether a second output would have existed) or of whether
-        // `trailing` still carries a Break/Error from evaluating further
-        // here — real jq never reaches whatever would have caused it, so
-        // it's discarded rather than propagated (Halt is the one exception,
-        // already handled above).
-        //
-        // Still doesn't cover every context: when this same value is being
-        // used as an assignment *target* for further indexing rather than
-        // `path(...)`'s own leaf (`(range(3) | .[("x","y")]) = 9`, or the
-        // single-output `(1 | .[("x","y")]) = 9`), real jq instead raises
-        // the "near attempt to access element ... of ..." wording (confirmed
-        // live for both) — `resolve_leaf` has no way to tell that context
-        // apart from `path(...)`'s own leaf today; filed as #989 rather than
-        // attempted here.
+
+    // General non-primitive case (#987): real jq's `path(...)` checks each
+    // output as it streams — the first non-path-shaped value raises
+    // "Invalid path expression" immediately, before a later output of the
+    // same expression is ever produced, even one that would itself error or
+    // break (confirmed live: `path(range(3))` raises on `0` alone, never
+    // reaching `1`/`2`; #861's own repro, `path(paths(if type=="string" then
+    // break $out else true end))` on `[1,"x",2]`, raises on `[0]` alone,
+    // never reaching the second candidate where the `break` sits) — and
+    // never even *asks the generator for that later value at all*, so any
+    // side effect embedded in it (`stderr`, a consumed `input`) must not
+    // fire either. `eval_owned_multi_keep_partial` (the eager evaluator this
+    // used to call) runs `expr`'s whole subtree to completion regardless, so
+    // a later output's side effect fired anyway even though its value was
+    // then discarded — the bug #987 tracked. A stop-after-first sink via
+    // `eval_each_owned` is what actually prevents the generator from being
+    // asked at all, for every arm `eval_each` has a native lazy path for
+    // (`Comma`, `Pipe`, `Paren`, `Builtin::PathsFilter`) — confirmed live:
+    // `path(paths(if . == 3 then (stderr,true) else true end))` on `[1,2,3]`
+    // no longer writes `3` to stderr. An un-lazified arm still falls back to
+    // `drain_result(eval_single(...))`, which is eager for that one
+    // sub-expression (a residual, documented divergence, not fixed by this
+    // change).
+    //
+    // Still doesn't cover every context: when this same value is being used
+    // as an assignment *target* for further indexing rather than
+    // `path(...)`'s own leaf (`(range(3) | .[("x","y")]) = 9`, or the
+    // single-output `(1 | .[("x","y")]) = 9`), real jq instead raises the
+    // "near attempt to access element ... of ..." wording (confirmed live
+    // for both) — `resolve_leaf` has no way to tell that context apart from
+    // `path(...)`'s own leaf today; filed as #989 rather than attempted
+    // here.
+    let mut first: Option<OwnedValue> = None;
+    let flow = eval_each_owned::<S>(expr, value, false, &mut |v| {
+        first = Some(v);
+        Demand::Stop
+    });
+
+    // Halt-first, exactly as the eager version checked `trailing` first —
+    // an already-triggered halt (whether it escaped bare, or is `pending`
+    // on a `Stopped` from an eager fallback that had already computed it
+    // before this sink was satisfied) must never be downgraded into a
+    // catchable path error, matching the primitive branch's identical rule
+    // above.
+    let halt = match &flow {
+        Flow::Escaped(Control::Halt(code))
+        | Flow::Stopped {
+            pending: Some(Control::Halt(code)),
+        } => Some(*code),
+        _ => None,
+    };
+    if let Some(code) = halt {
+        return Err((Vec::new(), EvalEscape::Halt(code)));
+    }
+
+    match first {
         // #986: *defer*, don't raise. Whether a non-path-shaped value is an
         // error depends on whether anything after it still has to navigate
         // into it, and only this branch's consumer knows that: `path(1)` is
@@ -15487,14 +15539,21 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         // untracked lets each of those be decided where the answer is
         // actually known (`resolve_dynamic_indexes`'s terminal check,
         // `resolve_static_tail`, `resolve_index_expr`'s post-target check),
-        // instead of guessing here.
-        //
-        // Only `values[0]` survives, for the streaming reason spelled out
-        // above: real jq checks each output as it is produced and never
-        // learns whether a second one existed.
-        _ => Ok(vec![PathBranch::untracked(Cow::Owned(
-            values.swap_remove(0),
-        ))]),
+        // instead of guessing here. Any trailing Break/Error past this first
+        // output — whether a bare `Escaped` the sink never had a chance to
+        // avoid, or `pending` on a `Stopped` from an eager fallback — is
+        // dropped: real jq never reaches whatever would have caused it.
+        Some(v) => Ok(vec![PathBranch::untracked(Cow::Owned(v))]),
+        // No output prunes the branch — unless there never would have been
+        // one because evaluating `expr` itself broke/errored (Halt excluded,
+        // handled above) before producing anything. `Flow::Stopped` with no
+        // `first` cannot actually occur (this sink always sets `first`
+        // before answering `Stop`); folded to `Ok(Vec::new())` rather than
+        // `unreachable!()` for the same reason as the primitive branch above.
+        None => match flow {
+            Flow::Exhausted | Flow::Stopped { .. } => Ok(Vec::new()),
+            Flow::Escaped(control) => Err((Vec::new(), EvalEscape::from(control))),
+        },
     }
 }
 
@@ -19815,7 +19874,7 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // $out` fires here, so nothing past that point is ever reached and a
         // trailing control from an eager fallback is dropped, exactly as the
         // excess *values* beyond `n` already were.
-        Flow::Stopped => result,
+        Flow::Stopped { .. } => result,
         Flow::Exhausted => result,
         // Fewer than `n` were produced, so the generator's own terminator is
         // what `limit` actually reaches (`[limit(3; 1,2,error("x"),4)]`
@@ -22618,6 +22677,109 @@ fn builtin_paths<W: Clone + AsRef<[u64]>>(
     owned_vec_to_result(paths)
 }
 
+/// Lazy producer for `paths(filter)` (`Builtin::PathsFilter`) — pushes each
+/// path whose value matches `filter` into `sink`, stopping as soon as `sink`
+/// says to (#987, Stage 3 of `docs/plan/jq-lazy-generator-consumers.md`).
+/// `builtin_paths_filter` is a thin collecting wrapper around this; `eval_each`'s
+/// own `Builtin::PathsFilter` arm dispatches here directly, so
+/// `path(paths(f))` — the shape #987 named — stops pulling from this
+/// generator exactly where jq's own generator would.
+///
+/// jq's own `paths(node_filter)` evaluates `node_filter` against every node
+/// `recurse` visits, root included — `recurse` always yields `.` before
+/// descending into children — even though the root's own path is later
+/// filtered out of the result (`length > 0`); confirmed live: `1 |
+/// [paths(error("x"))]` raises in real jq, though a scalar has no non-root
+/// paths at all. The loop below only visits non-root paths, so without this
+/// root pre-check, `paths(node_filter)` on a scalar/null/empty container
+/// never runs `filter` at all -- and (#850) even on a non-empty root, an
+/// error/break on the root itself must abort before any non-root path is
+/// produced, not just be missed. **This pre-check stays eager and
+/// unconditional even for a demand-driven sink**: nothing has been pushed
+/// yet at this point, so it is a bare `Error`/`Break`/`Halt`, never a
+/// `Partial`, and jq itself always runs it before any consumer could stop
+/// — confirmed against jq 1.7.1: `[1] | path(paths(stderr))` writes `[1]`
+/// to stderr even though `path()` stops the moment the first (root-excluded)
+/// path arrives. Uses `eval_owned_expr_ctrl` rather than its
+/// `eval_owned_expr` twin because this call site needs a `Control`-typed
+/// error, not `EvalEscape`. Confirmed against jq 1.7.1: `{"a":1} |
+/// paths(if type=="object" then error("x") else true end)` raises
+/// immediately with no output (not `["a"]`), and `label $out |
+/// [paths(break $out)]` on `1` produces no output and exits 0.
+///
+/// jq's `paths(node_filter)` is `path(recurse|select(node_filter))`, and
+/// `select(f)` is `if f then . else empty end` -- `if` forks over every
+/// output `f` produces, so a multi-output node_filter must be checked
+/// per-output, not collapsed into one value first. Confirmed against jq
+/// 1.7.1: `{"a":1,"b":{"c":2}} | [paths(false,false)]` is `[]`, and
+/// `[paths(true,true)]` duplicates every path, `[["a"],["a"], ["b"],["b"],
+/// ["b","c"],["b","c"]]` -- not each path once (#773). This per-node fan-out
+/// is itself demand-aware, not just the outer path loop: once `sink` is
+/// satisfied, this node's own `filter` is never asked for a second truthy
+/// output either. Confirmed against jq 1.7.1 (#987 review): `[1,2,3] |
+/// path(paths(if .==1 then (true,(stderr|true)) else false end))` writes
+/// nothing to stderr — `path()` stops right after node `[0]`'s first truthy
+/// output, so its second is never produced — while `[paths(<same>)]` (no
+/// consumer stop) writes `1` to stderr and yields `[[0],[0]]`.
+///
+/// Once credited, any control signal -- `halt` (#791), or an ordinary
+/// error/break -- aborts the whole generator instead of being swallowed and
+/// moving on to the next node (#850). This matches real jq:
+/// `paths(node_filter)` is `path(recurse|select(node_filter))`, and an
+/// uncaught error/break inside `select`'s fan-out aborts the entire
+/// generator, not just the current node. Confirmed against jq 1.7.1:
+/// `[1,"x",2] | paths(if type=="string" then error("bad") else true end)`
+/// streams `[0]` then raises, never reaching index 2. `break $label` also
+/// correctly unwinds to a `label` lexically enclosing the whole
+/// `paths(...)` call: `eval_each_owned` (like `eval_owned_input` before it)
+/// never collapses `Control::Break` into a "not in label" error. This does
+/// not extend to `path(paths(node_filter))`'s own trackable-path machinery
+/// treating this builtin's output as *path-shaped* -- that is a separate,
+/// still-open divergence (filed as #861).
+///
+/// `optional` (this function's own parameter, not a hardcoded `false`) must
+/// reach the per-node evaluation too, so a real `?` the caller wrote inside
+/// `node_filter` itself (e.g. `paths(.foo?, true)`) suppresses that node's
+/// own error the same way it would anywhere else, instead of a hardcoded
+/// `false` silently ignoring it. See `test_isvalid_paths_filter_node_error_not_swallowed_881`
+/// for the #881 regression this must keep passing.
+fn each_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    filter: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let owned = to_owned(&value);
+
+    if let Err(control) = eval_owned_expr_ctrl::<S>(filter, &owned, optional) {
+        return Flow::Escaped(control);
+    }
+
+    let mut all_paths = Vec::new();
+    collect_paths(&owned, &[], &mut all_paths);
+
+    for path in all_paths {
+        let OwnedValue::Array(path_arr) = &path else {
+            continue;
+        };
+        let Some(val_at_path) = get_value_at_path(&owned, path_arr) else {
+            continue;
+        };
+        let flow = eval_each_owned::<S>(filter, &val_at_path, optional, &mut |v| {
+            if v.is_truthy() {
+                sink(Item::Owned(path.clone()))
+            } else {
+                Demand::Continue
+            }
+        });
+        match flow {
+            Flow::Exhausted => {}
+            stopped_or_escaped => return stopped_or_escaped,
+        }
+    }
+    Flow::Exhausted
+}
+
 /// Builtin: paths(filter) - paths to values matching filter
 /// Returns each path as a separate output (streaming), matching jq behavior
 fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
@@ -22625,133 +22787,15 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let owned = to_owned(&value);
-
-    // jq's own `paths(node_filter)` evaluates `node_filter` against every
-    // node `recurse` visits, root included — `recurse` always yields `.`
-    // before descending into children — even though the root's own path is
-    // later filtered out of the result (`length > 0`); confirmed live:
-    // `1 | [paths(error("x"))]` raises in real jq, though a scalar has no
-    // non-root paths at all. The loop below only visits non-root paths, so
-    // without this, `paths(node_filter)` on a scalar/null/empty container
-    // never runs `filter` at all -- and (#850) even on a non-empty root, an
-    // error/break on the root itself must abort before any non-root path is
-    // produced, not just be missed. Nothing has been credited to
-    // `filtered_paths` yet at this point, so any escape here is a bare
-    // `Error`/`Break`/`Halt`, never a `Partial`. Uses `eval_owned_expr_ctrl`
-    // rather than its `eval_owned_expr` twin because this call site needs a
-    // `Control`-typed error to pass straight to `partial(...)` below --
-    // `eval_owned_expr` now propagates a bare `break` correctly too (#833),
-    // but still returns `EvalEscape`, not `Control`. Confirmed against jq 1.7.1: `{"a":1} |
-    // paths(if type=="object" then error("x") else true end)` raises
-    // immediately with no output (not `["a"]`), and `label $out |
-    // [paths(break $out)]` on `1` produces no output and exits 0.
-    if let Err(control) = eval_owned_expr_ctrl::<S>(filter, &owned, optional) {
-        return partial(Vec::new(), control);
+    let mut paths = Vec::new();
+    let flow = each_paths_filter::<W, S>(filter, value, optional, &mut |item| {
+        paths.push(item.into_owned());
+        Demand::Continue
+    });
+    match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => owned_vec_to_result(paths),
+        Flow::Escaped(control) => partial(paths, control),
     }
-
-    let mut all_paths = Vec::new();
-    collect_paths(&owned, &[], &mut all_paths);
-
-    let mut filtered_paths = Vec::new();
-    for path in all_paths {
-        if let OwnedValue::Array(path_arr) = &path {
-            // Get the value at this path
-            if let Some(val_at_path) = get_value_at_path(&owned, path_arr) {
-                // jq's `paths(node_filter)` is `path(recurse|select(node_filter))`,
-                // and `select(f)` is `if f then . else empty end` -- `if` forks
-                // over every output `f` produces, so a multi-output node_filter
-                // must be checked per-output, not collapsed into one value
-                // first. Confirmed against jq 1.7.1:
-                // `{"a":1,"b":{"c":2}} | [paths(false,false)]` is `[]`, and
-                // `[paths(true,true)]` duplicates every path, `[["a"],["a"],
-                // ["b"],["b"],["b","c"],["b","c"]]` -- not each path once
-                // (#773).
-                //
-                // `paths(node_filter)`'s own definition is `select(node_filter)`'s
-                // fan-out (`path(recurse|select(node_filter))`), and
-                // `push_truthiness` is the exact helper this codebase
-                // already uses for that fan-out shape (it backs `eval_if`/
-                // `builtin_select` via `eval_fanout`) -- collect one
-                // truthiness bit per output instead of collapsing them
-                // (matching `eval_owned_expr_fork`'s "keep every output"
-                // idiom that `reduce`/`foreach`/`while`/`until` build on,
-                // not the shared `eval_owned_multi` helper used by ~19
-                // *other* callers, whose contract collapses a `Partial`
-                // straight to `Err` and discards the outputs already
-                // produced -- correct there, #694, wrong here). A node's
-                // own truthy output(s) produced before an error/break/halt
-                // in the *same* node_filter fan-out must still be kept and
-                // counted once each. Confirmed against jq 1.7.1: `[1,"x",2]
-                // | paths(if type=="string" then (true, error("bad")) else
-                // true end)` streams `[0]`, `[1]`, then raises -- not just
-                // `[0]`.
-                //
-                // Once credited, any control signal -- `halt` (#791), or an
-                // ordinary error/break -- aborts the whole builtin instead of
-                // being swallowed and moving on to the next node (#850).
-                // This matches real jq: `paths(node_filter)` is
-                // `path(recurse|select(node_filter))`, and an uncaught
-                // error/break inside `select`'s fan-out aborts the entire
-                // generator, not just the current node. Confirmed against jq
-                // 1.7.1: `[1,"x",2] | paths(if type=="string" then
-                // error("bad") else true end)` streams `[0]` then raises,
-                // never reaching index 2. `break $label` also now correctly
-                // unwinds to a `label` lexically enclosing the whole
-                // `paths(...)` call: `eval_owned_input` never collapses
-                // `Control::Break` into a "not in label" error -- unlike
-                // `result_to_owned`/`eval_owned_expr` for their own
-                // still-open `Partial` case (#833's follow-up), this path
-                // has no such gap, since `push_truthiness` already threads
-                // a trailing `Break` through intact regardless of how many
-                // truthy outputs preceded it, so once this loop stops
-                // swallowing it, propagation just works. Confirmed: `label
-                // $out | paths(if type=="string"
-                // then break $out else true end)` on `[1,"x",2]` now matches
-                // real jq exactly (streams `[0]`, exit 0), including when
-                // the matching node is nested. This does not extend to
-                // `path(paths(node_filter))` -- wrapping this builtin's own
-                // output in `path(...)`'s trackable-path machinery is a
-                // separate, still-open divergence (filed as #861).
-                //
-                // `optional` (this builtin's own parameter, not a
-                // hardcoded `false`) must reach this per-node evaluation
-                // too, so a real `?` the caller wrote inside `node_filter`
-                // itself (e.g. `paths(.foo?, true)`) suppresses that node's
-                // own error the same way it would anywhere else, instead of
-                // a hardcoded `false` silently ignoring it.
-                //
-                // #881 update: prior to that fix, `isvalid(EXPR)` forced
-                // `optional=true` all the way down through this parameter
-                // too (not via the `?`/`try` path, which never forces it
-                // here per #693, but via `builtin_isvalid` calling
-                // `eval_single` with `true` directly) -- so
-                // `{"a":1,"b":2} | isvalid(paths(.foo, true))` used to
-                // report `true`, with `.foo`'s error on each scalar node
-                // silently swallowed by that forcing rather than by any `?`
-                // the caller actually wrote. `isvalid` no longer forces
-                // `optional`, so that swallowing no longer happens here:
-                // the same expression is `false` now, matching real jq
-                // (`{"a":1,"b":2} | [paths(.foo, true)]` itself errors
-                // there) -- see `test_isvalid_paths_filter_node_error_not_swallowed_881`.
-                let mut truthiness = Vec::new();
-                let control = push_truthiness(
-                    eval_owned_input::<Vec<u64>, S>(filter, &val_at_path, optional),
-                    &mut truthiness,
-                );
-                for &truthy in &truthiness {
-                    if truthy {
-                        filtered_paths.push(path.clone());
-                    }
-                }
-                if let Some(control) = control {
-                    return partial(filtered_paths, control);
-                }
-            }
-        }
-    }
-    // Stream individual paths instead of wrapping in array
-    owned_vec_to_result(filtered_paths)
 }
 
 /// Helper to get value at a path (alias for convenience)
@@ -27068,7 +27112,7 @@ fn builtin_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let satisfied = taken.len() >= n;
     let values: Vec<OwnedValue> = taken.into_iter().map(Item::into_owned).collect();
     match flow {
-        Flow::Stopped | Flow::Exhausted => owned_vec_to_result(values),
+        Flow::Stopped { .. } | Flow::Exhausted => owned_vec_to_result(values),
         Flow::Escaped(control) => {
             if satisfied {
                 owned_vec_to_result(values)
@@ -27213,7 +27257,7 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // answers `false` regardless. Oracle-confirmed for all three shapes:
         // `isempty(1, error("x"))`, `isempty(1, ("m"|halt_error(3)))` and
         // `label $o | isempty(1, break $o)` all answer `false`, exit 0.
-        Flow::Stopped => QueryResult::Owned(OwnedValue::Bool(false)),
+        Flow::Stopped { .. } => QueryResult::Owned(OwnedValue::Bool(false)),
 
         // `g` ran to exhaustion without ever calling the sink.
         Flow::Exhausted => QueryResult::Owned(OwnedValue::Bool(true)),
@@ -32141,7 +32185,7 @@ mod tests {
         });
         let result = items_to_result(items);
         match flow {
-            Flow::Exhausted | Flow::Stopped => result,
+            Flow::Exhausted | Flow::Stopped { .. } => result,
             Flow::Escaped(control) => {
                 let mut prefix = Vec::new();
                 push_owned_values(result, &mut prefix);
@@ -32202,6 +32246,19 @@ mod tests {
             (b"{\"a\":{\"b\":7}}", ".a.b, .a, ."),
             (b"{\"a\":{\"b\":7}}", ".a | .b, .b"),
             (b"{\"a\":1}", ".a, .missing, .a"),
+            // #987, Stage 3: `Builtin::PathsFilter` gained a native lazy arm
+            // (`each_paths_filter`) alongside `resolve_leaf`'s own switch to
+            // a demand-driven sink — this differential is what guards
+            // `each_paths_filter` against drifting from the eager
+            // `builtin_paths_filter` it replaced, the same way it already
+            // guards the lazy `Comma`/`Pipe`/`Paren` arms above.
+            (b"[1,2,3]", "paths(true)"),
+            (b"[1,2,3]", "paths(false)"),
+            (b"[1,2,3]", "paths(.==2)"),
+            (b"[1,2,3]", "paths(true,true)"),
+            (b"{\"a\":1,\"b\":{\"c\":2}}", "paths(true)"),
+            (b"[1,2,3]", "paths(if .==2 then error(\"x\") else true end)"),
+            (b"1", "paths(error(\"x\"))"),
         ];
 
         for (json, src) in cases {
@@ -43616,32 +43673,95 @@ mod tests {
         );
     }
 
-    /// Halt sibling of the fix above: switching `resolve_leaf` to
-    /// `eval_owned_multi_keep_partial` means a later `Break`/`Error` no
-    /// longer erases an already-produced prefix, but `Halt` must never be
-    /// folded into that same "discard the escape, raise an ordinary path
-    /// error" treatment. `EvalEscape::Halt`'s own doc: "Must reach the CLI
-    /// unconditionally; never catchable, never suppressible." Two
-    /// legitimate outputs (`[0]`, `[1]`, from the two number candidates)
-    /// are produced before the third candidate halts — unlike `break`, real
-    /// jq's own laziness never even reaches this halt either (it would
-    /// raise on `[0]` alone, same as #861's own repro), but this resolver's
-    /// evaluation is eager, not lazy, so by the time `resolve_leaf` sees
-    /// the escape, `halt_error`'s side effect has already run and its exit
-    /// code must still take effect rather than being silently downgraded
-    /// into a catchable "Invalid path expression".
+    /// Halt sibling of the fix above, flipped by #987's Stage 3: with
+    /// `resolve_leaf`'s catch-all now a stop-after-first sink over
+    /// `each_paths_filter` (a genuinely lazy producer, not just a
+    /// keep-partial one), `path(...)` stops pulling from `paths(...)`'s
+    /// generator the moment its first output arrives — node `[0]`'s value
+    /// `1` is type "number", so the filter's `else true` branch fires and
+    /// `[0]` becomes that first, computed (non-navigated) output. `path()`'s
+    /// terminal check raises on it directly, exactly as #861's sibling
+    /// break-based repro does — the halting third candidate (`"trigger"`)
+    /// is never reached at all, matching real jq's own laziness exactly
+    /// rather than merely not downgrading an already-fired halt. Confirmed
+    /// against jq 1.7.1: both queries below give "Invalid path expression
+    /// with result [0]", exit 5, with no halt and no `halt_error` side
+    /// effect.
+    ///
+    /// A halt genuinely reachable at the *first* candidate is a distinct,
+    /// still-uncatchable case — `EvalEscape::Halt`'s own doc: "Must reach
+    /// the CLI unconditionally; never catchable, never suppressible" — and
+    /// is covered by [`test_path_paths_filter_halts_when_the_first_candidate_halts_987`].
     #[test]
     fn test_path_paths_filter_never_swallows_a_later_halt() {
         query!(
             br#"[1,2,"trigger"]"#,
             r#"path(paths(if type=="string" then (.|halt_error) else true end))"#,
-            QueryResult::Halt(_) => {}
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result [0]");
+            }
         );
-        // Wrapping in try/catch must not change this: halt is uncatchable.
+        // `try`/`catch` now genuinely catches it, since it's an ordinary
+        // path error, not a halt.
         query!(
             br#"[1,2,"trigger"]"#,
             r#"try path(paths(if type=="string" then (.|halt_error) else true end)) catch "caught""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "caught");
+            }
+        );
+    }
+
+    /// #987: a halt genuinely reachable at `paths(...)`'s *first* candidate
+    /// — not merely one that used to be reached by the old eager evaluator
+    /// — is still uncatchable and still fires, matching real jq exactly
+    /// (jq's own laziness also reaches it, since it's the first candidate).
+    /// Confirmed against jq 1.7.1: `path(paths(if type=="number" then
+    /// (.|halt_error) else true end))` on `[1,2,"trigger"]` halts with exit
+    /// 5 (`halt_error`'s own default code) and `1` on stderr, both with and
+    /// without a wrapping `try`/`catch`.
+    #[test]
+    fn test_path_paths_filter_halts_when_the_first_candidate_halts_987() {
+        query!(
+            br#"[1,2,"trigger"]"#,
+            r#"path(paths(if type=="number" then (.|halt_error) else true end))"#,
             QueryResult::Halt(_) => {}
+        );
+        query!(
+            br#"[1,2,"trigger"]"#,
+            r#"try path(paths(if type=="number" then (.|halt_error) else true end)) catch "caught""#,
+            QueryResult::Halt(_) => {}
+        );
+    }
+
+    /// #987: `path(paths(f))`'s three basic output-count shapes, pinned as a
+    /// trio since they exercise `resolve_leaf`'s stop-after-first sink
+    /// against each of `values.len()`'s three possible outcomes (0 / 1 /
+    /// many) — a distinction the sink's caller still has to make explicitly
+    /// even once evaluation is lazy. See `jq_cli_tests.rs` for the
+    /// side-effecting, CLI-level over-stop traps this can't observe. All
+    /// three confirmed against jq 1.7.1.
+    #[test]
+    fn test_path_paths_filter_output_count_shapes_987() {
+        // Zero surviving candidates: silent prune, no output, no error.
+        query!(br"[1,2,3]", "path(paths(false))",
+            QueryResult::None => {}
+        );
+        // One surviving candidate: `paths()`'s own output (`[1]`, a plain
+        // array) is itself a *computed* value, never further path-trackable
+        // (#861) — so even the sole survivor still raises, naming its own
+        // value rather than succeeding.
+        query!(br"[1,2,3]", "path(paths(.==2))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result [1]");
+            }
+        );
+        // Many candidates would survive if fully evaluated, but `path()`
+        // only ever asks for the first: `[0]`, never `[1]`/`[2]`.
+        query!(br"[1,2,3]", "path(paths(true))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result [0]");
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14478,19 +14478,30 @@ fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> Pat
 /// once `$out` is satisfied, so an error/break/halt *after* the nth output
 /// is never raised in the first place.
 ///
-/// Sound only because every [`PathResolveResult`] producer upholds: **the
-/// `Err` side's prefix is exactly the branches jq's own generator emits
-/// before that escape, in order.** That is not decorative — an earlier
-/// attempt at this exact fix (PR #985, issue #972) assumed it without
+/// Sound only because no [`PathResolveResult`] producer emits an `Err` side
+/// prefix *longer* than the branches jq's own generator emits before that
+/// escape. That is not decorative — an earlier attempt at this exact fix
+/// (PR #985, issue #972) assumed the stronger "exactly equal" form without
 /// checking, and `resolve_index_expr`/`resolve_slice_expr`'s key/bound ×
 /// target cross product violated it: `del(limit(2; select((true,
 /// error("t")))[("x","y")]))` silently deleted both keys instead of
 /// raising, because the untruncated prefix (length 2) satisfied `limit(2)`.
 /// Both functions were fixed ahead of this helper's reinstatement (see their
 /// own doc comments) to restrict their key/bound loops to a single element
-/// once their `target` has escaped, and the invariant is now pinned by
-/// `test_path_prefix_matches_jq_before_escape_972` rather than merely
-/// asserted here.
+/// once their `target` has escaped, and that is pinned by
+/// [`test_resolve_index_expr_prefix_matches_jq_when_target_escapes_972`] and
+/// [`test_first_limit_path_truncation_does_not_overreach_index_fanout_972`]
+/// (both in `tests/jq_cli_tests.rs`) rather than merely asserted here.
+///
+/// **Only the "not longer" half holds universally, and only that half is
+/// what this function needs.** A prefix *shorter* than jq's is still
+/// possible — `resolve_slice_expr` drops the bound generator's own partial
+/// prefix, so `[10,20,30] | path(limit(1; .[(0,error("b")):(2,3)]))` raises
+/// here where jq answers `[{"start":0,"end":2}]`, exit 0 (pre-existing, on
+/// `main` too). A short prefix under-satisfies the `>= n` test below, so
+/// the escape propagates and the caller refuses — visibly wrong, never a
+/// false success, and never a write jq would not perform. Do not restate
+/// the invariant as "exactly equal": that is the form PR #985 assumed.
 ///
 /// Drops `Halt` along with `Error`/`Break` once satisfied. jq never reaches
 /// it either (`path(first(select((true, ("m"|halt_error(3))))))` is `[]`,
@@ -15109,24 +15120,48 @@ fn resolve_node<'a, S: EvalSemantics>(
         // `FoldRegister` for the full model, derived empirically against
         // jq 1.7.1.
         //
-        // `patterns.len() == 1` is the overwhelmingly common case (a bare
-        // `?//`-free `as` clause) and the only one `resolve_reduce`/
-        // `resolve_foreach` handle; #1365's own `?//`-alternatives retry
-        // machinery (`try_reduce_step_alternatives`/
-        // `try_foreach_step_alternatives`) landed on `main` after this
-        // arm was designed and isn't threaded through path-tracking here.
-        // Real jq still tracks a variable through a `?//`-alternatives
-        // fold (confirmed live: `path(. as $x | reduce (1) as $y ?// $z
-        // (0; $x))` is `[]`), so falling to `resolve_leaf`'s catch-all for
-        // that case is a real but safe (refuse-only, never a wrong path)
-        // divergence — documented in `docs/compliance/jq/limitations.md`.
+        // The guard is `[Pattern::Var(_)]` — exactly one alternative, and
+        // that alternative a bare `$var` — because everything outside it
+        // is a shape real jq itself refuses in path position, or one this
+        // resolver cannot model:
+        //
+        // - **A destructuring pattern** (`as [$i]`, `as {v:$v}`) is refused
+        //   by jq *unconditionally* here, even when it matches cleanly:
+        //   `path(. as $x | reduce ([1]) as [$i] (0; $x))` raises "near
+        //   attempt to access element 0 of [1]", and the object form raises
+        //   the analogous message (both confirmed live against jq 1.7.1),
+        //   while the bare-`$var` spelling of the same fold is `[]`. So
+        //   falling through to `resolve_leaf` for a destructuring pattern
+        //   is jq's own behaviour, not a divergence — matching it here is
+        //   what keeps `resolve_reduce`/`resolve_foreach` from *accepting*
+        //   a fold jq rejects (and, on the write side, mutating a document
+        //   jq leaves untouched). The refusal matches; only the wording
+        //   does not — the catch-all names the whole fold's own value
+        //   rather than the destructuring step jq blames, which is the
+        //   pre-existing `resolve_leaf` message gap, not a new one.
+        //
+        // - **`?//`-alternatives** (`patterns.len() > 1`) are the one case
+        //   where falling through *is* a divergence: real jq still tracks a
+        //   variable through them (confirmed live: `path(. as $x | reduce
+        //   (1) as $y ?// $z (0; $x))` is `[]`). #1365's retry machinery
+        //   (`try_reduce_step_alternatives`/`try_foreach_step_alternatives`,
+        //   plus its null-fill for names the matching alternative doesn't
+        //   bind) landed on `main` after this arm was designed and isn't
+        //   threaded through path-tracking, so refusing is the safe answer
+        //   until it is — a refuse-only divergence, never a wrong path,
+        //   documented in `docs/compliance/jq/limitations.md`.
+        //
+        // Both fallbacks are pinned by
+        // `test_reduce_foreach_path_dispatch_falls_back_1440`.
         Expr::Reduce {
             input,
             patterns,
             init,
             update,
         } => match patterns.as_slice() {
-            [pattern] => resolve_reduce::<S>(input, pattern, init, update, value, trackable),
+            [Pattern::Var(_)] => {
+                resolve_reduce::<S>(input, &patterns[0], init, update, value, trackable)
+            }
             _ => resolve_leaf::<S>(expr, value, trackable),
         },
         Expr::Foreach {
@@ -15136,9 +15171,9 @@ fn resolve_node<'a, S: EvalSemantics>(
             update,
             extract,
         } => match patterns.as_slice() {
-            [pattern] => resolve_foreach::<S>(
+            [Pattern::Var(_)] => resolve_foreach::<S>(
                 input,
-                pattern,
+                &patterns[0],
                 init,
                 update,
                 extract.as_deref(),
@@ -17286,14 +17321,14 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // `resolve_index_expr`/`resolve_slice_expr`'s own pre-#972 gap, a
     // different failure mode where the prefix was too *long*, not too
     // short) — confirmed for `first(.[]|.[]|.[])`-shaped multi-stage pipes
-    // by `test_path_prefix_matches_jq_before_escape_972`. The stage-by-stage
-    // (not depth-first) rebuild above is still a real divergence, but only
-    // in *evaluation order*: a not-yet-reached sibling this function's own
-    // fan-out never gets to is also a sibling jq's real depth-first
-    // generator would never reach either, so no branch either side actually
-    // emits is lost — see #987/#820 for the separate, still-open question
-    // of whether a sibling that's never *reached* was nonetheless
-    // *evaluated* (side effects included) ahead of being pruned.
+    // by `test_first_path_truncation_keeps_full_multistage_pipe_path_972`.
+    // The stage-by-stage (not depth-first) rebuild above is still a real
+    // divergence, but only in *evaluation order*: a not-yet-reached sibling
+    // this function's own fan-out never gets to is also a sibling jq's real
+    // depth-first generator would never reach either, so no branch either
+    // side actually emits is lost — see #987/#820 for the separate,
+    // still-open question of whether a sibling that's never *reached* was
+    // nonetheless *evaluated* (side effects included) ahead of being pruned.
     let tail = &flat[last_dynamic + 1..];
     // The root branch inherits this call's own trackability: seeding it
     // `true` regardless is what made `catch (getpath(["other"]) | .qqq)`
@@ -53423,5 +53458,75 @@ mod tests {
         );
         assert_eq!(foreach_paths.len(), 300);
         assert!(foreach_paths.iter().all(|p| p == r"[]"));
+    }
+
+    /// `resolve_node`'s fold dispatch admits exactly `[Pattern::Var(_)]`;
+    /// this pins both of its fallbacks, which have opposite reasons for
+    /// existing and would otherwise be silently re-routed into
+    /// `resolve_reduce`/`resolve_foreach` by a future widening.
+    ///
+    /// **A destructuring pattern falls back because jq refuses it too.**
+    /// Confirmed live against jq 1.7.1: `path(. as $x | reduce ([1]) as
+    /// [$i] (0; $x))` raises "Invalid path expression near attempt to
+    /// access element 0 of [1]" and the object form raises the analogous
+    /// message, even though both patterns match cleanly and the bare-`$var`
+    /// spelling of the same fold is `[]`. Widening the guard to any
+    /// single pattern would make succinctly *accept* a fold jq rejects,
+    /// and on the write side mutate a document jq leaves untouched. Only
+    /// the refusal is asserted, not the message: the catch-all says
+    /// "Invalid path expression with result ..." where jq says "near
+    /// attempt to access ...", a pre-existing `resolve_leaf` wording gap.
+    ///
+    /// **`?//`-alternatives fall back despite jq accepting them** — the one
+    /// refuse-only divergence here (confirmed live: `path(. as $x | reduce
+    /// (1) as $y ?// $z (0; $x))` is `[]` in jq), since #1365's retry +
+    /// null-fill machinery isn't threaded through path-tracking. Routing
+    /// `?//` into `resolve_reduce` with only `patterns[0]` would not error;
+    /// it would silently drop the null-fill for names the matching
+    /// alternative doesn't bind, which is why this needs a test and not
+    /// just a comment.
+    #[test]
+    fn test_reduce_foreach_path_dispatch_falls_back_1440() {
+        let refuses = |src: &str| {
+            let json: &[u8] = br#"{"a":1}"#;
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let expr = parse(src).unwrap();
+            match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+                QueryResult::Error(e) => assert!(
+                    e.message.starts_with("Invalid path expression"),
+                    "{src}: {}",
+                    e.message
+                ),
+                other => panic!("{src}: expected a refusal, got {other:?}"),
+            }
+        };
+
+        // Destructuring patterns: refuse, matching jq.
+        refuses("path(. as $x | reduce ([1]) as [$i] (0; $x))");
+        // Spaces after the object-pattern colons are cosmetic to jq (the
+        // spaced and unspaced spellings raise identically there) but keep
+        // clippy's `literal_string_with_formatting_args` from reading
+        // `{v:1}` as a format specifier.
+        refuses("path(. as $x | reduce ({v: 1}) as {v: $v} (0; $x))");
+        refuses("path(. as $x | foreach ([1]) as [$i] (0; $x))");
+        refuses("path(. as $x | foreach ({v: 1}) as {v: $v} (0; $x))");
+
+        // `?//` alternatives: refuse (jq accepts -- documented divergence).
+        refuses("path(. as $x | reduce (1) as $y ?// $z (0; $x))");
+        refuses("path(. as $x | foreach (1) as $y ?// $z (0; $x))");
+
+        // The admitted shape still works, so the guard didn't over-narrow.
+        assert_eq!(
+            outputs(br#"{"a":1}"#, "path(. as $x | reduce (1,2) as $i (0; $x))"),
+            [r"[]"]
+        );
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1},"c":2}"#,
+                "path(reduce (1,2) as $i (.a; .))"
+            ),
+            [r#"["a"]"#]
+        );
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14456,6 +14456,48 @@ fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> Pat
     }
 }
 
+/// Keep at most `n` resolved branches, dropping a trailing escape the
+/// consumer never reached — jq's own `def first(f): label $out | (f, break
+/// $out);` and `limit`'s identical `break $out` never resume `f`'s generator
+/// once `$out` is satisfied, so an error/break/halt *after* the nth output
+/// is never raised in the first place.
+///
+/// Sound only because every [`PathResolveResult`] producer upholds: **the
+/// `Err` side's prefix is exactly the branches jq's own generator emits
+/// before that escape, in order.** That is not decorative — an earlier
+/// attempt at this exact fix (PR #985, issue #972) assumed it without
+/// checking, and `resolve_index_expr`/`resolve_slice_expr`'s key/bound ×
+/// target cross product violated it: `del(limit(2; select((true,
+/// error("t")))[("x","y")]))` silently deleted both keys instead of
+/// raising, because the untruncated prefix (length 2) satisfied `limit(2)`.
+/// Both functions were fixed ahead of this helper's reinstatement (see their
+/// own doc comments) to restrict their key/bound loops to a single element
+/// once their `target` has escaped, and the invariant is now pinned by
+/// `test_path_prefix_matches_jq_before_escape_972` rather than merely
+/// asserted here.
+///
+/// Drops `Halt` along with `Error`/`Break` once satisfied. jq never reaches
+/// it either (`path(first(select((true, ("m"|halt_error(3))))))` is `[]`,
+/// exit 0, confirmed against jq 1.7.1), and the value-position twins
+/// `each_take_first`/`each_take_n` already drop it for the same consumers.
+/// `resolve_leaf`'s opposite Halt-*keeping* rule (relevant to #987) is not a
+/// counterexample: it is a terminal fallback for a value that has no path
+/// shape at all, where no consumer was ever satisfied by an earlier output.
+///
+/// This is not laziness: the resolver underneath is still eager, so a
+/// dropped escape's side effects (`stderr`, a consumed `input`, `halt_error`'s
+/// own write) have already fired by the time this runs — only the escape
+/// itself is discarded, never the work that produced it. Making the
+/// resolver stop pulling early is #987/#820's territory
+/// (`docs/plan/jq-lazy-generator-consumers.md`), not this function's.
+fn take_path_branches(result: PathResolveResult<'_>, n: usize) -> PathResolveResult<'_> {
+    match result {
+        Ok(branches) => Ok(branches.into_iter().take(n).collect()),
+        Err((prefix, _)) if prefix.len() >= n => Ok(prefix.into_iter().take(n).collect()),
+        Err(e) => Err(e),
+    }
+}
+
 /// Peel any wrapping `Expr::Paren` down to the inner expression — `(false)`
 /// and `false` are the same node for a caller that only cares about literal
 /// shape, not surface syntax (`Expr::Alternative`'s `#845` fix, below).
@@ -14830,10 +14872,7 @@ fn resolve_node<'a, S: EvalSemantics>(
         // parser path. Keeping both arms means it does not matter which one
         // a given call site produces.
         Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
-            Ok(resolve_node::<S>(inner, value, trackable)?
-                .into_iter()
-                .take(1)
-                .collect())
+            take_path_branches(resolve_node::<S>(inner, value, trackable), 1)
         }
 
         // `if cond then a else b end`: only the branch the runtime actually
@@ -15227,10 +15266,7 @@ fn resolve_limit<'a, S: EvalSemantics>(
     if n == 0 {
         return Ok(Vec::new());
     }
-    Ok(resolve_node::<S>(expr, value, trackable)?
-        .into_iter()
-        .take(n)
-        .collect())
+    take_path_branches(resolve_node::<S>(expr, value, trackable), n)
 }
 
 /// Convert a static, non-`Identity` path component into the `OwnedValue` jq
@@ -16189,8 +16225,32 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     // returns it as-is: everything already pushed before the failing
     // key/target combination, matching jq's own never-un-emit streaming
     // (#530's sibling fix).
+    //
+    // jq compiles `E[K]` as `K as $k | E | .[$k]` — target inner, key outer
+    // — so when `target` itself escapes, that escape fires while jq is
+    // still inside the *first* key's iteration; the key generator is never
+    // resumed for a second key. `target_branches` above was computed once,
+    // outside this loop, so restricting `keys` to its first element when
+    // `target` escaped is what keeps this function's `Err` prefix equal to
+    // jq's own pre-escape stream, rather than the full key × target cross
+    // product jq's generator would never actually produce. Confirmed
+    // against jq 1.7.1: `path(select((true,error("t")))[("x","y")])` on
+    // `{"x":9,"y":8}` prints only `["x"]` before raising `t` — `["y"]` is a
+    // branch jq's generator never reaches. Emitting it made this prefix
+    // longer than jq's, invisible to `path()`'s own streaming consumer
+    // (which prints it either way, escape or not) but unsound for any
+    // consumer that truncates the prefix and drops the escape (`first`/
+    // `limit`, #972) — this exact overshoot is what got PR #985 reverted:
+    // `del(limit(2; select((true,error("t")))[("x","y")]))` silently
+    // deleted both keys instead of raising, because the untruncated prefix
+    // (length 2) satisfied `limit(2)`.
+    let keys: &[OwnedValue] = if target_escape.is_some() {
+        &keys[..1]
+    } else {
+        &keys[..]
+    };
     let mut out = Vec::with_capacity(keys.len() * target_branches.len());
-    for k in &keys {
+    for k in keys {
         for PathBranch {
             path: components,
             value: target_value,
@@ -16374,9 +16434,25 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
         ));
     }
 
+    // jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]` — target
+    // inner, bounds outer — so when `target` escapes, that fires inside the
+    // very first `(s, e)` pair; neither bound generator is resumed for a
+    // second pair. `target_branches` was computed once, outside this loop,
+    // so restricting `starts`/`ends` to their first element when `target`
+    // escaped keeps this function's `Err` prefix equal to jq's own
+    // pre-escape stream, mirroring `resolve_index_expr`'s identical fix
+    // (#972). Confirmed against jq 1.7.1:
+    // `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
+    // prints only `[{"start":0,"end":2}]` before raising `t`.
+    let (starts, ends): (&[ResolvedSliceBound], &[ResolvedSliceBound]) = if target_escape.is_some()
+    {
+        (&starts[..1], &ends[..1])
+    } else {
+        (&starts[..], &ends[..])
+    };
     let mut out = Vec::with_capacity(starts.len() * ends.len() * target_branches.len());
-    for (s, s_key) in &starts {
-        for (e, e_key) in &ends {
+    for (s, s_key) in starts {
+        for (e, e_key) in ends {
             // #1326: a genuinely dynamic bound (unlike a literal one, which
             // the parser's own `fold_slice_bound` handles at parse time)
             // keeps its float spelling the same way -- `Expr::SliceNumber`
@@ -16684,7 +16760,20 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // What *does* survive an escape (#1013): the escaping branch's own
     // partial output (everything it produced before hitting its escape) is
     // still threaded through every remaining dynamic stage and the tail,
-    // exactly like a branch that never escaped at all — see below.
+    // exactly like a branch that never escaped at all — see below. That is
+    // what makes this function's `Err` *prefix content* faithful to jq's
+    // own pre-escape stream even across multiple dynamic stages (unlike
+    // `resolve_index_expr`/`resolve_slice_expr`'s own pre-#972 gap, a
+    // different failure mode where the prefix was too *long*, not too
+    // short) — confirmed for `first(.[]|.[]|.[])`-shaped multi-stage pipes
+    // by `test_path_prefix_matches_jq_before_escape_972`. The stage-by-stage
+    // (not depth-first) rebuild above is still a real divergence, but only
+    // in *evaluation order*: a not-yet-reached sibling this function's own
+    // fan-out never gets to is also a sibling jq's real depth-first
+    // generator would never reach either, so no branch either side actually
+    // emits is lost — see #987/#820 for the separate, still-open question
+    // of whether a sibling that's never *reached* was nonetheless
+    // *evaluated* (side effects included) ahead of being pruned.
     let tail = &flat[last_dynamic + 1..];
     // The root branch inherits this call's own trackability: seeding it
     // `true` regardless is what made `catch (getpath(["other"]) | .qqq)`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15098,6 +15098,56 @@ fn resolve_node<'a, S: EvalSemantics>(
             }
         }
 
+        // #1440: `reduce`/`foreach` are real sugar over the same
+        // variable-binding primitive every other construct uses (real jq
+        // has no fold-specific path machinery at all), so a path-trackable
+        // variable referenced inside UPDATE/EXTRACT should track the same
+        // way it does anywhere else — but until this arm existed, both
+        // fell to `resolve_leaf`'s catch-all, which evaluates the whole
+        // construct via the ordinary value evaluator and always marks the
+        // result untracked. See `resolve_reduce`/`resolve_foreach` and
+        // `FoldRegister` for the full model, derived empirically against
+        // jq 1.7.1.
+        //
+        // `patterns.len() == 1` is the overwhelmingly common case (a bare
+        // `?//`-free `as` clause) and the only one `resolve_reduce`/
+        // `resolve_foreach` handle; #1365's own `?//`-alternatives retry
+        // machinery (`try_reduce_step_alternatives`/
+        // `try_foreach_step_alternatives`) landed on `main` after this
+        // arm was designed and isn't threaded through path-tracking here.
+        // Real jq still tracks a variable through a `?//`-alternatives
+        // fold (confirmed live: `path(. as $x | reduce (1) as $y ?// $z
+        // (0; $x))` is `[]`), so falling to `resolve_leaf`'s catch-all for
+        // that case is a real but safe (refuse-only, never a wrong path)
+        // divergence — documented in `docs/compliance/jq/limitations.md`.
+        Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } => match patterns.as_slice() {
+            [pattern] => resolve_reduce::<S>(input, pattern, init, update, value, trackable),
+            _ => resolve_leaf::<S>(expr, value, trackable),
+        },
+        Expr::Foreach {
+            input,
+            patterns,
+            init,
+            update,
+            extract,
+        } => match patterns.as_slice() {
+            [pattern] => resolve_foreach::<S>(
+                input,
+                pattern,
+                init,
+                update,
+                extract.as_deref(),
+                value,
+                trackable,
+            ),
+            _ => resolve_leaf::<S>(expr, value, trackable),
+        },
+
         // #844: a frozen variable snapshot from a statically-verified
         // identity-passthrough `as`-binding (see `is_identity_passthrough`
         // and the two `substitute_var_tracked` call sites above). The
@@ -15655,6 +15705,417 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
             )),
         },
     }
+}
+
+/// The register `path()`-tracking compares each `reduce`/`foreach` fold
+/// iteration's own navigation against — jq's `(path, value_at_path)` pair,
+/// derived empirically against jq 1.7.1 (#1440; no fold-specific machinery
+/// exists in real jq, since `reduce`/`foreach` are sugar over the same
+/// variable-binding primitive every other construct uses — confirmed by
+/// `substitute_var_impl`'s existing `Reduce`/`Foreach` arms, which already
+/// correctly thread an outer `Expr::TrackedVar` marker into UPDATE/EXTRACT;
+/// the only missing piece was `resolve_node` never walking into the
+/// construct at all).
+///
+/// **Fixed once per INIT fork ([`FoldRegister::enter`]) — never advances
+/// across source-element iterations of the same fold.** Confirmed live:
+/// `path(reduce (1,2) as $i (.a; .b))` on `{"a":{"b":{"b":9}}}` raises
+/// "near attempt to access element \"b\" of {\"b\":9}" on the *second*
+/// iteration — if the register had advanced to iteration 1's own result
+/// (path `["a","b"]`, value `{"b":9}`), iteration 2's `.b` would have
+/// navigated it successfully instead of raising. `foreach` has the
+/// identical reset between source elements (confirmed live the same way),
+/// even though *within* one source element it does chain UPDATE into
+/// EXTRACT (see [`FoldRegister::advance`]) — the register resets at every
+/// "re-entry" into UPDATE for a new element, but not at the direct,
+/// same-step continuation from UPDATE into EXTRACT.
+///
+/// `reduce`'s own *final* accumulator gets the identical reset treatment,
+/// even though it isn't itself a new UPDATE call: confirmed live,
+/// `path(reduce (1) as $i (.a; .b))` on `{"a":{"b":9}}` raises "Invalid
+/// path expression with result 9" — `.b`'s own navigation inside that one
+/// UPDATE call *was* genuinely trackable (path `["a","b"]`), but reduce's
+/// exit back into its own caller is itself another such boundary, so the
+/// emitted value is re-checked against the same fixed register one more
+/// time rather than keeping UPDATE's own transient path. `foreach`'s own
+/// per-element emission (UPDATE directly, or via EXTRACT) is *not* such a
+/// boundary — confirmed live, `path(foreach (1) as $i (.a; .b; .))` on
+/// `{"a":{"b":5},"c":5}` is `["a","b"]`, inheriting UPDATE's own
+/// trackable result through EXTRACT directly, no reset.
+struct FoldRegister {
+    path: Vec<Expr>,
+    value: OwnedValue,
+    trackable: bool,
+}
+
+impl FoldRegister {
+    /// Seed the register from one INIT branch (one INIT fork) and the
+    /// accumulator's own starting value (always INIT's own computed
+    /// value, regardless of whether it was itself trackable).
+    ///
+    /// If INIT navigated to a real path, the register starts there.
+    /// Otherwise (INIT was computed, e.g. a literal `0`) the register
+    /// stays exactly where it was *before* INIT ran: the caller's own
+    /// ambient position — INIT's own computation doesn't "move" the
+    /// register, only genuine navigation does (the same rule
+    /// [`FoldRegister::advance`] applies within one fold step). Confirmed
+    /// live: `path(. as $x | reduce (1) as $i (0; $x))` is `[]` (register
+    /// never moved off the document root, despite INIT computing `0`),
+    /// but `path(. as $x | reduce (1,2) as $i (.a; $x))` raises (INIT's
+    /// own navigation moved the register off `$x`'s frozen position).
+    fn enter(
+        init_branch: &PathBranch<'_>,
+        value: &OwnedValue,
+        trackable: bool,
+    ) -> (Self, OwnedValue) {
+        let acc = init_branch.value.clone().into_owned();
+        let reg = if init_branch.trackable {
+            Self {
+                path: init_branch.path.clone(),
+                value: acc.clone(),
+                trackable: true,
+            }
+        } else {
+            Self {
+                path: Vec::new(),
+                value: value.clone(),
+                trackable,
+            }
+        };
+        (reg, acc)
+    }
+
+    /// Resolve `expr` (`UPDATE` or `EXTRACT`) against one fold step's own
+    /// input, relocating every resulting branch through this register.
+    ///
+    /// Mirrors jq's own per-emission `jv_identical(current_input,
+    /// value_at_path)` check, softened to structural equality since
+    /// `OwnedValue` has no stable identity to compare — the same softening
+    /// `Expr::TrackedVar`'s own arm already makes. `input` is always
+    /// resolved as `Cow::Owned` (via [`resolve_against_cow`]) since the
+    /// accumulator is always a freshly-computed `OwnedValue`, never a
+    /// literal subpart of the original document, mirroring
+    /// `eval_owned_expr_fork`'s identical convention in the value-position
+    /// evaluators this parallels.
+    fn resolve<'a, S: EvalSemantics>(
+        &self,
+        expr: &Expr,
+        input: OwnedValue,
+    ) -> PathResolveResult<'a> {
+        let tr = self.trackable && input == self.value;
+        match resolve_against_cow::<S>(expr, Cow::Owned(input), tr) {
+            Ok(branches) => Ok(self.relocate(branches)),
+            Err((prefix, e)) => Err((self.relocate(prefix), e)),
+        }
+    }
+
+    fn relocate<'a>(&self, branches: Vec<PathBranch<'a>>) -> Vec<PathBranch<'a>> {
+        branches
+            .into_iter()
+            .map(|b| {
+                if b.trackable {
+                    let mut path = self.path.clone();
+                    path.extend(b.path);
+                    PathBranch::new(path, b.value, true)
+                } else if self.trackable && *b.value == self.value {
+                    PathBranch::new(self.path.clone(), b.value, true)
+                } else {
+                    PathBranch::untracked(b.value)
+                }
+            })
+            .collect()
+    }
+
+    /// Move to a trackable UPDATE branch, for resolving `foreach`'s EXTRACT
+    /// against it — the only within-one-fold-step chain of two navigable
+    /// positions (UPDATE's own result feeds directly into EXTRACT, with no
+    /// "re-entry" boundary between them, unlike the reset between source
+    /// elements — see this type's own doc comment).
+    ///
+    /// An untracked UPDATE branch leaves the register unchanged (not
+    /// reset to untracked) — a computed UPDATE result doesn't erase where
+    /// the register already was, mirroring `enter`'s identical "computed
+    /// doesn't move the register" rule for INIT. Confirmed live:
+    /// `path(. as $x | foreach (1) as $i (0; 5; $x))` is `[]` — UPDATE=`5`
+    /// never navigates, so the register EXTRACT sees is still wherever it
+    /// was before UPDATE ran (the document root, from `enter`'s untracked
+    /// branch), letting `$x` (bound from that same root) match.
+    fn advance(&self, branch: &PathBranch<'_>) -> Self {
+        if branch.trackable {
+            Self {
+                path: branch.path.clone(),
+                value: branch.value.clone().into_owned(),
+                trackable: true,
+            }
+        } else {
+            Self {
+                path: self.path.clone(),
+                value: self.value.clone(),
+                trackable: self.trackable,
+            }
+        }
+    }
+}
+
+/// `path()`-tracking counterpart of [`eval_reduce`] — resolves
+/// `reduce EXPR as $var (INIT; UPDATE)` in path context, replicating
+/// `eval_reduce`'s own control flow (INIT forks, per-source-element UPDATE
+/// fold, shared step budget, `Halt`/`Break`/`Error` propagation, "only the
+/// last UPDATE output survives each step") while threading a
+/// [`FoldRegister`] through UPDATE instead of a plain value, so a
+/// path-trackable variable referenced inside UPDATE (#844's
+/// `Expr::TrackedVar`) can still resolve to a real path (#1440).
+///
+/// No new AST substitution is needed for the accumulator itself: unlike a
+/// named `$var` binding (`Expr::As`), the accumulator has no name — it's
+/// `.` inside UPDATE — and `.`/`.a`/`.a.b`-style bare navigation already
+/// resolves correctly by passing the accumulator as `resolve_node`'s own
+/// `value` parameter (via [`FoldRegister::resolve`]/[`resolve_against_cow`]),
+/// exactly the way a value computed mid-chain is already handled elsewhere
+/// in this file. `substitute_var_impl`'s existing `Reduce`/`Foreach` arms
+/// already correctly thread an outer `TrackedVar` marker into UPDATE, so
+/// this function receives it already embedded; `FoldRegister`'s only job is
+/// keeping that marker's own check comparing against the position it was
+/// actually bound from, not the accumulator's.
+fn resolve_reduce<'a, S: EvalSemantics>(
+    input: &Expr,
+    pattern: &Pattern,
+    init: &Expr,
+    update: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+) -> PathResolveResult<'a> {
+    // Mirrors `eval_reduce`'s own source-stream handling: `reduce`'s
+    // output is always single-shot, so a `Partial` input just extracts the
+    // control and drops the prefix (there's no path-tracking analogue of
+    // "a prefix" for the source stream itself, same as the value
+    // evaluator).
+    let (input_values, input_escape) = eval_owned_expr_fork::<S>(input, value, false);
+    if let Some(control) = input_escape {
+        return Err((Vec::new(), control.into()));
+    }
+
+    // INIT resolved through the path resolver, not the plain evaluator:
+    // each branch is one INIT fork, and whether it navigated (vs. was
+    // merely computed) is exactly what `FoldRegister::enter` needs.
+    let (init_branches, init_escape) = match resolve_node::<S>(init, value, trackable) {
+        Ok(branches) => (branches, None),
+        Err((prefix, e)) => (prefix, Some(e)),
+    };
+    if init_branches.is_empty() {
+        return path_result(Vec::new(), init_escape);
+    }
+
+    // `eval_reduce`'s own substitution, minus the two things this
+    // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s dispatch
+    // arm) rules out: #1365's `patterns`-matrix, and #1368's null-fill for
+    // names an alternative leaves unbound -- a bare `$var` pattern binds
+    // its one name unconditionally, so there is never an unbound name to
+    // fill.
+    let substituted_updates: Vec<Result<Expr, EvalError>> = input_values
+        .iter()
+        .map(|v| {
+            extract_pattern_bindings(pattern, v, false)
+                .map(|b| substitute_vars(update, as_var_refs(&b)))
+        })
+        .collect();
+
+    let mut out: Vec<PathBranch<'a>> = Vec::new();
+    // Shared across every INIT fork (#695), same "whole tree, not
+    // per-branch" accounting `eval_reduce` itself uses.
+    let mut budget = REDUCE_FOREACH_MAX_STEPS;
+    for init_branch in &init_branches {
+        let (reg, acc) = FoldRegister::enter(init_branch, value, trackable);
+        // `Option`, not a bare `OwnedValue`, mirroring `eval_reduce`'s own
+        // accumulator exactly: a step whose UPDATE produces zero outputs
+        // leaves it unbound rather than ending the fold, read back as
+        // `null` (#534), and `.take()` below moves it out without a clone
+        // since nothing reads the old value again once UPDATE has run.
+        let mut acc: Option<OwnedValue> = Some(acc);
+        let mut aborted: Option<Control> = None;
+        for substituted in &substituted_updates {
+            if let Some(control) = charge_budget(&mut budget, "reduce") {
+                aborted = Some(control);
+                break;
+            }
+            let substituted = match substituted {
+                Ok(expr) => expr,
+                Err(e) => {
+                    aborted = Some(Control::Error(e.clone()));
+                    break;
+                }
+            };
+            let acc_input = acc.take().unwrap_or(OwnedValue::Null);
+            match reg.resolve::<S>(substituted, acc_input) {
+                Ok(branches) => {
+                    // Only the last output of a multi-output UPDATE
+                    // becomes the new accumulator (same rule as
+                    // `eval_reduce`) — trackability is discarded here, not
+                    // just the path: it is re-derived from scratch against
+                    // the same fixed `reg` at every subsequent step and at
+                    // final emission below, never carried forward as a
+                    // value flows from one step to the next (see this
+                    // function's own doc comment and `FoldRegister`'s).
+                    acc = branches.into_iter().last().map(|b| b.value.into_owned());
+                }
+                Err((_prefix, e)) => {
+                    // Whatever this step's UPDATE partially resolved
+                    // before erroring never becomes a real accumulator —
+                    // the whole fork aborts here, same as `eval_reduce`'s
+                    // own `aborted = Some(control); break;`.
+                    aborted = Some(e.into());
+                    break;
+                }
+            }
+        }
+        match aborted {
+            Some(control) => return path_result(out, Some(control.into())),
+            None => {
+                // Final emission: the accumulator, re-checked against the
+                // same fixed register one more time — reduce's own exit
+                // back into its caller is itself a "re-entry" boundary,
+                // exactly like the reset between source-element
+                // iterations above, so a transient trackable result from
+                // the last UPDATE step does not automatically survive
+                // (confirmed live, see this function's own doc comment).
+                let acc = acc.unwrap_or(OwnedValue::Null);
+                out.extend(reg.relocate(vec![PathBranch::untracked(Cow::Owned(acc))]));
+            }
+        }
+    }
+    path_result(out, init_escape)
+}
+
+/// `path()`-tracking counterpart of [`eval_foreach`] — see [`resolve_reduce`]
+/// for the shared design; differs exactly where `eval_foreach` differs from
+/// `eval_reduce`: the source stream's own partial prefix is genuinely
+/// iterated (not discarded), each UPDATE output is emitted (or fed through
+/// EXTRACT) rather than folded away, and the source stream's own trailing
+/// control is applied per-fork after that fork's own inner loop (#534
+/// follow-up), not deferred until every fork has run.
+fn resolve_foreach<'a, S: EvalSemantics>(
+    input: &Expr,
+    pattern: &Pattern,
+    init: &Expr,
+    update: &Expr,
+    extract: Option<&Expr>,
+    value: &'a OwnedValue,
+    trackable: bool,
+) -> PathResolveResult<'a> {
+    // Unlike `reduce`, a `Partial` source stream's own prefix is iterated
+    // below — mirrors `eval_foreach`'s identical rule.
+    let (input_values, input_control) = eval_owned_expr_fork::<S>(input, value, false);
+
+    let (init_branches, init_escape) = match resolve_node::<S>(init, value, trackable) {
+        Ok(branches) => (branches, None),
+        Err((prefix, e)) => (prefix, Some(e)),
+    };
+    if init_branches.is_empty() {
+        return path_result(Vec::new(), init_escape);
+    }
+
+    let bindings_per_element: Vec<Result<Vec<(String, OwnedValue)>, EvalError>> = input_values
+        .iter()
+        .map(|v| extract_pattern_bindings(pattern, v, false))
+        .collect();
+    // Same single-alternative, no-null-fill reasoning as `resolve_reduce`'s
+    // own substitution above.
+    let substituted_updates: Vec<Result<Expr, EvalError>> = bindings_per_element
+        .iter()
+        .map(|b| {
+            b.as_ref()
+                .map(|b| substitute_vars(update, as_var_refs(b)))
+                .map_err(Clone::clone)
+        })
+        .collect();
+    let substituted_extracts: Option<Vec<Result<Expr, EvalError>>> = extract.map(|ext| {
+        bindings_per_element
+            .iter()
+            .map(|b| {
+                b.as_ref()
+                    .map(|b| substitute_vars(ext, as_var_refs(b)))
+                    .map_err(Clone::clone)
+            })
+            .collect()
+    });
+
+    let mut out: Vec<PathBranch<'a>> = Vec::new();
+    let mut budget = REDUCE_FOREACH_MAX_STEPS;
+    for init_branch in &init_branches {
+        let (reg, mut state) = FoldRegister::enter(init_branch, value, trackable);
+        let mut aborted: Option<Control> = None;
+        'input: for (idx, substituted_update) in substituted_updates.iter().enumerate() {
+            if let Some(control) = charge_budget(&mut budget, "foreach") {
+                aborted = Some(control);
+                break;
+            }
+            let substituted_update = match substituted_update {
+                Ok(expr) => expr,
+                Err(e) => {
+                    aborted = Some(Control::Error(e.clone()));
+                    break;
+                }
+            };
+            let update_branches = match reg.resolve::<S>(substituted_update, state) {
+                Ok(branches) => branches,
+                Err((_prefix, e)) => {
+                    aborted = Some(e.into());
+                    break;
+                }
+            };
+            for update_branch in &update_branches {
+                if let Some(extracts) = &substituted_extracts {
+                    if let Some(control) = charge_budget(&mut budget, "foreach") {
+                        aborted = Some(control);
+                        break 'input;
+                    }
+                    let ext_expr = match &extracts[idx] {
+                        Ok(expr) => expr,
+                        Err(e) => {
+                            aborted = Some(Control::Error(e.clone()));
+                            break 'input;
+                        }
+                    };
+                    let extract_reg = reg.advance(update_branch);
+                    match extract_reg
+                        .resolve::<S>(ext_expr, update_branch.value.clone().into_owned())
+                    {
+                        Ok(branches) => out.extend(branches),
+                        Err((prefix, e)) => {
+                            out.extend(prefix);
+                            aborted = Some(e.into());
+                            break 'input;
+                        }
+                    }
+                } else if update_branch.trackable {
+                    out.push(PathBranch::new(
+                        update_branch.path.clone(),
+                        update_branch.value.clone(),
+                        true,
+                    ));
+                } else {
+                    out.push(PathBranch::untracked(update_branch.value.clone()));
+                }
+            }
+            // Only the last UPDATE output carries forward as state for the
+            // next source element — same rule as `eval_foreach`.
+            // Trackability is discarded here too, for the same reason as
+            // `resolve_reduce`'s identical step: the next iteration
+            // re-derives it from scratch against the same fixed `reg`.
+            state = update_branches
+                .into_iter()
+                .last()
+                .map_or(OwnedValue::Null, |b| b.value.into_owned());
+        }
+        // The source stream's own trailing control belongs to this fork
+        // too, applied after its own inner loop — mirrors `eval_foreach`'s
+        // #534-follow-up fix exactly.
+        let aborted = aborted.or_else(|| input_control.clone());
+        if let Some(control) = aborted {
+            return path_result(out, Some(control.into()));
+        }
+    }
+    path_result(out, init_escape)
 }
 
 /// Apply `Expr::Try`'s `catch` clause (if any) after `expr` failed to
@@ -52557,5 +53018,410 @@ mod tests {
         );
         assert_eq!(paths.len(), 300);
         assert!(paths.iter().all(|p| p == r#"["root_marker",0]"#));
+    }
+
+    // =========================================================================
+    // #1440: path() tracks a variable referenced inside reduce/foreach's
+    // UPDATE/EXTRACT. All cases below confirmed live against jq 1.7.1.
+    // =========================================================================
+
+    /// The issue's own two repros: a trackable variable passed straight
+    /// through `reduce`/`foreach`'s UPDATE, never touched by it, still
+    /// resolves to the root path it was actually bound from.
+    #[test]
+    fn test_path_tracks_variable_through_reduce_foreach_update_1440() {
+        assert_eq!(
+            outputs(br#"{"a":1}"#, "path(. as $x | reduce (1,2) as $i (0; $x))"),
+            [r"[]"]
+        );
+        assert_eq!(
+            outputs(br#"{"a":1}"#, "path(. as $x | foreach (1,2) as $i (0; $x))"),
+            [r"[]", r"[]"]
+        );
+    }
+
+    /// `reduce`'s register-restore semantics: INIT's own path survives an
+    /// empty or non-empty fold untouched, but is checked fresh (not
+    /// inherited from a transient UPDATE result) at every iteration
+    /// boundary and at final emission — see `FoldRegister`'s own doc
+    /// comment for the full model.
+    #[test]
+    fn test_reduce_register_restore_semantics_1440() {
+        // INIT's path survives an empty fold (no source elements at all).
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1},"c":2}"#,
+                "path(reduce empty as $i (.a; .))"
+            ),
+            [r#"["a"]"#]
+        );
+        // ...and a non-empty one, since UPDATE (`.`) never moves off it.
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1},"c":2}"#,
+                "path(reduce (1,2) as $i (.a; .))"
+            ),
+            [r#"["a"]"#]
+        );
+        // The register restores between the fold's own internal steps and
+        // at final emission: UPDATE's `.b` genuinely navigates *within*
+        // one step, but the fold's own final value is re-checked against
+        // the fixed, INIT-derived register rather than inheriting that
+        // transient result.
+        query!(br#"{"a":{"b":9}}"#, "path(reduce (1) as $i (.a; .b))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result 9");
+            }
+        );
+        // The restore forces the "near attempt" wording on a *later*
+        // iteration navigating off a value the register no longer agrees
+        // with (iteration 1's own `.b` succeeded; iteration 2 restores the
+        // register to INIT's own position before trying `.b` again).
+        query!(
+            br#"{"a":{"b":{"b":9}}}"#,
+            "path(reduce (1,2) as $i (.a; .b))",
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("near attempt to access element \"b\" of {\"b\":9}"),
+                    "{}", e.message
+                );
+            }
+        );
+        query!(
+            br#"{"a":{"b":1},"c":2}"#,
+            "path(reduce (1,2) as $i (.; .a.b))",
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("near attempt to access element \"a\" of 1"),
+                    "{}", e.message
+                );
+            }
+        );
+    }
+
+    /// Multi-element input: only the *last* UPDATE output per step
+    /// survives the fold, same rule as `eval_reduce`'s own value-position
+    /// fold.
+    #[test]
+    fn test_reduce_last_update_output_wins_1440() {
+        query!(
+            br#"{"a":{"b":1},"c":2}"#,
+            "path(reduce (1,2) as $i (.; .a, .c))",
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("near attempt to access element \"a\" of 2"),
+                    "{}", e.message
+                );
+            }
+        );
+    }
+
+    /// Mixed per-iteration trackability — the issue's own open question,
+    /// now pinned both ways: whichever iteration's UPDATE is last decides,
+    /// and an intermediate iteration's own trackability never leaks into a
+    /// later one (the register is fixed per INIT fork, re-checked fresh
+    /// every step).
+    #[test]
+    fn test_reduce_mixed_per_iteration_trackability_1440() {
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                "path(. as $x | reduce (1,2) as $i (0; if $i==1 then $x else . end))"
+            ),
+            [r"[]"]
+        );
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                "path(. as $x | reduce (1,2) as $i (0; if $i==2 then $x else . end))"
+            ),
+            [r"[]"]
+        );
+    }
+
+    /// A fold whose UPDATE never derives from the trackable variable at
+    /// all behaves exactly like the pre-#844 baseline: an ordinary,
+    /// untracked computed result.
+    #[test]
+    fn test_reduce_foreach_never_derived_from_tracked_var_1440() {
+        query!(
+            br#"{"a":1,"b":2}"#,
+            "path(reduce (1,2) as $i (0; .+1))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result 2");
+            }
+        );
+        query!(
+            br#"{"a":1,"b":2}"#,
+            "path(foreach (1,2) as $i (0; .+1))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result 1");
+            }
+        );
+    }
+
+    /// `foreach`'s emission/register-advance rules: UPDATE's own trackable
+    /// result carries *directly* into EXTRACT (no reset), but a computed
+    /// (untracked) UPDATE result leaves the register wherever it already
+    /// was rather than clearing it — see `FoldRegister::advance`.
+    #[test]
+    fn test_foreach_register_advance_within_one_step_1440() {
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1},"b":7}"#,
+                "path(foreach (1) as $i (.; .a, .; .b))"
+            ),
+            [r#"["a","b"]"#, r#"["b"]"#]
+        );
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":7}}"#,
+                "path(foreach (1) as $i (.; .a; .b, .))"
+            ),
+            [r#"["a","b"]"#, r#"["a"]"#]
+        );
+        // UPDATE computes (doesn't navigate); EXTRACT's own $x reference
+        // still succeeds because the register never moved off the
+        // document root in the first place.
+        assert_eq!(
+            outputs(
+                br#"{"b":7}"#,
+                "path(. as $x | foreach (1) as $i (0; 5; $x))"
+            ),
+            [r"[]"]
+        );
+        assert_eq!(
+            outputs(
+                br#"{"b":7}"#,
+                "path(. as $x | foreach (1) as $i (0; $x; $x))"
+            ),
+            [r"[]"]
+        );
+    }
+
+    /// The register resets between *source elements* for `foreach` too,
+    /// exactly like `reduce`'s own per-iteration reset — the within-one-step
+    /// UPDATE→EXTRACT chain above is the only place it carries forward.
+    #[test]
+    fn test_foreach_register_resets_between_source_elements_1440() {
+        query!(
+            br#"{"a":{"b":{"b":9}}}"#,
+            "path(foreach (1,2) as $i (.a; .b))",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a","b"]"#]);
+                assert!(
+                    e.message.contains("near attempt to access element \"b\" of {\"b\":9}"),
+                    "{}", e.message
+                );
+            }
+        );
+    }
+
+    /// Empty UPDATE leaves the accumulator unbound (read back as `null`),
+    /// same rule as the value-position evaluator (#534) — for `reduce`
+    /// this becomes the terminal (untracked) value; for `foreach` it
+    /// simply never emits since there is no UPDATE output for EXTRACT (or
+    /// the implicit identity extract) to run on.
+    #[test]
+    fn test_reduce_foreach_empty_update_1440() {
+        query!(br#"{"a":1}"#, "path(reduce (1,2) as $i (.; empty))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result null");
+            }
+        );
+        assert_eq!(
+            outputs(br#"{"a":1}"#, "path(foreach (1,2) as $i (.; empty))"),
+            Vec::<String>::new()
+        );
+    }
+
+    /// Escapes and the `PathResolveResult` keep-partial contract: INIT's
+    /// own partial prefix still forks, the source stream's own partial
+    /// prefix behaves differently for `reduce` (single-shot, drops it)
+    /// vs. `foreach` (streams it), a mid-fold error aborts cleanly, and a
+    /// `break` reaches an outer `label` rather than being swallowed
+    /// (#824's contract, mirrored from `Expr::As`'s own arm).
+    #[test]
+    fn test_reduce_foreach_escapes_and_partial_prefix_1440() {
+        // INIT partial: the fork already produced from `.a` survives, then
+        // the error is raised — same shape for both constructs.
+        query!(
+            br#"{"a":{"b":1}}"#,
+            r#"path(reduce (1) as $i ((.a, error("z")); .))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
+                assert_eq!(e.message, "z");
+            }
+        );
+        query!(
+            br#"{"a":{"b":1}}"#,
+            r#"path(foreach (1) as $i ((.a, error("z")); .))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
+                assert_eq!(e.message, "z");
+            }
+        );
+
+        // Source-stream partial: `foreach` streams the produced prefix
+        // (two outputs) before raising; `reduce` is single-shot and drops
+        // it, raising with nothing.
+        query!(
+            br#"{"a":1}"#,
+            r#"path(foreach (1,2,error("s")) as $i (.; .))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r"[]", r"[]"]);
+                assert_eq!(e.message, "s");
+            }
+        );
+        query!(
+            br#"{"a":1}"#,
+            r#"path(reduce (1,2,error("s")) as $i (.; .))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "s");
+            }
+        );
+
+        // A mid-fold error aborts the whole construct, keeping whatever
+        // prior source elements already emitted (foreach only — reduce
+        // never emits per-element).
+        query!(
+            br#"{"a":{"b":1},"c":2}"#,
+            r#"path(foreach (1,2,3) as $i (.; if $i==2 then error("boom") else . end))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r"[]"]);
+                assert_eq!(e.message, "boom");
+            }
+        );
+
+        // `break` reaches an outer `label`, not swallowed into a synthetic
+        // "not in label" error — mirrors `Expr::As`'s own #824 contract.
+        assert_eq!(
+            outputs(
+                br#"{"a":1,"b":2}"#,
+                r"[label $out | path(reduce (1,2) as $i (.; if $i==2 then ., break $out else . end))]"
+            ),
+            [r"[]"]
+        );
+    }
+
+    /// `reduce`'s own INIT-fork behavior: each INIT output forks the whole
+    /// construct into an independent path, exactly mirroring
+    /// `eval_reduce`'s own value-position fork semantics.
+    #[test]
+    fn test_reduce_init_forks_1440() {
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1},"c":2}"#,
+                "path(reduce (1) as $i ((.a,.c); .))"
+            ),
+            [r#"["a"]"#, r#"["c"]"#]
+        );
+    }
+
+    /// Composition: a fold mid-pipe, a fold as a pipe's own source, and
+    /// nested folds — the register mechanism is purely local to each
+    /// `resolve_reduce`/`resolve_foreach` call, so nesting composes for
+    /// free with no special-casing.
+    #[test]
+    fn test_reduce_foreach_composition_1440() {
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, "path(.a | reduce (1,2) as $i (.; .))"),
+            [r#"["a"]"#]
+        );
+        assert_eq!(
+            outputs(
+                br#"{"a":{"b":1}}"#,
+                "path((reduce (1,2) as $i (.a; .)) | .b)"
+            ),
+            [r#"["a","b"]"#]
+        );
+        query!(
+            br#"{"a":{"b":1}}"#,
+            "path((reduce (1,2) as $i (0; .+1)) | .a)",
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("near attempt to access element \"a\" of 2"),
+                    "{}", e.message
+                );
+            }
+        );
+        assert_eq!(
+            outputs(
+                br#"{"a":1}"#,
+                "path(. as $x | reduce (1) as $i (0; reduce (1) as $j (0; $x)))"
+            ),
+            [r"[]"]
+        );
+        query!(
+            br#"{"a":{"b":1}}"#,
+            "path(reduce (1) as $i (.; reduce (1) as $j (.; .a)))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, r#"Invalid path expression with result {"b":1}"#);
+            }
+        );
+    }
+
+    /// Write side: a trackable fold result works as an assignment/delete
+    /// target too, not just for `path()` itself — `resolve_reduce`/
+    /// `resolve_foreach` are reached from the same `resolve_dynamic_indexes`
+    /// entry point `=`/`del()`/`|=` all share.
+    #[test]
+    fn test_reduce_foreach_write_side_1440() {
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, "(reduce (1,2) as $i (.a; .)) = 9"),
+            [r#"{"a":9}"#]
+        );
+        assert_eq!(
+            outputs(br#"{"a":{"b":1},"c":2}"#, "del(reduce (1) as $i (.a; .))"),
+            [r#"{"c":2}"#]
+        );
+        assert_eq!(
+            outputs(br#"{"b":7}"#, "(. as $x | reduce (1,2) as $i (0; $x)) |= 9"),
+            [r"9"]
+        );
+    }
+
+    /// A pattern that rebinds the same name as an outer trackable variable
+    /// must shadow it inside UPDATE, not accidentally resolve the outer
+    /// binding — `substitute_pattern`'s own untracked substitution for the
+    /// loop variable already handles this; this pins the negative case.
+    #[test]
+    fn test_reduce_pattern_shadowing_outer_var_1440() {
+        query!(
+            br#"{"a":1}"#,
+            "path(. as $x | reduce (1,2) as $x (0; $x))",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Invalid path expression with result 2");
+            }
+        );
+    }
+
+    /// Performance/correctness sanity over a larger fold, mirroring
+    /// `test_path_tracks_variable_referenced_in_a_loop_844`'s own shape:
+    /// 300 fold iterations over a bare passthrough of a trackable outer
+    /// variable still resolve to that variable's own root path, with
+    /// nothing degrading (correctness-wise) as the fold runs longer.
+    /// `FoldRegister` threads a small, fixed-size struct through a plain
+    /// loop (no per-iteration AST rebuild the way `Expr::As`'s own
+    /// marker-substitution needed `Rc` to keep O(1)), so this is a
+    /// regression pin on correctness at scale rather than a wall-clock
+    /// benchmark (too flaky for a unit test, same rationale as `_844`'s
+    /// own doc comment).
+    #[test]
+    fn test_reduce_foreach_tracks_a_large_loop_1440() {
+        let json = br#"{"a":1}"#;
+        assert_eq!(
+            outputs(
+                json,
+                r"path(. as $root | reduce range(300) as $i (0; $root))"
+            ),
+            [r"[]"]
+        );
+        let foreach_paths = outputs(
+            json,
+            r"path(. as $root | foreach range(300) as $i (0; $root))",
+        );
+        assert_eq!(foreach_paths.len(), 300);
+        assert!(foreach_paths.iter().all(|p| p == r"[]"));
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9442,6 +9442,255 @@ fn test_resolve_index_expr_indexes_targets_partial_fanout_before_its_own_error_8
     Ok(())
 }
 
+/// #972 Stage 1 precursor fix: `resolve_index_expr`/`resolve_slice_expr`
+/// compute `target`'s branches once, outside the key/bound loop, then cross
+/// them against every key/bound — so before this fix, a `target` escape
+/// still let every key/bound after the first contribute its own branch to
+/// the `Err` prefix, even though jq's `K as $k | E | .[$k]` compilation
+/// means `E`'s (the target's) whole generator — escape included — runs
+/// entirely inside the *first* key's iteration; the key generator is never
+/// resumed for a second key. Verified against jq 1.7.1: all four queries
+/// below print only the first key/bound's branch before raising.
+#[test]
+fn test_resolve_index_expr_prefix_matches_jq_when_target_escapes_972() -> Result<()> {
+    // Two keys, one target branch.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(select((true,error("t")))[("x","y")])"#],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"x\"]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Two keys, two target branches (full 2x2 cross product collapses to 1).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(select((true,true,error("t")))[("x","y")])"#],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"x\"]\n[\"x\"]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Propagated through a static tail after the computed index.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(select((true,error("t")))[("x","y")].z)"#],
+        Some(r#"{"x":{"z":1},"y":{"z":2}}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"x\",\"z\"]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    // Slice bound cross product: 2 starts x 2 ends collapses to 1.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select((true,error("t"))))[(0,1):(2,3)])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #972 Guard A: the exact shape that got PR #985 reverted for silent data
+/// corruption on the write side. Before the Stage 1 precursor fix above,
+/// `resolve_index_expr`'s untruncated `Err` prefix for
+/// `select((true,error("t")))[("x","y")]` was `[["x"],["y"]]` (length 2),
+/// which satisfied `limit(2)` and would have been promoted to a clean
+/// success — silently deleting both keys instead of raising. Verified
+/// against jq 1.7.1: `limit(2; ...)` still raises with the document
+/// untouched; `limit(1; ...)` correctly deletes only `"x"`.
+#[test]
+fn test_first_limit_path_truncation_does_not_overreach_index_fanout_972() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"del(limit(2; select((true,error("t")))[("x","y")]))"#,
+        ],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"del(limit(1; select((true,error("t")))[("x","y")]))"#,
+        ],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"y\":8}\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"(limit(2; select((true,error("t")))[("x","y")])) = 99"#,
+        ],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"(limit(1; select((true,error("t")))[("x","y")])) = 99"#,
+        ],
+        Some(r#"{"x":9,"y":8}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"x\":99,\"y\":8}\n");
+    assert_eq!(stderr, "");
+
+    Ok(())
+}
+
+/// #972 Guard B: the exact shape that got PR #985 reverted for a silently
+/// truncated computed path. `resolve_seq`'s multi-stage fan-out (fixed by
+/// #1013 ahead of this reinstatement) must keep threading an escaping
+/// branch's own full prefix through every remaining dynamic stage, so
+/// `first(...)` truncates to the *correct*, complete path rather than a
+/// silently short one. Verified against jq 1.7.1.
+#[test]
+fn test_first_path_truncation_keeps_full_multistage_pipe_path_972() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r"path(first(.[]|.[]|.[]))"],
+        Some(r#"{"a":{"p":{"q":1}},"b":3}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",\"p\",\"q\"]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r"path(first(.[]|.[]))"],
+        Some(r#"{"a":{"q":1},"b":3}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",\"q\"]\n");
+    assert_eq!(stderr, "");
+
+    Ok(())
+}
+
+/// #972: `first(f)`/`limit(n; f)` in path position used to fully resolve
+/// `f` before truncating to `n` outputs, so an error/break/halt after the
+/// nth output still surfaced even though jq's generator would have stopped
+/// pulling from `f` already. All cases verified against jq 1.7.1.
+#[test]
+fn test_first_limit_truncate_keep_partial_path_resolvers_972() -> Result<()> {
+    let cases: &[(&str, &str, &str)] = &[
+        ("1", r#"path(first(select((true, error("x")))))"#, "[]\n"),
+        ("1", r#"path(limit(1; select((true, error("x")))))"#, "[]\n"),
+        (
+            "1",
+            r#"path(first(if (true,error("x")) then . else empty end))"#,
+            "[]\n",
+        ),
+        ("[1,2,3]", r#"path(first(.[(0,error("x"))]))"#, "[0]\n"),
+        (
+            r#"{"a":1}"#,
+            r#"path(first(getpath((["a"],error("x")))))"#,
+            "[\"a\"]\n",
+        ),
+        (
+            r#"{"a":{"b":1}}"#,
+            r#"path(first(recurse(if type=="object" then .[] else error("x") end)))"#,
+            "[]\n",
+        ),
+    ];
+    for (input, query, expected_stdout) in cases {
+        let (stdout, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 0,
+            "query {query:?}: stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert_eq!(stdout, *expected_stdout, "query {query:?}");
+        assert_eq!(stderr, "", "query {query:?}");
+    }
+
+    // Write-side twins.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"del(first(recurse(if type=="object" then .[] else error("x") end)))"#,
+        ],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "null\n");
+    assert_eq!(stderr, "");
+
+    Ok(())
+}
+
+/// #972 Guard D: the under-satisfied / must-still-raise trap set — cases a
+/// too-aggressive truncation fix could wrongly silence. All verified
+/// against jq 1.7.1.
+#[test]
+fn test_first_limit_path_undersatisfied_still_raises_972() -> Result<()> {
+    // A bare escape (zero outputs) still propagates.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(first(select((error("x")))))"#], Some("1"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+
+    // limit(3; ...) over 2 outputs then an error is still under-satisfied.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(limit(3; select((true,true,error("x")))))"#],
+        Some("1"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n[]\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+
+    // limit(0; ...) evaluates nothing.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(limit(0; select((true,error("x")))))"#],
+        Some("1"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+
+    Ok(())
+}
+
+/// #972 Guard E: `take_path_branches` drops `Halt` along with `Error`/
+/// `Break` once the consumer is satisfied, matching jq
+/// (`path(first(select((true, ("m"|halt_error(3))))))` is `[]`, exit 0).
+/// The `m` payload still reaches stderr — the resolver underneath is still
+/// eager, so its side effect has already fired by the time the escape is
+/// discarded — that residual leak is #987/#820's territory, not a #972
+/// regression.
+#[test]
+fn test_first_limit_path_drops_a_satisfied_halt_972() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(
+        &["-c", r#"path(first(select((true, ("m"|halt_error(3))))))"#],
+        Some("1"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout, "[]\n");
+
+    // An UNDER-satisfied halt still surfaces (this is the trap: it's the
+    // consumer being satisfied that drops it, not the halt kind itself).
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(limit(2; select((true,("m"|halt_error(3))))))"#,
+        ],
+        Some("1"),
+    )?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+
+    Ok(())
+}
+
 /// #977: `resolve_seq`'s fan-out loop used to return an escaping element's
 /// partial prefix without ever applying a purely-static tail after it (a
 /// literal `.foo`/`[N]`/`[N:M]`, desugared to a flat `Pipe` at parse time —

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16410,6 +16410,26 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "5",
             0,
         ),
+        // #987 Stage 3 closed the bare-comma spelling of this shape
+        // (`path(paths((true,(stderr|true))))`, now in the "already match"
+        // table above) but not this `If`-wrapped one: `eval_each` has no
+        // native `Expr::If` arm, so node `[0]`'s own filter still falls
+        // back to eager `drain_result(eval_single(...))` for that one
+        // sub-expression, and the whole `If` runs to completion (both
+        // comma branches of its `then`) before `path()`'s stop-after-first
+        // sink ever sees `[0]`'s first truthy output. jq: no stderr, since
+        // its own generator never even reaches the `stderr` half of the
+        // comma before `path()` is satisfied by the `true` half.
+        (
+            &[
+                "-c",
+                "path(paths(if .==1 then (true,(stderr|true)) else false end))",
+            ],
+            Some("[1,2,3]"),
+            "",
+            "1jq: error (at <stdin>:0): Invalid path expression with result [0]",
+            5,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -16425,13 +16445,19 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     Ok(())
 }
 
-/// #987: `path(paths(f))` runs `f` against a node real jq never visits.
+/// #987 (Stage 3, `each_paths_filter`): `path(paths(f))` used to run `f`
+/// against a node real jq never visits, because `resolve_leaf`'s catch-all
+/// evaluated `paths(f)`'s whole generator eagerly before ever checking
+/// whether its first output was even path-shaped.
 ///
 /// jq's `path()` demands only `paths(f)`'s FIRST output and aborts on it, so
-/// node `3` is never reached and nothing is written. Note this is not comma
-/// laziness -- jq evaluates both branches of the `(stderr, true)` comma too.
+/// node `3` is never reached and nothing is written — `resolve_leaf`'s
+/// catch-all is now a stop-after-first sink over a genuinely lazy
+/// `each_paths_filter`, so node `3`'s `stderr` is no longer even evaluated.
+/// Note this is not comma laziness -- jq evaluates both branches of the
+/// `(stderr, true)` comma too, once a node is actually visited.
 #[test]
-fn test_path_paths_filter_leaks_a_never_visited_node_987() -> Result<()> {
+fn test_path_paths_filter_does_not_leak_a_never_visited_node_987() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -16441,14 +16467,86 @@ fn test_path_paths_filter_leaks_a_never_visited_node_987() -> Result<()> {
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
-    // jq writes only the diagnostic; succinctly prefixes the leaked `3`.
-    assert!(
-        stderr.starts_with('3'),
-        "expected the leaked `3` before the diagnostic; stderr: {stderr:?}"
+    assert_eq!(
+        stderr.trim_end(),
+        "jq: error (at <stdin>:0): Invalid path expression with result [0]"
     );
-    assert!(
-        stderr.contains("Invalid path expression with result [0]"),
-        "stderr: {stderr:?}"
+    Ok(())
+}
+
+/// #987 over-stop trap: a satisfied `path()` consumer must not suppress a
+/// side effect the *matching* node's own filter genuinely produces before
+/// its truthy output — only never-reached later nodes/candidates should go
+/// unevaluated. Confirmed against jq 1.7.1: node `[0]`'s `stderr` still
+/// fires (it is what makes `[0]` the first, satisfying output), but the
+/// subsequent nodes are never visited at all.
+#[test]
+fn test_path_paths_filter_still_evaluates_the_satisfying_node_987() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "path(paths(if .==1 then (stderr,true) else false end))",
+        ],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr.trim_end(),
+        "1jq: error (at <stdin>:0): Invalid path expression with result [0]"
+    );
+    Ok(())
+}
+
+/// #987 zero-surviving trap: when no candidate's filter is ever truthy,
+/// `path()` is never satisfied, so every node genuinely is visited — this
+/// is not a laziness regression, it's jq's own `recurse`-then-`select`
+/// behavior when `select` never once succeeds. Confirmed against jq 1.7.1:
+/// the root pre-check's own `stderr` fires first (`paths(node_filter)`
+/// always runs `node_filter` against the root, even though the root's own
+/// path is excluded from the result), then both non-root nodes' `stderr`
+/// fire too — no path output, exit 0.
+#[test]
+fn test_path_paths_filter_visits_every_node_when_none_survive_987() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path(paths((stderr|false)))"], Some("[1,2]"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr.trim_end(), "[1,2]12");
+    Ok(())
+}
+
+/// #987: `path()`'s laziness fix reaches every caller that resolves paths
+/// through `resolve_dynamic_indexes` (`path()` itself, `del()`, `=`, `|=`),
+/// since they all share the same `resolve_node`/`resolve_leaf` resolver —
+/// not just the `path(...)` spelling the issue's own repro used. Confirmed
+/// against jq 1.7.1: both raise identically to `path(...)`'s own case,
+/// with node `3`'s `stderr` never reached.
+#[test]
+fn test_paths_filter_laziness_reaches_del_and_assign_987() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "del(paths(if .==3 then (stderr,true) else true end))"],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr.trim_end(),
+        "jq: error (at <stdin>:0): Invalid path expression with result [0]"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "(paths(if .==3 then (stderr,true) else true end)) = 9",
+        ],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr.trim_end(),
+        "jq: error (at <stdin>:0): Invalid path expression with result [0]"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Three independent fixes to `path()`'s resolver in `src/jq/eval.rs`, bundled
together since they touch the same code region (`resolve_node`/`resolve_leaf`
and the machinery around them), plus two follow-up commits from review. Each
is oracle-verified against pinned jq 1.7.1 throughout.

### fix(jq): first()/limit() truncate the keep-partial path resolvers (#972)

`resolve_node`'s `first`/`limit` arms fully resolved their inner expression
before truncating to `n` outputs, so an error/break/halt after the `n`th
output still surfaced. A prior fix (PR #985) was reverted after review found
its core assumption — that a `PathResolveResult`'s `Err` prefix is always
exactly jq's pre-escape output — false for `resolve_index_expr`/
`resolve_slice_expr`'s key/bound × target cross product (`del(limit(2;
select((true,error("t")))[("x","y")]))` silently deleted both keys instead
of raising). Both are fixed to restrict their key/bound loops to a single
element once their target has escaped, before reinstating `first`/`limit`'s
truncation. The two PR #985 failure cases are pinned as regression tests.

`take_path_branches` only needs, and only claims, the half of that invariant
that holds universally: **a prefix is never *longer* than jq's.** A prefix
can still be *shorter* — `resolve_slice_expr` drops the bound generator's own
partial prefix, so `[10,20,30] | path(limit(1; .[(0,error("b")):(2,3)]))`
refuses where jq answers `[{"start":0,"end":2}]` (pre-existing, on `main`
too). Short under-satisfies the `>= n` test, so the escape propagates and the
caller refuses — visibly wrong, never a false success, and never a write jq
would not perform.

### fix(jq): path(paths(f)) stops pulling from f once path() is satisfied (#987)

`resolve_leaf`'s fallback for `path()`'s non-primitive argument fully
materialized the whole expression before checking whether the first output
was path-shaped, so a later output's side effects (`stderr`, a consumed
`input`) or error still fired even though real jq's streaming generator
never reaches them. Completes Stage 3 of
`docs/plan/jq-lazy-generator-consumers.md`: `builtin_paths_filter` becomes a
lazy producer (`each_paths_filter`, including each node's own filter fan-out,
not just the outer path loop), and `resolve_leaf` splits into a
stop-after-first sink for its general case and an always-continue sink for
the four static primitives that still need to distinguish 0/1/many outputs.

One residual is documented rather than claimed fixed: an un-lazified
`eval_each` arm (`If`/`Try`/`Label`/…) still leaks a side effect for a node's
own filter shaped that way, pinned as a known-remaining row in
`test_short_circuit_side_effect_leaks_820_932_987`. Likewise
`path(first(select((true, ("m"|halt_error(3))))))` now exits 0 like jq, but
`m` still reaches stderr — the resolver underneath is eager, so the escape is
dropped, not the work that produced it.

### feat(jq): path() tracks a variable through reduce/foreach's UPDATE (#1440)

`resolve_node` had no `Expr::Reduce`/`Expr::Foreach` arm at all, so a
path-trackable variable (#844's `Expr::TrackedVar`) referenced inside a
`reduce`/`foreach` `UPDATE`/`EXTRACT` expression never got tracked. New
`resolve_reduce`/`resolve_foreach` arms model jq's own `(path,
value_at_path)` register, derived empirically since real jq has no
fold-specific path machinery at all — the register resets between
source-element iterations of the same fold but carries forward within one
fold step from `UPDATE` into `EXTRACT`.

### fix(jq): refuse a destructuring fold in path position, as jq does (review)

The dispatch arm above originally admitted *any* single `as` pattern, so
`path(. as $x | reduce ([1]) as [$i] (0; $x))` resolved to `[]` where jq
raises — and, worse, `(reduce ([1]) as [$i] (.a; .)) = 9` wrote `{"a":9}` to
a document jq leaves untouched. Real jq refuses every destructuring loop
variable in path position, **even one whose pattern matches cleanly** (the
bare-`$var` spelling of the same fold is `[]`), so the guard is now
`[Pattern::Var(_)]`. Eight shapes moved from accept-and-write to refuse:

| Filter (input `{"a":1}` / `{"a":{"b":1}}`)            | before   | after   | jq      |
|-------------------------------------------------------|----------|---------|---------|
| `path(. as $x \| reduce ([1]) as [$i] (0; $x))`        | `[]`     | error/5 | error/5 |
| `(. as $x \| reduce ({v:.a}) as {v:$v} (0; $x)) = 9`   | `9`      | error/5 | error/5 |
| `del(. as $x \| reduce ({v:.a}) as {v:$v} (0; $x))`    | `null`   | error/5 | error/5 |
| `(reduce ([1]) as [$i] (.a; .)) = 9`                   | `{"a":9}`| error/5 | error/5 |

Same refusal, same exit 5, no document written either side. **Only the
wording differs** — the catch-all names the whole fold's own value
("Invalid path expression with result …") rather than the destructuring step
jq blames, which is the pre-existing `resolve_leaf` message gap, not a new
one. Both dispatch fallbacks (destructuring, and the `?//` one below) are now
pinned by `test_reduce_foreach_path_dispatch_falls_back_1440`: routing `?//`
into `resolve_reduce` with only `patterns[0]` would *not* error, it would
silently drop #1368's null-fill for names the matching alternative doesn't
bind, which a comment alone cannot catch.

### fix(jq): port the fold path resolvers to substitute_vars (rebase repair)

Straight port, no behaviour change — see **Rebase hazard** below.

## Remaining divergences, and what kind each is

`docs/compliance/jq/limitations.md` previously called all of these "safe
(refuse only, never emit a wrong path)". Two are; one is the opposite, and
that one reaches the write path — the list now separates the kinds and names
the effect.

| # | Divergence | Kind |
|---|------------|------|
| 1 | Variable-rooted navigation off a mismatched accumulator (`path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))`) | refuse-only |
| 2 | `?//`-alternatives folds aren't path-tracked (#1365's retry + null-fill machinery isn't threaded through) | refuse-only |
| 3 | Structural equality standing in for jq's `jv_identical` — **accepts, and writes, where jq refuses** | filed as #1466 |
| — | The fold's source expression (`reduce (keys[]) as $k`) | filed as #1467 |

On #3: `OwnedValue` carries no identity, so jq's exact check is not available
and only an approximation is; `FoldRegister`'s value comparison is the
over-approximating one. `Expr::TrackedVar`'s arm softens the same check but
is additionally gated on the node *being* a tracked variable, whereas
`FoldRegister::relocate` and `resolve_reduce`'s final emission gate on
equality alone, so an object literal reaching the same value is promoted too.
#1466 carries a provenance-based alternative to spike; it needs its own round
of live verification, since the current model reproduces 15+ oracle cases
exactly.

A loop-variable **destructuring pattern** is deliberately *not* on this list:
jq refuses those too, so the `[Pattern::Var(_)]` guard is fidelity, not a gap.

## Rebase hazard on this branch — read before rebasing again

This branch has now broken its own build **twice** on a conflict-free rebase,
both times in `resolve_reduce`/`resolve_foreach`, because the renamed symbol
and the calling code live in different regions of `eval.rs`:

1. #1365 renamed `Expr::Reduce`'s `pattern` field to `patterns` and removed
   `substitute_pattern`.
2. #1368 (`698974470`) replaced `substitute_bindings` with `substitute_vars`
   + `as_var_refs`.

Neither produced a conflict; both produced a non-compiling HEAD that looked
clean. **Build after every rebase of this branch** — agreement between the
rebase and the working tree is not evidence either way.

## Test plan

- [x] `cargo build --release --features cli` — clean
- [x] `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast`
      — **5611 passed, 0 failed**
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
      (ci.yml's second leg, which `--all-features` masks via `scalar-yaml`) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --no-default-features` — clean
- [x] 110-query differential sweep against pinned `/usr/bin/jq` 1.7.1
      (`main` vs this branch), including write-side `del`/`=`/`|=` variants —
      **0 regressions**, 15 shapes moved from diverging to matching
- [x] yq-mode `paths`/`paths(f)` output byte-identical to `main`
- [x] New regression tests pin both PR #985 failure cases (#972), the
      side-effect-leak repro and its residual (#987), the register-restore /
      mixed-trackability / escape-propagation semantics (#1440), and both
      dispatch fallbacks (review)
