### PR TITLE
fix(jq): propagate zero-output nth/combinations/halt_error arguments (#1408)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20645,7 +20645,11 @@ fn eval_nth_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match result_to_owned_full(n_result) {
         Ok(None) => return QueryResult::None,
-        Ok(Some((OwnedValue::Int(i), _))) if i >= 0 => i as usize,
+        Ok(Some((OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _), _)))
+            if i >= 0 =>
+        {
+            i as usize
+        }
         Ok(Some(_)) => {
             return QueryResult::Error(EvalError::new("nth requires non-negative integer"));
         }
@@ -52558,6 +52562,27 @@ mod tests {
         match eval_nth_expr::<Vec<u64>, JqSemantics>(&n_expr, &expr, cursor.value(), false) {
             QueryResult::Halt(code) => assert_eq!(code, 11),
             other => panic!("expected Halt(11), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eval_nth_expr_zero_output_n_argument_produces_no_output_1408() {
+        // Same unreachable-from-CLI function as the halt-propagation tests
+        // above (see `eval_nth_expr_n_argument_propagates_halt`'s doc
+        // comment for why `Expr::NthExpr` needs a direct call). This pins
+        // #1408's own fix for this function: `result_to_owned_full`'s
+        // `Ok(None)` arm (a zero-output `n`) must make the whole call
+        // produce `QueryResult::None`, not fall through to the
+        // non-negative-integer type error a `None` would previously have
+        // hit via the old `result_to_owned` + hard "no value" error.
+        let json_bytes: &[u8] = br"[1, 2, 3]";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let n_expr = parse("empty").unwrap();
+        let expr = Expr::Identity;
+        match eval_nth_expr::<Vec<u64>, JqSemantics>(&n_expr, &expr, cursor.value(), false) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20636,11 +20636,17 @@ fn eval_nth_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Evaluate n
+    // Evaluate n. `result_to_owned_full`, not `result_to_owned` (#1408):
+    // `nth(n; expr)`'s one-arg sibling `builtin_nth` was already migrated
+    // for exactly this -- a zero-output `n` (e.g. `nth(empty; .a,.b)`)
+    // must make the whole call produce zero output, matching real jq's
+    // `n as $n | ...` desugaring, not this call site's own leftover
+    // `result_to_owned` hard-erroring with "no value" instead.
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
-    let n = match result_to_owned(n_result) {
-        Ok(OwnedValue::Int(i)) if i >= 0 => i as usize,
-        Ok(_) => {
+    let n = match result_to_owned_full(n_result) {
+        Ok(None) => return QueryResult::None,
+        Ok(Some((OwnedValue::Int(i), _))) if i >= 0 => i as usize,
+        Ok(Some(_)) => {
             return QueryResult::Error(EvalError::new("nth requires non-negative integer"));
         }
         Err(e) => return e.into(),
@@ -27679,19 +27685,30 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Get n
-    let n = match result_to_owned(eval_single::<W, S>(n_expr, value.clone(), optional)) {
-        Ok(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _)) if i >= 0 => {
+    // Get n. `result_to_owned_full`, not `result_to_owned` (#1408): a
+    // zero-output `n` (e.g. `combinations(empty)`) must not hard-error --
+    // but unlike a plain `x as $x | ...` zero-fanout ("propagate
+    // QueryResult::None"), `n` here feeds an internal array constructor
+    // (real jq's own model is roughly `[range(n)|$dot] | combinations`),
+    // so a zero-output `n` desugars the same way `n=0` already does below
+    // (zero fan-out arrays either way) -- `Owned([])`, not `None`.
+    let n = match result_to_owned_full(eval_single::<W, S>(n_expr, value.clone(), optional)) {
+        Ok(None) => return QueryResult::Owned(OwnedValue::Array(Vec::new())),
+        Ok(Some((OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _), _)))
+            if i >= 0 =>
+        {
             i as usize
         }
-        Ok(OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)) if optional => {
+        Ok(Some((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _)))
+            if optional =>
+        {
             return QueryResult::None
         }
-        Ok(OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)) => {
+        Ok(Some((OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _), _))) => {
             return QueryResult::Error(EvalError::new("combinations(n): n must be non-negative"))
         }
-        Ok(_) if optional => return QueryResult::None,
-        Ok(_) => return QueryResult::Error(EvalError::type_error("number", "n")),
+        Ok(Some(_)) if optional => return QueryResult::None,
+        Ok(Some(_)) => return QueryResult::Error(EvalError::type_error("number", "n")),
         Err(e) => return e.into(),
     };
 
@@ -28159,6 +28176,10 @@ fn builtin_nth_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // a type error (#791).
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
+        // #1408: a zero-output `n` (e.g. `nth(empty; .a,.b)`) must make the
+        // whole call produce zero output, matching real jq's `n as $n | ...`
+        // desugaring -- not fall into the generic type-error catch-all below.
+        QueryResult::None => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
     };
 
@@ -29064,7 +29085,13 @@ fn builtin_halt_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let first = each_take_first::<W, S>(expr, value.clone(), optional);
             let n_result: Result<OwnedValue, EvalEscape> = match first {
                 Ok(Some(item)) => Ok(item.into_owned()),
-                Ok(None) => Err(EvalEscape::Error(EvalError::new("no value"))),
+                // #1408: a zero-output code expression (`halt_error(empty)`)
+                // must make the whole call produce zero output -- matching
+                // real jq's own `x as $x | ...` desugaring, the same fix
+                // already applied to the other instances of this bug class
+                // (#1045/#1280/#1313) -- not this call site's own leftover
+                // hard error.
+                Ok(None) => return QueryResult::None,
                 Err(control) => Err(control.into()),
             };
             match n_result {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17486,6 +17486,7 @@ fn test_nth_stream_empty_n_argument_produces_no_output_1408() -> Result<()> {
     let (out, err, code) = run_jq_full(&["-c", "nth(empty; .a,.b)"], Some(r#"{"a":1,"b":2}"#))?;
     assert_eq!(code, 0, "err={err}");
     assert_eq!(out, "");
+    assert_eq!(err, "");
     Ok(())
 }
 
@@ -17499,6 +17500,35 @@ fn test_nth_stream_ordinary_n_unaffected_by_1408() -> Result<()> {
     Ok(())
 }
 
+/// Control: `builtin_nth_stream`'s `n`-argument match only special-cases
+/// `QueryResult::Partial(_, Control::Halt(code))`, not `Control::Error`/
+/// `Control::Break` -- a genuinely multi-output `n` that produces one
+/// value and then errors falls into the generic `_ => Error("expected
+/// number, got null")` catch-all instead of using the first value and
+/// then propagating the trailing error, unlike real jq (`n as $n | ...`
+/// forks once per output of `n`). Pre-existing, not introduced by #1408's
+/// zero-output fix (which only added the separate bare-`QueryResult::None`
+/// arm above); same class of gap as #1277's cluster 3 (which named
+/// `eval_nth_expr`, unaware at the time that it's unreachable and
+/// `builtin_nth_stream` is the function real queries actually hit -- noted
+/// there). Pinning the current (wrong but stable) behavior, matching this
+/// file's existing precedent for `combinations`'s analogous gap
+/// (`test_combinations_n_break_semantics_documented_not_fixed_by_1164`).
+#[test]
+fn test_nth_stream_trailing_error_in_multi_output_n_documented_not_fixed_by_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#"nth((1,error("boom")); .a,.b,.c)"#],
+        Some(r#"{"a":1,"b":2,"c":3}"#),
+    )?;
+    assert_ne!(code, 0);
+    // Pre-existing divergence from real jq (which prints `2` to stdout
+    // before erroring "boom", verified live) -- see this test's own doc
+    // comment.
+    assert_eq!(out, "");
+    assert!(err.contains("expected number, got null"), "err={err}");
+    Ok(())
+}
+
 /// The issue's own repro: a zero-output `n` to `combinations(n)` (e.g.
 /// `combinations(empty)`) must produce zero output for the array
 /// constructor's own `n`-many-`range` desugaring -- matching the existing
@@ -17509,6 +17539,7 @@ fn test_combinations_n_empty_argument_produces_empty_array_1408() -> Result<()> 
     let (out, err, code) = run_jq_full(&["-cn", "[1,2] | combinations(empty)"], None)?;
     assert_eq!(code, 0, "err={err}");
     assert_eq!(out.trim(), "[]");
+    assert_eq!(err, "");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17475,3 +17475,74 @@ fn test_jq_string_interpolation_single_valued_slot_unaffected_1403() -> Result<(
     assert_eq!(stdout, "\"Hello world\"\n");
     Ok(())
 }
+
+/// The issue's own repro: `nth(n; expr)`'s two-arg (stream) form parses to
+/// `Builtin::NthStream`/`builtin_nth_stream`, not `Expr::NthExpr` -- a
+/// zero-output `n` (e.g. `nth(empty; .a,.b)`) must make the whole call
+/// produce zero output, matching real jq's `n as $n | ...` desugaring, not
+/// `builtin_nth_stream`'s prior catch-all "expected number, got null" error.
+#[test]
+fn test_nth_stream_empty_n_argument_produces_no_output_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", "nth(empty; .a,.b)"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// Regression guard: `nth(n; expr)` with an ordinary single-valued `n`
+/// stays completely unaffected by the new zero-output arm.
+#[test]
+fn test_nth_stream_ordinary_n_unaffected_by_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", "nth(1; .[])"], Some("[10,20,30]"))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "20");
+    Ok(())
+}
+
+/// The issue's own repro: a zero-output `n` to `combinations(n)` (e.g.
+/// `combinations(empty)`) must produce zero output for the array
+/// constructor's own `n`-many-`range` desugaring -- matching the existing
+/// `n == 0` case (`Owned([])`), not `builtin_combinations_n`'s prior
+/// "no value" hard error.
+#[test]
+fn test_combinations_n_empty_argument_produces_empty_array_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2] | combinations(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// Regression guard: `combinations(n)` with an ordinary `n` stays
+/// completely unaffected by the new zero-output arm.
+#[test]
+fn test_combinations_n_ordinary_n_unaffected_by_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "[1,2] | [combinations(2)]"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[[1,1],[1,2],[2,1],[2,2]]");
+    Ok(())
+}
+
+/// The issue's own repro: a zero-output code expression to `halt_error`
+/// (e.g. `halt_error(empty)`) must make the whole call produce zero
+/// output -- matching the same `x as $x | ...` desugaring already applied
+/// to every other instance of this bug class (#1045/#1280/#1313), not
+/// `builtin_halt_error`'s prior "no value" hard error.
+#[test]
+fn test_halt_error_empty_code_argument_produces_no_output_1408() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-cn", "\"x\" | halt_error(empty)"], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
+    assert_eq!(err, "");
+    Ok(())
+}
+
+/// Regression guard: `halt_error(code)` with an ordinary exit-code
+/// expression stays completely unaffected by the new zero-output arm --
+/// still writes the message to stderr and exits with that code.
+#[test]
+fn test_halt_error_ordinary_code_unaffected_by_1408() -> Result<()> {
+    let (_out, err, code) = run_jq_full(&["-cn", "\"msg\" | halt_error(7)"], None)?;
+    assert_eq!(code, 7);
+    assert_eq!(err, "msg");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20006,3 +20006,38 @@ fn test_yq_string_interpolation_path_context_optional_threaded_through_rest_1403
     assert_eq!(output, "");
     Ok(())
 }
+
+/// #1408's three fixes (`builtin_nth_stream`, `builtin_combinations_n`,
+/// `builtin_halt_error`) all live on `EvalSemantics`-generic functions
+/// shared verbatim between `succinctly jq` and `succinctly yq` -- pin
+/// yq-mode parity for each, so a future mode-specific edit to any of them
+/// has real CI signal here rather than only in `jq_cli_tests.rs`.
+#[test]
+fn test_yq_nth_stream_empty_n_argument_produces_no_output_1408() -> Result<()> {
+    let (output, stderr, code) =
+        run_yq_stdin_with_stderr("nth(empty; .a,.b)", "a: 1\nb: 2\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(output, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_yq_combinations_n_empty_argument_produces_empty_array_1408() -> Result<()> {
+    let (output, stderr, code) =
+        run_yq_stdin_with_stderr("combinations(empty)", "[1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(output.trim(), "[]");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+#[test]
+fn test_yq_halt_error_empty_code_argument_produces_no_output_1408() -> Result<()> {
+    let (output, stderr, code) =
+        run_yq_stdin_with_stderr(r#""x" | halt_error(empty)"#, "", &["-n"])?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(output, "");
+    assert_eq!(stderr, "");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Three more callers of the pre-#1313 lossy `result_to_owned` pattern collapsed a
zero-output generator argument into a fabricated value or a hard error, instead of
jq's own `x as $x | ...` desugaring where a zero-output generator argument makes the
whole call produce zero output — same root-cause family as #1045/#1280/#1313.

```
$ echo '{"a":1,"b":2}' | jq -c 'nth(empty; .a,.b)'          # real jq: nothing, exit 0
$ echo null | jq -c '[1,2] | combinations(empty)'           # real jq: []
$ echo '"x"' | jq -c 'halt_error(empty)'; echo "exit=$?"    # real jq: exit=0, no output
```

All three live-verified against pinned jq 1.7.1 both before and after this fix.

## Changes

- **`builtin_nth_stream`** — the parser's actual dispatch target for the two-arg
  `nth(n; expr)` form (`Expr::NthExpr`/`eval_nth_expr` is unreachable from any
  parseable query — the same parser-shadowing already documented in this file for
  `Builtin::Limit` vs `Expr::Limit`/`eval_limit`). Its `n`-evaluation match fell into a
  generic `"expected number, got null"` catch-all on a zero-output `n`; added a
  dedicated arm so the whole call now propagates zero output instead.
- **`builtin_combinations_n`** — migrated `n`'s evaluation from `result_to_owned` to
  `result_to_owned_full`. A zero-output `n` now produces `Owned([])`, matching the
  existing `n == 0` case, rather than hard-erroring — `n` feeds an internal array
  constructor, so this is the correct desugaring here (not a mechanical
  `Ok(None) => QueryResult::None`, per the issue's own reasoning).
- **`builtin_halt_error`** — migrated its optional `code_expr`'s evaluation the same
  way. A zero-output code expression now makes the whole call produce zero output
  (never halts) instead of hard-erroring.
- **`eval_nth_expr`** — also migrated from `result_to_owned` to `result_to_owned_full`
  for consistency with its own dedicated unit tests and with `builtin_nth` (the
  already-migrated one-arg sibling), even though it's unreachable from the CLI.

## Out of scope (already tracked elsewhere)

The issue named two further threads, both already covered by existing issues rather
than duplicated here:

- `limit`'s dropped trailing `Control` — #1277's cluster 3 already scopes this
  exact gap (`eval_limit`/`eval_nth_expr`/`resolve_limit`) as needing its own design
  pass.
- Multi-output-argument fan-out — while fixing `builtin_nth_stream` I confirmed `n`
  itself doesn't fan out over multiple outputs either (`nth((0,1); .a,.b,.c)` still
  hard-errors instead of producing two results); posted as a new confirmed instance on
  #1279, which already tracks this class of gap architecturally.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`) — all
      green, including the pre-existing `eval_nth_expr_*` unit tests
- [x] 6 new CLI tests (`tests/jq_cli_tests.rs`, suffixed `_1408`): the three issue
      repros plus a regression guard per call site
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only --fail-under-lines 0`
- [x] Manual live verification against the release binary for all three repros, plus
      regressions (`nth(1; .[])`, `nth(-1; ...)`, `combinations(2)`, `halt_error(7)`)

Fixes #1408