### PR TITLE
test(jq): pin the full blast radius of the regex l/n permanent gaps

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41654,6 +41654,117 @@ mod tests {
                 assert!(vs.is_empty(), "jq finds a match at offset 1 — known gap, #922");
             }
         );
+
+        // #1502: the gap is not specific to test/match/scan — sub/gsub/
+        // split/splits all route through the same first_captures/
+        // global_captures choke point, so they miss the same lazy-
+        // quantifier match and silently no-op instead of replacing/
+        // splitting. Verified live against jq 1.7.1, which returns
+        // "xXXb"/"xXab"/["x","","b"]/[["x","","b"]] for the four cases
+        // below.
+        query!(br#""xaab""#, r#"gsub("a*?"; "X"; "gn")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "xaab", "jq returns \"xXXb\" — known gap, #922");
+            }
+        );
+        query!(br#""xaab""#, r#"sub("a*?"; "X"; "n")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "xaab", "jq returns \"xXab\" — known gap, #922");
+            }
+        );
+        query!(br#""xaab""#, r#"[splits("a*?"; "gn")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(
+                    vs,
+                    vec![OwnedValue::String("xaab".to_string())],
+                    "jq returns [\"x\",\"\",\"b\"] — known gap, #922"
+                );
+            }
+        );
+        query!(br#""xaab""#, r#"[split("a*?"; "gn")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(
+                    vs,
+                    vec![OwnedValue::Array(vec![OwnedValue::String("xaab".to_string())])],
+                    "jq returns [[\"x\",\"\",\"b\"]] — known gap, #922"
+                );
+            }
+        );
+
+        // Boundary, greedy half: a greedy quantifier (no backtracking
+        // needed to find the non-empty match) and a `[0-9]*` character
+        // class are both unaffected and agree with jq — the gap is in
+        // *reaching* a non-empty match via backtracking, not in `n`
+        // itself. Complements the reordered-alternation boundary pinned
+        // above.
+        query!(br#""xaab""#, r#"[scan("a*"; "gn")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::String("aa".to_string())]);
+            }
+        );
+        query!(br#""a12b""#, r#"[match("[0-9]*"; "gn").string]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::String("12".to_string())]);
+            }
+        );
+    }
+
+    #[cfg(feature = "regex")]
+    #[test]
+    fn test_regex_l_flag_known_gap_920() {
+        // #920: jq's `l` flag switches from Perl-style leftmost-first to
+        // POSIX leftmost-longest matching (real oniguruma), applied
+        // recursively to every subexpression. Rust's `regex`/
+        // `regex-automata` stack has no `MatchKind::LeftmostLongest`
+        // implementation to switch to (the crate's own maintainers left
+        // the door open but never built it), so succinctly accepts `l` as
+        // valid flag syntax — see test_regex_unknown_flags_rejected_730 —
+        // but it has no effect on match semantics. Accepted as a
+        // permanent, documented limitation — see ADR-0019.
+        //
+        // This pins the *current, known-divergent* behavior rather than
+        // jq's — verified live against jq 1.7.1, which returns "aaa"/"X"/
+        // ["aaa"]/["aaa","a"] for the four cases below (`l` reorders a
+        // top-level alternation to prefer the longest branch at each
+        // position; succinctly keeps its own leftmost-first order and
+        // stops at the first alternative that matches, "a").
+        query!(br#""aaa""#, r#"match("a|aa|aaa"; "l").string"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "a", "jq returns \"aaa\" — known gap, #920");
+            }
+        );
+        query!(br#""aaa""#, r#"sub("a|aa|aaa"; "X"; "l")"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "Xaa", "jq returns \"X\" — known gap, #920");
+            }
+        );
+        query!(br#""aaa""#, r#"[scan("a|aa|aaa"; "gl")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(
+                    vs,
+                    vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string()),
+                    ],
+                    "jq returns [\"aaa\"] — known gap, #920"
+                );
+            }
+        );
+        query!(br#""aaaa""#, r#"[match("a|aa|aaa"; "gl").string]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(
+                    vs,
+                    vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string()),
+                    ],
+                    "jq returns [\"aaa\",\"a\"] — known gap, #920"
+                );
+            }
+        );
     }
 
     #[cfg(feature = "regex")]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41707,6 +41707,19 @@ mod tests {
                 assert_eq!(vs, vec![OwnedValue::String("12".to_string())]);
             }
         );
+
+        // #1502 review: `capture` is one of ADR-0019's eight regex builtin
+        // families sharing this choke point, and was otherwise untested
+        // under `n` anywhere in this file. It shares the exact no-match
+        // outcome as match/test above: no non-empty match is reachable
+        // without backtracking, so the generator produces no output at
+        // all (not `null`, not an empty object) rather than jq's
+        // `{"x":"a"}`.
+        query!(br#""xaab""#, r#"[capture("(?<x>a*?)"; "n")]"#,
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert!(vs.is_empty(), "jq returns [{{\"x\":\"a\"}}] — known gap, #922");
+            }
+        );
     }
 
     #[cfg(feature = "regex")]
@@ -41765,6 +41778,34 @@ mod tests {
                 );
             }
         );
+
+        // #1502 review: `capture` shares the same no-op `l` arm as
+        // match/sub above and was otherwise untested under `l` anywhere
+        // in this file.
+        query!(br#""aaa""#, r#"capture("(?<x>a|aa|aaa)"; "l")"#,
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(
+                    o.get("x"),
+                    Some(&OwnedValue::String("a".to_string())),
+                    "jq binds .x to \"aaa\" — known gap, #920"
+                );
+            }
+        );
+
+        // #1502 review: `l` and `n` are independent no-ops/approximations
+        // (`build_regex`'s `'l' => {}` arm and `global_captures`'s
+        // suppress-empty search are unrelated code paths), so combining
+        // them composes into a third, still-silent divergence rather than
+        // either flag masking the other. Verified live against jq 1.7.1,
+        // which returns "aaa" for both flag orderings (order is
+        // insignificant to jq's flag parsing).
+        for flags in ["ln", "nl"] {
+            query!(br#""aaa""#, &format!(r#"match("a|aa|aaa"; "{flags}").string"#),
+                QueryResult::Owned(OwnedValue::String(s)) => {
+                    assert_eq!(s, "a", "jq returns \"aaa\" — known gap, #920, flags: {flags:?}");
+                }
+            );
+        }
     }
 
     #[cfg(feature = "regex")]


### PR DESCRIPTION
## Summary

ADR-0019 accepted the regex `l` (#920) and `n` (#922) flag gaps as permanent, and its "already tested, not silently wrong" argument rested on `test_regex_n_flag_known_gap_lazy_quantifier_922` and `test_regex_unknown_flags_rejected_730` — but that's narrower than the actual divergence:

- `test_regex_n_flag_known_gap_lazy_quantifier_922` only pinned `test`/`match`/`scan` under `n`.
- `test_regex_unknown_flags_rejected_730` only confirmed `l` is accepted as valid flag syntax, not what it does — nothing pinned `l` actually changing match output.
- Nothing pinned the mutating builtins (`sub`/`gsub`/`split`/`splits`) under either flag, even though all eight regex builtin families route through the same `first_captures`/`global_captures`/`next_match_step` choke point ADR-0019 names.

For a divergence declared permanent, that's backwards — a permanent gap needs characterization tests precisely because nobody is going to fix it, so nothing else will notice if it silently starts (or stops) being one.

**Extends `test_regex_n_flag_known_gap_lazy_quantifier_922`** with:
- `gsub`/`sub`/`split`/`splits` under `n` — all silently no-op instead of jq's `"xXXb"`/`"xXab"`/`["x","","b"]`/`[["x","","b"]]`
- The greedy-quantifier boundary half (`a*`, `[0-9]*` — unaffected, agree with jq), complementing the reordered-alternation boundary already pinned there

**Adds `test_regex_l_flag_known_gap_920`** covering `match`/`sub`/`scan`/`match(...;"gl")` under `l` — all silently keep leftmost-first output instead of jq's POSIX-longest `"aaa"`/`"X"`/`["aaa"]`/`["aaa","a"]`.

Every probe was re-verified live against pinned jq 1.7.1 and this branch's own build before writing it down, not copied from the issue text.

Tests only — no `src/` behaviour change.

## Test plan

- [x] Live-verified all 10 new probe pairs (4 n-flag mutating-builtin gaps, 2 n-flag boundary, 4 l-flag shapes) against pinned `/usr/bin/jq` 1.7.1 and this branch's own debug build
- [x] `cargo test --lib test_regex_l_flag_known_gap_920` / `test_regex_n_flag_known_gap_lazy_quantifier_922` — both pass, pinning the current divergent behavior
- [x] `cargo test --features cli,simd,regex,serde` — full suite; two unrelated `jq_cli_tests` failures on first run (`test_short_circuit_side_effect_shapes_already_match_jq_820`, `test_walk_nested_break_reaches_its_enclosing_label`) reproduced as the known transient build-race signature — both pass in isolation and on a clean full re-run
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (second CI leg)
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps --features cli,simd,regex,serde` — clean
- [x] `cargo build --no-default-features` — no_std build still compiles

Closes #1502