### PR TITLE
refactor(jq): remove delete_expr_iterate_paths as confirmed-dead code

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24485,10 +24485,15 @@ struct DeleteStep {
 /// Flatten a resolved (fully static) `del` path into atomic steps.
 ///
 /// Mirrors `push_path_components`, but fully resolves `Optional` instead of
-/// leaving it as an opaque wrapper: [`delete_expr_paths_at`] compares steps
+/// leaving it as an opaque wrapper. Two callers, with different needs: the
+/// comma-grouped multi-path walker ([`delete_expr_paths_at`]) compares steps
 /// across sibling paths position by position, so it needs one flat sequence
-/// of `Field`/`Index`/`Iterate` rather than a tree that hides some of them
-/// behind `Optional`/`Pipe` nodes.
+/// rather than a tree that hides some components behind `Optional`/`Pipe`
+/// nodes; a `del()` path resolved this way never actually carries a literal
+/// `Iterate` component by the time it reaches that walker (#1382), only
+/// `Field`/`Index`/`Slice`. [`yq_del_slice_outcome`] is the other caller,
+/// and does need `Iterate` to survive flattening -- its trailing-slice-run
+/// scan walks a path that can genuinely still contain one.
 fn flatten_delete_path(expr: &Expr, optional: bool, out: &mut Vec<DeleteStep>) {
     match expr {
         Expr::Identity => {}
@@ -24573,21 +24578,29 @@ fn delete_expr_paths_at(
             | Expr::IndexNumber { .. }
             | Expr::Slice { .. }
             | Expr::SliceNumber { .. } => indices.push(path),
-            // A bare `Expr::Iterate` (`.[]`) never reaches this position:
-            // `resolve_dynamic_indexes` only returns more than one path once
-            // it has run its computed-key prepass, and that prepass's own
-            // fan-out (`needs_fanout_pass`) always expands `.[]` into
-            // concrete per-element `Field`/`Index` components first (#1382
-            // -- exhaustively verified reachability audit; a prior handler
-            // here, `delete_expr_iterate_paths`, was removed as confirmed
-            // dead code). The single-path case (no computed key at all)
-            // takes `builtin_del`'s `paths.len() <= 1` branch instead, whose
-            // `delete_at_path` has its own, still-live `Expr::Iterate` arm.
+            // See `needs_fanout_pass`'s doc comment for why a bare
+            // `Expr::Iterate` can never reach this position (#1382). Flagged
+            // loudly in debug/test builds via `debug_assert` rather than
+            // silently -- but still falls through to the same graceful `Err`
+            // the general catch-all below returns for every other
+            // unsupported shape, not `unreachable!()`: this invariant spans
+            // several functions and a future edit anywhere in that chain
+            // could break it, and `unreachable!()` panics unconditionally in
+            // release builds too, turning a user-supplied `del()` expression
+            // into a process crash instead of an ordinary error (the same
+            // failure mode #1098 removed elsewhere in this crate).
+            Expr::Iterate => {
+                debug_assert!(
+                    false,
+                    "a bare .[] should have been fanned out into concrete Field/Index \
+                     components before reaching delete_expr_paths_at (#1382)"
+                );
+                return Err(EvalError::new("cannot use expression as delete target"));
+            }
             // `flatten_delete_path` only ever leaves Field/Index/Slice
             // components behind at a position more than one sibling path can
-            // reach; anything else (including this unreachable `Iterate`
-            // case) is a path shape `del` has never supported here, matching
-            // `delete_at_path`'s catch-all.
+            // reach; anything else is a path shape `del` has never supported
+            // here, matching `delete_at_path`'s catch-all.
             _ => return Err(EvalError::new("cannot use expression as delete target")),
         }
     }
@@ -24767,15 +24780,16 @@ fn delete_expr_array_paths(
     // (building `owned_keys` for `delete_keys`) already discarded it. Dropped,
     // not because the flag can never be `true` here (#1331's investigation
     // found the broader claim that it can't doesn't generalize past this
-    // specific dead-write site -- see `delete_expr_iterate_paths`'s own doc
-    // comment for the narrower, verified version of that claim), but because
-    // deleting a *terminal* index/slice always goes through `delete_keys`,
-    // which already silently skips a step naming nothing to delete
-    // (#415/#477) -- `optional` never had anything left to gate once it
-    // reached this merge, whether or not it was ever `true`. Order-
-    // independence for `del(.[(0,5)], .[5]?)` (either argument order) still
-    // holds: `IndexSet::insert` already dedupes a repeated `step` regardless
-    // of which occurrence's own `?` set the (now-untracked) flag.
+    // specific dead-write site -- see the `debug_assert` a little further
+    // down in this same function for the narrower, verified version of that
+    // claim), but because deleting a *terminal* index/slice always goes
+    // through `delete_keys`, which already silently skips a step naming
+    // nothing to delete (#415/#477) -- `optional` never had anything left
+    // to gate once it reached this merge, whether or not it was ever
+    // `true`. Order-independence for `del(.[(0,5)], .[5]?)` (either
+    // argument order) still holds: `IndexSet::insert` already dedupes a
+    // repeated `step` regardless of which occurrence's own `?` set the
+    // (now-untracked) flag.
     let mut terminal: IndexSet<ArrayStep> = IndexSet::new();
     let mut groups: IndexMap<ArrayStep, Vec<&[DeleteStep]>> = IndexMap::new();
     for path in paths {
@@ -24809,12 +24823,14 @@ fn delete_expr_array_paths(
         // `Expr::Optional` before any comma-grouped `del()` path reaches
         // `flatten_delete_path`, so no `DeleteStep` here can carry
         // `optional == true`. Verified (not just asserted in a comment,
-        // #1331): see `delete_expr_iterate_paths`'s matching
-        // `debug_assert` below for the full rationale, including the one
-        // confirmed exception (`yq_del_slice_outcome`'s own `wrap`
-        // closure, a different, non-comma-grouped consumer of the same
-        // field) that this crate's usual "optional never forced true"
-        // pattern (#928/#1003/#1034) doesn't cover here.
+        // #1331), with one confirmed exception this crate's usual "optional
+        // never forced true" pattern (#928/#1003/#1034) doesn't cover:
+        // `yq_del_slice_outcome`'s own `wrap` closure is a different,
+        // non-comma-grouped consumer of the same `DeleteStep.optional`
+        // field, reachable via `del(.a?[1:3])`-shaped input, where an
+        // identically-worded claim was found wrong -- so this function's
+        // own version of the claim needed its own verification, not an
+        // assumption that it generalizes.
         debug_assert!(
             !paths.iter().any(|p| p[start].optional),
             "delete_expr_array_paths: no DeleteStep here should ever carry optional == true -- \

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14292,6 +14292,14 @@ fn needs_path_prepass(expr: &Expr) -> bool {
 /// `needs_path_prepass`, which is also called on whole (possibly
 /// un-flattened) expressions elsewhere, adding one here would be untested
 /// dead code.
+///
+/// The `Expr::Iterate => true` arm below is also load-bearing for
+/// `delete_expr_paths_at` (a comma-grouped `del()`'s multi-path walker):
+/// it's what guarantees a bare `.[]` never survives into that function's
+/// resolved paths, which is why `delete_expr_paths_at` has no `Iterate`
+/// case of its own (#1382 -- removed as confirmed-dead code once this arm
+/// was found to always fire first). Narrowing this arm would silently
+/// reopen that dead branch as a real one.
 fn needs_fanout_pass(expr: &Expr) -> bool {
     match expr {
         Expr::Iterate => true,
@@ -24551,7 +24559,6 @@ fn delete_expr_paths_at(
 
     let mut fields: Vec<&[DeleteStep]> = Vec::new();
     let mut indices: Vec<&[DeleteStep]> = Vec::new();
-    let mut iterates: Vec<&[DeleteStep]> = Vec::new();
     for &path in paths {
         match &path[start].component {
             Expr::Field(_) => fields.push(path),
@@ -24566,27 +24573,35 @@ fn delete_expr_paths_at(
             | Expr::IndexNumber { .. }
             | Expr::Slice { .. }
             | Expr::SliceNumber { .. } => indices.push(path),
-            Expr::Iterate => iterates.push(path),
-            // `flatten_delete_path` only ever leaves Field/Index/Slice/Iterate
-            // components behind; anything else is a path shape `del` has
-            // never supported, matching `delete_at_path`'s catch-all.
+            // A bare `Expr::Iterate` (`.[]`) never reaches this position:
+            // `resolve_dynamic_indexes` only returns more than one path once
+            // it has run its computed-key prepass, and that prepass's own
+            // fan-out (`needs_fanout_pass`) always expands `.[]` into
+            // concrete per-element `Field`/`Index` components first (#1382
+            // -- exhaustively verified reachability audit; a prior handler
+            // here, `delete_expr_iterate_paths`, was removed as confirmed
+            // dead code). The single-path case (no computed key at all)
+            // takes `builtin_del`'s `paths.len() <= 1` branch instead, whose
+            // `delete_at_path` has its own, still-live `Expr::Iterate` arm.
+            // `flatten_delete_path` only ever leaves Field/Index/Slice
+            // components behind at a position more than one sibling path can
+            // reach; anything else (including this unreachable `Iterate`
+            // case) is a path shape `del` has never supported here, matching
+            // `delete_at_path`'s catch-all.
             _ => return Err(EvalError::new("cannot use expression as delete target")),
         }
     }
 
     // `value` can only be one concrete type at a time, so at most one of
-    // these three actually mutates it — the others see a container of the
-    // wrong shape and take that branch's optional-vs-error path (see
-    // `delete_expr_object_paths`/`delete_expr_array_paths`). All three can
-    // be non-empty only when `value` is `null`, per the doc comment above.
+    // these two actually mutates it — the other sees a container of the
+    // wrong shape and takes that branch's optional-vs-error path (see
+    // `delete_expr_object_paths`/`delete_expr_array_paths`). Both can be
+    // non-empty only when `value` is `null`, per the doc comment above.
     if !fields.is_empty() {
         value = delete_expr_object_paths(value, &fields, start)?;
     }
     if !indices.is_empty() {
         value = delete_expr_array_paths(value, &indices, start)?;
-    }
-    if !iterates.is_empty() {
-        value = delete_expr_iterate_paths(value, &iterates, start)?;
     }
     Ok(value)
 }
@@ -24908,85 +24923,6 @@ enum ArrayStep {
     Slice(Option<i64>, Option<i64>),
 }
 
-/// [`delete_expr_paths_at`]'s `Iterate` case: every path here shares the same
-/// tail — an `Iterate` names no component of its own to differ by — so there
-/// is nothing to group. Either every path ends here, clearing the whole
-/// container, or every path continues, and each element/value recurses with
-/// the same sibling list.
-///
-/// `paths` here always traces back to [`resolve_dynamic_indexes`]'s own
-/// output, which strips every `Expr::Optional` wrapper via
-/// `strip_resolved_optional` before returning -- so `optional` below is
-/// always `false` in practice; kept as a live value (not deleted) rather
-/// than hardcoded, with a `debug_assert` verifying the invariant rather
-/// than silently trusting it (#1331 found that an identically-worded
-/// claim was wrong for a *different* consumer of the same
-/// `DeleteStep.optional` field -- [`yq_del_slice_outcome`]'s own `wrap`
-/// closure, reachable via `del(.a?[1:3])`-shaped input -- so each site's
-/// own version of the claim needs its own verification, not assumed to
-/// generalize).
-///
-/// This function itself may be entirely unreachable from `del()`'s own
-/// comma-grouped route: extensive live probing (#1331's second review
-/// round, three independent passes) found `resolve_node`'s own handling
-/// of `Expr::Iterate` eagerly expands a bare `.[]`/`.[]?` into concrete
-/// per-element `Field`/`Index` components *before* `flatten_delete_path`
-/// ever runs, for every shape tried -- meaning a literal `DeleteStep`
-/// carrying `Expr::Iterate` may never actually get constructed via
-/// `builtin_del`'s `paths.len() > 1` branch (the only external entry to
-/// `delete_expr_paths_at`) at all. Left as-is rather than removed:
-/// proving a function is *never* reachable, as opposed to not reachable
-/// via every input tried so far, needs more exhaustive verification than
-/// #1331's own scope covers -- filed as #1382 rather than assumed here.
-/// If genuinely dead, the `debug_assert` below (and the two `optional`-
-/// gated match arms further down, pre-dating this issue) are dead along
-/// with it, harmlessly.
-fn delete_expr_iterate_paths(
-    value: OwnedValue,
-    paths: &[&[DeleteStep]],
-    start: usize,
-) -> Result<OwnedValue, EvalError> {
-    let optional = paths[0][start].optional;
-    debug_assert!(
-        !optional,
-        "delete_expr_iterate_paths: DeleteStep.optional should always be false here -- \
-         resolve_dynamic_indexes strips Expr::Optional before any comma-grouped del() path \
-         reaches this function (#1331)"
-    );
-    if paths[0].len() == start + 1 {
-        return match value {
-            OwnedValue::Array(mut arr) => {
-                arr.clear();
-                Ok(OwnedValue::Array(arr))
-            }
-            OwnedValue::Object(mut map) => {
-                map.clear();
-                Ok(OwnedValue::Object(map))
-            }
-            other if optional => Ok(other),
-            other => Err(EvalError::cannot_iterate(&other)),
-        };
-    }
-    match value {
-        OwnedValue::Array(mut arr) => {
-            for elem in &mut arr {
-                let old = core::mem::replace(elem, OwnedValue::Null);
-                *elem = delete_expr_paths_at(old, paths, start + 1)?;
-            }
-            Ok(OwnedValue::Array(arr))
-        }
-        OwnedValue::Object(mut map) => {
-            for v in map.values_mut() {
-                let old = core::mem::replace(v, OwnedValue::Null);
-                *v = delete_expr_paths_at(old, paths, start + 1)?;
-            }
-            Ok(OwnedValue::Object(map))
-        }
-        other if optional => Ok(other),
-        other => Err(EvalError::cannot_iterate(&other)),
-    }
-}
-
 /// Recursively rewrite every already-static branch of `expr` with
 /// [`yq_del_slice_outcome`]'s chained-slice-parent-key rule
 /// (#1223), unwrapping and rewrapping any `Expr::Paren`/`Expr::Optional`
@@ -25107,8 +25043,12 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // Computed keys resolve against the original document; each becomes one
-    // fully static path expression (Field/Index/Iterate components — see
-    // `resolve_dynamic_indexes`).
+    // fully static path expression (Field/Index/Slice components — see
+    // `resolve_dynamic_indexes`). A path with no computed key at all is
+    // returned verbatim instead and may still contain a literal `Iterate`,
+    // but is always the sole entry, so it takes the `paths.len() <= 1`
+    // branch below rather than `delete_expr_paths_at`'s comma-grouped one
+    // (#1382).
     let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -1976,14 +1976,17 @@ fn test_del_static_comma_type_error_still_errors_with_every_sibling_optional_132
 
 /// #1322 (found by `/code-review`): `delete_expr_paths_at` buckets siblings
 /// by shape and processes the indices bucket (`delete_expr_array_paths`)
-/// before the iterates bucket (`delete_expr_iterate_paths`) at the same
-/// `start`. Before this fix, if the dead `optional` gate had ever actually
-/// been live, an all-optional indices bucket would have returned early
-/// with `Ok(value)` unchanged, and processing would have continued into
-/// the iterates bucket instead of erroring here. Since `optional` is
-/// always `false` in practice this was never reachable, but pinning the
+/// before anything else at the same `start`. Before this fix, if the dead
+/// `optional` gate had ever actually been live, an all-optional indices
+/// bucket would have returned early with `Ok(value)` unchanged, and
+/// processing would have continued into whatever the `.[]?` sibling
+/// resolved to instead of erroring here. Since `optional` is always
+/// `false` in practice this was never reachable, but pinning the
 /// combination directly guards against the ordering assumption silently
-/// changing.
+/// changing. (The `.[]?` sibling itself never reaches `delete_expr_paths_at`
+/// as a literal `Expr::Iterate` at all -- #1382 confirmed and removed the
+/// dead handler that used to be its dedicated bucket; it's fanned out by
+/// `resolve_dynamic_indexes` before this function ever sees it.)
 #[test]
 fn test_del_static_comma_mixed_indices_and_iterate_buckets_still_errors_1322() {
     check(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17127,15 +17127,16 @@ fn test_1331_comma_computed_key_and_static_optional_sibling_dedup() -> Result<()
 }
 
 /// #1331: two top-level comma branches each ending in a `?`-marked bare
-/// iterate. This was originally meant to exercise `delete_expr_iterate_paths`'s
-/// own `debug_assert`, but a live debug probe (#1331's second review
-/// round) found it doesn't: `resolve_node` eagerly expands `.a[]`/`.b[]?`
-/// into concrete per-element `Index` components before `flatten_delete_path`
-/// ever runs, so this actually reaches `delete_expr_array_paths` (already
-/// covered above) -- see `delete_expr_iterate_paths`'s own doc comment and
-/// #1382 for whether that function is reachable via `del()` at all. Kept
-/// as a plain correctness regression test for this realistic input shape,
-/// not as coverage for that specific debug_assert.
+/// iterate. This was originally meant to exercise the debug_assert of a
+/// dedicated `Iterate`-bucket handler this shape was expected to reach, but
+/// a live debug probe (#1331's second review round) found it doesn't:
+/// `resolve_node` eagerly expands `.a[]`/`.b[]?` into concrete per-element
+/// `Index` components before `flatten_delete_path` ever runs, so this
+/// actually reaches `delete_expr_array_paths` (already covered above).
+/// #1382 later confirmed and closed the open question that handler's own
+/// reachability posed: it was genuinely dead code, exhaustively verified
+/// and removed. Kept as a plain correctness regression test for this
+/// realistic input shape, not as coverage for any debug_assert.
 #[test]
 fn test_1331_comma_optional_iterate_siblings_clear_both_arrays() -> Result<()> {
     let (out, code) = run_yq_stdin(


### PR DESCRIPTION
## Summary
- Resolves #1382's question: is `delete_expr_iterate_paths` reachable from `del()`'s comma-grouped route? **No.**
- `resolve_dynamic_indexes` only returns more than one path once its computed-key prepass has run, and that prepass's fan-out (`needs_fanout_pass`) always expands a bare `.[]` into concrete per-element `Field`/`Index` components before `flatten_delete_path` ever runs. So a literal `Expr::Iterate` never survives into `delete_expr_paths_at`'s comma-grouped walker — the single-path case (no computed key at all) takes `builtin_del`'s separate `paths.len() <= 1` branch instead, whose `delete_at_path` has its own, still-live `Expr::Iterate` arm.
- Corroborated three independent ways, by three separate investigation/review passes:
  - **Coverage**: full-suite line coverage shows 0 hits on the function body and its dispatch arm.
  - **Git history**: the function was genuinely reachable for ~2 weeks after #424 introduced it, until #682's `5415a5e3e` (narrowing that issue's fan-out fix to avoid a `del()`/`path()` perf cliff) changed the fan-out gate and closed the window.
  - **Live probes**: ~60 `del()` shapes across both jq/yq modes, all matching fan-out behavior, none reaching the function.
- Removed the function and `delete_expr_paths_at`'s now-impossible `Iterate` bucket. Review (multiple independent passes) found the initial removal left 5 dangling comment references to the deleted function name, and that the replacement's `unreachable!()` panics unconditionally in *release* builds — a user-supplied `del()` expression could crash the whole process if this cross-function invariant is ever broken by a future edit, instead of getting the ordinary `EvalError` every other unsupported delete-path shape gets (the same failure mode #1098 removed elsewhere in this crate). Fixed both: all dangling references now point at accurate, self-contained explanations, and the `Iterate` arm uses `debug_assert!(false, ...)` with the same graceful `Err` fallback other arms use — loud in debug/test builds, safe in release.

Fixes #1382

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde` (2700+ tests, 0 failed — confirms no observable behavior moved, and the `debug_assert` never fires)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified representative `del()` shapes against the pinned `jq` 1.7.1 oracle post-removal — all byte-match
- [x] Patch coverage: 0/3 new lines covered (`src/jq/eval.rs:24590-24595`) — this is the `debug_assert`/fallback body inside the now-confirmed-dead `Expr::Iterate` arm; a test that reached it would disprove this PR's own premise, so it's genuinely untestable by design, not an oversight