### PR TITLE
fix(jq): IN(src; s) stops the compare fanout at the matching candidate (#1459)

### DIFF
--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -32,7 +32,7 @@ as such in `test_short_circuit_side_effect_leaks_820_932_987`: `first(.[] | stde
 `first((1,2) == (10, ("B"|stderr)))` (both a bare `first(...)` over a non-`Comma`, which
 Stage 2b's sibling walk does not reach — option (c)), and
 `("A"|stderr) == (("B"|stderr), ("C"|stderr))` (a *top-level* compare, which never reaches
-`eval_each` at all — see follow-up 6). Stage 3 also leaves one residual: an un-lazified
+`eval_each` at all — #1481). Stage 3 also leaves one residual: an un-lazified
 `eval_each` arm (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a side effect
 for a node's own filter when that filter's shape isn't one of
 `Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — pinned as a known-remaining row in the same
@@ -1048,7 +1048,8 @@ the reasoning behind each placement:
    `Expr::Compare` arm, which is what a top-level `==` actually reaches. With
    `input`/`inputs` operands it changes *values*, not just stderr ordering:
    `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in jq and
-   `["ca","db"]` here, so it is silent data loss rather than a cosmetic leak.
+   `["ca","db"]` here, so it is silent data loss rather than a cosmetic leak. **Filed as
+   #1481.**
 7. **Stage 5** — widen the lazy arm set (`If`, `Try`/`Optional`, `Label`, `AsPattern`,
    `FuncCall`, and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`). Not yet filed.
    One issue, not one per arm: each is a single lazy arm now that the primitive exists.

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -27,16 +27,17 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
 processed — is closed, as is `halt_error`'s wrong exit code and the stderr leak in
 `isempty`/`first`/`limit`/`nth`/`any`/`IN(s)`, and — since Stage 4 — `IN(src; s)` and every
-other compare reached through a lazy consumer. Three shapes remain divergent and are pinned
-as such in `test_short_circuit_side_effect_leaks_820_932_987`: `first(.[] | stderr)` and
-`first((1,2) == (10, ("B"|stderr)))` (both a bare `first(...)` over a non-`Comma`, which
-Stage 2b's sibling walk does not reach — option (c)), and
-`("A"|stderr) == (("B"|stderr), ("C"|stderr))` (a *top-level* compare, which never reaches
-`eval_each` at all — #1481). Stage 3 also leaves one residual: an un-lazified
+other compare reached through a lazy consumer. Five shapes remain divergent, all pinned as
+such in `test_short_circuit_side_effect_leaks_820_932_987`. Two are the bare-`first(...)`
+family: `first(.[] | stderr)` and `first((1,2) == (10, ("B"|stderr)))`, both a `first(...)`
+over a non-`Comma`, which Stage 2b's sibling walk does not reach — option (c). One is
+`("A"|stderr) == (("B"|stderr), ("C"|stderr))`, a *top-level* compare, which never reaches
+`eval_each` at all — #1481. The remaining two are Stage 5's own residual: an un-lazified
 `eval_each` arm (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a side effect
 for a node's own filter when that filter's shape isn't one of
-`Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — pinned as a known-remaining row in the same
-test, left to Stage 5.
+`Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — that is the `path(paths(if ...))` row, plus
+the `path(... halt_error ...)` pair Stage 4 added, whose stray `x` on stderr is the same
+un-lazified `Expr::If`.
 
 **One correction this document earned the hard way.** Stage 2 shipped an
 `eval_each_pipe` whose `Item::Owned` arm fell back to the eager `eval_owned_pipe`,
@@ -551,29 +552,30 @@ Columns are `stdout | exit | stderr`. Input is `null` (`-cn`) unless noted.
 
 ### Divergent today — the fix's targets
 
-| Query                                                              | jq 1.7.1      | succinctly today | Closed by |
-|--------------------------------------------------------------------|---------------|------------------|-----------|
-| `isempty(1, ("B"\|stderr))`                                        | `false\|0\|`  | `false\|0\|B`    | Stage 2   |
-| `isempty((1, ("B"\|stderr)))`                                      | `false\|0\|`  | `false\|0\|B`    | Stage 2   |
-| `first(1, ("B"\|stderr))`                                          | `1\|0\|`      | `1\|0\|B`        | Stage 2b  |
-| `limit(1; 1, ("B"\|stderr))`                                       | `1\|0\|`      | `1\|0\|B`        | Stage 2   |
-| `nth(0; 1, ("B"\|stderr))`                                         | `1\|0\|`      | `1\|0\|B`        | Stage 2   |
-| `"o" \| halt_error(1, ("B"\|stderr))`                              | `\|1\|o`      | `\|1\|Bo`        | Stage 2   |
-| `"outer" \| halt_error(1, ("inner"\|halt_error(2)))`               | `\|1\|outer`  | `\|2\|inner`     | Stage 2   |
-| `2 \| any(2, (5\|stderr); .==2)`                                   | `true\|0\|`   | `true\|0\|5`     | Stage 2   |
-| `2 \| IN(2, (5\|stderr))`                                          | `true\|0\|`   | `true\|0\|5`     | Stage 2   |
-| `[1,2] \| first(.[] \| stderr)`                                    | `1\|0\|1`     | `1\|0\|12`       | Stage 2b  |
-| `isempty(first(1, ("B"\|stderr)))`                                 | `false\|0\|`  | `false\|0\|B`    | Stage 2   |
-| `[1,2,3] \| path(paths(if .==3 then (stderr,true) else true end))` | `\|5\|<#530>` | `\|5\|3<#530>`   | Stage 3   |
-| `[IN((2,3); 2, (5\|stderr))]`                                      | `[true]\|0\|` | `[true]\|0\|5`   | Stage 4   |
-| `[isempty((1,2) == (10, ("B"\|stderr)))]`                          | `[false]\|0\|`| `[false]\|0\|B` | Stage 4   |
-| `[all((1,2) == (10, ("B"\|stderr)); .)]`                           | `[false]\|0\|`| `[false]\|0\|B` | Stage 4   |
-| `isempty(limit(3; 1, ("B"\|stderr)))`                              | `false\|0\|`  | `false\|0\|B`    | Stage 5   |
-| `first(if true then (1,("B"\|stderr)) else 9 end)`                 | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
-| `first(try (1,("B"\|stderr)) catch 9)`                             | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
-| `first(label $o \| (1,("B"\|stderr)))`                             | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
-| `first(1 as $x \| (1,("B"\|stderr)))`                              | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
-| `def f: (1,("B"\|stderr)); first(f)`                               | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
+| Query                                                              | jq 1.7.1       | succinctly today | Closed by |
+|--------------------------------------------------------------------|----------------|------------------|-----------|
+| `isempty(1, ("B"\|stderr))`                                        | `false\|0\|`   | `false\|0\|B`    | Stage 2   |
+| `isempty((1, ("B"\|stderr)))`                                      | `false\|0\|`   | `false\|0\|B`    | Stage 2   |
+| `first(1, ("B"\|stderr))`                                          | `1\|0\|`       | `1\|0\|B`        | Stage 2b  |
+| `limit(1; 1, ("B"\|stderr))`                                       | `1\|0\|`       | `1\|0\|B`        | Stage 2   |
+| `nth(0; 1, ("B"\|stderr))`                                         | `1\|0\|`       | `1\|0\|B`        | Stage 2   |
+| `"o" \| halt_error(1, ("B"\|stderr))`                              | `\|1\|o`       | `\|1\|Bo`        | Stage 2   |
+| `"outer" \| halt_error(1, ("inner"\|halt_error(2)))`               | `\|1\|outer`   | `\|2\|inner`     | Stage 2   |
+| `2 \| any(2, (5\|stderr); .==2)`                                   | `true\|0\|`    | `true\|0\|5`     | Stage 2   |
+| `2 \| IN(2, (5\|stderr))`                                          | `true\|0\|`    | `true\|0\|5`     | Stage 2   |
+| `[1,2] \| first(.[] \| stderr)`                                    | `1\|0\|1`      | `1\|0\|12`       | Stage 2b  |
+| `isempty(first(1, ("B"\|stderr)))`                                 | `false\|0\|`   | `false\|0\|B`    | Stage 2   |
+| `[1,2,3] \| path(paths(if .==3 then (stderr,true) else true end))` | `\|5\|<#530>`  | `\|5\|3<#530>`   | Stage 3   |
+| `[IN((2,3); 2, (5\|stderr))]`                                      | `[true]\|0\|`  | `[true]\|0\|5`   | Stage 4   |
+| `[isempty((1,2) == (10, ("B"\|stderr)))]`                          | `[false]\|0\|` | `[false]\|0\|B`  | Stage 4   |
+| `[isempty(.id == (1, input)), .id]` over 4 docs                    | `ids 1-4\|0\|` | `ids 1,3\|0\|`   | Stage 4   |
+| `[all((1,2) == (10, ("B"\|stderr)); .)]`                           | `[false]\|0\|` | `[false]\|0\|B`  | Stage 4   |
+| `isempty(limit(3; 1, ("B"\|stderr)))`                              | `false\|0\|`   | `false\|0\|B`    | Stage 5   |
+| `first(if true then (1,("B"\|stderr)) else 9 end)`                 | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
+| `first(try (1,("B"\|stderr)) catch 9)`                             | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
+| `first(label $o \| (1,("B"\|stderr)))`                             | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
+| `first(1 as $x \| (1,("B"\|stderr)))`                              | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
+| `def f: (1,("B"\|stderr)); first(f)`                               | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
 
 Plus the data-loss shapes in [Problem](#this-is-no-longer-a-cosmetic-leak--it-causes-silent-data-loss),
 closed by Stage 2 (`isempty`) and Stage 2b (`first`).
@@ -1050,6 +1052,25 @@ the reasoning behind each placement:
    `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in jq and
    `["ca","db"]` here, so it is silent data loss rather than a cosmetic leak. **Filed as
    #1481.**
+
+   **Two things review added afterwards.** (i) #1459's own severity line — "Low (stray
+   stderr write; no wrong output, no data loss)" — is true of its `IN(src; s)` repro and
+   false of the arm the fix adds. Once a compare's operands can pop `input`, the eager
+   fanout's discarded candidates eat documents the CLI's per-document driver loop then
+   never processes: `[isempty(.id == (1, input)), .id]` over four documents printed two
+   before Stage 4 and prints four after, matching jq. That is the same silent data loss
+   #820 was filed for, so Stage 4 closes a `Comma`-arm-equivalent hole in the `Compare`
+   arm, not just a stderr leak — pinned separately from the stderr tables in
+   `test_compare_operand_consuming_input_documents_1459`, because every stderr row would
+   stay green if the arm regressed to eager only for document-popping operands.
+   (ii) `binary_fanout_each` has two operands and so can be handed two `Flow::Stopped`
+   `pending`s; `abort.unwrap_or(outer)` keeps the *inner* one and drops the *outer* one.
+   `resolve_leaf` is the only consumer that reads `pending`, so the effect is confined to
+   a `Halt` under `path(...)`, and the drop is the half that lands on jq's verdict (jq's
+   `path()` is lazy end to end and never evaluates the trailing `halt_error` at all).
+   Left and right therefore answer differently, deliberately: both rows are pinned in
+   `test_short_circuit_side_effect_leaks_820_932_987`, and `Flow::Stopped`'s own doc
+   comment now records this as its one stated exception.
 7. **Stage 5** — widen the lazy arm set (`If`, `Try`/`Optional`, `Label`, `AsPattern`,
    `FuncCall`, and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`). Not yet filed.
    One issue, not one per arm: each is a single lazy arm now that the primitive exists.

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -2,12 +2,13 @@
 
 [Home](../../) > [Docs](../) > [Plan](./) > Lazy generator consumers
 
-**Status: Stages 1, 2, 2b and 3 implemented; Stages 4-5 open.** This document is the
+**Status: Stages 1, 2, 2b, 3 and 4 implemented; Stage 5 open.** This document is the
 deliverable for [#820](https://github.com/rust-works/succinctly/issues/820), which its
 own tier review (2026-08-20) classified Tier 3 — "evaluator-architecture change, design
 doc first, in the shape of #1282". It also scopes the two issues that name #820 as their
-real fix, [#932](https://github.com/rust-works/succinctly/issues/932) (partially closed —
-Stage 4 remains) and [#987](https://github.com/rust-works/succinctly/issues/987) (closed
+real fix, [#932](https://github.com/rust-works/succinctly/issues/932) (closed — Stage 2
+took `any`/`all`/`IN(s)`, Stage 4 the remaining `IN(src; s)`) and
+[#987](https://github.com/rust-works/succinctly/issues/987) (closed
 by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 [Follow-up issues](#follow-up-issues).
 
@@ -18,20 +19,24 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | 2b    | `eval_generic.rs`'s `first` comma walk              | ✅ merged — #1434, PR #1435 |
 | —     | `eval_each_pipe`'s owned-value arm (Stage 2 gap)    | ✅ merged — PR #1450        |
 | 3     | `paths(f)` producer + `resolve_leaf` sink           | ✅ merged — closes #987     |
-| 4     | `Expr::Compare`'s outer loop                        | ⬜ open — #1459             |
+| 4     | `Expr::Compare`'s outer loop                        | ✅ merged — closes #1459    |
 | 5     | Widen the lazy arm set                              | ⬜ not yet filed            |
 | (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ⬜ not yet filed            |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
 processed — is closed, as is `halt_error`'s wrong exit code and the stderr leak in
-`isempty`/`first`/`limit`/`nth`/`any`/`IN(s)`. Two shapes remain divergent and are pinned as
-such in `test_short_circuit_side_effect_leaks_820_932_987`: `first(.[] | stderr)` (a `Pipe`,
-so Stage 2b's comma walk does not reach it — option (c)) and `[IN((2,3); 2, (5|stderr))]`
-(Stage 4). Stage 3 also leaves one residual: an un-lazified `eval_each` arm (`If`/`Try`/
-`Label`/`AsPattern`/`FuncCall`, ...) still leaks a side effect for a node's own filter when
-that filter's shape isn't one of `Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — pinned as a
-known-remaining row in the same test, left to Stage 5.
+`isempty`/`first`/`limit`/`nth`/`any`/`IN(s)`, and — since Stage 4 — `IN(src; s)` and every
+other compare reached through a lazy consumer. Three shapes remain divergent and are pinned
+as such in `test_short_circuit_side_effect_leaks_820_932_987`: `first(.[] | stderr)` and
+`first((1,2) == (10, ("B"|stderr)))` (both a bare `first(...)` over a non-`Comma`, which
+Stage 2b's sibling walk does not reach — option (c)), and
+`("A"|stderr) == (("B"|stderr), ("C"|stderr))` (a *top-level* compare, which never reaches
+`eval_each` at all — see follow-up 6). Stage 3 also leaves one residual: an un-lazified
+`eval_each` arm (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a side effect
+for a node's own filter when that filter's shape isn't one of
+`Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — pinned as a known-remaining row in the same
+test, left to Stage 5.
 
 **One correction this document earned the hard way.** Stage 2 shipped an
 `eval_each_pipe` whose `Item::Owned` arm fell back to the eager `eval_owned_pipe`,
@@ -518,7 +523,7 @@ Each checked against the oracle. "already correct" means succinctly matches jq t
 | `FuncCall`/`FuncDef`                       | no                         | but `def f: (1,("B"\|stderr)); first(f)` leaks. Stage 5                                                 |
 | `FirstExpr`/`Limit`/`NthExpr` as producers | no                         | but `isempty(limit(3; 1, ("B"\|stderr)))` leaks — demand does not forward *through* a consumer. Stage 5 |
 | `Reduce`/`Foreach`                         | no                         | `reduce` has one output; `foreach`'s #534 fork machinery is a non-goal                                  |
-| **`Compare`**                              | **partially — for #932**   | see below                                                                                               |
+| **`Compare`**                              | **yes — for #932**         | Stage 4; see below                                                                                      |
 | **`Builtin::PathsFilter`**                 | **yes — for #987**         | Stage 3                                                                                                 |
 
 **Honest scoping of #932.** `builtin_upper_in` (`:3759`) synthesizes
@@ -526,8 +531,19 @@ Each checked against the oracle. "already correct" means succinctly matches jq t
 `any_all_gen_cond`. `binary_fanout_core` (`:1772`) evaluates the **right** operand to
 completion first, then re-evaluates the left per right value — jq's real nested-loop
 order, established and oracle-verified by #910. So `IN(src; s)` needs `Expr::Compare`
-demand-aware in its outer loop, or it keeps leaking. **Stage 2 closes `any`/`all`/`IN(s)`;
-`IN(src; s)` needs Stage 4.**
+demand-aware in its outer loop, or it keeps leaking. **Stage 2 closed `any`/`all`/`IN(s)`;
+Stage 4 closed `IN(src; s)`.**
+
+Stage 4 did that without moving the loop order into `builtin_upper_in`, which #910's own
+review had already rejected as a hand-rolled cross-product. `binary_fanout_core`'s body
+became `binary_fanout_each` — the same right-outer/left-inner loop, parameterized over how
+an operand is *enumerated* rather than merely evaluated. `binary_fanout_core` is now the
+collecting wrapper that supplies the eager strategy (evaluate the whole operand, replay it
+through `drain_result`), so `eval_arithmetic`, `eval_compare` and the path-context sibling
+are behaviourally untouched; `eval_each`'s new `Expr::Compare` arm supplies `eval_each`
+itself. Keeping one loop was the point: #768 fixed a collapse-to-first-value bug there that
+the then-duplicated path-context copy independently re-acquired and had to be fixed again
+for #822.
 
 ## Behaviour tables (oracle-verified at `cedee4cbb`)
 
@@ -550,6 +566,8 @@ Columns are `stdout | exit | stderr`. Input is `null` (`-cn`) unless noted.
 | `isempty(first(1, ("B"\|stderr)))`                                 | `false\|0\|`  | `false\|0\|B`    | Stage 2   |
 | `[1,2,3] \| path(paths(if .==3 then (stderr,true) else true end))` | `\|5\|<#530>` | `\|5\|3<#530>`   | Stage 3   |
 | `[IN((2,3); 2, (5\|stderr))]`                                      | `[true]\|0\|` | `[true]\|0\|5`   | Stage 4   |
+| `[isempty((1,2) == (10, ("B"\|stderr)))]`                          | `[false]\|0\|`| `[false]\|0\|B` | Stage 4   |
+| `[all((1,2) == (10, ("B"\|stderr)); .)]`                           | `[false]\|0\|`| `[false]\|0\|B` | Stage 4   |
 | `isempty(limit(3; 1, ("B"\|stderr)))`                              | `false\|0\|`  | `false\|0\|B`    | Stage 5   |
 | `first(if true then (1,("B"\|stderr)) else 9 end)`                 | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
 | `first(try (1,("B"\|stderr)) catch 9)`                             | `1\|0\|`      | `1\|0\|B`        | Stage 5   |
@@ -846,7 +864,9 @@ because it touches the path resolver, which #1283 Part 2 C says must not be work
 concurrently with cluster A's family.
 
 **Stage 4 — `Expr::Compare`'s outer loop.** Closes #932's remaining `IN(src; s)` half.
-Must preserve #910's live-verified nested-loop order. Own oracle sweep.
+Must preserve #910's live-verified nested-loop order. Own oracle sweep. **Implemented**
+as `binary_fanout_each` (the loop, sink-driven) plus `binary_fanout_core` (the eager
+collecting wrapper, behaviourally unchanged) and an `Expr::Compare` arm in `eval_each`.
 
 **Stage 5 — widen the arm set.** `If`, `Try`/`Optional`, `Label`, `AsPattern`, `FuncCall`,
 and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`. One divergence-table row per
@@ -935,7 +955,7 @@ differential gate at least as rigorous as #1282's.
   (`:1490`, Halt arm `:1511`); the ten consumers (`:24109`, `:16984`, `:23952`, `:16890`,
   `:23884`, `:17062`, `:24024`, `:4162`, `:3759`, `:24983`); the two deliberately
   unchanged (`:17022`, `:23987`); `resolve_leaf` (`:13813`) and `builtin_paths_filter`
-  (`:19590`) for Stage 3; `binary_fanout_core` (`:1772`) for Stage 4; `write_stderr`
+  (`:19590`) for Stage 3; `binary_fanout_core`/`binary_fanout_each` for Stage 4; `write_stderr`
   (`:24928`), `builtin_stderr` (`:24961`), `builtin_halt_error` (`:24983`) — the only
   sites with evaluation-time I/O; `mod remaining_inputs` (`:21428`) for the `input` queue.
 - **`src/jq/error.rs`** — `Control` (`:54`), `EvalEscape` (`:120`) and their doc comments;
@@ -1008,9 +1028,27 @@ the reasoning behind each placement:
    node's own filter when that filter's shape isn't one of `Comma`/`Pipe`/`Paren`/
    `Builtin::PathsFilter` — pinned as a known-remaining row in
    `test_short_circuit_side_effect_leaks_820_932_987`, left to Stage 5.
-6. **Stage 4** — `Expr::Compare`'s outer loop. Filed **#1459**. #932 was closed when Stage 2
-   landed, which was right for its `any`/`all`/`IN(s)` thirds but left `IN(src; s)` — still
-   divergent, and pinned as such in the test suite — with no open issue. #1459 carries it.
+6. **Stage 4** — `Expr::Compare`'s outer loop. Filed **#1459**, implemented. #932 was
+   closed when Stage 2 landed, which was right for its `any`/`all`/`IN(s)` thirds but left
+   `IN(src; s)` — still divergent, and pinned as such in the test suite — with no open
+   issue. #1459 carried it. `binary_fanout_core`'s body became `binary_fanout_each` (one
+   loop, two operand strategies) and `eval_each` gained an `Expr::Compare` arm. Its own
+   oracle sweep — 105 shapes covering all six `CompareOp`s × operand arities, every lazy
+   consumer, terminators in either operand, `?`/`try`, and `input` — took the divergence
+   count from 18 to 5.
+
+   **Two findings it did not close, both left as separate work rather than folded in.**
+   (a) A bare `first(<non-comma>)` never reaches `eval.rs` at all, so
+   `first((1,2) == (10, ("B"|stderr)))` stays eager — the same class as
+   `first(.[] | stderr)`, i.e. option (c) below. (b) The **eager** copies of the fanout
+   loop still finish the right operand before starting the left, where jq interleaves them.
+   That is broader than #820: it affects `Expr::Arithmetic` as much as `Expr::Compare`, and
+   it lives in three places — `binary_fanout_core` (via `eval_binary_fanout`),
+   `eval_binary_fanout_with_path_context`, and `eval_generic.rs`'s own third copy in its
+   `Expr::Compare` arm, which is what a top-level `==` actually reaches. With
+   `input`/`inputs` operands it changes *values*, not just stderr ordering:
+   `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in jq and
+   `["ca","db"]` here, so it is silent data loss rather than a cosmetic leak.
 7. **Stage 5** — widen the lazy arm set (`If`, `Try`/`Optional`, `Label`, `AsPattern`,
    `FuncCall`, and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`). Not yet filed.
    One issue, not one per arm: each is a single lazy arm now that the primitive exists.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1823,6 +1823,16 @@ enum Flow {
     /// *keep* a `Halt`: its own comment argues at length that an
     /// already-triggered halt must not be downgraded into a catchable path
     /// error, which is exactly what discarding `pending` would do for it.
+    ///
+    /// **One producer carries a stated exception**, added with the
+    /// `Expr::Compare` lazy arm (#1459, Stage 4):
+    /// [`binary_fanout_each`] has two operands and can therefore be handed
+    /// two `pending`s, so it has to pick. It keeps the *inner* (left)
+    /// operand's and drops the *outer* (right) one's -- see its own doc
+    /// comment for why that is the half that lands on jq's verdict, and
+    /// `test_short_circuit_side_effect_leaks_820_932_987` for the pinned
+    /// left/right pair. So `resolve_leaf`'s rule holds for every arm that
+    /// can produce only one `pending`, which is every arm but that one.
     Stopped { pending: Option<Control> },
     /// Terminated in a control. Everything produced before it was already
     /// delivered to the sink.
@@ -2450,6 +2460,29 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
 
     // The inner verdict wins over the outer loop's `Stopped`, which is only
     // the echo of our own driver returning `Stop`.
+    //
+    // That also **discards the outer operand's own `Flow::Stopped`
+    // `pending`**, in the one shape where it can carry a payload: an eager
+    // fallback on the right that had already raised a control before this
+    // loop stopped it. `resolve_leaf` is the only consumer that reads
+    // `pending` at all, so the effect is confined to a `Halt` under
+    // `path(...)`, and there the drop is the half that agrees with jq --
+    // jq's own `path()` is lazy end to end, never evaluates the trailing
+    // `halt_error`, and raises its "Invalid path expression" instead:
+    //
+    //     path(1 == (if true then (1, ("x"|halt_error(3))) else empty end))
+    //         jq       exit 5, the path error       (nothing on stderr)
+    //         this     exit 5, the path error       (stray `x`: Stage 5)
+    //     path((if true then (1, ("x"|halt_error(3))) else empty end) == 1)
+    //         jq       exit 5, the path error
+    //         this     exit 3, the halt wins        <- inner keeps `pending`
+    //
+    // Left and right therefore answer differently, deliberately rather than
+    // by accident; both rows are pinned in
+    // `test_short_circuit_side_effect_leaks_820_932_987`. Preserving the
+    // outer `pending` instead would move the first row back to exit 3, away
+    // from jq. The residual `x` on both is Stage 5's (`Expr::If` has no lazy
+    // arm), not this loop's.
     abort.unwrap_or(outer)
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1841,6 +1841,27 @@ enum Flow {
 /// only shrink the set of sub-expressions evaluated, never reorder or alter
 /// the values delivered. `collect_each` asserts this differentially in tests
 /// rather than leaving it asserted in prose.
+///
+/// **One arm carries a stated exception: `Expr::Compare` (#1459, Stage 4).**
+/// It has two operands, and making the outer one demand-aware necessarily
+/// *interleaves* their evaluation, where the eager `binary_fanout_core`
+/// finishes the right operand before starting the left. The delivered
+/// *values* are unchanged for side-effect-free operands — the same pairings
+/// in the same order — which is what
+/// `eval_each_with_a_never_stopping_sink_matches_eval_single_820` asserts.
+/// What changes is when each operand runs, and that is observable two ways,
+/// in both of which the lazy arm is the one that matches jq (oracle-verified
+/// against jq 1.7.1):
+///
+/// * ordering of evaluation-time I/O — `("A"|stderr) == (("B"|stderr),
+///   ("C"|stderr))` writes `B A C A` in jq, `B C A A` eagerly;
+/// * with `input`/`inputs` operands, the delivered values themselves, since
+///   which document each operand pops depends on that ordering —
+///   `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in
+///   jq, `["ca","db"]` eagerly.
+///
+/// So this is not a silent weakening of the invariant: it is the one place a
+/// lazy arm is deliberately *more* faithful than the eager path it shadows.
 fn drain_result<'a, W: Clone + AsRef<[u64]>>(
     result: QueryResult<'a, W>,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
@@ -1901,12 +1922,12 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
 
 /// Push every output of `expr` into `sink`, stopping as soon as `sink` says to.
 ///
-/// Native lazy arms: `Comma`, `Pipe`, `Paren`, and `Builtin::PathsFilter`
-/// (#987, Stage 3). Everything else falls back to `eval_single` +
-/// [`drain_result`]. `Paren` is not optional cosmetics: `isempty(...)`
-/// consumes only its own parentheses, so `isempty((1, stderr))` is
-/// `IsEmpty(Paren(Comma(..)))` and without this arm the fix would be a coin
-/// flip on spelling.
+/// Native lazy arms: `Comma`, `Pipe`, `Paren`, `Builtin::PathsFilter`
+/// (#987, Stage 3) and `Compare` (#1459, Stage 4). Everything else falls
+/// back to `eval_single` + [`drain_result`]. `Paren` is not optional
+/// cosmetics: `isempty(...)` consumes only its own parentheses, so
+/// `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and without this arm
+/// the fix would be a coin flip on spelling.
 fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
@@ -1931,6 +1952,40 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Expr::Builtin(Builtin::PathsFilter(f)) => {
             each_paths_filter::<W, S>(f, value, optional, sink)
         }
+        // #1459 (Stage 4): the demand-aware twin of `eval_compare`'s fanout.
+        // [`binary_fanout_each`] owns the loop order; passing `eval_each` as
+        // the operand strategy is what makes the *right* operand — jq's outer
+        // loop — stop producing candidates the sink never asked for. That is
+        // `IN(src; s)`'s leak (#932): `builtin_upper_in_src` hands
+        // `any_all_gen_cond` a synthesized `Expr::Compare` as its generator,
+        // so without this arm the whole comparison ran to completion before
+        // the first candidate ever reached the sink.
+        //
+        // No `needs_path_context` gate here, unlike `eval_each_pipe`: the
+        // eager fallback for `Expr::Compare` is `eval_compare` ->
+        // `eval_binary_fanout` -> `eval_single` per operand, which has no
+        // path-context diversion of its own, so there is nothing to preserve
+        // — and each operand's own `eval_each` re-derives exactly the routing
+        // `eval_single` would (a `Pipe` operand still hits `eval_each_pipe`'s
+        // gate before anything else).
+        //
+        // `Expr::Arithmetic` shares [`binary_fanout_each`] but deliberately
+        // gets no lazy arm: Stage 4 is scoped to `Expr::Compare`, and
+        // arithmetic's `combine` can fail, which is its own risk surface.
+        Expr::Compare { op, left, right } => binary_fanout_each(
+            |operand, operand_sink| {
+                eval_each::<W, S>(operand, value.clone(), optional, operand_sink)
+            },
+            left,
+            right,
+            optional,
+            |left_val, right_val| {
+                Ok(OwnedValue::Bool(apply_compare_op::<S>(
+                    *op, &left_val, &right_val,
+                )))
+            },
+            sink,
+        ),
         _ => drain_result(eval_single::<W, S>(expr, value, optional), sink),
     }
 }
@@ -2269,37 +2324,133 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
 /// again for #822: two definitions of the same algorithm can drift, one
 /// does not. `eval_operand` closes over whichever evaluator its caller
 /// wants; everything downstream of an operand's `QueryResult` is unchanged.
+///
+/// **This is the eager operand strategy**, not the loop itself: the loop
+/// moved to [`binary_fanout_each`] for #1459 (Stage 4), and this is the
+/// collecting wrapper over it. `each_operand` here evaluates a whole operand
+/// up front and replays it through [`drain_result`], so both callers keep the
+/// exact "right operand evaluated to completion, *then* left re-evaluated per
+/// right value" behaviour they had when this body *was* the loop.
+/// `eval_each`'s own `Expr::Compare` arm supplies the demand-driven strategy
+/// instead — same loop, lazy operands.
 fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
-    mut eval_operand: impl FnMut(&Expr) -> QueryResult<'a, W>,
+    eval_operand: impl Fn(&Expr) -> QueryResult<'a, W>,
+    left: &Expr,
+    right: &Expr,
+    optional: bool,
+    combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
+) -> QueryResult<'a, W> {
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let flow = binary_fanout_each(
+        |expr, sink| drain_result(eval_operand(expr), sink),
+        left,
+        right,
+        optional,
+        combine,
+        &mut |item: Item<'a, W>| {
+            out.push(item.into_owned());
+            Demand::Continue
+        },
+    );
+
+    match flow {
+        // This sink never stops, so `Stopped` cannot occur — folded in with
+        // `Exhausted` rather than given an `unreachable!()`, the same
+        // defensive choice `any_all_gen_cond` makes for its own impossible
+        // `Stopped`: an answer built from the outputs already produced is a
+        // better failure mode than a panic.
+        Flow::Exhausted | Flow::Stopped { .. } => owned_vec_to_result(out),
+        Flow::Escaped(control) => partial(out, control),
+    }
+}
+
+/// The one definition of jq's right-outer/left-inner fanout loop, written
+/// against the demand-driven sink (#1459, Stage 4 of
+/// `docs/plan/jq-lazy-generator-consumers.md`) and parameterized over *how*
+/// an operand is enumerated.
+///
+/// Two strategies exist, and only the strategy differs — never the loop:
+///
+/// * [`binary_fanout_core`] passes an eager `each_operand` (evaluate the
+///   whole operand, then replay it through [`drain_result`]), which is what
+///   `eval_arithmetic`/`eval_compare` and the path-context sibling have
+///   always done.
+/// * `eval_each`'s `Expr::Compare` arm passes [`eval_each`] itself, so the
+///   *right* operand — jq's outer loop — stops producing candidates the sink
+///   never asked for. That is what closes `IN(src; s)`'s side-effect leak
+///   (#932/#1459): a `stderr`/`halt_error` sitting past the matching
+///   candidate is no longer evaluated at all.
+///
+/// Keeping one loop is the whole point: #768 fixed a collapse-to-first-value
+/// bug here that the then-duplicated path-context copy independently
+/// re-acquired and had to be fixed again for #822. A third copy for the lazy
+/// arm would have been a third chance at the same drift.
+///
+/// `each_operand` is `Fn`, not `FnMut`, because it is called **re-entrantly**:
+/// the per-right-value call on `left` happens while the call on `right` is
+/// still on the stack.
+fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow,
     left: &Expr,
     right: &Expr,
     optional: bool,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
-) -> QueryResult<'a, W> {
-    let mut right_vals = Vec::new();
-    let right_control = push_owned_values(eval_operand(right), &mut right_vals);
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    // Why the fanout ended, recorded out-of-band because the driver closure
+    // can only answer `Demand` — the same shape as `eval_each_pipe`'s
+    // `downstream` and `any_all_gen_cond`'s `probe_escape`.
+    let mut abort: Option<Flow> = None;
 
-    let mut out: Vec<OwnedValue> = Vec::new();
-    for right_val in &right_vals {
-        let mut left_vals = Vec::new();
-        let left_control = push_owned_values(eval_operand(left), &mut left_vals);
+    let outer = each_operand(right, &mut |right_item: Item<'a, W>| {
+        let right_val = right_item.into_owned();
 
-        for left_val in left_vals {
-            match combine(left_val, right_val.clone()) {
-                Ok(v) => out.push(v),
-                Err(e) => return finish_fork(out, Some(e.into()), optional),
+        let inner = each_operand(left, &mut |left_item: Item<'a, W>| {
+            match combine(left_item.into_owned(), right_val.clone()) {
+                Ok(v) => sink(Item::Owned(v)),
+                Err(e) => {
+                    // The sink-world spelling of the eager body's
+                    // `finish_fork(out, Some(e.into()), optional)`: a
+                    // `combine` error (op-application failure, e.g. `"a" + 1`)
+                    // aborts the whole fanout rather than skipping just that
+                    // pairing, the outputs already pushed stand either way,
+                    // and `optional` decides whether the failure itself
+                    // survives.
+                    abort = Some(if optional {
+                        Flow::Exhausted
+                    } else {
+                        Flow::Escaped(Control::Error(e))
+                    });
+                    Demand::Stop
+                }
+            }
+        });
+
+        // A `combine` failure has already decided; the `Stopped` it induces
+        // in the inner loop must not overwrite that verdict.
+        if abort.is_some() {
+            return Demand::Stop;
+        }
+
+        match inner {
+            Flow::Exhausted => Demand::Continue,
+            // `Escaped` is the eager body's `return partial(out, control)`:
+            // an escape partway through the *inner* operand aborts the
+            // comparison before any later output of the *outer* one is
+            // reached (#910, oracle-verified: `IN(4, error("boom"); 9, 4)`
+            // raises rather than answering `true`). `Stopped` is the
+            // consumer's own demand, which ends the outer loop for the same
+            // reason `eval_each_pipe`'s downstream stop ends stage 1.
+            other => {
+                abort = Some(other);
+                Demand::Stop
             }
         }
+    });
 
-        if let Some(control) = left_control {
-            return partial(out, control);
-        }
-    }
-
-    match right_control {
-        Some(control) => partial(out, control),
-        None => owned_vec_to_result(out),
-    }
+    // The inner verdict wins over the outer loop's `Stopped`, which is only
+    // the echo of our own driver returning `Stop`.
+    abort.unwrap_or(outer)
 }
 
 /// Shared unary fork/negate/finish core behind [`eval_negate`] and its
@@ -4273,13 +4424,13 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// own doc comment documents. Confirmed against jq 1.7.1: `IN(2,
 /// error("boom"))` on `2` is `true` (the error is never reached), `IN(3,
 /// error("boom"))` on `2` still raises it (no earlier candidate matched, so
-/// the trailing escape is the only verdict left). Known gap (#932, shared
-/// with `any`/`all`, pre-existing there): `halt_error`/`stderr` print as an
-/// immediate side effect of being *evaluated*, not of their result being
-/// consumed, so a match found before reaching one in `s` still leaks its
-/// printed bytes even though the overall answer and process-exit behavior
-/// stay correct -- `debug`/`error` don't have this problem, since neither
-/// performs I/O at evaluation time.
+/// the trailing escape is the only verdict left). #932's leak — a
+/// `halt_error`/`stderr` past the matching candidate printing anyway, because
+/// both perform I/O as a side effect of being *evaluated* rather than of
+/// being consumed — was closed for this form by #820's Stage 2, which routed
+/// the candidate loop below through `eval_each_owned`, and for the
+/// `IN(src; s)` form by Stage 4 (#1459). Both are pinned in
+/// `test_short_circuit_side_effect_shapes_already_match_jq_820`.
 fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     s: &Expr,
     value: StandardJson<'a, W>,
@@ -4344,6 +4495,17 @@ fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// it correctly leaves `src` untouched entirely when `s` produces zero
 /// outputs, `IN(error("boom"); empty)` is `false`, not an error) fixes this
 /// by construction instead of re-deriving jq's evaluation order by hand.
+///
+/// #1459 (#820's Stage 4) is what makes that delegation lazy as well as
+/// correct. `any_all_gen_cond` has probed `cond` per output since Stage 2,
+/// but its `gen` here is the synthesized `Expr::Compare` below, and
+/// `eval_each` had no arm for it -- so the whole comparison ran to
+/// completion before the first candidate reached the sink, and a
+/// `stderr`/`halt_error` sitting past the matching candidate printed anyway
+/// (`[IN((2,3); 2, (5|stderr))]` leaked `5`; jq writes nothing).
+/// `eval_each`'s `Expr::Compare` arm closes that without moving the loop
+/// order back in here: it is the same [`binary_fanout_each`], driven from a
+/// demand-aware operand strategy.
 fn builtin_upper_in_src<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     src: &Expr,
     s: &Expr,
@@ -33337,6 +33499,39 @@ mod tests {
             (b"{\"a\":1,\"b\":{\"c\":2}}", "paths(true)"),
             (b"[1,2,3]", "paths(if .==2 then error(\"x\") else true end)"),
             (b"1", "paths(error(\"x\"))"),
+            // #1459, Stage 4: `Expr::Compare` gained a native lazy arm, so
+            // this differential is what guards it against drifting from
+            // `eval_compare`'s own fanout -- both now run the same loop
+            // ([`binary_fanout_each`]), but from opposite operand
+            // strategies, and only this asserts they agree.
+            //
+            // Every operand here is deliberately side-effect free. The lazy
+            // arm *interleaves* the two operands where the eager one
+            // finishes the right operand first (see [`drain_result`]'s own
+            // caveat), so a `stderr`/`input` operand would legitimately
+            // differ here while the values stayed the pairings jq produces.
+            (b"null", "(1,2) == (10,20)"),
+            (b"null", "(1,2) == 2"),
+            (b"null", "2 == (1,2)"),
+            (b"null", "(1,2) < (2,1)"),
+            (b"null", "(1,2) != 1"),
+            (b"null", "(1,2,3) >= (3,2,1)"),
+            (b"null", "empty == 1"),
+            (b"null", "1 == empty"),
+            (b"null", "empty == empty"),
+            (b"null", "(1, error(\"x\")) == (10,20)"),
+            (b"null", "(1,2) == (10, error(\"x\"))"),
+            (b"null", "error(\"x\") == (1,2)"),
+            (b"null", "label $o | ((1, break $o) == (10,20))"),
+            (b"null", "label $o | ((10,20) == (1, break $o))"),
+            (b"[1,2,3]", ".[] == 2"),
+            (b"[1,2,3]", "(.[] , 9) == (.[] , 0)"),
+            (b"{\"a\":1,\"b\":2}", ".a == (.a, .b)"),
+            // Nested inside the other lazy arms, and with the compare as a
+            // pipe stage, so the arm is reached through them too.
+            (b"null", "((1,2) == (10,20)), ((3,4) == (3,4))"),
+            (b"null", "(1,2) | . == (1,2)"),
+            (b"null", "[limit(2; (1,2,3) == (10,20))]"),
         ];
 
         for (json, src) in cases {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17140,6 +17140,26 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // The lazy arm's *interleaved* operand order, which is the one
+        // property `drain_result`'s own "one arm carries a stated exception"
+        // caveat rests on and the only row that catches a silent regression
+        // back to the eager loop while every stderr-suppression row above
+        // stays green. jq runs right's first output, then the whole left
+        // operand, then right's second -- `B A C A`; the eager
+        // `binary_fanout_core` finishes right first and writes `B C A A`.
+        // Distinct from the #1481 row in the leaks table below, which pins
+        // the *top-level* spelling of this same compare (it never reaches
+        // `eval_each`, so it keeps the eager order).
+        (
+            &[
+                "-cn",
+                r#"[all(("A"|stderr) == (("B"|stderr), ("C"|stderr)); true)]"#,
+            ],
+            None,
+            "[true]\n",
+            "BACA",
+            0,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -17255,6 +17275,49 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "",
             "1jq: error (at <stdin>:0): Invalid path expression with result [0]",
             5,
+        ),
+        // ---- `binary_fanout_each` drops the OUTER operand's `pending` -----
+        // `resolve_leaf` is the one consumer that reads `Flow::Stopped`'s
+        // `pending`, and this pair pins the left/right asymmetry that falls
+        // out of `binary_fanout_each`'s `abort.unwrap_or(outer)`: a `Halt`
+        // an eager-fallback operand had already triggered survives from the
+        // INNER (left) operand and is dropped from the OUTER (right) one.
+        // The drop is deliberate -- see `binary_fanout_each`'s own doc
+        // comment -- and it is the half that lands on jq's verdict, since
+        // jq's fully lazy `path()` never evaluates the `halt_error` at all
+        // and raises the path error instead.
+        //
+        // Both rows still diverge, and by the same Stage 5 residual rather
+        // than anything Stage 4 introduced: `Expr::If` has no lazy arm, so
+        // the `halt_error` is evaluated and writes `x` where jq writes
+        // nothing. Once Stage 5 lands neither operand evaluates it at all,
+        // so both rows lose the `x`, the second row's halt stops preempting
+        // the path error, and both move into the table above.
+        //
+        // Right operand (outer): pending dropped, so the path error wins --
+        // jq's own exit code and message, plus the stray `x`.
+        (
+            &[
+                "-cn",
+                r#"path(1 == (if true then (1, ("x"|halt_error(3))) else empty end))"#,
+            ],
+            None,
+            "",
+            "xjq: error (at <unknown>): Invalid path expression with result true",
+            5,
+        ),
+        // Left operand (inner): pending kept, so the already-triggered halt
+        // wins and the path error is never raised. jq: exit 5, same message
+        // as the row above.
+        (
+            &[
+                "-cn",
+                r#"path((if true then (1, ("x"|halt_error(3))) else empty end) == 1)"#,
+            ],
+            None,
+            "",
+            "x",
+            3,
         ),
     ];
 
@@ -17474,6 +17537,69 @@ fn test_owned_pipe_stage_ahead_of_comma_stays_lazy() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-cn", r#"limit(1; 1 | (1, ("B"|stderr)))"#], None)?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "1\n");
+
+    Ok(())
+}
+
+/// The `Expr::Compare` half of the same data loss, closed by Stage 4 (#1459).
+///
+/// #1459 is filed as "Severity: Low (stray stderr write; no wrong output, no
+/// data loss)", and for its own `IN(src; s)` repro that is true. It is not
+/// true of the arm the fix actually adds: once a compare's operands can pop
+/// `input`, the eager fanout's discarded candidates eat documents the CLI's
+/// per-document driver loop then never processes -- exit 0, empty stderr,
+/// correct-*looking* output, half the input gone. That is the same silent
+/// data loss `test_discarded_generator_branch_consumes_input_documents_820`
+/// pins for the `Comma` arm, and this is its `Compare` counterpart.
+///
+/// Deliberately separate from the stderr tables above: every row there would
+/// stay green if `eval_each`'s `Expr::Compare` arm regressed to eager *only*
+/// for operands that pop documents, and this is the test that would not.
+///
+/// Live against jq 1.7.1 (and against `main` before Stage 4, which processed
+/// documents 1 and 3 only).
+#[test]
+fn test_compare_operand_consuming_input_documents_1459() -> Result<()> {
+    const DOCS: &str = r#"{"id":1} {"id":2} {"id":3} {"id":4}"#;
+
+    // Control: every document is processed when nothing consumes the queue.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".id"], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "1\n2\n3\n4\n",
+        "control run must see all 4 documents"
+    );
+
+    // `isempty` stops the compare on its first pairing, so the `input` in
+    // the right operand's tail is never evaluated and never pops. Before
+    // Stage 4 this printed `[false,1]\n[false,3]\n` -- documents 2 and 4
+    // were eaten by a candidate whose value was then discarded.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[isempty(.id == (1, input)), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "[false,1]\n[false,2]\n[false,3]\n[false,4]\n",
+        "isempty over a compare must not pop a document"
+    );
+
+    // `all` short-circuits on the first falsy pairing, same shape.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[all(.id == (99, input); .), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "[false,1]\n[false,2]\n[false,3]\n[false,4]\n",
+        "all over a compare must not pop a document"
+    );
+
+    // `limit(1)` is satisfied by the first pairing, so right's tail is never
+    // demanded. The first document's own answer is `true` (1 == 1).
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[limit(1; .id == (1, input)), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "[true,1]\n[false,2]\n[false,3]\n[false,4]\n",
+        "limit over a compare must not pop a document"
+    );
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17226,8 +17226,9 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
         // before the left, where jq interleaves them. Stage 4 made only
         // `eval_each`'s arm demand-aware, so a top-level compare keeps the
         // old order. jq writes `B`, `A`, `C`, `A`; succinctly writes `B`,
-        // `C`, `A`, `A`. Tracked separately -- with `input` operands the same
-        // ordering changes *values*, not just stderr.
+        // `C`, `A`, `A`. Tracked as #1481 -- with `input` operands the same
+        // ordering changes *values*, not just stderr, and the loop it lives
+        // in is shared with `Expr::Arithmetic`.
         (
             &["-cn", r#"[("A"|stderr) == (("B"|stderr), ("C"|stderr))]"#],
             None,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16891,6 +16891,56 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             0,
         ),
         (&["-c", "IN(2, (5|stderr))"], Some("[2]"), "false\n", "5", 0),
+        // ---- Stage 4 (#1459) guard rails: `Expr::Compare`'s outer loop ----
+        // `binary_fanout_core` runs the RIGHT operand as the outer loop and
+        // re-runs the left per right value (#910's live-verified nested-loop
+        // order). So a side effect in the right operand's FIRST output is
+        // genuinely reached, and one the consumer's demand runs past is
+        // reached too. These are the rows a too-eager `Demand::Stop` breaks.
+        //
+        // The side effect is right's first output, so it precedes everything.
+        (
+            &["-cn", r#"[isempty((1,2) == ("B"|stderr, 3))]"#],
+            None,
+            "[false]\n",
+            "B",
+            0,
+        ),
+        // `limit(3)` is not satisfied by the two pairings right's first
+        // output produces, so right's second output IS demanded.
+        (
+            &["-cn", r#"[limit(3; (1,2) == (10, ("B"|stderr)))]"#],
+            None,
+            "[false,false,false]\n",
+            "B",
+            0,
+        ),
+        // No pairing is truthy, so `any` must exhaust the generator.
+        (
+            &["-cn", r#"[any((1,2) == (10, ("B"|stderr)); .)]"#],
+            None,
+            "[false]\n",
+            "B",
+            0,
+        ),
+        // #910's own case: an escape partway through the INNER operand
+        // aborts the comparison before a later output of the outer one is
+        // reached, so the match at `s`'s second output is never found.
+        (
+            &["-cn", r#"[IN(4, error("boom"); 9, 4)]"#],
+            None,
+            "",
+            "jq: error (at <unknown>): boom",
+            5,
+        ),
+        // The side effect is `s`'s FIRST candidate, before the matching one.
+        (
+            &["-cn", r"[IN((2,3); (5|stderr), 2)]"],
+            None,
+            "[true]\n",
+            "5",
+            0,
+        ),
         // Already lazy today, and must stay lazy.
         (
             &["-cn", r#"false and ("B"|stderr)"#],
@@ -17014,6 +17064,82 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "outer",
             1,
         ),
+        // ---- closed by #820 Stage 4 (#1459); these were leaking above -----
+        // `eval_each` gained a native `Expr::Compare` arm, so the RIGHT
+        // operand -- jq's outer loop -- stops producing candidates once the
+        // consumer is satisfied. #932's remaining `IN(src; s)` third: it
+        // hands `any_all_gen_cond` a synthesized `Expr::Compare` as its
+        // generator, so it inherits the laziness directly.
+        (
+            &["-cn", r"[IN((2,3); 2, (5|stderr))]"],
+            None,
+            "[true]\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r"[IN((2,3); 2, (5|stderr), 7)]"],
+            None,
+            "[true]\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"[IN((2,3); 2, ("X"|halt_error(7)))]"#],
+            None,
+            "[true]\n",
+            "",
+            0,
+        ),
+        // `src` sourced from the document rather than a literal, so the
+        // cursor path is exercised too.
+        (
+            &["-c", r"[IN(.[]; 2, (5|stderr))]"],
+            Some("[1,2]"),
+            "[true]\n",
+            "",
+            0,
+        ),
+        // Every other lazy consumer wrapped around a bare compare. Each has
+        // a matching guard-rail row above where the demand DOES reach the
+        // side effect, so these cannot be satisfied by stopping too early.
+        (
+            &["-cn", r#"[isempty((1,2) == (10, ("B"|stderr)))]"#],
+            None,
+            "[false]\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"[limit(2; (1,2) == (10, ("B"|stderr)))]"#],
+            None,
+            "[false,false]\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"[nth(1; (1,2) == (10, ("B"|stderr)))]"#],
+            None,
+            "[false]\n",
+            "",
+            0,
+        ),
+        // `all` short-circuits on the first falsy pairing.
+        (
+            &["-cn", r#"[all((1,2) == (10, ("B"|stderr)); .)]"#],
+            None,
+            "[false]\n",
+            "",
+            0,
+        ),
+        // `any` short-circuits on the first truthy one.
+        (
+            &["-cn", r#"[any((2,1) == (1, ("B"|stderr)); .)]"#],
+            None,
+            "[true]\n",
+            "",
+            0,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -17076,15 +17202,37 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "12",
             0,
         ),
-        // `IN(src; s)` synthesizes an `Expr::Compare` and hands it to
-        // `any_all_gen_cond` as `gen`, but `binary_fanout_core`'s outer loop
-        // is still eager, so the sink never sees the candidates one at a
-        // time. Closed by Stage 4. jq: no stderr.
+        // Same residual as the row above, found by Stage 4's own oracle
+        // sweep (#1459): a bare `first(...)` is intercepted by
+        // `eval_generic`'s native `first`/`last` arm, whose Stage 2b
+        // short-circuit only walks *comma* siblings -- an `Expr::Compare`
+        // argument falls through to eager `eval_single`, so `eval.rs`'s new
+        // lazy `Compare` arm is never reached. Wrapping the same compare in
+        // any consumer that does bounce into `eval.rs` (`isempty`, `limit`,
+        // `nth`, `any`, `all`, `IN`) already matches jq -- see the table
+        // above. jq: no stderr.
         (
-            &["-cn", "[IN((2,3); 2, (5|stderr))]"],
+            &["-cn", r#"[first((1,2) == (10, ("B"|stderr)))]"#],
             None,
-            "[true]\n",
-            "5",
+            "[false]\n",
+            "B",
+            0,
+        ),
+        // The eager copies of jq's right-outer/left-inner fanout loop
+        // (`binary_fanout_core` via `eval_binary_fanout`,
+        // `eval_binary_fanout_with_path_context`, and `eval_generic`'s own
+        // third copy in its `Expr::Compare` arm -- which is what a top-level
+        // `==` actually reaches) still run the right operand to completion
+        // before the left, where jq interleaves them. Stage 4 made only
+        // `eval_each`'s arm demand-aware, so a top-level compare keeps the
+        // old order. jq writes `B`, `A`, `C`, `A`; succinctly writes `B`,
+        // `C`, `A`, `A`. Tracked separately -- with `input` operands the same
+        // ordering changes *values*, not just stderr.
+        (
+            &["-cn", r#"[("A"|stderr) == (("B"|stderr), ("C"|stderr))]"#],
+            None,
+            "[false,false]\n",
+            "BCAA",
             0,
         ),
         // #987 Stage 3 closed the bare-comma spelling of this shape


### PR DESCRIPTION
Closes #1459. Closes #932.

#820's **Stage 4**. #932 was closed when Stage 2 (#1421) landed, which was right for its
`any`/`all`/`IN(s)` thirds but left `IN(src; s)` divergent — and `main` shipped a test
pinning the *wrong* output for it, so the tracker disagreed with the suite.

```
$ jq            -cn '[IN((2,3); 2, (5|stderr))]'   # [true]   (no stderr)
$ succinctly jq -cn '[IN((2,3); 2, (5|stderr))]'   # [true]   stderr: 5   <- before
```

## Root cause

`builtin_upper_in_src` synthesizes an `Expr::Compare` and hands it to `any_all_gen_cond`
as `gen`. That has probed `cond` per output since Stage 2, but `eval_each` had no
`Expr::Compare` arm, so it fell back to `eval_single` + `drain_result` and the whole
comparison ran to completion before the first candidate ever reached the sink.

## Approach — one loop, two operand strategies

Not a hand-rolled candidate loop inside `builtin_upper_in_src`: #910's review already
rejected that shape as an unsound cross-product. Instead `binary_fanout_core`'s body
becomes **`binary_fanout_each`** — the same right-outer/left-inner loop, parameterized over
how an operand is *enumerated* rather than merely evaluated:

* `binary_fanout_core` is now the collecting wrapper supplying the **eager** strategy
  (evaluate the whole operand, replay it through `drain_result`), so `eval_arithmetic`,
  `eval_compare` and `eval_binary_fanout_with_path_context` are behaviourally untouched.
* `eval_each`'s new `Expr::Compare` arm supplies **`eval_each` itself**, so the right
  operand — jq's outer loop — stops producing candidates the sink never asked for.

Keeping one loop is the point: #768 fixed a collapse-to-first-value bug there that the
then-duplicated path-context copy independently re-acquired and had to be fixed again for
#822. A third copy would have been a third chance at the same drift.

`each_operand` is `Fn`, not `FnMut`, because it is called re-entrantly — the per-right-value
call on `left` happens while the call on `right` is still on the stack.

## Oracle sweep

105 shapes — all six `CompareOp`s × operand arities, every lazy consumer (`isempty`,
`first`, `limit`, `nth`, `last`, `any`, `all`, `IN(s)`, `IN(src; s)`, `path(paths(f))`,
`halt_error`'s argument), terminators in either operand, `?`/`try`, and `input` — run
against pinned jq 1.7.1 with **stdout, stderr and exit code captured separately**.
Divergences went **18 → 5**. yq mode spot-checked separately (`Expr::Compare` is
`S`-generic); output unchanged.

## Both directions are pinned

Moved into `test_short_circuit_side_effect_shapes_already_match_jq_820`, now matching jq:
`[IN((2,3); 2, (5|stderr))]`, the `halt_error` variant, the cursor-sourced
`[IN(.[]; 2, (5|stderr))]`, plus `isempty`/`limit(2)`/`nth(1)`/`all`/`any` over a bare
compare.

Added as **guard rails** in the same table, because over-stopping is this design's
characteristic failure mode — each is a shape where the demand genuinely *does* reach the
side effect and jq writes it:

| Guard rail | jq stderr |
|---|---|
| `[isempty((1,2) == ("B"\|stderr, 3))]` | `B` |
| `[limit(3; (1,2) == (10, ("B"\|stderr)))]` | `B` |
| `[any((1,2) == (10, ("B"\|stderr)); .)]` | `B` |
| `[IN((2,3); (5\|stderr), 2)]` | `5` |
| `[IN(4, error("boom"); 9, 4)]` | raises (#910's order) |

`eval_each_with_a_never_stopping_sink_matches_eval_single_820` gains 20 side-effect-free
compare cases — that differential is what stops the new arm drifting from `eval_compare`.

## Two residuals, left as separate work

* A bare `first(<non-comma>)` never reaches `eval.rs`: `eval_generic`'s native `first`/`last`
  arm short-circuits only over *comma* siblings. Same class as the already-pinned
  `first(.[] | stderr)` — option (c).
* The **eager** copies of the loop still finish the right operand before the left, where jq
  interleaves them. Broader than #820 (it affects `Expr::Arithmetic` too, and lives in
  `eval_generic`'s own third copy of the loop), and with `input` operands it changes
  *values*: `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in jq and
  `["ca","db"]` here. Filed as **#1481**, and pinned meanwhile.

`drain_result`'s "a lazy arm never reorders or alters the values delivered" invariant gains
an explicit, documented carve-out for this arm rather than a silent exception.

## Verification

`cargo fmt --check`; all three `ci.yml` clippy legs (`--all-features`, and both explicit
feature sets) with `-D warnings`; `cargo check --no-default-features` (no_std);
`cargo test` and `cargo test --features cli` (5660 passed, 0 failed); plus the
`--features simd`, `--features portable-popcount`, `SUCCINCTLY_SIMD=sse2` and
`--features simd,scalar-yaml` legs. All run sequentially.

Interleaved A/B on arithmetic-heavy queries (9 reps each, per-rep interleaved) shows no
regression — 0.89–0.93× of baseline, since the eager wrapper no longer allocates the two
intermediate `Vec`s the old body built per fanout.