### PR TITLE
policy(yq): gate jq-only builtins behind --jq-extensions (#1512)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ syq '.users[].name' config.yaml
 syq -o json '.' config.yaml         # Output as JSON
 syq '.spec.containers[]' k8s.yaml
 syq --doc 0 '.' multi-doc.yaml      # First document only
+syq --jq-extensions '[paths]' config.yaml  # opt into jq-only builtins yq's lexer rejects (#1512)
 syq-locate config.yaml --offset 42
 syq-locate config.yaml --line 5 --column 10
 
@@ -301,7 +302,7 @@ printf 'a:\n  x: 1\nb:\n  x: 2\n  y: 3\n' | succinctly yq '.a *=n .b'  # a: {x: 
 
 ### `sub` divergence (yq mode only) — `gsub`/`scan`/`splits` aren't real yq builtins at all
 
-Real yq's bare, 2-arg `sub(re; s)` replaces *every* match, not just the first — jq's `sub` = first match only, `gsub` = all matches; yq's bare `sub` behaves like jq's `gsub` unconditionally (`"aaa" | sub("a";"X")` => `"XXX"` in yq, `"Xaa"` in jq, confirmed against yq v4.53.3). `gsub` is not a real yq builtin at any arity — its lexer rejects `gsub(...)` outright, same as `scan`/`splits` (confirmed live against yq v4.53.3, #1436) — so there's no jq-model "match" to speak of for succinctly's own `gsub` in yq mode; it's an unopposed succinctly behavior, not a verified divergence.
+Real yq's bare, 2-arg `sub(re; s)` replaces *every* match, not just the first — jq's `sub` = first match only, `gsub` = all matches; yq's bare `sub` behaves like jq's `gsub` unconditionally (`"aaa" | sub("a";"X")` => `"XXX"` in yq, `"Xaa"` in jq, confirmed against yq v4.53.3). `gsub` is not a real yq builtin at any arity — its lexer rejects `gsub(...)` outright, same as `scan`/`splits` (confirmed live against yq v4.53.3, #1436) — so there's no jq-model "match" to speak of for succinctly's own `gsub` in yq mode; it's a succinctly extension (ADR-0018 rule 5), gated behind `--jq-extensions` and off by default since #1512, not a verified divergence.
 
 Real yq's 3-arg `sub(re; replacement; flags)` never evaluates `replacement` or `flags` at all — it always performs a global replace-with-empty-string using only the pattern (near-certainly an upstream Go bug reading its replacement from a fixed AST slot that's empty once arity exceeds 2, not a designed feature; confirmed live that an `error(...)` in either position never fires). Per ADR-0018 rule 3, succinctly reproduces this bug-for-bug rather than "fixing" it into jq's model (`"aaa" | sub("a";"X";"g")` => `""` in both yq and succinctly yq mode; flags like `"i"` are silently ignored, and a 4th+ argument is accepted and discarded, matching real yq's own parser leniency — #1122).
 
@@ -420,6 +421,13 @@ This divergence is intentional: `leaf_paths` uses a tree-structural
 definition of "leaf" (no children), which the community recipe's
 type-based `scalars` filter doesn't fully capture. See
 [collect_leaf_paths](src/jq/eval.rs) and issue #771 for the full rationale.
+
+**In `succinctly yq`**, `leaf_paths` (along with `paths`, `getpath`, `limit`,
+`gsub`/`scan`/`splits`, and the rest of the jq-only surface real yq's lexer
+rejects) is gated behind `--jq-extensions` and off by default since #1512 —
+`succinctly jq` above is unaffected either way. See
+[docs/reference/yq-language.md](docs/reference/yq-language.md#gated-jq-builtins---jq-extensions)
+for the full list.
 
 ## Feature Flags
 

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -103,6 +103,11 @@ which is part of why the same family keeps being rediscovered
 | `leaf_paths` ([#771](https://github.com/rust-works/succinctly/issues/771)) | A succinctly **extension** — neither reference defines it; a third category |
 
 All four re-verified against the pinned binaries while writing this record.
+[#1512](https://github.com/rust-works/succinctly/issues/1512) later found `leaf_paths` wasn't
+the only member of its category — real yq's lexer rejects a further fifteen jq-only
+builtins `succinctly yq` also accepted unconditionally — and settled that the whole group
+stays extensions, but off by default behind `--jq-extensions` rather than always-on; see
+rule 5 below.
 
 ### Worked example: duplicate object keys (#1385)
 
@@ -282,6 +287,33 @@ more dangerous direction of a rule-5 error: because rule 5 exempts extensions fr
 mislabelling a reference feature as an extension retires a fidelity obligation rather than
 merely inventing a spurious one.
 
+### Amendment (#1512, implemented): "marked as an extension" can mean gated, off by default
+
+`leaf_paths` stood alone as this rule's worked example of the extension category for over a
+year. [#1512](https://github.com/rust-works/succinctly/issues/1512) found it had fifteen
+unacknowledged siblings: `succinctly yq` accepted `paths`, `getpath`, `tostream`,
+`IN`, `fromstream`, `truncate_stream`, `limit`, `isempty`, `debug`, `ltrimstr`, `infinite`,
+`isnan`, and `gsub`/`scan`/`splits` unconditionally, even though real yq's own lexer rejects
+every one of them — the same fact pattern as `leaf_paths`, just never brought under this
+rule. Two incompatible classifications of the identical situation had drifted into the
+docs: `compliance/yq/limitations.md` filed `gsub`/`scan`/`splits` under "open divergences (bugs,
+not decisions)" while `CLAUDE.md` called it "an unopposed succinctly behavior" — rule 5's
+own category, unnamed as such.
+
+The resolution folds all fifteen into rule 5's extension category — none of rule 4's carve-out
+conditions apply (the output is readable, nothing is corrupted, no process dies), so
+"divergence" was never the right label — but tightens what "marked as an extension" requires
+for a case where the reference doesn't merely lack a feature, it actively **rejects the
+syntax naming it**: `succinctly yq` now matches that rejection **by default**, and the
+extension is reached only through an explicit `--jq-extensions` flag. Off-by-default-plus-opt-in
+is not a new fourth category — it is what "marked as an extension" operationally means once
+the reference has a lexer error to be silently more permissive than. `at_offset`/`at_position`
+and `@dsv` need no such gate, since neither jq nor yq has any syntax to be more permissive
+than in the first place; `leaf_paths` moves from always-on to gated alongside its fifteen
+newly-acknowledged siblings, without changing which category it belongs to. See
+[compliance/yq/limitations.md](../compliance/yq/limitations.md) § Extensions for the full
+builtin list and the CLI flag.
+
 **6. Every divergence is recorded on the mode's compliance page.** jq-mode divergences go in
 [compliance/jq/limitations.md](../compliance/jq/limitations.md); yq-mode divergences go in
 [compliance/yq/limitations.md](../compliance/yq/limitations.md), created alongside this ADR
@@ -385,7 +417,8 @@ been found yet.
   deliberate-divergence precedent.
   [#1096](https://github.com/rust-works/succinctly/issues/1096) — the two modes deliberately
   differing. [#771](https://github.com/rust-works/succinctly/issues/771) — `leaf_paths`; the
-  extension category.
+  extension category. [#1512](https://github.com/rust-works/succinctly/issues/1512) — rule 5's
+  amendment: gated, off-by-default extensions for jq-only syntax real yq's lexer rejects.
 - [#1342](https://github.com/rust-works/succinctly/issues/1342),
   [#1343](https://github.com/rust-works/succinctly/issues/1343),
   [#1344](https://github.com/rust-works/succinctly/issues/1344) — yq duplicate-key issues

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -279,22 +279,6 @@ jq's queue is `Vec<(OwnedValue, u32, u32)>`. Reusing jq's queue would push YAML 
 through `OwnedValue` and silently lose all three, so real support needs a second,
 cursor-native queue. See #1507.
 
-### `gsub`, `scan`, `splits` are not real yq builtins at all
-
-Confirmed via the pinned binary's lexer rejecting all three outright, at any arity
-([#1436](https://github.com/rust-works/succinctly/issues/1436)) — this isn't "3-arg `gsub`
-diverges," it's that yq's grammar has no `gsub`/`scan`/`splits` token at all:
-
-```bash
-$ echo '"aaa"' | yq 'gsub("a";"X")'      # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\")"
-$ echo '"aaa"' | yq 'gsub("a";"X";"g")'  # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\";\"g\"..."
-$ echo '"aaa"' | yq 'scan("a")'          # Error: 1:1: lexer: invalid input text "scan(\"a\")"
-```
-
-| Filter on `"aaa"` | real yq | succinctly |
-|---|---|---|
-| `gsub("a";"X";"g")` | `Error: 1:1: lexer: invalid input text` | `"XXX"` |
-
 ### 3-argument `sub(re; s; flags)` — resolved, real yq ignores everything past the pattern
 
 [#1122](https://github.com/rust-works/succinctly/issues/1122) resolved what had looked like an
@@ -338,7 +322,8 @@ $ echo '"bab"' | succinctly yq 'sub("a*"; "X")'   # "XbXbX"  (matches)
 
 Deliberately **not** extended to `gsub`/`scan`/`splits` (not real yq builtins at all, per
 #1436 — there's no oracle for succinctly's own yq-mode extensions to diverge from, so they
-stay on the jq-style iteration) or to `split(re;flags)` (a real yq builtin, but with its own
+stay on the jq-style iteration; see [Extensions](#extensions) below — all three are gated
+behind `--jq-extensions` since #1512) or to `split(re;flags)` (a real yq builtin, but with its own
 separate, still-unresolved mystery, #1439 above — #1255's fix alone wouldn't make it
 oracle-correct given that deeper algorithm mismatch, so the two are deliberately decoupled
 rather than guessed at together).
@@ -579,12 +564,41 @@ must be verified in the other (ADR-0018 rule 2).
 
 ## Extensions
 
-succinctly adds capabilities neither reference has — `at_offset`/`at_position`,
-`leaf_paths`, `@dsv`. Under ADR-0018 rule 5 these are a third category: permitted where
-marked as extensions and where they change the behaviour of no filter the reference also
-accepts. They are documented in
-[yq Query Language Reference](../../reference/yq-language.md) and in
-[CLAUDE.md](../../../CLAUDE.md), not here — an extension is not a divergence.
+succinctly's extension surface falls into two groups. Under ADR-0018 rule 5 both are a
+third category: permitted where marked as extensions and where they change the behaviour of
+no filter the reference also accepts — an extension is not a divergence.
+
+**Wholly new syntax, unconditional** — `at_offset`/`at_position`, `@dsv`. Neither jq nor yq
+has anything resembling these; there is no reference token to gate them against.
+
+**jq-styled syntax real yq's lexer rejects, gated behind `--jq-extensions`, off by default
+([#1512](https://github.com/rust-works/succinctly/issues/1512))** — `paths`, `getpath`,
+`leaf_paths`, `tostream`/`fromstream`/`truncate_stream`, `IN`, `ltrimstr`, `limit`,
+`isempty`, `debug`, `infinite`, `isnan`, and `gsub`/`scan`/`splits`. `succinctly yq` matches
+real yq's rejection of all of these by default; the flag opts back into the jq-compatible
+surface. `leaf_paths` is grouped here even though it isn't real jq syntax either — real jq
+itself rejects it too (`leaf_paths/0 is not defined`; it's a succinctly-only invention
+modeled on a jq community recipe, see CLAUDE.md) — because, from `succinctly yq`'s
+syntax-surface point of view, it's the same kind of thing as the rest of this list: extra,
+off by default.
+
+`gsub`/`scan`/`splits` specifically: real yq's lexer rejects all three outright, at any
+arity ([#1436](https://github.com/rust-works/succinctly/issues/1436)) — this isn't "3-arg
+`gsub` diverges," it's that yq's grammar has no `gsub`/`scan`/`splits` token at all:
+
+```bash
+$ echo '"aaa"' | yq 'gsub("a";"X")'      # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\")"
+$ echo '"aaa"' | yq 'gsub("a";"X";"g")'  # Error: 1:1: lexer: invalid input text "gsub(\"a\";\"X\";\"g\"..."
+$ echo '"aaa"' | yq 'scan("a")'          # Error: 1:1: lexer: invalid input text "scan(\"a\")"
+```
+
+| Filter on `"aaa"` | real yq | succinctly (default) | succinctly `--jq-extensions` |
+|---|---|---|---|
+| `gsub("a";"X";"g")` | `Error: 1:1: lexer: invalid input text` | parse error, names the flag | `"XXX"` |
+
+The full builtin list is documented, with examples, in
+[yq Query Language Reference](../../reference/yq-language.md#gated-jq-builtins---jq-extensions)
+and in [CLAUDE.md](../../../CLAUDE.md) — not enumerated a second time here.
 
 **Not extensions, though a draft of this page listed them as such:** `--front-matter`,
 `--split-exp`, and cross-file evaluation. All three are real yq surface —

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -20,6 +20,12 @@ The `yq` command provides YAML querying using jq-compatible syntax. It supports 
 | Multi-document support    | Fully implemented | 100%     |
 | Anchors/aliases           | Fully implemented | 95%      |
 
+"All jq features" means the full jq language is available; a subset of jq's
+*builtins* that real yq's own lexer rejects (`paths`, `getpath`, `limit`,
+`gsub`/`scan`/`splits`, `leaf_paths`, etc.) is off by default and requires
+`--jq-extensions` — see [Gated jq Builtins](#gated-jq-builtins---jq-extensions)
+below.
+
 ---
 
 ## Performance
@@ -244,22 +250,23 @@ confirmed against yq v4.53.3):
 echo '"aaa"' | succinctly yq 'sub("a"; "X")'
 # "XXX" — every match replaced (unlike succinctly jq's identical-syntax "Xaa")
 
-echo '"aaa"' | succinctly yq 'gsub("a"; "X")'
+echo '"aaa"' | succinctly yq --jq-extensions 'gsub("a"; "X")'
 # "XXX" — same result for a non-zero-width pattern like this one
 ```
 
 `gsub` (any arity), `scan`, and `splits` are not real yq builtins at all — real yq's own
 lexer rejects them outright (confirmed live against yq v4.53.3, #1436). succinctly's `gsub`
-support in yq mode is therefore a succinctly-only convenience, not a verified match against
-an oracle that has nothing to compare against — and, as of #1255 below, it's no longer a
-strict synonym for bare `sub` even internally: a **zero-width-capable** pattern (`a*`,
-`x?`, `""`) makes the two diverge, since bare `sub` picks up #1255's real-yq-verified
-Go-`regexp` iteration while `gsub` deliberately keeps the original jq/Oniguruma-style
-iteration (there being no oracle for `gsub` to match instead):
+support in yq mode is therefore a succinctly-only convenience, gated behind
+`--jq-extensions` since #1512 (see [Gated jq Builtins](#gated-jq-builtins---jq-extensions)
+below) rather than a verified match against an oracle that has nothing to compare against —
+and, as of #1255 below, it's no longer a strict synonym for bare `sub` even internally: a
+**zero-width-capable** pattern (`a*`, `x?`, `""`) makes the two diverge, since bare `sub`
+picks up #1255's real-yq-verified Go-`regexp` iteration while `gsub` deliberately keeps the
+original jq/Oniguruma-style iteration (there being no oracle for `gsub` to match instead):
 
 ```bash
-echo '"bab"' | succinctly yq 'sub("a*"; "X")'    # "XbXbX"  (Go-style, matches real yq)
-echo '"bab"' | succinctly yq 'gsub("a*"; "X")'   # "XbXXbX" (jq/Oniguruma-style, unchanged)
+echo '"bab"' | succinctly yq 'sub("a*"; "X")'                     # "XbXbX"  (Go-style, matches real yq)
+echo '"bab"' | succinctly yq --jq-extensions 'gsub("a*"; "X")'    # "XbXXbX" (jq/Oniguruma-style, unchanged)
 ```
 
 **Resolved (#1122):** the 3-arg `sub(re; s; flags)` form doesn't fit jq's
@@ -350,6 +357,44 @@ succinctly yq 'at_offset(10)' config.yaml
 succinctly yq 'at_position(5; 3)' config.yaml
 ```
 
+### Gated jq Builtins (--jq-extensions)
+
+Real yq's own lexer rejects a chunk of the jq language outright — these
+builtins have no yq token at all, confirmed live against yq v4.53.3. Rather
+than silently accepting broader syntax than the reference it's meant to
+match, `succinctly yq` rejects them too by default (a parse error naming
+`--jq-extensions`); passing the flag opts back into the jq-compatible
+surface (#1512):
+
+| Builtin                                           | Description                               |
+|---------------------------------------------------|-------------------------------------------|
+| `paths`, `paths(f)`, `leaf_paths`                 | Paths to every node / every leaf node     |
+| `getpath(path)`                                   | Value at a path array                     |
+| `tostream`, `fromstream(f)`, `truncate_stream(f)` | Streaming event representation            |
+| `IN(s)`, `IN(src; s)`                             | Membership test                           |
+| `ltrimstr(s)`                                     | Strip a leading string prefix             |
+| `limit(n; f)`                                     | First `n` outputs of `f`                  |
+| `isempty(f)`                                      | True if `f` produces no output            |
+| `debug`, `debug(msg)`                             | Print to stderr, pass value through       |
+| `infinite`, `isnan`                               | IEEE 754 infinity literal / NaN test      |
+| `gsub(re; s)`, `scan(re)`, `splits(re)`           | Not real yq builtins at any arity (#1436) |
+
+```bash
+echo '{}' | succinctly yq 'paths'
+# Error: parse error: ... "paths" is not part of yq's syntax; pass --jq-extensions ...
+
+echo '{"a":1}' | succinctly yq --jq-extensions -o=json 'paths'
+# ["a"]
+```
+
+Real yq's own extensions (`sub`, `split`, the merge-flag suffixes on `*`/`*=`,
+date/time and format encoders above) are unaffected — they're already yq
+surface, not part of this gate. `leaf_paths` is a succinctly-only invention
+modeled on a jq community recipe (real jq itself rejects it too, see the
+[jq Language Reference](jq-language.md#succinctly-extensions)); it's grouped
+here because, from `succinctly yq`'s syntax-surface point of view, it's the
+same kind of thing as the rest of this table — extra, off by default.
+
 ---
 
 ## CLI Options
@@ -365,6 +410,7 @@ succinctly yq 'at_position(5; 3)' config.yaml
 | `--doc N`             | Select Nth document (0-indexed)                  |
 | `--eval-all`, `--ea`  | Combine docs/files into one eval context (below) |
 | `--front-matter MODE` | Extract/process YAML front matter (below)        |
+| `--jq-extensions`     | Accept jq-only builtins yq's lexer lacks (above) |
 
 ### Output Options
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1041,6 +1041,13 @@ pub struct YqCommand {
     #[arg(long)]
     pub validate: bool,
 
+    /// Accept jq-only builtins real yq's lexer rejects (`paths`, `getpath`,
+    /// `limit`, `gsub`/`scan`/`splits`, `leaf_paths`, etc.) as a succinctly
+    /// extension. Off by default so `succinctly yq` matches real yq's
+    /// syntax surface (#1512).
+    #[arg(long)]
+    pub jq_extensions: bool,
+
     /// Input format type [auto, yaml, json] (default: auto)
     #[arg(
         short = 'p',

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2941,8 +2941,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     }
 
     // Parse the jq program (use Yq mode for extended identifier syntax like kebab-case)
-    let mut program = jq::parse_program_with_mode(&filter_str, jq::ParserMode::Yq)
-        .map_err(|e| anyhow::anyhow!("parse error: {e}"))?;
+    let mut program = jq::parse_program_with_mode_and_extensions(
+        &filter_str,
+        jq::ParserMode::Yq,
+        args.jq_extensions,
+    )
+    .map_err(|e| anyhow::anyhow!("parse error: {e}"))?;
 
     // Parse variables
     let context = parse_variables(&args)?;
@@ -2967,7 +2971,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         .split_exp
         .as_deref()
         .map(|s| {
-            jq::parse_program_with_mode(s, jq::ParserMode::Yq)
+            jq::parse_program_with_mode_and_extensions(s, jq::ParserMode::Yq, args.jq_extensions)
                 .map(|p| jq::substitute_vars(&p.expr, all_vars.iter().copied()))
                 .map_err(|e| anyhow::anyhow!("parse error in --split-exp expression: {e}"))
         })

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33617,7 +33617,7 @@ fn eval_func_call<'a, W: Clone + AsRef<[u64]>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jq::{parse, parse_with_mode, ParserMode};
+    use crate::jq::{parse, parse_with_mode_and_extensions, ParserMode};
     use crate::json::JsonIndex;
 
     /// Collect an [`eval_each`] stream back into a `QueryResult`, so the
@@ -33785,12 +33785,17 @@ mod tests {
     /// `JsonIndex`: arithmetic/merge operate purely on `OwnedValue` after
     /// document conversion, so JSON input exercises the same code path YAML
     /// input would (see `eval_generic.rs`'s `to_owned` conversion).
+    ///
+    /// Always parses with jq extensions enabled: this macro tests
+    /// *evaluator* semantics under `YqSemantics`, not the parser's default
+    /// rejection of jq-only builtins real yq's lexer lacks (#1512) — that
+    /// policy has its own dedicated test coverage in `parser.rs`.
     macro_rules! yq_query {
         ($json:expr, $expr:expr, $pattern:pat $(if $guard:expr)? => $body:expr) => {{
             let json_bytes: &[u8] = $json;
             let index = JsonIndex::build(json_bytes);
             let cursor = index.root(json_bytes);
-            let expr = parse_with_mode($expr, ParserMode::Yq).unwrap();
+            let expr = parse_with_mode_and_extensions($expr, ParserMode::Yq, true).unwrap();
             match eval::<Vec<u64>, YqSemantics>(&expr, cursor) {
                 $pattern $(if $guard)? => $body,
                 other => panic!("unexpected result: {:?}", other),

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -103,7 +103,8 @@ pub use expr::{
 };
 pub use lazy::JqValue;
 pub use parser::{
-    parse, parse_program, parse_program_with_mode, parse_with_mode, ParseError, ParserMode,
+    parse, parse_program, parse_program_with_mode, parse_program_with_mode_and_extensions,
+    parse_with_mode, parse_with_mode_and_extensions, ParseError, ParserMode,
 };
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -177,6 +177,11 @@ struct Parser<'a> {
     input: &'a str,
     pos: usize,
     mode: ParserMode,
+    /// Whether yq mode accepts jq-only surface real yq's lexer rejects
+    /// (`paths`, `getpath`, `limit`, `gsub`/`scan`/`splits`, etc.), gated
+    /// behind `--jq-extensions` (#1512). Ignored in jq mode, which always
+    /// accepts this surface.
+    jq_extensions: bool,
     /// Current `Pattern` recursion depth; see [`MAX_PATTERN_DEPTH`].
     pattern_depth: usize,
     /// Current `Expr` recursion depth; see [`MAX_EXPR_DEPTH`].
@@ -190,16 +195,18 @@ impl<'a> Parser<'a> {
             input,
             pos: 0,
             mode: ParserMode::Jq,
+            jq_extensions: false,
             pattern_depth: 0,
             expr_depth: 0,
         }
     }
 
-    fn with_mode(input: &'a str, mode: ParserMode) -> Self {
+    fn with_mode_and_extensions(input: &'a str, mode: ParserMode, jq_extensions: bool) -> Self {
         Parser {
             input,
             pos: 0,
             mode,
+            jq_extensions,
             pattern_depth: 0,
             expr_depth: 0,
         }
@@ -290,6 +297,26 @@ impl<'a> Parser<'a> {
         }
         let next_char = self.input[after..].chars().next();
         !matches!(next_char, Some(c) if c.is_alphanumeric() || c == '_')
+    }
+
+    /// Real yq's lexer has no token for jq-only surface like `paths`,
+    /// `getpath`, `limit`, `gsub`/`scan`/`splits`, etc. -- gated behind
+    /// `--jq-extensions` (#1512) so yq mode matches that rejection by
+    /// default, the same way `?//` is gated to jq mode only in
+    /// `parse_pattern_alternatives` below. Call sites must invoke this
+    /// before consuming the keyword, so a rejected keyword's position is
+    /// still where the caller expects.
+    fn reject_unless_jq_extensions(&self, name: &str) -> Result<(), ParseError> {
+        if self.mode == ParserMode::Yq && !self.jq_extensions {
+            return Err(ParseError::new(
+                format!(
+                    "\"{name}\" is not part of yq's syntax; pass --jq-extensions to enable \
+                     succinctly's jq-compatible builtin surface"
+                ),
+                self.pos,
+            ));
+        }
+        Ok(())
     }
 
     /// Scan a run of yq merge-flag characters (`+ ? n d c`, any order,
@@ -1351,6 +1378,7 @@ impl<'a> Parser<'a> {
                 } else if self.matches_keyword("foreach") {
                     self.parse_foreach_expr()
                 } else if self.matches_keyword("limit") {
+                    self.reject_unless_jq_extensions("limit")?;
                     self.parse_limit_expr()
                 } else if self.matches_keyword("until") {
                     self.parse_until_expr()
@@ -2470,6 +2498,7 @@ impl<'a> Parser<'a> {
         // IN(s) - true if any output of s equals the current value
         // IN(src; s) - true if any output of src equals any output of s
         if self.matches_keyword("IN") {
+            self.reject_unless_jq_extensions("IN")?;
             self.consume_keyword("IN");
             self.skip_ws();
             self.expect('(')?;
@@ -2498,6 +2527,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::AsciiUpcase));
         }
         if self.matches_keyword("ltrimstr") {
+            self.reject_unless_jq_extensions("ltrimstr")?;
             self.consume_keyword("ltrimstr");
             self.skip_ws();
             self.expect('(')?;
@@ -2539,6 +2569,7 @@ impl<'a> Parser<'a> {
         }
         // Check splits before split since split is a prefix of splits
         if self.matches_keyword("splits") {
+            self.reject_unless_jq_extensions("splits")?;
             self.consume_keyword("splits");
             self.skip_ws();
             self.expect('(')?;
@@ -2658,6 +2689,7 @@ impl<'a> Parser<'a> {
         }
         // gsub function - replace all matches
         if self.matches_keyword("gsub") {
+            self.reject_unless_jq_extensions("gsub")?;
             self.consume_keyword("gsub");
             self.skip_ws();
             self.expect('(')?;
@@ -2685,6 +2717,7 @@ impl<'a> Parser<'a> {
         }
         // scan function - find all matches
         if self.matches_keyword("scan") {
+            self.reject_unless_jq_extensions("scan")?;
             self.consume_keyword("scan");
             self.skip_ws();
             self.expect('(')?;
@@ -2924,10 +2957,12 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::FromJsonStream));
         }
         if self.matches_keyword("tostream") {
+            self.reject_unless_jq_extensions("tostream")?;
             self.consume_keyword("tostream");
             return Ok(Some(Builtin::ToStream));
         }
         if self.matches_keyword("fromstream") {
+            self.reject_unless_jq_extensions("fromstream")?;
             self.consume_keyword("fromstream");
             self.skip_ws();
             self.expect('(')?;
@@ -2938,6 +2973,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::FromStream(Box::new(f))));
         }
         if self.matches_keyword("truncate_stream") {
+            self.reject_unless_jq_extensions("truncate_stream")?;
             self.consume_keyword("truncate_stream");
             self.skip_ws();
             self.expect('(')?;
@@ -2948,6 +2984,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::TruncateStream(Box::new(f))));
         }
         if self.matches_keyword("getpath") {
+            self.reject_unless_jq_extensions("getpath")?;
             self.consume_keyword("getpath");
             self.skip_ws();
             self.expect('(')?;
@@ -3043,11 +3080,13 @@ impl<'a> Parser<'a> {
         }
         // leaf_paths - must check before paths
         if self.matches_keyword("leaf_paths") {
+            self.reject_unless_jq_extensions("leaf_paths")?;
             self.consume_keyword("leaf_paths");
             return Ok(Some(Builtin::LeafPaths));
         }
         // paths or paths(filter)
         if self.matches_keyword("paths") {
+            self.reject_unless_jq_extensions("paths")?;
             self.consume_keyword("paths");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -3232,6 +3271,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::IsInfinite));
         }
         if self.matches_keyword("isnan") {
+            self.reject_unless_jq_extensions("isnan")?;
             self.consume_keyword("isnan");
             return Ok(Some(Builtin::IsNan));
         }
@@ -3244,6 +3284,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::IsFinite));
         }
         if self.matches_keyword("infinite") {
+            self.reject_unless_jq_extensions("infinite")?;
             self.consume_keyword("infinite");
             return Ok(Some(Builtin::Infinite));
         }
@@ -3254,6 +3295,7 @@ impl<'a> Parser<'a> {
 
         // Phase 10: Debug
         if self.matches_keyword("debug") {
+            self.reject_unless_jq_extensions("debug")?;
             self.consume_keyword("debug");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -3586,6 +3628,7 @@ impl<'a> Parser<'a> {
 
         // isempty(expr) - returns true if expr produces no outputs
         if self.matches_keyword("isempty") {
+            self.reject_unless_jq_extensions("isempty")?;
             self.consume_keyword("isempty");
             self.skip_ws();
             self.expect('(')?;
@@ -4726,9 +4769,25 @@ pub fn parse(input: &str) -> Result<Expr, ParseError> {
 
 /// Parse a jq expression with a specific parser mode.
 ///
-/// Use `ParserMode::Yq` to allow kebab-case identifiers like `.my-key`.
+/// Use `ParserMode::Yq` to allow kebab-case identifiers like `.my-key`. In
+/// `Yq` mode, jq-only builtins real yq's lexer rejects (`paths`, `getpath`,
+/// `limit`, `gsub`/`scan`/`splits`, etc.) are rejected too; use
+/// [`parse_with_mode_and_extensions`] to accept them (#1512).
 pub fn parse_with_mode(input: &str, mode: ParserMode) -> Result<Expr, ParseError> {
-    let mut parser = Parser::with_mode(input, mode);
+    parse_with_mode_and_extensions(input, mode, false)
+}
+
+/// Parse a jq expression with a specific parser mode, optionally accepting
+/// jq-only builtins real yq's lexer rejects (`--jq-extensions`, #1512).
+///
+/// `jq_extensions` is ignored in `ParserMode::Jq`, which always accepts this
+/// surface.
+pub fn parse_with_mode_and_extensions(
+    input: &str,
+    mode: ParserMode,
+    jq_extensions: bool,
+) -> Result<Expr, ParseError> {
+    let mut parser = Parser::with_mode_and_extensions(input, mode, jq_extensions);
     let expr = parser.parse_expr()?;
 
     // Ensure we consumed all input
@@ -4774,9 +4833,26 @@ pub fn parse_program(input: &str) -> Result<Program, ParseError> {
 
 /// Parse a complete jq program with a specific parser mode.
 ///
-/// Use `ParserMode::Yq` to allow kebab-case identifiers like `.my-key`.
+/// Use `ParserMode::Yq` to allow kebab-case identifiers like `.my-key`. In
+/// `Yq` mode, jq-only builtins real yq's lexer rejects (`paths`, `getpath`,
+/// `limit`, `gsub`/`scan`/`splits`, etc.) are rejected too; use
+/// [`parse_program_with_mode_and_extensions`] to accept them (#1512).
 pub fn parse_program_with_mode(input: &str, mode: ParserMode) -> Result<Program, ParseError> {
-    let mut parser = Parser::with_mode(input, mode);
+    parse_program_with_mode_and_extensions(input, mode, false)
+}
+
+/// Parse a complete jq program with a specific parser mode, optionally
+/// accepting jq-only builtins real yq's lexer rejects (`--jq-extensions`,
+/// #1512).
+///
+/// `jq_extensions` is ignored in `ParserMode::Jq`, which always accepts this
+/// surface.
+pub fn parse_program_with_mode_and_extensions(
+    input: &str,
+    mode: ParserMode,
+    jq_extensions: bool,
+) -> Result<Program, ParseError> {
+    let mut parser = Parser::with_mode_and_extensions(input, mode, jq_extensions);
     let program = parser.parse_program()?;
 
     // Ensure we consumed all input
@@ -6552,6 +6628,56 @@ mod tests {
         );
     }
 
+    /// #1512: yq mode rejects jq-only builtins real yq's lexer lacks by
+    /// default, and `parse_program_with_mode_and_extensions(.., true)`
+    /// (the `--jq-extensions` CLI flag's parser-level counterpart) accepts
+    /// them. jq mode is unaffected either way -- it already accepts this
+    /// whole surface unconditionally, gate or no gate.
+    #[test]
+    fn test_yq_mode_rejects_jq_only_builtins_unless_jq_extensions_1512() {
+        let cases: &[(&str, &str)] = &[
+            ("IN", "IN(1)"),
+            ("ltrimstr", r#"ltrimstr("a")"#),
+            ("splits", r#"splits(",")"#),
+            ("gsub", r#"gsub("a";"b")"#),
+            ("scan", r#"scan("a")"#),
+            ("tostream", "tostream"),
+            ("fromstream", "fromstream(.)"),
+            ("truncate_stream", "truncate_stream(.)"),
+            ("getpath", "getpath([])"),
+            ("leaf_paths", "leaf_paths"),
+            ("paths", "paths"),
+            ("isnan", "isnan"),
+            ("infinite", "infinite"),
+            ("debug", "debug"),
+            ("isempty", "isempty(empty)"),
+            ("limit", "limit(1; .)"),
+        ];
+
+        for (name, filter) in cases {
+            let rejected = parse_program_with_mode(filter, ParserMode::Yq);
+            assert!(
+                rejected.is_err(),
+                "`{name}` should be rejected in yq mode by default, got: {rejected:?}"
+            );
+            let message = &rejected.unwrap_err().message;
+            assert!(
+                message.contains("--jq-extensions"),
+                "`{name}`'s rejection message should mention --jq-extensions, got: {message}"
+            );
+
+            assert!(
+                parse_program_with_mode_and_extensions(filter, ParserMode::Yq, true).is_ok(),
+                "`{name}` should parse in yq mode once --jq-extensions is enabled"
+            );
+
+            assert!(
+                parse_program_with_mode(filter, ParserMode::Jq).is_ok(),
+                "`{name}` should parse in jq mode regardless of the yq-only gate"
+            );
+        }
+    }
+
     #[test]
     fn test_jq_mode_kebab_case_is_subtraction() {
         // In Jq mode (default), .foo-bar is parsed as .foo minus bar
@@ -6772,10 +6898,10 @@ mod tests {
 
     /// `Parser::new` (kept for tests and future use, per its own
     /// `#[allow(dead_code)]`; `parse`/`parse_with_mode` both go through
-    /// `Parser::with_mode` instead) initializes `pattern_depth` to `0` the
-    /// same as `with_mode`, and a parser built through it can still parse a
-    /// pattern -- #1240's new field didn't leave this alternate constructor
-    /// broken.
+    /// `Parser::with_mode_and_extensions` instead) initializes
+    /// `pattern_depth` to `0` the same as `with_mode_and_extensions`, and a
+    /// parser built through it can still parse a pattern -- #1240's new
+    /// field didn't leave this alternate constructor broken.
     #[test]
     fn test_parser_new_initializes_pattern_depth_1240() {
         let mut parser = Parser::new(". as {$a} | $a");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1123,7 +1123,7 @@ fn test_duplicate_json_key_to_entries_preserves_1398() -> Result<()> {
 #[test]
 fn test_yq_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
     let yaml = "a: 1\na: 2\nb: 3\n";
-    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0", "--jq-extensions"])?;
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["a"],["a"],["b"]]"#);
@@ -1136,7 +1136,7 @@ fn test_yq_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
 #[test]
 fn test_yq_paths_preserves_nested_duplicate_mapping_keys_868() -> Result<()> {
     let yaml = "x:\n  a: 1\n  a: 2\n  b: 3\n";
-    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin("[paths]", yaml, &["-o=json", "-I=0", "--jq-extensions"])?;
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["x"],["x","a"],["x","a"],["x","b"]]"#);
@@ -1157,7 +1157,13 @@ fn test_yq_paths_json_input_format_preserves_1398() -> Result<()> {
     let (output, code) = run_yq_stdin(
         "[paths]",
         json,
-        &["--input-format", "json", "-o=json", "-I=0"],
+        &[
+            "--input-format",
+            "json",
+            "-o=json",
+            "-I=0",
+            "--jq-extensions",
+        ],
     )?;
 
     assert_eq!(code, 0, "out: {output:?}");
@@ -1216,7 +1222,11 @@ fn test_1398_dup_key_format_parity_across_filters() -> Result<()> {
 #[test]
 fn test_yq_leaf_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
     let yaml = "a: 1\na: 2\nb: 3\n";
-    let (output, code) = run_yq_stdin("[leaf_paths]", yaml, &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin(
+        "[leaf_paths]",
+        yaml,
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["a"],["a"],["b"]]"#);
@@ -1230,7 +1240,11 @@ fn test_yq_leaf_paths_preserves_duplicate_mapping_keys_868() -> Result<()> {
 #[test]
 fn test_yq_leaf_paths_leaf_definition_unaffected_by_868() -> Result<()> {
     let yaml = "a: {}\nb: []\nc: null\nd: 5\n";
-    let (output, code) = run_yq_stdin("[leaf_paths]", yaml, &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin(
+        "[leaf_paths]",
+        yaml,
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["a"],["b"],["c"],["d"]]"#);
@@ -1247,6 +1261,40 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
+    Ok(())
+}
+
+/// #1512: `succinctly yq` rejects jq-only builtins real yq's lexer lacks by
+/// default -- a parse error mentioning `--jq-extensions`, not the CLI
+/// silently accepting broader syntax than the reference it's meant to
+/// match. Covers both `try_parse_builtin`'s ordinary gate (`paths`,
+/// `getpath`) and `limit`'s special-cased one in `parse_primary`.
+#[test]
+fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
+    for filter in ["paths", "getpath([])", "limit(1; .)"] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
+        assert!(
+            stderr.contains("--jq-extensions"),
+            "filter {filter:?} stderr should mention --jq-extensions, got: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #1512: the CLI flag actually reaches the parser -- `--jq-extensions`
+/// makes the same three filters succeed end to end through the real
+/// `succinctly yq` binary, not just through the parser's own unit tests.
+#[test]
+fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
+    for filter in ["paths", "getpath([])", "limit(1; .)"] {
+        let (_out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
+        assert_eq!(
+            code, 0,
+            "filter {filter:?} should succeed with --jq-extensions, stderr: {stderr}"
+        );
+    }
     Ok(())
 }
 
@@ -3332,7 +3380,11 @@ fn test_yaml_assign_then_debug_through_anchor_updates_alias() -> Result<()> {
     // `debug` passes its input through unchanged (aside from the stderr
     // side effect), so it must not block the sync either.
     let input = "a: &x 1\nb: *x\n";
-    let (output, exit_code) = run_yq_stdin(".a = 99 | debug", input, &["-o=json", "-I=0"])?;
+    let (output, exit_code) = run_yq_stdin(
+        ".a = 99 | debug",
+        input,
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), r#"{"a":99,"b":99}"#);
     Ok(())
@@ -15132,7 +15184,7 @@ fn test_object_slice_getpath_path_round_trip_1102() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "getpath(path(.[0:2]))",
         r#"{"a":1,"b":2,"c":3}"#,
-        &["-o", "json", "-I0"],
+        &["-o", "json", "-I0", "--jq-extensions"],
     )?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), r#"["a",1]"#);
@@ -15141,7 +15193,7 @@ fn test_object_slice_getpath_path_round_trip_1102() -> Result<()> {
     let (out, code) = run_yq_stdin(
         "getpath(path(.[(1-1):(1+1)]))",
         r#"{"a":1,"b":2,"c":3}"#,
-        &["-o", "json", "-I0"],
+        &["-o", "json", "-I0", "--jq-extensions"],
     )?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), r#"["a",1]"#);
@@ -15157,7 +15209,7 @@ fn test_object_slice_getpath_malformed_descriptor_errors_1102() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         r#"getpath([{"start":"bad","end":2}])"#,
         r#"{"a":1,"b":2}"#,
-        &["-o", "json"],
+        &["-o", "json", "--jq-extensions"],
     )?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
@@ -16536,7 +16588,8 @@ fn test_1197_add_builtin_inherits_right_null_gating_consistently() -> Result<()>
 /// rather than relying on `arith_add` to keep always producing a String.
 #[test]
 fn test_1119_gsub_array_flags_still_errors_cleanly_not_panics() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(r#"gsub("t"; "x"; [])"#, "\"test\"", &[])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr(r#"gsub("t"; "x"; [])"#, "\"test\"", &["--jq-extensions"])?;
     assert_ne!(code, 0);
     assert!(
         stderr.contains("cannot be added"),
@@ -20176,10 +20229,15 @@ fn test_yq_sub_3arg_zero_width_interaction_1255_1122() -> Result<()> {
 
 /// `gsub` is not a real yq builtin at any arity (#1436) -- confirm it
 /// deliberately does NOT get #1255's fix (stays on jq/Oniguruma-style
-/// iteration, since there's no yq oracle for it to match).
+/// iteration, since there's no yq oracle for it to match). Gated behind
+/// `--jq-extensions` since #1512.
 #[test]
 fn test_yq_gsub_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
-    let (output, code) = run_yq_stdin(r#"gsub("a*"; "X")"#, "\"bab\"\n", &["-o", "json"])?;
+    let (output, code) = run_yq_stdin(
+        r#"gsub("a*"; "X")"#,
+        "\"bab\"\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "output: {output:?}");
     assert_eq!(output.trim(), r#""XbXXbX""#);
     Ok(())
@@ -20188,10 +20246,15 @@ fn test_yq_gsub_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
 /// `scan` is not a real yq builtin at all (#1436) -- same non-fix as
 /// `gsub` above, guarding `scan_with_resolved_pattern`'s hardcoded
 /// `JqSemantics` call specifically (code review flagged that only `gsub`
-/// had a guard test here, not `scan`/`split`/`splits`).
+/// had a guard test here, not `scan`/`split`/`splits`). Gated behind
+/// `--jq-extensions` since #1512.
 #[test]
 fn test_yq_scan_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
-    let (output, code) = run_yq_stdin(r#"[scan("a*")]"#, "\"bab\"\n", &["-o", "json"])?;
+    let (output, code) = run_yq_stdin(
+        r#"[scan("a*")]"#,
+        "\"bab\"\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "output: {output:?}");
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v, serde_json::json!(["", "a", "", ""]));
@@ -20212,10 +20275,14 @@ fn test_yq_split_regex_keeps_jq_style_zero_width_1255() -> Result<()> {
 
 /// `splits` is not a real yq builtin at all (#1436) -- same non-fix as
 /// `scan`/`gsub`. Guards `splits_with_resolved_pattern`'s hardcoded
-/// `JqSemantics` call.
+/// `JqSemantics` call. Gated behind `--jq-extensions` since #1512.
 #[test]
 fn test_yq_splits_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
-    let (output, code) = run_yq_stdin(r#"[splits("a*")]"#, "\"bab\"\n", &["-o", "json"])?;
+    let (output, code) = run_yq_stdin(
+        r#"[splits("a*")]"#,
+        "\"bab\"\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "output: {output:?}");
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v, serde_json::json!(["", "b", "", "b", ""]));

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12849,7 +12849,7 @@ fn test_split_doc_hides_in_the_builtins_the_wildcard_skipped_1309() -> Result<()
         ".[], IN(split_doc)",
         ".[], IN(split_doc; .)",
     ] {
-        let (output, code) = run_yq_stdin(filter, yaml, &[])?;
+        let (output, code) = run_yq_stdin(filter, yaml, &["--jq-extensions"])?;
         assert_eq!(code, 0, "{filter}");
         assert_eq!(
             output, "1\n---\n2\n---\ntrue\n",


### PR DESCRIPTION
## Summary

Settles #1512 — a classification dispute between two docs pages over whether the jq-only builtins `succinctly yq` accepted (that real yq's own lexer rejects) counted as a divergence (bug) or an extension. This resolves it as **extension, but gated**: yq mode now matches real yq's rejection by default, with a new `--jq-extensions` flag to opt back into the jq-compatible surface.

- **Parser**: adds a `jq_extensions` field to `Parser` and `reject_unless_jq_extensions()`, checked at all 16 affected keyword sites (`paths`, `getpath`, `leaf_paths`, `tostream`/`fromstream`/`truncate_stream`, `IN`, `ltrimstr`, `limit`, `isempty`, `debug`, `infinite`, `isnan`, `gsub`/`scan`/`splits`). Modeled on the existing `?//` jq-mode-only gate. jq mode is unaffected — it already accepts this surface unconditionally.
- **CLI**: new `--jq-extensions` flag on `YqCommand`, threaded through both `yq_runner.rs` parse call sites (main filter and `--split-exp`).
- **Docs**: ADR-0018 rule 5 amended ("marked as an extension" can mean gated/off-by-default, not just documented), `compliance/yq/limitations.md`'s Extensions section split into unconditional vs. gated groups (moving `gsub`/`scan`/`splits` out of "Open divergences," where they were never a divergence under rule 4), `yq-language.md` gets a full gated-builtin table, `CLAUDE.md` updated.
- **Tests**: exhaustive parser-level table test covering all 16 keywords in both states, 2 CLI end-to-end tests, ~13 existing tests updated to pass `--jq-extensions` (including one review caught: `test_split_doc_hides_in_the_builtins_the_wildcard_skipped_1309`'s `IN(split_doc)` filters, which broke under the new default).

Closes #1512

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (1129/1129 in `yq_cli_tests`, all other targets and doctests passing)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --no-default-features` (no_std gate) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Manually verified both doc examples (`paths` rejected by default, accepted with `--jq-extensions`) against the built binary