### PR TITLE
docs: reconcile ADR-0019 with ADR-0018 rule 4

### DIFF
--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -185,7 +185,7 @@ The rule is not unbounded: where a reference's inconsistency would fall under ru
 it cannot re-read, data corruption, a process death — rule 4 wins. Fidelity yields to
 soundness, never to taste.
 
-**4. Divergence is permitted only under three named conditions**, and must be justified in
+**4. Divergence is permitted only under four named conditions**, and must be justified in
 writing against one of them:
 
 - **(a) The reference emits output it cannot itself consume.** Anchor soundness
@@ -199,10 +199,21 @@ writing against one of them:
   CLI, so a crash is a caller's crash. `null | setpath([1e30]; 9)` gets jq killed on the
   allocation; succinctly refuses with `Cannot grow array to <n> elements` — see
   [compliance/jq/limitations.md](../compliance/jq/limitations.md#refusing-an-allocation-jq-does-not-survive).
+- **(d) The reference's semantics have no expressible equivalent in any dependency that
+  clears the project's portability bar, and the cost of one that does clear it exceeds the
+  value of closing the gap.** Invoking (d) requires an evaluated-candidates table naming
+  what was considered and why each was rejected — a table with one entry and "too much
+  work" in the cost column does not meet the bar; the table has to show that *no* option
+  both clears the bar and closes the gap. [ADR-0019](adr-0019.md) (regex-engine swap for
+  jq's `l`/`n` flags) is the first application: its candidates table shows `onig`/`pcre2`
+  fail portability, `fancy-regex` closes neither gap, and a hand-rolled layer only covers
+  the shapes already enumerated in the issues it's declining to fix generally.
 
-Nothing else qualifies. In particular, "the reference's behaviour is surprising", "our
-architecture makes it awkward", and "the other mode does it differently" are not
-justifications.
+Nothing else qualifies on its own. In particular, "the reference's behaviour is
+surprising", "our architecture makes it awkward" asserted without a candidates table, and
+"the other mode does it differently" are not justifications — (d) exists precisely so the
+awkward-adjacent case has somewhere to go, but only once it clears the evidentiary bar the
+table requires, not on the strength of the claim alone.
 
 Rule 4 governs *evaluator and CLI behaviour*. A divergence originating in which inputs the
 parser accepts, or in how a plain scalar's type resolves against a published spec, is not a
@@ -218,8 +229,10 @@ the flagship carve-out, and both are recorded rather than grandfathered:
 
 - The yq merge-flag combination `*+d` diverges from real yq (`[3,4,3,4]` there, `[1,2,3,4]`
   here) on the stated grounds that real yq's behaviour is surprising and untested upstream.
-  That is not one of the three conditions, so it stands as a divergence to be fixed or
-  re-justified, not a settled decision.
+  That is not one of the four conditions — including (d), added below: this is a claim
+  about a reference tool's own behaviour being untested, not about a dependency search
+  turning up nothing portable — so it stands as a divergence to be fixed or re-justified,
+  not a settled decision.
 - Rule 4(a)'s own exemplar has a hole: `enforce_anchor_soundness` is not reached on the
   cursor-streaming path, so `succinctly yq --sort-keys` still emits an alias above its
   anchor — output succinctly itself refuses to parse
@@ -228,6 +241,28 @@ the flagship carve-out, and both are recorded rather than grandfathered:
 
 Both are enumerated in
 [compliance/yq/limitations.md](../compliance/yq/limitations.md), which is what rule 6 is for.
+
+### Amendment (#1501, implemented): rule 4 gains condition (d)
+
+[ADR-0019](adr-0019.md) merged 47 minutes *before* this ADR, so it was decided without
+rule 4 to test itself against, and nobody reconciled the two afterward. Re-verifying
+[#1283](https://github.com/rust-works/succinctly/issues/1283) cluster D
+([#1501](https://github.com/rust-works/succinctly/issues/1501)) found that ADR-0019's
+reasoning — the pure-Rust `regex` stack cannot express oniguruma's search policies, and
+every alternative costs more than the two gaps are worth — fit none of (a)/(b)/(c) as
+originally written, and read uncomfortably close to the "our architecture makes it
+awkward" excuse this rule already names as insufficient. Two Accepted ADRs stood in direct
+contradiction: this one forbidding what that one granted.
+
+The fix is condition (d) above, not a stretch-fit of ADR-0019 under (c) (an FFI
+dependency's build/cross-compilation cost is a portability argument, not a
+process-survival one) and not marking ADR-0019 Superseded (its decision was never in
+question — rejecting the engine swap is still right, and the candidates table still
+holds). (d) is deliberately narrower than "no good option exists": it requires the same
+kind of written evidence (a)/(b)/(c) already demand, just aimed at a dependency search
+instead of a single reference-tool observation, so that "awkward" alone still fails and
+only a documented absence of a portable, gap-closing dependency succeeds. ADR-0019 gained
+a matching *Relationship to ADR-0018* note pointing back here.
 
 **5. Extensions are a third category, and must not perturb the first two.** A succinctly
 extension adds a capability neither reference has — `leaf_paths`
@@ -301,7 +336,9 @@ been found yet.
 - Rule 4's list of conditions is closed *by this record*, not permanently. A fourth condition
   is reachable — by superseding or amending this ADR with the case that motivates it, which is
   a deliberate, reviewed act rather than a one-off justification in a pull request. That is
-  the intended path for revisiting any of the six rules.
+  the intended path for revisiting any of the six rules. *(Exercised by the #1501 amendment
+  above: condition (d) was reached because ADR-0019 already carried the evaluated-candidates
+  table the new condition requires, not by lowering the bar to fit it.)*
 
 ## Alternatives considered and rejected
 
@@ -333,6 +370,9 @@ been found yet.
 - [ADR-0000](adr-0000.md) — the ADR format this record follows.
 - [ADR-0017](adr-0017.md) — presentation-metadata side-trees; its #763 amendment records the
   anchor-soundness divergence that rule 4(a) generalises.
+- [ADR-0019](adr-0019.md) — reject regex-engine swap for jq's `l`/`n` flags; rule 4(d)'s
+  first application, added by the [#1501](https://github.com/rust-works/succinctly/issues/1501)
+  amendment above to reconcile the two records.
 - [compliance/jq/limitations.md](../compliance/jq/limitations.md) — jq-mode divergences.
 - [compliance/yq/limitations.md](../compliance/yq/limitations.md) — yq-mode divergences.
 - [reference/jq-language.md](../reference/jq-language.md),

--- a/docs/adrs/adr-0019.md
+++ b/docs/adrs/adr-0019.md
@@ -76,13 +76,38 @@ accepted as permanent, documented limitations:
   only for lazy quantifiers and empty-first alternation.
 
 Neither candidate engine clears the bar for a Low-severity (#920) and Medium-severity
-(#922) gap that are both narrow and rare in practice: the two C-FFI options (`onig`,
-`pcre2`) trade a pure-Rust, already-integrated, well-understood dependency for build
-portability and cross-compilation cost, in exchange for fixing edge cases most users
-will never hit; `fancy-regex` costs a second dependency for no actual coverage of either
-issue; and a hand-rolled special-case only covers the simple shapes already enumerated
-in the issues, while adding real correctness risk for the nested/nonlocal cases that
-POSIX/backtracking semantics actually diverge on.
+(#922) gap that are both narrow in the *flag combinations* that trigger them: the two
+C-FFI options (`onig`, `pcre2`) trade a pure-Rust, already-integrated, well-understood
+dependency for build portability and cross-compilation cost, in exchange for fixing flag
+combinations most users will never type; `fancy-regex` costs a second dependency for no
+actual coverage of either issue; and a hand-rolled special-case only covers the simple
+shapes already enumerated in the issues, while adding real correctness risk for the
+nested/nonlocal cases that POSIX/backtracking semantics actually diverge on. Narrow
+triggering conditions are not the same claim as low-stakes consequences — see
+Consequences → Negative below for what happens on the rare occasions these flags *are*
+used.
+
+### Relationship to ADR-0018
+
+This ADR merged 47 minutes *before* [ADR-0018](adr-0018.md), so it was decided without
+rule 4's divergence conditions to test itself against, and nobody reconciled the two
+records afterward — leaving two Accepted ADRs in direct contradiction, since rule 4 as
+originally written permitted divergence only for (a) output the reference cannot itself
+read back, (b) corruption or a discarded write, or (c) a process crash, and explicitly
+named "our architecture makes it awkward" as *not* a justification. The reasoning above —
+no dependency in the `regex`/`regex-automata` stack expresses oniguruma's search
+policies, and every alternative that does costs more than these two gaps are worth
+closing — fits none of the three and reads uncomfortably close to that excluded excuse.
+
+[#1501](https://github.com/rust-works/succinctly/issues/1501) resolved the conflict by
+amending ADR-0018 with rule 4(d): divergence is permitted where no dependency clearing
+the project's portability bar exists to close the gap, evidenced by an
+evaluated-candidates table. The **Candidates evaluated** table above is that evidence —
+this ADR is rule 4(d)'s first application. It is not a stretch-fit under (c) (an FFI
+dependency's build and cross-compilation cost is a portability argument, not a
+process-survival one), and the underlying decision was never in question: rejecting the
+engine swap is still correct, and the candidates table still holds. What changed is only
+which rule-4 condition names why.
 
 ## Consequences
 
@@ -100,10 +125,32 @@ POSIX/backtracking semantics actually diverge on.
 **Negative / trade-offs:**
 
 - `succinctly jq`/`yq` remain permanently divergent from real jq for two narrow flag
-  combinations: `match("a|aa|aaa";"l")` will keep returning the leftmost-first match
-  (`"a"`), not the POSIX-longest one (`"aaa"`); `test("a*?";"n")` and similar lazy-
-  quantifier/empty-first-alternation patterns combined with `n` will keep missing
-  non-empty matches real jq finds.
+  combinations, and — because every regex builtin shares the `first_captures`/
+  `global_captures`/`next_match_step` choke point named above — the divergence is not
+  confined to `match`/`test`. It reaches the string-transformation builtins too, and
+  there it is not a wrong-answer-with-a-clear-error case: it is a **silent no-op or
+  wrong-span replacement**, verified live against jq 1.7.1:
+
+  ```console
+  $ echo '"xaab"' | jq            -c 'gsub("a*?";"X";"gn")'   =>  "xXXb"
+  $ echo '"xaab"' | succinctly jq -c 'gsub("a*?";"X";"gn")'   =>  "xaab"   # no-op
+  $ echo '"xaab"' | jq            -c 'sub("a*?";"X";"n")'     =>  "xXab"
+  $ echo '"xaab"' | succinctly jq -c 'sub("a*?";"X";"n")'     =>  "xaab"   # no-op
+  $ echo '"aaa"'  | jq            -c 'sub("a|aa|aaa";"X";"l")'  =>  "X"
+  $ echo '"aaa"'  | succinctly jq -c 'sub("a|aa|aaa";"X";"l")'  =>  "Xaa"  # wrong span
+  ```
+
+  `split`/`splits` inherit the same two gaps, since both are built on the same match
+  discovery. Every one of the above exits 0 with empty stderr — by #1283 Part 3's own
+  criterion this is the "silently wrong output" class (the #1194/#1168 family), not a
+  right-output-wrong-error-wording case. The *flag combinations* that trigger it are rare
+  — greedy quantifiers and non-empty-first alternation are unaffected
+  (`[scan("a*";"gn")]`, `[match("(?:a|)";"gn").string]`, `[match("[0-9]*";"gn").string]`
+  all match jq) — but the consequence when one is hit is silent data loss, not a
+  cosmetic mismatch. `match("a|aa|aaa";"l")` keeps returning the leftmost-first match
+  (`"a"`) instead of POSIX-longest (`"aaa"`); `test("a*?";"n")` and similar lazy-
+  quantifier/empty-first-alternation patterns combined with `n` keep missing non-empty
+  matches real jq finds.
 - Anyone hand-rolling a fix later has to do so at the shared choke point
   (`first_captures`/`global_captures`/`next_match_step`/`build_regex`), which affects
   all eight builtins at once — there's no way to patch just one.


### PR DESCRIPTION
## Summary

Two Accepted ADRs contradicted each other: ADR-0019 (reject regex-engine swap
for jq's `l`/`n` flags) merged 47 minutes *before* ADR-0018 (reference-tool
fidelity rule), so ADR-0019's own justification was never tested against rule
4's divergence conditions — and it fit none of them.

- **Reconciliation**: adds rule 4(d) to ADR-0018 — divergence permitted where
  no dependency clearing the project's portability bar exists to close the
  gap, evidenced by an evaluated-candidates table (the same written-evidence
  bar (a)/(b)/(c) already require). ADR-0019 already carried such a table, so
  it becomes (d)'s first application via a new "Relationship to ADR-0018"
  section, rather than a stretch-fit under (c) or a Superseded status change.
  Neither ADR's underlying decision changes.
- **Blast-radius correction**: ADR-0019's Consequences named only
  `match(...;"l")` and `test(...;"n")` as affected, calling them "edge cases
  most users will never hit." `gsub`/`sub`/`split`/`splits` are affected too,
  and silently — `gsub("a*?";"X";"gn")` on `"xaab"` no-ops instead of jq's
  `"xXXb"`, `sub("a|aa|aaa";"X";"l")` replaces the wrong span. All exit 0 with
  empty stderr, which by #1283 Part 3's own criterion is the silently-wrong-
  output class, not the lower-stakes wrong-error-wording class. The existing
  boundary claim (greedy quantifiers / non-empty-first alternation unaffected)
  is kept, verified.

Closes #1501.

## Test plan

- [x] All jq/succinctly output pairs cited in the ADR re-verified live: real
      `jq` (1.7.1) via `/usr/bin/jq`, and succinctly via
      `cargo build --release --features cli` at this branch's HEAD.
- [x] Cited function names (`first_captures`, `global_captures`,
      `next_match_step`, `build_regex`) confirmed present in `src/jq/eval.rs`.
- [x] Timing claim ("47 minutes before") re-derived from
      `git log --diff-filter=A -- docs/adrs/adr-001{8,9}.md`.
- Docs-only change; no `src/` touched, no build/test/clippy impact.