### PR TITLE
fix(jq): --seq -s reports <unknown> for a stream-ending truncated record

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1510,10 +1510,15 @@ fn get_inputs(
     // and silently dropped (#1542): real jq's own incremental parser loses
     // its EOF position entirely for a record it never finished reading,
     // where a malformed record earlier in the stream (one a later valid
-    // record resyncs after) still reports normally.
+    // record resyncs after) still reports normally. `-R` takes over
+    // entirely from `--seq` for raw-text mode (matching the `-R -s` branch
+    // below, which never RS-splits either) -- `!args.raw_input` here keeps
+    // that same priority for the location, oracle-verified: `-R --seq -s`
+    // on a truncated trailing record still reports its plain newline count,
+    // not `<unknown>`.
     let slurp_eof_line: Option<usize> = if args.slurp {
         raw_inputs.last().and_then(|(_, raw)| {
-            if args.seq && seq_trailing_record_is_dropped(raw) {
+            if args.seq && !args.raw_input && seq_trailing_record_is_dropped(raw) {
                 None
             } else {
                 Some(line_at(raw.as_bytes(), raw.len()))
@@ -1530,6 +1535,13 @@ fn get_inputs(
         for (_, raw) in &raw_inputs {
             combined.push_str(raw);
         }
+        // `slurp_eof_line`'s only `None` case is gated on `!args.raw_input`
+        // above, which this branch's own `args.raw_input` guard rules out
+        // here -- so `slurp_eof` always returns `Some` in this branch, but
+        // the `match` still handles `None` explicitly (rather than
+        // `.unwrap()`) to stay correct if that gate's condition ever
+        // changes, matching this codebase's convention for exhaustive-but-
+        // currently-dead defensive arms (#1064).
         let at = match locations.slurp_eof(slurp_eof_line) {
             Some((src, line)) => locations.resolve(src, line),
             None => InputLocation::unknown(),

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1670,6 +1670,19 @@ fn json_seq_ends(raw: &[u8]) -> Vec<usize> {
         .collect()
 }
 
+/// Sentinel `per_value` line meaning "no real position" (#1542 -- a
+/// `--seq` trailing record real jq itself never resolves). Never a real
+/// line number: every genuine line comes from an actual newline count or
+/// 1-based line index, bounded by the input's own byte length, and no real
+/// input has close to `u32::MAX` lines. [`InputLocations::resolve`] checks
+/// for it once, centrally, so every consumer of a `(source, line)` pair --
+/// [`get`](InputLocations::get)'s direct lookup *and* the shared
+/// `input`/`inputs` queue's `#1309` `ErrorAt::Live` path, which reads
+/// straight from [`per_value`](InputLocations::per_value) -- answers
+/// `<unknown>` the same way, rather than only the direct-lookup path
+/// checking a side flag `resolve` itself didn't know about.
+const UNKNOWN_LINE: u32 = u32::MAX;
+
 /// Source locations for the values returned by [`get_inputs`].
 ///
 /// Kept apart from the values and stored as `(source, line)` pairs: an owned
@@ -1680,17 +1693,10 @@ pub struct InputLocations {
     /// File name per source, `None` for stdin.
     files: Vec<Option<String>>,
     /// `(source index, 1-based line)` per value. Empty means there is no input
-    /// to point at (`-n`), which jq renders as `<unknown>`.
+    /// to point at (`-n`), which jq renders as `<unknown>`. A line of
+    /// [`UNKNOWN_LINE`] means the same thing for one specific value within
+    /// an otherwise-populated table (#1542).
     per_value: Vec<(u32, u32)>,
-    /// Set only by [`single`](Self::single) when its one value has no real
-    /// position to report (#1542 -- a `--seq` trailing record real jq itself
-    /// can't resolve). `per_value` still carries a placeholder `(0, 0)`
-    /// entry regardless, so [`per_value`](Self::per_value)'s queue-seeding
-    /// consumer (`#1309`'s `input`/`inputs` path) keeps its "one location
-    /// per value" invariant and never loses the document -- only
-    /// [`get`](Self::get)'s direct lookup (the common, non-`input`-builtin
-    /// path) answers `<unknown>` instead of resolving that placeholder.
-    unknown_single: bool,
 }
 
 impl InputLocations {
@@ -1698,7 +1704,6 @@ impl InputLocations {
         Self {
             files,
             per_value: Vec::new(),
-            unknown_single: false,
         }
     }
 
@@ -1708,7 +1713,8 @@ impl InputLocations {
     }
 
     /// Locations for a single value at an already-resolved location, or at
-    /// no location at all (`at.line.is_none()`, #1542).
+    /// no location at all (`at.line.is_none()`, #1542 -- stored as
+    /// [`UNKNOWN_LINE`]).
     ///
     /// Always pushes exactly one `per_value` entry regardless of `at`:
     /// slurp mode always produces exactly one value, so `get_inputs`'s
@@ -1722,8 +1728,7 @@ impl InputLocations {
     /// -c -s '., inputs'` prints `[]`.
     fn single(at: InputLocation) -> Self {
         let mut locations = Self::new(vec![at.file.clone()]);
-        locations.unknown_single = at.line.is_none();
-        locations.push(0, at.line.unwrap_or(0));
+        locations.push(0, at.line.map_or(UNKNOWN_LINE as usize, |line| line));
         locations
     }
 
@@ -1761,9 +1766,6 @@ impl InputLocations {
 
     /// Location of the value at `idx`.
     pub fn get(&self, idx: usize) -> InputLocation {
-        if self.unknown_single {
-            return InputLocation::unknown();
-        }
         match self.per_value.get(idx) {
             Some(&(src, line)) => self.resolve(src, line),
             None => InputLocation::unknown(),
@@ -1772,7 +1774,10 @@ impl InputLocations {
 
     /// The `(source, line)` pairs, in input order, for seeding the shared
     /// input queue (#1309). The queue carries the tag rather than the file
-    /// name; [`resolve`](Self::resolve) turns it back.
+    /// name; [`resolve`](Self::resolve) turns it back -- including a
+    /// [`UNKNOWN_LINE`] tag, so a value with no real position (#1542) still
+    /// answers `<unknown>` once it's popped back off the queue and resolved
+    /// via `ErrorAt::Live`, the same as it would through [`get`](Self::get).
     fn per_value(&self) -> &[(u32, u32)] {
         &self.per_value
     }
@@ -1780,6 +1785,9 @@ impl InputLocations {
     /// Turn a raw `(source, line)` -- as handed back by
     /// `jq::current_input_location` -- into a printable location.
     fn resolve(&self, src: u32, line: u32) -> InputLocation {
+        if line == UNKNOWN_LINE {
+            return InputLocation::unknown();
+        }
         InputLocation::at(
             self.files.get(src as usize).and_then(Option::as_deref),
             line as usize,
@@ -2516,10 +2524,28 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
 fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
     let mut values = Vec::new();
 
+    // The stream's own trailing record, when real jq's incremental reader
+    // never resolves it (malformed, or an ambiguous bare number at true
+    // EOF -- see `seq_trailing_record_is_dropped`), is silently dropped
+    // from the *output* too, not just from the error-location computation
+    // (#1542): `printf '\x1e1\n\x1e2' | jq --seq -s '.'` gives `[1]` on
+    // real jq, not `[1,2]`, even though "2" alone is perfectly valid JSON.
+    // Computed once, up front, and checked only against the split's last
+    // element below -- the already-malformed case is caught either way
+    // (this check, or `seq_record_parses` failing on its own a few lines
+    // down), but the ambiguous-number case parses just fine on its own and
+    // needs this explicit exclusion to be dropped at all.
+    let drop_trailing = seq_trailing_record_is_dropped(s);
+    let segments: Vec<&str> = s.split('\x1E').collect();
+    let last_idx = segments.len().saturating_sub(1);
+
     // Split on RS character (0x1E)
-    for segment in s.split('\x1E') {
+    for (i, segment) in segments.into_iter().enumerate() {
         let segment = segment.trim();
         if segment.is_empty() {
+            continue;
+        }
+        if i == last_idx && drop_trailing {
             continue;
         }
 
@@ -2570,9 +2596,20 @@ fn seq_record_parses(segment: &str) -> bool {
 ///   trailing byte at all) reports `<unknown>`, but the same shape with
 ///   `true`/`"s"`/`{}`/`[]`/`null` in place of `2`, or `2` followed by even
 ///   one trailing space, all report their own line normally.
+///
+/// A third shape needs no record-level check at all: content with **no RS
+/// byte anywhere**. RFC 7464 requires every record to start with one, so
+/// real jq's `--seq` reader never even attempts to read unprefixed text --
+/// it's "abandoned" the instant EOF arrives with nothing synced onto,
+/// oracle-verified as `<unknown>` regardless of what the unprefixed text
+/// actually contains (even fully well-formed JSON). *Empty* content is the
+/// one exception: an empty last file has no text to abandon, so it keeps
+/// #1520's own plain "empty source, EOF at line 0" rule instead (oracle-
+/// verified: an empty last file after a valid one still reports
+/// `emptyfile:0`, not `<unknown>`).
 fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     let Some((_, tail)) = raw.rsplit_once('\u{1e}') else {
-        return false;
+        return !raw.trim().is_empty();
     };
     let segment = tail.trim();
     if segment.is_empty() {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1728,7 +1728,7 @@ impl InputLocations {
     /// -c -s '., inputs'` prints `[]`.
     fn single(at: InputLocation) -> Self {
         let mut locations = Self::new(vec![at.file.clone()]);
-        locations.push(0, at.line.map_or(UNKNOWN_LINE as usize, |line| line));
+        locations.push(0, at.line.unwrap_or(UNKNOWN_LINE as usize));
         locations
     }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1506,13 +1506,21 @@ fn get_inputs(
     // always out of bounds at `end == bytes.len()`, so it degenerates to a
     // plain newline count -- the same one-off, single-lookup use its own
     // doc comment describes, not `LineCounter`'s repeated-increasing-offset
-    // case.
-    let slurp_eof_line = if args.slurp {
-        raw_inputs
-            .last()
-            .map_or(0, |(_, raw)| line_at(raw.as_bytes(), raw.len()))
+    // case. `None` when `--seq`'s trailing record was truncated/malformed
+    // and silently dropped (#1542): real jq's own incremental parser loses
+    // its EOF position entirely for a record it never finished reading,
+    // where a malformed record earlier in the stream (one a later valid
+    // record resyncs after) still reports normally.
+    let slurp_eof_line: Option<usize> = if args.slurp {
+        raw_inputs.last().and_then(|(_, raw)| {
+            if args.seq && seq_trailing_record_is_dropped(raw) {
+                None
+            } else {
+                Some(line_at(raw.as_bytes(), raw.len()))
+            }
+        })
     } else {
-        0
+        None
     };
 
     // jq -R -s: the entire input (all files concatenated) becomes a single
@@ -1522,10 +1530,13 @@ fn get_inputs(
         for (_, raw) in &raw_inputs {
             combined.push_str(raw);
         }
-        let (src, line) = locations.slurp_eof(slurp_eof_line);
+        let at = match locations.slurp_eof(slurp_eof_line) {
+            Some((src, line)) => locations.resolve(src, line),
+            None => InputLocation::unknown(),
+        };
         return Ok(Ok((
             vec![OwnedValue::String(combined)],
-            InputLocations::single(locations.resolve(src, line)),
+            InputLocations::single(at),
         )));
     }
 
@@ -1597,10 +1608,13 @@ fn get_inputs(
 
     // Slurp mode: wrap all inputs in an array
     if args.slurp {
-        let (src, line) = locations.slurp_eof(slurp_eof_line);
+        let at = match locations.slurp_eof(slurp_eof_line) {
+            Some((src, line)) => locations.resolve(src, line),
+            None => InputLocation::unknown(),
+        };
         Ok(Ok((
             vec![OwnedValue::Array(values)],
-            InputLocations::single(locations.resolve(src, line)),
+            InputLocations::single(at),
         )))
     } else {
         Ok(Ok((values, locations)))
@@ -1656,6 +1670,15 @@ pub struct InputLocations {
     /// `(source index, 1-based line)` per value. Empty means there is no input
     /// to point at (`-n`), which jq renders as `<unknown>`.
     per_value: Vec<(u32, u32)>,
+    /// Set only by [`single`](Self::single) when its one value has no real
+    /// position to report (#1542 -- a `--seq` trailing record real jq itself
+    /// can't resolve). `per_value` still carries a placeholder `(0, 0)`
+    /// entry regardless, so [`per_value`](Self::per_value)'s queue-seeding
+    /// consumer (`#1309`'s `input`/`inputs` path) keeps its "one location
+    /// per value" invariant and never loses the document -- only
+    /// [`get`](Self::get)'s direct lookup (the common, non-`input`-builtin
+    /// path) answers `<unknown>` instead of resolving that placeholder.
+    unknown_single: bool,
 }
 
 impl InputLocations {
@@ -1663,6 +1686,7 @@ impl InputLocations {
         Self {
             files,
             per_value: Vec::new(),
+            unknown_single: false,
         }
     }
 
@@ -1671,24 +1695,22 @@ impl InputLocations {
         Self::default()
     }
 
-    /// Locations for a single value at an already-resolved location.
+    /// Locations for a single value at an already-resolved location, or at
+    /// no location at all (`at.line.is_none()`, #1542).
     ///
-    /// Always pushes exactly one `per_value` entry -- `at.line` is always
-    /// `Some(_)` from every current caller (both go through
-    /// [`slurp_eof`](Self::slurp_eof), which always resolves to a concrete
-    /// EOF line, never `None`), but the `unwrap_or(0)` below is not merely
-    /// decorative: slurp mode always produces exactly one value, so
-    /// `get_inputs`'s `values`/`locations` invariant ("one location per
-    /// value") must hold here unconditionally regardless of what `at`
-    /// contains -- the seeding `.zip()` in `run_jq` silently truncates to the
-    /// shorter side on a mismatch instead of erroring, so a skipped push
-    /// here previously lost the whole slurped document to `input`/`inputs`
-    /// (debug-build panic on the `debug_assert_eq!` guarding that zip,
-    /// release-build silent empty output instead of jq's own `[]`) --
-    /// confirmed live against jq 1.7.1: `printf '' | jq -c -s '., inputs'`
-    /// prints `[]`.
+    /// Always pushes exactly one `per_value` entry regardless of `at`:
+    /// slurp mode always produces exactly one value, so `get_inputs`'s
+    /// `values`/`locations` invariant ("one location per value") must hold
+    /// here unconditionally -- the seeding `.zip()` in `run_jq` silently
+    /// truncates to the shorter side on a mismatch instead of erroring, so
+    /// a skipped push here previously lost the whole slurped document to
+    /// `input`/`inputs` (debug-build panic on the `debug_assert_eq!`
+    /// guarding that zip, release-build silent empty output instead of
+    /// jq's own `[]`) -- confirmed live against jq 1.7.1: `printf '' | jq
+    /// -c -s '., inputs'` prints `[]`.
     fn single(at: InputLocation) -> Self {
         let mut locations = Self::new(vec![at.file.clone()]);
+        locations.unknown_single = at.line.is_none();
         locations.push(0, at.line.unwrap_or(0));
         locations
     }
@@ -1727,6 +1749,9 @@ impl InputLocations {
 
     /// Location of the value at `idx`.
     pub fn get(&self, idx: usize) -> InputLocation {
+        if self.unknown_single {
+            return InputLocation::unknown();
+        }
         match self.per_value.get(idx) {
             Some(&(src, line)) => self.resolve(src, line),
             None => InputLocation::unknown(),
@@ -1800,20 +1825,23 @@ impl InputLocations {
     }
 
     /// Where `--slurp`'s single combined value's `(at ...)` marker points
-    /// (#1520), as a raw `(source, line)` tag -- the same shape
-    /// [`exhausted`](Self::exhausted) returns, for the same reason (the
-    /// caller resolves it to a printable name only once it's actually
-    /// needed): the last source on the command line, at `eof_line` -- that
-    /// source's own newline count (`line_at(bytes, bytes.len())` at the call
-    /// site above).
+    /// (#1520), as a raw `(source, line)` tag -- the same `Option` shape
+    /// [`exhausted`](Self::exhausted) returns, for the same reason (`None`
+    /// means "no position to point at", i.e. `<unknown>`; the caller
+    /// resolves `Some` to a printable name only once it's actually needed):
+    /// the last source on the command line, at `eof_line` -- that source's
+    /// own newline count (`line_at(bytes, bytes.len())` at the call site
+    /// above), or `None` when the caller found `--seq`'s trailing record
+    /// truncated/malformed (#1542).
     ///
     /// The same "last source" rule as `exhausted`, but slurp collapses every
     /// input into one value up front, so there is no per-value table
     /// afterward to fall back on the way `exhausted` does -- the caller must
     /// compute `eof_line` directly from the last source's raw text before
     /// it's consumed, and pass it in.
-    fn slurp_eof(&self, eof_line: usize) -> (u32, u32) {
-        (self.last_src(), eof_line as u32)
+    fn slurp_eof(&self, eof_line: Option<usize>) -> Option<(u32, u32)> {
+        let line = eof_line?;
+        Some((self.last_src(), line as u32))
     }
 }
 
@@ -2484,18 +2512,65 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
         }
 
         // Try to parse as JSON, silently ignore failures
-        if validate::validate(segment.as_bytes()).is_ok() {
+        if seq_record_parses(segment) {
             values.push(crate::output::json_bytes_to_owned_value(segment.as_bytes()));
-        } else {
-            let normalized = normalize_leading_zero_numbers(segment);
-            if normalized != segment && validate_json_str(&normalized).is_ok() {
-                values.push(crate::output::json_bytes_to_owned_value(segment.as_bytes()));
-            }
-            // Genuine parse failures are silently ignored per RFC 7464
         }
+        // Genuine parse failures are silently ignored per RFC 7464
     }
 
     values
+}
+
+/// Whether a trimmed, non-empty `--seq` record segment parses as JSON --
+/// [`parse_json_seq`]'s own per-segment success check, factored out so
+/// [`seq_trailing_record_is_dropped`] can ask the identical question about
+/// one specific segment without duplicating the leading-zero retry logic.
+fn seq_record_parses(segment: &str) -> bool {
+    if validate::validate(segment.as_bytes()).is_ok() {
+        return true;
+    }
+    let normalized = normalize_leading_zero_numbers(segment);
+    normalized != segment && validate_json_str(&normalized).is_ok()
+}
+
+/// Whether `raw`'s trailing `--seq` record (RFC 7464, everything after the
+/// last RS byte) leaves real jq's own incremental parser with no EOF
+/// position to report -- distinct from a malformed record *elsewhere* in
+/// the stream, which a later valid record still resyncs after (#1542,
+/// oracle-verified: `\x1e1\n\x1e{"a":1\n\x1e3\n` still reports the trailing
+/// `3`'s own line; only the stream's actual *last* record can trigger this).
+///
+/// Two shapes, both silently swallowed by real jq's own `--seq` reader:
+///
+/// - **Genuinely malformed/truncated** -- [`seq_record_parses`] fails on it
+///   (an unterminated string/object, e.g.), matching
+///   [`parse_json_seq`]'s own silent-drop rule (RFC 7464's recommended
+///   failure mode, #1243).
+/// - **A bare number with nothing at all after it before EOF** -- valid
+///   JSON on its own, but jq's streaming number scanner can't rule out more
+///   digits still arriving without seeing a terminating byte (whitespace,
+///   or the start of the next token) after the last one it read, so a
+///   number that happens to butt right up against real EOF is
+///   indistinguishable from one truncated mid-digit. Every other JSON type
+///   has its own unambiguous closing delimiter (`"`, `}`, `]`, the last
+///   letter of `true`/`false`/`null`) and reports normally even with
+///   nothing trailing it -- oracle-verified: `\x1e1\n\x1e2` (bare `2`, no
+///   trailing byte at all) reports `<unknown>`, but the same shape with
+///   `true`/`"s"`/`{}`/`[]`/`null` in place of `2`, or `2` followed by even
+///   one trailing space, all report their own line normally.
+fn seq_trailing_record_is_dropped(raw: &str) -> bool {
+    let Some((_, tail)) = raw.rsplit_once('\u{1e}') else {
+        return false;
+    };
+    let segment = tail.trim();
+    if segment.is_empty() {
+        return false;
+    }
+    if !seq_record_parses(segment) {
+        return true;
+    }
+    let is_bare_number = matches!(segment.as_bytes().first(), Some(b'-' | b'0'..=b'9'));
+    is_bare_number && tail.trim_end() == tail
 }
 
 /// Validate that the DSV delimiter is acceptable.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17529,6 +17529,70 @@ fn test_jq_slurp_error_location_is_last_source_eof_1520() -> Result<()> {
     Ok(())
 }
 
+/// #1542: `--seq --slurp`'s EOF marker is `<unknown>`, not a resolved
+/// position, when the stream's *own last* record leaves real jq's
+/// incremental parser with nothing to point at -- either genuinely
+/// truncated/malformed content, or a bare number butting right up against
+/// EOF with no terminating byte after it (ambiguous: jq's streaming number
+/// scanner can't rule out more digits still arriving). A malformed record
+/// *earlier* in the stream, with a valid record after it, still resolves
+/// normally -- only the trailing position is ever lost. Every expectation
+/// here is jq 1.7.1's own live output.
+#[test]
+fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
+    // Genuinely truncated trailing record (unterminated object).
+    let (_, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
+
+    // Bare number with nothing at all after it before EOF -- ambiguous to
+    // jq's streaming parser even though "2" alone is valid JSON.
+    let (_, stderr, code, _paths) =
+        run_jq_over_files(&["--seq", "-c", "-s", r#"error("x")"#], &["\x1e1\n\x1e2"])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
+
+    // Control: the same bare number followed by even one trailing space
+    // resolves the ambiguity -- reports normally, not <unknown>.
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["--seq", "-c", "-s", r#"error("x")"#], &["\x1e1\n\x1e2 "])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[0])),
+        "{stderr}"
+    );
+
+    // Control: a malformed record *not* last -- the trailing valid record's
+    // own position still resolves normally, not <unknown>.
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1\n\x1e3\n"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:3): x", paths[0])),
+        "{stderr}"
+    );
+
+    // Data-safety control: a truncated trailing record must not lose the
+    // rest of the slurped document to `input`/`inputs` -- the `<unknown>`
+    // marker is carried by a placeholder table entry precisely so this
+    // still returns the wrapped array intact, not an empty/truncated one.
+    // `--seq` RS-prefixes output too (RFC 7464), not just input.
+    let (stdout, stderr, code) = run_jq_full(
+        &["--seq", "-c", "-s", "., inputs"],
+        Some("\x1e1\n\x1e{\"a\":1"),
+    )
+    .expect("seq slurp with truncated trailing record still runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "\x1e[1]\n", "{stderr}");
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3588,8 +3588,15 @@ fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Resul
 
 #[test]
 fn test_seq_output_format() -> Result<()> {
-    // --seq should prepend RS (0x1E) before each output value
-    let (output, code) = run_jq_binary_stdin(".", br#"{"a":1}"#, &["--seq", "-c"])?;
+    // --seq should prepend RS (0x1E) before each output value. Input must
+    // itself be RS-framed for --seq to read it at all -- RFC 7464 requires
+    // every record to start with one, and real jq's own reader treats
+    // unprefixed input as "abandoned text" and reads nothing, even when
+    // it's otherwise well-formed JSON and --slurp isn't in play (#1542
+    // found and fixed the same rule for --seq --slurp's own trailing-record
+    // case; oracle-verified live against jq 1.7.1 that it holds here too:
+    // `printf '{"a":1}' | jq --seq -c '.'` prints nothing at all).
+    let (output, code) = run_jq_binary_stdin(".", b"\x1e{\"a\":1}\n", &["--seq", "-c"])?;
     assert_eq!(code, 0);
 
     // Output should start with RS (0x1E)
@@ -3684,8 +3691,10 @@ fn test_seq_error_location_correct_with_many_preceding_records_1213() -> Result<
 
 #[test]
 fn test_seq_multiple_outputs() -> Result<()> {
-    // Each output from iterator should get RS prefix
-    let (output, code) = run_jq_binary_stdin(".[]", br"[1,2,3]", &["--seq"])?;
+    // Each output from iterator should get RS prefix. Input must be
+    // RS-framed for --seq to read it at all -- see test_seq_output_format's
+    // comment for why.
+    let (output, code) = run_jq_binary_stdin(".[]", b"\x1e[1,2,3]\n", &["--seq"])?;
     assert_eq!(code, 0);
 
     // Count RS characters - should be 3 (one per output)
@@ -17628,6 +17637,42 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
     .expect("seq slurp with truncated trailing record still runs");
     assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
     assert_eq!(stdout, "\x1e[1]\n", "{stderr}");
+
+    // The trailing record real jq itself never resolves must also be
+    // dropped from the slurped *value*, not just the error location --
+    // `printf '\x1e1\n\x1e2' | jq --seq -s '.'` gives `[1]` on real jq, not
+    // `[1,2]`, even though "2" alone is perfectly valid JSON on its own.
+    let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "-s", "."], Some("\x1e1\n\x1e2"))
+        .expect("seq slurp with ambiguous trailing number still runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "\x1e[1]\n", "{stderr}");
+
+    // A last file with real, non-empty content but no RS byte anywhere is
+    // "abandoned text" to real jq's --seq reader (RFC 7464 requires every
+    // record to start with one) -- unknown, not a resolved position, even
+    // though a truly *empty* last file still keeps #1520's own plain
+    // "empty source, line 0" rule (the companion control just above).
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n", "{\"a\":1"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}; {paths:?}");
+
+    // The `input`/`inputs`/`input_line_number`-consuming path
+    // (`ErrorAt::Live`, reached whenever the filter references any of
+    // them) must answer `<unknown>` for a dropped trailing record too, not
+    // just the plain `error(...)`-only path (`ErrorAt::Fixed`) the checks
+    // above exercise -- the two paths read the same placeholder through
+    // different accessors (`InputLocations::get` vs `::resolve`), and only
+    // fixing one previously left the other still resolving it to a
+    // spurious concrete location.
+    let (_, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"input_line_number, error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17591,6 +17591,17 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
         "{stderr}"
     );
 
+    // Control: the last file has no RS byte at all (empty) -- there is no
+    // trailing record to have dropped, so this resolves normally (line 0,
+    // #1520's own EOF rule), not <unknown>.
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["--seq", "-c", "-s", r#"error("x")"#], &["\x1e1\n", ""])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:0): x", paths[1])),
+        "{stderr}"
+    );
+
     // Control: `-R` takes over entirely from `--seq` for the location too
     // (matching --seq's own irrelevance to -R's raw-text value construction)
     // -- a "truncated" record by --seq's rules still reports its plain

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17577,6 +17577,34 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
         "{stderr}"
     );
 
+    // Control: an empty trailing record (a bare trailing RS with nothing,
+    // or only whitespace, after it) is not "dropped" in the #1542 sense --
+    // it never held content to begin with, so it reports normally off the
+    // preceding valid record's own position, not <unknown>.
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e2\n\x1e"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:2): x", paths[0])),
+        "{stderr}"
+    );
+
+    // Control: `-R` takes over entirely from `--seq` for the location too
+    // (matching --seq's own irrelevance to -R's raw-text value construction)
+    // -- a "truncated" record by --seq's rules still reports its plain
+    // newline count under `-R --seq -s`, not <unknown>.
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["-R", "--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[0])),
+        "{stderr}"
+    );
+
     // Data-safety control: a truncated trailing record must not lose the
     // rest of the slurped document to `input`/`inputs` -- the `<unknown>`
     // marker is carried by a placeholder table entry precisely so this


### PR DESCRIPTION
## Summary
- Real jq's incremental `--seq` parser loses its EOF position entirely for a record it never finished reading — either genuinely malformed content, or a bare number that butts right up against EOF with no terminating byte after it (ambiguous: the streaming number scanner can't rule out more digits still arriving). A malformed record earlier in the stream, with a valid record after it, still resolves normally — only the stream's own trailing position can ever be lost.
- **Also fixes the same rule for the actual output value, not just the error location**: `parse_json_seq` now excludes that same dropped/ambiguous trailing record from the slurped array, matching real jq (`printf '\x1e1\n\x1e2' | jq --seq -s '.'` gives `[1]`, not `[1,2]`, even though `2` alone is valid JSON).
- `-R` takes over entirely from `--seq` for raw-text mode (matching real jq); gated the check on `!args.raw_input` to match.
- Content with **no RS byte at all** is "abandoned text" to real jq's `--seq` reader (RFC 7464 requires every record to start with one) — unknown, regardless of content validity, unless the source is genuinely empty (which keeps #1520's own "empty source, line 0" rule). Fixing this incidentally corrected two pre-existing tests that had been asserting jq-divergent behavior for unprefixed `--seq` input all along (confirmed live: real jq drops unprefixed input even without `--slurp`).
- **The `input`/`inputs`-consuming path was still broken after the first review pass**: `InputLocations::resolve()` (used whenever a filter references `input`/`inputs`/`input_line_number`, via `ErrorAt::Live`) never checked the original `unknown_single` flag, only `InputLocations::get()` did. Replaced the per-instance bool with a `UNKNOWN_LINE` sentinel stored directly in the placeholder table entry and checked once, centrally, inside `resolve()` — every consumer of a `(source, line)` pair now agrees automatically.

This PR went through two full review rounds. The first found the `resolve()`/`unknown_single` gap and a `-R --seq` interaction bug (both fixed before the first push). A second, more extensive multi-agent pass (10 finder angles, live oracle A/B verification against `/usr/bin/jq` 1.7.1) found the `resolve()` gap was *still* incomplete (`get()` alone isn't enough — the queue-seeded `ErrorAt::Live` path bypassed it entirely) plus the missing-values bug and the no-RS-byte gap above — all fixed and re-verified.

Filed two follow-ups for findings needing bigger, riskier changes than this fix's scope:
- **#1549** — `input_line_number` reports the raw `UNKNOWN_LINE` sentinel (`4294967295`) instead of jq's own `0`, since it reads a queue value directly (`src/jq/eval.rs`) rather than through `resolve()` (`src/bin/succinctly/jq_runner.rs`) — fixing it needs a shared sentinel across that crate boundary, or a real `Option`-shaped queue tuple.
- **#1550** — the drop check only inspects the *last file*; a truncated record physically located in an earlier file, with the actual last file empty, isn't detected — needs tracking record boundaries across the whole concatenated multi-file stream, not per-file.

Fixes #1542

## Test plan
- [x] `cargo build --features cli`
- [x] Full `cargo test --features cli,simd,regex,serde` (0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Live-verified against pinned oracle `jq` 1.7.1 across: genuinely truncated record, bare-number-at-EOF ambiguity (both location *and* output values), the same number with one trailing space (control), a malformed record *not* last (control), an empty trailing RS record (control), `-R --seq -s` (control), no-RS-byte content (both single- and multi-file), and an `ErrorAt::Live` case (`input_line_number, error(...)`) confirming the marker is `<unknown>` there too
- [x] New/updated regression tests covering all of the above, plus two pre-existing tests corrected to match jq's actual (previously untested) unprefixed-input behavior
- [x] Patch coverage: 98% (49/50 new lines) — the one uncovered line is a `None` arm proven unreachable by construction, matching this codebase's established convention for exhaustive-but-currently-dead defensive arms (#1064)