### PR TITLE
refactor(jq): route remaining path-context arms through continue_rest_with_context

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21872,26 +21872,25 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
 
     let (first, rest) = exprs.split_first().unwrap();
 
-    // Handle PathNoArg - return the current path
+    // Handle PathNoArg - return the current path. Position unchanged, so
+    // `rest` continues against the ambient `root`/`current_path` (#1449:
+    // routed through the shared helper #1445 already extracted for this
+    // exact "keep root/current_path unchanged" pattern, instead of
+    // hand-rolling it a fourth time).
     if matches!(first, Expr::Builtin(Builtin::PathNoArg)) {
         let path_result = QueryResult::Owned(OwnedValue::Array(current_path.to_vec()));
-        if rest.is_empty() {
-            return path_result;
-        }
-        // Continue with remaining expressions
-        if let QueryResult::Owned(v) = path_result {
-            return eval_pipe_with_path_context_internal::<W, S>(
-                rest,
-                &v,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            );
-        }
+        return continue_rest_with_context::<W, S>(
+            path_result,
+            rest,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        );
     }
 
-    // Handle Key - return the last element of current path (current key)
+    // Handle Key - return the last element of current path (current key).
+    // Position unchanged (#1449).
     if matches!(first, Expr::Builtin(Builtin::Key)) {
         let key_result = if current_path.is_empty() {
             // At root - return null (yq behavior)
@@ -21900,20 +21899,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Get the last element of the path (the current key)
             QueryResult::Owned(current_path.last().unwrap().clone())
         };
-        if rest.is_empty() {
-            return key_result;
-        }
-        // Continue with remaining expressions
-        if let QueryResult::Owned(v) = key_result {
-            return eval_pipe_with_path_context_internal::<W, S>(
-                rest,
-                &v,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            );
-        }
+        return continue_rest_with_context::<W, S>(
+            key_result,
+            rest,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        );
     }
 
     // Handle FileIndex - return the origin file index of the top-level
@@ -21924,6 +21917,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     // is `None`) or once past the top level's index (defensive; `.first()`
     // always exists once inside an `--eval-all` array), matching
     // `document_index`'s existing "0 outside supported context" contract.
+    // Position unchanged (#1449).
     if matches!(first, Expr::Builtin(Builtin::FileIndex)) {
         let file_idx = current_path
             .first()
@@ -21932,54 +21926,44 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             .and_then(|i| file_origin.and_then(|origins| origins.get(i).copied()))
             .unwrap_or(0);
         let file_index_result = QueryResult::Owned(OwnedValue::Int(file_idx as i64));
-        if rest.is_empty() {
-            return file_index_result;
-        }
-        if let QueryResult::Owned(v) = file_index_result {
-            return eval_pipe_with_path_context_internal::<W, S>(
-                rest,
-                &v,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            );
-        }
+        return continue_rest_with_context::<W, S>(
+            file_index_result,
+            rest,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        );
     }
 
-    // Handle Parent - return the parent value
+    // Handle Parent - return the parent value. Unlike the three arms above,
+    // `rest` continues at the *parent's* path, not the ambient one -- still
+    // routed through the shared helper (#1449), just with a different
+    // `current_path` argument for the continuation.
     if matches!(first, Expr::Builtin(Builtin::Parent)) {
+        let parent_path = if current_path.is_empty() {
+            vec![]
+        } else {
+            current_path[..current_path.len() - 1].to_vec()
+        };
         let parent_result = if current_path.is_empty() {
             // At root - return empty object (yq behavior)
             QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
         } else {
-            // Get the parent path (all but last element)
-            let parent_path = &current_path[..current_path.len() - 1];
             // Navigate from root to parent
-            match get_value_at_owned_path(root, parent_path) {
+            match get_value_at_owned_path(root, &parent_path) {
                 Some(parent_value) => QueryResult::Owned(parent_value),
                 None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
             }
         };
-        if rest.is_empty() {
-            return parent_result;
-        }
-        if let QueryResult::Owned(v) = parent_result {
-            // Parent path is one level up
-            let parent_path = if current_path.is_empty() {
-                vec![]
-            } else {
-                current_path[..current_path.len() - 1].to_vec()
-            };
-            return eval_pipe_with_path_context_internal::<W, S>(
-                rest,
-                &v,
-                root,
-                file_origin,
-                &parent_path,
-                optional,
-            );
-        }
+        return continue_rest_with_context::<W, S>(
+            parent_result,
+            rest,
+            root,
+            file_origin,
+            &parent_path,
+            optional,
+        );
     }
 
     // Handle ParentN - return the nth parent value
@@ -22025,19 +22009,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
         };
 
-        if rest.is_empty() {
-            return parent_result;
-        }
-        if let QueryResult::Owned(v) = parent_result {
-            return eval_pipe_with_path_context_internal::<W, S>(
-                rest,
-                &v,
-                root,
-                file_origin,
-                &parent_path,
-                optional,
-            );
-        }
+        // Same "continue at the parent's path" shape as the plain `Parent`
+        // arm above (#1449).
+        return continue_rest_with_context::<W, S>(
+            parent_result,
+            rest,
+            root,
+            file_origin,
+            &parent_path,
+            optional,
+        );
     }
 
     // Evaluate first expression and update path
@@ -22653,18 +22634,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 }
             };
             let result = OwnedValue::Array(items);
-            if rest.is_empty() {
-                QueryResult::Owned(result)
-            } else {
-                eval_pipe_with_path_context_internal::<W, S>(
-                    rest,
-                    &result,
-                    &result,
-                    file_origin,
-                    &[],
-                    optional,
-                )
-            }
+            // The array just built is a fresh root with no path (#1449:
+            // routed through the same helper the `StringInterpolation` arm
+            // below already uses for its own identical reset).
+            continue_rest_with_fresh_root::<W, S>(
+                QueryResult::Owned(result),
+                rest,
+                file_origin,
+                optional,
+            )
         }
         // `"...\(key)..."` (#1334): the `Array` arm's own reasoning above,
         // applied to a string interpolation slot instead of an array

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21941,27 +21941,30 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     // routed through the shared helper (#1449), just with a different
     // `current_path` argument for the continuation.
     if matches!(first, Expr::Builtin(Builtin::Parent)) {
-        let parent_path = if current_path.is_empty() {
-            vec![]
-        } else {
-            current_path[..current_path.len() - 1].to_vec()
-        };
-        let parent_result = if current_path.is_empty() {
+        // `parent_path` borrows straight from `current_path` -- both this
+        // and `continue_rest_with_context` only ever need a `&[OwnedValue]`
+        // slice, never an owned one, so there's nothing to clone here
+        // (code review, #1449: routing this arm through the shared helper
+        // had accidentally turned the old code's on-demand `.to_vec()`,
+        // paid only when `rest` was non-empty, into an unconditional one).
+        let (parent_path, parent_result): (&[OwnedValue], _) = if current_path.is_empty() {
             // At root - return empty object (yq behavior)
-            QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
+            (&[], QueryResult::Owned(OwnedValue::Object(IndexMap::new())))
         } else {
+            let parent_path = &current_path[..current_path.len() - 1];
             // Navigate from root to parent
-            match get_value_at_owned_path(root, &parent_path) {
+            let parent_result = match get_value_at_owned_path(root, parent_path) {
                 Some(parent_value) => QueryResult::Owned(parent_value),
                 None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
-            }
+            };
+            (parent_path, parent_result)
         };
         return continue_rest_with_context::<W, S>(
             parent_result,
             rest,
             root,
             file_origin,
-            &parent_path,
+            parent_path,
             optional,
         );
     }
@@ -21992,18 +21995,21 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             Err(escape) => return escape.into(),
         };
 
-        // Calculate parent path (n levels up)
-        let parent_path = if n >= current_path.len() {
-            vec![]
+        // Calculate parent path (n levels up). A borrowed slice, same
+        // zero-allocation reasoning as the plain `Parent` arm above
+        // (#1449) -- pre-existing here, not introduced by this PR, but
+        // fixed in passing since it's the identical pattern.
+        let parent_path: &[OwnedValue] = if n >= current_path.len() {
+            &[]
         } else {
-            current_path[..current_path.len() - n].to_vec()
+            &current_path[..current_path.len() - n]
         };
 
         let parent_result = if parent_path.is_empty() && n > 0 {
             // Gone past root - return empty object
             QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
         } else {
-            match get_value_at_owned_path(root, &parent_path) {
+            match get_value_at_owned_path(root, parent_path) {
                 Some(parent_value) => QueryResult::Owned(parent_value),
                 None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
             }
@@ -22016,7 +22022,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             rest,
             root,
             file_origin,
-            &parent_path,
+            parent_path,
             optional,
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5331,6 +5331,28 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"{"b":{"c":1}}"#);
 
+    // `parent` at the document root (empty `current_path`): the
+    // yq-compatible "return an empty object" default, not a navigation
+    // failure. A leading `.` forces this through an actual `Expr::Pipe`
+    // (matching every other case in this test) -- a *bare* `parent` with
+    // no pipe operator at all doesn't route through `eval_pipe`'s own
+    // `needs_path_context` check the same way, and so wouldn't reach the
+    // arm this test means to exercise.
+    let (output, _, code) = run_jq_full(&["-c", ". | parent"], Some("1"))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{}");
+
+    // `parent(n)` with `n` strictly greater than the current path's depth
+    // (genuinely overshoots past the root, unlike `parent(2)` above which
+    // stays within the path) -- `n == depth` is #1476's exact-boundary bug,
+    // deliberately not exercised here since it would pin the wrong answer.
+    let (output, _, code) = run_jq_full(
+        &["-c", ".a.b.c | parent(4)"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{}");
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1449

## Summary

- #1313/#1445 converted three arms of `eval_pipe_with_path_context_internal` to route through the shared `continue_rest_with_context` helper instead of each hand-rolling "if `rest` is empty, return; else recurse". This PR converts the five remaining sites #1449 identified with the same shape:
  - The `PathNoArg`/`Key`/`FileIndex` early-return blocks — continuation keeps `root`/`current_path` unchanged, a direct drop-in for the helper's `Owned(v)` branch.
  - The `Parent`/`ParentN` early-return blocks — continuation needs the *parent's* path, not the ambient one; `continue_rest_with_context` already takes `current_path` as a plain parameter, so this is just passing `&parent_path` instead, not a signature change.
  - The `Expr::Array(inner) if needs_path_context(inner)` arm — routed through `continue_rest_with_fresh_root` (the sibling helper #1403's fix added for `StringInterpolation`'s identical "the value just built is a fresh root" reset), since array construction disconnects from the enclosing position the same way.

## Verification

- Pure refactor, no behavior change intended. Differential-tested the pre- and post-change binaries against ~25 queries covering every converted arm (`path`, `key`, `file_index`, `parent`, `parent(n)` including past-root and `parent(empty)`/type-error cases, `[key]` and its path-reset continuation, error/optional interaction) — all byte-identical output.
- Full local suite green: build, full test suite, both clippy legs (`--all-features` and the CI's narrower feature-set leg), `cargo fmt --check`, rustdoc, `--no-default-features` (no_std) build.
- No new executable lines (pure deletion/simplification), so no patch-coverage line count to report — confirmed via `omni-dev coverage diff`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo build --no-default-features`
- [x] Differential A/B testing against the pre-change binary