### PR TITLE
fix(yq): duplicate mapping keys collapse under JSON input and survive iteration (#1398)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -168,59 +168,67 @@ at all. The justification is the spec target, which is why the case belongs here
 Representative cases, each live-verified. These are gaps to close, listed here so they are
 not rediscovered from scratch.
 
-### Duplicate mapping keys
+### Duplicate mapping keys — the format leak and `.[]` collapse are resolved; four narrower gaps remain
 
-The subject of [ADR-0018](../../adrs/adr-0018.md)'s worked example. Real yq preserves
-duplicate keys almost everywhere but collapses them under iteration, and succinctly matches
-neither side consistently — and, worse, answers differently depending on whether the same
-logical document arrived as JSON or YAML:
+The subject of [ADR-0018](../../adrs/adr-0018.md)'s worked example.
+[#1398](https://github.com/rust-works/succinctly/issues/1398) resolved the two divergences it
+was filed against: real yq preserves duplicate keys almost everywhere but collapses them
+under iteration, and succinctly used to match neither side consistently — worse, it answered
+differently depending on whether the same logical document arrived as JSON or YAML:
 
 ```bash
 $ printf '{"b":1,"a":2,"b":3}' > dup.json
 $ printf 'b: 1\na: 2\nb: 3\n'   > dup.yaml
 
 $ yq            -o=json -I=0 'length' dup.json   # 3
-$ succinctly yq -o=json -I=0 'length' dup.json   # 2   <- format leaking into behaviour
+$ succinctly yq -o=json -I=0 'length' dup.json   # 3   (was 2 -- format no longer leaks)
 $ succinctly yq -o=json -I=0 'length' dup.yaml   # 3
 
 $ yq            -o=json -I=0 '[.[]]' dup.yaml    # [3,2]   — iteration collapses
-$ succinctly yq -o=json -I=0 '[.[]]' dup.yaml    # [1,2,3]
+$ succinctly yq -o=json -I=0 '[.[]]' dup.yaml    # [3,2]   (was [1,2,3])
 ```
 
 ADR-0018 rule 2 attributed the format leak to `DocumentFields::keys_dedup()`, which gated on
-input *format* where the reference tools decide on *mode*. **That attribution was wrong, and
-#1385 disproved it by removing the predicate:** `keys_dedup()` no longer exists — the rule now
-rides `EvalSemantics::COLLAPSE_DUPLICATE_KEYS`, on the mode axis rule 2 asks for — and the JSON
-column above did not move.
+input *format* where the reference tools decide on *mode*. **That attribution was wrong**:
+[#1385](https://github.com/rust-works/succinctly/issues/1385) removed the predicate entirely —
+the collapse rule now rides `EvalSemantics::COLLAPSE_DUPLICATE_KEYS`, on the mode axis rule 2
+asks for — and the JSON column above did not move, confirming the leak sat upstream of the
+evaluator the whole time.
 
-The real cause is upstream of the evaluator. `parse_input`'s `InputFormat::Json` arm
-([src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs)) materializes JSON
-input through `to_owned_canonicalizing_numbers`, an `IndexMap`, before any filter runs, so a
-repeated key has already collapsed by the time a duplicate-key rule could apply. Closing the
-format leak means giving that arm a cursor-native path, not adjusting a predicate.
+The real cause was `parse_input`'s `InputFormat::Json` arm
+([src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs)): it materialized
+JSON input through `to_owned_canonicalizing_numbers`, an `IndexMap`, before any filter ran, so a
+repeated key had already collapsed by the time a duplicate-key rule could apply. #1398 closes it
+by giving that arm a cursor-native path instead — JSON input now routes through the same
+`evaluate_yaml_direct_filtered`/`YamlIndex::mark_json_sourced` cursor evaluator YAML input (and
+JSON's own M2 fast path) already used, JSON being a syntactic subset of YAML's flow grammar.
 
-The iteration divergence (`[.[]]`) is unrelated to both and remains open on its own terms.
+The iteration divergence (`[.[]]`) is a separate axis: real yq collapses under `.[]`/`map(f)`
+traversal alone, an inconsistency `COLLAPSE_DUPLICATE_KEYS` deliberately doesn't reproduce (it's
+`false` for yq, matching every *other* builtin's preserve behavior) — its own doc comment names
+this exact gap as #1398's to fix, not its own. #1398 makes `.[]`/`map(f)` collapse
+unconditionally in both modes instead, reusing #1385's `effective_fields`/`collapsed_fields`
+rather than adding a second mechanism; the change lands on shared `eval_generic.rs` code, so it
+also fixes jq mode's own `[.[]]` as a side effect — one of #1385's five listed jq-mode gaps
+(`.`, `length`, `keys`, `keys_unsorted` remain open there).
 
-**Both divergences above are [#1398](https://github.com/rust-works/succinctly/issues/1398).**
-[#1385](https://github.com/rust-works/succinctly/issues/1385) is scoped to **jq mode** (its
-own body: *"In jq mode, `succinctly jq` emits duplicate JSON object keys verbatim"*) and
-names [#1342](https://github.com/rust-works/succinctly/issues/1342) (`paths(node_filter)`),
-[#1343](https://github.com/rust-works/succinctly/issues/1343) (`-s`/`--eval-all`/`-i` bypass
-the fix) and [#1344](https://github.com/rust-works/succinctly/issues/1344)
-(`tostream`/`walk`/`recurse`) as the yq-side continuation. None of the four covers the format
-leak or the missing `.[]` collapse, which is why #1398 exists — recording them here is the
-first half of ADR-0018 rule 6, and filing them is the second.
+Four narrower gaps this fix deliberately left alone remain open, each already filed before
+#1398 landed:
 
-Object slicing (`.[S:E]` on an object, [#1102](https://github.com/rust-works/succinctly/issues/1102))
-is another surface this same root cause reaches: it must materialize the target object into
-an `OwnedValue::Object` (an `IndexMap`) to build yq's AST-child-list view before slicing it,
-which silently collapses a genuine duplicate key the same way `to_owned()` does everywhere
-else in this list — `a: 1\nb: 2\na: 3` sliced with `.[0:6]` real yq returns `["a",1,"b",2,"a",3]`
-(6 children, both `a` entries present); succinctly returns `["a",3,"b",2]` (4 elements, the
-first `a`/`1` pair gone). Unlike the other surfaces above, there is no cursor-preserving
-alternative available here — the operation inherently needs to reorder/slice the entries, not
-just stream them — so this one is a real limit of `OwnedValue::Object`'s representation, not
-a missed wiring like #1343/#1344.
+- [#1342](https://github.com/rust-works/succinctly/issues/1342) — `paths(node_filter)` still
+  collapses (a YAML-only DOM-representation gap, unrelated to the format leak).
+- [#1343](https://github.com/rust-works/succinctly/issues/1343) — `-s`/`--eval-all`/`-i`'s DOM
+  fallback still routes through `parse_input`/`OwnedValue` for *both* formats (a pre-existing,
+  format-symmetric bug, not a new one #1398 introduced).
+- [#1344](https://github.com/rust-works/succinctly/issues/1344) — `del`/`with_entries`/
+  `map_values`/`tostream`/`walk`/`recurse` fall through `eval_generic.rs`'s wildcard bridge
+  (`eval_on_owned`), which still materializes via an `IndexMap` and collapses duplicates for
+  both formats today.
+- [#1102](https://github.com/rust-works/succinctly/issues/1102) — object slicing (`.[S:E]` on
+  an object) must materialize into an `OwnedValue::Object` to build yq's AST-child-list view
+  before slicing it, with no cursor-preserving alternative available (the operation inherently
+  needs to reorder/slice entries, not just stream them) — a real representation limit, not a
+  missed wiring like the three above.
 
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478) and

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3317,6 +3317,10 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
         ascii: config.ascii_output,
         float_style: FloatStyle::Shortest,
         control_escape: ControlEscape::Jq,
+        // Only meaningful alongside `ControlEscape::Yq` (see
+        // `JsonFormatOpts::json_sourced`'s own doc comment) -- jq mode
+        // never consults it.
+        json_sourced: false,
     };
     let json = output::format_json(value, &opts);
 

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -337,6 +337,14 @@ pub struct JsonFormatOpts<'a> {
     pub float_style: FloatStyle,
     /// Control-character escaping convention (jq vs yq).
     pub control_escape: ControlEscape,
+    /// Whether the source document was JSON (only meaningful alongside
+    /// `control_escape: Yq` — see the `Float` arm's own `json_sourced`
+    /// branch below). A JSON-sourced float never keeps a decimal point in
+    /// output, computed or not, compact or pretty (#978, #1398) — unlike
+    /// `float_style`, which only distinguishes compact/pretty for *jq*
+    /// mode (yq's own compact/pretty JSON output always agree with each
+    /// other on float formatting; see [`format_float_yq`]'s doc comment).
+    pub json_sourced: bool,
 }
 
 /// Escape a JSON string body per the opts' control-escape style and ASCII mode.
@@ -403,6 +411,15 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                     // `jq_runner.rs`'s two `LiteralFormatter` impls).
                     nonfinite_display_string::<JqSemantics>(*f).to_string()
                 }
+            } else if opts.control_escape == ControlEscape::Yq && opts.json_sourced {
+                // A JSON-sourced float never keeps a decimal point, in any
+                // output mode (#978, #1398) -- real yq's JSON-input
+                // convention is a plain re-serialize through bare `f64`
+                // `Display`, with no scientific-notation threshold at all
+                // (matching `format_float_yq`'s own doc comment on this
+                // exact exclusion, and the M2 streaming writers' identical
+                // `json_sourced_canonical_float` rule in `src/yaml/light.rs`).
+                f.to_string()
             } else if opts.control_escape == ControlEscape::Yq {
                 // yq mode: scientific notation past yq's magnitude threshold
                 // (#997), decimal-with-fraction otherwise, regardless of
@@ -962,6 +979,7 @@ mod tests {
             ascii: false,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         assert_eq!(format_json(&value, &opts), r#"{"a":2,"z":1}"#);
     }
@@ -975,6 +993,7 @@ mod tests {
             ascii: false,
             float_style,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         assert_eq!(format_json(&value, &opts(FloatStyle::Shortest)), "1");
         assert_eq!(
@@ -1022,6 +1041,7 @@ mod tests {
             ascii: false,
             float_style,
             control_escape: ControlEscape::Yq,
+            json_sourced: false,
         };
         let huge = OwnedValue::Float(1e100);
         assert_eq!(format_json(&huge, &opts(FloatStyle::Shortest)), "1e+100");
@@ -1127,6 +1147,7 @@ mod tests {
             ascii: true,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Yq,
+            json_sourced: false,
         };
         assert_eq!(
             format_json(&OwnedValue::Object(obj), &opts),
@@ -1147,6 +1168,7 @@ mod tests {
             ascii: false,
             float_style: FloatStyle::PreserveWholeFloat,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         assert_eq!(format_json(&OwnedValue::Float(f64::NAN), &opts), "null");
         assert_eq!(
@@ -1163,6 +1185,7 @@ mod tests {
         // than substituting anything).
         let yq_opts = JsonFormatOpts {
             control_escape: ControlEscape::Yq,
+            json_sourced: false,
             ..opts
         };
         assert_eq!(
@@ -1184,6 +1207,7 @@ mod tests {
             ascii: false,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         let overflowed = OwnedValue::NumberLiteral(
             succinctly::jq::NumberRepr::Float(f64::INFINITY),
@@ -1196,6 +1220,7 @@ mod tests {
         // against real yq.
         let yq_opts = JsonFormatOpts {
             control_escape: ControlEscape::Yq,
+            json_sourced: false,
             ..opts
         };
         assert_eq!(format_json(&overflowed, &yq_opts), "1e400");
@@ -1214,6 +1239,7 @@ mod tests {
             ascii: false,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         assert_eq!(format_json(&OwnedValue::Array(vec![]), &pretty), "[]");
         assert_eq!(
@@ -1236,6 +1262,7 @@ mod tests {
             ascii: true,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
         assert_eq!(
             format_json(&value, &opts),
@@ -1302,6 +1329,7 @@ mod tests {
             ascii: false,
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
+            json_sourced: false,
         };
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -130,6 +130,19 @@ struct OutputConfig {
     no_doc: bool,
     indent_str: String,
     use_color: bool,
+    /// A JSON-sourced float never keeps a decimal point in output,
+    /// computed or not, `-o=json` or `-o=yaml`, compact or pretty (#978,
+    /// confirmed live against yq v4.53.3: `-p json '. + 1'` on `1.0` gives
+    /// `2` in every output mode, where the same computation on genuine
+    /// YAML input keeps `2.0` under pretty `-o=json`). The cursor-native
+    /// evaluator (#1398) no longer routes JSON input through a text
+    /// round-trip that happened to erase the decimal point as a side
+    /// effect (`evaluate_input`'s reindex bridge), so this flag makes the
+    /// override explicit instead of relying on that accident. Per-input-
+    /// source, not global: set by the caller for the specific file/stream
+    /// currently being formatted, since `--input-format auto` can mix
+    /// JSON and YAML sources in one invocation.
+    json_sourced_floats: bool,
 }
 
 impl OutputConfig {
@@ -163,6 +176,7 @@ impl OutputConfig {
             no_doc: args.no_doc,
             indent_str,
             use_color,
+            json_sourced_floats: false,
         }
     }
 }
@@ -547,11 +561,35 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
 /// A single jq result value paired with its parallel [`CommentTree`] (issue #710).
 type ResultWithComments = (OwnedValue, CommentTree);
 
-/// Evaluate YAML input directly using the generic evaluator with per-document processing.
+/// Flags for [`evaluate_yaml_direct_filtered`], grouped into one struct
+/// rather than four bool parameters (clippy's `fn_params_excessive_bools`/
+/// `too_many_arguments`, #1398).
+struct DirectEvalOptions {
+    need_comments: bool,
+    strip_style: bool,
+    sort_keys: bool,
+    /// Route JSON input through `YamlIndex::mark_json_sourced` instead of
+    /// evaluating genuine YAML source — see the function's own doc comment.
+    mark_json_sourced: bool,
+}
+
+/// Evaluate YAML *or JSON* input directly using the generic evaluator with
+/// per-document processing.
 ///
-/// This processes YAML documents directly without intermediate OwnedValue conversion,
-/// preserving position metadata for `line` and `column` builtins. Returns results
-/// grouped by document for proper multi-doc handling (with `---` separators).
+/// This processes documents directly without intermediate `OwnedValue`
+/// conversion, preserving position metadata for `line`/`column` builtins
+/// (YAML) and, just as importantly, preserving duplicate mapping keys
+/// through builtins like `length`/`to_entries` (#1398) — `OwnedValue::Object`
+/// is `IndexMap`-backed and structurally can't represent them. JSON is a
+/// YAML subset, so `mark_json_sourced` routes JSON input through the same
+/// `YamlIndex`/cursor-native path the M2 streaming fast path already uses
+/// for JSON (`index.mark_json_sourced()` there too), rather than the
+/// eager-materializing `parse_input`/`evaluate_input` pair — this is what
+/// stops yq mode's duplicate-key behavior from depending on which format the
+/// same logical document arrived as.
+///
+/// Returns results grouped by document for proper multi-doc handling (with
+/// `---` separators).
 ///
 /// If `doc_filter` is Some((target_doc, global_offset)), only the document at global index
 /// `target_doc` will be evaluated (where global index = global_offset + local_doc_index).
@@ -561,11 +599,19 @@ fn evaluate_yaml_direct_filtered(
     expr: &Expr,
     doc_filter: Option<(usize, usize)>,
     sink: &mut ErrorSink,
-    need_comments: bool,
-    strip_style: bool,
-    sort_keys: bool,
+    opts: DirectEvalOptions,
 ) -> Result<(Vec<Vec<ResultWithComments>>, usize)> {
-    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+    let DirectEvalOptions {
+        need_comments,
+        strip_style,
+        sort_keys,
+        mark_json_sourced,
+    } = opts;
+    let mut index =
+        YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+    if mark_json_sourced {
+        index.mark_json_sourced();
+    }
     let root = index.root(bytes);
 
     // YAML documents are wrapped in a sequence at the root
@@ -1755,6 +1801,7 @@ fn output_value<W: Write>(
             } else {
                 FloatStyle::PreserveWholeFloat
             },
+            json_sourced: config.json_sourced_floats,
             control_escape: ControlEscape::Yq,
         },
     );
@@ -3599,94 +3646,75 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
             let mut global_doc_index: usize = 0;
             'files: for (bytes, format, _) in &input_sources {
-                match format {
-                    InputFormat::Yaml | InputFormat::Auto => {
-                        let doc_filter = args.document.map(|target| (target, global_doc_index));
-                        // Split-exp output files carry real comments when
-                        // written as YAML, same as the main output path (#710).
-                        let need_comments = output_config.output_format == OutputFormat::Yaml;
-                        let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
-                            bytes,
-                            &program.expr,
-                            doc_filter,
+                // Yaml/Auto and Json both go through the same cursor-native
+                // evaluator now (#1398) -- JSON is a YAML subset, and
+                // routing it through `YamlIndex`/`mark_json_sourced` here
+                // (rather than `parse_input`'s eager `OwnedValue`
+                // materialization) is what keeps duplicate-key handling
+                // consistent regardless of which format the same logical
+                // document arrived as. `--slurp`/`--eval-all`/`--inplace`'s
+                // DOM fallback still use the old `parse_input`/
+                // `evaluate_input` pair for both formats -- a separate,
+                // already-tracked issue (#1343), not touched here.
+                let doc_filter = args.document.map(|target| (target, global_doc_index));
+                // Split-exp output files carry real comments when
+                // written as YAML, same as the main output path (#710).
+                let need_comments = output_config.output_format == OutputFormat::Yaml;
+                let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+                    bytes,
+                    &program.expr,
+                    doc_filter,
+                    &mut sink,
+                    DirectEvalOptions {
+                        need_comments,
+                        strip_style: args.pretty_print,
+                        sort_keys: output_config.sort_keys,
+                        mark_json_sourced: *format == InputFormat::Json,
+                    },
+                )?;
+                global_doc_index += num_docs;
+                // A JSON-sourced float never keeps a decimal point in
+                // `-o=json` output (#978, #1398) -- see
+                // `OutputConfig::json_sourced_floats`'s own doc comment.
+                let file_output_config = if *format == InputFormat::Json {
+                    OutputConfig {
+                        json_sourced_floats: true,
+                        ..output_config.clone()
+                    }
+                } else {
+                    output_config.clone()
+                };
+                for results in doc_results {
+                    // See the --null-input arm above: a halt already
+                    // present when this document's batch starts
+                    // means every element of `results` is a
+                    // legitimate pre-halt prefix that still owes its
+                    // file, so only a *new* halt (from this batch's
+                    // own split-filename evaluation) should stop the
+                    // loop early (#791).
+                    let halted_before_batch = sink.halted().is_some();
+                    for (result, comments) in &results {
+                        any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
+                        write_split_result(
+                            result,
+                            comments,
+                            split_expr,
+                            output_index,
+                            &file_output_config,
+                            &mut written_split_files,
                             &mut sink,
-                            need_comments,
-                            args.pretty_print,
-                            output_config.sort_keys,
                         )?;
-                        global_doc_index += num_docs;
-                        for results in doc_results {
-                            // See the --null-input arm above: a halt already
-                            // present when this document's batch starts
-                            // means every element of `results` is a
-                            // legitimate pre-halt prefix that still owes its
-                            // file, so only a *new* halt (from this batch's
-                            // own split-filename evaluation) should stop the
-                            // loop early (#791).
-                            let halted_before_batch = sink.halted().is_some();
-                            for (result, comments) in &results {
-                                any_truthy |=
-                                    !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
-                                write_split_result(
-                                    result,
-                                    comments,
-                                    split_expr,
-                                    output_index,
-                                    &output_config,
-                                    &mut written_split_files,
-                                    &mut sink,
-                                )?;
-                                output_index += 1;
-                                // halt/halt_error (#791) outranks writing any
-                                // further split files or evaluating any
-                                // further documents/inputs/files.
-                                if !halted_before_batch && sink.halted().is_some() {
-                                    break 'files;
-                                }
-                            }
-                        }
-                        if sink.halted().is_some() {
+                        output_index += 1;
+                        // halt/halt_error (#791) outranks writing any
+                        // further split files or evaluating any
+                        // further documents/inputs/files.
+                        if !halted_before_batch && sink.halted().is_some() {
                             break 'files;
                         }
                     }
-                    InputFormat::Json => {
-                        let inputs = parse_input(bytes, InputFormat::Json)?;
-                        for input in inputs {
-                            if let Some(target_doc) = args.document {
-                                if global_doc_index != target_doc {
-                                    global_doc_index += 1;
-                                    continue;
-                                }
-                            }
-                            let results = evaluate_input(&input, &program.expr, &mut sink)?;
-                            // See the --null-input arm above: a pre-existing
-                            // halt means every element of `results` is a
-                            // legitimate pre-halt prefix still owed its file
-                            // (#791).
-                            let halted_before_batch = sink.halted().is_some();
-                            for result in &results {
-                                any_truthy |=
-                                    !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
-                                write_split_result(
-                                    result,
-                                    &CommentTree::empty(),
-                                    split_expr,
-                                    output_index,
-                                    &output_config,
-                                    &mut written_split_files,
-                                    &mut sink,
-                                )?;
-                                output_index += 1;
-                                if !halted_before_batch && sink.halted().is_some() {
-                                    break 'files;
-                                }
-                            }
-                            global_doc_index += 1;
-                            if sink.halted().is_some() {
-                                break 'files;
-                            }
-                        }
-                    }
+                }
+                if sink.halted().is_some() {
+                    break 'files;
                 }
             }
         }
@@ -4148,9 +4176,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
         }
     } else {
-        // Standard path: evaluate inputs
-        // For YAML inputs, use direct evaluation to preserve position metadata
-        // For JSON inputs, use the OwnedValue path
+        // Standard path: evaluate inputs. Both YAML and JSON input go
+        // through `evaluate_yaml_direct_filtered`'s cursor-native evaluator
+        // (#1398) -- see its own doc comment for why.
 
         // Collect input sources with their bytes and formats. `--front-matter`
         // is applied before validation, since the raw file bytes (e.g.
@@ -4171,70 +4199,40 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // This avoids double-parsing YAML for document counting
         // Each entry in all_results is a Vec of document results from one file.
         // Each result carries its parallel CommentTree (issue #710); JSON
-        // input has none, so it's paired with CommentTree::empty().
+        // input has none, so it's paired with CommentTree::empty()
+        // internally by `evaluate_yaml_direct_filtered`'s `need_comments`
+        // gate below.
         let mut all_results: Vec<Vec<Vec<ResultWithComments>>> = Vec::new();
         let mut global_doc_index: usize = 0;
         'collect: for (bytes, format, _) in &input_sources {
-            match format {
-                InputFormat::Yaml | InputFormat::Auto => {
-                    // Use direct YAML evaluation to preserve position metadata
-                    // Filter at evaluation time to avoid evaluating (and printing errors for)
-                    // documents that don't match the --doc filter
-                    let doc_filter = args.document.map(|target| (target, global_doc_index));
-                    // JSON output never reads `CommentTree` (see
-                    // `output_value`'s JSON branch), so don't build one (#710).
-                    let need_comments = output_config.output_format == OutputFormat::Yaml;
-                    let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
-                        bytes,
-                        &program.expr,
-                        doc_filter,
-                        &mut sink,
-                        need_comments,
-                        args.pretty_print,
-                        output_config.sort_keys,
-                    )?;
-                    global_doc_index += num_docs;
-                    all_results.push(doc_results);
-                    // halt/halt_error (#791) outranks evaluating any further
-                    // files — whatever was collected so far still prints below.
-                    if sink.halted().is_some() {
-                        break 'collect;
-                    }
-                }
-                InputFormat::Json => {
-                    // Use OwnedValue path for JSON
-                    let inputs = parse_input(bytes, InputFormat::Json)?;
-                    let mut json_results = Vec::new();
-                    for input in inputs {
-                        // Apply --doc filter if specified
-                        if let Some(target_doc) = args.document {
-                            if global_doc_index != target_doc {
-                                global_doc_index += 1;
-                                continue;
-                            }
-                        }
-                        let results = evaluate_input(&input, &program.expr, &mut sink)?;
-                        json_results.push(
-                            results
-                                .into_iter()
-                                .map(|v| (v, CommentTree::empty()))
-                                .collect::<Vec<_>>(),
-                        );
-                        global_doc_index += 1;
-                        // halt/halt_error (#791): stop evaluating further
-                        // inputs in this file (and, below, further files) —
-                        // whatever was collected so far still prints below.
-                        if sink.halted().is_some() {
-                            break;
-                        }
-                    }
-                    all_results.push(json_results);
-                    // halt/halt_error (#791) outranks evaluating any further
-                    // files — matches the sibling YAML arm above.
-                    if sink.halted().is_some() {
-                        break 'collect;
-                    }
-                }
+            // Yaml/Auto and Json both go through the same cursor-native
+            // evaluator now (#1398) -- see the matching comment on the
+            // `--split-exp` loop above for why (JSON is a YAML subset;
+            // routing it through `YamlIndex`/`mark_json_sourced` keeps
+            // duplicate-key handling format-independent, unlike the old
+            // `parse_input`/`evaluate_input` eager-`OwnedValue` path).
+            let doc_filter = args.document.map(|target| (target, global_doc_index));
+            // JSON output never reads `CommentTree` (see
+            // `output_value`'s JSON branch), so don't build one (#710).
+            let need_comments = output_config.output_format == OutputFormat::Yaml;
+            let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+                bytes,
+                &program.expr,
+                doc_filter,
+                &mut sink,
+                DirectEvalOptions {
+                    need_comments,
+                    strip_style: args.pretty_print,
+                    sort_keys: output_config.sort_keys,
+                    mark_json_sourced: *format == InputFormat::Json,
+                },
+            )?;
+            global_doc_index += num_docs;
+            all_results.push(doc_results);
+            // halt/halt_error (#791) outranks evaluating any further
+            // files — whatever was collected so far still prints below.
+            if sink.halted().is_some() {
+                break 'collect;
             }
         }
 
@@ -4253,6 +4251,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let front_matter_body = input_sources
                 .get(file_idx)
                 .and_then(|(_, _, body)| body.as_ref());
+            // A JSON-sourced float never keeps a decimal point in `-o=json`
+            // output (#978, #1398) -- see `OutputConfig::json_sourced_floats`'s
+            // own doc comment. Per file/source, not global: `--input-format
+            // auto` can mix JSON and YAML sources in one invocation.
+            let file_output_config = if input_sources.get(file_idx).map(|(_, format, _)| *format)
+                == Some(InputFormat::Json)
+            {
+                OutputConfig {
+                    json_sourced_floats: true,
+                    ..output_config.clone()
+                }
+            } else {
+                output_config.clone()
+            };
             if front_matter_body.is_some() {
                 writeln!(writer, "---")?;
             }
@@ -4267,9 +4279,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     writeln!(writer, "---")?;
                 }
                 for (result, comments) in results {
-                    split_doc_state.write_separator(&mut writer, &output_config)?;
+                    split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    output_value(&mut writer, &result, &comments, &output_config)?;
+                    output_value(&mut writer, &result, &comments, &file_output_config)?;
                 }
             }
             if let Some(body) = front_matter_body {
@@ -4398,6 +4410,7 @@ mod tests {
             no_doc: false,
             indent_str: String::new(),
             use_color: false,
+            json_sourced_floats: false,
         };
 
         let nan = OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), "nan".into());
@@ -4475,6 +4488,7 @@ mod tests {
             no_doc: false,
             indent_str: String::new(),
             use_color: false,
+            json_sourced_floats: false,
         };
 
         let mut obj = IndexMap::new();
@@ -4700,9 +4714,12 @@ mod tests {
             expr,
             None,
             &mut ErrorSink::default(),
-            true,
-            false,
-            false,
+            DirectEvalOptions {
+                need_comments: true,
+                strip_style: false,
+                sort_keys: false,
+                mark_json_sourced: false,
+            },
         )
         .unwrap();
         groups.into_iter().flatten().collect()
@@ -4918,6 +4935,7 @@ mod tests {
             no_doc: false,
             indent_str: String::new(),
             use_color: false,
+            json_sourced_floats: false,
         };
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -144,6 +144,22 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         ""
     }
 
+    /// Whether this cursor's document is JSON-sourced and should canonicalize
+    /// number literals rather than preserve their source spelling (#978,
+    /// #1398).
+    ///
+    /// Returns `false` by default (preserve spelling, #918's YAML behavior
+    /// and JSON-cursor evaluation's own long-standing behavior alike). Only
+    /// a `YamlCursor` whose index was
+    /// [`mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced)-
+    /// tagged overrides this — real yq's own JSON-input convention is a
+    /// JSON-sourced number never keeps its own spelling, computed or not, a
+    /// convention YAML's own `!!float`/exponent literal preservation must
+    /// not inherit just because JSON parses through the same cursor type.
+    fn canonicalize_numbers(&self) -> bool {
+        false
+    }
+
     /// Get this node's trailing same-line comment text, with the leading
     /// `#`/space stripped (the `line_comment` jq builtin, issue #710).
     ///

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -822,6 +822,19 @@ enum LazySource<V: DocumentValue> {
     /// Array `keys_unsorted | map(f)` (#724) — synthetic `[0, 1, ..., len-1]`,
     /// no cursor to point at.
     IndexRange { next: usize, len: usize },
+    /// `Values`'s duplicate-key fallback (#1398): `obj | map(f)` is `[.[] |
+    /// f]`, and `.[]` collapses a repeated key to its first position but
+    /// last-seen value in both modes (see `Expr::Iterate`'s identical
+    /// rule). That requires seeing every occurrence before any value can
+    /// be emitted, so it can't stay a `Fields` cons-list walk -- this
+    /// variant holds the already-collapsed value cursors instead.
+    /// Constructed only when `document::collapsed_fields` actually finds a
+    /// repeat, so the ordinary duplicate-free `Values` path above is
+    /// unaffected.
+    CollapsedValues {
+        cursors: Vec<V::Cursor>,
+        next: usize,
+    },
 }
 
 // See `LazyElem`'s `Debug` impl above for why this is hand-written, not derived.
@@ -835,6 +848,11 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
                 .debug_struct("LazySource::IndexRange")
                 .field("next", next)
                 .field("len", len)
+                .finish(),
+            Self::CollapsedValues { next, cursors } => f
+                .debug_struct("LazySource::CollapsedValues")
+                .field("next", next)
+                .field("len", &cursors.len())
                 .finish(),
         }
     }
@@ -868,6 +886,11 @@ impl<V: DocumentValue> LazySource<V> {
                 let i = *next;
                 *next += 1;
                 Some(LazyElem::Owned(OwnedValue::Int(i as i64)))
+            }
+            Self::CollapsedValues { cursors, next } => {
+                let cursor = cursors.get(*next).copied()?;
+                *next += 1;
+                Some(LazyElem::Cursor(cursor))
             }
         }
     }
@@ -2364,13 +2387,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     GenericResult::ManyCursor(cursors)
                 }
             } else if let Some(fields) = value.as_object() {
-                // Duplicate keys collapse here in jq mode (#1385): `.[]` on
-                // `{"b":1,"a":2,"b":3}` yields `3, 2`, not `1, 2, 3`, since
-                // the object jq iterates only ever had two members. yq keeps
-                // all three -- `S::COLLAPSE_DUPLICATE_KEYS` is false there,
-                // so `effective_fields` reduces to the plain walk this used
-                // to do inline, and monomorphization drops the check.
-                let cursors: Vec<_> = effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS)
+                // `.[]` collapses a repeated key to its first position but
+                // last-seen value in *both* modes (#1398) -- unlike every
+                // other builtin `S::COLLAPSE_DUPLICATE_KEYS` governs, real
+                // yq is inconsistent here and does collapse under `.[]`
+                // traversal alone (confirmed live against yq v4.53.3), so
+                // this always passes `true` rather than the mode flag.
+                let cursors: Vec<_> = effective_fields(&fields, true)
                     .into_iter()
                     .map(|field| field.value_cursor)
                     .collect();
@@ -4093,7 +4116,25 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     LazySeq::new(LazySource::Elements(elements)).push_map(f, S::TAG),
                 )
             } else if let Some(fields) = value.as_object() {
-                GenericResult::LazySeq(LazySeq::new(LazySource::Values(fields)).push_map(f, S::TAG))
+                // `.[]` collapses a repeated key to its first position but
+                // last-seen value in both modes (#1398), which needs every
+                // occurrence seen before any value can be emitted --
+                // incompatible with `Values`'s incremental cons-list pull.
+                // `collapsed_fields` gates the materializing fallback
+                // behind a cheap fingerprint probe (`document::census`),
+                // so the duplicate-free case (by far the common one) keeps
+                // #724/#725's lazy pull unchanged.
+                let source = match collapsed_fields(&fields) {
+                    Some(collapsed) => LazySource::CollapsedValues {
+                        cursors: collapsed
+                            .into_iter()
+                            .map(|field| field.value_cursor)
+                            .collect(),
+                        next: 0,
+                    },
+                    None => LazySource::Values(fields),
+                };
+                GenericResult::LazySeq(LazySeq::new(source).push_map(f, S::TAG))
             } else if optional {
                 GenericResult::None
             } else {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -219,6 +219,21 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(cursor: &C, depth: usize) -> Owne
         cursor
             .explicit_tag()
             .and_then(|tag| tagged_scalar_to_owned(tag, &value))
+            .or_else(|| {
+                // A JSON-sourced number literal never keeps its own
+                // spelling (#978, #1398) -- checked before the ordinary
+                // `to_owned_at_depth` fallback below, which preserves it
+                // (correct for genuine YAML, #918). `explicit_tag` still
+                // takes precedence: a tag-forced type is a stronger,
+                // narrower signal than the document's own source format.
+                if cursor.canonicalize_numbers() {
+                    value
+                        .number_literal()
+                        .map(|literal| OwnedValue::from_number_literal_plain(&literal))
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(|| to_owned_at_depth(&value, depth))
     }
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2573,6 +2573,20 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// rather than the value's real one (#835) — callers that can't
     /// guarantee `self` is already resolved must resolve first themselves.
     pub fn style(&self) -> &'static str {
+        // JSON has exactly one syntactic style for every container/string --
+        // it isn't a deliberate style choice the way YAML's block/flow or
+        // plain/quoted distinction is. Reporting it here would make the
+        // writer "preserve" flow style/quoting on every JSON-sourced node
+        // regardless of what the query did, which is not what real yq does:
+        // JSON -> YAML output always uses YAML's own default (block
+        // collections, unquoted scalars where safe) rather than echoing
+        // JSON's own `{}`/`""` syntax back (#1398). Style detection stays
+        // meaningful for JSON-sourced *output*'s number canonicalization
+        // sibling, `canonicalize_numbers` -- this only suppresses the style
+        // string itself.
+        if self.index.canonicalize_numbers() {
+            return "";
+        }
         let Some(text_pos) = self.text_position() else {
             return "";
         };

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6001,6 +6001,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn canonicalize_numbers(&self) -> bool {
+        self.index.canonicalize_numbers()
+    }
+
+    #[inline]
     fn line_comment(&self) -> Option<String> {
         YamlCursor::line_comment(self).map(ToString::to_string)
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1007,11 +1007,16 @@ fn test_duplicate_mapping_key_survives_comma_wrapped_to_entries_1168() -> Result
     Ok(())
 }
 
-/// #1168: `Expr::Array`/`Expr::Comma`'s new native arms must still dedupe a
-/// duplicate *JSON* key exactly like bare `to_entries` does (#1170) -- the
-/// wrapping fix must not disturb the format-aware dedup rule itself.
+/// #1168: `Expr::Array`/`Expr::Comma`'s new native arms must agree with bare
+/// `to_entries` on duplicate-key handling for *JSON* input too -- the
+/// wrapping fix must not disturb that rule either way. Updated for #1398:
+/// yq mode's `to_entries` preserves every duplicate key regardless of input
+/// format (real yq answers identically whether the document arrived as JSON
+/// or YAML) -- `[to_entries]`/`to_entries, to_entries` on JSON input used to
+/// collapse to the first-position/last-value entry, which was itself the
+/// #1398 format-leak bug, not a rule this wrapping fix needed to preserve.
 #[test]
-fn test_json_duplicate_key_array_comma_wrapped_to_entries_still_dedupes_1168() -> Result<()> {
+fn test_json_duplicate_key_array_comma_wrapped_to_entries_preserves_1398() -> Result<()> {
     let json = r#"{"a":1,"b":2,"a":3}"#;
     let extra_args = ["--input-format", "json", "-o=json", "-I=0"];
 
@@ -1019,14 +1024,14 @@ fn test_json_duplicate_key_array_comma_wrapped_to_entries_still_dedupes_1168() -
     assert_eq!(code, 0);
     assert_eq!(
         array_output.trim(),
-        r#"[[{"key":"a","value":3},{"key":"b","value":2}]]"#
+        r#"[[{"key":"a","value":1},{"key":"b","value":2},{"key":"a","value":3}]]"#
     );
 
     let (comma_output, code) = run_yq_stdin("to_entries, to_entries", json, &extra_args)?;
     assert_eq!(code, 0);
     assert_eq!(
         comma_output.trim(),
-        "[{\"key\":\"a\",\"value\":3},{\"key\":\"b\",\"value\":2}]\n[{\"key\":\"a\",\"value\":3},{\"key\":\"b\",\"value\":2}]"
+        "[{\"key\":\"a\",\"value\":1},{\"key\":\"b\",\"value\":2},{\"key\":\"a\",\"value\":3}]\n[{\"key\":\"a\",\"value\":1},{\"key\":\"b\",\"value\":2},{\"key\":\"a\",\"value\":3}]"
     );
     Ok(())
 }
@@ -1080,14 +1085,16 @@ fn test_yq_array_wrapped_partial_halt_discards_prefix_1168() -> Result<()> {
     Ok(())
 }
 
-/// #1170: unlike YAML's genuine duplicates (preserved unmerged above, per
-/// #443), a duplicate key on `--input-format json` input must collapse to
-/// one entry -- keeping the first occurrence's position but the last
-/// occurrence's value, matching real jq's own `to_entries` behavior on
-/// duplicate JSON keys (the two formats have opposite correct behavior
-/// here, and `to_entries`'s cursor-native walk is shared between them).
+/// Updated for #1398: real yq's `to_entries` preserves every duplicate key
+/// regardless of whether the input arrived as JSON or YAML (confirmed live
+/// against yq v4.53.3) -- unlike jq mode, where a duplicate *JSON* key does
+/// collapse (first position, last value, #1385's own separate axis). #1170
+/// originally pinned yq mode's JSON input to jq's collapsing rule; that was
+/// the `DocumentFields::keys_dedup()` format-leak #1398 fixes, not yq's
+/// actual behavior -- yq mode's `to_entries` no longer depends on input
+/// format at all.
 #[test]
-fn test_duplicate_json_key_to_entries_deduplicates_1170() -> Result<()> {
+fn test_duplicate_json_key_to_entries_preserves_1398() -> Result<()> {
     let json = r#"{"a":1,"b":2,"a":3}"#;
     let (output, code) = run_yq_stdin(
         "to_entries",
@@ -1098,7 +1105,7 @@ fn test_duplicate_json_key_to_entries_deduplicates_1170() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(
         output.trim(),
-        r#"[{"key":"a","value":3},{"key":"b","value":2}]"#
+        r#"[{"key":"a","value":1},{"key":"b","value":2},{"key":"a","value":3}]"#
     );
     Ok(())
 }
@@ -1136,14 +1143,16 @@ fn test_yq_paths_preserves_nested_duplicate_mapping_keys_868() -> Result<()> {
     Ok(())
 }
 
-/// #868: `paths` on `--input-format json` input must still apply *JSON's*
-/// own duplicate-key rule (first position, last value -- #1170) rather than
-/// YAML's preserve-every-occurrence rule, the same format-aware split
-/// `to_entries` already established. Confirms the fix's `effective_fields`
-/// call is genuinely format-aware, not a blanket switch to "always keep
-/// duplicates."
+/// Updated for #1398: `paths` on `--input-format json` input must now agree
+/// with YAML input (both preserve every duplicate-key occurrence, matching
+/// `to_entries`'s own format-independent behavior) rather than applying
+/// JSON's old collapsing rule -- there's no real-yq oracle for `paths` (a
+/// succinctly extension), so the acceptance criterion stays internal
+/// consistency: this must report the same path count as the sibling YAML
+/// test `test_yq_paths_preserves_duplicate_mapping_keys_868` above for the
+/// equivalent document, and as `to_entries` on this same JSON input.
 #[test]
-fn test_yq_paths_json_input_format_still_dedupes_868() -> Result<()> {
+fn test_yq_paths_json_input_format_preserves_1398() -> Result<()> {
     let json = r#"{"a":1,"a":2,"b":3}"#;
     let (output, code) = run_yq_stdin(
         "[paths]",
@@ -1152,7 +1161,52 @@ fn test_yq_paths_json_input_format_still_dedupes_868() -> Result<()> {
     )?;
 
     assert_eq!(code, 0, "out: {output:?}");
-    assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
+    assert_eq!(output.trim(), r#"[["a"],["a"],["b"]]"#);
+    Ok(())
+}
+
+/// #1398: the issue's own reproduction table, run against every filter it
+/// lists, on both `{"b":1,"a":2,"b":3}` (JSON) and the logically identical
+/// `b: 1\na: 2\nb: 3\n` (YAML). Every filter here must answer *identically*
+/// regardless of which format the same logical document arrived as -- the
+/// format-leak `DocumentFields::keys_dedup()` gated on input format instead
+/// of mode, which this pins directly, filter by filter. `map_values(.)`
+/// isn't included: it goes through the wildcard-bridge fallback
+/// (`eval_on_owned`), which still collapses duplicates for both formats
+/// today (#1344's scope, not fixed by this issue).
+#[test]
+fn test_1398_dup_key_format_parity_across_filters() -> Result<()> {
+    let json = r#"{"b":1,"a":2,"b":3}"#;
+    let yaml = "b: 1\na: 2\nb: 3\n";
+    let cases: &[(&str, &str)] = &[
+        (".", r#"{"b":1,"a":2,"b":3}"#),
+        ("length", "3"),
+        ("keys", r#"["b","a","b"]"#),
+        (
+            "to_entries",
+            r#"[{"key":"b","value":1},{"key":"a","value":2},{"key":"b","value":3}]"#,
+        ),
+        ("[.[]]", "[3,2]"),
+        (".b", "3"),
+    ];
+    for (filter, expected) in cases {
+        let (json_out, json_code) =
+            run_yq_stdin(filter, json, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(json_code, 0, "filter {filter:?} on JSON input");
+        assert_eq!(
+            json_out.trim(),
+            *expected,
+            "filter {filter:?} on JSON input"
+        );
+
+        let (yaml_out, yaml_code) = run_yq_stdin(filter, yaml, &["-o=json", "-I=0"])?;
+        assert_eq!(yaml_code, 0, "filter {filter:?} on YAML input");
+        assert_eq!(
+            yaml_out.trim(),
+            *expected,
+            "filter {filter:?} on YAML input"
+        );
+    }
     Ok(())
 }
 
@@ -13611,22 +13665,50 @@ fn test_json_input_rejects_adversarial_nesting_via_m2_path_996() -> Result<()> {
     Ok(())
 }
 
-/// Companion to the above: `-P` forces the DOM path (pretty-print isn't
-/// implemented by the M2 streamers), which parses JSON input through
-/// `JsonIndex::build` (no parse-time depth guard of its own) rather than
-/// `YamlIndex::build` -- #998's own `eval_generic::to_owned`
-/// conversion-time 256 guard is the one that fires here, unchanged by
-/// #996, confirming it's still live and not dead code now that the
-/// YAML-parser guard catches the M2-eligible case earlier.
+/// Companion to the above: `--eval-all` is the one remaining trigger for
+/// `JsonIndex::build` + `eval_generic::to_owned`'s conversion-time 256
+/// guard (no parse-time depth guard of its own) -- confirming it's still
+/// live and not dead code, now that the YAML-parser guard catches every
+/// other JSON-input path earlier.
+///
+/// Updated for #1398: `-P` (this test's original trigger) no longer forces
+/// the `JsonIndex` DOM path at all -- yq mode's "Standard path" and
+/// `--split-exp` now route *every* JSON query through
+/// `YamlIndex`/`mark_json_sourced` (the same cursor-native evaluator YAML
+/// input uses), specifically so duplicate-key handling stops depending on
+/// input format. `-P --input-format json` on this same adversarial input
+/// now hits the depth-128 parse-time guard instead (exit 1, "128"), same as
+/// bare identity above -- `--eval-all`/`--slurp` are the only flags still
+/// routed through `parse_input`'s `JsonIndex`-based path (#1343 tracks
+/// unifying those too), so `--eval-all` is what still reaches this
+/// conversion-time guard.
 #[test]
-fn test_json_input_rejects_adversarial_nesting_via_dom_path_998() -> Result<()> {
+fn test_json_input_rejects_adversarial_nesting_via_eval_all_998() -> Result<()> {
+    let depth = 500;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--eval-all"])?;
+    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1398: `-P` no longer forces the `JsonIndex` DOM path (see the
+/// `--eval-all` test above) -- it now hits the same depth-128 parse-time
+/// guard as bare identity, same as every other non-`--eval-all`/`--slurp`
+/// JSON-input path.
+#[test]
+fn test_json_input_rejects_adversarial_nesting_via_pretty_print_1398() -> Result<()> {
     let depth = 500;
     let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
     let (_stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "-P"])?;
-    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert_eq!(code, 1, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("nesting depth exceeds limit of 256"),
+        stderr.contains("nesting depth exceeds limit of 128"),
         "stderr: {stderr:?}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #1398: yq mode's duplicate-key handling used to depend on which
format the same logical document arrived as (JSON vs YAML), and
`.[]`/`map(f)` iteration never collapsed duplicates the way real yq
itself does.

- **Format leak**: `length`/`to_entries`/etc. on JSON input took a
  completely different evaluator (`parse_input` → eager
  `OwnedValue::Object`, `IndexMap`-backed and structurally unable to
  hold duplicate keys) than YAML input did. JSON input now routes
  through the same cursor-native evaluator YAML (and JSON's own M2
  fast path) already used — `YamlIndex::mark_json_sourced`, since
  JSON is a syntactic subset of YAML's flow grammar.
- **Missing iteration collapse**: real yq preserves duplicate keys
  almost everywhere but collapses them under `.[]` traversal — `.[]`/
  `map(f)` now collapse unconditionally (both jq and yq agree here),
  via a new `DocumentFields::collapsed_fields()`, gated behind a cheap
  duplicate pre-check so the duplicate-free case stays cheap.

Widening the JSON evaluation path surfaced two gaps that path had
never had to cover before (fixed alongside it, so this doesn't
regress existing behavior): JSON-sourced computed floats not dropping
their decimal point under `-o=json`, and a JSON-sourced number
literal reached via construction (`[.a]`) not canonicalizing. Also
fixes a pre-existing, independent bug where `-p json` output leaked
JSON's own flow/quote syntax into YAML output instead of using YAML's
own default style.

Commit series (see individual commit messages for full rationale):
1. `fix(jq): collapse duplicate keys under .[]/map(f) traversal`
2. `fix(yq): stop leaking JSON's flow/quote style into YAML output`
3. `fix(yq): route JSON queries through the cursor-native evaluator instead of eager OwnedValue materialization`
4. `docs(yq): update duplicate-mapping-keys limitations for #1398`
5. `perf(jq): stop double-walking object fields in .[] traversal` — fast-follow cleanup on commit 1's `Iterate` arm, replacing a redundant pre-check + walk with a single call to the already-O(n) `collapsed_fields()`

Deliberately out of scope (left open, tracked separately): #1342
(`paths(node_filter)`), #1343 (`-s`/`--eval-all`/`-i`'s DOM
fallback), #1344 (`del`/`with_entries`/`map_values`/wildcard-bridge
builtins), #1102 (object slicing). jq mode's remaining #1385 gaps
(`.`, `length`, `keys`, `keys_unsorted` not collapsing) are also
untouched — only `[.[]]` gets fixed here as a side effect of the
shared traversal code.

## Test plan

- [x] `cargo build --release --features cli` / `--no-default-features` (no_std)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (all 3 CI clippy legs)
- [x] Full `cargo test --features cli,simd,regex,serde` — green
- [x] Live-verified against the issue's own reproduction table (`length`/`keys`/`to_entries`/`[.[]]`/`.b`) on both JSON and YAML input, matches pinned `yq` v4.53.3 exactly
- [x] A/B perf sanity check against `main` on realistic (`users`-shaped) and pathological (100k-flat-key) inputs — no regression on realistic shapes; Fix A is a net win on realistic non-M2 JSON queries (avoids the old OwnedValue round-trip)