### PR TITLE
jq: widen eval_each's native lazy arm set (#1462, Stage 5)

### DIFF
--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -2,7 +2,7 @@
 
 [Home](../../) > [Docs](../) > [Plan](./) > Lazy generator consumers
 
-**Status: Stages 1, 2, 2b, 3 and 4 implemented; Stage 5 open.** This document is the
+**Status: Stages 1, 2, 2b, 3, 4 and 5 implemented.** This document is the
 deliverable for [#820](https://github.com/rust-works/succinctly/issues/820), which its
 own tier review (2026-08-20) classified Tier 3 — "evaluator-architecture change, design
 doc first, in the shape of #1282". It also scopes the two issues that name #820 as their
@@ -20,25 +20,39 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | —     | `eval_each_pipe`'s owned-value arm (Stage 2 gap)    | ✅ merged — PR #1450        |
 | 3     | `paths(f)` producer + `resolve_leaf` sink           | ✅ merged — closes #987     |
 | 4     | `Expr::Compare`'s outer loop                        | ✅ merged — closes #1459    |
-| 5     | Widen the lazy arm set                              | ⬜ open — #1462             |
+| 5     | Widen the lazy arm set                              | ✅ merged — closes #1462    |
 | (c)   | Mirror the sink into `eval_generic` for `Pipe`      | 🟡 partial — #1451, rest #1461 |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
 processed — is closed, as is `halt_error`'s wrong exit code and the stderr leak in
 `isempty`/`first`/`limit`/`nth`/`any`/`IN(s)`, and — since Stage 4 — `IN(src; s)` and every
-other compare reached through a lazy consumer. **Six** shapes remain divergent, all pinned
-as such in `test_short_circuit_side_effect_leaks_820_932_987`. Two are the bare-`first(...)`
-family: `first(.[] | stderr)` (see "Option (c), scoped" below) and
-`first((1,2) == (10, ("B"|stderr)))`, both a `first(...)` over a non-`Comma`, which Stage 2b's
-sibling walk does not reach — option (c), #1461. One is
+other compare reached through a lazy consumer. Since Stage 5, `eval_each` also carries native
+`If`, `Try`/`Optional`, `Label`, `As`, `AsPattern` and `Limit` arms, closing the
+demand-forwarding gap for a generator nested inside any of them (`isempty(limit(3; 1,
+("B"|stderr)))`, `isempty(if true then (1,("B"|stderr)) else 9 end)`, and the rest of the
+family the same shape). **Three** shapes remain divergent, all pinned as such in
+`test_short_circuit_side_effect_leaks_820_932_987`. Two are the bare-`first(...)` family:
+`first(.[] | stderr)` (see "Option (c), scoped" below) and
+`first((1,2) == (10, ("B"|stderr)))`, both a `first(...)` over a
+non-`Comma`, which Stage 2b's sibling walk does not reach — option (c), #1461. This is a
+*separate* obstacle from Stage 5's own arms: a bare `first(...)`/`last(...)` never even
+reaches `eval.rs` for a non-`Comma` argument, because `eval_generic.rs`'s own native
+`first`/`last` routing intercepts it first (confirmed live while implementing Stage 5, below);
+`isempty`, `limit`, `nth`, `path`, `any`, `all` and `IN` have no such native `eval_generic` arm
+and so reach every one of Stage 5's new arms correctly. The third divergent shape is
 `("A"|stderr) == (("B"|stderr), ("C"|stderr))`, a *top-level* compare, which never reaches
-`eval_each` at all — #1481. The remaining **three** are Stage 5's own residual (#1462): an
-un-lazified `eval_each` arm (`If`/`Try`/`Label`/`AsPattern`/`FuncCall`, ...) still leaks a
-side effect for a node's own filter when that filter's shape isn't one of
-`Comma`/`Pipe`/`Paren`/`Builtin::PathsFilter` — that is the `path(paths(if ...))` row, plus
-the `path(... halt_error ...)` pair Stage 4 added, whose stray `x` on stderr is the same
-un-lazified `Expr::If`.
+`eval_each` at all — #1481.
+
+**One divergence Stage 5's own oracle sweep found and did not attempt.** `?//`-alternatives
+wrapped in a short-circuiting consumer: real jq's builtins are macro-expanded `label $out |
+... break $out` definitions, and its `?//` operator retries the next alternative on *any*
+escaping break, including one addressed to a label entirely outside the `?//` — so
+`isempty(1 as $x ?// $y | 5)` is `false` **twice** in real jq (a three-alternative chain,
+three times), where succinctly's native, non-macro-expanded `?//` resolution always answers
+once. Confirmed pre-existing (unaffected by Stage 5's changes) and orthogonal to this
+document's own scope — filed as [#1519](https://github.com/rust-works/succinctly/issues/1519)
+rather than folded in.
 
 **Option (c), scoped.** `first`/`last` were the *only* `eval_generic.rs` consumers with a
 native, cursor-preserving fast-path arm shadowing `eval.rs`'s already-lazy implementation
@@ -835,7 +849,7 @@ pass it through via their existing `other => other` fallthrough — is unaffecte
 | 2b    | one narrowing arm in `eval_generic.rs`                                                                                                        | 1                       |
 | 3     | `Builtin::PathsFilter` lazy arm                                                                                                               | 2                       |
 | 4     | demand-aware outer loop                                                                                                                       | 3                       |
-| 5     | 6 more lazy arms                                                                                                                              | `eval_each` only        |
+| 5     | six new arms (`each_if`, `each_try`, `each_label`, `each_as`, `each_as_pattern`, `each_pattern_alternatives`, `each_limit`) + one inline arm  | `eval_each` only        |
 
 ### What does **not** change
 
@@ -928,9 +942,15 @@ Must preserve #910's live-verified nested-loop order. Own oracle sweep. **Implem
 as `binary_fanout_each` (the loop, sink-driven) plus `binary_fanout_core` (the eager
 collecting wrapper, behaviourally unchanged) and an `Expr::Compare` arm in `eval_each`.
 
-**Stage 5 — widen the arm set.** `If`, `Try`/`Optional`, `Label`, `AsPattern`, `FuncCall`,
-and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`. One divergence-table row per
-arm; each independently mergeable and measurable.
+**Stage 5 — widen the arm set.** Closes #1462. **Implemented** as six new native arms —
+`each_if`, `each_try` (also reached from `Expr::Optional`), `each_label`, `each_as` (the
+bare-`$var` bind node the parser actually builds for `EXPR as $x | body`), `each_as_pattern`
+(its destructuring/`?//` sibling, `Expr::AsPattern`) and `each_limit` (`Expr::Limit`'s own
+demand-*forwarding* gap) — plus one inline arm for `Expr::FuncDef` (pure AST substitution via
+the existing `expand_func_calls`, then `eval_each` on the expanded tree — no new function
+needed). `Expr::FuncCall` and `Expr::FirstExpr`/`NthExpr` turned out to need no arm at all; see
+[Follow-up issues](#follow-up-issues) for why, and for two more findings its own oracle sweep
+made along the way.
 
 **Option (c) — mirror the sink into `eval_generic`.** Originally scoped for
 `first(.[] | stderr)`. #1309 gave it two more owners, both now pinned in
@@ -1137,13 +1157,38 @@ the reasoning behind each placement:
    Left and right therefore answer differently, deliberately: both rows are pinned in
    `test_short_circuit_side_effect_leaks_820_932_987`, and `Flow::Stopped`'s own doc
    comment now records this as its one stated exception.
-7. **Stage 5** — widen the lazy arm set (`If`, `Try`/`Optional`, `Label`, `AsPattern`,
-   `FuncCall`, and demand-forwarding through `FirstExpr`/`Limit`/`NthExpr`). Filed **#1462**,
-   which re-rates it Medium rather than the low-priority tail this document predicted: the
-   wrappers destroy `input` documents, they do not merely leak stderr.
-   One issue, not one per arm: each is a single lazy arm now that the primitive exists.
-   Under ADR-0018 rule 6 these are divergences, so they need either a fix or entries in
-   `docs/compliance/jq/limitations.md`.
+7. **Stage 5** — widen the lazy arm set. Filed **#1462**, which re-rated it Medium rather
+   than the low-priority tail this document predicted: the wrappers destroy `input`
+   documents, they do not merely leak stderr. **Implemented** as `each_if`, `each_try`
+   (shared by `Expr::Try` and `Expr::Optional`), `each_label`, `each_as` (`Expr::As`, the
+   bare-`$var` bind node), `each_as_pattern` (`Expr::AsPattern`, its destructuring/`?//`
+   sibling) and `each_limit` (`Expr::Limit`, the one arm needed purely for
+   demand-*forwarding* — `FirstExpr`/`NthExpr` needed none, since both already emit at most
+   one downstream output and Stage 2's `each_take_first`/`each_take_nth` already drive that
+   through their own `eval_each` call). `Expr::FuncDef` needed no new function at all: it is
+   pure AST substitution (`expand_func_calls`), so routing the expanded tree through
+   `eval_each` instead of `eval_single` is the whole fix. `Expr::FuncCall` needed no arm
+   either — `eval_func_call` is unconditionally `"undefined function"`, since every real call
+   is resolved by `FuncDef`'s substitution before evaluation ever reaches it.
+
+   **Two things this stage's own oracle sweep found that the original plan didn't
+   anticipate.** (i) The parser builds `Expr::As`, not `Expr::AsPattern`, for the bare-`$var`
+   form — the plan's own `first(1 as $x | (1,("B"|stderr)))` repro is therefore an `Expr::As`
+   case, and needed `each_as` specifically; `AsPattern`/`each_as_pattern` covers only
+   destructuring and `?//`-chains. (ii) Every repro in this section's own divergence table
+   wraps its generator in a bare `first(...)`, but `eval_generic.rs`'s native `first`/`last`
+   routing intercepts a bare `first(...)`/`last(...)` before it ever reaches `eval.rs`'s
+   `eval_each` — so **none of Stage 5's new arms is reachable through a bare
+   `first(...)`/`last(...)` at the CLI**; that gap is option (c)/#1461, not this stage. Every
+   other short-circuiting consumer (`isempty`, `limit`, `nth`, `path`, `any`, `all`, `IN`) has
+   no such native `eval_generic` arm and reaches Stage 5's new arms correctly — confirmed via
+   `isempty(...)`-wrapped CLI tests instead.
+
+   **One divergence found and deliberately not attempted**: `?//`-alternatives wrapped in a
+   short-circuiting consumer re-run once per alternative in real jq (a macro-expansion/`?//`
+   retry-on-break interaction, unrelated to demand-forwarding) but not in succinctly. Confirmed
+   pre-existing, unaffected by this stage, and a materially larger design question — filed
+   separately as **#1519** rather than folded in.
 8. **Option (c)** — mirror `Demand`/`Item`/`Flow` into `eval_generic.rs` for
    `Comma`/`Pipe`/`Paren`. Filed **#1461**, also Medium for the same reason (`first(1 | (1,
    input))` consumes documents), with the narrower `first_over_comma_generic` gap it sits

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -842,14 +842,14 @@ pass it through via their existing `other => other` fallthrough — is unaffecte
 
 ### What changes
 
-| Stage | New code                                                                                                                                      | Function bodies changed |
-|-------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
-| 1     | none (tests only)                                                                                                                             | none                    |
-| 2     | `Demand`, `Item`, `Flow`, `eval_each`, `eval_each_pipe`, `eval_each_owned`, `drain_result`, `collect_each` — ~250 lines in a 46,898-line file | 10                      |
-| 2b    | one narrowing arm in `eval_generic.rs`                                                                                                        | 1                       |
-| 3     | `Builtin::PathsFilter` lazy arm                                                                                                               | 2                       |
-| 4     | demand-aware outer loop                                                                                                                       | 3                       |
-| 5     | six new arms (`each_if`, `each_try`, `each_label`, `each_as`, `each_as_pattern`, `each_pattern_alternatives`, `each_limit`) + one inline arm  | `eval_each` only        |
+| Stage | New code                                                                                                                                                                                       | Function bodies changed |
+|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| 1     | none (tests only)                                                                                                                                                                              | none                    |
+| 2     | `Demand`, `Item`, `Flow`, `eval_each`, `eval_each_pipe`, `eval_each_owned`, `drain_result`, `collect_each` — ~250 lines in a 46,898-line file                                                  | 10                      |
+| 2b    | one narrowing arm in `eval_generic.rs`                                                                                                                                                         | 1                       |
+| 3     | `Builtin::PathsFilter` lazy arm                                                                                                                                                                | 2                       |
+| 4     | demand-aware outer loop                                                                                                                                                                        | 3                       |
+| 5     | six new arms (`each_if`, `each_try`, `each_label`, `each_as`, `each_as_pattern`, `each_limit`; `each_pattern_alternatives` is a helper of `each_as_pattern`, not its own arm) + one inline arm | `eval_each` only        |
 
 ### What does **not** change
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2954,10 +2954,13 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // jq's own `path()` is lazy end to end, never evaluates the trailing
     // `halt_error`, and raises its "Invalid path expression" instead:
     //
-    //     path(1 == (if true then (1, ("x"|halt_error(3))) else empty end))
+    //     path(1 == (foreach (1,2,3) as $x (null; $x;
+    //         if $x==1 then $x else ("x"|halt_error(3)) end)))
     //         jq       exit 5, the path error       (nothing on stderr)
-    //         this     exit 5, the path error       (stray `x`: Stage 5)
-    //     path((if true then (1, ("x"|halt_error(3))) else empty end) == 1)
+    //         this     exit 5, the path error       (stray `x`: `foreach`
+    //                                                 has no Stage 5 arm)
+    //     path((foreach (1,2,3) as $x (null; $x;
+    //         if $x==1 then $x else ("x"|halt_error(3)) end)) == 1)
     //         jq       exit 5, the path error
     //         this     exit 3, the halt wins        <- inner keeps `pending`
     //
@@ -2965,8 +2968,16 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // by accident; both rows are pinned in
     // `test_short_circuit_side_effect_leaks_820_932_987`. Preserving the
     // outer `pending` instead would move the first row back to exit 3, away
-    // from jq. The residual `x` on both is Stage 5's (`Expr::If` has no lazy
-    // arm), not this loop's.
+    // from jq.
+    //
+    // The example above uses `foreach` rather than `if`: this asymmetry
+    // needs an operand that still falls back to eager `eval_single`, and
+    // Stage 5 (#1462) gave `Expr::If` its own native lazy arm, so an
+    // `if`-wrapped `halt_error` no longer reaches this eager fallback at
+    // all -- both such rows now agree with jq outright (moved into
+    // `test_short_circuit_side_effect_shapes_already_match_jq_820`).
+    // `foreach` has no Stage 5 arm and still falls back the same way this
+    // comment always meant to illustrate.
     abort.unwrap_or(outer)
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1934,7 +1934,7 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
 ///
 /// Native lazy arms: `Comma`, `Pipe`, `Paren`, `Builtin::PathsFilter`
 /// (#987, Stage 3), `Compare` (#1459, Stage 4), and -- #1462, Stage 5 --
-/// `If`, `Try`/`Optional`, `Label`, `AsPattern`, `FuncDef` and `Limit`.
+/// `If`, `Try`/`Optional`, `Label`, `As`, `AsPattern`, `FuncDef` and `Limit`.
 /// Everything else falls back to `eval_single` + [`drain_result`]. `Paren`
 /// is not optional cosmetics: `isempty(...)` consumes only its own
 /// parentheses, so `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30947,6 +30947,19 @@ fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// just the winning alternative's (or the last one's, if none win) -- so
 /// the returned `Vec<OwnedValue>` accumulates across every alternative
 /// actually attempted, not just the final one.
+///
+/// **A *pattern-match* failure on the last alternative must carry `carried`
+/// forward too** (code review, #1462) -- it is just another way this
+/// function's own last alternative can fail, exactly like a body
+/// error/break/halt, and every one of those already returns
+/// `Ok((carried, Some(control)))` rather than discarding the prefix. This
+/// arm alone used to `return Err(e)`, silently dropping `carried` and
+/// diverging from real jq (confirmed live, jq 1.7.1: `[1] as [$a] ?// {b:$c}
+/// | ($a, error("boom"))` prints `1` then the error) -- and, since Stage 5
+/// added a sink-based twin of this exact loop (`each_pattern_alternatives`,
+/// which never had anywhere to drop a prefix already pushed to its sink),
+/// the same jq expression was answering two different ways in the same
+/// binary depending on which evaluator reached it.
 fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     patterns: &[Pattern],
     all_var_names: &[String],
@@ -30973,7 +30986,7 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(b) => b,
             Err(e) => {
                 if is_last {
-                    return Err(e);
+                    return Ok((carried, Some(Control::Error(e))));
                 }
                 continue;
             }
@@ -34251,6 +34264,15 @@ mod tests {
             (b"null", "[1, 2] as [$a, $b] | ($a, $b)"),
             (b"null", "1 as $x ?// $y | ($x, $x)"),
             (b"null", "(1, [2]) as $x ?// [$y] | ($x, $y)"),
+            // #1462 code review: an earlier alternative's body produces
+            // output before erroring, *and* the final alternative's own
+            // pattern fails to match -- `try_pattern_alternatives`'s
+            // pattern-match-failure arm used to `return Err(e)` here,
+            // dropping that earlier output, while `each_pattern_alternatives`
+            // never had anywhere to drop it from (already pushed to its
+            // sink). Fixed to agree with each other and with jq (1.7.1,
+            // confirmed live: prints `1` then the error).
+            (b"null", "[1] as [$a] ?// {b:$c} | ($a, error(\"x\"))"),
             (b"null", "def f: 1, 2, 3; f"),
             (b"null", "def f: 1, 2; def g: f, f; g"),
             (b"null", "def f(x): x, x + 1; f(5)"),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2399,6 +2399,52 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     )
 }
 
+/// How many outputs `limit`'s already-evaluated `n` calls for. Mirrors jq's
+/// own `def limit($n; exp): if $n > 0 then ... elif $n == 0 then empty else
+/// exp end` (#983): a negative int/float, `null`, or a bool -- jq's total
+/// ordering places all three below every positive number -- means unlimited
+/// passthrough, not an error.
+///
+/// Shared by [`eval_limit`], [`resolve_limit`], and [`each_limit`] (code
+/// review, #1462) -- previously three independent copies of this exact
+/// ~20-line match, one per evaluator context (plain, path-tracking,
+/// demand-forwarding). That drifted once already: `resolve_limit`'s copy
+/// was missing the negative-float arm relative to `eval_limit`'s until a
+/// code-review pass caught it (#1313). Factoring out only the
+/// classification switch -- not `n_expr`'s own evaluation, which
+/// legitimately differs across borrowed/owned/path-tracking contexts, or
+/// what each caller does with the answer -- removes that drift risk
+/// categorically instead of relying on a differential test to catch the
+/// next divergence.
+enum LimitN {
+    /// Unlimited passthrough: run the caller's own `expr`/`resolve_node`
+    /// unbounded.
+    Unlimited,
+    /// Take at most this many outputs (`0` means the empty result).
+    Take(usize),
+}
+
+fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError> {
+    match n_value {
+        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
+            Ok(LimitN::Take(i as usize))
+        }
+        OwnedValue::Int(_)
+        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+        | OwnedValue::Null
+        | OwnedValue::Bool(_) => Ok(LimitN::Unlimited),
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
+            Ok(LimitN::Unlimited)
+        }
+        // A *positive* non-integer float (e.g. `1.9`) is a separate,
+        // pre-existing gap (jq's own fractional foreach-decrement loop
+        // bounds it to 2 outputs; succinctly errors instead) left untouched
+        // here -- out of #983's scope, which is specifically the
+        // negative/null/bool "no limit" branch.
+        _ => Err(EvalError::new("limit requires non-negative integer")),
+    }
+}
+
 /// Demand-forwarding twin of [`eval_limit`] (#1462, Stage 5): forwards every
 /// output of `expr` straight to `sink`, stopping the generator as soon as
 /// *either* `n` outputs have been forwarded or `sink` itself says to stop --
@@ -2407,14 +2453,6 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// sooner (`isempty(limit(3; 1, ("B"|stderr)))`) had no way to say so until
 /// this arm existed, because `eval_limit` fully materializes its `n`-bounded
 /// answer before returning to any wrapping `drain_result`.
-///
-/// `n`'s own resolution duplicates `eval_limit`'s (jq's `def limit($n; exp):
-/// if $n > 0 then ... elif $n == 0 then empty else exp end`, #983) rather
-/// than sharing it -- the blast radius this design commits to for Stage 5 is
-/// `eval_each` alone, not touching `eval_limit`'s already-shipped body (same
-/// precedent as `resolve_limit`, a third independent copy for `path()`'s own
-/// context). `eval_each_with_a_never_stopping_sink_matches_eval_single_820`
-/// guards the two from drifting apart.
 fn each_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     n_expr: &Expr,
     expr: &Expr,
@@ -2428,22 +2466,10 @@ fn each_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(Some((v, _trailing))) => v,
         Err(e) => return Flow::Escaped(e.into()),
     };
-    let n = match n_value {
-        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
-            i as usize
-        }
-        OwnedValue::Int(_)
-        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-        | OwnedValue::Null
-        | OwnedValue::Bool(_) => return eval_each::<W, S>(expr, value, optional, sink),
-        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
-            return eval_each::<W, S>(expr, value, optional, sink);
-        }
-        _ => {
-            return Flow::Escaped(Control::Error(EvalError::new(
-                "limit requires non-negative integer",
-            )));
-        }
+    let n = match classify_limit_n(n_value) {
+        Ok(LimitN::Unlimited) => return eval_each::<W, S>(expr, value, optional, sink),
+        Ok(LimitN::Take(n)) => n,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
     };
 
     if n == 0 {
@@ -16344,36 +16370,10 @@ fn resolve_limit<'a, S: EvalSemantics>(
         Ok(None) => return Ok(Vec::new()),
         Err(control) => return Err((Vec::new(), control.into())),
     };
-    let n = match n_value {
-        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
-            i as usize
-        }
-        // Same jq-matched "no limit at all" branch as `eval_limit` (#983):
-        // a negative count, `null`, or a bool (jq's total ordering places
-        // all three below every positive number) means unlimited
-        // passthrough, not an error.
-        OwnedValue::Int(_)
-        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-        | OwnedValue::Null
-        | OwnedValue::Bool(_) => {
-            return resolve_node::<S>(expr, value, trackable);
-        }
-        // Same for a negative float, matching `eval_limit`'s own identical
-        // arm -- missing here before this fix (code review, #1313), so
-        // `path(limit(-1.5; ...))` raised "limit requires non-negative
-        // integer" while plain-value-mode `limit(-1.5; ...)` correctly gave
-        // unlimited passthrough. Verified live against jq 1.7.1: both
-        // modes now agree (`path(limit(-1.5; .a,.b))` on `{"a":1,"b":2}` is
-        // `["a"]` then `["b"]` in both real jq and here).
-        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
-            return resolve_node::<S>(expr, value, trackable);
-        }
-        _ => {
-            return Err((
-                Vec::new(),
-                EvalError::new("limit requires non-negative integer").into(),
-            ));
-        }
+    let n = match classify_limit_n(n_value) {
+        Ok(LimitN::Unlimited) => return resolve_node::<S>(expr, value, trackable),
+        Ok(LimitN::Take(n)) => n,
+        Err(e) => return Err((Vec::new(), e.into())),
     };
     if n == 0 {
         return Ok(Vec::new());
@@ -21370,31 +21370,10 @@ fn eval_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(Some((v, _trailing))) => v,
         Err(e) => return e.into(),
     };
-    let n = match n_value {
-        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
-            i as usize
-        }
-        // A negative int, `null`, or a bool -- jq's total ordering places
-        // all three below every positive number, so each takes the same
-        // "no limit at all" branch of jq's own `def limit`, not an error
-        // -- verified against jq 1.7.1 (#983).
-        OwnedValue::Int(_)
-        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
-        | OwnedValue::Null
-        | OwnedValue::Bool(_) => {
-            return eval_single::<W, S>(expr, value, optional);
-        }
-        // Same for a negative float. A *positive* non-integer float (e.g.
-        // `1.9`) is a separate, pre-existing gap (jq's own fractional
-        // foreach-decrement loop bounds it to 2 outputs; succinctly errors
-        // instead) left untouched here -- out of #983's scope, which is
-        // specifically the negative/null/bool "no limit" branch.
-        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
-            return eval_single::<W, S>(expr, value, optional);
-        }
-        _ => {
-            return QueryResult::Error(EvalError::new("limit requires non-negative integer"));
-        }
+    let n = match classify_limit_n(n_value) {
+        Ok(LimitN::Unlimited) => return eval_single::<W, S>(expr, value, optional),
+        Ok(LimitN::Take(n)) => n,
+        Err(e) => return QueryResult::Error(e),
     };
 
     if n == 0 {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1933,11 +1933,27 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
 /// Push every output of `expr` into `sink`, stopping as soon as `sink` says to.
 ///
 /// Native lazy arms: `Comma`, `Pipe`, `Paren`, `Builtin::PathsFilter`
-/// (#987, Stage 3) and `Compare` (#1459, Stage 4). Everything else falls
-/// back to `eval_single` + [`drain_result`]. `Paren` is not optional
-/// cosmetics: `isempty(...)` consumes only its own parentheses, so
-/// `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and without this arm
-/// the fix would be a coin flip on spelling.
+/// (#987, Stage 3), `Compare` (#1459, Stage 4), and -- #1462, Stage 5 --
+/// `If`, `Try`/`Optional`, `Label`, `AsPattern`, `FuncDef` and `Limit`.
+/// Everything else falls back to `eval_single` + [`drain_result`]. `Paren`
+/// is not optional cosmetics: `isempty(...)` consumes only its own
+/// parentheses, so `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and
+/// without this arm the fix would be a coin flip on spelling.
+///
+/// **Why `FirstExpr`/`NthExpr` get no arm here, unlike `Limit`** (#1462):
+/// `first(f)`/`nth(n;f)` already emit *at most one* output no matter how
+/// large `f` is, and `each_take_first`/`each_take_nth` (Stage 2) already
+/// drive that single output through their own `eval_each` call on `f` --
+/// so a *wrapping* consumer's demand has nothing left to shrink; the one
+/// item either satisfies it or doesn't. `limit(n; f)` is different in kind:
+/// it forwards up to `n` outputs downstream, and Stage 2's `each_take_n`
+/// only bounded evaluation against its *own* `n`, not against whatever a
+/// wrapping consumer might want fewer of -- confirmed live,
+/// `isempty(nth(0; limit(3; 1, ("B"|stderr))))` leaked before this arm
+/// existed even though neither `FirstExpr` nor `NthExpr` needed one:
+/// `each_take_nth` already called `eval_each` on `Limit{3, G}`, and it was
+/// *that* callee falling back to eager `drain_result` that leaked --
+/// wiring `Limit` alone fixes every nesting of it.
 fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
@@ -2000,7 +2016,471 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // optimization -- see `each_inputs` for why the fallback below is
         // not a safe default for this particular producer (#1309).
         Expr::Builtin(Builtin::Inputs) => each_inputs::<W, S>(sink),
+
+        // #1462 (Stage 5): branch *selection* was already lazy (`eval_fanout`
+        // evaluates only the taken branch) -- what wasn't is a generator
+        // *inside* that branch. `cond` itself stays eager, mirroring
+        // `eval_if`/`eval_fanout` exactly: this fix is scoped to the taken
+        // branch's body, the same way `Expr::Compare` above leaves `cond`-less
+        // operand evaluation alone.
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => each_if::<W, S>(cond, then_branch, else_branch, value, optional, sink),
+
+        // `.[EXPR]?`/`.[S:E]?`: same carve-out as `eval_single`'s matching
+        // arm above -- `?` here guards only the final index/slice step, not
+        // the key/bounds sub-expression, and `IndexExpr`/`SliceExpr` are
+        // never multi-output generators, so there is nothing for a sink to
+        // shrink here; forward `optional: true` directly rather than
+        // wrapping in `each_try`, exactly as `eval_single` forwards to
+        // `eval_index_expr`/`eval_slice_expr` directly.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            eval_each::<W, S>(inner, value, true, sink)
+        }
+        // `E?` is sugar for `try E` (no catch handler) -- same ambient-
+        // `optional` forwarding rationale as `eval_single`'s own arm (#693).
+        Expr::Optional(inner) => each_try::<W, S>(inner, None, value, optional, sink),
+        Expr::Try { expr, catch } => {
+            each_try::<W, S>(expr, catch.as_deref(), value, optional, sink)
+        }
+
+        Expr::Label { name, body } => each_label::<W, S>(name, body, value, optional, sink),
+
+        // The parser builds `Expr::As` for the bare-`$var` spelling
+        // (`EXPR as $x | body`) and reserves `Expr::AsPattern` for anything
+        // destructured (`[$a,$b]`, `{a:$x}`, `?//`) — confirmed live: the
+        // divergence table's own `first(1 as $x | (1,("B"|stderr)))` repro
+        // parses to `Expr::As`, not `Expr::AsPattern`, so both need an arm.
+        Expr::As { expr, var, body } => each_as::<W, S>(expr, var, body, value, optional, sink),
+        Expr::AsPattern {
+            expr,
+            patterns,
+            body,
+        } => each_as_pattern::<W, S>(expr, patterns, body, value, optional, sink),
+
+        // `def name(params): body; then` is pure, evaluation-free AST
+        // substitution (`eval_func_def`'s whole body is `expand_func_calls`
+        // then evaluate) -- so unlike every other arm here, there is no
+        // producer logic of its own to make demand-aware. Routing the
+        // expanded tree through `eval_each` instead of `eval_single` is the
+        // entire fix: it lets a wrapping consumer's sink reach whatever
+        // native lazy arm (`Comma`, `Pipe`, ...) the expansion exposes,
+        // rather than stopping at this node and materializing the whole
+        // thing via `drain_result`'s fallback. Confirmed live that the
+        // *top-level* `def f: (1,("B"|stderr)); first(f)` already matched jq
+        // before this arm existed (`first`'s own `eval_first_expr` already
+        // reaches the expansion via `eval_single`, and is itself lazy) --
+        // the gap this arm closes is a `FuncDef` *nested inside* another
+        // consumer's argument, e.g. `isempty(def f: (1,("B"|stderr)); f)`.
+        Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } => {
+            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
+            eval_each::<W, S>(&expanded_then, value, optional, sink)
+        }
+
+        // #1462 (Stage 5): demand-forwarding through a nested consumer.
+        // `each_take_n` (Stage 2) already stops asking `expr` for more once
+        // `n` outputs exist, but it materializes all `n` into a `QueryResult`
+        // before this arm's fallback `drain_result` would get a chance to
+        // forward a wrapping consumer's own, possibly *smaller*, demand --
+        // so `isempty(limit(3; 1, ("B"|stderr)))` evaluated all 3 candidates
+        // to build `limit`'s answer before `isempty` ever saw the first one.
+        // `each_limit` below forwards every output straight to `sink` and
+        // stops on whichever comes first, `n` or `sink` itself.
+        Expr::Limit { n, expr } => each_limit::<W, S>(n, expr, value, optional, sink),
+
         _ => drain_result(eval_single::<W, S>(expr, value, optional), sink),
+    }
+}
+
+/// Lazy twin of [`eval_if`]: `cond` is evaluated eagerly (branch selection
+/// was already lazy -- `eval_fanout` only ever evaluates the taken branch),
+/// but the taken branch's own body is pushed through `eval_each` rather than
+/// materialized via `eval_single`, so a generator inside it honours the
+/// wrapping consumer's demand (#1462: `first(if true then (1,("B"|stderr))
+/// else 9 end)` no longer evaluates the `stderr` branch).
+///
+/// Mirrors `eval_fanout`'s own bit-by-bit walk (multi-output `cond`, e.g.
+/// `if (true,false) then "a" else "b" end`, #378) minus the borrowed/owned
+/// accumulator -- the sink *is* the accumulator here, same as `eval_each`'s
+/// `Comma` arm.
+fn each_if<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    cond: &Expr,
+    then_branch: &Expr,
+    else_branch: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let cond_result = eval_single::<W, S>(cond, value.clone(), optional);
+    let mut bits: Vec<bool> = Vec::new();
+    let cond_control = push_truthiness(cond_result, &mut bits);
+
+    for bit in bits {
+        let branch = if bit { then_branch } else { else_branch };
+        match eval_each::<W, S>(branch, value.clone(), optional, sink) {
+            Flow::Exhausted => {}
+            stopped_or_escaped => return stopped_or_escaped,
+        }
+    }
+
+    match cond_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Lazy twin of [`eval_try`]: pushes `expr`'s own outputs straight to `sink`,
+/// then -- only on a *bare* escape, i.e. `Flow::Escaped`, whose own contract
+/// guarantees every output produced before it was already delivered -- runs
+/// the catch handler (if any) and forwards its outputs too. `catch` runs
+/// bound to the raised payload for `Error`, or `null` for `Break` (#562,
+/// real jq binds its own internal break marker there, not worth
+/// replicating); `Halt` is never caught, matching `Control`'s own
+/// pass-through guarantee.
+///
+/// `Flow` makes the eager `eval_try`'s `Partial(prefix, control)` split
+/// unnecessary: there, the prefix and the control share one return slot, so
+/// "some outputs, then an error" needs its own arm distinct from "a bare
+/// error". Here the prefix is already gone -- pushed to `sink` as it was
+/// produced -- so both collapse into the same `Escaped` arm (plan doc,
+/// "Partial disappears from the lazy path").
+///
+/// If `sink` itself is satisfied before `expr` would have errored,
+/// `eval_each` returns `Flow::Stopped` rather than `Escaped`, and this
+/// function propagates it verbatim without ever running `catch` --
+/// matching jq exactly: `first(try (1, error("x")) catch "c")` is `1`, and
+/// jq never even reaches `error`, let alone `catch`.
+fn each_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    catch: Option<&Expr>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    match eval_each::<W, S>(expr, value, optional, sink) {
+        Flow::Escaped(Control::Error(e)) => match catch {
+            Some(catch_expr) => {
+                eval_each_owned::<S>(catch_expr, &e.payload(), optional, &mut |o| {
+                    sink(Item::Owned(o))
+                })
+            }
+            None => Flow::Exhausted,
+        },
+        Flow::Escaped(Control::Break(_)) => match catch {
+            Some(catch_expr) => {
+                eval_each_owned::<S>(catch_expr, &OwnedValue::Null, optional, &mut |o| {
+                    sink(Item::Owned(o))
+                })
+            }
+            None => Flow::Exhausted,
+        },
+        // Halt is never caught (`Control`'s own guarantee); other terminal
+        // shapes (`Exhausted`, `Stopped`) pass straight through.
+        other => other,
+    }
+}
+
+/// Lazy twin of [`eval_label`]: pushes `body`'s outputs straight to `sink`,
+/// then -- only on a bare `Flow::Escaped(Control::Break(name))` matching this
+/// label, whose contract guarantees every prior output was already delivered
+/// -- swallows it, mirroring `eval_label`'s `QueryResult::Break(label) if
+/// label == name => QueryResult::None` (and its `Partial` sibling, which
+/// collapses into the same arm here for the same reason `each_try` above
+/// does). Every other outcome -- a non-matching break, a bare or trailing
+/// `Error`/`Halt`, `Exhausted`, or a satisfied `Stopped` -- propagates
+/// unchanged; a `Stopped`'s own `pending` is left for whichever consumer
+/// ultimately reads it to decide, not intercepted here.
+fn each_label<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    name: &str,
+    body: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    match eval_each::<W, S>(body, value, optional, sink) {
+        Flow::Escaped(Control::Break(label)) if label == name => Flow::Exhausted,
+        other => other,
+    }
+}
+
+/// Lazy twin of [`eval_as`] (#1462): the bind expression (`expr`) is
+/// evaluated eagerly, exactly as `eval_as` already does -- mirroring
+/// `each_if`'s decision to leave `cond` eager, this fix is scoped to what
+/// runs *per bound value*, not to the binding itself. Each bound value's
+/// `body` is then pushed through `eval_each` rather than materialized via
+/// `eval_single`, so `isempty(1 as $x | (1,("B"|stderr)))` no longer
+/// evaluates the `stderr` branch. The parser reserves this bare-`$var` node
+/// for `Expr::As`; [`each_as_pattern`] below is its destructuring sibling
+/// (`Expr::AsPattern`, `?//`-chains included).
+fn each_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    var: &str,
+    body: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let bound_result = eval_single::<W, S>(expr, value.clone(), optional);
+    let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
+        match bound_result.materialize_cursor() {
+            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
+            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Owned(v) => (vec![v], None),
+            QueryResult::ManyOwned(vs) => (vs, None),
+            QueryResult::None => return Flow::Exhausted,
+            QueryResult::Error(e) => return Flow::Escaped(Control::Error(e)),
+            QueryResult::Break(label) => return Flow::Escaped(Control::Break(label)),
+            QueryResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
+            QueryResult::Partial(vs, control) => (vs, Some(control)),
+        };
+
+    for bound_val in bound_values {
+        let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
+        match eval_each::<W, S>(&substituted_body, value.clone(), optional, sink) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+
+    match bound_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Lazy twin of [`eval_as_pattern`]: the bind expression (`expr`) is
+/// evaluated eagerly, exactly as `eval_as_pattern` already does -- same
+/// reasoning as [`each_as`] above, its non-destructuring sibling. Each bound
+/// value's `body` (after `?//`-alternative substitution) is then pushed
+/// through `eval_each` rather than materialized, so
+/// `isempty([$x] as [$a] | (1,("B"|stderr)))`-shaped destructuring binds no
+/// longer evaluate a trailing `stderr` branch either.
+fn each_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    patterns: &[Pattern],
+    body: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let bound_result = eval_single::<W, S>(expr, value.clone(), optional);
+    let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
+        match bound_result.materialize_cursor() {
+            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
+            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Owned(v) => (vec![v], None),
+            QueryResult::ManyOwned(vs) => (vs, None),
+            QueryResult::None => return Flow::Exhausted,
+            QueryResult::Error(e) => return Flow::Escaped(Control::Error(e)),
+            QueryResult::Break(label) => return Flow::Escaped(Control::Break(label)),
+            QueryResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
+            QueryResult::Partial(vs, control) => (vs, Some(control)),
+        };
+
+    let mut all_var_names: Vec<String> = Vec::new();
+    for pattern in patterns {
+        collect_pattern_var_names(pattern, &mut all_var_names);
+    }
+    all_var_names.sort_unstable();
+    all_var_names.dedup();
+
+    for bound_val in bound_values {
+        match each_pattern_alternatives::<W, S>(
+            patterns,
+            &all_var_names,
+            body,
+            &bound_val,
+            &value,
+            optional,
+            sink,
+        ) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+
+    match bound_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Sink-based twin of [`try_pattern_alternatives`]: same `?//`-alternative
+/// fallthrough rule (a pattern-match failure, a body error, or a body break
+/// tries the next alternative unless this is the last one; halt never falls
+/// through), but each alternative's own successful outputs are pushed to
+/// `sink` as they're produced instead of collected -- so, exactly as that
+/// function's own doc comment requires, "each tried alternative's own
+/// partial output before its error/break is kept, not just the winning
+/// alternative's": those pushes already happened by the time an alternative
+/// fails, `sink` having seen them is what "kept" means here.
+///
+/// If `sink` itself is satisfied partway through an alternative,
+/// `eval_each` returns `Flow::Stopped` rather than `Escaped`, which this
+/// function propagates immediately rather than falling through to the next
+/// alternative -- once the consumer has what it wants, no further
+/// alternative is ever tried, matching `each_try`'s identical reasoning.
+fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    patterns: &[Pattern],
+    all_var_names: &[String],
+    body: &Expr,
+    bound_val: &OwnedValue,
+    value: &StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let last_idx = patterns.len() - 1;
+    // #1366: a genuine `?//`-chain (2+ patterns) inverts real jq's
+    // duplicate-binding dedup rule relative to a bare pattern -- see
+    // `extract_pattern_bindings`'s own doc comment.
+    let invert_dedup = patterns.len() > 1;
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        let is_last = i == last_idx;
+
+        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
+            Ok(b) => b,
+            Err(e) => {
+                if is_last {
+                    return Flow::Escaped(Control::Error(e));
+                }
+                continue;
+            }
+        };
+
+        let null_value = OwnedValue::Null;
+        let substituted_body = substitute_vars(
+            body,
+            as_var_refs(&bindings).chain(
+                all_var_names
+                    .iter()
+                    .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
+                    .map(|name| (name.as_str(), &null_value)),
+            ),
+        );
+
+        match eval_each::<W, S>(&substituted_body, value.clone(), optional, sink) {
+            Flow::Exhausted => return Flow::Exhausted,
+            Flow::Stopped { pending } => return Flow::Stopped { pending },
+            // #1457: `Break` falls through like `Error`, not immediately
+            // like `Halt` -- same live-verified correction
+            // `try_pattern_alternatives` itself documents.
+            Flow::Escaped(Control::Error(e)) => {
+                if is_last {
+                    return Flow::Escaped(Control::Error(e));
+                }
+                continue;
+            }
+            Flow::Escaped(Control::Break(label)) => {
+                if is_last {
+                    return Flow::Escaped(Control::Break(label));
+                }
+                continue;
+            }
+            Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+        }
+    }
+
+    unreachable!(
+        "patterns is always non-empty by construction (the parser never \
+         builds an empty AsPattern), and every loop iteration above \
+         returns on its `is_last` pass"
+    )
+}
+
+/// Demand-forwarding twin of [`eval_limit`] (#1462, Stage 5): forwards every
+/// output of `expr` straight to `sink`, stopping the generator as soon as
+/// *either* `n` outputs have been forwarded or `sink` itself says to stop --
+/// whichever comes first. `eval_limit`'s own `each_take_n` (Stage 2) already
+/// stops `expr` at `n`, but only `n`; a wrapping consumer that is satisfied
+/// sooner (`isempty(limit(3; 1, ("B"|stderr)))`) had no way to say so until
+/// this arm existed, because `eval_limit` fully materializes its `n`-bounded
+/// answer before returning to any wrapping `drain_result`.
+///
+/// `n`'s own resolution duplicates `eval_limit`'s (jq's `def limit($n; exp):
+/// if $n > 0 then ... elif $n == 0 then empty else exp end`, #983) rather
+/// than sharing it -- the blast radius this design commits to for Stage 5 is
+/// `eval_each` alone, not touching `eval_limit`'s already-shipped body (same
+/// precedent as `resolve_limit`, a third independent copy for `path()`'s own
+/// context). `eval_each_with_a_never_stopping_sink_matches_eval_single_820`
+/// guards the two from drifting apart.
+fn each_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
+    let n_value = match result_to_owned_full(n_result) {
+        Ok(None) => return Flow::Exhausted,
+        Ok(Some((v, _trailing))) => v,
+        Err(e) => return Flow::Escaped(e.into()),
+    };
+    let n = match n_value {
+        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
+            i as usize
+        }
+        OwnedValue::Int(_)
+        | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
+        | OwnedValue::Null
+        | OwnedValue::Bool(_) => return eval_each::<W, S>(expr, value, optional, sink),
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
+            return eval_each::<W, S>(expr, value, optional, sink);
+        }
+        _ => {
+            return Flow::Escaped(Control::Error(EvalError::new(
+                "limit requires non-negative integer",
+            )));
+        }
+    };
+
+    if n == 0 {
+        return Flow::Exhausted;
+    }
+
+    let mut count = 0usize;
+    let mut outer_stopped = false;
+    let flow = eval_each::<W, S>(expr, value, optional, &mut |item| {
+        count += 1;
+        if sink(item) == Demand::Stop {
+            outer_stopped = true;
+            Demand::Stop
+        } else if count >= n {
+            Demand::Stop
+        } else {
+            Demand::Continue
+        }
+    });
+
+    // The wrapping consumer, not our own `n` cap, is why the generator
+    // stopped -- propagate its verdict (and whatever `pending` came with it)
+    // verbatim, exactly as every other lazy arm does.
+    if outer_stopped {
+        return flow;
+    }
+    match flow {
+        // `n` outputs arrived (or the generator simply ran dry on its own):
+        // jq's own `foreach ... break $out` fires here, so a trailing
+        // control from an eager fallback past this point is dropped, exactly
+        // as `eval_limit`'s identical `Flow::Stopped { .. } => result` arm
+        // already drops it.
+        Flow::Stopped { .. } | Flow::Exhausted => Flow::Exhausted,
+        // Fewer than `n` were produced, so the generator's own terminator is
+        // what `limit` reaches -- same policy as `eval_limit`'s `Escaped`
+        // arm (`[limit(3; 1,2,error("x"),4)]` raises).
+        Flow::Escaped(control) => Flow::Escaped(control),
     }
 }
 
@@ -33740,6 +34220,56 @@ mod tests {
             (b"null", "((1,2) == (10,20)), ((3,4) == (3,4))"),
             (b"null", "(1,2) | . == (1,2)"),
             (b"null", "[limit(2; (1,2,3) == (10,20))]"),
+            // #1462, Stage 5: `If`, `Try`/`Optional`, `Label`, `As`,
+            // `AsPattern` and `Limit` all gained native lazy arms. This
+            // differential is what guards each against drifting from the
+            // eager sibling it now shadows (`eval_if`/`eval_fanout`,
+            // `eval_try`, `eval_label`, `eval_as`, `eval_as_pattern`,
+            // `eval_limit`) -- every case below is deliberately still
+            // side-effect free (`stderr`/`input` ordering differences are
+            // the CLI-level tests' job, not this one's), so an always-
+            // `Continue` sink must deliver the identical values in the
+            // identical order.
+            (b"null", "if true then 1, 2 else 3 end"),
+            (b"null", "if false then 1 else 2, 3 end"),
+            (b"null", "(true, false) | if . then 1 else 2 end"),
+            (b"null", "if true then (1, error(\"x\"), 3) else 9 end"),
+            (b"null", "if true then (1, break $o) else 9 end"),
+            (b"null", "try (1, 2) catch 9"),
+            (b"null", "try (1, error(\"x\"), 3) catch 9"),
+            (b"null", "try (error(\"x\"), 1) catch (9, 10)"),
+            (b"null", "try (1, break $o) catch 9"),
+            (b"null", "(1, error(\"x\"))?"),
+            (b"null", "(1, 2)?"),
+            (b"null", "label $o | (1, 2, 3)"),
+            (b"null", "label $o | (1, break $o, 3)"),
+            (b"null", "label $o | (1, break $p, 3)"),
+            (b"null", "1 as $x | ($x, $x + 1)"),
+            (b"null", "(1, 2) as $x | ($x, $x + 10)"),
+            (b"null", "(1, error(\"x\"), 3) as $x | $x"),
+            (b"null", "1 as $x | (1, break $o)"),
+            (b"null", "[1, 2] as [$a, $b] | ($a, $b)"),
+            (b"null", "1 as $x ?// $y | ($x, $x)"),
+            (b"null", "(1, [2]) as $x ?// [$y] | ($x, $y)"),
+            (b"null", "def f: 1, 2, 3; f"),
+            (b"null", "def f: 1, 2; def g: f, f; g"),
+            (b"null", "def f(x): x, x + 1; f(5)"),
+            (b"null", "[limit(2; 1, 2, 3)]"),
+            (b"null", "[limit(0; 1, 2, 3)]"),
+            (b"null", "[limit(-1; 1, 2, 3)]"),
+            (b"null", "[limit(null; 1, 2, 3)]"),
+            (b"null", "[limit(3; 1, 2, error(\"x\"), 4)]"),
+            (b"null", "[limit(5; 1, 2)]"),
+            (b"null", "limit(\"x\"; 1, 2)"),
+            // Nested inside each other, and inside the previously-lazified
+            // arms, so every arm is also reached indirectly.
+            (
+                b"null",
+                "(1, 2) | if . == 1 then (10, 11) else (20, 21) end",
+            ),
+            (b"null", "[limit(2; if true then (1,2,3) else 9 end)]"),
+            (b"null", "def f: (1, 2); [limit(1; f)]"),
+            (b"null", "label $o | (1 as $x | ($x, $x)), 99"),
         ];
 
         for (json, src) in cases {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34300,7 +34300,11 @@ mod tests {
             // exercises `each_limit` at all: `Array` isn't itself a lazy arm,
             // so `eval_each` falls back to `eval_single` for the whole
             // expression instead of reaching the `Expr::Limit` arm).
-            (b"[1,2,3]", ".[0]?"),
+            // A *constant* key/bound (`.[0]?`) never reaches `IndexExpr`/
+            // `SliceExpr` at all -- the parser folds it to a static
+            // `Expr::Index`/`Expr::Slice` (#1326); only a genuinely computed
+            // key (`.[1+0]?`) builds the `IndexExpr` this arm targets.
+            (b"[1,2,3]", ".[1+0]?"),
             (b"null", "if (true, error(\"x\")) then 1 else 2 end"),
             (b"null", "label $o | (1, break $o)?"),
             (b"{\"a\":1}", ".a as $x | ($x, $x)"),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2212,6 +2212,35 @@ fn each_label<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Materialize a bind expression's own `QueryResult` into the values
+/// [`each_as`]/[`each_as_pattern`] loop the shared `body`/pattern-match logic
+/// over, plus the control the bind itself trails (`#400`/`#494`: a
+/// `Partial` bind still has its produced prefix bound and run through the
+/// body, exactly as `eval_as`/`eval_as_pattern` already do). `Err(flow)`
+/// carries the caller's own early return for a bind that produced no
+/// values at all, or that raised without producing any.
+///
+/// Shared by both (code review, #1462) -- this exact `QueryResult` ->
+/// `(Vec<OwnedValue>, Option<Control>)` unpacking was already duplicated
+/// between the eager `eval_as`/`eval_as_pattern`; this collapses all four
+/// copies (the eager pair plus their two new lazy twins) into one.
+fn materialize_bound_values<W: Clone + AsRef<[u64]>>(
+    bound_result: QueryResult<'_, W>,
+) -> Result<(Vec<OwnedValue>, Option<Control>), Flow> {
+    match bound_result.materialize_cursor() {
+        QueryResult::One(v) => Ok((vec![to_owned(&v)], None)),
+        QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
+        QueryResult::Many(vs) => Ok((vs.iter().map(to_owned).collect(), None)),
+        QueryResult::Owned(v) => Ok((vec![v], None)),
+        QueryResult::ManyOwned(vs) => Ok((vs, None)),
+        QueryResult::None => Err(Flow::Exhausted),
+        QueryResult::Error(e) => Err(Flow::Escaped(Control::Error(e))),
+        QueryResult::Break(label) => Err(Flow::Escaped(Control::Break(label))),
+        QueryResult::Halt(code) => Err(Flow::Escaped(Control::Halt(code))),
+        QueryResult::Partial(vs, control) => Ok((vs, Some(control))),
+    }
+}
+
 /// Lazy twin of [`eval_as`] (#1462): the bind expression (`expr`) is
 /// evaluated eagerly, exactly as `eval_as` already does -- mirroring
 /// `each_if`'s decision to leave `cond` eager, this fix is scoped to what
@@ -2230,19 +2259,10 @@ fn each_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
     let bound_result = eval_single::<W, S>(expr, value.clone(), optional);
-    let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
-        match bound_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
-            QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
-            QueryResult::Owned(v) => (vec![v], None),
-            QueryResult::ManyOwned(vs) => (vs, None),
-            QueryResult::None => return Flow::Exhausted,
-            QueryResult::Error(e) => return Flow::Escaped(Control::Error(e)),
-            QueryResult::Break(label) => return Flow::Escaped(Control::Break(label)),
-            QueryResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
-            QueryResult::Partial(vs, control) => (vs, Some(control)),
-        };
+    let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
+        Ok(pair) => pair,
+        Err(flow) => return flow,
+    };
 
     for bound_val in bound_values {
         let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
@@ -2274,19 +2294,10 @@ fn each_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
     let bound_result = eval_single::<W, S>(expr, value.clone(), optional);
-    let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
-        match bound_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
-            QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
-            QueryResult::Owned(v) => (vec![v], None),
-            QueryResult::ManyOwned(vs) => (vs, None),
-            QueryResult::None => return Flow::Exhausted,
-            QueryResult::Error(e) => return Flow::Escaped(Control::Error(e)),
-            QueryResult::Break(label) => return Flow::Escaped(Control::Break(label)),
-            QueryResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
-            QueryResult::Partial(vs, control) => (vs, Some(control)),
-        };
+    let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
+        Ok(pair) => pair,
+        Err(flow) => return flow,
+    };
 
     let mut all_var_names: Vec<String> = Vec::new();
     for pattern in patterns {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34293,6 +34293,39 @@ mod tests {
             (b"null", "[limit(2; if true then (1,2,3) else 9 end)]"),
             (b"null", "def f: (1, 2); [limit(1; f)]"),
             (b"null", "label $o | (1 as $x | ($x, $x)), 99"),
+            // #1462 code review: coverage sweep for branches only reachable
+            // when the *root* expression itself is a native lazy arm (this
+            // harness calls `eval_each` on the parsed root directly, so a
+            // `[...]`-wrapped `limit(...)` -- the earlier rows above -- never
+            // exercises `each_limit` at all: `Array` isn't itself a lazy arm,
+            // so `eval_each` falls back to `eval_single` for the whole
+            // expression instead of reaching the `Expr::Limit` arm).
+            (b"[1,2,3]", ".[0]?"),
+            (b"null", "if (true, error(\"x\")) then 1 else 2 end"),
+            (b"null", "label $o | (1, break $o)?"),
+            (b"{\"a\":1}", ".a as $x | ($x, $x)"),
+            (b"[1,2,3]", ".[] as $x | $x"),
+            (b"null", "empty as $x | 1"),
+            (b"null", "error(\"x\") as $x | 1"),
+            (b"null", "label $o | break $o as $x | 1"),
+            (b"null", "halt_error(3) as $x | 1"),
+            (b"null", "empty as [$x] | 1"),
+            (b"null", "error(\"x\") as [$x] | 1"),
+            (b"null", "label $o | break $o as [$x] | 1"),
+            (b"null", "halt_error(3) as [$x] | 1"),
+            (b"null", "([1], error(\"x\")) as [$x] | $x"),
+            (b"null", "[1] as {b:$c} ?// [$a] | $a"),
+            (b"null", "[1] as [$a] | ($a, error(\"x\"))"),
+            (b"null", "label $o | [1] as [$a] ?// [$b] | ($a, break $o)"),
+            (b"null", "[1] as [$a] | ($a, halt_error(3))"),
+            (b"null", "limit(empty; 1, 2, 3)"),
+            (b"null", "limit(error(\"x\"); 1, 2, 3)"),
+            (b"null", "limit(-1; 1, 2, 3)"),
+            (b"null", "limit(null; 1, 2, 3)"),
+            (b"null", "limit(0; 1, 2, 3)"),
+            (b"null", "limit(2; 1, 2, 3)"),
+            (b"null", "limit(5; 1, 2)"),
+            (b"null", "limit(3; 1, 2, error(\"x\"), 4)"),
         ];
 
         for (json, src) in cases {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17934,6 +17934,20 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // #1462 code review: `try_pattern_alternatives`'s pattern-match-
+        // failure arm used to `return Err(e)` on the last `?//` alternative,
+        // silently dropping the output an earlier alternative's body had
+        // already produced -- diverging from jq (which keeps it) for the
+        // *bare* spelling specifically, since the new `each_pattern_alternatives`
+        // never had anywhere to drop that output from (already pushed to its
+        // sink). Fixed so both agree with jq (1.7.1, confirmed live).
+        (
+            &["-cn", r#"[1] as [$a] ?// {b:$c} | ($a, error("x"))"#],
+            None,
+            "1\n",
+            r#"jq: error (at <unknown>): Cannot index array with string "b""#,
+            5,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18211,6 +18211,69 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
     Ok(())
 }
 
+/// #1519, found while implementing #1462's own oracle sweep: real jq's
+/// short-circuiting builtins are macro-expanded `label $out | ... break
+/// $out` definitions, and its `?//`-alternatives operator retries the next
+/// alternative on *any* escaping `break` -- including one addressed to a
+/// `label` entirely outside the `?//` expression, established by whatever
+/// builtin is consuming it. So wrapping a `?//` bind in `isempty` makes the
+/// whole thing run once per alternative, not once total: confirmed live
+/// against jq 1.7.1, `isempty(1 as $x ?// $y | 5)` is `false` **twice**, a
+/// three-alternative chain is `false` **three** times, and the *unwrapped*
+/// expression (`1 as $x ?// $y | 5`, no consumer at all) is an ordinary
+/// single `5`.
+///
+/// succinctly's `?//` resolution (`each_pattern_alternatives`/
+/// `try_pattern_alternatives`) has no concept of an enclosing `label`/
+/// `break` at all -- its short-circuiting builtins are native Rust
+/// functions, not user-space macro expansions -- so it always produces
+/// exactly one answer regardless of alternative count. Orthogonal to
+/// #1462's own scope (whether a wrapping consumer's demand reaches a nested
+/// generator; here demand reaches it correctly, and stops it after exactly
+/// the number of outputs succinctly itself produces) and confirmed
+/// pre-existing on `main` before that work landed, so pinned here rather
+/// than attempted there.
+///
+/// The table below records succinctly's own current (single-answer,
+/// jq-diverging) output directly, in the same style as
+/// `test_short_circuit_side_effect_leaks_820_932_987` above -- jq's answer
+/// for each row is given in a comment rather than asserted, since matching
+/// it is #1519's own future fix, not this test's job.
+#[test]
+fn test_as_pattern_alternatives_do_not_retry_under_a_wrapping_label_1519() -> Result<()> {
+    let cases: &[SideEffectCase] = &[
+        // No wrapping consumer: jq and succinctly already agree (`5`, once).
+        (&["-cn", "1 as $x ?// $y | 5"], None, "5\n", "", 0),
+        // Wrapped in `isempty`: jq is `false` twice; succinctly, once.
+        (
+            &["-cn", "isempty(1 as $x ?// $y | 5)"],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // Three alternatives: jq is `false` three times; succinctly, once.
+        (
+            &["-cn", "isempty(1 as $x ?// $y ?// $z | 5)"],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+    ];
+
+    for (args, stdin, want_out, want_err, want_code) in cases {
+        let (stdout, stderr, code) = run_jq_full(args, *stdin)?;
+        assert_eq!(
+            (stdout.as_str(), stderr.trim_end_matches('\n'), code),
+            (*want_out, *want_err, *want_code),
+            "`{}` changed -- if #1519 is fixed, update this test's expectations",
+            args.join(" ")
+        );
+    }
+    Ok(())
+}
+
 /// #987 (Stage 3, `each_paths_filter`): `path(paths(f))` used to run `f`
 /// against a node real jq never visits, because `resolve_leaf`'s catch-all
 /// evaluated `paths(f)`'s whole generator eagerly before ever checking

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17801,6 +17801,139 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "BACA",
             0,
         ),
+        // ---- closed by #820 Stage 5 (#1462); these were leaking above -----
+        // `eval_each` gained native `If`/`Try`/`Optional`/`Label`/`As`/
+        // `AsPattern`/`FuncDef` arms and a demand-forwarding `Limit` arm, so
+        // a generator inside any of these -- reached through a consumer that
+        // has no native `eval_generic` routing of its own (`isempty`,
+        // `limit`, `nth`, `path`, ... -- NOT a bare `first(...)`/`last(...)`,
+        // which `eval_generic`'s own native arm intercepts before this
+        // subtree ever reaches `eval.rs`; that gap is #1461) -- now stops on
+        // the output that satisfies the consumer instead of running to
+        // completion first.
+        //
+        // `path(paths(if...))`: node `[0]`'s own `if`-filter now stops after
+        // its `true` branch's first output, so `path()`'s stop-after-first
+        // sink is satisfied before the `stderr` half of the comma is ever
+        // reached.
+        (
+            &[
+                "-c",
+                "path(paths(if .==1 then (true,(stderr|true)) else false end))",
+            ],
+            Some("[1,2,3]"),
+            "",
+            "jq: error (at <stdin>:0): Invalid path expression with result [0]",
+            5,
+        ),
+        // The `binary_fanout_each` left/right `halt_error` pair Stage 4 added
+        // (see the leaks table's own historical note): with `Expr::If` now
+        // lazy, neither operand ever evaluates `halt_error` at all, so both
+        // rows lose their stray `x` and agree with jq's own path error --
+        // including the second row, whose already-triggered halt no longer
+        // has anything to preempt it with.
+        (
+            &[
+                "-cn",
+                r#"path(1 == (if true then (1, ("x"|halt_error(3))) else empty end))"#,
+            ],
+            None,
+            "",
+            "jq: error (at <unknown>): Invalid path expression with result true",
+            5,
+        ),
+        (
+            &[
+                "-cn",
+                r#"path((if true then (1, ("x"|halt_error(3))) else empty end) == 1)"#,
+            ],
+            None,
+            "",
+            "jq: error (at <unknown>): Invalid path expression with result true",
+            5,
+        ),
+        // `Expr::Limit`'s own demand-forwarding gap: `each_take_n` (Stage 2)
+        // already stops asking its generator for more once `n` outputs
+        // exist, but materialized all of them before a *wrapping* consumer's
+        // own, possibly smaller, demand had any way to shrink that -- so
+        // `isempty` used to see `limit(3; ...)`'s full 3-item answer only
+        // after all 3 had already run.
+        (
+            &["-cn", r#"isempty(limit(3; 1, ("B"|stderr)))"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // `Expr::If`: branch *selection* was already lazy; the generator
+        // *inside* the taken branch was not.
+        (
+            &[
+                "-cn",
+                r#"isempty(if true then (1,("B"|stderr)) else 9 end)"#,
+            ],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // `Expr::Try` and its `?` sugar (`Expr::Optional`).
+        (
+            &["-cn", r#"isempty(try (1,("B"|stderr)) catch 9)"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"isempty((1,("B"|stderr))?)"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // `Expr::Label`: already correct when it wraps a satisfied consumer
+        // (`label $o | first(...)`, in the leaks-table history above) --
+        // this is the other direction, a label *inside* the consumer's own
+        // argument.
+        (
+            &["-cn", r#"isempty(label $o | (1,("B"|stderr)))"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // `Expr::As` (bare `$var`) and `Expr::AsPattern` (destructuring) --
+        // two distinct parser nodes for `EXPR as PATTERN | body`, so both
+        // need their own arm.
+        (
+            &["-cn", r#"isempty(1 as $x | (1,("B"|stderr)))"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"isempty([1] as [$a] | (1,("B"|stderr)))"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // `Expr::FuncDef`: pure AST substitution, so the fix is routing the
+        // *expanded* tree through `eval_each` instead of `eval_single` --
+        // the top-level `def f: (1,("B"|stderr)); first(f)` spelling already
+        // matched jq before this arm existed (`first`'s own
+        // `eval_first_expr` reaches the expansion through `eval_single`,
+        // which is itself already lazy); the gap was a `FuncDef` *nested*
+        // inside another consumer's argument, as here.
+        (
+            &["-cn", r#"isempty(def f: (1,("B"|stderr)); f)"#],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -17902,69 +18035,6 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "[false,false]\n",
             "BCAA",
             0,
-        ),
-        // #987 Stage 3 closed the bare-comma spelling of this shape
-        // (`path(paths((true,(stderr|true))))`, now in the "already match"
-        // table above) but not this `If`-wrapped one: `eval_each` has no
-        // native `Expr::If` arm, so node `[0]`'s own filter still falls
-        // back to eager `drain_result(eval_single(...))` for that one
-        // sub-expression, and the whole `If` runs to completion (both
-        // comma branches of its `then`) before `path()`'s stop-after-first
-        // sink ever sees `[0]`'s first truthy output. jq: no stderr, since
-        // its own generator never even reaches the `stderr` half of the
-        // comma before `path()` is satisfied by the `true` half.
-        (
-            &[
-                "-c",
-                "path(paths(if .==1 then (true,(stderr|true)) else false end))",
-            ],
-            Some("[1,2,3]"),
-            "",
-            "1jq: error (at <stdin>:0): Invalid path expression with result [0]",
-            5,
-        ),
-        // ---- `binary_fanout_each` drops the OUTER operand's `pending` -----
-        // `resolve_leaf` is the one consumer that reads `Flow::Stopped`'s
-        // `pending`, and this pair pins the left/right asymmetry that falls
-        // out of `binary_fanout_each`'s `abort.unwrap_or(outer)`: a `Halt`
-        // an eager-fallback operand had already triggered survives from the
-        // INNER (left) operand and is dropped from the OUTER (right) one.
-        // The drop is deliberate -- see `binary_fanout_each`'s own doc
-        // comment -- and it is the half that lands on jq's verdict, since
-        // jq's fully lazy `path()` never evaluates the `halt_error` at all
-        // and raises the path error instead.
-        //
-        // Both rows still diverge, and by the same Stage 5 residual rather
-        // than anything Stage 4 introduced: `Expr::If` has no lazy arm, so
-        // the `halt_error` is evaluated and writes `x` where jq writes
-        // nothing. Once Stage 5 lands neither operand evaluates it at all,
-        // so both rows lose the `x`, the second row's halt stops preempting
-        // the path error, and both move into the table above.
-        //
-        // Right operand (outer): pending dropped, so the path error wins --
-        // jq's own exit code and message, plus the stray `x`.
-        (
-            &[
-                "-cn",
-                r#"path(1 == (if true then (1, ("x"|halt_error(3))) else empty end))"#,
-            ],
-            None,
-            "",
-            "xjq: error (at <unknown>): Invalid path expression with result true",
-            5,
-        ),
-        // Left operand (inner): pending kept, so the already-triggered halt
-        // wins and the path error is never raised. jq: exit 5, same message
-        // as the row above.
-        (
-            &[
-                "-cn",
-                r#"path((if true then (1, ("x"|halt_error(3))) else empty end) == 1)"#,
-            ],
-            None,
-            "",
-            "x",
-            3,
         ),
     ];
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18050,6 +18050,48 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "BCAA",
             0,
         ),
+        // ---- `binary_fanout_each`'s inner/outer `pending` asymmetry -------
+        // (code review, #1462): `resolve_leaf` is the one consumer that
+        // reads `Flow::Stopped`'s `pending`, and this pair pins the
+        // left/right asymmetry that falls out of `binary_fanout_each`'s
+        // `abort.unwrap_or(outer)` -- an already-triggered `Halt` an eager
+        // fallback operand raised survives from the INNER (left) operand and
+        // is dropped from the OUTER (right) one. The original pair pinning
+        // this (an `if`-wrapped `halt_error`) stopped demonstrating it once
+        // Stage 5 gave `Expr::If` a native lazy arm -- `if` no longer falls
+        // back to eager `eval_single` at all, so `halt_error` is never
+        // reached and both rows now agree with jq (moved into
+        // `test_short_circuit_side_effect_shapes_already_match_jq_820`).
+        // `foreach` has no Stage 5 arm and still falls back the same way, so
+        // it reproduces the identical asymmetry live.
+        //
+        // Right operand (outer): pending dropped, so the path error wins --
+        // jq's own exit code and message, plus the stray `x` this eager
+        // fallback still leaks (jq's own `path()` never evaluates the
+        // trailing `halt_error` at all).
+        (
+            &[
+                "-cn",
+                r#"path(1 == (foreach (1,2,3) as $x (null; $x; if $x==1 then $x else ("x"|halt_error(3)) end)))"#,
+            ],
+            None,
+            "",
+            "xjq: error (at <unknown>): Invalid path expression with result true",
+            5,
+        ),
+        // Left operand (inner): pending kept, so the already-triggered halt
+        // wins and the path error is never raised. jq: exit 5, same message
+        // as the row above.
+        (
+            &[
+                "-cn",
+                r#"path((foreach (1,2,3) as $x (null; $x; if $x==1 then $x else ("x"|halt_error(3)) end)) == 1)"#,
+            ],
+            None,
+            "",
+            "x",
+            3,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {


### PR DESCRIPTION
## Summary

Closes #1462 (Stage 5 of `docs/plan/jq-lazy-generator-consumers.md`).

Widens `eval_each`'s native lazy arms beyond `Comma`/`Pipe`/`Paren`/`Compare`
to `If`, `Try`/`Optional`, `Label`, `As`/`AsPattern`, `FuncDef`, and `Limit` —
closing the data-loss bug where a wrapper expression between a
short-circuiting consumer (`isempty`, `limit`, `nth`, `path`, `any`, `all`,
`IN`) and a generator caused `input`/`inputs` documents to be silently
dropped (`isempty(limit(3; 1, input))` used to consume all 3 documents
before `isempty` ever saw the first output).

- `fix(jq): widen eval_each's native lazy arm set (#1462, Stage 5)` — the six
  new sink-driven arms (`each_if`, `each_try`, `each_label`, `each_as`,
  `each_as_pattern`, `each_limit`) plus one inline `FuncDef` arm.
- `test(jq): pin ?//-alternatives retry divergence found by Stage 5's sweep
  (#1519)` — pins a separately-filed, pre-existing divergence found along the
  way.
- `docs(jq): mark Stage 5 complete and record its findings (#1462)` — updates
  the plan doc.
- `fix(jq): keep ?//-alternative prefix on a last-alternative match failure`
  — a review-found correctness bug: the same `?//`-chain query answered two
  different ways depending on whether it was reached bare or through one of
  the new lazy arms. Fixed at the shared root cause
  (`try_pattern_alternatives`), confirmed against the pinned jq 1.7.1 oracle.
- `test(jq): restore binary_fanout_each's pending-asymmetry coverage` — a
  pre-existing doc comment's worked example went stale once `Expr::If`
  became lazy; replaced with a still-live `foreach`-based repro and restored
  the regression test it needs.
- `docs(jq): fix Stage 5 arm-count and add missing As to eval_each's arm
  list` — two doc nits found in review.
- `refactor(jq): share limit's n-classification across its three copies` —
  extracts `classify_limit_n`, closing off a duplication class that already
  caused one shipped drift bug (#1313).
- `refactor(jq): share each_as/each_as_pattern's bound-value extraction` —
  extracts `materialize_bound_values`.

## Test plan

- [x] `cargo build --features cli` / `--no-default-features`
- [x] `cargo test --lib jq::eval::tests` (918 passed)
- [x] `cargo test --test jq_cli_tests` (875 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (clean)
- [x] `cargo doc --no-deps` (clean)
- [x] Every intermediate commit verified to build standalone