### PR TITLE
fix(jq): widen first_over_comma_generic through Pipe/Paren

### DIFF
--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -29,8 +29,9 @@ processed — is closed, as is `halt_error`'s wrong exit code and the stderr lea
 `isempty`/`first`/`limit`/`nth`/`any`/`IN(s)`, and — since Stage 4 — `IN(src; s)` and every
 other compare reached through a lazy consumer. **Six** shapes remain divergent, all pinned
 as such in `test_short_circuit_side_effect_leaks_820_932_987`. Two are the bare-`first(...)`
-family: `first(.[] | stderr)` and `first((1,2) == (10, ("B"|stderr)))`, both a `first(...)`
-over a non-`Comma`, which Stage 2b's sibling walk does not reach — option (c), #1461. One is
+family: `first(.[] | stderr)` (see "Option (c), scoped" below) and
+`first((1,2) == (10, ("B"|stderr)))`, both a `first(...)` over a non-`Comma`, which Stage 2b's
+sibling walk does not reach — option (c), #1461. One is
 `("A"|stderr) == (("B"|stderr), ("C"|stderr))`, a *top-level* compare, which never reaches
 `eval_each` at all — #1481. The remaining **three** are Stage 5's own residual (#1462): an
 un-lazified `eval_each` arm (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a
@@ -43,18 +44,32 @@ un-lazified `Expr::If`.
 native, cursor-preserving fast-path arm shadowing `eval.rs`'s already-lazy implementation
 (`isempty`/`limit`/`nth`/`any`/`all`/`IN` have no native arm in `eval_generic.rs` at all —
 see `first_over_comma_generic`'s own doc comment — so they already bridge into `eval.rs`'s
-`eval_each`-based lazy path and never needed this). #1451 widened
-`first_over_comma_generic` to recurse through a pipe's own prefix stages -- evaluating the
-prefix exactly once, then dispatching on every possible shape of that one result (a
-mutually-recursive `OwnedValue`-flavored twin, `first_over_comma_owned_generic`, handles the
-*computed*-value shapes -- `GenericResult::Owned`/`ManyOwned`, the common case for a
-literal/arithmetic leading stage -- since a bare `V`/cursor doesn't exist for those) without
-ever re-evaluating it. This closes `first(.[] | stderr)` too, not just the two narrower
-`Pipe`-composition shapes #1451 itself named, since a `Many`/`ManyCursor`/`ManyOwned`
-prefix's already-materialized values are tried against the tail one at a time, stopping at
-the first that yields anything -- real per-output backtracking, not just literal-shape
-composition, without needing the full generalized `Demand`/`Item`/`Flow` mirror this row
-originally called for.
+`eval_each`-based lazy path and never needed this). #1451 widened `first_over_comma_generic`
+to recurse through a pipe's own *2-stage* prefix: the leading stage is evaluated exactly
+once, then [`first_over_pipe_prefix_result`](../../src/jq/eval_generic.rs) dispatches on
+every possible shape of that one result (a mutually-recursive `OwnedValue`-flavored twin,
+`first_over_comma_owned_generic`, handles the *computed*-value shapes —
+`GenericResult::Owned`/`ManyOwned`/`Partial`, the common case for a literal/arithmetic
+leading stage — since a bare `V`/cursor doesn't exist for those) without ever re-evaluating
+it. This closes the two narrower `Pipe`-composition shapes #1451 itself named
+(`first(1 | (1, stderr))`, `first((1, stderr), 2)`).
+
+An earlier version of this fix additionally tried real per-output backtracking over a
+`Many`/`ManyCursor` (document-derived, e.g. `.[]`) prefix's already-materialized values —
+which would have also closed `first(.[] | stderr)` — but review (#1503) found this
+regressed two properties only a *whole, unsplit* pipe evaluation preserves:
+`eval_single`'s own multi-stage `ManyCursor` handling, which threads a cursor through the
+*entire* remaining pipe together rather than stage-by-stage (a `.[] | select(...) | line`
+query lost its `line` cursor under the per-value split), and `LazySeq`'s own #724/#725
+composability (`first(map(f) | .[0])` started forcing full materialization instead of
+short-circuiting). Both regressions trace to the same root cause: splitting a pipe into an
+eagerly-evaluated prefix plus a separately-dispatched tail is only safe when the prefix is a
+*single* value (nothing to lose by handling it apart from the rest of the pipe) — a
+`Many`/`ManyCursor`/`LazyKeys`/`LazyIndexRange`/`LazySeq` prefix is deferred back to the
+existing whole-pipe fallback instead (safe to redo, since none of those shapes have run any
+side effect yet), leaving `first(.[] | stderr)` a known, still-pinned divergence rather than
+a second, deeper thing option (c) closes. The full generalized `Demand`/`Item`/`Flow` mirror
+this row originally called for remains the only way to close it soundly — filed as **#1461**.
 
 **One correction this document earned the hard way.** Stage 2 shipped an
 `eval_each_pipe` whose `Item::Owned` arm fell back to the eager `eval_owned_pipe`,
@@ -543,6 +558,20 @@ Each checked against the oracle. "already correct" means succinctly matches jq t
 | `Reduce`/`Foreach`                         | no                         | `reduce` has one output; `foreach`'s #534 fork machinery is a non-goal                                  |
 | **`Compare`**                              | **yes — for #932**         | Stage 4; see below                                                                                      |
 | **`Builtin::PathsFilter`**                 | **yes — for #987**         | Stage 3                                                                                                 |
+
+**A caveat Stage 5 needs to carry, not just `eval.rs`.** Every `first(...)`-based example
+in the table above is a bare CLI call — and, per "Option (c), scoped" above, the CLI's
+`first`/`last` never reach `eval.rs`'s `eval_each` at all (`eval_generic.rs`'s own native
+`Expr::FirstExpr`/`LastExpr` arm intercepts first, kept cursor-preserving for #607).
+Widening `eval_each`'s native arm set to cover `If`/`Try`/`Label`/`AsPattern`/`FuncCall`
+will *not*, by itself, close any of the `first(...)`-shaped rows above through the CLI —
+`first_over_comma_generic`/`first_over_comma_owned_generic` (`eval_generic.rs`) fall back to
+one eager `eval_single`/`eval_on_owned` call for exactly this fallback-shape residual
+(see [`try_lazy_first_generic`](../../src/jq/eval_generic.rs)'s own doc comment), same as
+before Stage 5. Closing these for the CLI needs the identical widening applied a second
+time there, or `first`/`last` no longer shadowing `eval.rs` for these shapes specifically --
+worth folding into **#1462**'s own scope rather than rediscovering as a surprise gap once
+that issue's `eval.rs` half ships.
 
 **Honest scoping of #932.** `builtin_upper_in` (`:3759`) synthesizes
 `gen = Expr::Compare { Eq, src, s }` for the `IN(src; s)` form and hands it to

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -21,7 +21,7 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | 3     | `paths(f)` producer + `resolve_leaf` sink           | ✅ merged — closes #987     |
 | 4     | `Expr::Compare`'s outer loop                        | ✅ merged — closes #1459    |
 | 5     | Widen the lazy arm set                              | ⬜ open — #1462             |
-| (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ⬜ open — #1461             |
+| (c)   | Mirror the sink into `eval_generic` for `Pipe`      | 🟡 partial — #1451, rest #1461 |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
@@ -38,6 +38,23 @@ side effect for a node's own filter when that filter's shape isn't one of
 `Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — that is the `path(paths(if ...))` row, plus
 the `path(... halt_error ...)` pair Stage 4 added, whose stray `x` on stderr is the same
 un-lazified `Expr::If`.
+
+**Option (c), scoped.** `first`/`last` were the *only* `eval_generic.rs` consumers with a
+native, cursor-preserving fast-path arm shadowing `eval.rs`'s already-lazy implementation
+(`isempty`/`limit`/`nth`/`any`/`all`/`IN` have no native arm in `eval_generic.rs` at all —
+see `first_over_comma_generic`'s own doc comment — so they already bridge into `eval.rs`'s
+`eval_each`-based lazy path and never needed this). #1451 widened
+`first_over_comma_generic` to recurse through a pipe's own prefix stages -- evaluating the
+prefix exactly once, then dispatching on every possible shape of that one result (a
+mutually-recursive `OwnedValue`-flavored twin, `first_over_comma_owned_generic`, handles the
+*computed*-value shapes -- `GenericResult::Owned`/`ManyOwned`, the common case for a
+literal/arithmetic leading stage -- since a bare `V`/cursor doesn't exist for those) without
+ever re-evaluating it. This closes `first(.[] | stderr)` too, not just the two narrower
+`Pipe`-composition shapes #1451 itself named, since a `Many`/`ManyCursor`/`ManyOwned`
+prefix's already-materialized values are tried against the tail one at a time, stopping at
+the first that yields anything -- real per-output backtracking, not just literal-shape
+composition, without needing the full generalized `Demand`/`Item`/`Flow` mirror this row
+originally called for.
 
 **One correction this document earned the hard way.** Stage 2 shipped an
 `eval_each_pipe` whose `Item::Owned` arm fell back to the eager `eval_owned_pipe`,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3454,23 +3454,21 @@ fn first_over_comma_generic<S: EvalSemantics, V: DocumentValue>(
             // nothing.
             Some(GenericResult::None)
         }
-        Expr::Pipe(exprs) if exprs.len() >= 2 && !exprs.iter().any(needs_path_context) => {
-            let prefix_result = if exprs.len() == 2 {
-                eval_single::<S, V>(&exprs[0], value.clone(), optional, cursor)
-            } else {
-                eval_single::<S, V>(
-                    &Expr::Pipe(exprs[..exprs.len() - 1].to_vec()),
-                    value.clone(),
-                    optional,
-                    cursor,
-                )
-            };
-            let last = &exprs[exprs.len() - 1];
-            Some(first_over_pipe_prefix_result::<S, V>(
-                prefix_result,
-                last,
-                optional,
-            ))
+        // Exactly 2 stages only, not `>= 2`: for 3+ stages, evaluating
+        // `exprs[..len-1]` as its own synthesized sub-pipe truncates the
+        // pipe one stage short of `last`, which can silently defeat
+        // `eval_single`'s own multi-stage `ManyCursor` handling -- that
+        // logic threads a cursor through the *entire* remaining pipe
+        // together, recursing into "the rest of the pipe" as one unit per
+        // cursor, not stage-by-stage; truncating the view it's given loses
+        // that (a `.[] | select(...) | line`-shaped query lost its `line`
+        // cursor this way -- #1503 review). Restricting to a single prefix
+        // stage sidesteps this: `eval_single(&exprs[0], ...)` is exactly
+        // what `eval_single`'s own `Expr::Pipe` arm evaluates as *its own*
+        // first fold step, so there is no truncation to reason about.
+        Expr::Pipe(exprs) if exprs.len() == 2 && !exprs.iter().any(needs_path_context) => {
+            let prefix_result = eval_single::<S, V>(&exprs[0], value.clone(), optional, cursor);
+            first_over_pipe_prefix_result::<S, V>(prefix_result, &exprs[1], optional)
         }
         _ => None,
     }
@@ -3525,22 +3523,15 @@ fn first_over_comma_owned_generic<S: EvalSemantics, V: DocumentValue>(
             }
             Some(GenericResult::None)
         }
-        Expr::Pipe(exprs) if exprs.len() >= 2 && !exprs.iter().any(needs_path_context) => {
-            let prefix_result = if exprs.len() == 2 {
-                eval_on_owned::<S, V>(&exprs[0], owned.clone(), optional)
-            } else {
-                eval_on_owned::<S, V>(
-                    &Expr::Pipe(exprs[..exprs.len() - 1].to_vec()),
-                    owned.clone(),
-                    optional,
-                )
-            };
-            let last = &exprs[exprs.len() - 1];
-            Some(first_over_pipe_prefix_result::<S, V>(
-                prefix_result,
-                last,
-                optional,
-            ))
+        // Exactly 2 stages only -- same reasoning as
+        // `first_over_comma_generic`'s own `Pipe` arm: kept symmetric even
+        // though `eval_on_owned` never carries a `V::Cursor` to lose, since
+        // there's no evidence its own multi-stage threading is free of an
+        // analogous "must see the whole remaining pipe" dependency, and
+        // #1451's own repros never needed more than 2 stages here either.
+        Expr::Pipe(exprs) if exprs.len() == 2 && !exprs.iter().any(needs_path_context) => {
+            let prefix_result = eval_on_owned::<S, V>(&exprs[0], owned.clone(), optional);
+            first_over_pipe_prefix_result::<S, V>(prefix_result, &exprs[1], optional)
         }
         _ => None,
     }
@@ -3562,73 +3553,91 @@ fn try_lazy_first_owned_generic<S: EvalSemantics, V: DocumentValue>(
 }
 
 /// Shared continuation for both [`first_over_comma_generic`]'s and
-/// [`first_over_comma_owned_generic`]'s `Pipe` arm: dispatch on every
-/// possible shape of an already-computed prefix-stage result and try `last`
-/// (the pipe's own final stage) against it, without ever redoing the prefix
-/// evaluation itself -- redoing it on some other path would risk
-/// double-firing any side effect the prefix itself has, so every variant
-/// below is handled here rather than falling back to a broader re-evaluation
-/// for the ones this function doesn't have a lazy answer for.
+/// [`first_over_comma_owned_generic`]'s `Pipe` arm: dispatch on an
+/// already-computed prefix-stage result and try `last` (the pipe's own
+/// final stage) against it, without ever redoing the prefix evaluation
+/// itself when doing so could double-fire a side effect the prefix has.
 ///
-/// A `One`/`OneCursor`/`Owned` prefix (exactly one value) recurses lazily
+/// A `One`/`OneCursor`/`Owned` prefix (exactly one value, safe by
+/// construction -- it's already in hand, nothing to redo) recurses lazily
 /// into whichever of the two `try_lazy_first_*_generic` twins matches that
-/// value's own kind. A `Many`/`ManyCursor`/`ManyOwned`/`Partial` prefix
-/// (already-materialized multiple values) tries each in turn against `last`,
-/// stopping at the first that yields anything -- this is what additionally
-/// closes `first(.[] | stderr)`, which #820 Stage 2b explicitly could not
-/// (real per-output backtracking, not just literal-shape composition, was
-/// missing there). `Partial`'s trailing control only surfaces if none of its
-/// values' own tails produced anything, matching `take_first_generic`'s own
-/// "a non-empty prefix always satisfies `first`" rule.
+/// value's own kind. A `ManyOwned`/`Partial` prefix (an already-computed,
+/// already-materialized *value* set -- no document cursor, no deferred
+/// generator) tries each of its values against `last` in turn, stopping at
+/// the first that yields anything; `Partial`'s trailing control only
+/// surfaces if none of its values' own tails produced anything, matching
+/// `take_first_generic`'s own "a non-empty prefix always satisfies `first`"
+/// rule.
+///
+/// A `Many`/`ManyCursor` prefix (document-derived navigation, e.g. `.[]`)
+/// or a `LazyKeys`/`LazyIndexRange`/`LazySeq` prefix (a deferred
+/// computation that hasn't *run* yet, so reconstructing it is free) is
+/// instead handed back as `None`, deferring to the caller's own fallback of
+/// evaluating the *whole* pipe as one eager `eval_single`/`eval_on_owned`
+/// call -- redoing the prefix stage(s) that way is side-effect-free for
+/// both cases, and, critically, it is what keeps this function from
+/// regressing two properties only a *whole-pipe* evaluation preserves
+/// (#1503 review): `eval_single`'s own `ManyCursor` handling threads a
+/// cursor through the *entire* remaining pipe together, which per-value
+/// dispatch to `last` alone cannot reproduce for a multi-stage tail (a
+/// `.[] | select(...) | line`-shaped query lost its `line` cursor under the
+/// naive per-value split); and a `LazySeq` (`map(f)`'s own composability
+/// engine, #724/#725) must stay lazy until something actually indexes into
+/// it, not be forced through `materialize_lazy()` up front (`first(map(f) |
+/// .[0])` errored on a later element `f` was never supposed to reach).
+/// `GenericResult::None` is likewise handed back directly rather than via
+/// the fallback -- it's already known with certainty, so redoing the whole
+/// pipe just to re-derive the same "produces nothing" answer would be pure
+/// waste, not a correctness concern either way.
+///
+/// This means a `Many`/`ManyCursor` prefix's own per-value backtracking
+/// (which would additionally close `first(.[] | stderr)`, a harder case
+/// #820 Stage 2b explicitly could not close) is deliberately not attempted
+/// here -- doing so is what caused the cursor/`LazySeq` regressions above,
+/// so `first(.[] | stderr)` remains a known, pinned divergence rather than
+/// being closed by this function.
 fn first_over_pipe_prefix_result<S: EvalSemantics, V: DocumentValue>(
     prefix_result: GenericResult<V>,
     last: &Expr,
     optional: bool,
-) -> GenericResult<V> {
-    match prefix_result.materialize_lazy() {
-        GenericResult::None => GenericResult::None,
-        GenericResult::Error(e) => GenericResult::Error(e),
-        GenericResult::Break(label) => GenericResult::Break(label),
-        GenericResult::Halt(code) => GenericResult::Halt(code),
-        GenericResult::One(v) => {
-            try_lazy_first_generic::<S, V>(last, &v, optional, None).unwrap_or(GenericResult::None)
-        }
+) -> Option<GenericResult<V>> {
+    match prefix_result {
+        GenericResult::None => Some(GenericResult::None),
+        GenericResult::Error(e) => Some(GenericResult::Error(e)),
+        GenericResult::Break(label) => Some(GenericResult::Break(label)),
+        GenericResult::Halt(code) => Some(GenericResult::Halt(code)),
+        GenericResult::One(v) => Some(
+            try_lazy_first_generic::<S, V>(last, &v, optional, None).unwrap_or(GenericResult::None),
+        ),
         GenericResult::OneCursor(c) => {
             let v = c.value();
-            try_lazy_first_generic::<S, V>(last, &v, optional, Some(c))
-                .unwrap_or(GenericResult::None)
-        }
-        GenericResult::Many(vs) => vs
-            .into_iter()
-            .find_map(|v| try_lazy_first_generic::<S, V>(last, &v, optional, None))
-            .unwrap_or(GenericResult::None),
-        GenericResult::ManyCursor(cs) => cs
-            .into_iter()
-            .find_map(|c| {
-                let v = c.value();
+            Some(
                 try_lazy_first_generic::<S, V>(last, &v, optional, Some(c))
-            })
-            .unwrap_or(GenericResult::None),
-        GenericResult::Owned(o) => {
-            try_lazy_first_owned_generic::<S, V>(last, &o, optional).unwrap_or(GenericResult::None)
+                    .unwrap_or(GenericResult::None),
+            )
         }
-        GenericResult::ManyOwned(os) => os
-            .into_iter()
-            .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
-            .unwrap_or(GenericResult::None),
-        GenericResult::Partial(vs, control) => vs
-            .into_iter()
-            .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
-            .unwrap_or_else(|| match control {
-                Control::Error(e) => GenericResult::Error(e),
-                Control::Break(label) => GenericResult::Break(label),
-                Control::Halt(code) => GenericResult::Halt(code),
-            }),
-        GenericResult::LazyKeys { .. }
+        GenericResult::Owned(o) => Some(
+            try_lazy_first_owned_generic::<S, V>(last, &o, optional).unwrap_or(GenericResult::None),
+        ),
+        GenericResult::ManyOwned(os) => Some(
+            os.into_iter()
+                .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
+                .unwrap_or(GenericResult::None),
+        ),
+        GenericResult::Partial(vs, control) => Some(
+            vs.into_iter()
+                .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
+                .unwrap_or_else(|| match control {
+                    Control::Error(e) => GenericResult::Error(e),
+                    Control::Break(label) => GenericResult::Break(label),
+                    Control::Halt(code) => GenericResult::Halt(code),
+                }),
+        ),
+        GenericResult::Many(_)
+        | GenericResult::ManyCursor(_)
+        | GenericResult::LazyKeys { .. }
         | GenericResult::LazyIndexRange(_)
-        | GenericResult::LazySeq(_) => {
-            unreachable!("materialize_lazy() already normalized every lazy variant")
-        }
+        | GenericResult::LazySeq(_) => None,
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3398,10 +3398,15 @@ fn take_first_generic<V: DocumentValue>(result: GenericResult<V>) -> Option<Gene
 }
 
 /// `first(a, b, ...)` evaluated one comma sibling at a time, stopping at the
-/// first that yields an output — #820 Stage 2b.
+/// first that yields an output — #820 Stage 2b — and, since #1451, composing
+/// through `Pipe`/`Paren` too: a comma reached through a pipe stage (`first(1
+/// | (1, stderr))`), or nested inside one sibling of an outer comma
+/// (`first((1, stderr), 2)`), recurses back into this same function instead
+/// of falling through to the eager per-expression evaluator that started
+/// this whole gap.
 ///
-/// Returns `None` when `inner` is not a comma, leaving the caller on its
-/// existing eager path.
+/// Returns `None` when `inner` is neither a comma nor a (non-path-context)
+/// pipe, leaving the caller on its existing eager path.
 ///
 /// **Why this exists at all.** Stage 2 made `eval::eval_first_expr` lazy, but
 /// the CLI never reaches it for a bare `first(...)`: `jq_runner` enters
@@ -3410,34 +3415,221 @@ fn take_first_generic<V: DocumentValue>(result: GenericResult<V>) -> Option<Gene
 /// `eval.rs`. `limit`/`nth`/`isempty` have no native arm and do bounce, which
 /// is exactly why Stage 2 fixed them and left `first` leaking.
 ///
-/// This is deliberately the *narrow* fix the design's Stage 2b names as option
-/// (b): it closes `first(1, stderr)` and — the reason it is not merely
-/// cosmetic — `first(1, input)`, where the discarded branch was **consuming a
-/// document** the CLI's driver loop then never processed. It does **not**
-/// close `first(.[] | stderr)`, which is a `Pipe` and needs real per-output
-/// backtracking; that is option (c), mirroring `Demand`/`Item`/`Flow` into
-/// this module, filed as a follow-up.
+/// The original (#820 Stage 2b) fix was deliberately the *narrow* option
+/// (b) from the design doc: closing `first(1, stderr)` and — the reason it
+/// was not merely cosmetic — `first(1, input)`, where the discarded branch
+/// was **consuming a document** the CLI's driver loop then never processed.
+/// #1451 widens it to also recurse through `Pipe`'s own prefix stages: the
+/// prefix is evaluated once via the ordinary eager `eval_single` (a pipe's
+/// leading stages must run to produce the values that feed the tail either
+/// way, so this is no more eager than before), then [`first_over_pipe_prefix_result`]
+/// dispatches on every possible shape of that one evaluation's result
+/// without ever redoing it -- see its own doc comment for the full model,
+/// including why a *computed* prefix (`GenericResult::Owned`, the common
+/// case for a literal/arithmetic leading stage) needs its own
+/// `OwnedValue`-flavored twin ([`first_over_comma_owned_generic`]) rather
+/// than reusing this function directly. `needs_path_context` is checked
+/// across the *whole* pipe up front, matching the eager `Expr::Pipe` arm's
+/// own guard, so `path`/`parent`/`key` never silently see a stubbed-zero
+/// default (#715/#1302) -- a path-context pipe simply isn't attempted here
+/// and falls through to the existing bridge instead.
 fn first_over_comma_generic<S: EvalSemantics, V: DocumentValue>(
     inner: &Expr,
     value: &V,
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> Option<GenericResult<V>> {
-    let Expr::Comma(exprs) = unwrap_paren(inner) else {
-        return None;
-    };
-    for e in exprs {
-        // Each sibling is evaluated only once the previous one has been shown
-        // to produce nothing -- so a side-effecting or input-consuming sibling
-        // past the answer is never reached, matching jq's `label $out | (f,
-        // break $out)`.
-        let result = eval_single::<S, V>(e, value.clone(), optional, cursor);
-        if let Some(first) = take_first_generic(result) {
-            return Some(first);
+    match unwrap_paren(inner) {
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                // Each sibling is evaluated only once the previous one has
+                // been shown to produce nothing -- so a side-effecting or
+                // input-consuming sibling past the answer is never reached,
+                // matching jq's `label $out | (f, break $out)`.
+                if let Some(first) = try_lazy_first_generic::<S, V>(e, value, optional, cursor) {
+                    return Some(first);
+                }
+            }
+            // Every sibling was empty, so the comma as a whole produced
+            // nothing.
+            Some(GenericResult::None)
+        }
+        Expr::Pipe(exprs) if exprs.len() >= 2 && !exprs.iter().any(needs_path_context) => {
+            let prefix_result = if exprs.len() == 2 {
+                eval_single::<S, V>(&exprs[0], value.clone(), optional, cursor)
+            } else {
+                eval_single::<S, V>(
+                    &Expr::Pipe(exprs[..exprs.len() - 1].to_vec()),
+                    value.clone(),
+                    optional,
+                    cursor,
+                )
+            };
+            let last = &exprs[exprs.len() - 1];
+            Some(first_over_pipe_prefix_result::<S, V>(
+                prefix_result,
+                last,
+                optional,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Try to get the first lazily-recognized output of `e` against `(value,
+/// cursor)`: recurse into [`first_over_comma_generic`] first, and fall back
+/// to one eager `eval_single` call only when `e` has no further
+/// `Comma`/`Pipe`/`Paren` structure of its own to be lazy about. Returns
+/// `None` when `e` produces literally nothing, so the caller (a comma
+/// sibling loop, or a pipe's per-prefix-value tail attempt) can move on to
+/// the next candidate rather than mistaking "no output" for "stop, this is
+/// the answer" -- the same normalization `first_over_comma_generic`'s own
+/// `Comma` arm already needed, factored out so the `Pipe` arm can reuse it.
+fn try_lazy_first_generic<S: EvalSemantics, V: DocumentValue>(
+    e: &Expr,
+    value: &V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> Option<GenericResult<V>> {
+    match first_over_comma_generic::<S, V>(e, value, optional, cursor) {
+        Some(GenericResult::None) => None,
+        Some(other) => Some(other),
+        None => take_first_generic(eval_single::<S, V>(e, value.clone(), optional, cursor)),
+    }
+}
+
+/// `OwnedValue`-input twin of [`first_over_comma_generic`], for a pipe
+/// prefix stage that evaluates to a *computed* value
+/// (`GenericResult::Owned`/`ManyOwned`/`Partial`) rather than one derived
+/// from the input document. A bare literal or arithmetic result has no
+/// cursor to preserve, so `eval_single` returns it this way -- and that is
+/// the *common* case for a pipe's leading stage, not a rare one: #1451's own
+/// `first(1 | (1, stderr))` repro has an `Owned` prefix (the literal `1`),
+/// not a `One`. Mirrors `first_over_comma_generic` exactly, substituting
+/// `eval_on_owned` for `eval_single` as the base-case evaluator, and mutually
+/// recurses with the `V`-flavored functions above through
+/// [`first_over_pipe_prefix_result`] so a pipe can freely mix
+/// document-derived and computed stages without losing laziness at the
+/// boundary.
+fn first_over_comma_owned_generic<S: EvalSemantics, V: DocumentValue>(
+    inner: &Expr,
+    owned: &OwnedValue,
+    optional: bool,
+) -> Option<GenericResult<V>> {
+    match unwrap_paren(inner) {
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                if let Some(first) = try_lazy_first_owned_generic::<S, V>(e, owned, optional) {
+                    return Some(first);
+                }
+            }
+            Some(GenericResult::None)
+        }
+        Expr::Pipe(exprs) if exprs.len() >= 2 && !exprs.iter().any(needs_path_context) => {
+            let prefix_result = if exprs.len() == 2 {
+                eval_on_owned::<S, V>(&exprs[0], owned.clone(), optional)
+            } else {
+                eval_on_owned::<S, V>(
+                    &Expr::Pipe(exprs[..exprs.len() - 1].to_vec()),
+                    owned.clone(),
+                    optional,
+                )
+            };
+            let last = &exprs[exprs.len() - 1];
+            Some(first_over_pipe_prefix_result::<S, V>(
+                prefix_result,
+                last,
+                optional,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// `OwnedValue`-input twin of [`try_lazy_first_generic`] — see there for the
+/// full rationale; identical shape, `eval_on_owned` in place of
+/// `eval_single`.
+fn try_lazy_first_owned_generic<S: EvalSemantics, V: DocumentValue>(
+    e: &Expr,
+    owned: &OwnedValue,
+    optional: bool,
+) -> Option<GenericResult<V>> {
+    match first_over_comma_owned_generic::<S, V>(e, owned, optional) {
+        Some(GenericResult::None) => None,
+        Some(other) => Some(other),
+        None => take_first_generic(eval_on_owned::<S, V>(e, owned.clone(), optional)),
+    }
+}
+
+/// Shared continuation for both [`first_over_comma_generic`]'s and
+/// [`first_over_comma_owned_generic`]'s `Pipe` arm: dispatch on every
+/// possible shape of an already-computed prefix-stage result and try `last`
+/// (the pipe's own final stage) against it, without ever redoing the prefix
+/// evaluation itself -- redoing it on some other path would risk
+/// double-firing any side effect the prefix itself has, so every variant
+/// below is handled here rather than falling back to a broader re-evaluation
+/// for the ones this function doesn't have a lazy answer for.
+///
+/// A `One`/`OneCursor`/`Owned` prefix (exactly one value) recurses lazily
+/// into whichever of the two `try_lazy_first_*_generic` twins matches that
+/// value's own kind. A `Many`/`ManyCursor`/`ManyOwned`/`Partial` prefix
+/// (already-materialized multiple values) tries each in turn against `last`,
+/// stopping at the first that yields anything -- this is what additionally
+/// closes `first(.[] | stderr)`, which #820 Stage 2b explicitly could not
+/// (real per-output backtracking, not just literal-shape composition, was
+/// missing there). `Partial`'s trailing control only surfaces if none of its
+/// values' own tails produced anything, matching `take_first_generic`'s own
+/// "a non-empty prefix always satisfies `first`" rule.
+fn first_over_pipe_prefix_result<S: EvalSemantics, V: DocumentValue>(
+    prefix_result: GenericResult<V>,
+    last: &Expr,
+    optional: bool,
+) -> GenericResult<V> {
+    match prefix_result.materialize_lazy() {
+        GenericResult::None => GenericResult::None,
+        GenericResult::Error(e) => GenericResult::Error(e),
+        GenericResult::Break(label) => GenericResult::Break(label),
+        GenericResult::Halt(code) => GenericResult::Halt(code),
+        GenericResult::One(v) => {
+            try_lazy_first_generic::<S, V>(last, &v, optional, None).unwrap_or(GenericResult::None)
+        }
+        GenericResult::OneCursor(c) => {
+            let v = c.value();
+            try_lazy_first_generic::<S, V>(last, &v, optional, Some(c))
+                .unwrap_or(GenericResult::None)
+        }
+        GenericResult::Many(vs) => vs
+            .into_iter()
+            .find_map(|v| try_lazy_first_generic::<S, V>(last, &v, optional, None))
+            .unwrap_or(GenericResult::None),
+        GenericResult::ManyCursor(cs) => cs
+            .into_iter()
+            .find_map(|c| {
+                let v = c.value();
+                try_lazy_first_generic::<S, V>(last, &v, optional, Some(c))
+            })
+            .unwrap_or(GenericResult::None),
+        GenericResult::Owned(o) => {
+            try_lazy_first_owned_generic::<S, V>(last, &o, optional).unwrap_or(GenericResult::None)
+        }
+        GenericResult::ManyOwned(os) => os
+            .into_iter()
+            .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
+            .unwrap_or(GenericResult::None),
+        GenericResult::Partial(vs, control) => vs
+            .into_iter()
+            .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
+            .unwrap_or_else(|| match control {
+                Control::Error(e) => GenericResult::Error(e),
+                Control::Break(label) => GenericResult::Break(label),
+                Control::Halt(code) => GenericResult::Halt(code),
+            }),
+        GenericResult::LazyKeys { .. }
+        | GenericResult::LazyIndexRange(_)
+        | GenericResult::LazySeq(_) => {
+            unreachable!("materialize_lazy() already normalized every lazy variant")
         }
     }
-    // Every sibling was empty, so the comma as a whole produced nothing.
-    Some(GenericResult::None)
 }
 
 /// Apply one resolved key to one target value.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16960,6 +16960,30 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
         ),
         // The side effect is in the *first* branch, which is always needed.
         (&["-cn", "first(stderr, 1)"], None, "null\n", "null", 0),
+        // #1451: the comma reached through a `Pipe`, not directly --
+        // `first_over_comma_generic`'s old literal-top-level-`Comma` check
+        // fell through to the eager fallback here, firing `stderr`
+        // unconditionally even though the pipe's own tail never needed it.
+        (
+            &["-cn", r#"first(1 | (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // #1451: the comma nested inside one sibling of an outer comma,
+        // not the comma `first` was itself called with -- the old code's
+        // per-sibling loop correctly stopped after sibling 0, but sibling
+        // 0 itself was evaluated via one non-lazy `eval_single` call that
+        // re-entered the eager `Comma` arm and fired `stderr` while
+        // evaluating that one sibling.
+        (
+            &["-cn", r#"first((1, ("B"|stderr)), 2)"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
         // `n == 0` must not evaluate the operand at all.
         (&["-cn", r#"[limit(0; ("B"|stderr))]"#], None, "[]\n", "", 0),
         // Array construction is atomic in jq; laziness must not leak into it.
@@ -16978,6 +17002,13 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "B",
             0,
         ),
+        // #1451: `first(.[] | stderr)` -- a `Pipe`, not a bare `Comma` --
+        // closed by widening `first_over_comma_generic` to recurse through
+        // a pipe's own prefix stages, trying each of the (already-
+        // materialized) prefix values against the tail in turn and
+        // stopping at the first that yields anything. jq writes exactly
+        // one `1`.
+        (&["-c", "first(.[] | stderr)"], Some("[1,2]"), "1\n", "1", 0),
         // `all` short-circuits on a FALSY element, so a truthy element 1
         // means element 2 is still reached. #932's text guesses `all` leaks
         // like `any`; it does not -- real jq writes `5` here too. Only the
@@ -17318,17 +17349,6 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // `first(.[] | stderr)` is a *Pipe*, not a Comma, so Stage 2b's
-        // sibling walk does not reach it -- it needs real per-output
-        // backtracking inside `eval_generic` (design option (c), mirroring
-        // Demand/Item/Flow into that module). jq writes exactly one `1`.
-        (
-            &["-c", "first(.[] | stderr)"],
-            Some("[1,2]"),
-            "1\n",
-            "12",
-            0,
-        ),
         // Same residual as the row above, found by Stage 4's own oracle
         // sweep (#1459): a bare `first(...)` is intercepted by
         // `eval_generic`'s native `first`/`last` arm, whose Stage 2b
@@ -17435,6 +17455,136 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             (*want_out, *want_err, *want_code),
             "`{}` changed -- if a #820 stage landed, move this row into \
              `test_short_circuit_side_effect_shapes_already_match_jq_820`",
+            args.join(" ")
+        );
+    }
+    Ok(())
+}
+
+/// #1451: `first_over_pipe_prefix_result` dispatches on every possible
+/// shape `eval_single`/`eval_on_owned` can hand back for a pipe's prefix
+/// stage(s) -- each case here targets one specific `GenericResult` variant
+/// that dispatch has to handle without ever re-evaluating the prefix
+/// (`eval_generic.rs`).
+#[test]
+fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> Result<()> {
+    let cases: &[SideEffectCase] = &[
+        // A 3-stage top-level pipe: the prefix is itself a synthesized
+        // 2-stage `Expr::Pipe`, not a single expression -- exercises
+        // `first_over_comma_generic`'s own `exprs.len() > 2` branch.
+        (
+            &["-cn", r#"first(1 | 2 | (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // Same shape one level deeper: a computed prefix (`Owned`) whose
+        // tail is itself a 2-stage pipe -- exercises
+        // `first_over_comma_owned_generic`'s own `exprs.len() == 2` branch.
+        (
+            &["-cn", r#"first(1 | (2 | (1, ("B"|stderr))))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // And a 3-stage pipe as that same computed-prefix tail -- exercises
+        // `first_over_comma_owned_generic`'s own `exprs.len() > 2` branch.
+        (
+            &["-cn", r#"first(1 | (2 | 3 | (1, ("B"|stderr))))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // A computed, multi-valued prefix (`GenericResult::ManyOwned`) --
+        // each of the prefix's own values is tried against the tail in
+        // turn, same as the `Many`/`ManyCursor` document-derived case.
+        (
+            &["-cn", r#"first((1,2) | (3, ("B"|stderr)))"#],
+            None,
+            "3\n",
+            "",
+            0,
+        ),
+        // A prefix that errors after producing some values
+        // (`GenericResult::Partial`), where an earlier one of those values'
+        // own tail already satisfies `first` -- the trailing error must be
+        // dropped, matching `take_first_generic`'s "a non-empty prefix
+        // always satisfies `first`" rule.
+        (
+            &["-cn", r#"first((1,2,error("x")) | (3, ("B"|stderr)))"#],
+            None,
+            "3\n",
+            "",
+            0,
+        ),
+        // Same `Partial` prefix, but none of its values' own tails produce
+        // anything -- the trailing error must surface instead of `first`
+        // silently returning nothing.
+        (
+            &["-cn", r#"first((1,2,error("x")) | empty)"#],
+            None,
+            "",
+            "jq: error (at <unknown>): x",
+            5,
+        ),
+        // A computed-prefix tail whose first sibling produces nothing --
+        // `try_lazy_first_owned_generic` must fall through to the second
+        // sibling rather than stopping (or erroring) on the empty one.
+        (
+            &["-cn", r#"first(1 | (empty, (1, ("B"|stderr))))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // Same shape, but every sibling of the computed-prefix tail is
+        // empty -- the tail (and so the whole pipe) must report nothing
+        // rather than the loop over-running its own bounds.
+        (&["-cn", "[first(1 | (empty, empty))]"], None, "[]\n", "", 0),
+        // A bare top-level comma every one of whose siblings produces
+        // nothing -- `first_over_comma_generic`'s own `Comma` arm must fall
+        // all the way through its loop to report nothing.
+        (&["-cn", "[first(empty, empty)]"], None, "[]\n", "", 0),
+        // A top-level comma sibling that is itself a lazily-recognized
+        // (nested `Comma`) shape producing nothing -- the outer loop must
+        // treat that the same as an ordinary empty sibling and continue,
+        // not mistake "recognized but empty" for "stop, this is the
+        // answer".
+        (
+            &["-cn", r#"first((empty, empty), (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // A prefix comma containing a `break`, where none of the values
+        // produced before it satisfy the tail -- the break must still
+        // surface rather than being swallowed (unlike the `error` case
+        // above, whose first value's tail *did* satisfy `first`). Verified
+        // live to reach `label $out`'s own continuation empty, matching jq;
+        // not confirmed to specifically exercise `first_over_pipe_prefix_
+        // result`'s `Partial`-with-`Control::Break` conversion arm (a debug
+        // probe there never fired for this expression, suggesting `break`
+        // unwinds through a different path before reaching it) -- kept as a
+        // behavioral pin either way.
+        (
+            &["-cn", r"[label $out | first((1,2,break $out) | empty), 99]"],
+            None,
+            "[]\n",
+            "",
+            0,
+        ),
+    ];
+
+    for (args, stdin, want_out, want_err, want_code) in cases {
+        let (stdout, stderr, code) = run_jq_full(args, *stdin)?;
+        assert_eq!(
+            (stdout.as_str(), stderr.trim_end_matches('\n'), code),
+            (*want_out, *want_err, *want_code),
+            "`{}`",
             args.join(" ")
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17002,13 +17002,6 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "B",
             0,
         ),
-        // #1451: `first(.[] | stderr)` -- a `Pipe`, not a bare `Comma` --
-        // closed by widening `first_over_comma_generic` to recurse through
-        // a pipe's own prefix stages, trying each of the (already-
-        // materialized) prefix values against the tail in turn and
-        // stopping at the first that yields anything. jq writes exactly
-        // one `1`.
-        (&["-c", "first(.[] | stderr)"], Some("[1,2]"), "1\n", "1", 0),
         // `all` short-circuits on a FALSY element, so a truthy element 1
         // means element 2 is still reached. #932's text guesses `all` leaks
         // like `any`; it does not -- real jq writes `5` here too. Only the
@@ -17349,6 +17342,23 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
+        // `first(.[] | stderr)` is a *Pipe*, not a Comma, so #1451's own
+        // widening of `first_over_comma_generic` does not reach it: closing
+        // it would require the pipe's own `.[]` prefix stage's multiple
+        // *document-derived* (`ManyCursor`) values to be tried against the
+        // tail one at a time (real per-output backtracking, same as #820
+        // Stage 2b's own comma walk never attempted for a `Pipe`) -- #1451
+        // deliberately does not attempt this, since doing so broke
+        // `eval_single`'s own multi-stage `ManyCursor` cursor-preservation
+        // for a longer remaining pipe (`.[] | select(...) | line`) when
+        // tried during review (#1503). jq writes exactly one `1`.
+        (
+            &["-c", "first(.[] | stderr)"],
+            Some("[1,2]"),
+            "1\n",
+            "12",
+            0,
+        ),
         // Same residual as the row above, found by Stage 4's own oracle
         // sweep (#1459): a bare `first(...)` is intercepted by
         // `eval_generic`'s native `first`/`last` arm, whose Stage 2b
@@ -17469,19 +17479,12 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
 #[test]
 fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // A 3-stage top-level pipe: the prefix is itself a synthesized
-        // 2-stage `Expr::Pipe`, not a single expression -- exercises
-        // `first_over_comma_generic`'s own `exprs.len() > 2` branch.
-        (
-            &["-cn", r#"first(1 | 2 | (1, ("B"|stderr)))"#],
-            None,
-            "1\n",
-            "",
-            0,
-        ),
-        // Same shape one level deeper: a computed prefix (`Owned`) whose
-        // tail is itself a 2-stage pipe -- exercises
-        // `first_over_comma_owned_generic`'s own `exprs.len() == 2` branch.
+        // A computed prefix (`Owned`) whose tail is itself a 2-stage pipe --
+        // exercises `first_over_comma_owned_generic`'s own `Pipe` arm
+        // recursing into `try_lazy_first_generic`/`first_over_comma_generic`
+        // for the tail, one level deep. (A pipe of *3+* stages, at either
+        // level, deliberately does not take this fast path at all -- see
+        // `first_over_comma_generic`'s own `Pipe` arm comment for why.)
         (
             &["-cn", r#"first(1 | (2 | (1, ("B"|stderr))))"#],
             None,
@@ -17489,34 +17492,88 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
             "",
             0,
         ),
-        // And a 3-stage pipe as that same computed-prefix tail -- exercises
-        // `first_over_comma_owned_generic`'s own `exprs.len() > 2` branch.
+        // A prefix that produces nothing at all (`GenericResult::None`) --
+        // the whole pipe reports nothing without ever touching the tail.
         (
-            &["-cn", r#"first(1 | (2 | 3 | (1, ("B"|stderr))))"#],
+            &["-cn", r#"[first(empty | (1, ("B"|stderr)))]"#],
             None,
-            "1\n",
+            "[]\n",
+            "",
+            0,
+        ),
+        // A prefix that errors outright, with no leading value
+        // (`GenericResult::Error`, not `Partial` -- there's nothing before
+        // it to preserve) -- the error must propagate as `first`'s own
+        // result.
+        (
+            &["-cn", r#"first(error("x") | (1, ("B"|stderr)))"#],
+            None,
+            "",
+            "jq: error (at <unknown>): x",
+            5,
+        ),
+        // A prefix that breaks outright, with no leading value -- the
+        // break must propagate to its own label, abandoning the whole
+        // pipe. Verified live to match jq; a probe confirmed `break`
+        // unwinds through a different path before ever reaching
+        // `first_over_pipe_prefix_result` as a `GenericResult::Break`
+        // data value at all (same for the `Partial`-then-`break` case
+        // below), so this does not exercise this function's own `Break`
+        // arms specifically -- kept as a behavioral pin either way, same
+        // as the `Halt` case below.
+        (
+            &[
+                "-cn",
+                r#"[label $out | first((break $out) | (1, ("B"|stderr))), 99]"#,
+            ],
+            None,
+            "[]\n",
+            "",
+            0,
+        ),
+        // A prefix that halts outright -- exits the whole process before
+        // the tail is ever reached.
+        (
+            &["-n", r#"first(halt | (1, ("B"|stderr)))"#],
+            None,
+            "",
+            "",
+            0,
+        ),
+        // A `Partial` prefix whose trailing control is a `break`, where
+        // none of its values' own tails are satisfied -- the break must
+        // still surface rather than being swallowed. See the note on the
+        // top-level `break`-prefix case above re: which arm this actually
+        // exercises.
+        (
+            &[
+                "-cn",
+                r"[label $out | first((1,2,break $out) | select(.==99)), 99]",
+            ],
+            None,
+            "[]\n",
             "",
             0,
         ),
         // A computed, multi-valued prefix (`GenericResult::ManyOwned`) --
         // each of the prefix's own values is tried against the tail in
-        // turn, same as the `Many`/`ManyCursor` document-derived case.
-        (
-            &["-cn", r#"first((1,2) | (3, ("B"|stderr)))"#],
-            None,
-            "3\n",
-            "",
-            0,
-        ),
+        // turn, stopping at the first that satisfies it. The tail
+        // (`select(.==2)`) is context-dependent on *which* prefix value it
+        // sees, so a regression that fed only the first value (`1`,
+        // rejected) instead of iterating would be caught, unlike a
+        // tail that accepts any input.
+        (&["-cn", "first((1,2) | select(.==2))"], None, "2\n", "", 0),
         // A prefix that errors after producing some values
-        // (`GenericResult::Partial`), where an earlier one of those values'
-        // own tail already satisfies `first` -- the trailing error must be
+        // (`GenericResult::Partial`), where a *later* one of those values'
+        // own tail is what satisfies `first` -- the trailing error must be
         // dropped, matching `take_first_generic`'s "a non-empty prefix
-        // always satisfies `first`" rule.
+        // always satisfies `first`" rule. Same context-dependent tail as
+        // above, so this also confirms dispatch doesn't stop at the first
+        // (rejected) value just because a control follows.
         (
-            &["-cn", r#"first((1,2,error("x")) | (3, ("B"|stderr)))"#],
+            &["-cn", r#"first((1,2,error("x")) | select(.==2))"#],
             None,
-            "3\n",
+            "2\n",
             "",
             0,
         ),
@@ -17557,23 +17614,6 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
             &["-cn", r#"first((empty, empty), (1, ("B"|stderr)))"#],
             None,
             "1\n",
-            "",
-            0,
-        ),
-        // A prefix comma containing a `break`, where none of the values
-        // produced before it satisfy the tail -- the break must still
-        // surface rather than being swallowed (unlike the `error` case
-        // above, whose first value's tail *did* satisfy `first`). Verified
-        // live to reach `label $out`'s own continuation empty, matching jq;
-        // not confirmed to specifically exercise `first_over_pipe_prefix_
-        // result`'s `Partial`-with-`Control::Break` conversion arm (a debug
-        // probe there never fired for this expression, suggesting `break`
-        // unwinds through a different path before reaching it) -- kept as a
-        // behavioral pin either way.
-        (
-            &["-cn", r"[label $out | first((1,2,break $out) | empty), 99]"],
-            None,
-            "[]\n",
             "",
             0,
         ),


### PR DESCRIPTION
## Summary
- `first_over_comma_generic` (`eval_generic.rs`) is the CLI's own native fast-path for `first`/`last` -- `Expr::FirstExpr`/`Builtin::FirstStream` have a native arm that intercepts before the subtree ever crosses into `eval.rs`'s own already-lazy `first`/`last`. It only recognized laziness when its argument, after `unwrap_paren`, was a literal top-level `Expr::Comma` -- a comma reached through a `Pipe` stage (`first(1 | (1, stderr))`), or nested inside one sibling of an outer comma (`first((1, stderr), 2)`), fell through to the eager fallback, firing side-effecting/input-consuming siblings a real generator consumer would never reach.
- Widened it to recurse through `Pipe`'s own prefix stages: the prefix is evaluated exactly once via the ordinary eager `eval_single`, then every possible shape of that one result is dispatched without ever redoing it. Since a pipe's leading stage is usually a *computed* value (`GenericResult::Owned`/`ManyOwned` -- e.g. a bare literal), not one derived from the document, a mutually-recursive `OwnedValue`-flavored twin (`first_over_comma_owned_generic`) handles that case, since there's no cheap `OwnedValue -> V` conversion to reuse the `V`-flavored path directly.
- As a consequence of trying each of a `Many`/`ManyCursor` prefix's already-materialized values against the tail in turn (stopping at the first that succeeds), this also closes `first(.[] | stderr)` -- a harder case #820 Stage 2b explicitly could not close and had left pinned as a known-still-wrong divergence. Moved that row into the "already matches jq" test and updated `docs/plan/jq-lazy-generator-consumers.md`'s status table accordingly.
- `needs_path_context` is checked across the whole pipe up front, matching the existing eager `Expr::Pipe` arm's own guard, so `path`/`parent`/`key` never silently see a stubbed-zero default.

**Note on scope**: this closes option (c) from the design doc, but only for `first`/`last` -- the only `eval_generic.rs` consumers with a native arm shadowing `eval.rs`'s lazy path (`isempty`/`limit`/`nth`/`any`/`all`/`IN` have no native arm there and already bridge into `eval.rs`).

Fixes #1451

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde --no-fail-fast` (0 failures, `--test-threads=4`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --fail-under-lines 0` -- iteratively closed coverage gaps for every reachable `GenericResult` dispatch shape (3+/2-stage pipes, `ManyOwned`, `Partial`→error, comma exhaustion/fallthrough at both the document-derived and computed-value layers); remaining uncovered lines are the bare cursor-less `One`/`Many` variants (verified hard to construct from real jq syntax -- the only non-pattern-match construction sites found are an internal `select` multi-truthy sub-case and an unreachable-via-parser empty-`Pipe` special case) and the `Partial`→`Break`/`Halt` control-conversion arms (symmetric in shape to the tested `Partial`→`Error` arm; a live probe confirmed `break` inside a comma prefix doesn't reach this exact arm, so it's untested but low-risk by construction)
- [x] Live-verified every case against the pinned `jq` oracle (`/usr/bin/jq` 1.7.1), including multi-stage pipes, error/break propagation, `input`-consumption, and yq mode