### PR TITLE
fix(jq): thread per-output path through path-context Comma

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21814,8 +21814,11 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 /// comparison, an `if`/`then`/`else`, or a `try`/`catch` result is still
 /// "at" the position it was computed from) and fanning a multi-valued
 /// result back out over `rest` the same way `Iterate` does above. Shared by
-/// `If`/`Comma`/`Try`/`Label` below to avoid re-deriving this fan-out loop
-/// at each call site.
+/// `If`/`Try`/`Label` below to avoid re-deriving this fan-out loop at each
+/// call site (`Comma` used to as well, until #1409 moved it onto the
+/// combine-with-`rest` idiom `Optional`/`Pipe` already use, since threading
+/// one ambient `current_path` through every comma branch lost each
+/// branch's own per-output path).
 fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     intermediate: QueryResult<'a, W>,
     rest: &[Expr],
@@ -22558,9 +22561,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // output's real one (`.a | (.[])? | key` would wrongly report every
         // element's key as `"a"` instead of its index). This is a
         // pre-existing limitation of the isolate-then-continue shape shared
-        // by the `Comma`/`Try`/`Label` arms elsewhere in this function, not
-        // something new here -- filed as #1409 (needs a real
-        // path-preserving redesign of that shared shape) -- but this arm
+        // by the `Try`/`Label` arms elsewhere in this function (`Comma` had
+        // it too, until #1409 fixed it there by combining each branch with
+        // `rest` instead -- a trick that doesn't carry over to `Try`/`Label`,
+        // since it would let `rest`'s own errors be caught by `try`'s
+        // handler or `label`'s break scope), not something new here -- but
+        // this arm
         // must not regress it for `Optional` specifically, so it only takes
         // the fast, isolated path when `rest` doesn't consult path context
         // in the first place, and otherwise falls back to evaluating
@@ -22659,8 +22665,8 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // arithmetic is typically a mid-pipe computation, not the pipe's
             // final value, so later `key`/`file_index` calls must still
             // resolve against the pre-arithmetic position. Uses the same
-            // accumulate-or-stop continuation `Comma`/`If`/`Select` already
-            // share, since the fanout above can now legitimately produce
+            // accumulate-or-stop continuation `If`/`Select` already share,
+            // since the fanout above can now legitimately produce
             // `ManyOwned`/`Partial`/`Break`, not just `Owned`/`None`/`Error`.
             continue_rest_with_context::<W, S>(
                 arith_result,
@@ -23290,7 +23296,6 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // jq never does -- tracked separately, #1409 remains open for
             // those two.
             let mut branch_outputs = Vec::new();
-            let mut stopped = None;
             for sub_expr in exprs {
                 let mut combined = vec![sub_expr.clone()];
                 combined.extend(rest.iter().cloned());
@@ -23303,11 +23308,10 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     optional,
                 );
                 if let Some(stop) = accumulate_path_context_step(&mut branch_outputs, step) {
-                    stopped = Some(stop);
-                    break;
+                    return stop;
                 }
             }
-            stopped.unwrap_or_else(|| owned_vec_to_result(branch_outputs))
+            owned_vec_to_result(branch_outputs)
         }
         Expr::Try {
             expr: try_expr,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23268,11 +23268,34 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // before a later branch errors/breaks, matching the plain
             // evaluator's `eval_comma` (line ~690) instead of re-deriving a
             // different (collapse-to-array, discard-on-error) policy here.
+            //
+            // Combines each branch with `rest` into one recursive call
+            // (#1409) rather than isolating the branch (empty `rest`) and
+            // continuing the accumulated result through
+            // `continue_rest_with_context` afterward: `,` distributes over
+            // `|` in jq (`(a, b) | rest` is `(a | rest), (b | rest)`,
+            // live-verified against jq 1.7.1 including under error/break
+            // interaction), and combining lets `Field`/`Index`/`Iterate`
+            // inside `rest` see each branch's own true per-output
+            // `current_path` -- isolating first only ever built `new_path`
+            // for a non-empty `rest` *within that same recursive call*, so
+            // the old code's separate continuation always saw the stale,
+            // pre-comma path instead (`.a | (.[], empty) | key` wrongly
+            // reported every element's key as `"a"` instead of its index).
+            // `Try`/`Label` share this function's identical isolate-then-
+            // continue shape but can't take the same fix: naively
+            // rewriting `try f catch c | rest` as
+            // `try (f | rest) catch (c | rest)` would let an error from
+            // `rest` itself be caught by `try`'s own handler, which real
+            // jq never does -- tracked separately, #1409 remains open for
+            // those two.
             let mut branch_outputs = Vec::new();
             let mut stopped = None;
             for sub_expr in exprs {
+                let mut combined = vec![sub_expr.clone()];
+                combined.extend(rest.iter().cloned());
                 let step = eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(sub_expr),
+                    &combined,
                     value,
                     root,
                     file_origin,
@@ -23284,18 +23307,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     break;
                 }
             }
-            let comma_result = stopped.unwrap_or_else(|| owned_vec_to_result(branch_outputs));
-            if rest.is_empty() {
-                return comma_result;
-            }
-            continue_rest_with_context::<W, S>(
-                comma_result,
-                rest,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            )
+            stopped.unwrap_or_else(|| owned_vec_to_result(branch_outputs))
         }
         Expr::Try {
             expr: try_expr,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5457,9 +5457,16 @@ fn test_path_context_fanout_preserves_output_before_break_or_error_715() -> Resu
 /// updated path when *they* have a non-empty `rest` to recurse into, so
 /// isolating them first meant `rest` always saw the stale path (#1409).
 /// Fixed by combining each branch with `rest` into one recursive call
-/// instead (`,` distributes over `|` in jq, live-verified against jq
-/// 1.7.1), so `Field`/`Iterate` inside `rest` build `new_path` in the same
-/// call chain as the branch that produced their input.
+/// instead, so `Field`/`Iterate` inside `rest` build `new_path` in the same
+/// call chain as the branch that produced their input. This relies on `,`
+/// distributing over `|` in jq (`(a, b) | rest` is `(a | rest), (b |
+/// rest)`) -- live-verified against real jq 1.7.1 using plain constructs
+/// with no path-context builtins (e.g. `(1, error("x")) | tostring` vs.
+/// `(1|tostring), (error("x")|tostring)`), since that identity is what the
+/// fix depends on. `key`/`parent` themselves have no real-jq equivalent
+/// (succinctly extensions), so every assertion *in this test* pins
+/// internal consistency against that already-verified identity, not a
+/// separate oracle claim about `key` specifically.
 #[test]
 fn test_comma_path_context_threads_per_output_path_1409() -> Result<()> {
     // The issue's own repro: `.[]` isolated inside a comma used to report
@@ -5495,6 +5502,35 @@ fn test_comma_path_context_threads_per_output_path_1409() -> Result<()> {
     )?;
     assert_eq!(stdout, "0\n1\n2\n");
     assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert_eq!(code, 5);
+
+    Ok(())
+}
+
+/// Side effect of combining each branch with `rest` (#1409 code review):
+/// a later branch's own body (including any of its own side effects) is
+/// no longer entered at all once an earlier branch's combined
+/// `branch | rest` recursion has already stopped on an error -- unlike the
+/// old isolate-then-continue shape, which always fully evaluated *every*
+/// branch (running its side effects) before `rest` was ever applied to
+/// any of them. Live-verified this matches real jq's own generator
+/// semantics for the identical shape with a plain (non-path-context)
+/// value in place of `key`: `(1, ("m"|stderr)) | if .==1 then error("x")
+/// else . end` prints no `m` in jq 1.7.1 either, since jq's own pipe
+/// never visits a later comma branch once an earlier one already failed
+/// downstream.
+#[test]
+fn test_comma_path_context_skips_unreached_later_branch_side_effects_1409() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[".a | (.[], (\"MARKER_RAN\" | stderr)) | if . == 2 then error(\"boom\") else key end"],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("MARKER_RAN"),
+        "the never-reached second branch's stderr side effect must not fire: {stderr}"
+    );
     assert_eq!(code, 5);
 
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5449,6 +5449,57 @@ fn test_path_context_fanout_preserves_output_before_break_or_error_715() -> Resu
     Ok(())
 }
 
+/// `Comma`'s own arm used to isolate each branch (evaluated with an empty
+/// `rest`) and continue the *accumulated* result through `rest` afterward,
+/// reusing the pre-comma `current_path` for every output regardless of
+/// which branch (or which fan-out iteration within a branch) actually
+/// produced it -- `Field`/`Index`/`Iterate` only compute and thread an
+/// updated path when *they* have a non-empty `rest` to recurse into, so
+/// isolating them first meant `rest` always saw the stale path (#1409).
+/// Fixed by combining each branch with `rest` into one recursive call
+/// instead (`,` distributes over `|` in jq, live-verified against jq
+/// 1.7.1), so `Field`/`Iterate` inside `rest` build `new_path` in the same
+/// call chain as the branch that produced their input.
+#[test]
+fn test_comma_path_context_threads_per_output_path_1409() -> Result<()> {
+    // The issue's own repro: `.[]` isolated inside a comma used to report
+    // every element's key as the pre-comma path (`"a"`) instead of its own
+    // index.
+    let (stdout, _stderr, code) =
+        run_jq_full(&[".a | (.[], empty) | key"], Some(r#"{"a":[10,20,30]}"#))?;
+    assert_eq!(stdout, "0\n1\n2\n");
+    assert_eq!(code, 0);
+
+    // Two independent branches, each its own field of the root -- `key`
+    // after the comma must resolve per-branch (`"a"`, then `"b"`), not
+    // fall back to `null` (no path at all) or the pre-comma path.
+    let (stdout, _stderr, code) =
+        run_jq_full(&["(.a, .b) | key"], Some(r#"{"a":{"x":1},"b":{"y":2}}"#))?;
+    assert_eq!(stdout, "\"a\"\n\"b\"\n");
+    assert_eq!(code, 0);
+
+    // Two independently-iterated arrays: each `.[]` branch's own elements
+    // must report their own array's index, not leak into the other's.
+    let (stdout, _stderr, code) =
+        run_jq_full(&["(.a[], .b[]) | key"], Some(r#"{"a":[1,2],"b":[3,4]}"#))?;
+    assert_eq!(stdout, "0\n1\n0\n1\n");
+    assert_eq!(code, 0);
+
+    // An error/break/halt from a later branch (or from `rest` itself) must
+    // still abort the whole comma, preserving whatever earlier branches'
+    // *correctly-pathed* output already produced -- not just the fix's
+    // main case in isolation.
+    let (stdout, stderr, code) = run_jq_full(
+        &[".a | (.[], error(\"boom\")) | key"],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(stdout, "0\n1\n2\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert_eq!(code, 5);
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::Array` arm (#1302), so `[key]` --
 /// semantically equivalent to `(key,key)`'s single-branch case, just
 /// array-wrapped instead of comma-joined -- silently lost path context and

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5536,6 +5536,26 @@ fn test_comma_path_context_skips_unreached_later_branch_side_effects_1409() -> R
     Ok(())
 }
 
+/// Coverage-gap regression (#1409 code review): `continue_rest_with_context`'s
+/// `ManyOwned` branch mid-loop `return stop` was previously only reached via
+/// `Comma`'s own (now-removed) call into this helper; nothing else in this
+/// test suite happened to feed it a multi-valued intermediate whose `rest`
+/// continuation stops partway through. Exercises the same line through
+/// `If`'s still-`continue_rest_with_context`-based tail instead: `(1,2)`
+/// (the taken branch) fans out to a `ManyOwned` intermediate, and `rest`
+/// (`error("stop")`) fails on the very first of those two values.
+#[test]
+fn test_if_path_context_many_owned_continuation_stops_mid_loop_1409() -> Result<()> {
+    let (_stdout, stderr, code) = run_jq_full(
+        &[".a | if key then (1,2) else 3 end | error(\"stop\")"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert!(stderr.contains("stop"), "stderr: {stderr}");
+    assert_eq!(code, 5);
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::Array` arm (#1302), so `[key]` --
 /// semantically equivalent to `(key,key)`'s single-branch case, just
 /// array-wrapped instead of comma-joined -- silently lost path context and

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20894,3 +20894,20 @@ fn test_yq_auto_output_mixed_format_separator_order_independent_1493() -> Result
     );
     Ok(())
 }
+
+/// #1409's `Comma` path-threading fix in yq mode too, since
+/// `eval_pipe_with_path_context_internal` is shared verbatim between jq
+/// and yq (`key`/`parent` reachable in yq mode via its own `--eval-all`
+/// support) -- pins yq-mode parity so a future mode-specific edit has real
+/// CI signal here, not just in `jq_cli_tests.rs`.
+#[test]
+fn test_yq_comma_path_context_threads_per_output_path_1409() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".a | (.[], empty) | key",
+        "a:\n  - 10\n  - 20\n  - 30\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output, "0\n1\n2\n");
+    Ok(())
+}


### PR DESCRIPTION
Addresses #1409 (Comma only — Try/Label remain, see below)

## Summary

`eval_pipe_with_path_context_internal`'s `Expr::Comma` arm isolated each branch's evaluation (empty `rest`), accumulated the flat `OwnedValue`s, then continued the whole accumulated result through `rest` using the pre-comma `current_path` unconditionally. `Field`/`Index`/`Iterate` only compute and thread an updated path when *they* have a non-empty `rest` to recurse into, so isolating them first meant `rest` always saw the stale path regardless of which branch (or which fan-out iteration within a branch) actually produced each value:

```
$ echo '{"a":[10,20,30]}' | succinctly jq -c '.a | (.[], empty) | key'
"a"
"a"
"a"
# expected: 0, 1, 2 (matches plain `.a | .[] | key`)
```

## Fix

Combines each branch with `rest` into one recursive call instead of isolating first and continuing separately — the same `combined = vec![...]; combined.extend(rest.iter().cloned())` idiom this file already uses for `Expr::Optional`/`Expr::Pipe`. This works because `,` distributes over `|` in jq (`(a, b) | rest` is `(a | rest), (b | rest)`), live-verified against jq 1.7.1 including under error/break/halt interaction — an error from a later branch, or from `rest` itself, still aborts the whole comma the same way, since the identity holds end-to-end, not just for the successful case.

## Why this doesn't close #1409 outright

`Try`/`Label` share this function's identical isolate-then-continue shape, but can't take the same fix: naively rewriting `try f catch c | rest` as `try (f | rest) catch (c | rest)` would let an error *from `rest` itself* get caught by `try`'s own catch handler, which real jq never does (live-verified). That needs the more invasive path-carrying redesign #1409 originally called for. Leaving #1409 open, narrowed to those two, rather than closing it.

## Verification

- Live-verified the underlying algebraic identity (`,` distributes over `|`) against jq 1.7.1 across plain-value cases (error timing, break-through-label, nested multi-output `rest`) before committing to this fix direction.
- Differentially tested the pre- and post-fix binaries against the issue's own repro plus additional cases (independent object-field branches, two independently-iterated arrays, self-comma duplication, nested comma-of-comma, error/break/halt from a later branch or from `rest` itself, `?`-swallowed errors) — every diff is the intended fix (wrong-before, correct-after, manually verified against jq's real per-branch/per-index semantics); every case that shouldn't change (no path context needed, no `rest`, plain error-no-rest) is byte-identical.
- New regression test (`test_comma_path_context_threads_per_output_path_1409`) covering the repro plus three more shapes.
- Full local suite green: build, full test suite, both clippy legs, `cargo fmt --check`, rustdoc, `--no-default-features` build.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, incl. new regression test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo build --no-default-features`
- [x] Differential A/B testing against the pre-fix binary