### PR TITLE
fix(yq): --slurp anchor/tag-deferred sequence items use the '- ' width too

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2028,8 +2028,11 @@ fn emit_yaml_value_at_depth(
                             let compact_indent = format!("{indent}  ");
                             // An anchor written on the item's own line
                             // (`- &x\n  ...`) takes the slot the compact
-                            // form would use, so the value stays deferred
-                            // to its own full-indent line — mirroring
+                            // form would otherwise put the value's first
+                            // field/element in, so the value defers to its
+                            // own line below — at the same 2-column compact
+                            // width as an unanchored compact element (#1362),
+                            // not a full indent step — mirroring
                             // `stream_yaml_value`'s sequence arm in
                             // `light.rs`, which real yq is pinned against
                             // (#763).

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6864,7 +6864,15 @@ where
                     out.write_char('-')?;
                     write_deferred_prefix(out, None, anchor, tag)?;
                     out.write_char('\n')?;
-                    let child_indent = deeper_yaml_indent("", current_indent + indent_spaces, unit);
+                    // Same "compact" rule as the non-anchored `else` arm
+                    // below: the value's own content aligns under the `- `
+                    // prefix's width, not a full indent step (#1484, the
+                    // `--slurp` counterpart of #1362's fix to
+                    // `stream_yaml_value`'s own Sequence arm -- the anchor/
+                    // tag prefix occupies the `- ` slot on its own line, but
+                    // that doesn't change how deep its value nests).
+                    let own_indent = deeper_yaml_indent("", current_indent, unit);
+                    let child_indent = compact_yaml_indent(&own_indent);
                     out.write_str(&child_indent)?;
                     cursor.stream_yaml_value(
                         out,
@@ -8314,6 +8322,26 @@ mod tests {
 
         let mut out = String::new();
         stream_yaml_sequence([cursor_a], &mut out, 0, 2, ' ', false).unwrap();
+        assert_eq!(out, "- &x\n  a: 1\n  b: 2");
+    }
+
+    #[test]
+    fn test_stream_yaml_sequence_item_anchor_deferred_value_uses_compact_width_at_non_default_indent_slurp_1484(
+    ) {
+        // #1484: the `--slurp` counterpart of the
+        // `..._1362` test below -- `stream_yaml_sequence`'s own
+        // anchor/tag-deferred branch had the identical full-step-instead-
+        // of-compact-width bug, invisible at the default `indent_spaces=2`
+        // (where `deeper_yaml_indent`'s full step and `compact_yaml_indent`'s
+        // fixed 2-column width coincide) but real at any wider setting.
+        // Verified against real yq v4.53.3, which puts `a` at column 2 here
+        // regardless of `indent_spaces`, not the pre-fix column 4.
+        let bytes_a = b"&x\n  a: 1\n  b: 2\n".to_vec();
+        let index_a = YamlIndex::build(&bytes_a).unwrap();
+        let cursor_a = index_a.root(&bytes_a).first_child().unwrap();
+
+        let mut out = String::new();
+        stream_yaml_sequence([cursor_a], &mut out, 0, 4, ' ', false).unwrap();
         assert_eq!(out, "- &x\n  a: 1\n  b: 2");
     }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6839,7 +6839,15 @@ where
         }
         out.write_char(']')
     } else {
-        // Block style
+        // Block style. `current_indent`/`unit` never vary across the loop
+        // below (this function is never itself called recursively -- it's
+        // only ever the outermost entry point, the `--slurp` array itself
+        // -- so `current_indent` has no inherited compact "extra spaces"
+        // baggage of its own yet), so both the plain and compact-adjusted
+        // forms of this level's indent are computed once here rather than
+        // separately per branch per item.
+        let own_indent = deeper_yaml_indent("", current_indent, unit);
+        let child_indent = compact_yaml_indent(&own_indent);
         let mut first = true;
         for cursor in iter {
             if !first {
@@ -6849,13 +6857,7 @@ where
             first = false;
             // Mirrors `stream_yaml_value`'s `Sequence` block-style arm
             // exactly, including its `#785` compact-form handling (see the
-            // comment there). This function is never itself called
-            // recursively (it's only ever the outermost entry point - the
-            // `--slurp` array itself), so `current_indent` has no inherited
-            // compact "extra spaces" baggage of its own yet - converting it
-            // to a plain `unit`-repeated string here before handing off to
-            // `stream_yaml_value` (which *is* recursive and needs the
-            // general string form) is exact, not an approximation.
+            // comment there).
             let style = cursor.style();
             if is_yaml_cursor_container(&cursor) && style != "flow" {
                 let anchor = cursor.anchor();
@@ -6871,8 +6873,6 @@ where
                     // `stream_yaml_value`'s own Sequence arm -- the anchor/
                     // tag prefix occupies the `- ` slot on its own line, but
                     // that doesn't change how deep its value nests).
-                    let own_indent = deeper_yaml_indent("", current_indent, unit);
-                    let child_indent = compact_yaml_indent(&own_indent);
                     out.write_str(&child_indent)?;
                     cursor.stream_yaml_value(
                         out,
@@ -6884,8 +6884,6 @@ where
                     )?;
                 } else {
                     out.write_str("- ")?;
-                    let own_indent = deeper_yaml_indent("", current_indent, unit);
-                    let child_indent = compact_yaml_indent(&own_indent);
                     cursor.stream_yaml_value(
                         out,
                         &child_indent,
@@ -6911,7 +6909,6 @@ where
                 // live (`- &anc null` instead of `- &anc !!mytag`), so this
                 // now routes through the same `write_deferred_value` helper
                 // instead of hand-writing the anchor.
-                let own_indent = deeper_yaml_indent("", current_indent, unit);
                 out.write_char('-')?;
                 write_deferred_value(out, &cursor, &own_indent, indent_spaces, unit, sort_keys)?;
                 write_line_comment(out, cursor.line_comment_raw())?;
@@ -8353,8 +8350,9 @@ mod tests {
         // step deeper -- it still occupies the `- ` slot, so the value nests
         // exactly as deep as `compact_yaml_indent` puts a non-anchored
         // element (2 columns), never `indent_spaces` columns. Verified
-        // against real yq v4.53.3, which puts `a` at column 6 here, not the
-        // pre-fix column 8 a bare `deeper_yaml_indent` step produced.
+        // against real yq v4.53.3, which puts `a` at column 2 here (this
+        // fixture has no outer nesting), not the pre-fix column 4 a bare
+        // `deeper_yaml_indent` step produced.
         let yaml = b"- &x\n  a: 1\n  b: 2\n";
         let index = YamlIndex::build(yaml).unwrap();
         let mut out = String::new();

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2024,6 +2024,26 @@ fn test_seq_item_anchor_deferred_indent_at_non_default_width_dom_1362() -> Resul
     Ok(())
 }
 
+/// #1484: the `--slurp` counterpart of the two tests above, exercised
+/// end-to-end through the CLI's own `--slurp` argument wiring rather than
+/// calling `stream_yaml_sequence` directly — `stream_yaml_value`/
+/// `emit_yaml_value_at_depth` (fixed by #1362) and `stream_yaml_sequence`
+/// (fixed by this issue) are three independently hand-maintained
+/// implementations of the same compact-width rule, so this pins the
+/// `--slurp`-specific argument path in addition to the unit-level coverage
+/// in `src/yaml/light.rs`. Expected output verified live against real yq
+/// v4.53.3 (`yq ea -I=4 '[.]'`).
+#[test]
+fn test_seq_item_anchor_deferred_indent_at_non_default_width_slurp_1484() -> Result<()> {
+    let yaml = "&x\np: 1\n---\n7\n";
+
+    let (slurped, code) = run_yq_stdin(".", yaml, &["--slurp", "-I=4"])?;
+    assert_eq!(code, 0);
+    assert_eq!(slurped, "- &x\n  p: 1\n- 7\n");
+
+    Ok(())
+}
+
 /// `--tab`'s fix (#733) widened `can_stream_pretty`, which also covers
 /// `keys_unsorted` (part of `can_use_m2_streaming`) — not a duplicate-key
 /// case (keys_unsorted returns an array of key names, so nothing to


### PR DESCRIPTION
## Summary
- `stream_yaml_sequence` (the `--slurp` fast-path entry point) had the same bug #1362 fixed in `stream_yaml_value` and `emit_yaml_value_at_depth`: its anchor/tag-deferred sequence-item branch used `deeper_yaml_indent` (a full `indent_spaces` step) instead of `compact_yaml_indent` (the 2-column `- ` width) for the deferred value's indentation, diverging from real yq at any non-default `--indent`. Invisible at the default `-I=2` since the two widths coincide there.
- This is a third, independently hand-mirrored implementation of the same rendering rule (per `stream_yaml_sequence`'s own doc comment, which claims parity with `stream_yaml_value` — this was the one place that claim didn't hold).
- Found while reviewing #1362's own fix; filed as #1484 and now fixed here.

Fixes #1484

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde` (0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned oracle `yq` v4.53.3 (`yq ea -I=4 '[.]'`): anchored, tag-only, non-anchored control, and default `-I=2` — all byte-match
- [x] New regression test added mirroring #1362's own `..._1362` test, at `indent_spaces=4` through `stream_yaml_sequence` directly
- [x] Patch coverage: 100% (11/11 new lines covered, `omni-dev coverage diff`)