### PR TITLE
fix(yq): resolve -o=auto against the input's own format (#1493)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -439,6 +439,39 @@ $ printf 'a: [1, 2]\n' | yq            -o=json '.a[].b = error("boom")'   # {"a"
 $ printf 'a: [1, 2]\n' | succinctly yq -o=json '.a[].b = error("boom")'   # Error: boom
 ```
 
+### `-o=auto` on a genuinely mixed-format multi-source run doesn't match per-element
+
+[#1493](https://github.com/rust-works/succinctly/issues/1493) made `-o=auto` resolve
+against the input's own format instead of always rendering JSON — YAML input renders as
+YAML, JSON input as JSON, per-source (`--split-exp`, the standard multi-file path,
+`--eval-all`, `--inplace`) or per-invocation-uniform-format (`--slurp`/`--eval-all` when
+every source agrees). A genuinely *mixed*-format run is the one case left unresolved:
+real yq treats the whole output as one YAML stream with each JSON-sourced document
+embedded flow-style, `---` between every document regardless of source format —
+succinctly instead gives each document its own correct format independently, with no
+separator between differently-formatted documents and no flow-style JSON embedding:
+
+```bash
+$ printf 'a: 1\n' > a.yaml && printf '{"b":2}' > b.json
+
+$ yq            -o=auto '.' a.yaml b.json   # a: 1
+                                             # ---
+                                             # {"b": 2}
+$ succinctly yq -o=auto '.' a.yaml b.json   # a: 1
+                                             # {
+                                             #   "b": 2
+                                             # }
+
+$ yq            -o=auto --slurp '.' a.yaml b.json   # - a: 1
+                                                      # - {"b": 2}
+$ succinctly yq -o=auto --slurp '.' a.yaml b.json    # - a: 1
+                                                       # - b: 2
+```
+
+Live-verified against yq v4.53.3. Pinned as known gaps (current, not the desired end
+state) by `test_yq_auto_output_mixed_format_multi_file_known_gap_1493` and
+`test_yq_auto_output_slurp_mixed_format_known_gap_1493` in `tests/yq_cli_tests.rs`.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -117,6 +117,29 @@ pub struct EvalContext {
     pub named: IndexMap<String, OwnedValue>,
 }
 
+/// Resolve `OutputFormat::Auto` against a concrete `InputFormat` (#1493):
+/// real yq's `-o=auto` matches the input's own format -- YAML input stays
+/// YAML, JSON input becomes JSON. Anything already concrete passes through
+/// unchanged. `InputFormat::Auto` shouldn't reach here in practice
+/// (`resolve_input_format`/`detect_format_from_path` already resolve it
+/// before any source reaches this point), but it's handled the same as
+/// `InputFormat::Yaml` (Yaml is the safer default of the two either way).
+/// Real yq's own "nothing to match" case (`--null-input`, `--raw-input`,
+/// mixed-format `--slurp`) also defaults to Yaml -- confirmed live: `yq -n
+/// -p=json '{}' -o=auto` still prints YAML (with a backwards-compatibility
+/// warning), not JSON, so callers with no per-source `InputFormat` of their
+/// own should resolve against `InputFormat::Yaml` here too, not skip the
+/// call.
+fn resolve_output_format(output_format: OutputFormat, input_format: InputFormat) -> OutputFormat {
+    if output_format != OutputFormat::Auto {
+        return output_format;
+    }
+    match input_format {
+        InputFormat::Json => OutputFormat::Json,
+        InputFormat::Yaml | InputFormat::Auto => OutputFormat::Yaml,
+    }
+}
+
 /// Output configuration
 #[derive(Clone)]
 struct OutputConfig {
@@ -157,37 +180,9 @@ impl OutputConfig {
         // Compact output when indent is 0 (yq-compatible)
         let compact = args.indent == 0;
 
-        let indent_str = if compact {
-            String::new()
-        } else if args.tab {
-            "\t".to_string()
-        } else {
-            // `-I1` clamps to 2 for YAML output (#1486): real yq's YAML
-            // output at `-I1` is byte-identical to its own `-I2` output at
-            // every level, mirroring the fast-path streamer's identical
-            // clamp on `yaml_indent_spaces` below. JSON has no such quirk
-            // (verified live: `-I1 -o=json` genuinely indents 1 space per
-            // level in real yq) -- `indent_str` is shared by both formats'
-            // DOM emitters (see its use in the JSON branch of
-            // `output_value`), so the clamp only applies when `output_value`
-            // will actually take the YAML branch below, i.e.
-            // `output_format == Yaml` exactly -- matching that dispatch's
-            // own condition (`if config.output_format == OutputFormat::Yaml`),
-            // not its complement. `Auto` is *not* YAML here: this build
-            // currently routes `-o=auto` to the JSON branch regardless of
-            // input format, a separate pre-existing divergence from real
-            // yq's own "match the input format" semantics, out of scope for
-            // this fix -- but this clamp must still track whichever branch
-            // `output_value` actually takes, or `-o=auto -I=1` would get
-            // JSON content clamped as if it were YAML.
-            let width = args.indent as usize;
-            let width = if args.output_format == OutputFormat::Yaml {
-                width.max(2)
-            } else {
-                width
-            };
-            " ".repeat(width)
-        };
+        // `args.output_format` itself, not yet resolved against any
+        // source's `InputFormat` -- see `Self::for_source` below (#1493).
+        let indent_str = Self::compute_indent_str(args, args.output_format);
 
         Self {
             output_format: args.output_format,
@@ -201,6 +196,60 @@ impl OutputConfig {
             indent_str,
             use_color,
             json_sourced_floats: false,
+        }
+    }
+
+    /// `-I1` clamps to 2 for YAML output (#1486): real yq's YAML output at
+    /// `-I1` is byte-identical to its own `-I2` output at every level,
+    /// mirroring the fast-path streamer's identical clamp on
+    /// `yaml_indent_spaces` below. JSON has no such quirk (verified live:
+    /// `-I1 -o=json` genuinely indents 1 space per level in real yq) --
+    /// `indent_str` is shared by both formats' DOM emitters (see its use in
+    /// the JSON branch of `output_value`), so the clamp only applies when
+    /// `output_value` will actually take the YAML branch, i.e.
+    /// `effective_output_format == Yaml` exactly -- matching that
+    /// dispatch's own condition, not its complement.
+    ///
+    /// Takes the caller's *effective* format rather than reading
+    /// `args.output_format` directly: `Self::from_args` passes
+    /// `args.output_format` itself (nothing resolved yet), while
+    /// `Self::for_source` passes the per-source *resolved* format, so an
+    /// `Auto` that resolves to `Yaml` for a given source still gets the
+    /// clamp there, and one that resolves to `Json` doesn't (#1493) --
+    /// before that fix, `Auto` was treated as "not YAML" here
+    /// unconditionally, since `-o=auto` always rendered JSON regardless of
+    /// input format anyway.
+    fn compute_indent_str(args: &YqCommand, effective_output_format: OutputFormat) -> String {
+        if args.indent == 0 {
+            return String::new();
+        }
+        if args.tab {
+            return "\t".to_string();
+        }
+        let width = args.indent as usize;
+        let width = if effective_output_format == OutputFormat::Yaml {
+            width.max(2)
+        } else {
+            width
+        };
+        " ".repeat(width)
+    }
+
+    /// Per-source override (#1493): resolves `OutputFormat::Auto` against
+    /// this specific source's own `InputFormat` (real yq's `-o=auto`
+    /// matches the input format, confirmed live), recomputing `indent_str`
+    /// to match, and folds in the pre-existing `json_sourced_floats`
+    /// override (#978/#1398) for the same reason -- both need the
+    /// *specific* source's own format, not the invocation-wide default,
+    /// since `--input-format auto` can mix JSON and YAML sources in one
+    /// run.
+    fn for_source(&self, args: &YqCommand, input_format: InputFormat) -> Self {
+        let output_format = resolve_output_format(self.output_format, input_format);
+        Self {
+            output_format,
+            indent_str: Self::compute_indent_str(args, output_format),
+            json_sourced_floats: input_format == InputFormat::Json,
+            ..self.clone()
         }
     }
 }
@@ -3017,19 +3066,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if args.slurp {
                 anyhow::bail!("--front-matter=process and --slurp are incompatible");
             }
-            // `output_value` treats anything other than `Yaml` as JSON
-            // output (including `Auto`, which has no YAML/Markdown-file
-            // detection of its own) -- so the guard must reject everything
-            // but `Yaml`, not just the explicit `Json` variant, or `-o auto`
-            // silently slips through and wraps a JSON body in `---` fences.
-            if args.output_format != OutputFormat::Yaml {
+            // Only explicit `Json` is rejected now (#1493): front-matter
+            // content is always forced to `InputFormat::Yaml`
+            // (`apply_front_matter`), so `Auto` always resolves to `Yaml`
+            // here too (`Self::for_source`) -- accepting it is no longer
+            // the "silently slips through and wraps a JSON body in `---`
+            // fences" bug this guard was written to close, since `Auto`
+            // can no longer resolve to anything but `Yaml` in this
+            // specific context.
+            if args.output_format == OutputFormat::Json {
                 anyhow::bail!(
-                    "--front-matter=process requires YAML output (got -o/--output-format {})",
-                    if args.output_format == OutputFormat::Json {
-                        "json"
-                    } else {
-                        "auto"
-                    }
+                    "--front-matter=process requires YAML output (got -o/--output-format json)"
                 );
             }
         }
@@ -3657,6 +3704,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // this batch's own split-filename evaluation) actually occurs
             // (#791, mirrors `write_split_result`'s own `halted_before`).
             let halted_before_batch = sink.halted().is_some();
+            // No source to match against `--null-input` (#1493): real yq's
+            // own `-o=auto` here still defaults to Yaml (confirmed live),
+            // matching `Self::for_source`'s own "nothing to match" arm.
+            let null_input_output_config = output_config.for_source(&args, InputFormat::Yaml);
             for result in &results {
                 any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
                 write_split_result(
@@ -3664,7 +3715,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     &CommentTree::empty(),
                     split_expr,
                     output_index,
-                    &output_config,
+                    &null_input_output_config,
                     &mut written_split_files,
                     &mut sink,
                 )?;
@@ -3701,9 +3752,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // `evaluate_input` pair for both formats -- a separate,
                 // already-tracked issue (#1343), not touched here.
                 let doc_filter = args.document.map(|target| (target, global_doc_index));
-                // Split-exp output files carry real comments when
-                // written as YAML, same as the main output path (#710).
-                let need_comments = output_config.output_format == OutputFormat::Yaml;
+                // Per-file `OutputConfig` (#978/#1398's `json_sourced_floats`,
+                // #1493's `Auto` resolution) -- both need this specific
+                // source's own `InputFormat`, not the invocation-wide
+                // default, since `--input-format auto` can mix JSON and
+                // YAML sources in one run.
+                let file_output_config = output_config.for_source(&args, *format);
+                // Split-exp output files carry real comments when written
+                // as YAML, same as the main output path (#710) -- resolved
+                // per-file now, not the invocation-wide default (#1493).
+                let need_comments = file_output_config.output_format == OutputFormat::Yaml;
                 let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
                     bytes,
                     &program.expr,
@@ -3717,17 +3775,6 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     },
                 )?;
                 global_doc_index += num_docs;
-                // A JSON-sourced float never keeps a decimal point in
-                // `-o=json` output (#978, #1398) -- see
-                // `OutputConfig::json_sourced_floats`'s own doc comment.
-                let file_output_config = if *format == InputFormat::Json {
-                    OutputConfig {
-                        json_sourced_floats: true,
-                        ..output_config.clone()
-                    }
-                } else {
-                    output_config.clone()
-                };
                 for results in doc_results {
                     // See the --null-input arm above: a halt already
                     // present when this document's batch starts
@@ -3763,7 +3810,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
         }
     } else if args.null_input {
-        // Handle --null-input
+        // Handle --null-input. No source to resolve `Auto` against
+        // (#1493): real yq's own `-o=auto` here still defaults to Yaml
+        // (confirmed live), matching `Self::for_source`'s "nothing to
+        // match" arm.
+        let output_config = output_config.for_source(&args, InputFormat::Yaml);
         let mut split_doc_state = SplitDocState::new(has_split_doc);
         let results = evaluate_input(&OwnedValue::Null, &program.expr, &mut sink)?;
         for result in results {
@@ -3772,7 +3823,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
         }
     } else if args.raw_input {
-        // Handle --raw-input: read each line as a string instead of parsing as YAML
+        // Handle --raw-input: read each line as a string instead of
+        // parsing as YAML. Same "nothing to resolve `Auto` against" case
+        // as `--null-input` above (#1493) -- a raw line is never
+        // parsed/detected as YAML or JSON.
+        let output_config = output_config.for_source(&args, InputFormat::Yaml);
         let input_content = if input_files.is_empty() {
             read_stdin_string()?
         } else {
@@ -3910,6 +3965,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             })?;
             writeln!(writer)?;
         } else {
+            // #1493: resolve `Auto` against the uniform format of every
+            // source, if they all agree (confirmed live: an all-JSON slurp
+            // renders JSON, an all-YAML slurp renders YAML). A genuinely
+            // mixed-format slurp falls back to Yaml, the same "nothing
+            // single to match" treatment as `--null-input` above -- real
+            // yq's own mixed-format `-o=auto --slurp` renders each element
+            // in its own source format, a much deeper per-element behavior
+            // this fix doesn't attempt to replicate (pinned as a known gap
+            // in the test suite).
+            let mut source_formats = input_sources.iter().map(|(_, format, _)| *format);
+            let uniform_format = match source_formats.next() {
+                Some(first) if source_formats.all(|f| f == first) => first,
+                _ => InputFormat::Yaml,
+            };
+            let output_config = output_config.for_source(&args, uniform_format);
+
             let mut all_docs: Vec<OwnedValue> = Vec::new();
 
             // Parse all inputs and collect documents
@@ -3973,8 +4044,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `compact ||` gate short-circuits before color is checked),
             // and nothing forced color off on that path, so
             // `-C -I0 --inplace` wrote raw ANSI bytes straight into the
-            // file.
-            let mut output_config = output_config.clone();
+            // file. Also resolves `Auto` against this file's own format
+            // (#1493) -- the fast paths above require `output_format ==
+            // Json`/`== Yaml` exactly, so `Auto` always reaches this slow
+            // DOM branch regardless, same pre-existing scope limit as
+            // `--slurp`'s fast path.
+            let mut output_config = output_config.for_source(&args, format);
             output_config.use_color = false;
 
             // halt/halt_error (#791): tracks whether any *real* evaluated
@@ -4257,8 +4332,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `parse_input`/`evaluate_input` eager-`OwnedValue` path).
             let doc_filter = args.document.map(|target| (target, global_doc_index));
             // JSON output never reads `CommentTree` (see
-            // `output_value`'s JSON branch), so don't build one (#710).
-            let need_comments = output_config.output_format == OutputFormat::Yaml;
+            // `output_value`'s JSON branch), so don't build one (#710) --
+            // resolved per-source, not the invocation-wide default (#1493:
+            // `Auto` must match this source's own format).
+            let need_comments =
+                resolve_output_format(output_config.output_format, *format) == OutputFormat::Yaml;
             let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
                 bytes,
                 &program.expr,
@@ -4286,42 +4364,52 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
         // Output all results with proper separators
         // For split_doc: add --- BETWEEN each result (not before first)
-        // For regular multi-doc: add --- before each document's results
+        // For regular multi-doc: add --- BETWEEN each document's results
+        // (not before the first -- `any_doc_output` below, #1493 review: a
+        // pre-existing gap in this "standard"/slow path specifically, only
+        // now reachable with `output_format == Yaml` for real, since any
+        // invocation that would have hit it before either took the M2 fast
+        // path instead (which already tracks this correctly, see
+        // `yaml_doc_streamed` in the fast-path arm above) or -- for
+        // `-o=auto` specifically, pre-#1493 -- never satisfied the `Yaml`
+        // check here at all).
         // For --front-matter=process: each file's own leading/closing ---
         // fences wrap its transformed front matter, followed by its
         // untouched body (carried alongside `input_sources`, gathered above).
         let mut split_doc_state = SplitDocState::new(has_split_doc);
+        let mut any_doc_output = false;
         for (file_idx, doc_results) in all_results.into_iter().enumerate() {
             let front_matter_body = input_sources
                 .get(file_idx)
                 .and_then(|(_, _, body)| body.as_ref());
-            // A JSON-sourced float never keeps a decimal point in `-o=json`
-            // output (#978, #1398) -- see `OutputConfig::json_sourced_floats`'s
-            // own doc comment. Per file/source, not global: `--input-format
-            // auto` can mix JSON and YAML sources in one invocation.
-            let file_output_config = if input_sources.get(file_idx).map(|(_, format, _)| *format)
-                == Some(InputFormat::Json)
-            {
-                OutputConfig {
-                    json_sourced_floats: true,
-                    ..output_config.clone()
-                }
-            } else {
-                output_config.clone()
-            };
+            // Per-file `OutputConfig` (#978/#1398's `json_sourced_floats`,
+            // #1493's `Auto` resolution) -- both need this specific
+            // source's own `InputFormat`, not the invocation-wide default,
+            // since `--input-format auto` can mix JSON and YAML sources in
+            // one invocation.
+            let source_format = input_sources
+                .get(file_idx)
+                .map_or(InputFormat::Yaml, |(_, format, _)| *format);
+            let file_output_config = output_config.for_source(&args, source_format);
             if front_matter_body.is_some() {
                 writeln!(writer, "---")?;
             }
             for results in doc_results {
-                // Add document separator in YAML mode for multi-doc (before each doc's results)
+                // Add document separator in YAML mode for multi-doc,
+                // between documents only, not before the first
+                // (`any_doc_output`, see this loop's own comment above) --
+                // resolved per-file, not the invocation-wide default
+                // (#1493).
                 if !has_split_doc
-                    && output_config.output_format == OutputFormat::Yaml
+                    && file_output_config.output_format == OutputFormat::Yaml
                     && !output_config.no_doc
                     && is_multi_doc
                     && front_matter_body.is_none()
+                    && any_doc_output
                 {
                     writeln!(writer, "---")?;
                 }
+                any_doc_output = true;
                 for (result, comments) in results {
                     split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -245,11 +245,22 @@ impl OutputConfig {
     /// run.
     fn for_source(&self, args: &YqCommand, input_format: InputFormat) -> Self {
         let output_format = resolve_output_format(self.output_format, input_format);
+        // Every other field is a plain `Copy` bool -- written out
+        // explicitly rather than `..self.clone()`, which would otherwise
+        // heap-allocate a throwaway copy of the old `indent_str` only to
+        // immediately discard it in favor of the recomputed one below.
         Self {
             output_format,
+            compact: self.compact,
+            raw_output: self.raw_output,
+            join_output: self.join_output,
+            nul_output: self.nul_output,
+            ascii_output: self.ascii_output,
+            sort_keys: self.sort_keys,
+            no_doc: self.no_doc,
             indent_str: Self::compute_indent_str(args, output_format),
+            use_color: self.use_color,
             json_sourced_floats: input_format == InputFormat::Json,
-            ..self.clone()
         }
     }
 }
@@ -3636,6 +3647,21 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             GatheredSources::ExitCode(code) => return Ok(code),
         };
 
+        // #1493 review: this branch was missed by the original fix --
+        // every other output-producing branch resolves `Auto` per-source,
+        // but `--eval-all` combines every source into one evaluation the
+        // same way `--slurp` does, so it gets the identical "uniform
+        // format across every source, falling back to Yaml if they
+        // disagree" treatment `--slurp`'s own fix already established
+        // (see that branch's own comment for the real-yq-mismatch
+        // rationale on the mixed-format case).
+        let mut source_formats = input_sources.iter().map(|(_, format, _)| *format);
+        let uniform_format = match source_formats.next() {
+            Some(first) if source_formats.all(|f| f == first) => first,
+            _ => InputFormat::Yaml,
+        };
+        let output_config = output_config.for_source(&args, uniform_format);
+
         let mut all_docs: Vec<OwnedValue> = Vec::new();
         let mut file_origin: Vec<usize> = Vec::new();
         let mut global_doc_index: usize = 0;
@@ -4184,6 +4210,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // that may already be sitting in `buf_writer` above.
                 let mut any_real_output = false;
                 let mut split_doc_state = SplitDocState::new(has_split_doc);
+                // Tracks "has any *earlier* document in this file already
+                // had real output" (#1497 review) -- `doc_had_output`
+                // below resets per document, deciding only where within
+                // *that* document's own results the separator goes, not
+                // whether this is the file's first document overall. Every
+                // invocation that would reach this multi-doc separator
+                // logic with `output_format == Yaml` used to take the M2
+                // fast path instead (which already gets this right via its
+                // own `yaml_doc_streamed` flag); `-o=auto` could never
+                // satisfy that fast path's exact-format gate pre-#1493, so
+                // this dormant "leading separator on the first document
+                // too" bug in the DOM branch went unreachable until this
+                // fix made `Auto` resolve to `Yaml` for real.
+                let mut any_doc_output_this_file = false;
                 for (local_idx, input) in inputs.iter().enumerate() {
                     let current_doc_index = global_doc_index + local_idx;
                     // Apply --doc filter if specified
@@ -4214,10 +4254,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && !output_config.no_doc
                             && is_multi_doc
                             && front_matter_body.is_none()
+                            && any_doc_output_this_file
                         {
                             writeln!(buf_writer, "---")?;
                         }
                         doc_had_output = true;
+                        any_doc_output_this_file = true;
                         split_doc_state.write_separator(&mut buf_writer, &output_config)?;
                         any_truthy |=
                             !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
@@ -4364,20 +4406,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
         // Output all results with proper separators
         // For split_doc: add --- BETWEEN each result (not before first)
-        // For regular multi-doc: add --- BETWEEN each document's results
-        // (not before the first -- `any_doc_output` below, #1493 review: a
-        // pre-existing gap in this "standard"/slow path specifically, only
-        // now reachable with `output_format == Yaml` for real, since any
-        // invocation that would have hit it before either took the M2 fast
-        // path instead (which already tracks this correctly, see
-        // `yaml_doc_streamed` in the fast-path arm above) or -- for
-        // `-o=auto` specifically, pre-#1493 -- never satisfied the `Yaml`
-        // check here at all).
+        // For regular multi-doc: add --- BETWEEN each YAML-resolved
+        // document's results (not before the first -- `any_yaml_doc_output`
+        // below, #1493 review: a pre-existing gap in this "standard"/slow
+        // path specifically, only now reachable with `output_format ==
+        // Yaml` for real, since any invocation that would have hit it
+        // before either took the M2 fast path instead (which already
+        // tracks this correctly, see `yaml_doc_streamed` in the fast-path
+        // arm above) or -- for `-o=auto` specifically, pre-#1493 -- never
+        // satisfied the `Yaml` check here at all).
         // For --front-matter=process: each file's own leading/closing ---
         // fences wrap its transformed front matter, followed by its
         // untouched body (carried alongside `input_sources`, gathered above).
         let mut split_doc_state = SplitDocState::new(has_split_doc);
-        let mut any_doc_output = false;
+        let mut any_yaml_doc_output = false;
         for (file_idx, doc_results) in all_results.into_iter().enumerate() {
             let front_matter_body = input_sources
                 .get(file_idx)
@@ -4396,20 +4438,32 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
             for results in doc_results {
                 // Add document separator in YAML mode for multi-doc,
-                // between documents only, not before the first
-                // (`any_doc_output`, see this loop's own comment above) --
-                // resolved per-file, not the invocation-wide default
-                // (#1493).
+                // between YAML-resolved documents only, not before the
+                // first one (`any_yaml_doc_output`, see this loop's own
+                // comment above) -- resolved per-file, not the
+                // invocation-wide default (#1493). Tracked per *this
+                // document's own resolved format*, not "any document at
+                // all": a mixed-format run's JSON documents never
+                // participate in the YAML `---` convention either way
+                // (the condition already requires `== Yaml`), so they
+                // must not count toward "has the first YAML document
+                // already appeared" -- doing so made the separator
+                // decision file-*order*-dependent (#1497 review): a
+                // YAML document immediately after a JSON one would
+                // wrongly get a leading separator, while the same YAML
+                // document appearing first would not.
                 if !has_split_doc
                     && file_output_config.output_format == OutputFormat::Yaml
                     && !output_config.no_doc
                     && is_multi_doc
                     && front_matter_body.is_none()
-                    && any_doc_output
+                    && any_yaml_doc_output
                 {
                     writeln!(writer, "---")?;
                 }
-                any_doc_output = true;
+                if file_output_config.output_format == OutputFormat::Yaml {
+                    any_yaml_doc_output = true;
+                }
                 for (result, comments) in results {
                     split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2184,6 +2184,19 @@ fn test_inplace_multi_doc_field_navigation() -> Result<()> {
 /// `can_use_m2_streaming`'s doc comment) and stands in instead. A two-document
 /// file also drives the DOM loop's multi-doc `---` separator logic, which a
 /// single document can't reach.
+///
+/// Expected value's leading `---` removed by #1493's review (this DOM
+/// branch had the same "leading separator before the first document" bug
+/// the standard/stdout path's own `any_yaml_doc_output` fix addresses).
+/// The *between*-results separator this test still asserts is itself a
+/// known, narrower divergence from real yq for this specific case: live
+/// oracle output for `length` on this exact input is `2\n1\n`, with no
+/// separator between the two scalar results at all (`yq -i '.' ` on the
+/// same file, by contrast, does insert one between the two full-document
+/// results -- real yq's separator convention differs by whether a result
+/// is a per-document container vs. a computed scalar, a much narrower
+/// question outside this issue's own scope of "does -o=auto match the
+/// input format").
 #[test]
 fn test_inplace_non_m2_filter_still_works() -> Result<()> {
     let mut input_file = NamedTempFile::new()?;
@@ -2199,7 +2212,7 @@ fn test_inplace_non_m2_filter_still_works() -> Result<()> {
 
     assert!(output.status.success());
     let rewritten = std::fs::read_to_string(input_file.path())?;
-    assert_eq!(rewritten, "---\n2\n---\n1\n");
+    assert_eq!(rewritten, "2\n---\n1\n");
     Ok(())
 }
 
@@ -9320,11 +9333,21 @@ fn test_inplace_halt_before_any_output_in_multi_doc_file_does_not_truncate_file(
 /// ordinary empty-output document with no halt involved at all (`empty`
 /// case below), since the separator was written speculatively regardless of
 /// whether the document that followed it ever produced anything.
+///
+/// Expected values updated by #1493's review: real yq doesn't parse
+/// `halt`/`if`/`then`/`end` the same way (no oracle to check against, per
+/// this file's own established convention for succinctly-only control
+/// flow), so these are checked for *internal consistency* with the
+/// standard/stdout path instead, which produces the identical content for
+/// the identical filter+input (confirmed live) -- neither case has a
+/// leading `---`, only fixed by #1497's review finding that this DOM
+/// branch had the same "leading separator before the very first document"
+/// bug the standard path's own `any_yaml_doc_output` fix addresses.
 #[test]
 fn test_inplace_multi_doc_no_dangling_separator_before_halting_or_empty_document() -> Result<()> {
     for (filter, want) in [
-        ("if .a == 2 then halt else . end", "---\na: 1\n"),
-        ("if .a == 2 then empty else . end", "---\na: 1\n---\na: 3\n"),
+        ("if .a == 2 then halt else . end", "a: 1\n"),
+        ("if .a == 2 then empty else . end", "a: 1\n---\na: 3\n"),
     ] {
         let mut input_file = NamedTempFile::new()?;
         write!(input_file, "a: 1\n---\na: 2\n---\na: 3\n")?;
@@ -20770,5 +20793,104 @@ fn test_yq_auto_output_inplace_matches_file_format_1493() -> Result<()> {
     assert!(output.status.success());
     let rewritten = std::fs::read_to_string(input_file.path())?;
     assert_eq!(rewritten, "a: 2\n");
+    Ok(())
+}
+
+/// #1497 review: `--eval-all` was the one output-producing branch missed
+/// by #1493's original fix -- it combines every source the same way
+/// `--slurp` does, so it needed the identical uniform-format-or-fallback
+/// treatment, not just any `for_source` call.
+#[test]
+fn test_yq_auto_output_eval_all_matches_yaml_input_1493() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--eval-all")
+        .arg("-o=auto")
+        .arg(".[0]")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout, "a: 1\n");
+    Ok(())
+}
+
+/// `--inplace -o=auto` on a multi-document YAML file must not gain a
+/// spurious leading `---` before the first document -- the same
+/// "leading, not just between" separator bug #1493's own fix uncovered in
+/// the standard/stdout path (fixed there via `any_yaml_doc_output`) also
+/// existed, unreached until now, in `--inplace`'s DOM branch (#1497
+/// review).
+#[test]
+fn test_yq_auto_output_inplace_multi_doc_no_leading_separator_1493() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1\n---\nb: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-o=auto")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 1\n---\nb: 2\n");
+    Ok(())
+}
+
+/// The multi-doc `---` separator decision for a mixed-format, non-slurp
+/// multi-file run must not depend on file *order* -- #1497 review found
+/// `any_doc_output` (now `any_yaml_doc_output`, tracked only for
+/// YAML-resolved documents) flipped true even for a JSON-resolved
+/// document, making a YAML document immediately after a JSON one wrongly
+/// get a leading separator while the same YAML document appearing first
+/// would not.
+#[test]
+fn test_yq_auto_output_mixed_format_separator_order_independent_1493() -> Result<()> {
+    let dir = TempDir::new()?;
+    let yaml_file = dir.path().join("a.yaml");
+    let json_file = dir.path().join("b.json");
+    std::fs::write(&yaml_file, "a: 1\n")?;
+    std::fs::write(&json_file, r#"{"b":2}"#)?;
+
+    let yaml_then_json = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg(".")
+        .arg(&yaml_file)
+        .arg(&json_file)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(yaml_then_json.status.success());
+
+    let json_then_yaml = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg(".")
+        .arg(&json_file)
+        .arg(&yaml_file)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(json_then_yaml.status.success());
+
+    // Neither order should insert a `---` before the lone YAML document
+    // (see the mixed-format known-gap test above for why there's no
+    // separator here at all, only order-independence is asserted).
+    let yaml_then_json_stdout = String::from_utf8(yaml_then_json.stdout)?;
+    let json_then_yaml_stdout = String::from_utf8(json_then_yaml.stdout)?;
+    assert!(
+        !yaml_then_json_stdout.contains("---"),
+        "yaml-then-json: {yaml_then_json_stdout:?}"
+    );
+    assert!(
+        !json_then_yaml_stdout.contains("---"),
+        "json-then-yaml: {json_then_yaml_stdout:?}"
+    );
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2086,27 +2086,28 @@ fn test_indent_1_json_output_not_clamped_1486() -> Result<()> {
     Ok(())
 }
 
-/// #1486 review: the clamp's own predicate must track `output_value`'s real
-/// dispatch (`output_format == Yaml` decides the YAML branch; anything else,
-/// including `Auto`, currently falls through to the JSON branch here --
-/// itself a separate, pre-existing divergence from real yq's own
-/// match-the-input-format `-o=auto` semantics, out of scope for this fix,
-/// filed as #1493). A first version of this fix checked `!= Json` instead
-/// of `== Yaml`, so `-o=auto` (neither) wrongly inherited the YAML clamp
-/// even though it renders as JSON -- this pins `-o=auto`'s *content* stays
-/// self-consistent with explicit `-o=json` at the same `-I`, regardless of
-/// which pre-existing format the content itself renders as.
+/// #1486 review, updated by #1493: the clamp's own predicate must track
+/// `output_value`'s real dispatch (`effective_output_format == Yaml`
+/// decides the YAML branch, where `effective_output_format` is `Auto`
+/// resolved against the current source -- #1493 -- not the raw,
+/// unresolved `config.output_format`). A first version of #1486's fix
+/// checked `!= Json` instead of `== Yaml`, so `-o=auto` (neither, before
+/// #1493) wrongly inherited the YAML clamp even though it rendered as
+/// JSON at the time. Now that `-o=auto` on YAML input resolves to `Yaml`
+/// (#1493), this pins the *opposite* equivalence: `-o=auto`'s content
+/// (including the `-I=1` clamp) matches explicit `-o=yaml` at the same
+/// `-I`, not `-o=json`.
 #[test]
-fn test_indent_1_auto_format_matches_explicit_json_1486() -> Result<()> {
+fn test_indent_1_auto_format_matches_explicit_yaml_1486_1493() -> Result<()> {
     let yaml = "l:\n  m:\n    p: 1\n";
 
     let (auto, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=auto"])?;
     assert_eq!(code, 0);
 
-    let (json, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=json"])?;
+    let (explicit_yaml, code) = run_yq_stdin(".", yaml, &["-I=1", "-o=yaml"])?;
     assert_eq!(code, 0);
 
-    assert_eq!(auto, json);
+    assert_eq!(auto, explicit_yaml);
 
     Ok(())
 }
@@ -11638,19 +11639,32 @@ fn test_front_matter_process_rejects_json_output() -> Result<()> {
     Ok(())
 }
 
-/// Regression test: `output_value` treats anything other than `Yaml` as
-/// JSON output (including `Auto`), but the compat guard only checked for
-/// the explicit `Json` variant -- `-o auto` slipped through and wrapped a
-/// JSON body in `---` fences (#715 follow-up).
+/// Updated by #1493: `-o auto` used to slip through this guard and wrap a
+/// JSON body in `---` fences, back when `output_value` treated anything
+/// other than `Yaml` as JSON output (including `Auto`) -- the compat guard
+/// only checked for the explicit `Json` variant (#715 follow-up). Now that
+/// `Auto` resolves per-source (#1493), and front-matter content is always
+/// forced to `InputFormat::Yaml` (`apply_front_matter`), `-o auto` here
+/// always resolves to `Yaml` too -- it's no longer the bug this guard was
+/// written to close, so it's legitimately accepted now, matching explicit
+/// `-o yaml`'s own output byte-for-byte.
 #[test]
-fn test_front_matter_process_rejects_auto_output() -> Result<()> {
-    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+fn test_front_matter_process_accepts_auto_output_1493() -> Result<()> {
+    let (auto_output, code) = run_yq_stdin(
         ".",
         FRONT_MATTER_FIXTURE,
         &["--front-matter", "process", "-o", "auto"],
     )?;
-    assert_ne!(code, 0);
-    assert!(stderr.contains("auto"), "stderr: {stderr}");
+    assert_eq!(code, 0, "output: {auto_output:?}");
+
+    let (yaml_output, code) = run_yq_stdin(
+        ".",
+        FRONT_MATTER_FIXTURE,
+        &["--front-matter", "process", "-o", "yaml"],
+    )?;
+    assert_eq!(code, 0, "output: {yaml_output:?}");
+
+    assert_eq!(auto_output, yaml_output);
     Ok(())
 }
 
@@ -20547,5 +20561,214 @@ fn test_yq_error_value_preview_computed_whole_float_diverges_from_tostring_known
          if this now shows \"100\", the gap this test pins has been fixed; \
          update/remove this test"
     );
+    Ok(())
+}
+
+// =============================================================================
+// #1493: `-o=auto` must match the input's own format (YAML input -> YAML
+// output, JSON input -> JSON output), not always resolve to JSON. Real yq's
+// own "nothing to match" cases (`--null-input`, `--raw-input`, a genuinely
+// mixed-format `--slurp`) default to Yaml, live-verified against pinned yq
+// v4.53.3.
+
+/// The issue's own repro: `-o=auto` on YAML stdin must render YAML, not
+/// JSON.
+#[test]
+fn test_yq_auto_output_matches_yaml_input_1493() -> Result<()> {
+    let yaml = "l:\n  m:\n    p: 1\n";
+    let (output, code) = run_yq_stdin(".", yaml, &["-o=auto"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, yaml);
+    Ok(())
+}
+
+/// Same, for JSON input via `-p=json` -- `-o=auto` must still render JSON.
+#[test]
+fn test_yq_auto_output_matches_json_input_1493() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", r#"{"a":1}"#, &["-o=auto", "-p=json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(
+        output, "{\n  \"a\": 1\n}\n",
+        "auto should match JSON input's own format"
+    );
+    Ok(())
+}
+
+/// `-o=auto` resolution is per-*file*, not a single invocation-wide guess:
+/// two YAML files processed independently in one invocation (not
+/// `--slurp`, which merges them) both render as YAML, with a `---`
+/// *between* them (not before the first -- a genuine, pre-existing bug in
+/// this "standard"/slow multi-file path found and fixed alongside #1493's
+/// own change, since it was previously unreachable with `output_format ==
+/// Yaml` for any invocation that also happened to have more than one
+/// document: every such case took the M2 fast path instead, which already
+/// gets this right).
+#[test]
+fn test_yq_auto_output_resolves_per_file_1493() -> Result<()> {
+    let dir = TempDir::new()?;
+    let file1 = dir.path().join("a.yaml");
+    let file2 = dir.path().join("b.yaml");
+    std::fs::write(&file1, "a: 1\n")?;
+    std::fs::write(&file2, "b: 2\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg(".")
+        .arg(&file1)
+        .arg(&file2)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout, "a: 1\n---\nb: 2\n");
+    Ok(())
+}
+
+/// Known gap (#1493's own scope note, same reasoning as the `--slurp`
+/// mixed-format gap above): a YAML file and a JSON file processed
+/// independently (not `--slurp`) in one `-o=auto` invocation each resolve
+/// to their own format correctly, but the combined output doesn't fully
+/// match real yq's own mixed-format multi-doc rendering, which treats the
+/// whole stream as one YAML sequence with the JSON-sourced document
+/// embedded flow-style and a `---` between every document regardless of
+/// format (confirmed live: `a: 1\n---\n{"b": 2}\n`). This fix gives each
+/// document its own correct format independently, but neither inserts a
+/// separator between differently-formatted documents nor renders the
+/// JSON one in YAML's flow style -- pinning the current (correct-per-file,
+/// not fully oracle-matching) behavior.
+#[test]
+fn test_yq_auto_output_mixed_format_multi_file_known_gap_1493() -> Result<()> {
+    let dir = TempDir::new()?;
+    let yaml_file = dir.path().join("a.yaml");
+    let json_file = dir.path().join("b.json");
+    std::fs::write(&yaml_file, "a: 1\n")?;
+    std::fs::write(&json_file, r#"{"b":2}"#)?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg(".")
+        .arg(&yaml_file)
+        .arg(&json_file)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    // Real yq: `a: 1\n---\n{"b": 2}\n` -- not replicated here; if this ever
+    // changes, update or remove this test.
+    assert_eq!(stdout, "a: 1\n{\n  \"b\": 2\n}\n");
+    Ok(())
+}
+
+/// `--null-input -o=auto`: no source to match, defaults to Yaml (confirmed
+/// live against real yq: `yq -n '{"a":1}' -o=auto` prints YAML).
+#[test]
+fn test_yq_auto_output_null_input_defaults_to_yaml_1493() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-n")
+        .arg("-o=auto")
+        .arg(r#"{"a":1}"#)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout, "a: 1\n");
+    Ok(())
+}
+
+/// `--slurp -o=auto` with every source sharing one format resolves to that
+/// format (confirmed live against real yq for both all-YAML and all-JSON).
+#[test]
+fn test_yq_auto_output_slurp_uniform_format_1493() -> Result<()> {
+    let dir = TempDir::new()?;
+    let file1 = dir.path().join("a.yaml");
+    let file2 = dir.path().join("b.yaml");
+    std::fs::write(&file1, "a: 1\n")?;
+    std::fs::write(&file2, "b: 2\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg("--slurp")
+        .arg(".")
+        .arg(&file1)
+        .arg(&file2)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout, "- a: 1\n- b: 2\n");
+
+    let json_file1 = dir.path().join("c.json");
+    let json_file2 = dir.path().join("d.json");
+    std::fs::write(&json_file1, r#"{"c":3}"#)?;
+    std::fs::write(&json_file2, r#"{"d":4}"#)?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg("--slurp")
+        .arg(".")
+        .arg(&json_file1)
+        .arg(&json_file2)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(
+        stdout,
+        "[\n  {\n    \"c\": 3\n  },\n  {\n    \"d\": 4\n  }\n]\n"
+    );
+    Ok(())
+}
+
+/// Known gap (#1493's own scope note): a genuinely mixed-format `--slurp
+/// -o=auto` falls back to Yaml for the whole output here, where real yq
+/// renders each element in its own source format (a much deeper
+/// per-element behavior, live-verified but not replicated by this fix).
+/// Pinning the current (documented, not the real-yq-matching) behavior.
+#[test]
+fn test_yq_auto_output_slurp_mixed_format_known_gap_1493() -> Result<()> {
+    let dir = TempDir::new()?;
+    let yaml_file = dir.path().join("a.yaml");
+    let json_file = dir.path().join("b.json");
+    std::fs::write(&yaml_file, "a: 1\n")?;
+    std::fs::write(&json_file, r#"{"b":2}"#)?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o=auto")
+        .arg("--slurp")
+        .arg(".")
+        .arg(&yaml_file)
+        .arg(&json_file)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    // Real yq: `- a: 1\n- {"b": 2}\n` (per-element format) -- not
+    // replicated here; if this ever changes, update or remove this test.
+    assert_eq!(stdout, "- a: 1\n- b: 2\n");
+    Ok(())
+}
+
+/// `--inplace -o=auto` on a YAML file must rewrite it as YAML, not JSON.
+#[test]
+fn test_yq_auto_output_inplace_matches_file_format_1493() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-o=auto")
+        .arg(".a = 2")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 2\n");
     Ok(())
 }


### PR DESCRIPTION
## Summary

`output_value`'s dispatch (`if config.output_format == Yaml {...} else {...JSON...}`)
never resolved `OutputFormat::Auto` to a concrete format anywhere, so `-o=auto` always
fell into the JSON else-branch regardless of input format, contradicting real yq's own
"match the input format" semantics:

```
$ printf 'l:\n  m:\n    p: 1\n' | succinctly yq '.' -o=auto
{                                    # was; now: l:\n  m:\n    p: 1
  "l": { "m": { "p": 1 } }
}
```

## Design

Adds `OutputConfig::for_source(args, input_format)`, mirroring the existing
`json_sourced_floats` per-source override pattern (#978/#1398): resolves `Auto` against
the concrete `InputFormat` and recomputes `indent_str`'s `-I=1` YAML clamp (#1486) to
match, since that clamp only applies when `output_value` will actually take the YAML
branch — which `Auto` may or may not, depending on what it resolves to.

Wired into every place that previously either cloned `OutputConfig` ad hoc (the default
and `--split-exp` per-source loops) or read `output_format` directly with no per-source
resolution at all:
- `need_comments` (JSON output never reads `CommentTree`)
- the multi-doc `---` separator gate
- `--inplace`'s per-file config
- the `--front-matter=process` compat guard, which now **accepts** `-o=auto` (front-matter
  content is always forced to `InputFormat::Yaml`, so `Auto` can no longer resolve to
  anything the guard was written to reject)

`--null-input`/`--raw-input` have no source to resolve against; matches real yq's own
confirmed-live default (Yaml, with a backwards-compat warning even under `-p=json`).
`--slurp` resolves against every source's uniform format if they agree (confirmed live
for both all-YAML and all-JSON slurps), falling back to Yaml for a genuinely
mixed-format slurp — real yq's own mixed-format `--slurp -o=auto` renders each element
in its own source format, a much deeper per-element behavior not attempted here (pinned
as a known gap in the test suite).

## A related, previously-unreachable bug this change exposes (also fixed)

The "standard" (non-M2-fast-path) multi-file loop wrote a `---` separator before
*every* document, including the first, whenever `is_multi_doc` — correct only
*between* documents everywhere else in this file. This never manifested before
because any invocation that would reach this loop with `output_format == Yaml` and
more than one document always took the M2 fast path instead (which already tracks this
correctly via its own `yaml_doc_streamed` flag), and `-o=auto` could never satisfy that
fast path's exact `Yaml`/`Json` check pre-#1493. Fixed with the same "has anything
already been written" tracking the M2 path and `SplitDocState` already use.

## Existing tests updated (encoded the old, buggy behavior)

- `test_indent_1_auto_format_matches_explicit_json_1486` — asserted `-o=auto ==
  -o=json`; now asserts `-o=auto == -o=yaml`, since YAML input now correctly resolves
  to YAML.
- `test_front_matter_process_rejects_auto_output` — asserted `-o=auto` was rejected
  under `--front-matter=process`; now asserts it's accepted (renamed to
  `test_front_matter_process_accepts_auto_output_1493`).

## Test plan

- [x] New yq CLI tests (suffixed `_1493`): the issue's own repro (YAML→YAML), the JSON
      case, per-file resolution across independent files (same-format, clean; and a
      "known gap" pin for mixed-format), `--null-input` defaulting to Yaml, `--slurp`
      with uniform format (both all-YAML and all-JSON) and a "known gap" pin for mixed
      format, and `--inplace`
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, `--no-fail-fast`,
      `--test-threads=4` — two unrelated tests were flaky under full default
      parallelism on this shared machine, confirmed spurious by re-running in
      isolation; unrelated to this change)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (matches CI's
      Documentation job)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only --fail-under-lines 0`
- [x] Manual live verification of every case above against both the release binary and
      the pinned yq v4.53.3 oracle

Fixes #1493