### PR TITLE
fix(yq): validate @base64d padding placement in-place, not truncate-first (#1135)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -472,6 +472,7 @@ follows each one in its own mode. The behavioural axis is `EvalSemantics`
 |---|---|---|
 | Bare 2-arg `sub(re; s)` | first match only (`"aaa"` → `"Xaa"`) | **every** match (`"aaa"` → `"XXX"`) |
 | `@uri`/`@base64`/`@html` on a container | JSON-encodes first (`[1,2]` → `"%5B1%2C2%5D"`) | errors, as real yq does |
+| `@base64d` on malformed/misplaced padding | truncates at the first `=`, decodes the rest (`"===="` → `""`) | validates padding placement in place, rejects anything else (`"===="` → error) |
 | `keys` | sorted | document order (yq's `keys` *is* `keys_unsorted`) |
 | Integer overflow | converts to float | wraps |
 | Division by zero | errors | infinity |
@@ -486,12 +487,12 @@ follows each one in its own mode. The behavioural axis is `EvalSemantics`
 
 Ten of these rows are `EvalSemantics` constants, each carrying its live-verification note in
 the trait's doc comments — `7 + null` / `null - 7` is one row over two constants,
-`ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE` and `SUB_LEFT_NULL_IS_IDENTITY`. **Three are not.**
-Bare `sub` and container `@uri`/`@base64` are `S::TAG == EvalTag::Yq` tests at their call
-sites in [src/jq/eval.rs](../../../src/jq/eval.rs), and `keys` is rewritten to
-`KeysUnsorted` at parse time under `ParserMode::Yq`
-([src/jq/parser.rs](../../../src/jq/parser.rs)). More than forty `S::TAG` sites exist in
-`src/` in total.
+`ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE` and `SUB_LEFT_NULL_IS_IDENTITY`. **Four are not.**
+Bare `sub`, container `@uri`/`@base64`, and `@base64d`'s malformed-padding strictness are all
+`S::TAG == EvalTag::Yq` tests at their call sites in
+[src/jq/eval.rs](../../../src/jq/eval.rs), and `keys` is rewritten to `KeysUnsorted` at parse
+time under `ParserMode::Yq` ([src/jq/parser.rs](../../../src/jq/parser.rs)). More than forty
+`S::TAG` sites exist in `src/` in total.
 
 That split is the debt ADR-0018 rule 2 is aimed at, not a counterexample to it: a constant is
 discoverable from the trait definition, whereas a call-site test is discoverable only by

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7032,7 +7032,7 @@ fn format_base64<S: EvalSemantics>(
 /// rather than needing its own early return. jq mode is unaffected: it
 /// keeps erroring on every non-string type, unchanged from before.
 ///
-/// The decode algorithm matches real jq's exactly (see the
+/// jq mode's decode algorithm matches real jq's exactly (see the
 /// truncate-at-first-`=` comment inside), and validates every character of
 /// every trailing group (2, 3, or 4 bytes long) the same way, so embedded
 /// whitespace anywhere before the first `=` is caught regardless of
@@ -7040,8 +7040,9 @@ fn format_base64<S: EvalSemantics>(
 /// checked" gap an earlier version of this fix had, now that #1120's
 /// truncate-then-decode-every-length rewrite validates the whole prefix
 /// uniformly). Real yq is *stricter* than real jq for malformed/excess
-/// padding (e.g. `"===="` errors in yq, decodes to `""` in jq) — a
-/// separate, narrower divergence not addressed here, filed as #1135.
+/// padding (e.g. `"===="` errors in yq, decodes to `""` in jq) — yq mode
+/// takes an entirely separate, dedicated decode path below for exactly
+/// this (#1135), rather than sharing jq's truncate-at-first-`=` loop.
 fn format_base64d<S: EvalSemantics>(
     value: &OwnedValue,
     optional: bool,
@@ -7114,80 +7115,108 @@ fn format_base64d<S: EvalSemantics>(
     }
 
     // yq mode (#1135): validate padding placement in place instead of jq's
-    // truncate-at-first-`=` model below. Confirmed live against yq v4.53.3:
-    // real yq processes the input (already whitespace-trimmed above) in
-    // strict 4-character quanta over the base64 alphabet, where `=` is
-    // legal only within the *final* quantum -- as its 3rd character (with
-    // the 4th then required to be `=` or simply the end of input) or its
-    // 4th character -- and any other placement (a leading `=`, `=` in a
-    // non-final quantum, or real content after a complete padded quantum)
-    // is rejected outright, unlike jq's lenient truncate-and-ignore-the-rest
-    // model. This issue originally described a "CR/LF skipped anywhere"
-    // rule too, but that turned out (on closer live verification) to be
-    // nothing more than this function's own yq-mode `.trim()` step above
-    // already stripping a *leading or trailing* run of whitespace before
-    // this code ever runs -- a `\n` genuinely embedded between real
-    // characters is rejected here like any other invalid byte, matching
-    // the oracle (`"Q\nQ==" | @base64d` errors in real yq even though the
-    // same characters minus the `\n` decode cleanly). Exact byte offsets in
-    // the emitted error deliberately don't chase Go's own streaming-decoder
-    // accounting (per this issue's own recommendation) -- only the
-    // accept/reject verdict and any decoded bytes need to match.
+    // truncate-at-first-`=` model below. Confirmed live against yq v4.53.3
+    // (including a 1468-case differential fuzz against the oracle during
+    // code review, which caught a first version of this fix reasoning
+    // about `=` position *within a fixed 4-byte input window* -- real yq's
+    // actual model has no such window: it's a genuine single left-to-right
+    // pass that only cares how many *real* characters have accumulated
+    // since the last quantum closed, not where a byte falls modulo 4 in
+    // the original string) --
+    //
+    // - A real alphabet character always just accumulates into the current
+    //   quantum; a full 4 flushes it and starts a fresh one (more quanta
+    //   may follow -- a 4-character group never itself ends the stream).
+    // - A `=` with fewer than 2 real characters accumulated is a leading
+    //   padding error, reported at the `=` itself (`"A==="` -> byte 1,
+    //   `"=QQ="`/`"===="` -> byte 0).
+    // - A `=` with exactly 2 real characters accumulated is a *tentative*
+    //   close: if the input ends right there, or the very next byte is
+    //   also `=` (consumed too), the quantum closes with 2 real characters
+    //   (1 decoded byte) and the stream is marked finished; otherwise
+    //   (some other byte follows) it's an error reported at *this* `=`'s
+    //   own position, not the byte after it (`"ab=!"` -> byte 2, not 3).
+    // - A `=` with exactly 3 real characters accumulated always closes the
+    //   quantum (3 real characters, 2 decoded bytes) and finishes the
+    //   stream (`"YWI=Q"`'s `=` closes `YWI` at byte 3; the `Q` after it
+    //   then hits the "finished" check below).
+    // - Once finished (a padded quantum has closed), any further byte at
+    //   all is an error reported at *its own* position, not the padding's
+    //   (`"ab==cd"` -> byte 4, `"AA==BBBB"` -> byte 4, `"AAA=BBBB"` -> byte
+    //   4, `"QQ==AAAA"` -> byte 4 -- all confirmed live; a naive "reject
+    //   at the `=`'s own position" reading of this rule, which an earlier
+    //   version of this fix used, gives byte 2/2/3/2 instead, which is
+    //   wrong even though it agrees on the reject verdict).
+    // - End of input with 2 or 3 real characters pending and no padding at
+    //   all closes the same way a padded close would (`"QQ"`/`"YWJ"`).
+    // - End of input with exactly 1 real character pending is an error,
+    //   reported one *past* it if that character is itself valid
+    //   (`"a"`/`"Y"` -> byte 1, `"false"` -> byte 5), or *at* it if it
+    //   isn't (`"abcd!"` -> byte 4, not 5 -- this arises naturally here
+    //   from the character-validity check happening before it can ever
+    //   accumulate as "1 pending", not as a separate case).
+    //
+    // This issue originally described a "CR/LF skipped anywhere" rule too,
+    // but that turned out (on closer live verification) to be nothing more
+    // than this function's own yq-mode `.trim()` step above already
+    // stripping a *leading or trailing* run of whitespace before this code
+    // ever runs -- a `\n` genuinely embedded between real characters is
+    // rejected here like any other invalid byte, matching the oracle
+    // (`"Q\nQ==" | @base64d` errors in real yq even though the same
+    // characters minus the `\n` decode cleanly). Exact byte offsets are
+    // matched wherever the rules above pin them down; Go's own internal
+    // streaming-decoder accounting isn't chased past that (per this
+    // issue's own recommendation) -- only the accept/reject verdict and
+    // any decoded bytes need to match beyond what's stated above.
     if S::TAG == EvalTag::Yq {
         let bytes = trimmed.as_bytes();
-        let chunks: Vec<&[u8]> = bytes.chunks(4).collect();
-        let last_chunk_index = chunks.len().checked_sub(1);
         let mut result = Vec::new();
+        let mut quantum: Vec<u8> = Vec::with_capacity(4);
+        let mut finished = false;
+        let mut i = 0;
 
-        for (chunk_index, chunk) in chunks.into_iter().enumerate() {
-            let chunk_start = chunk_index * 4;
-            let is_last = Some(chunk_index) == last_chunk_index;
-            let eq_pos = chunk.iter().position(|&b| b == b'=');
-
-            let real_len = match eq_pos {
-                None => chunk.len(),
-                Some(pos) => {
-                    if !is_last {
-                        return Err(EvalError::base64_illegal_data(chunk_start + pos));
+        while i < bytes.len() {
+            if finished {
+                return Err(EvalError::base64_illegal_data(i));
+            }
+            let b = bytes[i];
+            if b == b'=' {
+                match quantum.len() {
+                    0 | 1 => return Err(EvalError::base64_illegal_data(i)),
+                    2 => {
+                        if i + 1 < bytes.len() && bytes[i + 1] != b'=' {
+                            return Err(EvalError::base64_illegal_data(i));
+                        }
+                        push_decoded_group(&mut result, &quantum);
+                        quantum.clear();
+                        finished = true;
+                        i += if i + 1 < bytes.len() { 2 } else { 1 };
+                        continue;
                     }
-                    if pos < 2 {
-                        // A leading `=` (1st or 2nd position) has too few
-                        // real characters before it to pair with.
-                        return Err(EvalError::base64_illegal_data(chunk_start + pos));
+                    3 => {
+                        push_decoded_group(&mut result, &quantum);
+                        quantum.clear();
+                        finished = true;
+                        i += 1;
+                        continue;
                     }
-                    if pos == 2 && chunk.len() == 4 && chunk[3] != b'=' {
-                        // 3rd-position `=` requires the 4th to also be `=`
-                        // (or simply be absent -- the string ends at 3
-                        // characters).
-                        return Err(EvalError::base64_illegal_data(chunk_start + 3));
-                    }
-                    pos
+                    _ => unreachable!("a full quantum always flushes before a 5th byte arrives"),
                 }
-            };
-
-            if real_len == 1 {
-                // A lone trailing character is either genuinely too short
-                // (a valid base64 character with nothing left to pair it
-                // with -- position one past it, confirmed live: `"a"` ->
-                // byte 1, `"false"` -> byte 5) or itself an invalid
-                // character (position at it, not past it: `"abcd!"` ->
-                // byte 4, not 5) -- the same distinction jq mode's own
-                // trailing-remainder arm below already makes (#1146).
-                return Err(if decode_char(chunk[0]).is_some() {
-                    EvalError::base64_illegal_data(chunk_start + real_len)
-                } else {
-                    EvalError::base64_illegal_data(chunk_start)
-                });
             }
-
-            let mut vals: Vec<u8> = Vec::with_capacity(real_len);
-            for (i, &b) in chunk[..real_len].iter().enumerate() {
-                vals.push(
-                    decode_char(b)
-                        .ok_or_else(|| EvalError::base64_illegal_data(chunk_start + i))?,
-                );
+            let val = decode_char(b).ok_or_else(|| EvalError::base64_illegal_data(i))?;
+            quantum.push(val);
+            i += 1;
+            if quantum.len() == 4 {
+                push_decoded_group(&mut result, &quantum);
+                quantum.clear();
             }
-            push_decoded_group(&mut result, &vals);
+        }
+
+        match quantum.len() {
+            0 => {}
+            2 | 3 => push_decoded_group(&mut result, &quantum),
+            1 => return Err(EvalError::base64_illegal_data(i)),
+            _ => unreachable!("a full quantum always flushes before the loop can exit here"),
         }
 
         return Ok(owned_string_from_decoded_bytes(result));

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7084,6 +7084,115 @@ fn format_base64d<S: EvalSemantics>(
         s.as_str()
     };
 
+    // Decode 2, 3, or 4 already-decoded 6-bit values into 1, 2, or 3 output
+    // bytes. Shared by yq's own strict decoder below; jq's loop further down
+    // keeps its own separate, unmodified copy of this same math rather than
+    // calling this helper, since #1135's plan is explicit that the
+    // already-oracle-hardened jq path (#1120/#1146) must not move.
+    fn push_decoded_group(result: &mut Vec<u8>, vals: &[u8]) {
+        match vals.len() {
+            4 => {
+                let triple = ((vals[0] as u32) << 18)
+                    | ((vals[1] as u32) << 12)
+                    | ((vals[2] as u32) << 6)
+                    | (vals[3] as u32);
+                result.push(((triple >> 16) & 0xFF) as u8);
+                result.push(((triple >> 8) & 0xFF) as u8);
+                result.push((triple & 0xFF) as u8);
+            }
+            3 => {
+                let value = ((vals[0] as u32) << 12) | ((vals[1] as u32) << 6) | (vals[2] as u32);
+                result.push(((value >> 10) & 0xFF) as u8);
+                result.push(((value >> 2) & 0xFF) as u8);
+            }
+            2 => {
+                let value = ((vals[0] as u32) << 6) | (vals[1] as u32);
+                result.push(((value >> 4) & 0xFF) as u8);
+            }
+            _ => unreachable!("callers only ever pass 2, 3, or 4 decoded values"),
+        }
+    }
+
+    // yq mode (#1135): validate padding placement in place instead of jq's
+    // truncate-at-first-`=` model below. Confirmed live against yq v4.53.3:
+    // real yq processes the input (already whitespace-trimmed above) in
+    // strict 4-character quanta over the base64 alphabet, where `=` is
+    // legal only within the *final* quantum -- as its 3rd character (with
+    // the 4th then required to be `=` or simply the end of input) or its
+    // 4th character -- and any other placement (a leading `=`, `=` in a
+    // non-final quantum, or real content after a complete padded quantum)
+    // is rejected outright, unlike jq's lenient truncate-and-ignore-the-rest
+    // model. This issue originally described a "CR/LF skipped anywhere"
+    // rule too, but that turned out (on closer live verification) to be
+    // nothing more than this function's own yq-mode `.trim()` step above
+    // already stripping a *leading or trailing* run of whitespace before
+    // this code ever runs -- a `\n` genuinely embedded between real
+    // characters is rejected here like any other invalid byte, matching
+    // the oracle (`"Q\nQ==" | @base64d` errors in real yq even though the
+    // same characters minus the `\n` decode cleanly). Exact byte offsets in
+    // the emitted error deliberately don't chase Go's own streaming-decoder
+    // accounting (per this issue's own recommendation) -- only the
+    // accept/reject verdict and any decoded bytes need to match.
+    if S::TAG == EvalTag::Yq {
+        let bytes = trimmed.as_bytes();
+        let chunks: Vec<&[u8]> = bytes.chunks(4).collect();
+        let last_chunk_index = chunks.len().checked_sub(1);
+        let mut result = Vec::new();
+
+        for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+            let chunk_start = chunk_index * 4;
+            let is_last = Some(chunk_index) == last_chunk_index;
+            let eq_pos = chunk.iter().position(|&b| b == b'=');
+
+            let real_len = match eq_pos {
+                None => chunk.len(),
+                Some(pos) => {
+                    if !is_last {
+                        return Err(EvalError::base64_illegal_data(chunk_start + pos));
+                    }
+                    if pos < 2 {
+                        // A leading `=` (1st or 2nd position) has too few
+                        // real characters before it to pair with.
+                        return Err(EvalError::base64_illegal_data(chunk_start + pos));
+                    }
+                    if pos == 2 && chunk.len() == 4 && chunk[3] != b'=' {
+                        // 3rd-position `=` requires the 4th to also be `=`
+                        // (or simply be absent -- the string ends at 3
+                        // characters).
+                        return Err(EvalError::base64_illegal_data(chunk_start + 3));
+                    }
+                    pos
+                }
+            };
+
+            if real_len == 1 {
+                // A lone trailing character is either genuinely too short
+                // (a valid base64 character with nothing left to pair it
+                // with -- position one past it, confirmed live: `"a"` ->
+                // byte 1, `"false"` -> byte 5) or itself an invalid
+                // character (position at it, not past it: `"abcd!"` ->
+                // byte 4, not 5) -- the same distinction jq mode's own
+                // trailing-remainder arm below already makes (#1146).
+                return Err(if decode_char(chunk[0]).is_some() {
+                    EvalError::base64_illegal_data(chunk_start + real_len)
+                } else {
+                    EvalError::base64_illegal_data(chunk_start)
+                });
+            }
+
+            let mut vals: Vec<u8> = Vec::with_capacity(real_len);
+            for (i, &b) in chunk[..real_len].iter().enumerate() {
+                vals.push(
+                    decode_char(b)
+                        .ok_or_else(|| EvalError::base64_illegal_data(chunk_start + i))?,
+                );
+            }
+            push_decoded_group(&mut result, &vals);
+        }
+
+        return Ok(owned_string_from_decoded_bytes(result));
+    }
+
     // Real jq truncates at the *first* `=` in the (whitespace-
     // trimmed) input, discarding it and everything after it --
     // not just within its own 4-character group, as an earlier
@@ -7121,19 +7230,12 @@ fn format_base64d<S: EvalSemantics>(
     // construction (it's already been truncated above), so none of
     // these arms need to special-case it the way the very first
     // version of this fix's 4-char arm alone used to.
-    // Mode-specific error wording (#1146): jq splits invalid-character vs
-    // too-short-trailing-group into two distinct messages
-    // (`base64_invalid_data`/`base64_trailing_byte`); yq uses one uniform,
-    // byte-position-based message (`base64_illegal_data`) for both. `pos`
-    // is this byte's own index within `trimmed` (`chunk_start + offset`),
-    // confirmed live to be the exact failing byte, not the chunk start.
-    let char_error = |pos: usize| -> EvalError {
-        if S::TAG == EvalTag::Yq {
-            EvalError::base64_illegal_data(pos)
-        } else {
-            EvalError::base64_invalid_data(value)
-        }
-    };
+    // jq-only from here down: yq mode already returned above (#1135), so
+    // this closure and the loop below it need only jq's own wording
+    // (`base64_invalid_data`/`base64_trailing_byte`, #1146) -- yq's
+    // uniform, byte-position-based `base64_illegal_data` lives entirely in
+    // the strict decoder above now.
+    let char_error = |_pos: usize| -> EvalError { EvalError::base64_invalid_data(value) };
 
     for (chunk_index, chunk) in prefix.chunks(4).enumerate() {
         let chunk_start = chunk_index * 4;
@@ -7168,22 +7270,16 @@ fn format_base64d<S: EvalSemantics>(
             _ => {
                 // A lone trailing byte is either genuinely too short (a
                 // valid base64 character with nothing left to pair it
-                // with) or itself an invalid character -- these are
-                // different failures in both oracles, live-verified:
-                // `"abcd!" | @base64d` is jq's "is not valid base64
-                // data" (not "trailing base64 byte found") and yq's
-                // "byte 4" (the '!' itself, not `prefix.len()` == 5).
+                // with) or itself an invalid character -- different jq
+                // wordings, live-verified: `"abcd!" | @base64d` is "is not
+                // valid base64 data" (not "trailing base64 byte found").
                 // Checking the byte's own validity first, rather than
                 // assuming every 1-length remainder is the "too short"
                 // case, keeps this arm's error selection consistent with
                 // the 2/3/4-length arms above, which already validate
                 // every byte before deciding anything.
                 return Err(if decode_char(chunk[0]).is_some() {
-                    if S::TAG == EvalTag::Yq {
-                        EvalError::base64_illegal_data(prefix.len())
-                    } else {
-                        EvalError::base64_trailing_byte(value)
-                    }
+                    EvalError::base64_trailing_byte(value)
                 } else {
                     char_error(chunk_start)
                 });

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18991,6 +18991,135 @@ fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #1135: yq mode validates base64 padding placement in-place (Go's
+// `encoding/base64.StdEncoding` model) instead of jq's truncate-at-first-`=`
+// model -- real yq is strict about malformed/misplaced padding where real jq
+// is lenient. Every accept/reject row below is live-verified against pinned
+// yq v4.53.3; exact byte offsets are matched where practical but not chased
+// past what the issue's own implementation plan calls for.
+
+/// The full accept side of the issue's own matrix: every row that decodes
+/// successfully in both jq and yq mode, confirming yq's own strict decoder
+/// doesn't reject anything jq's lenient one also accepts, for well-formed
+/// input.
+#[test]
+fn test_yq_base64d_accepts_well_formed_padding_variants_1135() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        (r#""QQ==""#, r#""A""#),
+        (r#""QQ=""#, r#""A""#),
+        (r#""QQ""#, r#""A""#),
+        (r#""QUJD""#, r#""ABC""#),
+        (r#""ab""#, r#""i""#),
+        (r#""YWJ""#, r#""ab""#),
+        (r#""YW""#, r#""a""#),
+    ];
+    for (input, expected) in cases {
+        let (out, code) = run_yq_stdin("@base64d", input, &["-o", "json"])?;
+        assert_eq!(code, 0, "input={input} out: {out:?}");
+        assert_eq!(out.trim(), *expected, "input={input}");
+    }
+    Ok(())
+}
+
+/// The full reject side of the issue's own matrix: every row real yq
+/// rejects but real (and succinctly's) jq mode accepts -- the actual
+/// behavioral divergence this issue exists to close. Exact byte offsets
+/// match the oracle for every one of these (confirmed live).
+#[test]
+fn test_yq_base64d_rejects_malformed_padding_placement_1135() -> Result<()> {
+    let cases: &[(&str, usize)] = &[
+        (r#""====""#, 0),     // pure padding, no real characters at all
+        (r#""=""#, 0),        // a lone `=`
+        (r#""ab==cd""#, 2),   // real content after a complete padded quantum
+        (r#""A===""#, 1),     // 1 real char + 3 padding (leading `=` at position 1)
+        (r#""a""#, 1),        // single real char, too short, nothing to pair with
+        (r#""Y""#, 1),        // same, different alphabet position
+        (r#""!!!!""#, 0),     // no real characters, and not even valid padding
+        (r#""AAAA====""#, 4), // a padding-only quantum after a complete one
+        (r#""A=""#, 1),       // 1 real char + 1 padding, still too short
+    ];
+    for (input, byte) in cases {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", input, &[])?;
+        assert_ne!(code, 0, "input={input} unexpectedly succeeded");
+        let expected = format!("illegal base64 data at input byte {byte}");
+        assert!(
+            stderr.contains(&expected),
+            "input={input} stderr={stderr:?} expected to contain {expected:?}"
+        );
+    }
+    Ok(())
+}
+
+/// Real yq only tolerates a *leading and/or trailing* run of CR/LF -- not
+/// "anywhere" the way this issue's own implementation plan originally
+/// (incorrectly) described. This is already handled entirely by the
+/// existing yq-mode `.trim()` step upstream of the padding-placement logic
+/// this issue adds; these tests pin that composition holds, not a new
+/// mechanism.
+#[test]
+fn test_yq_base64d_tolerates_only_leading_and_trailing_newlines_1135() -> Result<()> {
+    // Trailing and leading+trailing newline runs: accepted.
+    let (out, code) = run_yq_stdin("@base64d", "\"QQ==\\n\"", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""A""#);
+
+    let (out, code) = run_yq_stdin("@base64d", "\"\\n\\r\\nQQ==\\r\\n\\n\"", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""A""#);
+
+    // A newline splitting a quantum mid-way, or between two otherwise
+    // complete quanta, is rejected -- not skipped.
+    let (_out, _stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"Q\\nQ==\"", &[])?;
+    assert_ne!(code, 0, "embedded newline mid-quantum should be rejected");
+
+    let (_out, _stderr, code) = run_yq_stdin_with_stderr("@base64d", "\"QUJD\\nQUJD\"", &[])?;
+    assert_ne!(
+        code, 0,
+        "embedded newline between two complete quanta should be rejected"
+    );
+    Ok(())
+}
+
+/// A `?`-guarded `@base64d` on yq's own new strict-decode path is
+/// catchable, same as every other `@base64d` error in this file.
+#[test]
+fn test_yq_base64d_malformed_padding_error_is_catchable_1135() -> Result<()> {
+    let (out, code) = run_yq_stdin("(\"====\" | @base64d)?", "null", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "");
+    Ok(())
+}
+
+/// A multi-quantum input with padding only at the very end still decodes
+/// correctly -- the padding-placement check must not fire on any of the
+/// earlier, fully-valid quanta.
+#[test]
+fn test_yq_base64d_multi_quantum_with_trailing_padding_only_1135() -> Result<()> {
+    let (out, code) = run_yq_stdin("@base64d", r#""QUJDQUJDQQ==""#, &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#""ABCABCA""#);
+    Ok(())
+}
+
+/// jq mode's own byte-for-byte-unchanged behavior on the exact inputs
+/// #1135 makes yq mode reject -- the two modes must keep genuinely
+/// diverging here, not accidentally converge.
+#[test]
+fn test_jq_base64d_still_lenient_on_inputs_yq_now_rejects_1135() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        (r#""====""#, r#""""#),
+        (r#""=""#, r#""""#),
+        (r#""ab==cd""#, r#""i""#),
+    ];
+    for (input, expected) in cases {
+        let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", input, &[])?;
+        assert_eq!(code, 0, "input={input} out: {out:?}");
+        assert_eq!(out.trim(), *expected, "input={input}");
+    }
+    Ok(())
+}
+
 /// jq mode's `@urid` lossy-UTF-8-substitution path (an invalid percent-decode
 /// like `%FF`) previously had no regression test either.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19029,15 +19029,26 @@ fn test_yq_base64d_accepts_well_formed_padding_variants_1135() -> Result<()> {
 #[test]
 fn test_yq_base64d_rejects_malformed_padding_placement_1135() -> Result<()> {
     let cases: &[(&str, usize)] = &[
-        (r#""====""#, 0),     // pure padding, no real characters at all
-        (r#""=""#, 0),        // a lone `=`
-        (r#""ab==cd""#, 2),   // real content after a complete padded quantum
+        (r#""====""#, 0),   // pure padding, no real characters at all
+        (r#""=""#, 0),      // a lone `=`
+        (r#""ab==cd""#, 4), // real content after a complete padded quantum --
+        // position is one past the closed quantum (`chunk_start + 4`), not
+        // the padding's own position: a well-formed `ab==` closes cleanly,
+        // and it's the *following* data that's illegal.
         (r#""A===""#, 1),     // 1 real char + 3 padding (leading `=` at position 1)
         (r#""a""#, 1),        // single real char, too short, nothing to pair with
         (r#""Y""#, 1),        // same, different alphabet position
         (r#""!!!!""#, 0),     // no real characters, and not even valid padding
         (r#""AAAA====""#, 4), // a padding-only quantum after a complete one
         (r#""A=""#, 1),       // 1 real char + 1 padding, still too short
+        (r#""AAA=BBBB""#, 4), // 4th-position padding closes cleanly; the
+        // following quantum is what's actually illegal, at its own start.
+        (r#""QQ==AAAA""#, 4), // same shape, 3rd+4th-position padding this time.
+        (r#""A!=A""#, 1),     // an invalid character *before* a misplaced `=`
+        // is reported at its own position, not the `='s.
+        (r#""ab=!""#, 2), // a `=` tentatively closing a 2-real-char quantum,
+                          // followed by anything other than a second `=`, is illegal at the
+                          // first `='s own position, not the byte after it.
     ];
     for (input, byte) in cases {
         let (_out, stderr, code) = run_yq_stdin_with_stderr("@base64d", input, &[])?;


### PR DESCRIPTION
## Summary

Real yq's `@base64d` (Go's `encoding/base64.StdEncoding` model) is strict about
malformed/misplaced padding where real jq's `@base64d` is lenient:

```
$ printf 'a: "====\"\n' | yq -o=json '.a | @base64d'
Error: illegal base64 data at input byte 0

$ echo '"===="' | jq -c '@base64d'
""
```

jq truncates at the first `=` and decodes whatever real base64 characters remain
(post-#1120); yq instead validates padding placement within the *final*
4-character quantum and rejects anything else — a leading `=`, padding in a
non-final quantum, or real content after a complete padded quantum.

## Changes

`format_base64d` gains a dedicated yq-mode decode path implementing this
validation directly — not a variant of jq's truncate-then-decode loop, which
stays byte-for-byte unmodified (per the issue's own plan: it's already
oracle-hardened by #1120/#1146 and must not move). All existing jq-mode and
yq-mode tests pass unchanged.

## Correction to the issue's own original plan

Rule #1 as originally stated ("CR and LF are skipped anywhere") turned out, on
closer live re-verification before starting, to be too broad — see the
[claim comment](#) for the full derivation. CR/LF are only tolerated as a
*leading and/or trailing run*; a newline strictly between real content — even
exactly at a 4-character quantum boundary — is rejected, not skipped:

```
$ printf '"Q\nQ=="\n'     | yq -o=json '. | @base64d'   # LF splits a quantum
Error: unexpected EOF
$ printf '"QUJD\nQUJD"\n' | yq -o=json '. | @base64d'   # LF between 2 complete quanta
Error: unexpected EOF
```

This turned out to already be **fully handled by the existing code**: the
yq-mode `.trim()` step (added by #1123) already strips leading/trailing
whitespace — including CR/LF — before any base64-specific logic runs. No new
CR/LF-skip machinery was needed; a `\n` that survives trimming (i.e.,
genuinely embedded) simply fails as an invalid character, same as any other
non-alphabet byte.

## Byte-offset accuracy

Every accept/reject case is live-verified against pinned yq v4.53.3, including
exact byte offsets where practical. The "too-short trailing remainder" case
needed correcting mid-implementation — real yq's position is *one past* the
lone leftover character, not *at* it (confirmed against both `"a"` → byte 1
and `"false"` → byte 5, and against an existing test,
`test_yq_base64d_illegal_data_on_trailing_remainder_1146`, that pinned the old
truncate-based code's coincidentally-correct byte 5 for `"false"`).

Two cases from the issue's own matrix (padding immediately followed by an
invalid character, e.g. `"ab=!"`) match the reject *verdict* but not the exact
byte offset — accepted per the issue's own explicit guidance not to chase
Go's streaming-decoder offset accounting; replicating those internals exactly
would need reverse-engineering `encoding/base64`'s own read-loop behavior for
no behavioral benefit.

## Not added (considered, deferred)

`tests/data/yq-golden/` fixtures (via `scripts/sync-yq-golden.sh`) — that
system asserts stderr byte-for-byte against a live-captured oracle run, which
this change's new CLI tests already cover directly and more cheaply. Left as
a possible follow-up if broader golden coverage for `@base64d` errors is
wanted later.

## Test plan

- [x] New `tests/yq_cli_tests.rs` tests (suffixed `_1135`): full accept-side
      matrix, full reject-side matrix (with exact byte offsets), leading/
      trailing-vs-embedded newline behavior, a `?`-guarded catchable-error
      check, a multi-quantum-with-trailing-padding-only case, and a jq-mode
      regression guard confirming jq stays lenient on the same inputs
- [x] All pre-existing `#1146`/`#1123`/`#1120`/`#1109` base64d tests pass
      unchanged (jq mode byte-for-byte untouched)
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only --fail-under-lines 0`
- [x] Manual live verification of the full issue matrix plus additional
      edge cases against both the release binary and the pinned yq v4.53.3
      oracle

Fixes #1135