### PR TITLE
fix(jq): parent(n) agrees with chained parent at the exact root boundary

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22007,15 +22007,29 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
 
         // Calculate parent path (n levels up). A borrowed slice, same
         // zero-allocation reasoning as the plain `Parent` arm above
-        // (#1449) -- pre-existing here, not introduced by this PR, but
-        // fixed in passing since it's the identical pattern.
-        let parent_path: &[OwnedValue] = if n >= current_path.len() {
+        // (#1449).
+        //
+        // #1476: landing *exactly* on the root (`n == current_path.len()`)
+        // must resolve to the root value, same as chaining bare `parent`
+        // `n` times would -- `.a | parent` and `.a | parent(1)` must agree.
+        // The old `n >= current_path.len()` guard conflated that case with
+        // genuinely overshooting *past* the root (`n > current_path.len()`,
+        // where there's nothing left to resolve), so `parent(1)` on a
+        // depth-1 path wrongly gave `{}` instead of the root. Testing
+        // `n > current_path.len()` directly distinguishes the two: at
+        // exactly `n == len`, `parent_path` is the empty slice and
+        // `get_value_at_owned_path(root, &[])` already resolves to `root`
+        // itself, so no separate root-shortcut is needed here (unlike the
+        // plain `Parent` arm, which has no "past root" case of its own to
+        // guard against and so never needed this distinction).
+        let overshoot = n > current_path.len();
+        let parent_path: &[OwnedValue] = if overshoot {
             &[]
         } else {
             &current_path[..current_path.len() - n]
         };
 
-        let parent_result = if parent_path.is_empty() && n > 0 {
+        let parent_result = if overshoot {
             // Gone past root - return empty object
             QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
         } else {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21681,6 +21681,45 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Resolve the value `n` levels up from `current_path` -- `parent` is this
+/// with `n = 1`, `parent(n)` with whatever `n` evaluates to. Returns both
+/// the ancestor's own path (for `rest`'s continuation, via
+/// `continue_rest_with_context`) and its resolved value.
+///
+/// Shared by both the `Parent` and `ParentN` arms below: they used to
+/// independently hand-roll this same arithmetic, and that duplication is
+/// exactly what caused #1476 -- `ParentN`'s own copy had a subtly
+/// different, wrong boundary condition (`n >= current_path.len()`
+/// conflating "landed exactly on the root" with "overshot past it") that
+/// `Parent`'s copy never had reason to get wrong, since it only ever steps
+/// up by one. `current_path.len().checked_sub(n)` makes the distinction
+/// direct: `None` means `n` exceeds the path's depth (overshoot, nothing
+/// to resolve); `Some(len)` (including `len == 0`, landing exactly on
+/// root) means `&current_path[..len]` is a real path to resolve via
+/// `get_value_at_owned_path`, which already returns `root` itself for an
+/// empty path.
+fn resolve_ancestor_path<'a, 'p, W: Clone + AsRef<[u64]>>(
+    root: &OwnedValue,
+    current_path: &'p [OwnedValue],
+    n: usize,
+) -> (&'p [OwnedValue], QueryResult<'a, W>) {
+    match current_path.len().checked_sub(n) {
+        None => (
+            &[],
+            // Gone past root - return empty object
+            QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
+        ),
+        Some(len) => {
+            let ancestor_path = &current_path[..len];
+            let result = match get_value_at_owned_path(root, ancestor_path) {
+                Some(v) => QueryResult::Owned(v),
+                None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
+            };
+            (ancestor_path, result)
+        }
+    }
+}
+
 /// Path-context analog of `eval_binary_fanout` (#768/#822): evaluate `left op
 /// right` over every pairing jq's cartesian fanout produces (right operand
 /// outer / left operand inner), routed through
@@ -21951,24 +21990,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     // routed through the shared helper (#1449), just with a different
     // `current_path` argument for the continuation.
     if matches!(first, Expr::Builtin(Builtin::Parent)) {
-        // `parent_path` borrows straight from `current_path` -- both this
-        // and `continue_rest_with_context` only ever need a `&[OwnedValue]`
-        // slice, never an owned one, so there's nothing to clone here
-        // (code review, #1449: routing this arm through the shared helper
-        // had accidentally turned the old code's on-demand `.to_vec()`,
-        // paid only when `rest` was non-empty, into an unconditional one).
-        let (parent_path, parent_result): (&[OwnedValue], _) = if current_path.is_empty() {
-            // At root - return empty object (yq behavior)
-            (&[], QueryResult::Owned(OwnedValue::Object(IndexMap::new())))
-        } else {
-            let parent_path = &current_path[..current_path.len() - 1];
-            // Navigate from root to parent
-            let parent_result = match get_value_at_owned_path(root, parent_path) {
-                Some(parent_value) => QueryResult::Owned(parent_value),
-                None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
-            };
-            (parent_path, parent_result)
-        };
+        let (parent_path, parent_result) = resolve_ancestor_path::<W>(root, current_path, 1);
         return continue_rest_with_context::<W, S>(
             parent_result,
             rest,
@@ -22005,42 +22027,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             Err(escape) => return escape.into(),
         };
 
-        // Calculate parent path (n levels up). A borrowed slice, same
-        // zero-allocation reasoning as the plain `Parent` arm above
-        // (#1449).
-        //
-        // #1476: landing *exactly* on the root (`n == current_path.len()`)
-        // must resolve to the root value, same as chaining bare `parent`
-        // `n` times would -- `.a | parent` and `.a | parent(1)` must agree.
-        // The old `n >= current_path.len()` guard conflated that case with
-        // genuinely overshooting *past* the root (`n > current_path.len()`,
-        // where there's nothing left to resolve), so `parent(1)` on a
-        // depth-1 path wrongly gave `{}` instead of the root. Testing
-        // `n > current_path.len()` directly distinguishes the two: at
-        // exactly `n == len`, `parent_path` is the empty slice and
-        // `get_value_at_owned_path(root, &[])` already resolves to `root`
-        // itself, so no separate root-shortcut is needed here (unlike the
-        // plain `Parent` arm, which has no "past root" case of its own to
-        // guard against and so never needed this distinction).
-        let overshoot = n > current_path.len();
-        let parent_path: &[OwnedValue] = if overshoot {
-            &[]
-        } else {
-            &current_path[..current_path.len() - n]
-        };
-
-        let parent_result = if overshoot {
-            // Gone past root - return empty object
-            QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
-        } else {
-            match get_value_at_owned_path(root, parent_path) {
-                Some(parent_value) => QueryResult::Owned(parent_value),
-                None => QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
-            }
-        };
-
-        // Same "continue at the parent's path" shape as the plain `Parent`
-        // arm above (#1449).
+        // Same shared helper as the plain `Parent` arm above (`n = 1`'s
+        // special case) -- unified by #1476's own review, which found the
+        // two arms had each hand-rolled this arithmetic separately, and
+        // that divergence (a subtly different boundary condition in this
+        // arm alone) was the exact bug #1476 fixed.
+        let (parent_path, parent_result) = resolve_ancestor_path::<W>(root, current_path, n);
         return continue_rest_with_context::<W, S>(
             parent_result,
             rest,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5344,14 +5344,46 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 
     // `parent(n)` with `n` strictly greater than the current path's depth
     // (genuinely overshoots past the root, unlike `parent(2)` above which
-    // stays within the path) -- `n == depth` is #1476's exact-boundary bug,
-    // deliberately not exercised here since it would pin the wrong answer.
+    // stays within the path).
     let (output, _, code) = run_jq_full(
         &["-c", ".a.b.c | parent(4)"],
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "{}");
+
+    Ok(())
+}
+
+/// `parent(n)` must agree with chaining bare `parent` `n` times, including
+/// exactly *at* the root boundary (#1476): `n == current_path.len()` lands
+/// on the root and must resolve to it, distinct from `n >
+/// current_path.len()` (#5349 above), which genuinely overshoots past the
+/// root into an empty object. The old code conflated the two (both produce
+/// an empty `parent_path`), so `.a | parent(1)` on a depth-1 document
+/// wrongly gave `{}` instead of the root.
+#[test]
+fn test_parent_n_agrees_with_chained_parent_at_root_boundary_1476() -> Result<()> {
+    let (chained, _, code) = run_jq_full(&["-c", ".a | parent"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    let (n_form, _, code) = run_jq_full(&["-c", ".a | parent(1)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(n_form, chained, "parent(1) must agree with parent");
+    assert_eq!(n_form.trim(), r#"{"a":1}"#);
+
+    let (chained, _, code) =
+        run_jq_full(&["-c", ".a.b | parent | parent"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    let (n_form, _, code) = run_jq_full(&["-c", ".a.b | parent(2)"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(n_form, chained, "parent(2) must agree with parent | parent");
+    assert_eq!(n_form.trim(), r#"{"a":{"b":1}}"#);
+
+    // The fresh-root reset after landing on the boundary still applies --
+    // `key` afterward is `null`, same as it is after a plain `parent`.
+    let (output, _, code) = run_jq_full(&["-c", ".a | parent(1) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5358,10 +5358,11 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 /// `parent(n)` must agree with chaining bare `parent` `n` times, including
 /// exactly *at* the root boundary (#1476): `n == current_path.len()` lands
 /// on the root and must resolve to it, distinct from `n >
-/// current_path.len()` (#5349 above), which genuinely overshoots past the
-/// root into an empty object. The old code conflated the two (both produce
-/// an empty `parent_path`), so `.a | parent(1)` on a depth-1 document
-/// wrongly gave `{}` instead of the root.
+/// current_path.len()` (the genuine-overshoot case
+/// `test_path_context_builtins_across_pipe_stages_554`'s own `parent(4)`
+/// case already covers), which produces an empty object instead. The old
+/// code conflated the two (both produce an empty `parent_path`), so `.a |
+/// parent(1)` on a depth-1 document wrongly gave `{}` instead of the root.
 #[test]
 fn test_parent_n_agrees_with_chained_parent_at_root_boundary_1476() -> Result<()> {
     let (chained, _, code) = run_jq_full(&["-c", ".a | parent"], Some(r#"{"a":1}"#))?;
@@ -10827,6 +10828,29 @@ fn test_parent_n_argument_still_swallows_ordinary_error_under_optional() -> Resu
     Ok(())
 }
 
+/// Same swallow as the test above, but with a trailing `| key` that still
+/// needs path context, so `optional=true` threads straight into `ParentN`'s
+/// own `n` evaluation (`eval_owned_expr_opt`) instead of being caught by an
+/// external `Expr::Optional` wrapper (the `rest.is_empty()` case the test
+/// above exercises). `error(...)`'s own evaluation (`eval_error`) already
+/// self-swallows to `QueryResult::None` whenever the ambient `optional` is
+/// true -- before the error ever reaches `eval_owned_expr_opt`'s own
+/// `Err(EvalEscape::Error(_)) if optional` guard -- so this still confirms
+/// the observable swallow-through-rest behavior, even though (per
+/// investigation) that specific guard line appears unreachable today: no
+/// error-raising path in this evaluator currently propagates an `Err` all
+/// the way up while `optional` is `true`.
+#[test]
+fn test_parent_n_argument_error_swallow_threaded_through_rest() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a.b | (parent(has(error("x"))))? | key"#],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
 /// Companion to `test_path_context_optional_does_not_swallow_halt_in_builtin_arm`:
 /// that test proves a halt escapes `eval_pipe_with_path_context_internal`'s
 /// `Expr::Builtin` arm even under `?`.
@@ -16008,6 +16032,25 @@ fn test_path_context_parent_n_argument_wrong_type_optional_1280() -> Result<()> 
     )?;
     assert_eq!(code, 0, "err={err}");
     assert_eq!(out.trim(), "\"b\"");
+    Ok(())
+}
+
+/// Same `Ok(Some(_)) if optional` swallow as the test above, but reached
+/// via `Expr::Optional`'s *other* routing branch: `key` after the `?`
+/// still needs path context, so `optional=true` threads straight into
+/// `ParentN`'s own match instead of being caught by an external wrapper
+/// (mirrors `test_string_interpolation_path_context_fanout_continues_rest_1403`'s
+/// identical `? | key`-shaped case for the sibling `StringInterpolation`
+/// arm).
+#[test]
+fn test_path_context_parent_n_argument_wrong_type_optional_threaded_through_rest_1280() -> Result<()>
+{
+    let (out, err, code) = run_jq_full(
+        &["-c", r#".a.b | (parent("x"))? | key"#],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20153,3 +20153,21 @@ fn test_yq_halt_error_empty_code_argument_produces_no_output_1408() -> Result<()
     assert_eq!(stderr, "");
     Ok(())
 }
+
+/// #1476: `parent(n)` must agree with bare `parent` exactly at the root
+/// boundary (`n == current_path.len()`) in yq mode too, since both route
+/// through the same `eval_pipe_with_path_context_internal` shared by jq
+/// and yq mode. `parent`/`parent(n)` are succinctly-only extensions with
+/// no real yq equivalent, so this is an internal-consistency check, not a
+/// yq-parity one: `.a | parent` and `.a | parent(1)` must still agree with
+/// each other, and both give the root.
+#[test]
+fn test_yq_parent_n_agrees_with_chained_parent_at_root_boundary_1476() -> Result<()> {
+    let (chained, code) = run_yq_stdin(".a | parent", "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {chained:?}");
+    let (n_form, code) = run_yq_stdin(".a | parent(1)", "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {n_form:?}");
+    assert_eq!(n_form, chained, "parent(1) must agree with parent");
+    assert!(n_form.contains(r#""a": 1"#), "output: {n_form:?}");
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1476

## Summary

`parent(n)`'s "gone past root" guard (`parent_path.is_empty() && n > 0`) conflated two distinct cases that both produce an empty `parent_path`:
- `n == current_path.len()` — landed *exactly* on the root, should resolve to the root value (same as chaining bare `parent` `n` times would).
- `n > current_path.len()` — genuinely overshot *past* the root, correctly an empty object.

The bare `parent` arm (effectively `n=1`'s special case) never had this ambiguity, since it only ever steps up by exactly one level and checks `current_path.is_empty()` *before* stepping.

## Repro

```
$ echo '{"a":1}' | succinctly jq -c '.a | parent'      # {"a":1}  (correct)
$ echo '{"a":1}' | succinctly jq -c '.a | parent(1)'   # {}       (wrong, should agree)
```

Reproducible in both jq and yq mode (both share `eval_pipe_with_path_context_internal`). Found during code review of #1449/#1475.

## Fix

Test `n > current_path.len()` directly instead of testing emptiness of the already-computed `parent_path` after the fact. At the exact boundary, `parent_path` is the empty slice and `get_value_at_owned_path(root, &[])` already resolves to `root` itself, so no separate shortcut is needed there — only the genuine overshoot case needs the explicit empty-object short-circuit.

## Verification

- Differentially tested the pre- and post-fix binaries: only the three intended exact-boundary queries changed output (all from `{}` to the correct root value); every other `parent`/`parent(n)` shape (within-path, overshoot, `n=0`, error/optional interaction) is byte-identical.
- New regression tests in both `tests/jq_cli_tests.rs` (`.a | parent` vs `.a | parent(1)`, `.a.b | parent | parent` vs `.a.b | parent(2)`, plus the fresh-root-reset-still-applies case) and `tests/yq_cli_tests.rs` (same boundary check in yq mode).
- Full local suite green: build, full test suite, both clippy legs, `cargo fmt --check`, rustdoc, `--no-default-features` build.
- `omni-dev coverage diff` confirms no new executable lines that need covering beyond what the new tests already exercise (one pre-existing, unrelated defensive `None` arm stays uncovered, same as before this fix).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo build --no-default-features`
- [x] Differential A/B testing against the pre-fix binary