### PR TITLE
docs(jq): record regex l/n flag gaps in compliance/jq/limitations.md

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -539,11 +539,13 @@ still pads, so `[1,2] | setpath([5]; 9)` still agrees with jq.
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)
 of [ADR-0018](../../adrs/adr-0018.md): no dependency in the `regex`/`regex-automata` stack
-expresses oniguruma's search policies, and every alternative that does (`onig`, `pcre2`,
-`fancy-regex`) costs more than closing #920/#922 is worth. `l` (POSIX leftmost-longest) is
-accepted as valid flag syntax but has no effect; `n` (suppress empty matches) still misses a
-non-empty match reachable only by backtracking to a different alternative — lazy
-quantifiers (`a*?`) and alternations with an empty-matching branch listed first (`(?:|a)`).
+expresses oniguruma's search policies, and of the alternatives evaluated, the ones that do
+(`onig`, `pcre2`) cost more than closing #920/#922 is worth (both are C FFI, breaking pure-
+`cargo build` portability), while the one that doesn't cost that (`fancy-regex`) closes
+neither gap at all. `l` (POSIX leftmost-longest) is accepted as valid flag syntax but has
+no effect; `n` (suppress empty matches) still misses a non-empty match reachable only by
+backtracking to a different alternative — lazy quantifiers (`a*?`) and alternations with an
+empty-matching branch listed first (`(?:|a)`).
 
 Both gaps route through `first_captures`/`global_captures`/`next_match_step`
 (`src/jq/eval.rs`), the one choke point every regex builtin shares, so the divergence is

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -535,6 +535,48 @@ refuses with `Cannot grow array to <n> elements` — succinctly's own wording, s
 no jq sentence to copy. Only the impossible is refused; every length that fits in memory
 still pads, so `[1,2] | setpath([5]; 9)` still agrees with jq.
 
+## Regex flags `l` and `n`
+
+[ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)
+of [ADR-0018](../../adrs/adr-0018.md): no dependency in the `regex`/`regex-automata` stack
+expresses oniguruma's search policies, and every alternative that does (`onig`, `pcre2`,
+`fancy-regex`) costs more than closing #920/#922 is worth. `l` (POSIX leftmost-longest) is
+accepted as valid flag syntax but has no effect; `n` (suppress empty matches) still misses a
+non-empty match reachable only by backtracking to a different alternative — lazy
+quantifiers (`a*?`) and alternations with an empty-matching branch listed first (`(?:|a)`).
+
+Both gaps route through `first_captures`/`global_captures`/`next_match_step`
+(`src/jq/eval.rs`), the one choke point every regex builtin shares, so the divergence is
+not confined to `match`/`test` — it reaches the string-transformation builtins too, and
+there it is not a wrong-answer-with-a-clear-error case, but a silent no-op or wrong-span
+replacement:
+
+```console
+$ echo '"aaa"'  | jq            -c 'match("a|aa|aaa";"l").string'   =>  "aaa"
+$ echo '"aaa"'  | succinctly jq -c 'match("a|aa|aaa";"l").string'   =>  "a"
+$ echo '"aaa"'  | jq            -c 'sub("a|aa|aaa";"X";"l")'        =>  "X"
+$ echo '"aaa"'  | succinctly jq -c 'sub("a|aa|aaa";"X";"l")'        =>  "Xaa"   # wrong span
+$ echo '"xaab"' | jq            -c 'gsub("a*?";"X";"gn")'           =>  "xXXb"
+$ echo '"xaab"' | succinctly jq -c 'gsub("a*?";"X";"gn")'           =>  "xaab"  # no-op
+$ echo '"xaab"' | jq            -c 'sub("a*?";"X";"n")'             =>  "xXab"
+$ echo '"xaab"' | succinctly jq -c 'sub("a*?";"X";"n")'             =>  "xaab"  # no-op
+```
+
+`split`/`splits` inherit the same two gaps, since both are built on the same match
+discovery as `sub`/`gsub`. Every probe above exits 0 with empty stderr — silently wrong
+output, not a wrong-error-wording case. The flag combinations that trigger it are narrow:
+greedy quantifiers and non-empty-first alternation are unaffected and agree with jq —
+`[scan("a*";"gn")]` on `"xaab"` is `["aa"]` in both, and `[match("(?:a|)";"gn").string]` on
+`"xa"` is `["a"]` in both.
+
+Unlike every other section on this page, this divergence is **not** tracked by
+[`tests/data/jq-error-known-divergences.txt`](../../../tests/data/jq-error-known-divergences.txt) —
+that corpus pins probes where jq *errors* and succinctly does not; here jq returns a value
+and succinctly returns a different one, so there is no error message for the two-sided
+check to pin. This section is hand-maintained instead, the same caveat
+[ADR-0018](../../adrs/adr-0018.md)'s Consequences already record for
+[yq Limitations](../yq/limitations.md).
+
 ## A slice is a path component
 
 jq models `.[1:2]` as indexing with `{"start":1,"end":2}`, and treats that object as a
@@ -726,6 +768,7 @@ diff.
 ## Depends On
 
 - [ADR-0018](../../adrs/adr-0018.md) - the fidelity rule this page enumerates exceptions to
+- [ADR-0019](../../adrs/adr-0019.md) - the decision that made the regex `l`/`n` gaps permanent
 - [jq Evaluator](../../reference/jq-evaluator.md) - the evaluator raising these errors
 - [jq Language Support](../../reference/jq-language.md) - feature coverage matrix
 - [yq Limitations](../yq/limitations.md) - the yq-mode counterpart to this page

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -569,11 +569,15 @@ greedy quantifiers and non-empty-first alternation are unaffected and agree with
 `[scan("a*";"gn")]` on `"xaab"` is `["aa"]` in both, and `[match("(?:a|)";"gn").string]` on
 `"xa"` is `["a"]` in both.
 
-Unlike every other section on this page, this divergence is **not** tracked by
+Like [Where succinctly errors and jq does not](#where-succinctly-errors-and-jq-does-not)
+above, this divergence is **not** tracked by
 [`tests/data/jq-error-known-divergences.txt`](../../../tests/data/jq-error-known-divergences.txt) —
-that corpus pins probes where jq *errors* and succinctly does not; here jq returns a value
-and succinctly returns a different one, so there is no error message for the two-sided
-check to pin. This section is hand-maintained instead, the same caveat
+that corpus pins probes where jq *errors* and succinctly does not, so it is blind to any
+shape where jq itself doesn't error. That section's shape is succinctly erroring where jq
+returns a value; this one is a third shape neither of the two error-corpus-driven sections
+covers — both jq and succinctly return a value, exit 0, with empty stderr, and the values
+just disagree. Both sections are hand-maintained for the same reason: no error message
+exists for the two-sided check to pin, the same caveat
 [ADR-0018](../../adrs/adr-0018.md)'s Consequences already record for
 [yq Limitations](../yq/limitations.md).
 


### PR DESCRIPTION
## Summary

ADR-0019 accepted the regex `l` (#920) and `n` (#922) flag gaps as permanent under ADR-0018 rule 4(d), but per ADR-0018 rule 6 ("every divergence is recorded on the mode's compliance page"), neither gap was ever written down on `docs/compliance/jq/limitations.md`. The only places they were mentioned were ADR-0019 itself and, for `n`, the *wrong* mode's compliance page (`docs/compliance/yq/limitations.md`, only as context for yq's own flag-grammar rejection).

Adds a **"Regex flags `l` and `n`"** section to `docs/compliance/jq/limitations.md`, following the shape of the existing "Refusing an allocation jq does not survive" section:

- What diverges and why (ADR-0019's rule 4(d) rationale, in one sentence)
- The full blast radius — both gaps route through `first_captures`/`global_captures`/`next_match_step`, so they reach every regex builtin sharing that choke point, not just `match`/`test`. `gsub`/`sub` silently no-op or replace the wrong span, exiting 0 with empty stderr — verified live against pinned jq 1.7.1 and this branch's own build (all 6 probe pairs re-verified, not copied from the issue text)
- The boundary: greedy quantifiers and non-empty-first alternation are unaffected
- Why this section can't be driven by `tests/data/jq-error-known-divergences.txt` like "Behaviour and parser gaps" is (these are output divergences with exit 0 / empty stderr, not error-message probes — hand-maintained instead, the same caveat ADR-0018 already records for the yq page)

Also adds ADR-0019 to the page's "Depends On" list (it wasn't linked anywhere in this file before).

Docs only — no `src/` or test changes.

## Test plan

- [x] Live-verified all 6 probe pairs (l+match, l+sub, n+gsub, n+sub, plus both boundary cases) against pinned `/usr/bin/jq` 1.7.1 and this branch's own release build
- [x] `cargo test --features cli,regex --test jq_error_message_tests` — the page's quoted numbers/table are untouched, still parse correctly (3/3 pass)
- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps --features cli,simd,regex,serde` — clean
- [x] `cargo build --no-default-features` — no_std build still compiles
- [x] Confirmed both new relative markdown links (`../../adrs/adr-0019.md`) resolve on disk

Closes #1500