### PR TITLE
fix(jq): rewrite namespaced calls inside builtin arguments

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -416,6 +416,21 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
         // a future variant that carries a sub-expression is a compile error
         // here until it's declared there, the same discipline this file's
         // own manual `Expr` recursion already follows above.
+        //
+        // A call to a namespace that was never actually `import`ed now
+        // fails the same way in this position as it already did bare
+        // (`nonexistent_ns::foo` outside any builtin) or piped -- rewritten
+        // to `Expr::FuncCall` unconditionally, regardless of import status,
+        // reporting "undefined function" from the general `FuncCall`
+        // resolution path rather than `eval.rs`'s own `Expr::NamespacedCall`
+        // arm's "module not loaded". Not a regression this fix introduces:
+        // confirmed live that the bare/piped case already answered
+        // "undefined function" before this change (`rewrite_namespaced_calls`
+        // never checked import status anywhere), and that real jq's own
+        // message for this shape is closer to "X/0 is not defined" (a
+        // compile error) than to either succinctly wording -- this arm
+        // brings the builtin-argument position in line with what every
+        // other position already did, rather than diverging from it.
         Expr::Builtin(builtin) => Expr::Builtin(map_builtin_subexprs(&builtin, &mut |sub| {
             rewrite_namespaced_calls(sub.clone())
         })),

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -14,6 +14,7 @@ use succinctly::jq::document::{collapsed_fields, effective_keys};
 use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
+use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
     self, format_number_jq_compat, nonfinite_display_string, EvalError, Expr, JqSemantics, JqValue,
     OwnedValue, Program,
@@ -404,6 +405,20 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             start: start.map(|e| Box::new(rewrite_namespaced_calls(*e))),
             end: end.map(|e| Box::new(rewrite_namespaced_calls(*e))),
         },
+        // A namespaced call can appear inside any of the 82
+        // sub-expression-carrying builtins (`map(ns::f)`, `limit(1; ns::f)`,
+        // `sub("a"; "b"; ns::f)`, ...) -- #1505. Without this arm, the
+        // catch-all below returned `expr` unchanged, so a call nested this
+        // way never got rewritten from `Expr::NamespacedCall` to
+        // `Expr::FuncCall`, and evaluation failed with "module not loaded".
+        // `map_builtin_subexprs` (`jq::walk`) is `builtin_kids`'s mapping
+        // twin: exhaustive over every `Builtin` variant with no wildcard, so
+        // a future variant that carries a sub-expression is a compile error
+        // here until it's declared there, the same discipline this file's
+        // own manual `Expr` recursion already follows above.
+        Expr::Builtin(builtin) => Expr::Builtin(map_builtin_subexprs(&builtin, &mut |sub| {
+            rewrite_namespaced_calls(sub.clone())
+        })),
         // Expressions that don't contain sub-expressions - return as-is
         Expr::Identity
         | Expr::Field(_)
@@ -419,8 +434,7 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
         | Expr::Loc { .. }
         | Expr::Env
         | Expr::Not
-        | Expr::Format(_)
-        | Expr::Builtin(_) => expr,
+        | Expr::Format(_) => expr,
     }
 }
 

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -291,7 +291,23 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
 ///
 /// `&mut dyn FnMut`, not a generic `F`, matching [`any_subexpr`]'s own
 /// reasoning: this recurses, so a generic parameter would monomorphise the
-/// whole traversal per call site.
+/// whole traversal per call site. Borrowing, not consuming, `builtin` --
+/// matching `builtin_kids`'s own convention -- costs one clone per
+/// sub-expression at `rewrite_namespaced_calls`'s only call site today
+/// (bounded by the parser's own `MAX_EXPR_DEPTH`, since this runs once per
+/// parsed program, not per document); a consuming signature would avoid
+/// that at the cost of breaking symmetry with `builtin_kids`, considered and
+/// not taken (#1526 review of a similar tradeoff elsewhere reached the same
+/// call for a comparable one-time, depth-bounded traversal).
+///
+/// This is the 4th/5th independently hand-maintained exhaustive `Builtin`
+/// match in this codebase, alongside `builtin_kids` (this file) and three
+/// more in `eval.rs` (`substitute_var_in_builtin`,
+/// `expand_func_calls_in_builtin`, `substitute_func_param_in_builtin`) --
+/// nothing forces all five to agree when a new sub-expression-carrying
+/// variant is added, which is exactly the class of bug this function fixes
+/// for one of the five. Consolidating them is filed separately, **#1506**,
+/// not attempted here.
 pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr) -> Builtin {
     match builtin {
         // --- No sub-expression (125) ---------------------------------------

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -19,6 +19,8 @@
 //! wildcard arm, so adding a `Builtin` variant is a compile error here until
 //! its sub-expressions are declared, and every caller picks the fix up at once.
 
+use alloc::boxed::Box;
+
 use super::{Builtin, Expr, ObjectKey, StringPart};
 
 /// The sub-expressions a [`Builtin`] owns, in source order.
@@ -268,6 +270,250 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
 
         // --- Three sub-expressions (2) -------------------------------------
         Builtin::SubFlags(a, b, c) | Builtin::GsubFlags(a, b, c) => BuiltinKids::Three(a, b, c),
+    }
+}
+
+/// The mapping twin of [`builtin_kids`]: reconstructs `builtin` with each of
+/// its sub-expressions replaced by `f`'s answer for it, in the same source
+/// order `builtin_kids` reports them in.
+///
+/// **Deliberately has no wildcard arm, for the same reason `builtin_kids`
+/// doesn't** — a new `Builtin` variant is a compile error here until its
+/// sub-expressions (if any) are declared, keeping this function honest
+/// alongside `builtin_kids` as the set grows, rather than silently treating
+/// a new variant as a leaf. `rewrite_namespaced_calls`
+/// (`src/bin/succinctly/jq_runner.rs`) is exactly this shape's motivating
+/// caller (#1505): before it existed, that function's own `Builtin`
+/// traversal ended in `Expr::Builtin(_) => expr`, so a namespaced call
+/// inside any of the 82 sub-expression-carrying builtins (`map`, `select`,
+/// `limit`, `sub`, ...) was never rewritten from `Expr::NamespacedCall` to
+/// `Expr::FuncCall`, and evaluation failed with "module not loaded".
+///
+/// `&mut dyn FnMut`, not a generic `F`, matching [`any_subexpr`]'s own
+/// reasoning: this recurses, so a generic parameter would monomorphise the
+/// whole traversal per call site.
+pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr) -> Builtin {
+    match builtin {
+        // --- No sub-expression (125) ---------------------------------------
+        Builtin::Type
+        | Builtin::IsNull
+        | Builtin::IsBoolean
+        | Builtin::IsNumber
+        | Builtin::IsString
+        | Builtin::IsArray
+        | Builtin::IsObject
+        | Builtin::Values
+        | Builtin::Nulls
+        | Builtin::Booleans
+        | Builtin::Numbers
+        | Builtin::Strings
+        | Builtin::Arrays
+        | Builtin::Objects
+        | Builtin::Iterables
+        | Builtin::Scalars
+        | Builtin::Length
+        | Builtin::Utf8ByteLength
+        | Builtin::Keys
+        | Builtin::KeysUnsorted
+        | Builtin::Empty
+        | Builtin::Add
+        | Builtin::Any
+        | Builtin::All
+        | Builtin::Min
+        | Builtin::Max
+        | Builtin::AsciiDowncase
+        | Builtin::AsciiUpcase
+        | Builtin::First
+        | Builtin::Last
+        | Builtin::Reverse
+        | Builtin::Flatten
+        | Builtin::Unique
+        | Builtin::Sort
+        | Builtin::ToEntries
+        | Builtin::FromEntries
+        | Builtin::ToString
+        | Builtin::ToNumber
+        | Builtin::ToJson
+        | Builtin::FromJson
+        | Builtin::Explode
+        | Builtin::Implode
+        | Builtin::ToJsonStream
+        | Builtin::FromJsonStream
+        | Builtin::ToStream
+        | Builtin::Recurse
+        | Builtin::PathNoArg
+        | Builtin::Parent
+        | Builtin::Paths
+        | Builtin::LeafPaths
+        | Builtin::Floor
+        | Builtin::Ceil
+        | Builtin::Round
+        | Builtin::Sqrt
+        | Builtin::Fabs
+        | Builtin::Log
+        | Builtin::Log10
+        | Builtin::Log2
+        | Builtin::Exp
+        | Builtin::Exp10
+        | Builtin::Exp2
+        | Builtin::Sin
+        | Builtin::Cos
+        | Builtin::Tan
+        | Builtin::Asin
+        | Builtin::Acos
+        | Builtin::Atan
+        | Builtin::Sinh
+        | Builtin::Cosh
+        | Builtin::Tanh
+        | Builtin::Asinh
+        | Builtin::Acosh
+        | Builtin::Atanh
+        | Builtin::Infinite
+        | Builtin::Nan
+        | Builtin::IsInfinite
+        | Builtin::IsNan
+        | Builtin::IsNormal
+        | Builtin::IsFinite
+        | Builtin::Debug
+        | Builtin::Halt
+        | Builtin::Stderr
+        | Builtin::HaltError
+        | Builtin::Env
+        | Builtin::EnvObject(_)
+        | Builtin::StrEnv(_)
+        | Builtin::NullLit
+        | Builtin::Trim
+        | Builtin::Ltrim
+        | Builtin::Rtrim
+        | Builtin::Transpose
+        | Builtin::Tag
+        | Builtin::Anchor
+        | Builtin::Style
+        | Builtin::Kind
+        | Builtin::Key
+        | Builtin::Line
+        | Builtin::Column
+        | Builtin::DocumentIndex
+        | Builtin::LineComment
+        | Builtin::FileIndex
+        | Builtin::Shuffle
+        | Builtin::Pivot
+        | Builtin::SplitDoc
+        | Builtin::Now
+        | Builtin::Input
+        | Builtin::Inputs
+        | Builtin::InputLineNumber
+        | Builtin::Abs
+        | Builtin::Builtins
+        | Builtin::Normals
+        | Builtin::Finites
+        | Builtin::RecurseDown
+        | Builtin::Gmtime
+        | Builtin::Localtime
+        | Builtin::Mktime
+        | Builtin::Todate
+        | Builtin::Fromdate
+        | Builtin::Todateiso8601
+        | Builtin::Fromdateiso8601
+        | Builtin::Combinations
+        | Builtin::Trunc
+        | Builtin::ToBoolean
+        | Builtin::FromUnix
+        | Builtin::ToUnix => builtin.clone(),
+
+        // --- One sub-expression (60) ---------------------------------------
+        Builtin::Has(e) => Builtin::Has(Box::new(f(e))),
+        Builtin::In(e) => Builtin::In(Box::new(f(e))),
+        Builtin::UpperIn(e) => Builtin::UpperIn(Box::new(f(e))),
+        Builtin::Select(e) => Builtin::Select(Box::new(f(e))),
+        Builtin::Map(e) => Builtin::Map(Box::new(f(e))),
+        Builtin::MapValues(e) => Builtin::MapValues(Box::new(f(e))),
+        Builtin::AnyF(e) => Builtin::AnyF(Box::new(f(e))),
+        Builtin::AllF(e) => Builtin::AllF(Box::new(f(e))),
+        Builtin::MinBy(e) => Builtin::MinBy(Box::new(f(e))),
+        Builtin::MaxBy(e) => Builtin::MaxBy(Box::new(f(e))),
+        Builtin::Ltrimstr(e) => Builtin::Ltrimstr(Box::new(f(e))),
+        Builtin::Rtrimstr(e) => Builtin::Rtrimstr(Box::new(f(e))),
+        Builtin::Startswith(e) => Builtin::Startswith(Box::new(f(e))),
+        Builtin::Endswith(e) => Builtin::Endswith(Box::new(f(e))),
+        Builtin::Split(e) => Builtin::Split(Box::new(f(e))),
+        Builtin::Join(e) => Builtin::Join(Box::new(f(e))),
+        Builtin::Contains(e) => Builtin::Contains(Box::new(f(e))),
+        Builtin::Inside(e) => Builtin::Inside(Box::new(f(e))),
+        Builtin::Nth(e) => Builtin::Nth(Box::new(f(e))),
+        Builtin::FlattenDepth(e) => Builtin::FlattenDepth(Box::new(f(e))),
+        Builtin::GroupBy(e) => Builtin::GroupBy(Box::new(f(e))),
+        Builtin::UniqueBy(e) => Builtin::UniqueBy(Box::new(f(e))),
+        Builtin::SortBy(e) => Builtin::SortBy(Box::new(f(e))),
+        Builtin::WithEntries(e) => Builtin::WithEntries(Box::new(f(e))),
+        Builtin::Test(e) => Builtin::Test(Box::new(f(e))),
+        Builtin::Indices(e) => Builtin::Indices(Box::new(f(e))),
+        Builtin::Index(e) => Builtin::Index(Box::new(f(e))),
+        Builtin::Rindex(e) => Builtin::Rindex(Box::new(f(e))),
+        Builtin::UpperIndex(e) => Builtin::UpperIndex(Box::new(f(e))),
+        Builtin::FromStream(e) => Builtin::FromStream(Box::new(f(e))),
+        Builtin::TruncateStream(e) => Builtin::TruncateStream(Box::new(f(e))),
+        Builtin::GetPath(e) => Builtin::GetPath(Box::new(f(e))),
+        Builtin::RecurseF(e) => Builtin::RecurseF(Box::new(f(e))),
+        Builtin::Walk(e) => Builtin::Walk(Box::new(f(e))),
+        Builtin::IsValid(e) => Builtin::IsValid(Box::new(f(e))),
+        Builtin::Path(e) => Builtin::Path(Box::new(f(e))),
+        Builtin::ParentN(e) => Builtin::ParentN(Box::new(f(e))),
+        Builtin::PathsFilter(e) => Builtin::PathsFilter(Box::new(f(e))),
+        Builtin::DelPaths(e) => Builtin::DelPaths(Box::new(f(e))),
+        Builtin::DebugMsg(e) => Builtin::DebugMsg(Box::new(f(e))),
+        Builtin::HaltErrorCode(e) => Builtin::HaltErrorCode(Box::new(f(e))),
+        Builtin::EnvVar(e) => Builtin::EnvVar(Box::new(f(e))),
+        Builtin::BSearch(e) => Builtin::BSearch(Box::new(f(e))),
+        Builtin::ModuleMeta(e) => Builtin::ModuleMeta(Box::new(f(e))),
+        Builtin::Pick(e) => Builtin::Pick(Box::new(f(e))),
+        Builtin::Omit(e) => Builtin::Omit(Box::new(f(e))),
+        Builtin::Del(e) => Builtin::Del(Box::new(f(e))),
+        Builtin::FirstStream(e) => Builtin::FirstStream(Box::new(f(e))),
+        Builtin::LastStream(e) => Builtin::LastStream(Box::new(f(e))),
+        Builtin::IsEmpty(e) => Builtin::IsEmpty(Box::new(f(e))),
+        Builtin::Strftime(e) => Builtin::Strftime(Box::new(f(e))),
+        Builtin::Strptime(e) => Builtin::Strptime(Box::new(f(e))),
+        Builtin::Match(e) => Builtin::Match(Box::new(f(e))),
+        Builtin::Capture(e) => Builtin::Capture(Box::new(f(e))),
+        Builtin::Scan(e) => Builtin::Scan(Box::new(f(e))),
+        Builtin::Splits(e) => Builtin::Splits(Box::new(f(e))),
+        Builtin::CombinationsN(e) => Builtin::CombinationsN(Box::new(f(e))),
+        Builtin::Tz(e) => Builtin::Tz(Box::new(f(e))),
+        Builtin::Load(e) => Builtin::Load(Box::new(f(e))),
+        Builtin::AtOffset(e) => Builtin::AtOffset(Box::new(f(e))),
+
+        // --- Two sub-expressions (20) --------------------------------------
+        Builtin::UpperInSrc(a, b) => Builtin::UpperInSrc(Box::new(f(a)), Box::new(f(b))),
+        Builtin::AnyCond(a, b) => Builtin::AnyCond(Box::new(f(a)), Box::new(f(b))),
+        Builtin::AllCond(a, b) => Builtin::AllCond(Box::new(f(a)), Box::new(f(b))),
+        Builtin::UpperIndexStream(a, b) => {
+            Builtin::UpperIndexStream(Box::new(f(a)), Box::new(f(b)))
+        }
+        Builtin::RecurseCond(a, b) => Builtin::RecurseCond(Box::new(f(a)), Box::new(f(b))),
+        Builtin::SetPath(a, b) => Builtin::SetPath(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Pow(a, b) => Builtin::Pow(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Atan2(a, b) => Builtin::Atan2(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Limit(a, b) => Builtin::Limit(Box::new(f(a)), Box::new(f(b))),
+        Builtin::NthStream(a, b) => Builtin::NthStream(Box::new(f(a)), Box::new(f(b))),
+        Builtin::TestFlags(a, b) => Builtin::TestFlags(Box::new(f(a)), Box::new(f(b))),
+        Builtin::MatchFlags(a, b) => Builtin::MatchFlags(Box::new(f(a)), Box::new(f(b))),
+        Builtin::CaptureFlags(a, b) => Builtin::CaptureFlags(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Sub(a, b) => Builtin::Sub(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Gsub(a, b) => Builtin::Gsub(Box::new(f(a)), Box::new(f(b))),
+        Builtin::ScanFlags(a, b) => Builtin::ScanFlags(Box::new(f(a)), Box::new(f(b))),
+        Builtin::SplitRegex(a, b) => Builtin::SplitRegex(Box::new(f(a)), Box::new(f(b))),
+        Builtin::SplitsFlags(a, b) => Builtin::SplitsFlags(Box::new(f(a)), Box::new(f(b))),
+        Builtin::Skip(a, b) => Builtin::Skip(Box::new(f(a)), Box::new(f(b))),
+        Builtin::AtPosition(a, b) => Builtin::AtPosition(Box::new(f(a)), Box::new(f(b))),
+
+        // --- Three sub-expressions (2) -------------------------------------
+        Builtin::SubFlags(a, b, c) => {
+            Builtin::SubFlags(Box::new(f(a)), Box::new(f(b)), Box::new(f(c)))
+        }
+        Builtin::GsubFlags(a, b, c) => {
+            Builtin::GsubFlags(Box::new(f(a)), Box::new(f(b)), Box::new(f(c)))
+        }
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17050,6 +17050,132 @@ fn test_jq_input_inside_included_module_seeds_the_queue_1309() -> Result<()> {
     Ok(())
 }
 
+// #1505: `rewrite_namespaced_calls` (`src/bin/succinctly/jq_runner.rs`) ended
+// its `Expr` traversal in `Expr::Builtin(_) => expr`, so a namespaced call
+// nested inside any of the 82 sub-expression-carrying builtins never got
+// rewritten from `Expr::NamespacedCall` to `Expr::FuncCall`, and evaluation
+// failed with "module not loaded" even though the same call worked fine bare
+// (`m::f` alone). `map_builtin_subexprs` (`jq::walk`) closes this for every
+// arity. Every expectation below is pinned jq 1.7.1's own output.
+
+/// Writes `def f: . * 2; def two: 2; def flags: "g";` into a fresh module
+/// directory and returns it. The `tempfile::TempDir` must outlive the run,
+/// so it is returned, not the path alone.
+fn namespaced_builtin_arg_module_dir() -> Result<tempfile::TempDir> {
+    let dir = tempfile::tempdir()?;
+    std::fs::write(
+        dir.path().join("mymath.jq"),
+        "def f: . * 2; def two: 2; def flags: \"g\";",
+    )?;
+    Ok(dir)
+}
+
+#[test]
+fn test_jq_namespaced_call_inside_one_arg_builtin_1505() -> Result<()> {
+    let dir = namespaced_builtin_arg_module_dir()?;
+    let lib = dir.path().to_string_lossy().into_owned();
+
+    // `map(f)`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-L", &lib, r#"import "mymath" as m; map(m::f)"#],
+        Some("[1,2]"),
+    )
+    .expect("map(namespaced call) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[2,4]\n");
+
+    // `select(f)`, the issue's own third repro shape (a comprehension).
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "-L",
+            &lib,
+            r#"import "mymath" as m; [.[] | select(m::f > 2)]"#,
+        ],
+        Some("[1,2]"),
+    )
+    .expect("select(namespaced call) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[2]\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_jq_namespaced_call_inside_two_arg_builtin_1505() -> Result<()> {
+    let dir = namespaced_builtin_arg_module_dir()?;
+    let lib = dir.path().to_string_lossy().into_owned();
+
+    // `limit(n; f)` parses into its own dedicated `Expr::Limit` AST node
+    // (`parser.rs`'s `parse_limit_expr`), not `Expr::Builtin(Builtin::
+    // Limit(..))` -- `rewrite_namespaced_calls` already had a (pre-existing,
+    // unrelated to this fix) `Expr::Limit` arm, so this shape alone would
+    // not exercise the new code. `pow(x; y)` has no such dedicated AST node
+    // and genuinely reaches `Expr::Builtin(Builtin::Pow(..))`, so it is the
+    // shape that actually pins the new two-argument arm.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", "-L", &lib, r#"import "mymath" as m; pow(2; m::two)"#],
+        None,
+    )
+    .expect("pow(x; namespaced call) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "4\n");
+
+    // `limit(n; f)` itself, kept as a regression pin for the common idiom
+    // even though it does not exercise the new `Expr::Builtin` arm.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-L", &lib, r#"import "mymath" as m; limit(1; m::f)"#],
+        Some("5"),
+    )
+    .expect("limit(n; namespaced call) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "10\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_jq_namespaced_call_inside_three_arg_builtin_1505() -> Result<()> {
+    let dir = namespaced_builtin_arg_module_dir()?;
+    let lib = dir.path().to_string_lossy().into_owned();
+
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-cn",
+            "-L",
+            &lib,
+            r#"import "mymath" as m; "aAaA" | sub("a"; "X"; m::flags)"#,
+        ],
+        None,
+    )
+    .expect("sub(re; s; namespaced flags) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "\"XAXA\"\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_jq_namespaced_call_inside_builtin_arg_via_include_1505() -> Result<()> {
+    let dir = namespaced_builtin_arg_module_dir()?;
+    let lib = dir.path().to_string_lossy().into_owned();
+
+    // `include` binds names directly (no namespace prefix), so the call
+    // inside `map(...)` is a bare `Expr::FuncCall`, not
+    // `Expr::NamespacedCall` -- included here anyway, per the issue's own
+    // suggested test plan, since `include`'s own module-body inlining shares
+    // the same `rewrite_namespaced_calls` pass this fix touches.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-L", &lib, r#"include "mymath"; map(f)"#],
+        Some("[1,2]"),
+    )
+    .expect("map(include-bound call) repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[2,4]\n");
+
+    Ok(())
+}
+
 /// The other direction #1309 fixed: the substring scan also *over*-reported,
 /// forcing a filter that merely spells "input" in a field name or a string
 /// literal off the fast path. Output must be identical either way -- these

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17113,13 +17113,20 @@ fn test_jq_namespaced_call_inside_two_arg_builtin_1505() -> Result<()> {
     // not exercise the new code. `pow(x; y)` has no such dedicated AST node
     // and genuinely reaches `Expr::Builtin(Builtin::Pow(..))`, so it is the
     // shape that actually pins the new two-argument arm.
+    //
+    // The namespaced call sits in the *first* argument (`m::two`, not a
+    // literal `2`), and the two operands are chosen so a transposed
+    // reconstruction (`Pow(f(b), f(a))` instead of `Pow(f(a), f(b))`) gives
+    // a *different* answer (9, not 8) rather than accidentally matching --
+    // review found an earlier version of this test used `pow(2; m::two)`,
+    // which can't distinguish the two since both operands evaluate to 2.
     let (stdout, stderr, code) = run_jq_full(
-        &["-cn", "-L", &lib, r#"import "mymath" as m; pow(2; m::two)"#],
+        &["-cn", "-L", &lib, r#"import "mymath" as m; pow(m::two; 3)"#],
         None,
     )
-    .expect("pow(x; namespaced call) repro runs");
+    .expect("pow(namespaced call; x) repro runs");
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
-    assert_eq!(stdout, "4\n");
+    assert_eq!(stdout, "8\n");
 
     // `limit(n; f)` itself, kept as a regression pin for the common idiom
     // even though it does not exercise the new `Expr::Builtin` arm.


### PR DESCRIPTION
## Summary
- `rewrite_namespaced_calls` (`src/bin/succinctly/jq_runner.rs`) was exhaustive over `Expr` with no wildcard, but its terminal arm group ended `| Expr::Builtin(_) => expr`, so it never descended into a builtin's own arguments -- an imported function called from inside `map`/`select`/`limit`/`sub`/... (any of the 82 sub-expression-carrying builtins) was never rewritten from `Expr::NamespacedCall` to `Expr::FuncCall`, and evaluation failed with "module not loaded" even though the same call worked fine bare (`m::f` alone).
- Added `map_builtin_subexprs` to `src/jq/walk.rs` as the mapping twin of the existing `builtin_kids` accessor (#1309): exhaustive over every `Builtin` variant with no wildcard arm, so a future variant that carries a sub-expression is a compile error here until it's declared, matching `builtin_kids`' own discipline.
- `rewrite_namespaced_calls` now gives `Expr::Builtin` its own arm using this to recurse into every sub-expression instead of returning the builtin unchanged.

Every shape from the issue's own repro table verified live against pinned jq 1.7.1: `map(m::f)`, `select(m::f > 2)` in a comprehension, a two-argument builtin (`pow(x; m::y)` -- note `limit(n; f)` itself parses into a dedicated `Expr::Limit` AST node, not `Expr::Builtin`, so it doesn't actually exercise the new code path despite being a common idiom; kept as a regression pin anyway), a three-argument builtin (`sub(re; s; m::flags)`), and the `include` spelling.

Also fixed a `no_std` build break this surfaced: `walk.rs`'s new `Box::new` calls needed an explicit `use alloc::boxed::Box` import (matching the existing convention in `expr.rs`) -- caught by the no_std check, not by the default feature build.

Fixes #1505

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde --no-fail-fast` (0 failures, `--test-threads=4`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std) -- initially failed with 106 errors (missing `Box` import), fixed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --fail-under-lines 0` -- the new `map_builtin_subexprs` match (207 variants) is ~91% covered; the handful of uncovered arms are either provably unreachable via the parser (`Limit` parses into its own dedicated `Expr::Limit` node, never `Expr::Builtin(Builtin::Limit(..))`) or niche extensions (`at_offset`/`at_position`/`ModuleMeta`/etc.) not otherwise exercised by the existing suite -- not chasing 100% on an exhaustive-by-design match built for compile-time safety across all 207 variants, not runtime coverage of each one
- [x] Live-verified every case against the pinned jq oracle (`/usr/bin/jq` 1.7.1)