### PR TITLE
ci(bench): add an instruction-count regression guard for jq/yq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,53 @@ jobs:
           name: benchmark-results-${{ matrix.arch }}
           path: bench-*.txt
 
+  # Instruction-count regression guard (#1523): `bench` above times
+  # `rank_select` and uploads artifacts nobody compares against a baseline --
+  # #1385's 2-3x jq slowdown shipped through it unnoticed. Wall-clock timing
+  # on a shared runner is the wrong mechanism (too noisy for a threshold
+  # tight enough to matter); `valgrind --tool=cachegrind` counts instructions
+  # instead, which is deterministic regardless of runner noise. Not run on
+  # macOS: valgrind has no Apple Silicon support at all. Not run in the merge
+  # queue for the same reason `bench` isn't (see its own `if`, above).
+  perf-guard:
+    name: Perf Regression Guard (${{ matrix.name }})
+    needs: gate
+    if: needs.gate.outputs.code == 'true' && github.event_name != 'merge_group'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64
+            runner: ubuntu-latest
+          - name: ARM64-Linux
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.name }}-perf-guard-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Build release binary
+        run: cargo build --release --features cli
+
+      - name: Run perf guard
+        run: python3 scripts/perf-guard.py --binary target/release/succinctly --arch "${{ matrix.name }}" --check
+
   clippy:
     name: Clippy
     needs: gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
   # Required-context jobs (Test x86/ARM/macOS, Clippy, Format, Documentation)
   # always run so their contexts always report `success`; on the fast path every
   # step is skipped, which is a genuine passing job — not a `skipped` conclusion
-  # whose branch-protection semantics vary. Non-required jobs (bench, coverage)
-  # below skip wholesale via a job-level `if`.
+  # whose branch-protection semantics vary. Non-required jobs (bench, coverage,
+  # perf-guard) below skip wholesale via a job-level `if`.
   test-x86:
     name: Test (x86_64)
     needs: gate
@@ -362,7 +362,7 @@ jobs:
   # above stays on `stable` so we don't triple CI minutes. `beta` gates CI;
   # `nightly` is advisory (`continue-on-error`) because it is the flakiest. Not a
   # required status context, so it skips wholesale on the docs-only fast path
-  # (job-level `if`, like bench/coverage) rather than run-and-skip-steps. Also
+  # (job-level `if`, like bench/coverage/perf-guard) rather than run-and-skip-steps. Also
   # skipped on `merge_group` (#310): it is advisory, not required, so running it
   # per queue entry would just add latency to every merge without gating it.
   test-x86-upstream:

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -159,6 +159,24 @@ GitHub Actions runs `rank_select` benchmarks on every PR/push for smoke testing:
 
 **Note**: CI does not run full benchmark suite (too time-consuming).
 
+**Perf Regression Guard** (issue #1523): a separate CI job measures `succinctly
+jq`/`yq` instruction counts via `valgrind --tool=cachegrind` (`scripts/perf-guard.py`)
+for a fixed query/shape matrix, and fails if any drifts more than 5% from the
+checked-in baseline (`tests/data/perf-guard-baseline.json`). Deterministic
+instruction counts, not wall-clock time, are what make a tight threshold viable on a
+shared, noisy CI runner — this exists because #1385's 2-3x regression shipped through
+`rank_select`-only smoke testing unnoticed. Runs on x86_64 and ARM64-Linux only
+(valgrind has no Apple Silicon support); currently a non-required check while it
+builds a track record. To deliberately update the baseline after a real, understood
+cost change:
+
+```bash
+cargo build --release --features cli
+scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --update-baseline
+```
+
+(run once per arch you can reach; state the reason in the commit message).
+
 ---
 
 ## How to Run Benchmarks

--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -45,6 +45,20 @@ Fixtures are generated fresh each run (`succinctly json generate --seed
 without growing the repo -- generation is deterministic per pattern/seed, so
 the *content* measured is stable run to run.
 
+Known scope limits, deliberate for this minimum-viable-set v1 rather than
+oversights -- worth revisiting once this guard has a track record:
+
+- One fixed size (2mb) per query, not a scaling curve across sizes. Catches
+  the #1514 shape (a regression visible at a realistic size) but not one
+  that only shows up at a different scale.
+- The CI job builds with `cargo build --release --features cli`, which does
+  not enable the `simd` feature -- so a regression confined to
+  `BalancedParens`'s SIMD-accelerated rank/select index build (`src/trees/
+  bp.rs`'s NEON/SSE4.1 L1/L2 index builders, gated behind `feature = "simd"`)
+  or `src/bits/popcount.rs`'s explicit intrinsics is invisible here, the same
+  split `bench`'s own default/simd/portable-popcount 3-way matrix exists to
+  separate for `rank_select`.
+
 Standard library only; no third-party dependencies.
 """
 
@@ -66,7 +80,9 @@ FIXTURE_SEED = 20260101
 # (id, generate-pattern, size, mode, filter) -- ids are the baseline file's
 # keys, so renaming one here orphans its old baseline entry (caught by
 # `--check`'s own "missing baseline entry" error) rather than silently
-# comparing against the wrong row.
+# comparing against the wrong row. Several rows share a (pattern, size) --
+# `measure_all` below generates each distinct (pattern, size) fixture once
+# and reuses it, rather than regenerating an identical file per row.
 QUERIES = [
     ("wide_keys_unsorted", "wide", "2mb", "jq", "keys_unsorted"),
     ("wide_identity", "wide", "2mb", "jq", "."),
@@ -80,12 +96,35 @@ IR_PATTERN = re.compile(r"I\s+refs:\s+([\d,]+)")
 
 DEFAULT_THRESHOLD = 5.0
 
+# argparse wants a plain string for `epilog`; keeping it as a real constant
+# (not a slice of `__doc__`) means reflowing the module docstring above can
+# never silently truncate or misplace `--help` output.
+EPILOG = (
+    "The query/shape matrix is #1523's own \"minimum viable set\": #1514's two "
+    "regressions were complementary and each was invisible to the other's own "
+    "signal (one showed only in a `wide`-shaped `keys_unsorted` query, the "
+    "other only in a plain `.` identity query and would have looked like an "
+    "*improvement* under `keys_unsorted` alone) -- so this covers both queries "
+    "against both a `wide` (many top-level keys, no nesting) and a `users` "
+    "(typical small-record) shape, plus an `arrays` shape (no objects, "
+    "isolates whether a regression is object-specific) and one `yq`-mode "
+    "query (the shared evaluator's cost is otherwise unverified in yq mode "
+    "at all)."
+)
+
+
+def positive_int(text):
+    value = int(text)
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {value}")
+    return value
+
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(
         description="CI instruction-count regression guard for succinctly jq/yq.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__.split("\n\n", 1)[1],
+        epilog=EPILOG,
     )
     p.add_argument("--binary", required=True, help="path to the succinctly binary (release build)")
     p.add_argument("--baseline", default="tests/data/perf-guard-baseline.json",
@@ -98,7 +137,8 @@ def parse_args(argv=None):
     p.add_argument("--valgrind-bin", default="valgrind", help="path to valgrind")
     p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
                     help="max allowed instruction-count drift, in percent")
-    p.add_argument("--reps", type=int, default=3, help="measurement repetitions per query (median reported)")
+    p.add_argument("--reps", type=positive_int, default=3,
+                    help="measurement repetitions per query (median reported)")
     mode = p.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true", help="compare against the baseline; exit 1 on drift")
     mode.add_argument("--update-baseline", action="store_true", help="overwrite the baseline file")
@@ -106,10 +146,10 @@ def parse_args(argv=None):
 
 
 def generate_fixture(binary, pattern, size, seed, out_path):
-    subprocess.run(
-        [binary, "json", "generate", size, "-p", pattern, "-s", str(seed), "-o", out_path],
-        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True,
-    )
+    cmd = [binary, "json", "generate", size, "-p", pattern, "-s", str(seed), "-o", out_path]
+    result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        sys.exit(f"'{' '.join(cmd)}' exited {result.returncode}; stderr:\n{result.stderr}")
 
 
 def run_cachegrind_once(valgrind_bin, binary, mode, filter_expr, fixture_path):
@@ -121,28 +161,80 @@ def run_cachegrind_once(valgrind_bin, binary, mode, filter_expr, fixture_path):
             f"--cachegrind-out-file={cg_out}",
             binary, mode, filter_expr, fixture_path,
         ]
-        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # `--log-file` captures valgrind's own diagnostics; the *traced*
+        # binary's stderr is separate and captured too (not discarded) so a
+        # failure -- the traced binary erroring on a query it always used to
+        # handle, for instance -- reports why, not just an opaque nonzero
+        # exit. `LC_ALL=C` pins cachegrind's number formatting so a locale
+        # change on the runner can't silently alter how IR_PATTERN below
+        # needs to parse it.
+        env = {**os.environ, "LC_ALL": "C"}
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+        if result.returncode != 0:
+            sys.exit(
+                f"'{' '.join(cmd)}' exited {result.returncode}; stderr:\n{result.stderr}"
+            )
+        # A query that silently starts producing no output (a bug that
+        # changes correctness, not just cost) would look exactly like a
+        # legitimate speedup -- catch that before the instruction count is
+        # ever trusted, rather than only checking the exit code.
+        if not result.stdout.strip():
+            sys.exit(
+                f"'{' '.join(cmd)}' exited 0 but produced no output -- refusing to trust "
+                f"its instruction count (a correctness regression can look exactly like a "
+                f"speedup)"
+            )
+        if not os.path.exists(log):
+            sys.exit(f"'{' '.join(cmd)}' exited 0 but wrote no cachegrind log at {log}")
         with open(log) as f:
             text = f.read()
-        if result.returncode != 0:
-            sys.exit(f"'{' '.join(cmd)}' exited {result.returncode}; cachegrind log:\n{text}")
         m = IR_PATTERN.search(text)
         if not m:
             sys.exit(f"could not find instruction count in cachegrind output:\n{text}")
         return int(m.group(1).replace(",", ""))
 
 
-def measure_query(args, query_id, pattern, size, mode, filter_expr):
+def measure_query(valgrind_bin, binary, mode, filter_expr, fixture_path, reps):
+    counts = [
+        run_cachegrind_once(valgrind_bin, binary, mode, filter_expr, fixture_path)
+        for _ in range(reps)
+    ]
+    # `statistics.median` returns a float for an even-length input (the
+    # average of the two middle values) but an int for odd-length -- round
+    # to a plain int either way so the baseline file's schema doesn't flip
+    # between int/float purely as a side effect of --reps's parity.
+    return round(statistics.median(counts))
+
+
+def measure_all(binary, valgrind_bin, reps):
+    """Generate each distinct (pattern, size) fixture exactly once -- several
+    `QUERIES` rows share one, and regenerating an identical file per row
+    would be pure waste -- then measure every query against its fixture.
+    Returns {query_id: median instruction count}."""
     with tempfile.TemporaryDirectory() as tmp:
-        # `yq` accepts JSON input directly (auto-detects by content), so every
-        # fixture is plain JSON regardless of which CLI mode measures it.
-        fixture_path = os.path.join(tmp, f"{query_id}.json")
-        generate_fixture(args.binary, pattern, size, FIXTURE_SEED, fixture_path)
-        counts = [
-            run_cachegrind_once(args.valgrind_bin, args.binary, mode, filter_expr, fixture_path)
-            for _ in range(args.reps)
-        ]
-    return statistics.median(counts)
+        fixture_paths = {}
+        for _, pattern, size, _, _ in QUERIES:
+            shape = (pattern, size)
+            if shape not in fixture_paths:
+                # `succinctly json generate` always writes JSON; the `.json`
+                # extension matters for the `yq`-mode query above -- `yq`'s
+                # input-format auto-detection is by file extension, not
+                # content sniffing, so this is what makes it resolve to JSON
+                # rather than falling through to YAML's own default.
+                path = os.path.join(tmp, f"{pattern}_{size}.json")
+                generate_fixture(binary, pattern, size, FIXTURE_SEED, path)
+                fixture_paths[shape] = path
+
+        measured = {}
+        print(f"{'query':<26} {'instructions':>16}")
+        print("-" * 44)
+        for query_id, pattern, size, mode, filter_expr in QUERIES:
+            ir = measure_query(valgrind_bin, binary, mode, filter_expr, fixture_paths[(pattern, size)], reps)
+            measured[query_id] = ir
+            print(f"{query_id:<26} {ir:>16,.0f}")
+            sys.stdout.flush()
+        print()
+    return measured
 
 
 def load_baseline_file(path):
@@ -150,7 +242,11 @@ def load_baseline_file(path):
     if not os.path.exists(path):
         return {}
     with open(path) as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            sys.exit(f"{path} is not valid JSON ({e}) -- a stale conflict marker from a bad "
+                     f"rebase/merge, or a truncated write?")
 
 
 def save_baseline_file(path, data):
@@ -171,6 +267,8 @@ def main(argv=None):
         )
     if not os.path.exists(args.binary):
         sys.exit(f"binary not found: {args.binary}")
+    if not os.access(args.binary, os.X_OK):
+        sys.exit(f"binary is not executable: {args.binary} (lost its execute bit in transit?)")
 
     # Fail fast on a missing/incomplete baseline before running any of the
     # (expensive, cachegrind-instrumented) measurements below. Instruction
@@ -189,15 +287,7 @@ def main(argv=None):
                 f"-- run with --update-baseline first (and commit the result)."
             )
 
-    measured = {}
-    print(f"{'query':<26} {'instructions':>16}")
-    print("-" * 44)
-    for query_id, pattern, size, mode, filter_expr in QUERIES:
-        ir = measure_query(args, query_id, pattern, size, mode, filter_expr)
-        measured[query_id] = ir
-        print(f"{query_id:<26} {ir:>16,.0f}")
-        sys.stdout.flush()
-    print()
+    measured = measure_all(args.binary, args.valgrind_bin, args.reps)
 
     if args.update_baseline:
         baseline_file[args.arch] = measured
@@ -228,10 +318,13 @@ def main(argv=None):
         for query_id, drift in failed:
             print(f"  {query_id}: {drift:+.1f}%")
         print()
-        print("If this is a real, understood regression (e.g. new correctness work that "
-              "genuinely costs more), re-run with --update-baseline and say why in the "
-              "commit message. If it's unexpected, that's exactly what this guard exists "
-              "to catch -- see docs/guides/benchmarking.md for how to investigate.")
+        print("A drift in either direction fails: a genuine improvement needs the same "
+              "conscious baseline update as a regression, so a stale baseline can't quietly "
+              "keep passing. If this is real and understood (new correctness work that "
+              "genuinely costs more, or an optimization that genuinely costs less), re-run "
+              "with --update-baseline and say why in the commit message. If it's unexpected, "
+              "that's exactly what this guard exists to catch -- see "
+              "docs/guides/benchmarking.md for how to investigate.")
         return 1
 
     print("OK: all queries within threshold")

--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""CI instruction-count regression guard for `succinctly jq`/`yq` (issue #1523).
+
+#1385's two fix commits made `succinctly jq` 2-3x slower on object-heavy input,
+landed on `main`, and were found only because someone happened to re-verify an
+unrelated, already-deferred perf issue on a pinned bench box a day later --
+nothing in CI would have caught it. Wall-clock timing in CI is the wrong
+mechanism (shared runners are noisy neighbours; a threshold loose enough not
+to flake is loose enough to let a real 2-3x regression through). This script
+uses `valgrind --tool=cachegrind` instead: binary instruction-count
+instrumentation, deterministic regardless of what else the runner is doing,
+so a real 2-3x work increase shows up as a 2-3x instruction-count increase and
+a 5% threshold is meaningful rather than aspirational.
+
+Two modes (both require --arch, since instruction counts are architecture-
+specific -- different ISA, different codegen -- so the baseline file holds
+one set of counts per arch, not one shared set):
+
+    scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --check
+        Measure the fixed query/shape matrix below, compare each against
+        that arch's entry in the committed baseline
+        (tests/data/perf-guard-baseline.json), and fail (exit 1) if any
+        drifts by more than --threshold percent.
+
+    scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --update-baseline
+        Re-measure and overwrite that arch's entry in the baseline file. Run
+        this deliberately, with a stated reason in the commit message --
+        never automatically -- or the guard silently ratchets and stops
+        catching anything (the exact failure mode this issue was filed to
+        prevent). `--arch` must match one of ci.yml's `perf-guard` matrix
+        names (currently `x86_64`, `ARM64-Linux`) for the CI job to find it.
+
+The query/shape matrix is #1523's own "minimum viable set": #1514's two
+regressions were complementary and each was invisible to the other's own
+signal (one showed only in a `wide`-shaped `keys_unsorted` query, the other
+only in a plain `.` identity query and would have looked like an *improvement*
+under `keys_unsorted` alone) -- so this covers both queries against both a
+`wide` (many top-level keys, no nesting) and a `users` (typical small-record)
+shape, plus an `arrays` shape (no objects, isolates whether a regression is
+object-specific) and one `yq`-mode query (the shared evaluator's cost is
+otherwise unverified in yq mode at all).
+
+Fixtures are generated fresh each run (`succinctly json generate --seed
+<fixed>`) rather than checked in, so instruction counts stay meaningful
+without growing the repo -- generation is deterministic per pattern/seed, so
+the *content* measured is stable run to run.
+
+Standard library only; no third-party dependencies.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+
+# Fixed seed for every generated fixture -- the whole point of a checked-in
+# instruction-count baseline is that the input content doesn't change between
+# runs, only the code being measured does.
+FIXTURE_SEED = 20260101
+
+# (id, generate-pattern, size, mode, filter) -- ids are the baseline file's
+# keys, so renaming one here orphans its old baseline entry (caught by
+# `--check`'s own "missing baseline entry" error) rather than silently
+# comparing against the wrong row.
+QUERIES = [
+    ("wide_keys_unsorted", "wide", "2mb", "jq", "keys_unsorted"),
+    ("wide_identity", "wide", "2mb", "jq", "."),
+    ("users_keys_unsorted", "users", "2mb", "jq", "keys_unsorted"),
+    ("users_identity", "users", "2mb", "jq", "."),
+    ("arrays_identity", "arrays", "2mb", "jq", "."),
+    ("users_yq_keys_unsorted", "users", "2mb", "yq", "keys_unsorted"),
+]
+
+IR_PATTERN = re.compile(r"I\s+refs:\s+([\d,]+)")
+
+DEFAULT_THRESHOLD = 5.0
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="CI instruction-count regression guard for succinctly jq/yq.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("\n\n", 1)[1],
+    )
+    p.add_argument("--binary", required=True, help="path to the succinctly binary (release build)")
+    p.add_argument("--baseline", default="tests/data/perf-guard-baseline.json",
+                    help="path to the checked-in baseline file")
+    p.add_argument("--arch", required=True,
+                    help="baseline key for this run, e.g. x86_64/ARM64-Linux -- instruction "
+                         "counts are architecture-specific (different ISA, different codegen), "
+                         "so the baseline file holds one set of counts per arch, not one shared "
+                         "set")
+    p.add_argument("--valgrind-bin", default="valgrind", help="path to valgrind")
+    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                    help="max allowed instruction-count drift, in percent")
+    p.add_argument("--reps", type=int, default=3, help="measurement repetitions per query (median reported)")
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="compare against the baseline; exit 1 on drift")
+    mode.add_argument("--update-baseline", action="store_true", help="overwrite the baseline file")
+    return p.parse_args(argv)
+
+
+def generate_fixture(binary, pattern, size, seed, out_path):
+    subprocess.run(
+        [binary, "json", "generate", size, "-p", pattern, "-s", str(seed), "-o", out_path],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True,
+    )
+
+
+def run_cachegrind_once(valgrind_bin, binary, mode, filter_expr, fixture_path):
+    with tempfile.TemporaryDirectory() as tmp:
+        log = os.path.join(tmp, "cg.log")
+        cg_out = os.path.join(tmp, "cg.out")
+        cmd = [
+            valgrind_bin, "--tool=cachegrind", f"--log-file={log}",
+            f"--cachegrind-out-file={cg_out}",
+            binary, mode, filter_expr, fixture_path,
+        ]
+        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        with open(log) as f:
+            text = f.read()
+        if result.returncode != 0:
+            sys.exit(f"'{' '.join(cmd)}' exited {result.returncode}; cachegrind log:\n{text}")
+        m = IR_PATTERN.search(text)
+        if not m:
+            sys.exit(f"could not find instruction count in cachegrind output:\n{text}")
+        return int(m.group(1).replace(",", ""))
+
+
+def measure_query(args, query_id, pattern, size, mode, filter_expr):
+    with tempfile.TemporaryDirectory() as tmp:
+        # `yq` accepts JSON input directly (auto-detects by content), so every
+        # fixture is plain JSON regardless of which CLI mode measures it.
+        fixture_path = os.path.join(tmp, f"{query_id}.json")
+        generate_fixture(args.binary, pattern, size, FIXTURE_SEED, fixture_path)
+        counts = [
+            run_cachegrind_once(args.valgrind_bin, args.binary, mode, filter_expr, fixture_path)
+            for _ in range(args.reps)
+        ]
+    return statistics.median(counts)
+
+
+def load_baseline_file(path):
+    """The whole checked-in file: {arch: {query_id: instructions}}."""
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_baseline_file(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    if shutil.which(args.valgrind_bin) is None:
+        sys.exit(
+            f"valgrind not found at {args.valgrind_bin!r} -- install it (e.g. `apt-get install "
+            f"valgrind` on Linux) or pass --valgrind-bin. This guard has no valgrind on macOS "
+            f"(Apple Silicon isn't supported by valgrind at all), so it only runs on the "
+            f"Linux CI legs (issue #1523)."
+        )
+    if not os.path.exists(args.binary):
+        sys.exit(f"binary not found: {args.binary}")
+
+    # Fail fast on a missing/incomplete baseline before running any of the
+    # (expensive, cachegrind-instrumented) measurements below. Instruction
+    # counts are architecture-specific (different ISA, different codegen),
+    # so the baseline file is keyed by `--arch` -- x86_64's counts are not a
+    # valid baseline for ARM64-Linux's run or vice versa.
+    baseline_file = load_baseline_file(args.baseline)
+    baseline = {}
+    known_ids = {q[0] for q in QUERIES}
+    if args.check:
+        baseline = baseline_file.get(args.arch, {})
+        missing = known_ids - set(baseline)
+        if missing:
+            sys.exit(
+                f"baseline for arch {args.arch!r} is missing entries for: {sorted(missing)} "
+                f"-- run with --update-baseline first (and commit the result)."
+            )
+
+    measured = {}
+    print(f"{'query':<26} {'instructions':>16}")
+    print("-" * 44)
+    for query_id, pattern, size, mode, filter_expr in QUERIES:
+        ir = measure_query(args, query_id, pattern, size, mode, filter_expr)
+        measured[query_id] = ir
+        print(f"{query_id:<26} {ir:>16,.0f}")
+        sys.stdout.flush()
+    print()
+
+    if args.update_baseline:
+        baseline_file[args.arch] = measured
+        save_baseline_file(args.baseline, baseline_file)
+        print(f"Wrote {len(measured)} entries for arch {args.arch!r} to {args.baseline}")
+        return 0
+
+    stale = set(baseline) - known_ids
+    if stale:
+        print(f"NOTE: baseline has stale entries no longer measured: {sorted(stale)}")
+
+    failed = []
+    print(f"{'query':<26} {'baseline':>14} {'current':>14} {'drift':>8}")
+    print("-" * 66)
+    for query_id, _, _, _, _ in QUERIES:
+        base = baseline[query_id]
+        cur = measured[query_id]
+        drift = (cur / base - 1) * 100 if base else float("inf")
+        flag = "  <-- FAIL" if abs(drift) > args.threshold else ""
+        print(f"{query_id:<26} {base:>14,.0f} {cur:>14,.0f} {drift:>+7.1f}%{flag}")
+        if abs(drift) > args.threshold:
+            failed.append((query_id, drift))
+
+    print()
+    if failed:
+        print(f"FAILED: {len(failed)} quer{'y' if len(failed) == 1 else 'ies'} exceeded "
+              f"the {args.threshold}% threshold:")
+        for query_id, drift in failed:
+            print(f"  {query_id}: {drift:+.1f}%")
+        print()
+        print("If this is a real, understood regression (e.g. new correctness work that "
+              "genuinely costs more), re-run with --update-baseline and say why in the "
+              "commit message. If it's unexpected, that's exactly what this guard exists "
+              "to catch -- see docs/guides/benchmarking.md for how to investigate.")
+        return 1
+
+    print("OK: all queries within threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,0 +1,18 @@
+{
+  "ARM64-Linux": {
+    "arrays_identity": 1441480786,
+    "users_identity": 330130356,
+    "users_keys_unsorted": 43261762,
+    "users_yq_keys_unsorted": 72626751,
+    "wide_identity": 736876694,
+    "wide_keys_unsorted": 478638146
+  },
+  "x86_64": {
+    "arrays_identity": 1496423517,
+    "users_identity": 372062228,
+    "users_keys_unsorted": 67471861,
+    "users_yq_keys_unsorted": 82680144,
+    "wide_identity": 821574633,
+    "wide_keys_unsorted": 573924928
+  }
+}


### PR DESCRIPTION
## Summary

Nothing in CI catches a jq/yq performance regression. #1385's two fix commits made `succinctly jq` **2-3x slower** on object-heavy input, landed on `main`, and were found only because someone happened to re-verify an unrelated, already-deferred perf issue (#789) on a pinned bench box a day later. The regression survived a perf commit aimed squarely at it — `"10.4% to 3.9%"` was a share-of-runtime figure measured inside an already-inflated total, not a delta against the pre-series parent, so it read as a win while the 2-3x regression stayed in place.

The existing `bench` CI job only times `rank_select` and uploads the results as artifacts nobody reads — no jq/yq CLI workload is benchmarked in CI at all, and even `rank_select` has no comparison against any baseline.

## Why cachegrind, not wall-clock

Wall-clock timing on a shared CI runner is the wrong mechanism: this repo already measured a **-4.2%..+1.1% control band** on a *dedicated, idle* 7950X, so a threshold loose enough not to flake on a noisy shared runner would also be loose enough to let a real 2-3x regression through. Uses `valgrind --tool=cachegrind` instead: binary instruction counts are deterministic regardless of what else the runner is doing, so a 2-3x work increase shows up as a 2-3x instruction-count increase and a 5% threshold is meaningful rather than aspirational.

## What's covered

Adds `scripts/perf-guard.py` (`--check` / `--update-baseline`) and a new **Perf Regression Guard** CI job (x86_64 and ARM64-Linux only — valgrind has no Apple Silicon support), checking the fixed query/shape matrix the issue itself specified as the minimum viable set: #1514's two regressions were complementary and each was invisible to the other's own signal (one showed only under a `wide`-shaped `keys_unsorted` query, the other only under a plain identity query and would have looked like an *improvement* under `keys_unsorted` alone). Covers `wide`/`users`/`arrays` shapes, both `keys_unsorted` and identity queries, and one yq-mode query (the shared evaluator's cost is otherwise unverified in yq mode at all).

`tests/data/perf-guard-baseline.json` is keyed **per architecture** — instruction counts depend on ISA/codegen, not just wall-clock noise — and was generated from this PR's own CI runs (x86_64 and ARM64-Linux GitHub Actions runners themselves), not a different machine, so the checking environment and the baseline's own origin match exactly.

Deliberately **not** added to the repo's required-checks list yet, per the issue's own ask — a flaky first iteration of a new gate must not be able to block the merge queue. Promote it once it has a track record.

## Test plan

- [x] Verified the script's control flow end-to-end locally with a fake-valgrind shim (no real valgrind available on this dev machine — Apple Silicon) — `--update-baseline`, `--check` (pass and fail paths), missing-baseline-entries fail-fast, missing-binary, missing-valgrind
- [x] Bootstrapped the real baseline from this PR's own CI runs: ran `--update-baseline` on both `x86_64` and `ARM64-Linux` GitHub Actions runners, downloaded the resulting artifacts, merged them into the committed baseline file
- [x] Confirmed the final `--check`-mode CI job passes against that freshly-generated baseline (both legs green)
- [x] `python3 -m py_compile scripts/perf-guard.py` — clean
- [x] YAML validated (`yaml.safe_load`)
- [x] Updated `docs/guides/benchmarking.md`'s CI/CD section to document the new job and how to update the baseline

Closes #1523