### PR TITLE
fix(jq): try_pattern_alternatives retries break like error, not halt

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28914,19 +28914,34 @@ fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Try each `?//`-separated pattern alternative against `bound_val`, in
 /// order. The first alternative whose pattern matches *and* whose
-/// substituted body doesn't error wins. A pattern-match failure or a body
-/// `error(...)`/type error falls through to the next alternative; `break`,
-/// `halt`, and empty output do not (confirmed live: both propagate
-/// immediately, never retried). On the *last* alternative, either failure
-/// is the final outcome -- this degrades to exactly the pre-`?//` single-
-/// pattern behavior when `patterns` has one element.
+/// substituted body doesn't error wins. A pattern-match failure, a body
+/// `error(...)`/type error, or a body `break` falls through to the next
+/// alternative; `halt` and empty output do not. On the *last* alternative,
+/// any of these is the final outcome -- this degrades to exactly the
+/// pre-`?//` single-pattern behavior when `patterns` has one element.
 ///
-/// A body error's own partial output (if the body is itself a generator,
-/// e.g. `(1, error("x"))`) is *not* discarded on fallthrough -- confirmed
-/// live: each tried alternative's own partial output before its error is
-/// kept, not just the winning alternative's (or the last one's, if none
-/// win) -- so the returned `Vec<OwnedValue>` accumulates across every
-/// alternative actually attempted, not just the final one.
+/// **`break` retrying (rather than propagating immediately) is corrected
+/// behavior, not the original design** -- #1457, found and fixed while
+/// implementing `reduce`/`foreach`'s own `?//` support (#1365), whose
+/// accumulator-rollback retry loop needed the exact same break-vs-halt
+/// question answered and got it live-verified there first. This function's
+/// own prior doc comment claimed break propagates immediately just like
+/// halt, matching neither a real design decision nor a passing test --
+/// verified wrong against the pinned oracle (jq 1.7.1): `label $out | (.
+/// as {a:$x} ?// {a:$y} | if $x==1 then break $out else [$x,$y] end)` on
+/// `{"a":1}` is `[null,1]` (alt2's output), not an empty result from an
+/// uncaught break reaching `label $out`. `halt` alone was and remains
+/// correct: `. as {a:$x} ?// {a:$y} | if $x==1 then halt else [$x,$y] end`
+/// on `{"a":1}` terminates the process immediately with no output, never
+/// retried.
+///
+/// A body error's or break's own partial output (if the body is itself a
+/// generator, e.g. `(1, error("x"))` or `(1, break $out)`) is *not*
+/// discarded on fallthrough -- confirmed live for both: each tried
+/// alternative's own partial output before its error/break is kept, not
+/// just the winning alternative's (or the last one's, if none win) -- so
+/// the returned `Vec<OwnedValue>` accumulates across every alternative
+/// actually attempted, not just the final one.
 fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     patterns: &[Pattern],
     all_var_names: &[String],
@@ -29003,21 +29018,29 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
                 continue;
             }
-            QueryResult::Break(label) => return Ok((carried, Some(Control::Break(label)))),
+            // #1457: `Break` falls through like `Error`, not immediately
+            // like `Halt` -- verified live against the pinned oracle (jq
+            // 1.7.1), correcting this arm's own prior claim otherwise. See
+            // this function's own doc comment for the exact repro.
+            QueryResult::Break(label) => {
+                if is_last {
+                    return Ok((carried, Some(Control::Break(label))));
+                }
+                continue;
+            }
             QueryResult::Halt(code) => return Ok((carried, Some(Control::Halt(code)))),
-            QueryResult::Partial(vs, control) => match control {
-                Control::Error(e) => {
-                    carried.extend(vs);
-                    if is_last {
-                        return Ok((carried, Some(Control::Error(e))));
+            QueryResult::Partial(vs, control) => {
+                carried.extend(vs);
+                match control {
+                    Control::Error(_) | Control::Break(_) => {
+                        if is_last {
+                            return Ok((carried, Some(control)));
+                        }
+                        continue;
                     }
-                    continue;
+                    Control::Halt(_) => return Ok((carried, Some(control))),
                 }
-                Control::Break(_) | Control::Halt(_) => {
-                    carried.extend(vs);
-                    return Ok((carried, Some(control)));
-                }
-            },
+            }
         }
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11418,6 +11418,84 @@ fn test_as_pattern_alt_substituted_as_func_param_bind_expr_720() -> Result<()> {
     Ok(())
 }
 
+/// #1457: `break` inside a `?//` alternative's body falls through to the
+/// next alternative, exactly like `error(...)` -- confirmed live against
+/// jq 1.7.1. `try_pattern_alternatives`'s own prior doc comment claimed
+/// otherwise (that `break` propagates immediately, same as `halt`); this
+/// pins the corrected behavior so it can't silently regress. If alt1's
+/// `break $out` genuinely escaped uncaught, `label $out` would swallow the
+/// whole expression and produce no output at all -- instead alt2's own
+/// output survives, proving the break was caught and retried.
+#[test]
+fn test_as_pattern_alt_break_falls_through_like_error_1457() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | (. as {a:$x} ?// {a:$y} | if $x==1 then break $out else [$x,$y] end)",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[null,1]");
+    Ok(())
+}
+
+/// #1457: unlike `break`, `halt` inside a `?//` alternative's body still
+/// propagates immediately, terminating the process with no output --
+/// confirmed live against jq 1.7.1. Pins that the fix for `break` (above)
+/// didn't accidentally also start retrying `halt`.
+#[test]
+fn test_as_pattern_alt_halt_still_propagates_immediately_1457() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            ". as {a:$x} ?// {a:$y} | if $x==1 then halt else [$x,$y] end",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "");
+    Ok(())
+}
+
+/// #1457: a `break` in the genuinely *last* alternative still propagates
+/// (nothing left to fall through to) -- the same "last alternative's
+/// failure is the final outcome" rule `error` already had. Forces alt1 to
+/// fail via a real pattern-match type error (destructuring `5` as an
+/// object), so alt2's own `break` is reached and is the one that escapes.
+#[test]
+fn test_as_pattern_alt_break_in_last_alternative_still_propagates_1457() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | (. as {a:$x} ?// $y | if $y==5 then break $out else [$x,$y] end)",
+        ],
+        Some("5"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "");
+    Ok(())
+}
+
+/// #1457: a body that's itself a generator keeps its own pre-break partial
+/// output even when that alternative ultimately loses and falls through --
+/// the same "partial output survives fallthrough" rule already pinned for
+/// `error` (see `try_pattern_alternatives`'s own doc comment), now also
+/// verified for `break`. Confirmed live against jq 1.7.1.
+#[test]
+fn test_as_pattern_alt_break_partial_output_survives_fallthrough_1457() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | [(. as {a:$x} ?// {a:$y} | ($x, if $x == 1 then break $out else empty end))]",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1,null]");
+    Ok(())
+}
+
 /// `expand_func_calls`'s `Expr::AsPattern` arm: a call to a zero-arg
 /// function reached only by recursing into a `?//` binding's body.
 #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11070,20 +11070,27 @@ fn test_as_pattern_alt_bind_expr_generator_fans_out_720() -> Result<()> {
     Ok(())
 }
 
-/// `break`/`halt`/empty output inside the body do *not* trigger
-/// fallthrough -- only a genuine `error(...)`/type error does. Confirmed
-/// live: `break` propagates cleanly with no output (not caught as a
-/// pattern/body failure), and `empty` is genuinely empty output, not an
-/// implicit retry signal.
+/// Empty output inside the body does *not* trigger fallthrough -- only a
+/// genuine `error(...)`/type error, or (since #1457) `break`, does.
+/// `empty` is genuinely empty output, not an implicit retry signal, and a
+/// matching alternative that legitimately produces nothing is not a
+/// "failure" the next alternative should override.
+///
+/// This test previously also asserted `break` here, under the claim that
+/// it behaves like `halt` (propagates immediately, never falls through).
+/// #1457 found and fixed that claim: `break` actually falls through like
+/// `error`, verified against the pinned oracle (jq 1.7.1). That sub-case
+/// was removed rather than corrected in place, since it happened to use
+/// the *same* body (`break $out`) for both alternatives -- a shape that
+/// can't distinguish "propagates immediately" from "falls through, then
+/// the last alternative's own break propagates" (both give the same empty
+/// final output), so it was passing on the old, wrong code by coincidence
+/// rather than actually exercising fallthrough. `break`'s real fallthrough
+/// behavior is now covered by the `_1457` tests below, which use different
+/// bodies per alternative specifically so the two behaviors are
+/// distinguishable.
 #[test]
-fn test_as_pattern_alt_break_and_empty_are_not_fallthrough_720() -> Result<()> {
-    let (stdout, _, code) = run_jq_full(
-        &["-c", "label $out | (. as {a: $a} ?// $a | (break $out))"],
-        Some(r#"{"a":1}"#),
-    )?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "");
-
+fn test_as_pattern_alt_empty_is_not_fallthrough_720() -> Result<()> {
     let (stdout, _, code) =
         run_jq_full(&["-c", "[. as {a: $a} ?// $a | empty]"], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);


### PR DESCRIPTION
## Summary
- `try_pattern_alternatives` (backs `. as PATTERN ?// PATTERN2 | body`) had a doc comment claiming `break` inside an alternative's body propagates immediately, exactly like `halt` — this claim was wrong, and the code matched the wrong claim.
- Verified against the pinned oracle (jq 1.7.1): `label $out | (. as {a:$x} ?// {a:$y} | if $x==1 then break $out else [$x,$y] end)` on `{"a":1}` gives `[null,1]` (alt2's output) — if `break` genuinely escaped uncaught, `label $out` would swallow the whole expression and produce nothing. `break` is caught by `?//`'s own retry and the next alternative is tried, exactly like `error(...)`. `halt` alone still propagates immediately, unconditionally, never retried.
- Fix: split the previously-combined `Control::Break(_) | Control::Halt(_)` catch-all into two arms — `Break` now falls through to the next alternative (propagating only from the last one, matching `Error`'s existing rule, including that its own pre-break partial output survives fallthrough the same way `Error`'s does); `Halt` still propagates immediately.

## Context
Discovered and independently live-verified while implementing `reduce`/`foreach`'s own `?//` support (#1365, PR #1455) — that work's accumulator-rollback retry loop needed the exact same break-vs-halt question answered for its own new code, and already implements the corrected behavior (verified against the same oracle repros). This PR applies the identical fix to the pre-existing `try_pattern_alternatives`, which #1365 deliberately left untouched as out of scope.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second leg)
- [x] `cargo build --no-default-features` (no_std check)
- [x] `cargo llvm-cov` full run, all green
- [x] 4 new CLI tests: break-in-non-last-alternative retries; halt still propagates immediately; break in the genuinely-last alternative still propagates; a generator body's pre-break partial output survives fallthrough
- [x] Manually verified all four scenarios against a compiled release binary before writing tests

Fixes #1457