### PR TITLE
fix(jq): string interpolation fans out a multi-valued \(...) slot (#1403)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -282,6 +282,22 @@ separate, still-unresolved mystery, #1439 above — #1255's fix alone wouldn't m
 oracle-correct given that deeper algorithm mismatch, so the two are deliberately decoupled
 rather than guessed at together).
 
+### String interpolation with a multi-valued `\(...)` slot — yq takes the first value only
+
+[#1403](https://github.com/rust-works/succinctly/issues/1403) fixed jq mode's `"\(...)"` string
+interpolation to fan out over a multi-valued embedded generator, matching real jq's cartesian
+product across every slot (`"\(1,2)-\(3,4)"` → 4 strings, the *first* slot varying fastest).
+yq deliberately does **not** get the same fix — live-verified against yq v4.53.3 that a
+multi-valued slot silently collapses to its first value alone, not a fan-out:
+
+```bash
+$ printf 'a: 1\n' | yq            -o=json '"\(.a,2)"'   # "1" — only one output
+$ printf 'a: 1\n' | succinctly yq -o=json '"\(.a,2)"'   # "1" — matches
+```
+
+`succinctly yq` keeps its pre-#1403 single-value-taking behavior (`eval_string_interpolation`'s
+own doc comment has the exact byte-for-byte reasoning); only jq mode became a genuine generator.
+
 ### Regex flag grammar — `test`/`match`/`capture` fixed, `split` still open
 
 **Fixed by [#1426](https://github.com/rust-works/succinctly/issues/1426):** real yq doesn't

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6199,8 +6199,137 @@ fn owned_to_json_bytes<S: EvalSemantics>(value: &OwnedValue) -> Vec<u8> {
 // Phase 6: String Interpolation & Format Strings
 // =============================================================================
 
-/// Evaluate string interpolation: `"Hello \(.name)"`
+/// Materialize a `\(...)` slot's own outputs as rendered strings, plus a
+/// deferred escape if its generator terminates in an error/break/halt.
+///
+/// Reuses [`object_outputs`] (already fully general -- it just unpacks a
+/// `QueryResult` into `(Vec<OwnedValue>, Option<Control>)` with no
+/// object-specific coupling) and stringifies each output the same way a
+/// single-valued slot already did (`owned_to_string`).
+fn string_part_outputs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    result: QueryResult<'_, W>,
+) -> (Vec<String>, Option<Control>) {
+    let (values, control) = object_outputs(result);
+    (values.iter().map(owned_to_string::<S>).collect(), control)
+}
+
+/// Emit one interpolated string per combination of the remaining `\(...)`
+/// slots' outputs (#1403). Real jq's string interpolation is a generator
+/// exactly like object construction (#354) is, but with the *opposite*
+/// nesting order: confirmed live against jq 1.7.1 that
+/// `"\(1,2)-\(3,4)"` yields `"1-3","2-3","1-4","2-4"` -- the *first*
+/// (leftmost) slot varies fastest, the *last* slot slowest, which is
+/// backwards from object construction's "last entry varies fastest"
+/// (`build_object_entries`'s own doc comment).
+///
+/// `parts` shrinks from the right via `split_last()` each recursive call,
+/// so the *last* slot's loop is outermost (evaluated once, checked for a
+/// trailing control only after every value it's paired with below has been
+/// tried) and the *first* slot ends up innermost -- giving exactly that
+/// observed ordering. `slots` is a fixed-size array (sized once, at the
+/// call in [`eval_string_interpolation`]) rather than a single growing
+/// `String` precisely because the loop order and the textual assembly
+/// order are opposite: each recursive call only ever overwrites its own
+/// `slots[idx]` (`idx = rest.len()`, that part's original position) before
+/// recursing deeper, so nothing needs undoing on the way back out, and the
+/// base case joins every slot in its original left-to-right order
+/// regardless of which order they were assigned in.
+///
+/// Live-verified error/break/halt semantics match object construction's
+/// own all-or-nothing backtracking exactly (just under the reversed
+/// nesting): a slot's own deferred control fires only once every
+/// combination it can still contribute to has been tried (`"\(1)-\((2,
+/// error("x")))"` -> `"1-2"` then the error, not silently dropped), and a
+/// deferred control from any level unwinds every enclosing loop
+/// immediately rather than resuming them (`"\((1,error("x")))-\(3,4)"` ->
+/// `"1-3"` then the error, never trying slot 2's second value `4`).
+fn build_string_parts<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    parts: &[StringPart],
+    value: &StandardJson<'_, W>,
+    optional: bool,
+    slots: &mut [String],
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), Control> {
+    let Some((part, rest)) = parts.split_last() else {
+        out.push(OwnedValue::String(slots.concat()));
+        return Ok(());
+    };
+    let idx = rest.len();
+
+    match part {
+        StringPart::Literal(s) => {
+            slots[idx].clone_from(s);
+            build_string_parts::<W, S>(rest, value, optional, slots, out)
+        }
+        StringPart::Expr(expr) => {
+            let (outputs, trailing) = string_part_outputs::<W, S>(
+                eval_single::<W, S>(expr, value.clone(), optional).materialize_cursor(),
+            );
+
+            for s in outputs {
+                slots[idx] = s;
+                build_string_parts::<W, S>(rest, value, optional, slots, out)?;
+            }
+
+            if let Some(control) = trailing {
+                return Err(control);
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Evaluate string interpolation: `"Hello \(.name)"`.
+///
+/// jq mode is a genuine fan-out generator (#1403, `build_string_parts`
+/// above). yq mode is deliberately **not** — live-verified against yq
+/// v4.53.3 that `"\(.a,2)"` on `a: 1` gives only `"1"`, a single output,
+/// not the two combinations jq's model would produce
+/// (`printf 'a: 1\n' | yq '"\(.a,2)"'` -> `1`, never `2`). This mirrors
+/// #1403's own single-value-taking code exactly (kept verbatim, not
+/// reimplemented against the new generator) rather than risk a
+/// behavioral drift in code this issue never asked to touch — not
+/// recorded elsewhere until now; see
+/// [docs/compliance/yq/limitations.md](../../../docs/compliance/yq/limitations.md)
+/// for the write-up (ADR-0018 rule 6).
 fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    parts: &[StringPart],
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    if S::TAG == EvalTag::Yq {
+        return eval_string_interpolation_single_value::<W, S>(parts, value, optional);
+    }
+
+    let mut slots: Vec<String> = alloc::vec![String::new(); parts.len()];
+    let mut out = Vec::new();
+
+    if let Err(control) = build_string_parts::<W, S>(parts, &value, optional, &mut slots, &mut out)
+    {
+        return match control {
+            Control::Error(e) if out.is_empty() => QueryResult::Error(e),
+            Control::Error(e) => QueryResult::Partial(out, Control::Error(e)),
+            Control::Break(label) if out.is_empty() => QueryResult::Break(label),
+            Control::Break(label) => QueryResult::Partial(out, Control::Break(label)),
+            Control::Halt(code) if out.is_empty() => QueryResult::Halt(code),
+            Control::Halt(code) => QueryResult::Partial(out, Control::Halt(code)),
+        };
+    }
+
+    owned_vec_to_result(out)
+}
+
+/// yq mode's own string interpolation: takes only the first value of each
+/// `\(...)` slot's generator, exactly as this whole function used to
+/// (#1403) before jq mode became a genuine fan-out generator above.
+/// Preserved verbatim rather than derived from the new generator, since
+/// deriving "take only the first combination" from `build_string_parts`
+/// would still need to replicate this exact per-`QueryResult`-variant
+/// dispatch (a `Partial` here discards even its own first value and
+/// propagates the control immediately, unlike jq mode's "combinations
+/// already produced travel onward") to stay byte-for-byte identical to
+/// yq's oracle-verified behavior.
+fn eval_string_interpolation_single_value<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     parts: &[StringPart],
     value: StandardJson<'a, W>,
     optional: bool,
@@ -35010,12 +35139,14 @@ mod tests {
             // they forward their operand as a stream, not a value, so they no
             // longer belong in this list; see
             // `partial_prefix_survives_the_stream_forwarding_constructs`.
-            (
-                b"null",
-                r#""v=\((1,error("x")))""#,
-                "x",
-                r#"jq 1.7.1 prints "v=1", then fails"#,
-            ),
+            //
+            // String interpolation *used* to be listed here too
+            // (`"v=\((1,error("x")))"` collapsing straight to the error),
+            // but #1403's rewrite made jq mode a real generator like
+            // object construction's own #354 fix — it now streams "v=1"
+            // before failing, the same as jq 1.7.1. See
+            // `partial_prefix_survives_the_stream_forwarding_constructs`
+            // for its coverage.
             (
                 b"[10,20,30]",
                 r#".[(1,error("x"))]"#,
@@ -35061,8 +35192,8 @@ mod tests {
             (b"null", "[1,(2,break $out),3]"),
             (b"[1,2]", "map((.,break $out))"),
             (br#"{"a":1}"#, "with_entries((.,break $out))"),
-            // `select`/`if`: see the comment in `atomic` above.
-            (b"null", r#""v=\((1,break $out))""#),
+            // `select`/`if`, string interpolation: see the comment in
+            // `atomic` above.
             (b"[10,20,30]", ".[(1,break $out)]"),
             (b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0)]"),
             (br#"{"a":1}"#, "map_values((.,break $out))"),
@@ -35230,6 +35361,40 @@ mod tests {
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(prefix_json(&vs), [r#"{"x":10}"#, r#"{"x":20}"#]);
                 assert_eq!(e.message, "Cannot use number (1) as object key");
+            }
+        );
+
+        // #1403: jq mode's string interpolation is now the same kind of
+        // generator object construction became under #354 -- it used to be
+        // listed in `partial_in_value_position_collapses_to_its_control`'s
+        // `atomic` table (labelled as a documented divergence from jq
+        // 1.7.1, which the old comment already recorded as printing "v=1"
+        // then failing); now that it's a real fan-out generator, it agrees
+        // with jq 1.7.1 exactly, same as object construction's own move.
+        query!(b"null", r#""v=\((1,error("x")))""#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#""v=1""#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(b"null", r#""v=\((1,break $out))""#,
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), [r#""v=1""#]);
+                assert_eq!(label, "out");
+            }
+        );
+        // A trailing control on an *earlier* slot aborts every enclosing
+        // loop outright rather than resuming it -- matches object
+        // construction's identical rule above, just under string
+        // interpolation's own reversed nesting (#1403: the *first*/
+        // leftmost slot varies fastest, the opposite of object
+        // construction's "last entry varies fastest"). jq 1.7.1 agrees the
+        // second slot's `4` is never tried once the first slot fails on
+        // its own second output.
+        query!(b"null", r#""\((1,error("x")))-\(3,4)""#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#""1-3""#]);
+                assert_eq!(e.message, "x");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6262,9 +6262,8 @@ fn build_string_parts<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             build_string_parts::<W, S>(rest, value, optional, slots, out)
         }
         StringPart::Expr(expr) => {
-            let (outputs, trailing) = string_part_outputs::<W, S>(
-                eval_single::<W, S>(expr, value.clone(), optional).materialize_cursor(),
-            );
+            let (outputs, trailing) =
+                string_part_outputs::<W, S>(eval_single::<W, S>(expr, value.clone(), optional));
 
             for s in outputs {
                 slots[idx] = s;
@@ -6306,14 +6305,7 @@ fn eval_string_interpolation<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     if let Err(control) = build_string_parts::<W, S>(parts, &value, optional, &mut slots, &mut out)
     {
-        return match control {
-            Control::Error(e) if out.is_empty() => QueryResult::Error(e),
-            Control::Error(e) => QueryResult::Partial(out, Control::Error(e)),
-            Control::Break(label) if out.is_empty() => QueryResult::Break(label),
-            Control::Break(label) => QueryResult::Partial(out, Control::Break(label)),
-            Control::Halt(code) if out.is_empty() => QueryResult::Halt(code),
-            Control::Halt(code) => QueryResult::Partial(out, Control::Halt(code)),
-        };
+        return partial(out, control);
     }
 
     owned_vec_to_result(out)
@@ -21545,6 +21537,76 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Continue evaluating `rest` for each output of an already-computed
+/// intermediate `QueryResult`, treating each output as a *fresh root* with
+/// an empty path -- the counterpart to `continue_rest_with_context` for a
+/// construct that builds a brand new value disconnected from any enclosing
+/// container position (a `"\(...)"`, `[...]`, or `{...}` literal) rather
+/// than a mid-pipe computation that stays "at" its enclosing position.
+/// Mirrors the `Array` arm's own inline `&result, &result, file_origin,
+/// &[], optional` reset a few dozen lines up, generalized to a
+/// multi-valued `intermediate` the way `continue_rest_with_context`
+/// generalizes the non-resetting case -- needed once a `\(...)` slot can
+/// fan out (#1403 follow-up: the path-context `StringInterpolation` arm is
+/// the first path-context construct with genuine multi-valued output of
+/// its own to reach this).
+fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    intermediate: QueryResult<'a, W>,
+    rest: &[Expr],
+    file_origin: Option<&[usize]>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    match intermediate {
+        QueryResult::Owned(v) if rest.is_empty() => QueryResult::Owned(v),
+        QueryResult::ManyOwned(vs) if rest.is_empty() => owned_vec_to_result(vs),
+        QueryResult::Owned(v) => {
+            eval_pipe_with_path_context_internal::<W, S>(rest, &v, &v, file_origin, &[], optional)
+        }
+        QueryResult::ManyOwned(vs) => {
+            let mut results = Vec::new();
+            for v in vs {
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    &v,
+                    file_origin,
+                    &[],
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
+                }
+            }
+            owned_vec_to_result(results)
+        }
+        QueryResult::None => QueryResult::None,
+        QueryResult::Error(e) => QueryResult::Error(e),
+        QueryResult::Break(label) => QueryResult::Break(label),
+        QueryResult::Halt(code) => QueryResult::Halt(code),
+        QueryResult::Partial(vs, outer_control) => {
+            let mut results = Vec::new();
+            for v in vs {
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    &v,
+                    file_origin,
+                    &[],
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
+                }
+            }
+            partial(results, outer_control)
+        }
+        QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => unreachable!(
+            "eval_pipe_with_path_context_internal only ever produces \
+             Owned/ManyOwned/None/Error/Break/Partial"
+        ),
+    }
+}
+
 /// Path-context analog of `eval_binary_fanout` (#768/#822): evaluate `left op
 /// right` over every pairing jq's cartesian fanout produces (right operand
 /// outer / left operand inner), routed through
@@ -21584,6 +21646,107 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         optional,
         combine,
     )
+}
+
+/// Path-context analog of `string_part_outputs`: `eval_pipe_with_path_context_internal`
+/// never produces `One`/`OneCursor`/`Many` (every `unreachable!` in this file says so),
+/// so this matches that narrower shape directly instead of going through
+/// `object_outputs`/`collect_owned`, which exist to handle the fully generic evaluator's
+/// borrowed-cursor variants too.
+fn path_context_string_part_outputs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    result: QueryResult<'_, W>,
+) -> (Vec<String>, Option<Control>) {
+    match result {
+        QueryResult::Owned(v) => (alloc::vec![owned_to_string::<S>(&v)], None),
+        QueryResult::ManyOwned(vs) => (vs.iter().map(owned_to_string::<S>).collect(), None),
+        QueryResult::None => (Vec::new(), None),
+        QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
+        QueryResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
+        QueryResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
+        QueryResult::Partial(vs, control) => {
+            (vs.iter().map(owned_to_string::<S>).collect(), Some(control))
+        }
+        QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+            unreachable!(
+                "eval_pipe_with_path_context_internal only ever produces \
+                 Owned/ManyOwned/None/Error/Break/Partial"
+            )
+        }
+    }
+}
+
+/// Path-context analog of `build_string_parts` (#1403 follow-up): the plain evaluator's
+/// own fan-out fix for `\(...)` never reached this evaluator, since it's a wholly
+/// separate function that never calls `build_string_parts` -- this is the same
+/// recursive cartesian-product algorithm, but each slot is evaluated through
+/// `eval_pipe_with_path_context_internal` instead of `eval_single`, so `key`/`parent`/
+/// `file_index` nested in a slot still resolves against
+/// `root`/`current_path`/`file_origin`.
+///
+/// Each slot's own evaluation is forced to `optional=false`, mirroring the sibling
+/// `Array` arm's identical reasoning (a few dozen lines up in
+/// `eval_pipe_with_path_context_internal`): passing the ambient `optional` straight
+/// through would let a genuine error self-swallow at some leaf's own `if optional`
+/// check before ever reaching this function's own accounting, corrupting
+/// `"\(key, error("boom"))"?` into silently dropping the error's very existence instead
+/// of the caller matching it against `optional` itself.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors eval_pipe_with_path_context_internal's
+                                     // own root/file_origin/current_path threading.
+fn build_string_parts_with_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    parts: &[StringPart],
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    slots: &mut [String],
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), Control> {
+    let Some((part, rest)) = parts.split_last() else {
+        out.push(OwnedValue::String(slots.concat()));
+        return Ok(());
+    };
+    let idx = rest.len();
+    match part {
+        StringPart::Literal(s) => {
+            slots[idx].clone_from(s);
+            build_string_parts_with_context::<W, S>(
+                rest,
+                value,
+                root,
+                file_origin,
+                current_path,
+                slots,
+                out,
+            )
+        }
+        StringPart::Expr(expr) => {
+            let slot_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(expr),
+                value,
+                root,
+                file_origin,
+                current_path,
+                false,
+            );
+            let (outputs, trailing) = path_context_string_part_outputs::<W, S>(slot_result);
+            for s in outputs {
+                slots[idx] = s;
+                build_string_parts_with_context::<W, S>(
+                    rest,
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    slots,
+                    out,
+                )?;
+            }
+            if let Some(control) = trailing {
+                return Err(control);
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Internal helper that also tracks the root value for parent navigation,
@@ -22371,84 +22534,114 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // the string via the plain, context-less `eval_string_interpolation`
         // regardless) never gave it a chance to resolve.
         //
-        // Matches `eval_string_interpolation`'s own existing "embed just
-        // the first output" convention for a multi-valued slot exactly --
-        // real jq instead fans out a `\(...)` slot's generator into one
-        // string per value, a separate, pre-existing, unrelated gap (not
-        // this fix's to close, #1403).
-        //
-        // Each slot's inner evaluation is deliberately run with `optional`
-        // forced to `false`, not the ambient value (#1302's `?`-atomicity
-        // lesson, carried over from the start rather than rediscovered
-        // here): otherwise a genuine error inside a slot could
-        // self-swallow at its own leaf-level `if optional` check before
-        // ever reaching this arm's own construction, corrupting
-        // `"a\(key, error("x"))"?` into a partial string instead of the
-        // whole interpolation being caught atomically. Forcing `false`
-        // lets a genuine error surface as a real `Error`/`Partial(_,
-        // Error)`, caught below using *this* arm's own `optional` -- the
-        // same evaluate-then-catch shape as the `Array` arm above.
+        // jq mode fans out a multi-valued slot into one string per
+        // combination via `build_string_parts_with_context`, the same
+        // cartesian-product algorithm `build_string_parts` gave the plain
+        // evaluator for #1403 -- that fix never reached here, since this is
+        // a wholly separate function with its own inlined (and, until now,
+        // still pre-#1403) string-building loop (found in review of #1403
+        // itself). yq mode keeps the pre-#1403 "embed just the first
+        // output" behavior verbatim, matching `eval_string_interpolation`'s
+        // own yq carve-out -- confirmed live that `key`/`parent`/
+        // `file_index` are reachable in yq mode too (`succinctly yq`'s own
+        // `--eval-all`), so this arm needs the identical mode gate its
+        // plain-evaluator counterpart already has.
         Expr::StringInterpolation(parts) if string_interpolation_needs_path_context(parts) => {
-            let mut rendered = String::new();
-            for part in parts {
-                let inner = match part {
-                    StringPart::Literal(s) => {
-                        rendered.push_str(s);
-                        continue;
-                    }
-                    StringPart::Expr(inner) => inner,
+            if S::TAG == EvalTag::Yq {
+                let mut rendered = String::new();
+                for part in parts {
+                    let inner = match part {
+                        StringPart::Literal(s) => {
+                            rendered.push_str(s);
+                            continue;
+                        }
+                        StringPart::Expr(inner) => inner,
+                    };
+                    let slot = eval_pipe_with_path_context_internal::<W, S>(
+                        core::slice::from_ref(inner),
+                        value,
+                        root,
+                        file_origin,
+                        current_path,
+                        false,
+                    );
+                    let s = match slot {
+                        QueryResult::Owned(v) => owned_to_string::<S>(&v),
+                        QueryResult::ManyOwned(vs) => {
+                            vs.first().map(owned_to_string::<S>).unwrap_or_default()
+                        }
+                        QueryResult::None => String::new(),
+                        QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_))
+                            if optional =>
+                        {
+                            return QueryResult::None;
+                        }
+                        QueryResult::Error(e) => return QueryResult::Error(e),
+                        QueryResult::Break(label) => return QueryResult::Break(label),
+                        QueryResult::Halt(code) => return QueryResult::Halt(code),
+                        QueryResult::Partial(_, Control::Error(e)) => {
+                            return QueryResult::Error(e);
+                        }
+                        QueryResult::Partial(_, Control::Break(label)) => {
+                            return QueryResult::Break(label);
+                        }
+                        QueryResult::Partial(_, Control::Halt(code)) => {
+                            return QueryResult::Halt(code);
+                        }
+                        QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                            unreachable!(
+                                "eval_pipe_with_path_context_internal only ever produces \
+                                 Owned/ManyOwned/None/Error/Break/Partial"
+                            )
+                        }
+                    };
+                    rendered.push_str(&s);
+                }
+                let result = OwnedValue::String(rendered);
+                return if rest.is_empty() {
+                    QueryResult::Owned(result)
+                } else {
+                    eval_pipe_with_path_context_internal::<W, S>(
+                        rest,
+                        &result,
+                        &result,
+                        file_origin,
+                        &[],
+                        optional,
+                    )
                 };
-                let slot = eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(inner),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    false,
-                );
-                let s = match slot {
-                    QueryResult::Owned(v) => owned_to_string::<S>(&v),
-                    QueryResult::ManyOwned(vs) => {
-                        vs.first().map(owned_to_string::<S>).unwrap_or_default()
-                    }
-                    QueryResult::None => String::new(),
-                    QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_))
-                        if optional =>
-                    {
-                        return QueryResult::None;
-                    }
-                    QueryResult::Error(e) => return QueryResult::Error(e),
-                    QueryResult::Break(label) => return QueryResult::Break(label),
-                    QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
-                    QueryResult::Partial(_, Control::Break(label)) => {
-                        return QueryResult::Break(label);
-                    }
-                    QueryResult::Partial(_, Control::Halt(code)) => {
-                        return QueryResult::Halt(code);
-                    }
-                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-                        unreachable!(
-                            "eval_pipe_with_path_context_internal only ever produces \
-                             Owned/ManyOwned/None/Error/Break/Partial"
-                        )
-                    }
-                };
-                rendered.push_str(&s);
             }
-            let result = OwnedValue::String(rendered);
-            if rest.is_empty() {
-                QueryResult::Owned(result)
-            } else {
-                eval_pipe_with_path_context_internal::<W, S>(
-                    rest,
-                    &result,
-                    &result,
-                    file_origin,
-                    &[],
-                    optional,
-                )
-            }
+
+            let mut slots: Vec<String> = alloc::vec![String::new(); parts.len()];
+            let mut out = Vec::new();
+            let intermediate = match build_string_parts_with_context::<W, S>(
+                parts,
+                value,
+                root,
+                file_origin,
+                current_path,
+                &mut slots,
+                &mut out,
+            ) {
+                Ok(()) => owned_vec_to_result(out),
+                // `?` swallows only a genuine error, and -- unlike the
+                // `Array` arm's atomic catch above -- string
+                // interpolation's own already-produced output survives the
+                // swallow: live-verified `"\(1,error("x"))"?` => `"1"`
+                // against jq 1.7.1, matching `{a:(1,error("x"))}?` =>
+                // `{"a":1}`, not `[1,error("x")]?`'s empty result.
+                // `Break`/`Halt` are never caught by `?`, matching every
+                // other `?` site in this file.
+                Err(Control::Error(_)) if optional => owned_vec_to_result(out),
+                Err(control) => partial(out, control),
+            };
+            // Each fanned-out string is a fresh root with no path, same as
+            // the single-valued `Array` arm above -- `rest`'s own
+            // `key`/`parent` must resolve against the *string just built*,
+            // not the array/object this interpolation was evaluated inside
+            // of (verified live: `.a | "\(key)" | key` is `null`, not `"a"`
+            // again).
+            continue_rest_with_fresh_root::<W, S>(intermediate, rest, file_origin, optional)
         }
         // `def name(params): body; then` (#1306): the plain evaluator's own
         // `eval_func_def` expands every call to `name` within `then` into

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5472,6 +5472,88 @@ fn test_string_interpolation_path_context_builtin_optional_is_atomic_1334() -> R
     Ok(())
 }
 
+/// Follow-up coverage for the path-context `StringInterpolation` arm's own
+/// fan-out fix (#1403 follow-up): a fanned-out string is a *fresh root*
+/// (matching the sibling `Array` arm's identical path reset), so `rest`
+/// after the interpolation must run once per combination, independently
+/// resetting path context each time -- not something the single-slot tests
+/// above exercise, since none of them have anything after the string in the
+/// same pipe.
+#[test]
+fn test_string_interpolation_path_context_fanout_continues_rest_1403() -> Result<()> {
+    // Two combinations, each independently continuing through `| key` --
+    // both must see the fresh (empty) path, not the enclosing object's.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | \"\\(key, key)\" | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "null\nnull\n");
+
+    // A single slot that succeeds once before erroring: the successful
+    // combination still streams through `| key` (fresh root -> null)
+    // before the error propagates -- confirmed live against jq 1.7.1 with
+    // a plain literal standing in for `key`:
+    // `null | "\(1,error("boom"))" | length` prints `1` then errors.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | \"\\(key, error(\"boom\"))\" | key"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "null\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // An error in a *non-outermost* slot (the first of two, since parts
+    // fan out right-to-left) must still abort every enclosing slot's loop,
+    // not just its own -- confirmed live against jq 1.7.1:
+    // `null | "\(1,error("boom"))-\(2)"` prints `"1-2"` then errors.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | \"\\(key, error(\"boom\"))-\\(key)\""],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "\"a-a\"\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `?` wraps only the interpolation, with a downstream `| key` still
+    // needing path context -- routes through the general `Expr::Optional`
+    // arm's *other* branch (rest non-empty, needs path context), which
+    // flattens and threads `optional=true` straight into this arm instead
+    // of catching externally the way the tail-position `?` cases above do.
+    // Exercises this arm's own `optional`-gated catch directly.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | (\"\\(key, error(\"boom\"))\")? | key"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "null\n");
+
+    // `rest` itself fails on a fanned-out combination with no trailing
+    // control of the interpolation's own (a plain `ManyOwned` result):
+    // the whole thing must abort at that failure, discarding output, not
+    // silently swallow it or keep trying the remaining combinations.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | \"\\(key, key)\" | error(\"stop\")"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("stop"), "stderr: {stderr}");
+
+    // Same, but the interpolation's own result is already `Partial` (one
+    // slot fanned out twice before erroring) when `rest` also fails on one
+    // of those combinations -- exercises the `Partial` counterpart of the
+    // `ManyOwned` early-stop path above.
+    let (_stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            ".a | \"\\(key, key, error(\"boom\"))\" | error(\"stop\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("stop"), "stderr: {stderr}");
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::FuncDef` arm (#1306), so a `def`
 /// scope's own `then` continuation -- even one as simple as `def f: 5; f,
 /// key` -- never routed into path-context evaluation at all: the whole

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5319,30 +5319,29 @@ fn test_string_interpolation_path_context_builtins_1334() -> Result<()> {
     Ok(())
 }
 
-/// Exercises the non-`Owned` arms of the new `StringInterpolation` slot
-/// match -- mirrors #1302's identical `Array`-arm coverage
-/// (`test_array_wrapped_path_context_builtin_control_flow_1302`), one slot
-/// at a time. A slot construction is atomic *per slot*, not across the
-/// whole string: unlike `Array`'s single collection point, each `\(...)`
-/// slot embeds independently, so `break`/`halt`/an uncaught error from any
-/// one slot still aborts the entire surrounding string (nothing partial is
-/// ever embedded), matching `eval_string_interpolation`'s own existing
-/// early-return-on-control-signal behavior for the plain (non-path-context)
-/// case.
+/// Exercises the non-`Owned` arms of the `StringInterpolation` slot match,
+/// mirroring #1302's identical `Array`-arm coverage
+/// (`test_array_wrapped_path_context_builtin_control_flow_1302`). Originally
+/// written against the pre-fix, single-value-collapsing version of this arm
+/// (before #1403's fan-out fix reached it); every case below was
+/// re-verified against jq 1.7.1 using a plain literal in place of `key`
+/// (e.g. `"[\(1,1)]"`, `"\(1,break $out)"`) to confirm the *fanned-out*
+/// expectations here, not just re-derived from #1403's own model.
 #[test]
 fn test_string_interpolation_path_context_builtin_control_flow_1334() -> Result<()> {
     // A multi-valued slot (`key, key`, a `Comma` of two path-context
-    // builtins) -- embeds just the *first* output, matching
-    // `eval_string_interpolation`'s own existing convention (the
-    // `QueryResult::ManyOwned` arm).
+    // builtins) fans out into one embedding per value, same as any other
+    // jq-mode `\(...)` slot since #1403 -- confirmed live that
+    // `null | "[\(1,1)]"` likewise yields `"[1]"` twice, not deduplicated.
     let (stdout, _, code) = run_jq_full(&["-c", ".a | \"[\\(key, key)]\""], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), r#""[a]""#);
+    assert_eq!(stdout, "\"[a]\"\n\"[a]\"\n");
 
     // A bare `break` out of a slot (no prior output within that slot)
     // aborts the whole string construction and unwinds past it to the
     // enclosing label -- the comma's second branch ("reached") must never
-    // run.
+    // run. Unaffected by the fan-out fix: there is nothing produced yet to
+    // preserve.
     let (stdout, _, code) = run_jq_full(
         &[
             "-c",
@@ -5361,8 +5360,12 @@ fn test_string_interpolation_path_context_builtin_control_flow_1334() -> Result<
 
     // Same, but with real output already produced within that one slot's
     // own generator first (`key` succeeds with "a" before `break` fires) --
-    // exercises the `Partial(_, Control::Break(_))` arm rather than the
-    // bare one above.
+    // exercises the `Partial(_, Control::Break(_))` arm. Confirmed live
+    // that jq streams the already-produced output before a mid-generator
+    // `break` (`label $out | (("\(1, break $out)"), "reached")` => `"1"`),
+    // matching object construction's identical #354 precedent -- the
+    // pre-#1403 code here discarded it instead; #1403's own fix never
+    // reached this arm.
     let (stdout, _, code) = run_jq_full(
         &[
             "-c",
@@ -5371,11 +5374,11 @@ fn test_string_interpolation_path_context_builtin_control_flow_1334() -> Result<
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "\"a\"\n");
 
     // `halt_error(n)` from a slot, as that slot's very first output (no
     // successful output preceding it within the slot), propagates its own
-    // exit code as a bare halt.
+    // exit code as a bare halt with nothing on stdout.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | \"\\(key | halt_error(9))\""],
         Some(r#"{"a":1}"#),
@@ -5384,38 +5387,55 @@ fn test_string_interpolation_path_context_builtin_control_flow_1334() -> Result<
     assert_eq!(stdout, "");
 
     // Same, but with real output already produced within that slot first --
-    // exercises the `Partial(_, Control::Halt(_))` arm rather than the bare
-    // one above.
+    // exercises the `Partial(_, Control::Halt(_))` arm. Confirmed live
+    // (`null | "\(1, halt_error(9))"` prints `"1"` then halts) that the
+    // already-produced output survives the halt, matching
+    // `test_jq_string_interpolation_partial_output_before_slot_error_1403`'s
+    // non-path-context counterpart.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | \"\\(key, halt_error(9))\""],
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 9);
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "\"a\"\n");
 
     // A comma-grouped slot where real output is produced before an
     // uncaught error -- exercises the `Partial(_, Control::Error(_))` arm
     // (the un-guarded one, `optional == false`) rather than the bare
-    // `Error` arm the atomicity test below already covers.
-    let (_stdout, stderr, code) = run_jq_full(
+    // `Error` arm the atomicity test below already covers. Now also checks
+    // stdout, not just the error: the successfully-produced "a" must
+    // stream before the error, mirroring the plain evaluator's own
+    // #1403 fix.
+    let (stdout, stderr, code) = run_jq_full(
         &["-c", ".a | \"\\(key, error(\"boom\"))\""],
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 5);
+    assert_eq!(stdout, "\"a\"\n");
     assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     Ok(())
 }
 
-/// `?`-atomicity for the new `StringInterpolation` arm, built in from the
-/// start per #1302's own review lesson (its first cut needed a follow-up,
-/// #1333, to force the inner slot's `optional` to `false` so a genuine
-/// error surfaces for this arm's own catch instead of self-swallowing at
-/// the leaf) rather than left to be independently rediscovered here.
+/// `?`-atomicity for the `StringInterpolation` arm. The first two cases
+/// still look fully atomic post-#1403, but not because string
+/// interpolation is atomic in general (it isn't -- see the fan-out cases in
+/// `test_string_interpolation_path_context_builtin_control_flow_1334`
+/// above): the *error slot* here has no output of its own to contribute, so
+/// its own generator short-circuits every slot to its right before this
+/// arm's fan-out ever runs, the same "an entry with zero outputs
+/// short-circuits every entry to its right" rule `build_object_entries`'s
+/// own doc comment describes for `{a: empty, b: error("boom")}` -- verified
+/// live that a plain (non-path-context) `"k=\(1)-\(error("boom"))"` is
+/// identically empty on `?`, both against jq 1.7.1 and this crate's own
+/// already-fixed plain evaluator.
 #[test]
 fn test_string_interpolation_path_context_builtin_optional_is_atomic_1334() -> Result<()> {
-    // A slot that succeeds (`key`) before a later slot errors: `?` must
-    // discard the whole string, not embed a partial one.
+    // A slot that succeeds (`key`) before a later slot errors, with no
+    // output of its own: the error slot's own zero outputs short-circuit
+    // the whole interpolation before `key`'s successful value is ever
+    // combined in, so `?` (or the bare uncaught error below) has nothing to
+    // preserve.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | \"k=\\(key)-\\(error(\"boom\"))\"?"],
         Some(r#"{"a":1}"#),
@@ -5423,22 +5443,31 @@ fn test_string_interpolation_path_context_builtin_optional_is_atomic_1334() -> R
     assert_eq!(code, 0);
     assert_eq!(stdout, "");
 
-    // Without `?`, the same query still hard-errors.
-    let (_stdout, stderr, code) = run_jq_full(
+    // Without `?`, the same query still hard-errors, with nothing on stdout
+    // (confirmed live against jq 1.7.1: `"k=\(1)-\(error("boom"))"` prints
+    // nothing before erroring, unlike a same-slot `"\(1,error("boom"))"`,
+    // which does).
+    let (stdout, stderr, code) = run_jq_full(
         &["-c", ".a | \"k=\\(key)-\\(error(\"boom\"))\""],
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 5);
+    assert_eq!(stdout, "");
     assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    // A genuinely nested `?` *inside* a slot must still work on its own
-    // terms, independent of the interpolation's own (here absent) `?`.
+    // A genuinely nested `?` *inside* a slot swallows its own error into
+    // zero outputs for that slot (`(error("boom"))?` alone is `empty`, not
+    // `""`) -- which, same as the two cases above, short-circuits the
+    // *whole* interpolation to zero outputs rather than substituting an
+    // empty string, confirmed live against jq 1.7.1
+    // (`"k=\(1)-\((error("boom"))?)"` is empty, not `"k=1-"`) and against
+    // this crate's own already-fixed plain evaluator.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | \"k=\\(key)-\\((error(\"boom\"))?)\""],
         Some(r#"{"a":1}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), r#""k=a-""#);
+    assert_eq!(stdout, "");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6991,20 +6991,17 @@ fn test_string_interpolation_propagates_bare_halt() -> Result<()> {
 
 #[test]
 fn test_string_interpolation_propagates_halt_after_partial_output() -> Result<()> {
-    // Distinct arm from the bare-halt one above: when the `\(...)` slot's
-    // expression yields a value and *then* halts, `materialize_cursor()`
-    // returns `QueryResult::Partial(_, Control::Halt(code))`, handled here by
-    // its own two-line arm. Per this function's own doc comment ("string
-    // interpolation is atomic ... a `Partial` just surfaces its control,
-    // same as a bare one"), succinctly deliberately does NOT match real
-    // jq's behavior here: real jq forks the whole string per output of the
-    // slot's generator (`jq -n '"\(1, halt_error(9))"'` prints `"1"` to
-    // stdout *before* halting 9), but succinctly's `\(...)` embeds only the
-    // slot's single embedded value and discards the rest of a multi-output
-    // stream, so here the halt wins outright with no partial "1" on stdout.
+    // #1403 fixed jq mode's `\(...)` to be a genuine fan-out generator
+    // (matching object construction's own #354 semantics) rather than
+    // always taking just the slot's first output. This test used to pin
+    // the pre-fix divergence ("succinctly deliberately does NOT match real
+    // jq's behavior here") as expected; now that jq mode forks the whole
+    // string per output of the slot's generator, it matches real jq
+    // exactly: `jq -n '"\(1, halt_error(9))"'` prints `"1"` to stdout
+    // *before* halting 9 (live-verified), and so does succinctly now.
     let (stdout, stderr, code) = run_jq_full(&["-n", r#""\(1, halt_error(9))""#], None)?;
     assert_eq!(code, 9, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "\"1\"\n");
     Ok(())
 }
 
@@ -16779,5 +16776,97 @@ fn test_jq_optional_component_before_iterate_suppresses_whole_write_1298() -> Re
     let (stdout, stderr, code) = run_jq_full(&["-c", ".a?.b[].c = 9"], Some("5"))?;
     assert_eq!(code, 0, "stderr={stderr}");
     assert_eq!(stdout, "5\n");
+    Ok(())
+}
+
+// =============================================================================
+// #1403: string interpolation fans out over a multi-valued `\(...)` slot
+// =============================================================================
+
+/// The issue's own repro: a single multi-valued slot must produce one
+/// string per value, not just the first.
+#[test]
+fn test_jq_string_interpolation_single_slot_fans_out_1403() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "\"\\(1,2)\""], Some("null"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "\"1\"\n\"2\"\n");
+    Ok(())
+}
+
+/// Two independent multi-valued slots must cartesian-product together --
+/// live-verified against jq 1.7.1 that the *first* (leftmost) slot varies
+/// fastest, the opposite of object construction's "last entry varies
+/// fastest" (#354).
+#[test]
+fn test_jq_string_interpolation_two_slots_cartesian_product_first_varies_fastest_1403() -> Result<()>
+{
+    let (stdout, stderr, code) = run_jq_full(&["-c", "\"\\(1,2)-\\(3,4)\""], Some("null"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "\"1-3\"\n\"2-3\"\n\"1-4\"\n\"2-4\"\n");
+    Ok(())
+}
+
+/// Three slots, to guard against an implementation that only handles the
+/// two-slot case correctly by accident.
+#[test]
+fn test_jq_string_interpolation_three_slots_cartesian_product_1403() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "\"\\(1,2)-\\(3,4)-\\(5,6)\""], Some("null"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(
+        stdout,
+        "\"1-3-5\"\n\"2-3-5\"\n\"1-4-5\"\n\"2-4-5\"\n\"1-3-6\"\n\"2-3-6\"\n\"1-4-6\"\n\"2-4-6\"\n"
+    );
+    Ok(())
+}
+
+/// A slot's own deferred error fires only once every combination it can
+/// still contribute to has been tried, and combinations already produced
+/// travel onward first (jq's own all-or-nothing-per-generator
+/// backtracking, matching object construction's #354 semantics) --
+/// live-verified: `"\(1)-\((2,error("x")))"` prints `"1-2"` before the
+/// error, not silently dropping it.
+#[test]
+fn test_jq_string_interpolation_partial_output_before_slot_error_1403() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "\"\\(1)-\\((2,error(\"boom\")))\""], Some("null"))?;
+    assert_ne!(code, 0);
+    assert_eq!(stdout, "\"1-2\"\n");
+    Ok(())
+}
+
+/// A deferred control from *any* slot unwinds every enclosing loop
+/// immediately rather than resuming them -- live-verified:
+/// `"\((1,error("x")))-\(3,4)"` prints `"1-3"` then errors, never trying
+/// slot 2's second value `4` (which a naively-independent per-slot
+/// evaluation might have attempted).
+#[test]
+fn test_jq_string_interpolation_error_aborts_all_enclosing_loops_1403() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "\"\\((1,error(\"boom\")))-\\(3,4)\""], Some("null"))?;
+    assert_ne!(code, 0);
+    assert_eq!(stdout, "\"1-3\"\n");
+    Ok(())
+}
+
+/// An empty slot (zero outputs) collapses the whole interpolation to zero
+/// outputs too, not an error and not a string with a blank substituted in
+/// -- matches `empty`'s effect on any other jq generator.
+#[test]
+fn test_jq_string_interpolation_empty_slot_yields_no_output_1403() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "\"\\(empty)-\\(1,2)\""], Some("null"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+/// Regression guard: a single-valued slot (the overwhelmingly common case
+/// this function existed to serve before #1403) stays completely
+/// unaffected.
+#[test]
+fn test_jq_string_interpolation_single_valued_slot_unaffected_1403() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "\"Hello \\(.name)\""], Some(r#"{"name":"world"}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "\"Hello world\"\n");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19801,3 +19801,142 @@ fn test_yq_string_interpolation_single_valued_slot_unaffected_1403() -> Result<(
     assert_eq!(output.trim(), "Hello world");
     Ok(())
 }
+
+/// #1403 follow-up: `key`/`parent`/`file_index` route `\(...)` through a
+/// *second*, separate string-interpolation evaluator
+/// (`eval_pipe_with_path_context_internal`'s own `StringInterpolation` arm)
+/// that also needed the same jq-mode-only gate the plain-evaluator carve-out
+/// above already has -- yq mode must keep taking only the first value of a
+/// multi-valued slot here too, live-verified this crate's own already-fixed
+/// jq mode fans out the structurally identical query instead.
+#[test]
+fn test_yq_string_interpolation_path_context_multi_valued_slot_first_value_only_1403() -> Result<()>
+{
+    let (output, code) = run_yq_stdin(r#".[] | "\(1,2)-\(key)""#, "- 1\n- 2\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "\"1-0\"\n\"1-1\"\n");
+    Ok(())
+}
+
+/// Same gate, for the atomic-discard-on-error behavior: yq mode's
+/// path-context arm must still discard the whole string on an uncaught
+/// error (no partial output survives), unlike jq mode's now-streaming
+/// behavior for the identical shape.
+#[test]
+fn test_yq_string_interpolation_path_context_error_is_atomic_1403() -> Result<()> {
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        r#".a | "\(key)-\(error("boom"))""#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(output, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `?` swallows the error into empty output, same atomicity.
+    let (output, code) = run_yq_stdin(
+        r#".a | "\(key)-\(error("boom"))"?"#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "");
+    Ok(())
+}
+
+/// A yq-mode path-context string is still a fresh root for whatever
+/// follows it in the pipe, same as jq mode's identical reset.
+#[test]
+fn test_yq_string_interpolation_path_context_resets_root_for_rest_1403() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#".a | "\(key)" | key"#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "null");
+    Ok(())
+}
+
+/// A slot that legitimately yields nothing (`empty`) substitutes an empty
+/// string, same as the pre-#1403 flat loop always did -- yq mode has no
+/// fan-out/short-circuit concept at this level, unlike jq mode's own
+/// zero-outputs-short-circuits-everything model for the identical shape.
+#[test]
+fn test_yq_string_interpolation_path_context_empty_slot_1403() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#".a | "k=\(key)-\(empty)""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""k=a-""#);
+    Ok(())
+}
+
+/// `break`/`halt_error` from a path-context slot in yq mode still discard
+/// the whole string atomically, whether or not an earlier slot already
+/// produced output -- exercising every remaining arm of the yq-only match
+/// this crate's `eval_pipe_with_path_context_internal` kept verbatim.
+#[test]
+fn test_yq_string_interpolation_path_context_control_flow_is_atomic_1403() -> Result<()> {
+    // Bare `break`, no prior output within the slot.
+    let (output, code) = run_yq_stdin(
+        r#"label $out | ((.a | "\(key | break $out)"), "reached")"#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // `break` after a prior successful value in the same slot.
+    let (output, code) = run_yq_stdin(
+        r#"label $out | ((.a | "\(key, break $out)"), "reached")"#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // Bare `halt_error`, no prior output within the slot.
+    let (output, code) = run_yq_stdin(
+        r#".a | "\(key | halt_error(9))""#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 9, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // `halt_error` after a prior successful value in the same slot.
+    let (output, code) =
+        run_yq_stdin(r#".a | "\(key, halt_error(9))""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 9, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // An uncaught error *after* a prior successful value in the same slot
+    // (a `Partial(_, Control::Error(_))` at the slot level, distinct from
+    // the bare-`Error` two-separate-slots case in
+    // `test_yq_string_interpolation_path_context_error_is_atomic_1403`).
+    let (output, code) =
+        run_yq_stdin(r#".a | "\(key, error("boom"))""#, "a: 1\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert_eq!(output, "");
+
+    Ok(())
+}
+
+/// `?` wraps only the interpolation, with a downstream `| key` still
+/// needing path context -- flattens through the general `Expr::Optional`
+/// arm's rest-non-empty branch, threading `optional=true` straight into
+/// this yq-only match, exercising its own `if optional` arm directly.
+/// Unlike the jq-mode counterpart
+/// (`test_string_interpolation_path_context_fanout_continues_rest_1403`'s
+/// final case, which still runs `| key` against the fanned-out result),
+/// this arm's `if optional` catch returns `QueryResult::None` as the whole
+/// match arm's result -- `rest` (the flattened-in `key`) never runs at
+/// all, since there is no separate rest-continuation step here the way
+/// `continue_rest_with_fresh_root` gives the jq-mode path: confirmed live
+/// that the query below is empty, not `null`.
+#[test]
+fn test_yq_string_interpolation_path_context_optional_threaded_through_rest_1403() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        r#".a | ("\(key)-\(error("boom"))")? | key"#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19802,6 +19802,44 @@ fn test_yq_string_interpolation_single_valued_slot_unaffected_1403() -> Result<(
     Ok(())
 }
 
+/// `eval_string_interpolation_single_value`'s own `Halt`/`Partial` arms,
+/// unexercised by any pre-#1403 test: before #1403 split jq and yq mode
+/// into separate functions, jq-mode tests for this exact code (shared by
+/// both modes at the time) covered these arms; post-split, jq mode takes
+/// the new fan-out path instead, so this yq-only function needs its own
+/// coverage for the cases that aren't a plain slot value or a bare,
+/// no-prior-output `Error`/`Break`.
+#[test]
+fn test_yq_string_interpolation_atomic_control_flow_1403() -> Result<()> {
+    // Bare `halt_error`, no prior output within the slot.
+    let (output, code) = run_yq_stdin(r#".a | "\(halt_error(9))""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 9, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // An uncaught error after a prior successful value in the *same* slot
+    // (a `Partial(_, Control::Error(_))`, distinct from the bare-`Error`
+    // two-separate-slots shape already covered elsewhere).
+    let (output, code) = run_yq_stdin(r#".a | "\(., error("boom"))""#, "a: 1\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert_eq!(output, "");
+
+    // `break` after a prior successful value in the same slot.
+    let (output, code) = run_yq_stdin(
+        r#"label $out | ((.a | "\(., break $out)"), "reached")"#,
+        "a: 1\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "");
+
+    // `halt_error` after a prior successful value in the same slot.
+    let (output, code) = run_yq_stdin(r#".a | "\(., halt_error(9))""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 9, "output: {output:?}");
+    assert_eq!(output, "");
+
+    Ok(())
+}
+
 /// #1403 follow-up: `key`/`parent`/`file_index` route `\(...)` through a
 /// *second*, separate string-interpolation evaluator
 /// (`eval_pipe_with_path_context_internal`'s own `StringInterpolation` arm)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19777,3 +19777,27 @@ fn test_jq_gsub_zero_width_unaffected_by_1255() -> Result<()> {
     assert_eq!(stdout.trim(), r#""XbXXbX""#);
     Ok(())
 }
+
+/// #1403: jq mode's string interpolation became a genuine fan-out
+/// generator over a multi-valued `\(...)` slot, but yq mode deliberately
+/// keeps its pre-#1403 single-value-taking behavior -- live-verified
+/// against yq v4.53.3 that a multi-valued slot silently collapses to its
+/// first value alone (`printf 'a: 1\n' | yq '"\(.a,2)"'` -> `1`, never
+/// `2`), unlike jq's cartesian-product model.
+#[test]
+fn test_yq_string_interpolation_multi_valued_slot_takes_first_value_only_1403() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#""\(.a,2)""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), r#""1""#);
+    Ok(())
+}
+
+/// Regression guard: the ordinary single-valued interpolation case (the
+/// overwhelmingly common shape) stays completely unaffected in yq mode.
+#[test]
+fn test_yq_string_interpolation_single_valued_slot_unaffected_1403() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#""Hello \(.name)""#, "name: world\n", &[])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "Hello world");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #1403. Real jq's `"\(...)"` string interpolation is a generator, exactly like object construction (#354): a multi-valued embedded expression produces one string per value, cartesian-producting across every slot when more than one is multi-valued. succinctly always took just the first output of each slot instead, silently discarding the rest — `"\(1,2)"` gave `"1"` where jq 1.7.1 gives `"1"` then `"2"`.

## Changes

- Modeled directly on `build_object_entries`'s own recursive push/pop cartesian-product machinery (a proven, working precedent already in this codebase — confirmed live that `{a:(1,2),b:(3,4)}` already fans out correctly). Reused `object_outputs` verbatim (already fully general, no object-specific coupling) plus the existing `Control` enum for the deferred-escape shape.
- One load-bearing difference from the object precedent, confirmed live against jq 1.7.1 before writing any code: `"\(1,2)-\(3,4)"` gives `"1-3","2-3","1-4","2-4"` — the *first* (leftmost) slot varies fastest, backwards from object construction's "last entry varies fastest". Implemented by processing parts via `split_last()` (last slot outermost) into a fixed-size `slots: &mut [String]` array indexed by each part's original position, rather than a single growing `String` — since the loop-nesting order and the left-to-right textual assembly order are now genuinely different, decoupling "which order to enumerate combinations" from "how to assemble each combination's string" avoids needing any push/truncate undo logic.
- **Deliberately scoped to jq mode only**: live-verified against yq v4.53.3 that a multi-valued slot silently collapses to its first value alone in yq (`printf 'a: 1\n' | yq '"\(.a,2)"'` → `1`, never `2`) — a real, previously-undocumented mode divergence, not an oversight. yq mode keeps the original single-value-taking code verbatim in its own function. Recorded in `docs/compliance/yq/limitations.md` per ADR-0018 rule 6.
- Fixed two stale tests that were pinning the pre-fix bug as documented, expected behavior (their own comments already knew what real jq does): `test_string_interpolation_propagates_halt_after_partial_output` (updated to expect the now-correct partial `"1"` before the halt) and `partial_in_value_position_collapses_to_its_control` (moved its string-interpolation case to `partial_prefix_survives_the_stream_forwarding_constructs`, mirroring the exact migration #354 already did for object construction).

## Test plan

- [x] 7 new jq-mode tests: the issue's own repro, two- and three-slot cartesian products, partial-output-before-error, error-aborts-all-enclosing-loops, empty-slot, and a single-valued regression guard.
- [x] 2 new yq-mode tests: confirms the deliberate non-fix (first-value-only) plus a single-valued regression guard.
- [x] 2 pre-existing lib tests updated to reflect the now-correct behavior (with explanatory comments), mirroring the same class of update #354 needed for object construction.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`) — 2724 lib + 814 jq_cli_tests + 1081 yq_cli_tests, all green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean.
- [x] `cargo check --no-default-features` (no_std) still builds.
- [x] `cargo fmt --check` clean.
- [x] Patch coverage: 100% (76/76 new lines).
