### PR TITLE
fix(jq): keep resolve_slice_expr's bound-generator partial prefix

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17436,15 +17436,24 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     }
     let (ends, ends_escape) =
         resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
+    // `end` (`T`) is nested inside `start` (`S`)'s own iteration -- jq's `S
+    // as $s | T as $t | ...` re-runs `T` fresh for `$s`'s very first value,
+    // so a `T` escape (if any) fires before `S` ever gets a chance to
+    // expose its own. `ends_escape` therefore wins over `starts_escape` --
+    // computed once as `bounds_escape` and reused both by the
+    // `ends.is_empty()` early return just below and by the full
+    // `target`/`end`/`start` priority chain further down, so the two sites
+    // that need this rule can't silently drift apart (#1526 review).
+    // `ends_escaped` is split off first since `.or()` moves its operand and
+    // the truncation logic below still needs to ask "did `end` specifically
+    // escape" on its own. Confirmed against jq 1.7.1:
+    // `path(.[(0,1):error("b")])` on `[10,20,30]` prints nothing before
+    // raising `b` -- `end`'s own escape, with *zero* prior values, still
+    // wins over `start`'s later one.
+    let ends_escaped = ends_escape.is_some();
+    let bounds_escape = ends_escape.or(starts_escape);
     if ends.is_empty() {
-        // `end` (`T`) is nested inside `start` (`S`)'s own iteration --
-        // jq's `S as $s | T as $t | ...` re-runs `T` fresh for `$s`'s very
-        // first value, so a `T` escape (if any) fires before `S` ever gets
-        // a chance to expose its own. `ends_escape` therefore wins over
-        // `starts_escape` here, same "innermost escape wins" rule as the
-        // `target_escape`/`ends_escape`/`starts_escape` priority chain
-        // below.
-        return path_result(Vec::new(), ends_escape.or(starts_escape));
+        return path_result(Vec::new(), bounds_escape);
     }
     // #843: same rule as `resolve_index_expr` above, for a slice's bounds
     // instead of an index's key.
@@ -17518,44 +17527,50 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // to advance far enough to reach their own escape at all (#1517;
     // `starts`/`ends` here are each already truncated to their own
     // pre-escape partial prefix by `resolve_slice_bound`, so only the
-    // *cross-product* needs restricting, not the lists themselves):
+    // *cross-product* needs restricting, not the lists themselves). Two
+    // independent lengths, not a three-way branch on *which* escape fired
+    // (#1526 review — the old three-arm form repeated `&starts[..1]`
+    // identically in two branches, obscuring that `start` truncates
+    // whenever anything *more inner* escaped, while `end` only truncates
+    // when `target` itself did):
     //
-    // - `target` (`E`) escapes inside the very first `(s, t)` pair --
-    //   neither bound generator is ever resumed for a second pair, so both
-    //   restrict to their first element. `target_branches` was computed
-    //   once, outside this loop, so this keeps this function's `Err`
-    //   prefix equal to jq's own pre-escape stream, mirroring
+    // - `starts_len` is `1` whenever `target` *or* `end` escaped — either
+    //   one means `start` never got to try a second value (`end`, nested
+    //   inside `start`'s own iteration, escaping during `start`'s first
+    //   value has the identical effect on `start` as `target` escaping
+    //   does) — otherwise `starts`'s own pre-escape prefix is already the
+    //   right length. Confirmed against jq 1.7.1:
+    //   `path(.[(0,1):(2,error("b"))])` on `[10,20,30]` prints only
+    //   `[{"start":0,"end":2}]` before raising `b` -- `$s=1` is never
+    //   tried; `path(.[(0,error("b")):(2,3)])` prints *both*
+    //   `[{"start":0,"end":2}]` and `[{"start":0,"end":3}]` before raising
+    //   `b` (`T` fully iterated for `$s=0` before `S` ever tries to
+    //   advance, so no truncation here).
+    // - `ends_len` is `1` only when `target` itself escaped -- `target`
+    //   escapes inside the very first `(s, t)` pair, so neither bound
+    //   generator is ever resumed for a second pair. `target_branches` was
+    //   computed once, outside this loop, so this keeps this function's
+    //   `Err` prefix equal to jq's own pre-escape stream, mirroring
     //   `resolve_index_expr`'s identical fix (#972, pre-existing).
     //   Confirmed against jq 1.7.1:
     //   `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
     //   prints only `[{"start":0,"end":2}]` before raising `t`.
-    // - `end` (`T`) escapes during `start`'s (`S`'s) very first value's own
-    //   iteration -- `S` never gets to try a second value, so `starts`
-    //   restricts to its first element; `ends` keeps its own full
-    //   pre-escape prefix (nothing "outside" it was ever short-circuited).
-    //   Confirmed against jq 1.7.1: `path(.[(0,1):(2,error("b"))])` on
-    //   `[10,20,30]` prints only `[{"start":0,"end":2}]` before raising
-    //   `b` -- `$s=1` is never tried.
-    // - `start` (`S`) escapes on its own later value -- every prior `$s`
-    //   value already had `T`/`E` run to completion for it (unaffected by
-    //   `S`'s later escape), so neither `ends` nor `target_branches` needs
-    //   any restriction; `starts`'s own pre-escape prefix is already the
-    //   right length. Confirmed against jq 1.7.1:
-    //   `path(.[(0,error("b")):(2,3)])` on `[10,20,30]` prints *both*
-    //   `[{"start":0,"end":2}]` and `[{"start":0,"end":3}]` before raising
-    //   `b` (`T` fully iterated for `$s=0` before `S` ever tries to
-    //   advance).
-    let (starts, ends): (&[ResolvedSliceBound], &[ResolvedSliceBound]) = if target_escape.is_some()
-    {
-        (&starts[..1], &ends[..1])
-    } else if ends_escape.is_some() {
-        (&starts[..1], &ends[..])
+    let starts_len = if target_escape.is_some() || ends_escaped {
+        1
     } else {
-        (&starts[..], &ends[..])
+        starts.len()
     };
+    let ends_len = if target_escape.is_some() {
+        1
+    } else {
+        ends.len()
+    };
+    let (starts, ends): (&[ResolvedSliceBound], &[ResolvedSliceBound]) =
+        (&starts[..starts_len], &ends[..ends_len]);
     // Innermost escape wins, same reasoning as the restriction above and
-    // the `ends.is_empty()` early return: `target` > `end` > `start`.
-    let escape = target_escape.or(ends_escape).or(starts_escape);
+    // the `ends.is_empty()` early return: `target` > `end` > `start` --
+    // `bounds_escape` already carries the `end` > `start` half.
+    let escape = target_escape.or(bounds_escape);
     let mut out = Vec::with_capacity(starts.len() * ends.len() * target_branches.len());
     for (s, s_key) in starts {
         for (e, e_key) in ends {
@@ -17646,13 +17661,27 @@ type ResolvedSliceBound = (Option<i64>, Option<NumberKey>);
 /// Keeps the bound generator's own partial prefix rather than discarding it
 /// on escape (#1517) -- `eval_owned_multi_keep_partial`, not the
 /// discard-prefix `eval_owned_multi`, mirroring `resolve_index_expr`'s
-/// `key`/`key_escape` split for its own (single) generator argument. A
-/// resolved-but-non-numeric bound is a genuinely different failure (a type
-/// error on a value the generator already committed to, not an escape mid-
-/// stream) and still fails the whole call immediately via the outer
-/// `Result`, unchanged from before this fix -- only the generator's own
-/// error/break/halt is now threaded through as a *partial* result instead
-/// of silently reset to an empty `Vec`.
+/// `key`/`key_escape` split for its own (single) generator argument.
+///
+/// **Residual, found in #1517's own review, not fixed here.** A
+/// resolved-but-non-numeric bound (e.g. `"x"` in `.[(0,1,"x"):(2,3)]`) is a
+/// genuinely different failure from a generator's own error/break/halt (a
+/// type error on a value the generator already committed to, not an escape
+/// mid-stream) -- but the `.collect::<Result<Vec<_>, _>>()?` below still
+/// discards the *whole* converted prefix on the first such value, including
+/// any that resolved cleanly before it, the same shape of bug #1517 fixes
+/// for a genuine escape. Confirmed against jq 1.7.1: `path(.[(0,1,"x"):(2,3)])`
+/// on `[10,20,30]` prints `[{"start":0,"end":2}]`, `[{"start":0,"end":3}]`,
+/// `[{"start":1,"end":2}]`, `[{"start":1,"end":3}]` before raising
+/// `Array/string slice indices must be integers`; this function answers
+/// with none of the four. Not a regression -- confirmed present (with a
+/// *different*, wrong error message) before this fix too, since the old
+/// discard-prefix `eval_owned_multi` already threw the whole prefix away on
+/// any escape, generator or type, before this distinction was even
+/// visible. Left as a known gap rather than folded into this PR: giving a
+/// type failure the same keep-partial treatment as a generator escape needs
+/// its own priority-ordering pass against `target_escape`/`bounds_escape`
+/// above, re-verified against jq the same way, not a quick addition here.
 fn resolve_slice_bound<S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: &OwnedValue,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17429,13 +17429,22 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     optional: bool,
     trackable: bool,
 ) -> PathResolveResult<'a> {
-    let starts = resolve_slice_bound::<S>(start, value, f64::floor).map_err(|e| (Vec::new(), e))?;
+    let (starts, starts_escape) =
+        resolve_slice_bound::<S>(start, value, f64::floor).map_err(|e| (Vec::new(), e))?;
     if starts.is_empty() {
-        return Ok(Vec::new());
+        return path_result(Vec::new(), starts_escape);
     }
-    let ends = resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
+    let (ends, ends_escape) =
+        resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
     if ends.is_empty() {
-        return Ok(Vec::new());
+        // `end` (`T`) is nested inside `start` (`S`)'s own iteration --
+        // jq's `S as $s | T as $t | ...` re-runs `T` fresh for `$s`'s very
+        // first value, so a `T` escape (if any) fires before `S` ever gets
+        // a chance to expose its own. `ends_escape` therefore wins over
+        // `starts_escape` here, same "innermost escape wins" rule as the
+        // `target_escape`/`ends_escape`/`starts_escape` priority chain
+        // below.
+        return path_result(Vec::new(), ends_escape.or(starts_escape));
     }
     // #843: same rule as `resolve_index_expr` above, for a slice's bounds
     // instead of an index's key.
@@ -17501,22 +17510,52 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
         ));
     }
 
-    // jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]` — target
-    // inner, bounds outer — so when `target` escapes, that fires inside the
-    // very first `(s, e)` pair; neither bound generator is resumed for a
-    // second pair. `target_branches` was computed once, outside this loop,
-    // so restricting `starts`/`ends` to their first element when `target`
-    // escaped keeps this function's `Err` prefix equal to jq's own
-    // pre-escape stream, mirroring `resolve_index_expr`'s identical fix
-    // (#972). Confirmed against jq 1.7.1:
-    // `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
-    // prints only `[{"start":0,"end":2}]` before raising `t`.
+    // jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]` — `S`
+    // outer, `T` middle (re-run fresh for every `$s`), `E` innermost. Three
+    // generators can each independently escape after producing some
+    // values, and whichever is *innermost* is the one that actually fires
+    // first in jq's real depth-first walk — the others never get a chance
+    // to advance far enough to reach their own escape at all (#1517;
+    // `starts`/`ends` here are each already truncated to their own
+    // pre-escape partial prefix by `resolve_slice_bound`, so only the
+    // *cross-product* needs restricting, not the lists themselves):
+    //
+    // - `target` (`E`) escapes inside the very first `(s, t)` pair --
+    //   neither bound generator is ever resumed for a second pair, so both
+    //   restrict to their first element. `target_branches` was computed
+    //   once, outside this loop, so this keeps this function's `Err`
+    //   prefix equal to jq's own pre-escape stream, mirroring
+    //   `resolve_index_expr`'s identical fix (#972, pre-existing).
+    //   Confirmed against jq 1.7.1:
+    //   `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
+    //   prints only `[{"start":0,"end":2}]` before raising `t`.
+    // - `end` (`T`) escapes during `start`'s (`S`'s) very first value's own
+    //   iteration -- `S` never gets to try a second value, so `starts`
+    //   restricts to its first element; `ends` keeps its own full
+    //   pre-escape prefix (nothing "outside" it was ever short-circuited).
+    //   Confirmed against jq 1.7.1: `path(.[(0,1):(2,error("b"))])` on
+    //   `[10,20,30]` prints only `[{"start":0,"end":2}]` before raising
+    //   `b` -- `$s=1` is never tried.
+    // - `start` (`S`) escapes on its own later value -- every prior `$s`
+    //   value already had `T`/`E` run to completion for it (unaffected by
+    //   `S`'s later escape), so neither `ends` nor `target_branches` needs
+    //   any restriction; `starts`'s own pre-escape prefix is already the
+    //   right length. Confirmed against jq 1.7.1:
+    //   `path(.[(0,error("b")):(2,3)])` on `[10,20,30]` prints *both*
+    //   `[{"start":0,"end":2}]` and `[{"start":0,"end":3}]` before raising
+    //   `b` (`T` fully iterated for `$s=0` before `S` ever tries to
+    //   advance).
     let (starts, ends): (&[ResolvedSliceBound], &[ResolvedSliceBound]) = if target_escape.is_some()
     {
         (&starts[..1], &ends[..1])
+    } else if ends_escape.is_some() {
+        (&starts[..1], &ends[..])
     } else {
         (&starts[..], &ends[..])
     };
+    // Innermost escape wins, same reasoning as the restriction above and
+    // the `ends.is_empty()` early return: `target` > `end` > `start`.
+    let escape = target_escape.or(ends_escape).or(starts_escape);
     let mut out = Vec::with_capacity(starts.len() * ends.len() * target_branches.len());
     for (s, s_key) in starts {
         for (e, e_key) in ends {
@@ -17584,7 +17623,7 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
             }
         }
     }
-    path_result(out, target_escape)
+    path_result(out, escape)
 }
 
 /// One resolved slice bound, paired with the [`NumberKey`] it should
@@ -17603,22 +17642,35 @@ type ResolvedSliceBound = (Option<i64>, Option<NumberKey>);
 /// `.[(1+1):]`) needs exactly the same key-preservation `fold_slice_bound`'s
 /// static sibling already gives a literal one, and this is where that value
 /// is still on hand to check.
+///
+/// Keeps the bound generator's own partial prefix rather than discarding it
+/// on escape (#1517) -- `eval_owned_multi_keep_partial`, not the
+/// discard-prefix `eval_owned_multi`, mirroring `resolve_index_expr`'s
+/// `key`/`key_escape` split for its own (single) generator argument. A
+/// resolved-but-non-numeric bound is a genuinely different failure (a type
+/// error on a value the generator already committed to, not an escape mid-
+/// stream) and still fails the whole call immediately via the outer
+/// `Result`, unchanged from before this fix -- only the generator's own
+/// error/break/halt is now threaded through as a *partial* result instead
+/// of silently reset to an empty `Vec`.
 fn resolve_slice_bound<S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: &OwnedValue,
     round: fn(f64) -> f64,
-) -> Result<Vec<ResolvedSliceBound>, EvalEscape> {
+) -> Result<(Vec<ResolvedSliceBound>, Option<EvalEscape>), EvalEscape> {
     let Some(expr) = bound else {
-        return Ok(vec![(None, None)]);
+        return Ok((vec![(None, None)], None));
     };
-    eval_owned_multi::<S>(expr, value)?
+    let (values, escape) = eval_owned_multi_keep_partial::<S>(expr, value);
+    let resolved = values
         .iter()
         .map(|v| {
             owned_bound_to_i64(v, round)
                 .map(|i| (i, numeric_slice_bound_key(v)))
                 .map_err(EvalEscape::from)
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((resolved, escape))
 }
 
 /// Thread a value through a run of static path components, without expanding

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10558,6 +10558,17 @@ fn test_resolve_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1517(
     assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
     assert_eq!(stderr, "");
 
+    // `end` escapes with *zero* prior values (a bare `error(...)`, not a
+    // comma with a leading success) -- `ends_escape` still wins over
+    // `starts_escape`, matching the `ends.is_empty()` early return's own
+    // "innermost escape wins" rule rather than falling through to
+    // `start`'s own (later, never-reached) escape.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(.[(0,1):error("b")])"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
     Ok(())
 }
 
@@ -10605,6 +10616,29 @@ fn test_first_limit_path_truncation_does_not_overreach_slice_bound_fanout_1517()
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
     assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #1517 review's own known-gap residual, documented on `resolve_slice_bound`
+/// itself: a resolved-but-non-numeric bound value still discards the whole
+/// converted prefix, including values that resolved cleanly before it --
+/// the same shape of bug #1517 fixes for a genuine generator escape, just
+/// not extended to a type failure in this PR. Not a regression: confirmed
+/// present (with a *different*, wrong error message -- `b` instead of the
+/// correct type-error text) before this fix too. Pinning today's honest,
+/// still-imperfect output rather than asserting nothing here, so a future
+/// fix's diff shows exactly what changes.
+#[test]
+fn test_resolve_slice_bound_type_error_still_drops_valid_prefix_1517_known_gap() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(.[(0,1,"x"):(2,3)])"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    // jq 1.7.1 prints all four combinations of the two valid `start` values
+    // (0, 1) against both `end` values (2, 3) before raising -- this
+    // function currently drops all four instead.
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10485,6 +10485,130 @@ fn test_resolve_slice_expr_keeps_target_partial_fanout_before_its_own_error_973(
     Ok(())
 }
 
+/// #1517: `resolve_slice_expr` resolved `start`/`end`'s own bound generator
+/// via the discard-prefix `eval_owned_multi`, so a bound generator that
+/// produced some values before escaping (`(0,error("b"))`) reset the whole
+/// prefix to empty instead of keeping what it had already produced --
+/// unlike `target`'s own escape (#973 above), which was already correctly
+/// kept. A short `Err` prefix under-satisfies `take_path_branches`' `>= n`
+/// test, so `first`/`limit` in path position wrongly refused a filter real
+/// jq answers. Both bound axes covered, both verified live against jq
+/// 1.7.1: `start`'s own escape lets `end` (nested inside `start`'s first
+/// value, per jq's `S as $s | T as $t | ...` compilation) run to full
+/// completion before `start` ever tries to advance, so *both*
+/// `{"start":0,"end":2}` and `{"start":0,"end":3}` appear; `end`'s own
+/// escape fires during `start`'s very first value, so `start` never tries
+/// a second one and only `{"start":0,"end":2}` appears.
+#[test]
+fn test_resolve_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1517() -> Result<()> {
+    // `start` escapes: `end` (nested inside) is fully iterated for the one
+    // `start` value that did resolve.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.[(0,error("b")):(2,3)])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":2}]\n[{\"start\":0,\"end\":3}]\n"
+    );
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    // `end` escapes: `start` never gets to try a second value.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.[(0,1):(2,error("b"))])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    // The issue's own `first`/`limit` repros: previously raised `b` where
+    // jq answers cleanly, since the (wrongly empty) prefix under-satisfied
+    // `take_path_branches`' `>= 1` test.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(limit(1; .[(0,error("b")):(2,3)]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(first(.[(0,error("b")):(2,3)]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(limit(1; .[(0,1):(2,error("b"))]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(limit(1; .[(0,error("b")):2]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert_eq!(stderr, "");
+
+    Ok(())
+}
+
+/// #1517 Guard A (the write-side twin of #972's own Guard A, this time on
+/// the bound axis instead of the key axis): the exact boundary that would
+/// silently over-satisfy `take_path_branches` if the fix above overshot
+/// jq's real pre-escape count instead of matching it exactly. `limit(2; ...)`
+/// on the `start`-escape shape (real prefix length 2, per the test above) is
+/// fully satisfied and must write both; `limit(3; ...)` is still
+/// under-satisfied and must refuse untouched. Same pairing for the
+/// `end`-escape shape (real prefix length 1): `limit(1; ...)` writes,
+/// `limit(2; ...)` refuses. All four verified against jq 1.7.1.
+#[test]
+fn test_first_limit_path_truncation_does_not_overreach_slice_bound_fanout_1517() -> Result<()> {
+    // `start`-escape axis: real prefix length is 2.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"del(limit(2; .[(0,error("b")):(2,3)]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"del(limit(3; .[(0,error("b")):(2,3)]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    // `end`-escape axis: real prefix length is 1.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"del(limit(1; .[(0,1):(2,error("b"))]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[30]\n");
+    assert_eq!(stderr, "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"del(limit(2; .[(0,1):(2,error("b"))]))"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
     // `walk_impl` applies `f` via `eval_owned_expr_fork` at every level


### PR DESCRIPTION
## Summary
- `resolve_slice_bound` resolved `start`/`end`'s own bound generator via the discard-prefix `eval_owned_multi`, so a bound generator that produced some values before escaping (e.g. `(0,error("b"))`) reset the whole bound list to empty instead of keeping what it had already produced. Unlike `target`'s own escape (#973), which already correctly kept its partial prefix, this made `resolve_slice_expr`'s `Err` prefix shorter than jq's real pre-escape stream, under-satisfying `take_path_branches`' `>= n` test -- `first`/`limit` in path position wrongly refused a filter real jq answers successfully.
- `resolve_slice_bound` now calls `eval_owned_multi_keep_partial` (mirroring `resolve_index_expr`'s own `key`/`key_escape` split) and returns the escape alongside its partial value list.
- `resolve_slice_expr` combines the three possible escape sources -- `target` (`E`, innermost), `end` (`T`, middle, re-run fresh per `start` value per jq's `S as $s | T as $t | E | .[$s:$t]` compilation), `start` (`S`, outermost) -- with innermost-wins priority, since jq's real depth-first execution means a more-nested escape fires before an outer generator ever gets a chance to expose its own:
  - `target` escaping restricts both bound lists to their first element (unchanged, pre-existing #972 fix).
  - `end` escaping restricts only `start` to its first element (`end`'s own list is already its correctly-truncated partial prefix).
  - `start` escaping needs no restriction at all (every earlier `start` value already had `end`/`target` run to full completion, unaffected by `start`'s later escape).

**Hazard this needed care around**: `take_path_branches`' own doc comment explicitly warns that PR #985 attempted a similar fix on the analogous key/target axis with an "exactly equal" assumption and got reverted for silently over-satisfying `limit(n)` -- `del(limit(2; select((true,error("t")))[("x","y")]))` silently deleted both keys instead of raising. This fix's own design was verified live against that exact class of boundary (the precise `limit(n)`-satisfied vs `limit(n+1)`-refuses cutoff on both the `start`-escape and `end`-escape axes) before writing any code, not just the narrower `path()`-only repro.

Fixes #1517

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde --no-fail-fast` (0 failures, `--test-threads=4`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std) -- pre-existing, unrelated `sink` warning confirmed present on unmodified main too, not introduced by this change
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --fail-under-lines 0` -- 100% line coverage on every changed line
- [x] Live-verified every case against the pinned `jq` oracle (`/usr/bin/jq` 1.7.1): all 4 of the issue's own repro shapes, the `path()`-only forms for both escape axes, and -- critically -- the exact write-side `limit(n)`-satisfied vs `limit(n+1)`-refuses boundary on both axes (matching jq's real branch count precisely, not just "enough to pass the narrow repro")