### PR TITLE
perf(jq): skip get_inputs' per-value location tracking under --slurp

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1579,9 +1579,15 @@ fn get_inputs(
             // DSV input: each row becomes a JSON array of strings
             let parsed = parse_dsv_input(&raw, delimiter);
             // One row per line (approximate for embedded newlines; jq has no
-            // DSV input mode, so there is no oracle to match here).
-            for line in 1..=parsed.len() {
-                locations.push(src, line);
+            // DSV input mode, so there is no oracle to match here). Skipped
+            // under `--slurp` (#1541): the combined array's own location
+            // comes from `slurp_eof_line` above, not from any of these
+            // per-value entries, which `get_inputs` discards wholesale when
+            // it replaces `locations` with `InputLocations::single` below.
+            if !args.slurp {
+                for line in 1..=parsed.len() {
+                    locations.push(src, line);
+                }
             }
             values.extend(parsed);
         } else if args.raw_input {
@@ -1593,7 +1599,10 @@ fn get_inputs(
         } else if args.seq {
             // JSON sequence input (RFC 7464): split on RS, ignore parse failures
             let parsed = parse_json_seq(&raw);
-            locations.extend_from_ends(src, &raw, &json_seq_ends(raw.as_bytes()), parsed.len());
+            // Skipped under `--slurp` (#1541) -- see the DSV branch above.
+            if !args.slurp {
+                locations.extend_from_ends(src, &raw, &json_seq_ends(raw.as_bytes()), parsed.len());
+            }
             values.extend(parsed);
         } else {
             // JSON input: validate first if --validate is set
@@ -1606,33 +1615,41 @@ fn get_inputs(
                 Ok(p) => p,
                 Err(e) => return Ok(Err(e)),
             };
-            // `parse_json_stream` (above) already validated this exact
-            // input successfully via `serde_json`, which is strictly
-            // pickier than `find_json_values`'s own lenient heuristic
-            // scan (RFC 8259 plus #1094's leading-zero tolerance, vs.
-            // `find_json_values`'s RFC 8259 plus leading-zero *and*
-            // leading-dot tolerance, #1171) -- so `find_json_values`
-            // should never fail here in practice; unreachable through
-            // this crate's own public CLI surface, not exercised by a
-            // test for that reason (matching this codebase's established
-            // convention for exhaustive-but-dead defensive arms, e.g.
-            // #1064). Surfaced as an internal error rather than silently
-            // reusing a stale/wrong offset list if the two validators
-            // ever do diverge.
-            let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
-                Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
-                Err(offset) => {
-                    return Ok(Err(anyhow::anyhow!(
-                        "internal error: find_json_values failed at byte {offset} \
-                         after parse_json_stream already validated this input"
-                    )));
-                }
-            };
-            locations.extend_from_ends(src, &raw, &ends, parsed.len());
+            // Skipped under `--slurp` (#1541) -- see the DSV branch above.
+            // `find_json_values` exists here only to feed
+            // `locations.extend_from_ends`, so slurp mode skips that scan
+            // entirely rather than running it and discarding the result.
+            if !args.slurp {
+                // `parse_json_stream` (above) already validated this exact
+                // input successfully via `serde_json`, which is strictly
+                // pickier than `find_json_values`'s own lenient heuristic
+                // scan (RFC 8259 plus #1094's leading-zero tolerance, vs.
+                // `find_json_values`'s RFC 8259 plus leading-zero *and*
+                // leading-dot tolerance, #1171) -- so `find_json_values`
+                // should never fail here in practice; unreachable through
+                // this crate's own public CLI surface, not exercised by a
+                // test for that reason (matching this codebase's established
+                // convention for exhaustive-but-dead defensive arms, e.g.
+                // #1064). Surfaced as an internal error rather than silently
+                // reusing a stale/wrong offset list if the two validators
+                // ever do diverge.
+                let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
+                    Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
+                    Err(offset) => {
+                        return Ok(Err(anyhow::anyhow!(
+                            "internal error: find_json_values failed at byte {offset} \
+                             after parse_json_stream already validated this input"
+                        )));
+                    }
+                };
+                locations.extend_from_ends(src, &raw, &ends, parsed.len());
+            }
             values.extend(parsed);
         }
 
-        debug_assert_eq!(locations.len(), values.len(), "one location per value");
+        if !args.slurp {
+            debug_assert_eq!(locations.len(), values.len(), "one location per value");
+        }
     }
 
     // Slurp mode: wrap all inputs in an array

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1591,7 +1591,13 @@ fn get_inputs(
             }
             values.extend(parsed);
         } else if args.raw_input {
-            // Raw input: each line becomes a string
+            // Raw input: each line becomes a string. Deliberately ungated by
+            // `!args.slurp` (#1541), unlike its three siblings above/below --
+            // `args.raw_input && args.slurp` can only reach this arm when
+            // `args.input_dsv` is also set (otherwise the dedicated `-R -s`
+            // early return above already handled it), and the DSV check is
+            // tried first in this `if`/`else if` chain, so it always wins:
+            // this arm is unreachable whenever `args.slurp` is true.
             for (line_idx, line) in raw.lines().enumerate() {
                 values.push(OwnedValue::String(line.to_string()));
                 locations.push(src, line_idx + 1);
@@ -1619,6 +1625,15 @@ fn get_inputs(
             // `find_json_values` exists here only to feed
             // `locations.extend_from_ends`, so slurp mode skips that scan
             // entirely rather than running it and discarding the result.
+            // Side effect: the divergence check below (`find_json_values`
+            // disagreeing with `parse_json_stream`/`serde_json`) no longer
+            // runs under `--slurp` either -- if the two validators were ever
+            // to disagree on some input, non-slurp mode would still raise
+            // the internal error below, but slurp mode would now silently
+            // proceed. Accepted: the comment above already treats that
+            // divergence as unreachable through this crate's public CLI
+            // surface, so this only narrows *where* an already-believed-dead
+            // safety net runs, not what output a real input can produce.
             if !args.slurp {
                 // `parse_json_stream` (above) already validated this exact
                 // input successfully via `serde_json`, which is strictly
@@ -1647,6 +1662,12 @@ fn get_inputs(
             values.extend(parsed);
         }
 
+        // Scoped to `!args.slurp` (#1541): under slurp, `locations` is left
+        // empty by design (the branches above skip their pushes), so this
+        // invariant no longer holds there and isn't meaningful to check --
+        // the real slurp-mode invariant is `InputLocations::single`'s own
+        // unconditional single push, asserted independently by `run_jq`'s
+        // `debug_assert_eq!(inputs.len(), locations.per_value().len())`.
         if !args.slurp {
             debug_assert_eq!(locations.len(), values.len(), "one location per value");
         }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17618,6 +17618,81 @@ fn test_jq_dsv_slurp_skips_location_tracking_1541() -> Result<()> {
     Ok(())
 }
 
+/// #1541: the DSV branch's skipped `locations.push` loop feeds two
+/// independently-buggable accessors (per #1542's own precedent for `--seq`)
+/// -- `error(...)`'s direct `InputLocations::get` (covered above) and
+/// `input`/`inputs`/`input_line_number`'s live queue, seeded from
+/// `InputLocations::per_value()`/`ErrorAt::Live`. Confirm the Live path
+/// resolves the same last-source-EOF location under DSV slurp.
+#[test]
+fn test_jq_dsv_slurp_live_input_builtins_1541() -> Result<()> {
+    let (stdout, _, code, _paths) = run_jq_over_files(
+        &["--input-dsv", ",", "-c", "-s", "inputs"],
+        &["a,b\n1,2\n", "c,d\n"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["--input-dsv", ",", "-c", "-s", "., input_line_number"],
+        &["a,b\n1,2\n", "c,d\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "[[\"a\",\"b\"],[\"1\",\"2\"],[\"c\",\"d\"]]\n1\n");
+
+    Ok(())
+}
+
+/// #1541: DSV slurp's row-count loop (`for line in 1..=parsed.len()`,
+/// skipped entirely under `--slurp`) still needs its *values* to come out
+/// right at `parsed.len()`'s boundary cases -- a single file, zero rows,
+/// and exactly one (header-only) row.
+#[test]
+fn test_jq_dsv_slurp_row_count_edge_cases_1541() -> Result<()> {
+    // Single file, multiple rows.
+    let (stdout, _, code, _paths) =
+        run_jq_over_files(&["--input-dsv", ",", "-c", "-s", "."], &["a,b\n1,2\n3,4\n"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\",\"b\"],[\"1\",\"2\"],[\"3\",\"4\"]]\n");
+
+    // Empty file: zero rows.
+    let (stdout, _, code, _paths) =
+        run_jq_over_files(&["--input-dsv", ",", "-c", "-s", "."], &[""])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n");
+
+    // Header-only file: exactly one row.
+    let (stdout, _, code, _paths) =
+        run_jq_over_files(&["--input-dsv", ",", "-c", "-s", "."], &["a,b\n"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\",\"b\"]]\n");
+
+    Ok(())
+}
+
+/// #1541: the plain-JSON branch is the one whose `find_json_values` scan
+/// this issue actually removes under `--slurp` -- existing coverage tests
+/// either a single multi-value source or two single-value files, never
+/// multiple files *each* holding multiple values together. Confirm both the
+/// combined values and the last-source-EOF error location are still right
+/// for that combination.
+#[test]
+fn test_jq_slurp_multi_file_multi_value_json_1541() -> Result<()> {
+    let (stdout, _, code, _paths) = run_jq_over_files(&["-c", "-s", "."], &["1\n2\n", "3\n4\n"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[1,2,3,4]\n");
+
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["-c", "-s", r#"error("x")"#], &["1\n2\n", "3\n4\n"])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:2): x", paths[1])),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1542: `--seq --slurp`'s EOF marker is `<unknown>`, not a resolved
 /// position, when the stream's *own last* record leaves real jq's
 /// incremental parser with nothing to point at -- either genuinely

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17590,6 +17590,34 @@ fn test_jq_slurp_error_location_is_last_source_eof_1520() -> Result<()> {
     Ok(())
 }
 
+/// #1541: `--input-dsv` under `--slurp` skips `get_inputs`'s per-row
+/// `locations.push` loop entirely (it's pure overhead once `--slurp`
+/// replaces the whole table with a single `slurp_eof` location below) --
+/// confirm that skip doesn't touch the actual values, and that the error
+/// location still follows the same last-source-EOF rule #1520 established
+/// for the other three input modes.
+#[test]
+fn test_jq_dsv_slurp_skips_location_tracking_1541() -> Result<()> {
+    let (stdout, _, code, _paths) = run_jq_over_files(
+        &["--input-dsv", ",", "-c", "-s", "."],
+        &["a,b\n1,2\n", "c,d\n"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\",\"b\"],[\"1\",\"2\"],[\"c\",\"d\"]]\n");
+
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--input-dsv", ",", "-c", "-s", r#"error("x")"#],
+        &["a,b\n1,2\n", "c,d\n"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[1])),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1542: `--seq --slurp`'s EOF marker is `<unknown>`, not a resolved
 /// position, when the stream's *own last* record leaves real jq's
 /// incremental parser with nothing to point at -- either genuinely


### PR DESCRIPTION
Fixes #1541

## Summary

`get_inputs`'s per-file loop unconditionally built a per-value `(source, line)`
location table (`locations.push`/`extend_from_ends`) for every input mode --
including a dedicated `find_json_values` scan for the JSON branch, run only to
feed that table. #1520 replaced `--slurp`'s own EOF location with
`InputLocations::slurp_eof`, which reads only `self.files` and an
independently-computed EOF line -- never `self.per_value` -- so under
`--slurp` the per-file loop's location-tracking calls became pure overhead:
real scanning work whose result nothing downstream reads.

This skips those calls (DSV/seq/JSON branches; the raw-input branch is
already unreachable under `--slurp`, see below) when `args.slurp` is set,
while still populating `values` unconditionally, and relaxes the
`debug_assert_eq!(locations.len(), values.len(), ...)` invariant to only
check when tracking actually ran.

## Why the raw-input branch needed no change

`args.raw_input && args.slurp && args.input_dsv.is_none()` already returns
early via its own dedicated `-R -s` branch before the per-file loop starts.
The only way to reach `args.slurp` inside the loop with `args.raw_input` set
is when `args.input_dsv` is also set -- and the DSV check is tried first in
the loop's `if`/`else if` chain, so it always wins. The `args.raw_input`
branch is therefore unreachable whenever `args.slurp` is true, with or
without this change.

## Testing

- Added `test_jq_dsv_slurp_skips_location_tracking_1541` -- the one input
  mode (`--input-dsv`) with no prior `--slurp` coverage, and exactly the path
  this change touches. Confirms the slurped values are unaffected and the
  error location still follows #1520's last-source-EOF rule.
- Full suite green locally (`cargo test --features cli,simd,regex,serde`),
  both required clippy legs clean, `cargo build --no-default-features`
  (no_std) clean, `cargo doc --all-features` clean.
- Manually cross-checked DSV/raw/seq/JSON `--slurp` output and error
  locations against pinned `jq` 1.7.1 where an oracle exists.

## Benchmark (Phase 3 discipline)

Interleaved A/B, 5-file `--slurp -c '.'` JSON corpus at 5/25/100MB, 7 reps,
output identity gated, on both pinned machines (full tables in the
[issue comment](https://github.com/rust-works/succinctly/issues/1541#issuecomment-5384824492)):

**Result: neutral on both architectures.** Every delta is within the ~0.7-0.8%
control noise floor measured on the same machine at the same tier -- no
size-scaling signature either direction. `find_json_values`'s scan is real
work, but it's a small fraction of end-to-end time next to file I/O and
`parse_json_stream`'s own full parse, both of which run regardless -- too
small to isolate from process-level noise at these sizes.

Keeping the change anyway: it's a verified elimination of genuinely dead work
(identity-gated correct on every tier tested), adds no complexity, and has no
measured downside on either architecture.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features`
- [x] A/B benchmark on both pinned machines, output identity gated