### PR TITLE
fix(jq): last(f) over an empty stream answers null, not nothing

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20930,32 +20930,33 @@ fn eval_first_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `first`/`last` are `.[0]`/`.[-1]` and answer `null` on `[]`; that is a
 /// different construct and already correct.)
 ///
-/// The operand is evaluated with `optional: false` even when this call is
-/// `last(f)?`, and the error is suppressed here instead: `last` has to tell
-/// "the stream was empty" (answer `null`) from "the operand raised and `?`
-/// swallowed it" (answer nothing), and once `eval_single` has flattened a
-/// swallowed error into `None` those two are indistinguishable. Oracle:
-/// `last(empty)?` is `null` but `last(error("x"))?` is empty.
+/// No local `optional` handling is needed for `last(f)?`: post-#693,
+/// `Expr::Optional(inner)` evaluates `inner` with the *ambient* `optional`
+/// (never forced `true`) and catches the resulting `Error`/`Partial(_,
+/// Error)` itself, one layer out, so this function's own `optional`
+/// parameter is always `false` on every dispatch path that can reach it
+/// today. `last(empty)?` still answers `null` and `last(error("x"))?` is
+/// still empty — that split is entirely the outer `Expr::Optional`/
+/// `eval_try` boundary's job, not this function's.
 fn eval_last_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let result = eval_single::<W, S>(expr, value, false);
+    let result = eval_single::<W, S>(expr, value, optional);
     match result.materialize_cursor() {
         QueryResult::One(v) => QueryResult::One(v),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => match vs.into_iter().last() {
+        QueryResult::Many(vs) => match vs.into_iter().next_back() {
             Some(last) => QueryResult::One(last),
             None => QueryResult::Owned(OwnedValue::Null),
         },
         QueryResult::Owned(v) => QueryResult::Owned(v),
-        QueryResult::ManyOwned(vs) => match vs.into_iter().last() {
+        QueryResult::ManyOwned(vs) => match vs.into_iter().next_back() {
             Some(last) => QueryResult::Owned(last),
             None => QueryResult::Owned(OwnedValue::Null),
         },
         QueryResult::None => QueryResult::Owned(OwnedValue::Null),
-        QueryResult::Error(_) if optional => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
@@ -20964,7 +20965,6 @@ fn eval_last_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `last(1,2,error("x"))` raises, it does not answer `2`) — so a
         // `Partial` just surfaces its control, dropping the prefix, the
         // same as `reduce`'s input-stream handling.
-        QueryResult::Partial(_, Control::Error(_)) if optional => QueryResult::None,
         QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
         QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
         QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
@@ -28508,34 +28508,38 @@ fn builtin_first_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: last(expr) - output only the last value from expr (stream version)
+///
+/// Mirrors [`eval_last_expr`]'s `null`-for-an-empty-stream rule (#1521); see
+/// its doc comment for the rule and for why no local `optional` handling is
+/// needed here either. Unlike `eval_last_expr`, this function is never
+/// actually reached from parsed `succinctly jq`/`succinctly yq` filter text
+/// -- `last(expr)` always parses to `Expr::LastExpr`, not
+/// `Builtin::LastStream` (see `builtin_last_stream_propagates_bare_halt`) --
+/// so this update exists purely to keep the two implementations in sync.
 fn builtin_last_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Same `null`-for-an-empty-stream rule and same `optional` handling as
-    // [`eval_last_expr`]; see its doc comment for why (#1521).
-    let result = eval_single::<W, S>(expr, value, false);
+    let result = eval_single::<W, S>(expr, value, optional);
     match result {
         QueryResult::One(v) => QueryResult::Owned(to_owned(&v)),
         QueryResult::OneCursor(c) => QueryResult::Owned(to_owned(&c.value())),
         QueryResult::Owned(v) => QueryResult::Owned(v),
-        QueryResult::Many(results) => match results.into_iter().last() {
+        QueryResult::Many(results) => match results.into_iter().next_back() {
             Some(last) => QueryResult::Owned(to_owned(&last)),
             None => QueryResult::Owned(OwnedValue::Null),
         },
-        QueryResult::ManyOwned(results) => match results.into_iter().last() {
+        QueryResult::ManyOwned(results) => match results.into_iter().next_back() {
             Some(last) => QueryResult::Owned(last),
             None => QueryResult::Owned(OwnedValue::Null),
         },
         QueryResult::None => QueryResult::Owned(OwnedValue::Null),
-        QueryResult::Error(_) if optional => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
         // Same semantics as `eval_last_expr`: `last` cannot short-circuit,
         // so a `Partial` just surfaces its control, dropping the prefix.
-        QueryResult::Partial(_, Control::Error(_)) if optional => QueryResult::None,
         QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
         QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
         QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20917,31 +20917,45 @@ fn eval_first_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Evaluate `last(expr)` - take last output.
+///
+/// jq defines `last(f)` as `reduce f as $x (null; $x)`, and `reduce` always
+/// produces exactly one output — so an empty operand answers the *seed*,
+/// `null`, not nothing (#1521). Oracle-confirmed: `jq -n 'last(empty)'` is
+/// `null`, as is `[] | last(.[])`.
+///
+/// `first(f)` is deliberately **not** symmetric and must not be "fixed" to
+/// match: it is `label $out | (f, break $out)`, which simply has nothing to
+/// yield, and `jq -n 'first(empty)'` is genuinely empty. The asymmetry is in
+/// jq's own definitions, so ADR-0018 rule 3 says reproduce it. (The *0-arity*
+/// `first`/`last` are `.[0]`/`.[-1]` and answer `null` on `[]`; that is a
+/// different construct and already correct.)
+///
+/// The operand is evaluated with `optional: false` even when this call is
+/// `last(f)?`, and the error is suppressed here instead: `last` has to tell
+/// "the stream was empty" (answer `null`) from "the operand raised and `?`
+/// swallowed it" (answer nothing), and once `eval_single` has flattened a
+/// swallowed error into `None` those two are indistinguishable. Oracle:
+/// `last(empty)?` is `null` but `last(error("x"))?` is empty.
 fn eval_last_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let result = eval_single::<W, S>(expr, value, optional);
+    let result = eval_single::<W, S>(expr, value, false);
     match result.materialize_cursor() {
         QueryResult::One(v) => QueryResult::One(v),
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => {
-            if let Some(last) = vs.into_iter().last() {
-                QueryResult::One(last)
-            } else {
-                QueryResult::None
-            }
-        }
+        QueryResult::Many(vs) => match vs.into_iter().last() {
+            Some(last) => QueryResult::One(last),
+            None => QueryResult::Owned(OwnedValue::Null),
+        },
         QueryResult::Owned(v) => QueryResult::Owned(v),
-        QueryResult::ManyOwned(vs) => {
-            if let Some(last) = vs.into_iter().last() {
-                QueryResult::Owned(last)
-            } else {
-                QueryResult::None
-            }
-        }
-        QueryResult::None => QueryResult::None,
+        QueryResult::ManyOwned(vs) => match vs.into_iter().last() {
+            Some(last) => QueryResult::Owned(last),
+            None => QueryResult::Owned(OwnedValue::Null),
+        },
+        QueryResult::None => QueryResult::Owned(OwnedValue::Null),
+        QueryResult::Error(_) if optional => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
@@ -20950,6 +20964,7 @@ fn eval_last_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `last(1,2,error("x"))` raises, it does not answer `2`) — so a
         // `Partial` just surfaces its control, dropping the prefix, the
         // same as `reduce`'s input-stream handling.
+        QueryResult::Partial(_, Control::Error(_)) if optional => QueryResult::None,
         QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
         QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
         QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
@@ -28498,31 +28513,29 @@ fn builtin_last_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let result = eval_single::<W, S>(expr, value, optional);
+    // Same `null`-for-an-empty-stream rule and same `optional` handling as
+    // [`eval_last_expr`]; see its doc comment for why (#1521).
+    let result = eval_single::<W, S>(expr, value, false);
     match result {
         QueryResult::One(v) => QueryResult::Owned(to_owned(&v)),
         QueryResult::OneCursor(c) => QueryResult::Owned(to_owned(&c.value())),
         QueryResult::Owned(v) => QueryResult::Owned(v),
-        QueryResult::Many(results) => {
-            if let Some(last) = results.into_iter().last() {
-                QueryResult::Owned(to_owned(&last))
-            } else {
-                QueryResult::None
-            }
-        }
-        QueryResult::ManyOwned(results) => {
-            if let Some(last) = results.into_iter().last() {
-                QueryResult::Owned(last)
-            } else {
-                QueryResult::None
-            }
-        }
-        QueryResult::None => QueryResult::None,
+        QueryResult::Many(results) => match results.into_iter().last() {
+            Some(last) => QueryResult::Owned(to_owned(&last)),
+            None => QueryResult::Owned(OwnedValue::Null),
+        },
+        QueryResult::ManyOwned(results) => match results.into_iter().last() {
+            Some(last) => QueryResult::Owned(last),
+            None => QueryResult::Owned(OwnedValue::Null),
+        },
+        QueryResult::None => QueryResult::Owned(OwnedValue::Null),
+        QueryResult::Error(_) if optional => QueryResult::None,
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
         // Same semantics as `eval_last_expr`: `last` cannot short-circuit,
         // so a `Partial` just surfaces its control, dropping the prefix.
+        QueryResult::Partial(_, Control::Error(_)) if optional => QueryResult::None,
         QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
         QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
         QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3327,12 +3327,14 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         }
     }
 
-    // `last` evaluates its operand with `optional: false` even for `last(f)?`
-    // and suppresses the error itself below: it must tell "the stream was
-    // empty" (jq answers `null`) from "the operand raised and `?` swallowed
-    // it" (jq answers nothing), and those are indistinguishable once flattened
-    // to `None` (#1521). `first` keeps the existing propagation.
-    let result = eval_single::<S, V>(inner, value, !want_last && optional, cursor);
+    // No local `optional` handling is needed for `last(f)?` here: post-#693,
+    // `Expr::Optional(inner)`'s own dispatch evaluates `inner` with the
+    // *ambient* `optional` (never forced `true`) and catches the resulting
+    // `Error`/`Partial(_, Error)` itself, one layer out. So `optional` is
+    // always `false` on every dispatch path that reaches this function
+    // today, and `last(empty)?` (`null`) vs. `last(error("x"))?` (empty)
+    // stays correct entirely via that outer boundary, not anything here.
+    let result = eval_single::<S, V>(inner, value, optional, cursor);
     if want_last {
         match result {
             GenericResult::One(v) => GenericResult::One(v),
@@ -3373,7 +3375,6 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             // produces exactly one output -- an empty operand answers the
             // seed. `first` is deliberately not symmetric (#1521).
             GenericResult::None => GenericResult::Owned(OwnedValue::Null),
-            GenericResult::Error(_) if optional => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
             GenericResult::Halt(code) => GenericResult::Halt(code),
@@ -3381,7 +3382,6 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             // last one until the stream is exhausted -- so a `Partial` just
             // surfaces its trailing control, dropping the prefix (matches
             // `eval::eval_last_expr`).
-            GenericResult::Partial(_, Control::Error(_)) if optional => GenericResult::None,
             GenericResult::Partial(_, Control::Error(e)) => GenericResult::Error(e),
             GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
             GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3327,23 +3327,28 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         }
     }
 
-    let result = eval_single::<S, V>(inner, value, optional, cursor);
+    // `last` evaluates its operand with `optional: false` even for `last(f)?`
+    // and suppresses the error itself below: it must tell "the stream was
+    // empty" (jq answers `null`) from "the operand raised and `?` swallowed
+    // it" (jq answers nothing), and those are indistinguishable once flattened
+    // to `None` (#1521). `first` keeps the existing propagation.
+    let result = eval_single::<S, V>(inner, value, !want_last && optional, cursor);
     if want_last {
         match result {
             GenericResult::One(v) => GenericResult::One(v),
             GenericResult::OneCursor(c) => GenericResult::OneCursor(c),
             GenericResult::Many(vs) => match vs.into_iter().next_back() {
                 Some(v) => GenericResult::One(v),
-                None => GenericResult::None,
+                None => GenericResult::Owned(OwnedValue::Null),
             },
             GenericResult::ManyCursor(cs) => match cs.into_iter().next_back() {
                 Some(c) => GenericResult::OneCursor(c),
-                None => GenericResult::None,
+                None => GenericResult::Owned(OwnedValue::Null),
             },
             GenericResult::Owned(v) => GenericResult::Owned(v),
             GenericResult::ManyOwned(vs) => match vs.into_iter().next_back() {
                 Some(v) => GenericResult::Owned(v),
-                None => GenericResult::None,
+                None => GenericResult::Owned(OwnedValue::Null),
             },
             // `inner`'s stream has exactly one output (the whole `keys`/
             // `keys_unsorted` result) — forward it unchanged, same as
@@ -3364,7 +3369,11 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             // anything -- whoever consumes the returned `LazySeq` next
             // materializes it, and any error surfaces there.
             GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
-            GenericResult::None => GenericResult::None,
+            // jq's `last(f)` is `reduce f as $x (null; $x)`, which always
+            // produces exactly one output -- an empty operand answers the
+            // seed. `first` is deliberately not symmetric (#1521).
+            GenericResult::None => GenericResult::Owned(OwnedValue::Null),
+            GenericResult::Error(_) if optional => GenericResult::None,
             GenericResult::Error(e) => GenericResult::Error(e),
             GenericResult::Break(label) => GenericResult::Break(label),
             GenericResult::Halt(code) => GenericResult::Halt(code),
@@ -3372,6 +3381,7 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
             // last one until the stream is exhausted -- so a `Partial` just
             // surfaces its trailing control, dropping the prefix (matches
             // `eval::eval_last_expr`).
+            GenericResult::Partial(_, Control::Error(_)) if optional => GenericResult::None,
             GenericResult::Partial(_, Control::Error(e)) => GenericResult::Error(e),
             GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
             GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16774,6 +16774,58 @@ fn test_jq_field_named_input_is_not_an_input_builtin_1309() -> Result<()> {
     Ok(())
 }
 
+/// #1521: `last(f)` over an empty stream answers `null`, not nothing.
+///
+/// jq defines it as `reduce f as $x (null; $x)` and `reduce` always produces
+/// exactly one output, so an empty operand yields the seed. succinctly mapped
+/// the empty case to "no output" in all three of its `last` paths
+/// (`eval_last_expr`, `builtin_last_stream`, `eval_first_or_last_generic`).
+///
+/// Every expectation is pinned jq 1.7.1's own output. The `first` rows are the
+/// guard against over-fixing: jq's `first(f)` is `label $out | (f, break $out)`,
+/// which genuinely yields nothing, and the asymmetry is jq's own — ADR-0018
+/// rule 3 says reproduce it rather than normalise it. The 0-arity `first`/`last`
+/// are `.[0]`/`.[-1]`, a different construct that was already correct.
+#[test]
+fn test_jq_last_of_an_empty_stream_is_null_1521() -> Result<()> {
+    for (filter, input, expected) in [
+        // The fix.
+        ("last(empty)", "null", "null\n"),
+        ("last(.[])", "[]", "null\n"),
+        ("last(limit(0; 1,2))", "null", "null\n"),
+        ("[last(empty)]", "null", "[null]\n"),
+        (r#"last(empty)//"alt""#, "null", "\"alt\"\n"),
+        // `?` must not turn the (non-erroring) empty case into no output...
+        ("last(empty)?", "null", "null\n"),
+        // ...but a genuinely raising operand under `?` still yields nothing,
+        // which is why `last` evaluates its operand unswallowed and suppresses
+        // the error itself.
+        (r#"[last(error("x"))?]"#, "null", "[]\n"),
+        (r#"[last(1,2,error("x"))?]"#, "null", "[]\n"),
+        // `first` is deliberately NOT symmetric.
+        ("[first(empty)]", "null", "[]\n"),
+        ("[first(empty)?]", "null", "[]\n"),
+        // 0-arity forms, unchanged.
+        ("first", "[]", "null\n"),
+        ("last", "[]", "null\n"),
+        // Non-empty `last` unchanged, including nested under iteration.
+        ("last(.[])", "[1,2]", "2\n"),
+        ("[.[] | last(.[])]", "[[1,2],[3]]", "[2,3]\n"),
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-c", filter], Some(input)).expect("last-empty repro runs");
+        assert_eq!(code, 0, "{filter} on {input}: stderr: {stderr}");
+        assert_eq!(stdout, expected, "{filter} on {input}");
+    }
+
+    // An uncaught error still raises rather than answering `null`.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"last(error("x"))"#], Some("null")).expect("last-error repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}");
+    assert!(stderr.contains("): x"), "{stderr}");
+    Ok(())
+}
+
 // #1309 item 2: a truncating combinator over `inputs` must consume only the
 // documents it actually uses. The queue is shared with the CLI's own
 // per-document loop and is non-replayable, so an over-eager drain does not

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8781,6 +8781,32 @@ fn test_first_last_wrapping_computation_gets_scientific_notation_997() -> Result
     Ok(())
 }
 
+/// `last(f)`/`first(f)` are succinctly-only extensions in yq mode -- real yq
+/// (Homebrew v4.53.3) rejects both outright with "lexer: invalid input
+/// text", live-confirmed -- so #1521's "empty operand answers `null`" rule
+/// has no yq oracle to check against. succinctly mirrors jq's own semantics
+/// here by design; this pins that choice on both dispatch routes so a future
+/// change to only one of `eval_generic.rs`'s `eval_first_or_last_generic` or
+/// `eval.rs`'s `eval_last_expr` can't silently regress the other for yq mode.
+#[test]
+fn test_yq_last_of_an_empty_stream_is_null_1521() -> Result<()> {
+    // M2/streaming route.
+    let (out, code) = run_yq_stdin("last(.a[])", "a: []\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+
+    // DOM fallback route (`--sort-keys` forces it past `can_use_m2_streaming`).
+    let (out, code) = run_yq_stdin("last(.a[])", "a: []\n", &["-o=json", "-I=0", "--sort-keys"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+
+    // `first` stays asymmetric here too, same as jq mode (#1521).
+    let (out, code) = run_yq_stdin("first(.a[])", "a: []\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "");
+    Ok(())
+}
+
 /// `succinctly jq` (JSON mode) must be completely unaffected: the fix is
 /// gated on `ControlEscape::Yq`, and jq mode's own analogous formatter gap
 /// (different threshold, out of scope for #997) keeps its pre-existing


### PR DESCRIPTION
Closes #1521.

## The bug

jq defines `last(f)` as `reduce f as $x (null; $x)`, and `reduce` always
produces exactly one output — so an empty operand yields the **seed**.
succinctly mapped the empty case to "no output" in all three of its `last`
paths, a silent wrong answer wherever a `last(...)` operand can be empty:

| filter | jq 1.7.1 | succinctly (before) |
|---|---|---|
| `last(empty)` | `null` | *(nothing)* |
| `[] \| last(.[])` | `null` | *(nothing)* |
| `last(limit(0; 1,2))` | `null` | *(nothing)* |
| `[last(empty)]` | `[null]` | `[]` |
| `last(empty) // "alt"` | `"alt"` | *(nothing)* |

Sites: `eval_last_expr` and `builtin_last_stream` (`src/jq/eval.rs`),
`eval_first_or_last_generic` (`src/jq/eval_generic.rs`).

## `first` is deliberately untouched

jq's `first(f)` is `label $out | (f, break $out)` — it genuinely has nothing to
yield, and `first(empty)` is empty in jq too. **The asymmetry is in jq's own
definitions, so ADR-0018 rule 3 says reproduce it, not normalise it.** The tests
pin `first` explicitly so nobody "fixes" it into symmetry later.

The *0-arity* `first`/`last` are `.[0]`/`.[-1]` — a different construct that
already answered `null` on an empty array. Also pinned.

## The subtlety: `?`

```
jq -n 'last(empty)?'        => null      # nothing raised; the seed still applies
jq -n '[last(error("x"))?]' => []        # the operand raised; ? swallows the output
```

So the empty case **cannot** be read off a `None` result — `eval_single`
flattens a `?`-swallowed error into exactly the same `None`. All three paths now
evaluate the operand with `optional: false` and suppress the error themselves,
which keeps every error shape byte-identical while making the empty case
answerable.

`eval_first_or_last_generic` shares one `eval_single` call between its `first`
and `last` branches, so that change is scoped to the `last` branch
(`!want_last && optional`) rather than applied to both.

## Verification

25 shapes against pinned jq 1.7.1 — the fix, the full `?`/error matrix, the
`first` non-regression, and non-empty `last` including nesting — **all
matching**.

Re-ran #1508's 1155-case differential sweep:

```
before: TOTAL=1155 DIFFS=34
after:  TOTAL=1155 DIFFS=18
```

The 16 that disappeared are this bug (13 of the 34, plus 3 `-s -n` variants).
The remaining 18 are entirely **#1504** (`inputs | input_line_number`
interleaving) and **#1520** (`--slurp` value location) — both already filed,
neither touched here.

Gates: `test-jq-cli` / `test-yq-cli` / `test-default` / golden + parity +
error-message suites / `clippy -D warnings` / `fmt` / `--no-default-features`
all PASS.

Refs #1508
