### PR TITLE
refactor(jq): fuse resolve_foreach's three parallel Vecs into one

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16370,43 +16370,35 @@ fn resolve_foreach<'a, S: EvalSemantics>(
         return path_result(Vec::new(), init_escape);
     }
 
-    let bindings_per_element: Vec<Result<Vec<(String, OwnedValue)>, EvalError>> = input_values
+    // Fused into one `Vec` (rather than three parallel ones keyed by the
+    // same index) so the extract/update agreement is unrepresentable rather
+    // than merely unreachable-in-practice — see #1369. Each element's
+    // bindings are dropped as soon as they are consumed instead of being
+    // retained as a second full copy of the input stream for the rest of
+    // the call.
+    let substituted: Vec<Result<(Expr, Option<Expr>), EvalError>> = input_values
         .iter()
-        .map(|v| extract_pattern_bindings(pattern, v, false))
-        .collect();
-    // Same single-alternative, no-null-fill reasoning as `resolve_reduce`'s
-    // own substitution above.
-    let substituted_updates: Vec<Result<Expr, EvalError>> = bindings_per_element
-        .iter()
-        .map(|b| {
-            b.as_ref()
-                .map(|b| substitute_vars(update, as_var_refs(b)))
-                .map_err(Clone::clone)
+        .map(|v| {
+            let b = extract_pattern_bindings(pattern, v, false)?;
+            Ok((
+                substitute_vars(update, as_var_refs(&b)),
+                extract.map(|ext| substitute_vars(ext, as_var_refs(&b))),
+            ))
         })
         .collect();
-    let substituted_extracts: Option<Vec<Result<Expr, EvalError>>> = extract.map(|ext| {
-        bindings_per_element
-            .iter()
-            .map(|b| {
-                b.as_ref()
-                    .map(|b| substitute_vars(ext, as_var_refs(b)))
-                    .map_err(Clone::clone)
-            })
-            .collect()
-    });
 
     let mut out: Vec<PathBranch<'a>> = Vec::new();
     let mut budget = REDUCE_FOREACH_MAX_STEPS;
     for init_branch in &init_branches {
         let (reg, mut state) = FoldRegister::enter(init_branch, value, trackable);
         let mut aborted: Option<Control> = None;
-        'input: for (idx, substituted_update) in substituted_updates.iter().enumerate() {
+        'input: for substituted in &substituted {
             if let Some(control) = charge_budget(&mut budget, "foreach") {
                 aborted = Some(control);
                 break;
             }
-            let substituted_update = match substituted_update {
-                Ok(expr) => expr,
+            let (substituted_update, substituted_extract) = match substituted {
+                Ok((upd, ext)) => (upd, ext),
                 Err(e) => {
                     aborted = Some(Control::Error(e.clone()));
                     break;
@@ -16420,18 +16412,11 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                 }
             };
             for update_branch in &update_branches {
-                if let Some(extracts) = &substituted_extracts {
+                if let Some(ext_expr) = substituted_extract {
                     if let Some(control) = charge_budget(&mut budget, "foreach") {
                         aborted = Some(control);
                         break 'input;
                     }
-                    let ext_expr = match &extracts[idx] {
-                        Ok(expr) => expr,
-                        Err(e) => {
-                            aborted = Some(Control::Error(e.clone()));
-                            break 'input;
-                        }
-                    };
                     let extract_reg = reg.advance(update_branch);
                     match extract_reg
                         .resolve::<S>(ext_expr, update_branch.value.clone().into_owned())

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16370,20 +16370,27 @@ fn resolve_foreach<'a, S: EvalSemantics>(
         return path_result(Vec::new(), init_escape);
     }
 
-    // Fused into one `Vec` (rather than three parallel ones keyed by the
-    // same index) so the extract/update agreement is unrepresentable rather
-    // than merely unreachable-in-practice — see #1369. Each element's
-    // bindings are dropped as soon as they are consumed instead of being
-    // retained as a second full copy of the input stream for the rest of
-    // the call.
-    let substituted: Vec<Result<(Expr, Option<Expr>), EvalError>> = input_values
+    // `eval_foreach`'s own substitution, minus the two things this
+    // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s dispatch
+    // arm) rules out: #1365's `patterns`-matrix, and #1368's null-fill for
+    // names an alternative leaves unbound — a bare `$var` pattern binds its
+    // one name unconditionally, so there is never an unbound name to fill
+    // (same reasoning as `resolve_reduce`'s own substitution above). Fused
+    // into one `Vec` (rather than three parallel ones keyed by the same
+    // index, reusing `eval_foreach`'s own `ForeachStepAlternative` pair
+    // type) so the extract/update agreement is unrepresentable rather than
+    // merely unreachable-in-practice — see #1369. Each element's bindings
+    // are dropped as soon as they are consumed instead of being retained as
+    // a second full copy of the input stream for the rest of the call.
+    let substituted: Vec<ForeachStepAlternative> = input_values
         .iter()
         .map(|v| {
-            let b = extract_pattern_bindings(pattern, v, false)?;
-            Ok((
-                substitute_vars(update, as_var_refs(&b)),
-                extract.map(|ext| substitute_vars(ext, as_var_refs(&b))),
-            ))
+            extract_pattern_bindings(pattern, v, false).map(|b| {
+                (
+                    substitute_vars(update, as_var_refs(&b)),
+                    extract.map(|ext| substitute_vars(ext, as_var_refs(&b))),
+                )
+            })
         })
         .collect();
 
@@ -16392,12 +16399,12 @@ fn resolve_foreach<'a, S: EvalSemantics>(
     for init_branch in &init_branches {
         let (reg, mut state) = FoldRegister::enter(init_branch, value, trackable);
         let mut aborted: Option<Control> = None;
-        'input: for substituted in &substituted {
+        'input: for step in &substituted {
             if let Some(control) = charge_budget(&mut budget, "foreach") {
                 aborted = Some(control);
                 break;
             }
-            let (substituted_update, substituted_extract) = match substituted {
+            let (substituted_update, substituted_extract) = match step {
                 Ok((upd, ext)) => (upd, ext),
                 Err(e) => {
                     aborted = Some(Control::Error(e.clone()));


### PR DESCRIPTION
## Summary
- `resolve_foreach` (the `path()`-tracking counterpart of `eval_foreach`) built three parallel `Vec`s (`bindings_per_element`/`substituted_updates`/`substituted_extracts`) indexed by the same position, whose agreement nothing type-checked — forcing an "unreachable in practice" error arm on the extract side and retaining a second full copy of the input stream for the life of the call.
- Fused into one `Vec<Result<(Expr, Option<Expr>), EvalError>>` so the invariant is unrepresentable rather than merely unenforced — no behavior change, pure internal cleanup, per the issue's own scope note.

**Note on the issue's premise**: the issue names `eval_foreach` and cites helper names (`substitute_bindings`, 2-arg `extract_pattern_bindings`) from before #1365's multi-pattern `?//` rewrite. On current `main`, `eval_foreach` has since been rewritten to a `substituted_steps_matrix` design supporting `patterns: &[Pattern]` and no longer has this shape. The exact bug described is still present, verbatim in spirit, in `resolve_foreach` — confirmed as the correct target (see claim comment on #1369 for the full trace, including why `resolve_foreach`'s single-`Pattern::Var`-only scope is a separate, already-documented, deliberate design decision unrelated to this cleanup).

Fixes #1369

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde --no-fail-fast` (2750+ tests, 0 failures, `--test-threads=4`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --fail-under-lines 0` — confirmed refactored lines are exercised by the existing suite; only-uncovered branches (budget-exceeded, extract-binding-Err) are pre-existing unreachable-in-practice paths, unchanged by this refactor