### PR TITLE
fix(yq): clamp YAML output indentation to 2 columns at -I=1

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -162,7 +162,26 @@ impl OutputConfig {
         } else if args.tab {
             "\t".to_string()
         } else {
-            " ".repeat(args.indent as usize)
+            // `-I1` clamps to 2 for YAML output (#1486): real yq's YAML
+            // output at `-I1` is byte-identical to its own `-I2` output at
+            // every level, mirroring the fast-path streamer's identical
+            // clamp on `yaml_indent_spaces` below. JSON has no such quirk
+            // (verified live: `-I1 -o=json` genuinely indents 1 space per
+            // level in real yq) -- `indent_str` is shared by both formats'
+            // DOM emitters (see its use in the JSON branch of
+            // `output_value`), so the clamp only applies when this
+            // invocation isn't explicitly `-o=json`. `-o=auto` resolving to
+            // JSON for a JSON-formatted input is the one case this doesn't
+            // reach (the same pre-existing per-input-vs-global sharing gap
+            // `json_sourced_floats` works around elsewhere in this struct),
+            // not a new inconsistency this fix introduces.
+            let width = args.indent as usize;
+            let width = if args.output_format == OutputFormat::Json {
+                width
+            } else {
+                width.max(2)
+            };
+            " ".repeat(width)
         };
 
         Self {
@@ -3235,18 +3254,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // otherwise a special case: real `yq` treats it as "use the library
     // default" (4 spaces), and succinctly's existing (pre-#442) compact-YAML
     // fast path hardcodes 2 regardless of `-I` — preserved as-is here since
-    // reconciling that mismatch is a separate, out-of-scope issue. Every
-    // other value threads through directly, matching what the DOM path
-    // already produces (verified against `-I1` through `-I6`). JSON has no
-    // such quirk: `-I0` means compact/flow for both real yq and succinctly
-    // today.
+    // reconciling that mismatch is a separate, out-of-scope issue. `-I1`
+    // clamps to 2 (#1486): real yq's YAML output at `-I1` is byte-identical
+    // to its own `-I2` output at every level (mappings, sequences, and
+    // compact/anchor-deferred sequence items alike, verified live against
+    // v4.53.3) — every other value (`-I2` and above) threads through
+    // directly, matching what the DOM path already produces (verified
+    // against `-I1` through `-I6`). JSON has no such quirk: `-I0` means
+    // compact/flow and `-I1` genuinely means a literal 1-space step, for
+    // both real yq and succinctly today (verified live: `-I1 -o=json`
+    // indents 1/2/3 spaces per level in real yq, not clamped).
     let indent_unit: char = if args.tab { '\t' } else { ' ' };
     let yaml_indent_spaces: usize = if args.tab {
         1
     } else if args.indent == 0 {
         2
     } else {
-        args.indent as usize
+        (args.indent as usize).max(2)
     };
     let json_indent_spaces: usize = if args.tab { 1 } else { args.indent as usize };
     let yaml_indent = IndentSpec {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -169,17 +169,22 @@ impl OutputConfig {
             // (verified live: `-I1 -o=json` genuinely indents 1 space per
             // level in real yq) -- `indent_str` is shared by both formats'
             // DOM emitters (see its use in the JSON branch of
-            // `output_value`), so the clamp only applies when this
-            // invocation isn't explicitly `-o=json`. `-o=auto` resolving to
-            // JSON for a JSON-formatted input is the one case this doesn't
-            // reach (the same pre-existing per-input-vs-global sharing gap
-            // `json_sourced_floats` works around elsewhere in this struct),
-            // not a new inconsistency this fix introduces.
+            // `output_value`), so the clamp only applies when `output_value`
+            // will actually take the YAML branch below, i.e.
+            // `output_format == Yaml` exactly -- matching that dispatch's
+            // own condition (`if config.output_format == OutputFormat::Yaml`),
+            // not its complement. `Auto` is *not* YAML here: this build
+            // currently routes `-o=auto` to the JSON branch regardless of
+            // input format, a separate pre-existing divergence from real
+            // yq's own "match the input format" semantics, out of scope for
+            // this fix -- but this clamp must still track whichever branch
+            // `output_value` actually takes, or `-o=auto -I=1` would get
+            // JSON content clamped as if it were YAML.
             let width = args.indent as usize;
-            let width = if args.output_format == OutputFormat::Json {
-                width
-            } else {
+            let width = if args.output_format == OutputFormat::Yaml {
                 width.max(2)
+            } else {
+                width
             };
             " ".repeat(width)
         };

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2086,6 +2086,31 @@ fn test_indent_1_json_output_not_clamped_1486() -> Result<()> {
     Ok(())
 }
 
+/// #1486 review: the clamp's own predicate must track `output_value`'s real
+/// dispatch (`output_format == Yaml` decides the YAML branch; anything else,
+/// including `Auto`, currently falls through to the JSON branch here --
+/// itself a separate, pre-existing divergence from real yq's own
+/// match-the-input-format `-o=auto` semantics, out of scope for this fix,
+/// filed as #1493). A first version of this fix checked `!= Json` instead
+/// of `== Yaml`, so `-o=auto` (neither) wrongly inherited the YAML clamp
+/// even though it renders as JSON -- this pins `-o=auto`'s *content* stays
+/// self-consistent with explicit `-o=json` at the same `-I`, regardless of
+/// which pre-existing format the content itself renders as.
+#[test]
+fn test_indent_1_auto_format_matches_explicit_json_1486() -> Result<()> {
+    let yaml = "l:\n  m:\n    p: 1\n";
+
+    let (auto, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=auto"])?;
+    assert_eq!(code, 0);
+
+    let (json, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=json"])?;
+    assert_eq!(code, 0);
+
+    assert_eq!(auto, json);
+
+    Ok(())
+}
+
 /// `--tab`'s fix (#733) widened `can_stream_pretty`, which also covers
 /// `keys_unsorted` (part of `can_use_m2_streaming`) — not a duplicate-key
 /// case (keys_unsorted returns an array of key names, so nothing to

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2044,6 +2044,48 @@ fn test_seq_item_anchor_deferred_indent_at_non_default_width_slurp_1484() -> Res
     Ok(())
 }
 
+/// #1486: `-I=1`'s YAML output clamps to the same 2-column step as `-I=2`
+/// in real yq (verified live against v4.53.3, byte-identical at every
+/// level -- mappings, sequences, and compact/anchor-deferred sequence
+/// items alike), not a literal 1-column step. Covers the streaming path
+/// (plain identity) and the DOM path (forced via a write, `.c = 1`).
+#[test]
+fn test_indent_1_clamps_to_2_streaming_1486() -> Result<()> {
+    let yaml = "l:\n  m:\n    p: 1\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &["-I=1"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed, "l:\n  m:\n    p: 1\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_indent_1_clamps_to_2_dom_1486() -> Result<()> {
+    let yaml = "l:\n  m:\n    p: 1\n";
+
+    let (dom, code) = run_yq_stdin(".c = 1", yaml, &["-I=1"])?;
+    assert_eq!(code, 0);
+    assert_eq!(dom, "l:\n  m:\n    p: 1\nc: 1\n");
+
+    Ok(())
+}
+
+/// #1486: the clamp is YAML-specific -- real yq's `-o=json` output at
+/// `-I=1` genuinely uses a literal 1-space step (verified live), unlike
+/// YAML's clamp-to-2. `indent_str` is shared by both formats' DOM
+/// emitters, so this guards against the clamp leaking into JSON output.
+#[test]
+fn test_indent_1_json_output_not_clamped_1486() -> Result<()> {
+    let yaml = "l:\n  m:\n    p: 1\n";
+
+    let (json, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(json, "{\n \"l\": {\n  \"m\": {\n   \"p\": 1\n  }\n }\n}\n");
+
+    Ok(())
+}
+
 /// `--tab`'s fix (#733) widened `can_stream_pretty`, which also covers
 /// `keys_unsorted` (part of `can_use_m2_streaming`) — not a duplicate-key
 /// case (keys_unsorted returns an array of key names, so nothing to


### PR DESCRIPTION
## Summary
- Real yq's YAML output at `-I=1` is byte-identical to its own `-I=2` output at every nesting level — mappings, sequences, and compact/anchor-deferred sequence items alike (verified live against v4.53.3). succinctly previously honored the literal requested width of 1.
- Fixed in both the fast-path streamer (`yaml_indent_spaces`, already a YAML-only variable) and the DOM writer's `indent_str`.
- `indent_str` is shared between YAML and JSON DOM output, and real yq's JSON output at `-I=1` genuinely uses a literal 1-space step (not clamped) — verified live. The DOM-side fix is guarded on `output_format != Json` so it doesn't leak the YAML-only clamp into JSON output.
- Unrelated to anchors/tags; this is a plain nesting-indent divergence, found while investigating #1362/#1484.

Fixes #1486

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde` (0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned oracle `yq` v4.53.3 across mappings, sequences, deep nesting, compact sequence items, and anchor-deferred sequence items at `-I=1`, plus `-I=2/3/6` controls (unaffected) and `-o=json` at `-I=1` (unaffected, confirming the guard)
- [x] New regression tests: streaming, DOM-forced write, and JSON-not-clamped
- [x] Patch coverage: 100% (6/6 new lines covered, `omni-dev coverage diff`)