### PR TITLE
test(cli): report a signal-killed cargo run child as such, not as -1

### DIFF
--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -27,20 +27,44 @@ const MAX_CARGO_RETRIES: u32 = 3;
 /// mid-replacement and fail with `ENOENT` (#550).
 const MAX_SPAWN_RETRIES: u32 = 3;
 
+/// Builds the "child was killed by signal N" error for a signal-terminated
+/// process (`ExitStatus::code()` returns `None` only in that case, on
+/// Unix), naming the signal and the captured stderr -- shared by
+/// `classify_cargo_run_exit` below and by `run_jq_full`, which spawns the
+/// pre-built binary directly rather than through `cargo run` and so has no
+/// retry loop to hook a classifier into, but is just as exposed to a
+/// signal-killed child under heavy concurrent load. Historically both
+/// silently coerced this to `-1` via `.code().unwrap_or(-1)`, which renders
+/// as an inscrutable `left: -1, right: 0` with no indication a child was
+/// ever killed -- exactly what cost a wrong root-cause call in the #1459
+/// review (#1516).
+fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
+    // `ExitStatus::code()` returns `None` only when the child was
+    // terminated by a signal (Unix) -- there is no other cause.
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    anyhow::anyhow!(
+        "child was killed by signal {}; stderr:\n{stderr}",
+        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
+    )
+}
+
 /// Classifies a `cargo run` child's exit for the retry loops below, so each
-/// of the four call sites doesn't hand-roll the same "retry on 101" check
-/// (and, historically, the same bug: silently coercing a signal death to
-/// `-1` via `.code().unwrap_or(-1)`).
+/// of the four call sites doesn't hand-roll the same "retry on 101" check.
 ///
 /// Returns `Ok(Some(code))` once a real exit code is available to the
 /// caller, or `Ok(None)` when the caller should sleep (per `attempt`) and
 /// retry -- covering both the existing `101` lock-contention case and a
-/// signal death within `MAX_CARGO_RETRIES` attempts. Once retries are
-/// exhausted on a signal death, returns `Err` naming the signal and the
-/// captured stderr, instead of letting the caller's exit-code assertion
-/// render as an inscrutable `left: -1, right: 0` with no indication a child
-/// was ever killed -- which is exactly what cost a wrong root-cause call in
-/// the #1459 review (#1516).
+/// signal death within `MAX_CARGO_RETRIES` attempts (a signal death under
+/// the same heavy concurrent load -- an OOM kill, another session's
+/// `pkill`, or fallout from that same lock contention -- is just as
+/// plausible as `101` is). Once retries are exhausted on a signal death,
+/// returns the `signal_death_error` above instead of `Ok(Some(-1))`.
 fn classify_cargo_run_exit(
     status: std::process::ExitStatus,
     stderr: &str,
@@ -52,24 +76,10 @@ fn classify_cargo_run_exit(
         }
         return Ok(Some(code));
     }
-
-    // `ExitStatus::code()` returns `None` only when the child was
-    // terminated by a signal (Unix) -- there is no other cause.
     if attempt + 1 < MAX_CARGO_RETRIES {
         return Ok(None);
     }
-    #[cfg(unix)]
-    let signal = {
-        use std::os::unix::process::ExitStatusExt;
-        status.signal()
-    };
-    #[cfg(not(unix))]
-    let signal: Option<i32> = None;
-    anyhow::bail!(
-        "cargo run child was killed by signal {} after {} attempt(s); stderr:\n{stderr}",
-        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
-        attempt + 1,
-    );
+    Err(signal_death_error(status, stderr))
 }
 
 /// #1516: a signal-killed child used to render as an inscrutable
@@ -108,11 +118,18 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
     );
 
     // Within the retry budget, the same signal death asks the caller to
-    // retry instead of erroring immediately.
+    // retry instead of erroring immediately -- at both the first attempt
+    // and an interior one (`MAX_CARGO_RETRIES` is 3, so attempt 1 is the
+    // only non-boundary value).
     assert_eq!(
         classify_cargo_run_exit(killed, "", 0).unwrap(),
         None,
         "a signal death within retry budget should ask for a retry"
+    );
+    assert_eq!(
+        classify_cargo_run_exit(killed, "", 1).unwrap(),
+        None,
+        "a signal death on an interior attempt should still ask for a retry"
     );
 
     // Exit code 101 (lock contention) keeps its pre-existing retry
@@ -127,6 +144,11 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
         classify_cargo_run_exit(contention, "", 0).unwrap(),
         None,
         "101 within retry budget should still retry"
+    );
+    assert_eq!(
+        classify_cargo_run_exit(contention, "", 1).unwrap(),
+        None,
+        "101 on an interior attempt should still retry"
     );
     assert_eq!(
         classify_cargo_run_exit(contention, "", MAX_CARGO_RETRIES - 1).unwrap(),
@@ -187,13 +209,15 @@ fn run_jq_stdin_streams(
         }
 
         let output = cmd.wait_with_output()?;
-        let stderr = String::from_utf8(output.stderr)?;
-        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
+        let lossy_stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) = classify_cargo_run_exit(output.status, &lossy_stderr, attempt)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
         };
 
         let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
         return Ok((stdout, stderr, exit_code));
     }
     unreachable!()
@@ -221,11 +245,12 @@ fn run_jq_full(args: &[&str], input: Option<&str>) -> Result<(String, String, i3
     }
 
     let output = cmd.wait_with_output()?;
-    Ok((
-        String::from_utf8(output.stdout)?,
-        String::from_utf8(output.stderr)?,
-        output.status.code().unwrap_or(-1),
-    ))
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    Ok((stdout, stderr, exit_code))
 }
 
 /// Spawns the pre-built `succinctly` binary, retrying on `ENOENT`.
@@ -260,6 +285,7 @@ fn run_jq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
         let output = Command::new("cargo")
             .args([
                 "run",
+                "--quiet",
                 "--features",
                 "cli",
                 "--bin",
@@ -290,6 +316,7 @@ fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
         let output = Command::new("cargo")
             .args([
                 "run",
+                "--quiet",
                 "--features",
                 "cli",
                 "--bin",
@@ -3528,6 +3555,7 @@ fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Resul
         let mut cmd = Command::new("cargo")
             .args([
                 "run",
+                "--quiet",
                 "--features",
                 "cli",
                 "--bin",

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10,8 +10,13 @@ use std::time::Duration;
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
-/// Maximum retries for cargo run commands that fail with exit code 101.
-/// This handles flaky failures from cargo lock contention when tests run in parallel.
+/// Maximum retries for cargo run commands that fail with exit code 101, or
+/// whose child is killed by a signal (`ExitStatus::code()` returns `None`
+/// only in that case, on Unix). Both are treated as transient: `101` often
+/// means cargo lock contention between concurrently running tests, and a
+/// signal death under the same heavy concurrent load (an OOM kill, another
+/// session's `pkill`, or fallout from that same lock contention) is just as
+/// likely to be environmental as a real bug in the code under test (#1516).
 const MAX_CARGO_RETRIES: u32 = 3;
 
 /// Maximum retries for spawning the pre-built binary directly.
@@ -21,6 +26,125 @@ const MAX_CARGO_RETRIES: u32 = 3;
 /// `run_jq_stdin_streams`). `spawn()` can transiently observe that path
 /// mid-replacement and fail with `ENOENT` (#550).
 const MAX_SPAWN_RETRIES: u32 = 3;
+
+/// Classifies a `cargo run` child's exit for the retry loops below, so each
+/// of the four call sites doesn't hand-roll the same "retry on 101" check
+/// (and, historically, the same bug: silently coercing a signal death to
+/// `-1` via `.code().unwrap_or(-1)`).
+///
+/// Returns `Ok(Some(code))` once a real exit code is available to the
+/// caller, or `Ok(None)` when the caller should sleep (per `attempt`) and
+/// retry -- covering both the existing `101` lock-contention case and a
+/// signal death within `MAX_CARGO_RETRIES` attempts. Once retries are
+/// exhausted on a signal death, returns `Err` naming the signal and the
+/// captured stderr, instead of letting the caller's exit-code assertion
+/// render as an inscrutable `left: -1, right: 0` with no indication a child
+/// was ever killed -- which is exactly what cost a wrong root-cause call in
+/// the #1459 review (#1516).
+fn classify_cargo_run_exit(
+    status: std::process::ExitStatus,
+    stderr: &str,
+    attempt: u32,
+) -> Result<Option<i32>> {
+    if let Some(code) = status.code() {
+        if code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+            return Ok(None);
+        }
+        return Ok(Some(code));
+    }
+
+    // `ExitStatus::code()` returns `None` only when the child was
+    // terminated by a signal (Unix) -- there is no other cause.
+    if attempt + 1 < MAX_CARGO_RETRIES {
+        return Ok(None);
+    }
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    anyhow::bail!(
+        "cargo run child was killed by signal {} after {} attempt(s); stderr:\n{stderr}",
+        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
+        attempt + 1,
+    );
+}
+
+/// #1516: a signal-killed child used to render as an inscrutable
+/// `left: -1, right: 0` panic -- exercises `classify_cargo_run_exit`
+/// directly against constructed `ExitStatus` values (via
+/// `ExitStatusExt::from_raw`) rather than by actually killing a `cargo run`
+/// child, which would make the test itself exactly as flaky as the bug it
+/// pins.
+#[cfg(unix)]
+#[test]
+fn test_classify_cargo_run_exit_reports_signal_death_1516() {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    // Raw wait-status encoding (see `man 2 wait`): a signal death stores the
+    // signal number in the low 7 bits with no exit-code shift; SIGKILL is 9.
+    let killed = ExitStatus::from_raw(9);
+    assert_eq!(
+        killed.code(),
+        None,
+        "sanity: from_raw(9) must look signal-killed"
+    );
+
+    // On the last allowed attempt, a signal death must be a real error --
+    // naming the signal and the captured stderr -- not `Ok(Some(-1))`.
+    let err = classify_cargo_run_exit(killed, "some stderr output", MAX_CARGO_RETRIES - 1)
+        .expect_err("a signal death on the last attempt must error, not return a fake exit code");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("signal 9"),
+        "expected the signal number in the message: {msg}"
+    );
+    assert!(
+        msg.contains("some stderr output"),
+        "expected captured stderr in the message: {msg}"
+    );
+
+    // Within the retry budget, the same signal death asks the caller to
+    // retry instead of erroring immediately.
+    assert_eq!(
+        classify_cargo_run_exit(killed, "", 0).unwrap(),
+        None,
+        "a signal death within retry budget should ask for a retry"
+    );
+
+    // Exit code 101 (lock contention) keeps its pre-existing retry
+    // behavior unchanged.
+    let contention = ExitStatus::from_raw(101 << 8);
+    assert_eq!(
+        contention.code(),
+        Some(101),
+        "sanity: from_raw encodes exit code 101"
+    );
+    assert_eq!(
+        classify_cargo_run_exit(contention, "", 0).unwrap(),
+        None,
+        "101 within retry budget should still retry"
+    );
+    assert_eq!(
+        classify_cargo_run_exit(contention, "", MAX_CARGO_RETRIES - 1).unwrap(),
+        Some(101),
+        "101 with no retries left surfaces as-is, same as before this change"
+    );
+
+    // A genuine, non-101 exit code passes through unchanged regardless of
+    // attempt number.
+    assert_eq!(
+        classify_cargo_run_exit(ExitStatus::from_raw(0), "", 0).unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        classify_cargo_run_exit(ExitStatus::from_raw(1 << 8), "", 0).unwrap(),
+        Some(1)
+    );
+}
 
 /// Helper to run jq command with input from stdin
 fn run_jq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
@@ -63,16 +187,13 @@ fn run_jq_stdin_streams(
         }
 
         let output = cmd.wait_with_output()?;
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8(output.stderr)?;
+        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
         let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
         return Ok((stdout, stderr, exit_code));
     }
     unreachable!()
@@ -151,13 +272,11 @@ fn run_jq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
             .arg(file_path)
             .output()?;
 
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
         let stdout = String::from_utf8(output.stdout)?;
         return Ok((stdout, exit_code));
@@ -183,13 +302,11 @@ fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
             .arg(filter)
             .output()?;
 
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
         let stdout = String::from_utf8(output.stdout)?;
         return Ok((stdout, exit_code));
@@ -3430,13 +3547,11 @@ fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Resul
         }
 
         let output = cmd.wait_with_output()?;
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
         return Ok((output.stdout, exit_code));
     }


### PR DESCRIPTION
## Summary

Follow-up to #550, which fixed the ENOENT-at-`spawn()` failure mode of the shared `target/debug/succinctly` path and left this one open (explicitly named as #550's own "option 3, not taken").

Four independent `cargo run`-based helpers in `tests/jq_cli_tests.rs` (`run_jq_stdin_streams`, `run_jq_file`, `run_jq_null`, `run_jq_binary_stdin`) each computed `output.status.code().unwrap_or(-1)` — but `ExitStatus::code()` returns `None` **only** when the child was terminated by a signal, so that `unwrap_or` silently turned "the child was killed" into a fake exit code indistinguishable from a genuine `-1`. The resulting `left: -1, right: 0` assertion failure names no signal and prints no stderr, so it reads like a behavioural bug in the code under test — exactly what cost a wrong root-cause call in the #1459 review, as the issue documents.

Adds a shared `classify_cargo_run_exit()` that all four call sites now use instead of duplicating the same retry-on-`101` check. It treats a signal death as transient the same way `101` (lock contention) already is — plausible under the heavy concurrent `cargo` load these helpers run under (an OOM kill, another session's `pkill`, or lock-contention fallout) — retrying up to `MAX_CARGO_RETRIES` times. Only once retries are exhausted does it surface as an error naming the signal number and the captured stderr, never as a silently-coerced `-1`.

New `test_classify_cargo_run_exit_reports_signal_death_1516` exercises the classifier directly against constructed `ExitStatus` values (via `ExitStatusExt::from_raw`), rather than by actually killing a `cargo run` child — which would make the test itself exactly as flaky as the bug it pins.

Tests only — no `src/` behaviour change.

## Scope note

The issue's acceptance criteria lists three items: (1) report signal death properly — explicitly called "enough on its own to close the misdiagnosis half"; (2) **preferably also** switch these helpers to exec the pre-built `CARGO_BIN_EXE_succinctly` binary like `run_jq_full` does, removing the `cargo`-inside-`cargo` structure entirely; (3) if the `cargo run` calls stay, extend the retry to cover signal death and document it.

This PR does (1) and (3) in full. (2) is left out — it's explicitly framed as "preferably", not required, and it's a materially larger, riskier change (every one of the ~100+ call sites across this file would need its feature-flag-resolution behavior re-verified against the pre-built binary instead of a fresh `cargo run --features cli`). Better suited to its own follow-up than bundled with a diagnostics fix; will file one after this merges.

## Test plan

- [x] New `test_classify_cargo_run_exit_reports_signal_death_1516` — covers signal-death-with-retries-left (asks to retry), signal-death-on-last-attempt (errors, naming signal + stderr), `101`-with-retries-left (retries, unchanged), `101`-on-last-attempt (surfaces as-is, unchanged), and genuine exit codes 0/1 (pass through unchanged)
- [x] `cargo test --features cli --test jq_cli_tests` — 875/875 pass
- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (second CI leg)
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps --features cli,simd,regex,serde` — clean
- [x] `cargo build --no-default-features` — no_std build still compiles

Closes #1516