### PR TITLE
refactor(jq): route path-context If arm through eval_fanout

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21557,13 +21557,15 @@ fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Fold one fan-out step's result into `results`, matching the project's
 /// #400/#494 guarantee: an `Error`/`Break` produced partway through a
 /// fan-out must not discard outputs already produced by earlier steps. Every
-/// fan-out loop in `eval_pipe_with_path_context_internal` (`Iterate`, `If`'s
-/// multi-valued `cond`, `Comma`, `Select`'s continuation) and
+/// fan-out loop in `eval_pipe_with_path_context_internal` (`Iterate`,
+/// `Comma`, `Map`, `Select`'s and `If`'s continuation) and
 /// `continue_rest_with_context` shares this exact accumulate-or-stop shape;
 /// this is the one place it's implemented (#715 follow-up -- six near-copies
 /// of this loop each independently collapsed `Break`/`Partial` to a bare
 /// `None`, silently dropping both the escaping control signal and any output
-/// already produced).
+/// already produced). `If`'s own multi-valued `cond` fan-out no longer goes
+/// through this helper (#1393) -- it now shares `eval_fanout`'s own,
+/// separate accumulate-or-stop logic with the sibling `Select` arm instead.
 ///
 /// Returns `Some(result)` when the loop must stop and propagate that result
 /// immediately (an error, an escaping `break`, or a nested partial result);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23019,6 +23019,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // (#715 follow-up: previously there was no explicit `If` arm
             // here, so it fell into the generic fallback below and lost
             // path context for anything nested in cond/then/else).
+            //
+            // Forks on `cond`'s truthiness via the shared `eval_fanout`
+            // (#1393), the same helper the sibling `Select` arm above
+            // already uses -- this arm used to hand-roll the identical
+            // "unpack cond into values + trailing control, loop dispatching
+            // a branch per value, accumulate via `accumulate_path_context_step`"
+            // shape independently, the exact "duplicated predicates diverge
+            // silently" pattern this project's own CLAUDE.md warns about.
             let cond_result = eval_pipe_with_path_context_internal::<W, S>(
                 core::slice::from_ref(cond),
                 value,
@@ -23027,55 +23035,17 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 current_path,
                 optional,
             );
-            // Unpack `cond_result` into its truthy/falsy values plus any
-            // trailing control (#400/#494) -- `cond` itself can produce more
-            // than one value (e.g. `if .[] then ... end`) and/or end in an
-            // error/break after producing some, and both must still drive a
-            // branch evaluation per value with the control propagated after.
-            let (cond_values, cond_control): (Vec<OwnedValue>, Option<Control>) = match cond_result
-            {
-                QueryResult::Owned(v) => (vec![v], None),
-                QueryResult::ManyOwned(vs) => (vs, None),
-                QueryResult::None => (Vec::new(), None),
-                QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
-                QueryResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
-                QueryResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
-                QueryResult::Partial(vs, control) => (vs, Some(control)),
-                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-                    unreachable!(
-                        "eval_pipe_with_path_context_internal only ever produces \
-                         Owned/ManyOwned/None/Error/Break/Partial"
-                    )
-                }
-            };
-            let mut results = Vec::new();
-            let mut stopped = None;
-            for v in cond_values {
-                let branch = if v.is_truthy() {
-                    then_branch
-                } else {
-                    else_branch
-                };
-                let step = eval_pipe_with_path_context_internal::<W, S>(
+            let branch_result = eval_fanout(cond_result, |truthy| {
+                let branch = if truthy { then_branch } else { else_branch };
+                eval_pipe_with_path_context_internal::<W, S>(
                     core::slice::from_ref(branch),
                     value,
                     root,
                     file_origin,
                     current_path,
                     optional,
-                );
-                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
-                    stopped = Some(stop);
-                    break;
-                }
-            }
-            let branch_result = if let Some(stop) = stopped {
-                stop
-            } else if let Some(control) = cond_control {
-                partial(results, control)
-            } else {
-                owned_vec_to_result(results)
-            };
+                )
+            });
             if rest.is_empty() {
                 return branch_result;
             }


### PR DESCRIPTION
Fixes #1393

## Summary

`eval_pipe_with_path_context_internal`'s `Expr::If` arm hand-rolled the exact "evaluate cond, fork per truthiness, dispatch then/else per branch, accumulate with a trailing control" shape its sibling `Builtin::Select` arm (a few dozen lines above, in the same function) already delegates to the shared `eval_fanout` helper — the same helper `builtin_select`/`eval_if` use in the plain evaluator. Converting removes ~30 lines of duplicated fork-and-accumulate logic that could have silently drifted from `eval_fanout`'s own policy, matching this project's own documented "duplicated predicates diverge silently" lesson (#106, cited in CLAUDE.md).

Not a live bug — both the old hand-rolled loop and `eval_fanout` already agreed on every case tested (see below) — this is a maintainability/future-drift fix, per the issue's own framing.

## Verification

Pure refactor, no intended behavior change. Differentially tested the pre- and post-change binaries against 17 queries covering:
- single- and multi-valued `cond` (fan-out)
- `cond` erroring/breaking/halting, both bare and after producing some truthy values
- the taken branch itself erroring/breaking/halting, both bare and after partial output
- `?`-swallowed errors from both `cond` and the taken branch
- rest-continuation after the `if` (both when it needs path context and when it fans out further)
- the no-path-context-needed case (confirms the generic fallback below this arm is unaffected)

All byte-identical output and exit codes between the two binaries.

- Full local suite green: build, full test suite, both clippy legs, `cargo fmt --check`, rustdoc, `--no-default-features` build.
- No new executable lines (pure deletion/simplification), confirmed via `omni-dev coverage diff`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo build --no-default-features`
- [x] Differential A/B testing against the pre-change binary (17 queries)