### PR TITLE
fix(jq): support arity-based function overloading in def

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -614,6 +614,44 @@ the exit-code fix.
 succinctly also omits jq's `(at <stdin>:N)` input-location prefix, which is emitted by
 jq's CLI rather than its evaluator and is therefore outside the message the two share.
 
+## Undefined functions and arity mismatches are runtime errors, not compile errors
+
+Real jq resolves every function call at compile time, before any input is read: a call to
+an undefined function, or an undefined arity of an existing one, fails immediately and
+unconditionally — `jq: error: f/2 is not defined at <top-level>, line 1: ...`, exit **3**
+— regardless of whether that call site is ever reached at runtime, and it cannot be
+caught by `try`/`catch` or `?` (compilation fails before evaluation, and thus before
+`try`, ever begins).
+
+`succinctly jq` resolves user-defined `def` calls via `expand_func_calls`'s static AST
+substitution (`src/jq/eval.rs`), which turns an unresolvable call into an `Expr::Error`
+node rather than failing immediately. That node is then evaluated lazily like any other
+expression, so:
+
+```
+$ jq -n 'def f(x): x; if false then f(1;2;3) else 1 end'
+jq: error: f/3 is not defined at <top-level>, line 1:   # compile error, exit 3, unconditional
+$ succinctly jq -n 'def f(x): x; if false then f(1;2;3) else 1 end'
+1                                                        # exit 0 -- the branch is never reached
+$ jq -n 'def f(x): x; try f(1;2) catch "caught"'
+jq: error: f/2 is not defined ...                        # exit 3, try never runs
+$ succinctly jq -n 'def f(x): x; try f(1;2) catch "caught"'
+"caught"                                                  # exit 0
+```
+
+Exit code for the surfaced case is succinctly's general runtime-error code, 5, not jq's
+compile-error code, 3 — a different pairing from the "wrong exit code" gap just above
+(that one is 0-vs-5; this is 5-vs-3). A related, narrower symptom of the same root cause
+also lets a `def` forward-reference a not-yet-defined arity of itself and silently
+compute a value instead of failing — see
+[`test_func_def_forward_arity_reference_in_own_body_known_gap_1376`](../../../tests/jq_cli_tests.rs)
+for the pinned repro.
+
+Fixing this properly needs genuine compile-time (or runtime-call) function resolution —
+the same architectural change [#1371](https://github.com/rust-works/succinctly/issues/1371)
+already scopes for self-recursive `def`s — rather than a narrow patch to the substitution
+walker; tracked as [#1473](https://github.com/rust-works/succinctly/issues/1473).
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30138,6 +30138,25 @@ fn expand_func_calls(
         // or outside this one's own scope) might still resolve it, or
         // reaches `eval_func_call`'s "undefined function" fallback if none
         // ever does.
+        //
+        // **Known gap** (code review, #1473): this fallthrough can also
+        // let a call resolve that real jq would reject as a forward
+        // reference. If `func_name`'s own body (here, `body`) itself
+        // contains a call to a not-yet-defined arity of the same name
+        // (`def f(x): f(x; 99); def f(x; y): x + y; f(1)`), that call gets
+        // substituted into the tree at `f(1)`'s position -- inside `f/2`'s
+        // own `then` -- and `f/2`'s own later expansion pass then resolves
+        // it, even though at `f/1`'s own lexical position `f/2` isn't in
+        // scope yet (jq: `f/2 is not defined`, compile error; succinctly:
+        // silently computes `100`). This isn't fixable by a narrower guard
+        // here -- it needs the substitution architecture to track lexical
+        // position (or a real compile-time/runtime resolution pass), which
+        // is the same class of work #1473 already scopes. Confirmed the
+        // same root cause also explains a pre-existing, non-arity case
+        // (`def f: g; def g: 42; f` also wrongly resolves); this arm's
+        // #1376 fix didn't introduce that general gap, only re-exposed one
+        // arity-flavored sub-case of it that a since-removed blanket arity
+        // error happened to catch by accident.
         Expr::FuncCall { name, args } if name == func_name && args.len() == params.len() => {
             // #1016: a self-recursive `def` (e.g. `def deep(n): if n == 0
             // then . else [deep(n-1)] end;`) has no base case at expansion
@@ -30824,20 +30843,19 @@ fn expand_func_calls(
             then,
         } => {
             // #1376: shadowing needs the *same arity*, not just the same
-            // name -- jq supports overloading a name by arity (`def
-            // f(x): ...; def f(x;y): ...;` are distinct functions, both
-            // remain callable), and a same-name-different-arity def here
-            // doesn't touch `func_name`'s own calls at all: they live at a
-            // different arity, so they're neither redefined nor shadowed
-            // by this one. Verified live against jq 1.7.1: `f/1` stays
-            // callable from *inside* `f/2`'s own body too (`def f(x):
-            // x+1; def f(x;y): (f(x))+y; f(2;3)` is `6` = f(2)+3), so this
-            // arm must keep descending into both `inner_body` and `then`
-            // when only the name matches, exactly like the "different
-            // name entirely" case below already does -- only a genuine
-            // same-arity redefinition (which really does make the earlier
-            // definition permanently unreachable from this point on)
-            // stops expansion.
+            // name -- see the `FuncCall` arm above for why arity
+            // overloading matters and its own worked example. A same-
+            // name-different-arity def here doesn't touch `func_name`'s
+            // own calls at all: they live at a different arity, so
+            // they're neither redefined nor shadowed by this one.
+            // Verified live against jq 1.7.1: `f/1` stays callable from
+            // *inside* `f/2`'s own body too (`def f(x): x+1; def f(x;y):
+            // (f(x))+y; f(2;3)` is `6` = f(2)+3), so this arm must keep
+            // descending into both `inner_body` and `then` when only the
+            // name matches, exactly like the "different name entirely"
+            // case below already does -- only a genuine same-arity
+            // redefinition (which really does make the earlier definition
+            // permanently unreachable from this point on) stops expansion.
             if inner_name == func_name && inner_params.len() == params.len() {
                 // Don't expand in the body or then - this is a new definition
                 expr.clone()
@@ -30865,7 +30883,10 @@ fn expand_func_calls(
             }
         }
         Expr::FuncCall { name, args } => {
-            // Different function name, just expand in arguments
+            // Reached for a different function name entirely, or (#1376)
+            // a same-name call whose arity doesn't match this occurrence
+            // -- either way, not this pass's call to resolve, so just
+            // expand in arguments and leave the call itself untouched.
             Expr::FuncCall {
                 name: name.clone(),
                 args: args

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30123,16 +30123,22 @@ fn expand_func_calls(
     chain_depth: usize,
 ) -> Expr {
     match expr {
-        Expr::FuncCall { name, args } if name == func_name => {
-            // Check arity
-            if args.len() != params.len() {
-                return expansion_error(format!(
-                    "function {} takes {} arguments, got {}",
-                    func_name,
-                    params.len(),
-                    args.len()
-                ));
-            }
+        // #1376: the arity check used to live *inside* this arm, matching
+        // on name alone and erroring on any arity mismatch -- which broke
+        // arity-based overloading (`def f(x): ...; def f(x;y): ...;`),
+        // since a 2-arg call reached while expanding the 1-arg `f` would
+        // hard-error instead of being left alone for the 2-arg `f`'s own
+        // expansion pass to find. Folding the arity check into the guard
+        // itself means a name-matching, arity-mismatched call falls
+        // through to the generic `Expr::FuncCall` arm below instead (which
+        // just recurses into `args`, leaving the call itself untouched) --
+        // exactly the same "not this occurrence's problem" treatment a
+        // different-*name* call already gets, so it stays available for
+        // whatever other def (a different arity of the same name, inside
+        // or outside this one's own scope) might still resolve it, or
+        // reaches `eval_func_call`'s "undefined function" fallback if none
+        // ever does.
+        Expr::FuncCall { name, args } if name == func_name && args.len() == params.len() => {
             // #1016: a self-recursive `def` (e.g. `def deep(n): if n == 0
             // then . else [deep(n-1)] end;`) has no base case at expansion
             // time -- expansion is static AST substitution, run before any
@@ -30817,8 +30823,22 @@ fn expand_func_calls(
             body: inner_body,
             then,
         } => {
-            // If this defines the same function name, it shadows our function
-            if inner_name == func_name {
+            // #1376: shadowing needs the *same arity*, not just the same
+            // name -- jq supports overloading a name by arity (`def
+            // f(x): ...; def f(x;y): ...;` are distinct functions, both
+            // remain callable), and a same-name-different-arity def here
+            // doesn't touch `func_name`'s own calls at all: they live at a
+            // different arity, so they're neither redefined nor shadowed
+            // by this one. Verified live against jq 1.7.1: `f/1` stays
+            // callable from *inside* `f/2`'s own body too (`def f(x):
+            // x+1; def f(x;y): (f(x))+y; f(2;3)` is `6` = f(2)+3), so this
+            // arm must keep descending into both `inner_body` and `then`
+            // when only the name matches, exactly like the "different
+            // name entirely" case below already does -- only a genuine
+            // same-arity redefinition (which really does make the earlier
+            // definition permanently unreachable from this point on)
+            // stops expansion.
+            if inner_name == func_name && inner_params.len() == params.len() {
                 // Don't expand in the body or then - this is a new definition
                 expr.clone()
             } else {
@@ -32653,13 +32673,28 @@ fn substitute_func_param_in_builtin(builtin: &Builtin, param: &str, arg: &Expr) 
 
 /// Evaluate a function call to an undefined function.
 /// This is an error case - the function was not defined.
+///
+/// #1376: includes arity (`name/N`), not just `name` -- an arity-mismatched
+/// call to an *existing* def (e.g. `def f(x): x; f(1;2)`) now reaches this
+/// same fallback rather than a dedicated arity-check error, since
+/// `expand_func_calls`'s `FuncCall` arm folds its arity check into its own
+/// match guard (so arity overloading -- a different arity of the same name
+/// defined elsewhere -- can still resolve the call, rather than hard-
+/// erroring the moment one non-matching-arity def is found). Naming the
+/// arity here keeps that merged case's error at least as informative as
+/// the dedicated check it replaced, and edges closer to real jq's own
+/// `name/arity is not defined` wording without fully matching its
+/// compile-time-error format.
 fn eval_func_call<'a, W: Clone + AsRef<[u64]>>(
     name: &str,
-    _args: &[Expr],
+    args: &[Expr],
     _value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    QueryResult::Error(EvalError::new(format!("undefined function: {name}")))
+    QueryResult::Error(EvalError::new(format!(
+        "undefined function: {name}/{}",
+        args.len()
+    )))
 }
 
 #[cfg(test)]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13869,6 +13869,59 @@ fn test_func_def_three_way_arity_overload_1376() -> Result<()> {
     Ok(())
 }
 
+/// #1376 known gap, tracked by #1473: forward-referencing a not-yet-
+/// defined arity from *within a def's own body* silently computes a value
+/// instead of failing, where real jq rejects it as a compile-time forward
+/// reference (`f/2 is not defined`, exit 3, oracle-verified against jq
+/// 1.7.1). `f/1`'s own body (`f(x; 99)`) textually references `f/2`, which
+/// doesn't exist yet at that lexical point -- but `expand_func_calls`'s
+/// substitution model has no concept of lexical position, so once `f/1`'s
+/// own expansion substitutes that body into `f(1)`'s call site (found
+/// while walking past `f/2`'s own definition), the result becomes
+/// indistinguishable from a call genuinely written after `f/2` and gets
+/// picked up by `f/2`'s own, later expansion pass.
+///
+/// This isn't fixable by a narrower guard in `#1376`'s own fix (see the
+/// `FuncCall` arm's own doc comment in `src/jq/eval.rs`) -- it needs the
+/// same lexical-scope tracking (or genuine compile-time/runtime
+/// resolution) #1473 already scopes. Pinning the *current* (wrong, known)
+/// behavior here so it can't silently drift further, and so this test
+/// starts failing -- correctly -- the moment #1473 lands a real fix.
+#[test]
+fn test_func_def_forward_arity_reference_in_own_body_known_gap_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): f(x; 99); def f(x; y): x + y; f(1)"],
+        Some("null"),
+    )?;
+    // NOT the correct behavior -- real jq rejects this at compile time
+    // (`f/2 is not defined`, exit 3). Pinned as documented, tracked-as-
+    // known-wrong output; see this test's own doc comment and #1473.
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "100");
+    Ok(())
+}
+
+/// #1376: `eval_pipe_with_path_context_internal`'s own `Expr::FuncDef` arm
+/// (`src/jq/eval.rs`) is a *second*, independent call site into the same
+/// `expand_func_calls`/arity-overload logic -- a query built entirely from
+/// non-path-context queries (like this file's other `_1376` tests) never
+/// reaches it, so it needs its own coverage. `path(...)` forces evaluation
+/// through the path-context evaluator; both overloads still resolve
+/// correctly there. Oracle-verified against jq 1.7.1.
+#[test]
+fn test_func_def_arity_overload_through_path_context_evaluator_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"def go(k): .[k]; def go(k;k2): path(.[k][k2]); [go("a"), go("a";"b")]"#,
+        ],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#"[{"b":1},["a","b"]]"#);
+    Ok(())
+}
+
 /// #998: the bare identity `.` never materializes an `OwnedValue` tree (it
 /// stays lazy, streaming straight from the cursor via `print_json`), so
 /// `eval_generic::to_owned`'s own depth guard never gets a chance to fire

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13763,21 +13763,109 @@ cover(1)"#,
     Ok(())
 }
 
-/// #1016 patch-coverage: `expand_func_calls`'s arity-mismatch check (right
-/// above the depth guard this PR adds, in the same `FuncCall` match arm)
-/// had zero direct test coverage anywhere in this crate before this PR --
-/// confirmed by grepping for its exact message. Calling a `def` with the
-/// wrong number of arguments must still surface that pre-existing, clean
-/// `EvalError` rather than reaching (or being masked by) the new depth
-/// guard added just below it in the same arm.
+/// #1016 patch-coverage: calling a `def` with the wrong number of
+/// arguments must still surface a clean, catchable `EvalError` (exit 5),
+/// not a crash or a silently wrong result.
+///
+/// #1376 changed *which* error this is and *where* it comes from.
+/// `expand_func_calls`'s `FuncCall` arm used to hard-error the moment it
+/// found a name-matching, arity-mismatched call, with a dedicated
+/// "function f takes 1 arguments, got 2" message -- but that broke arity
+/// overloading (`def f(x): ...; def f(x;y): ...;`), since a 2-arg call
+/// reached while expanding the 1-arg `f` would error out instead of being
+/// left alone for the 2-arg `f`'s own expansion to find. The arity check
+/// is now folded into that arm's own match guard, so an arity-mismatched
+/// call (with no other overload anywhere to resolve it, as here) falls
+/// through unexpanded and reaches `eval_func_call`'s "undefined function"
+/// fallback instead -- still a clean `EvalError`, now naming the arity too
+/// (`f/2`) rather than the dedicated check's own wording.
 #[test]
 fn test_func_call_arity_mismatch_reports_clean_error_1016() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "def f(x): x; f(1;2)"], Some("null"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
-        stderr.contains("function f takes 1 arguments, got 2"),
+        stderr.contains("undefined function: f/2"),
         "stderr: {stderr:?}"
     );
+    Ok(())
+}
+
+/// #1376: `succinctly jq` now supports arity overloading, matching real
+/// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
+/// (`f/1` and `f/2`), and both stay callable after the second definition.
+/// The issue's own repro, oracle-verified against jq 1.7.1.
+#[test]
+fn test_func_def_arity_overload_both_callable_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): x + 1; def f(x; y): x + y; [f(1), f(2;3)]"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[2,5]");
+    Ok(())
+}
+
+/// #1376: the earlier-defined arity stays callable from *inside* the
+/// later, different-arity overload's own body too -- not just from code
+/// that comes after both definitions. Oracle-verified against jq 1.7.1:
+/// `f(2;3)` is `f(2)+3` = `3+3` = `6`.
+#[test]
+fn test_func_def_arity_overload_visible_inside_other_arity_body_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): x+1; def f(x;y): (f(x)) + y; f(2;3)"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "6");
+    Ok(())
+}
+
+/// #1376 regression guard: a genuine *same-arity* redefinition must still
+/// shadow (the later definition completely replaces the earlier one, not
+/// an overload) -- arity overloading must not weaken this pre-existing,
+/// oracle-verified rule. `f(x): x+1` becomes permanently unreachable once
+/// `f(x): x+100` redefines it at the same arity.
+#[test]
+fn test_func_def_same_arity_redefinition_still_shadows_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): x+1; def f(x): x+100; f(5)"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "105");
+    Ok(())
+}
+
+/// #1376 regression guard: calling an arity that no overload defines still
+/// errors cleanly, rather than silently matching the wrong overload or
+/// succeeding with a wrong value.
+#[test]
+fn test_func_def_arity_overload_unmatched_arity_still_errors_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): x+1; def f(x;y): x+y; f(1;2;3)"],
+        Some("null"),
+    )?;
+    assert_ne!(code, 0, "stdout: {stdout:?}");
+    assert!(
+        stderr.contains("undefined function: f/3"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1376: a three-way arity overload (0, 1, and 2 arguments), each
+/// remaining independently callable. Oracle-verified against jq 1.7.1.
+#[test]
+fn test_func_def_three_way_arity_overload_1376() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "def f: 1; def f(x): x+1; def f(x;y): x+y; [f, f(2), f(3;4)]",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1,3,7]");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- `def f(x): ...; def f(x;y): ...;` defines `f/1` and `f/2` as distinct functions in real jq, both remaining callable — but `succinctly jq`'s `expand_func_calls` treated any same-named inner def as shadowing the outer one **regardless of arity**, so `f/1` became permanently unreachable the moment `f/2` was defined.
- Repro: `def f(x): x + 1; def f(x; y): x + y; [f(1), f(2;3)]` errored on `f(1)` where real jq gives `[2,5]`.
- Two changes, both in `expand_func_calls` (`src/jq/eval.rs`):
  - The `FuncDef` arm's shadow check now also compares arity — a same-name-*different*-arity inner def doesn't shadow at all (verified live: an earlier arity stays callable both after and *from inside* a later, different-arity overload's own body — `def f(x): x+1; def f(x;y): (f(x))+y; f(2;3)` is `6`); only a genuine same-arity redefinition still shadows (unchanged, still verified: `def f(x): x+1; def f(x): x+100; f(5)` is `105`).
  - The `FuncCall` self-reference arm's arity check moved from an immediate hard error into its own match guard, so a name-matching, arity-mismatched call falls through to the generic `FuncCall` arm instead of erroring out — leaving it available for a different arity of the same name (found elsewhere in scope) to resolve it.
- Side effect: an arity-mismatched call with no matching overload anywhere now reaches `eval_func_call`'s "undefined function" fallback instead of a dedicated arity-check error. That fallback's message now names the arity too (`f/2`, not just `f`), since the removed check no longer owns a more specific message for this case — a pre-existing test (`test_func_call_arity_mismatch_reports_clean_error_1016`) is updated accordingly.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green, including all 10 pre-existing #1016 guard tests)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's second leg)
- [x] `cargo build --no-default-features` (no_std check)
- [x] `cargo llvm-cov` full run, all green
- [x] 5 new CLI tests: the issue's own repro; cross-arity visibility from inside another arity's own body; same-arity redefinition still shadows (regression guard); an unmatched arity still errors cleanly; a three-way (0/1/2-arg) overload
- [x] Manually verified all scenarios against a compiled release binary, cross-checked against real jq 1.7.1 for the three-way overload case

Fixes #1376