### PR TITLE
fix(jq): retry the next ?// alternative when foreach's EXTRACT errors

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21212,16 +21212,36 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Whether a `Control` escaping a `?//` alternative's attempt should retry
+/// the next alternative rather than propagate: `Halt` never retries (must
+/// bypass `try`/`catch` and `label`/`break` -- see [`Control::Halt`]'s own
+/// doc comment), and neither does `Error`/`Break` on the *last* alternative,
+/// since there's nothing left to fall through to.
+///
+/// Shared by both of [`try_foreach_step_alternatives`]'s retry decisions
+/// (UPDATE's own, and EXTRACT's -- #1458) so the two can't independently
+/// drift on what counts as retryable, the way `try_pattern_alternatives`'s
+/// own copy of this same predicate already once did (#1457).
+/// [`try_reduce_step_alternatives`] hand-rolls an equivalent match rather
+/// than calling this, since its single UPDATE-only retry predates this
+/// helper; consolidating it too is tracked separately (#1571) rather than
+/// attempted here, to keep this fix scoped to the bug it's actually fixing.
+fn is_retryable_control(control: &Control, is_last: bool) -> bool {
+    !is_last && matches!(control, Control::Error(_) | Control::Break(_))
+}
+
 /// Try each `?//`-separated pattern alternative (#1365) for one `foreach`
 /// step, in order, against a single `input_val`.
 ///
-/// Only UPDATE participates in the `?//` retry -- the state-threading rule
-/// is identical to [`try_reduce_step_alternatives`]'s (a pattern-match
-/// failure leaves `state` untouched; a body `Error`/`Break` still updates
-/// it first, from whatever partial output that attempt produced, *then*
-/// falls through; `Halt` alone always propagates immediately) -- see that
-/// function's own doc comment for the oracle-verified rationale and repro,
-/// which applies here unchanged.
+/// Only UPDATE participated in the `?//` retry until #1458 -- the state-
+/// threading rule for UPDATE's own retry is identical to
+/// [`try_reduce_step_alternatives`]'s (a pattern-match failure leaves
+/// `state` untouched; a body `Error`/`Break` still updates it first, from
+/// whatever partial output that attempt produced, *then* falls through;
+/// `Halt` alone always propagates immediately) -- see that function's own
+/// doc comment for the oracle-verified rationale and repro, which applies
+/// here unchanged. EXTRACT now participates too, with its own, stranger
+/// state-threading rule -- see below.
 ///
 /// EXTRACT runs only once UPDATE has picked a winning alternative, fanning
 /// out over every one of UPDATE's (possibly multiple) outputs using that
@@ -21314,30 +21334,28 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
                 let (ext_vals, ext_control) =
                     eval_owned_expr_fork::<S>(ext_expr, update_val, optional);
                 outputs.extend(ext_vals);
-                if let Some(control) = ext_control {
-                    match control {
-                        // #1458: real jq retries here too, but with a state-
-                        // threading rule found nowhere else in this file --
-                        // the *next* alternative's UPDATE resumes from this
-                        // failed EXTRACT call's own input (`update_val`), not
-                        // the pre-attempt state and not `update_vals.last()`
-                        // (this same attempt's own final UPDATE output,
-                        // which may not even be `update_val` -- the failure
-                        // can land on an earlier one while later ones sit
-                        // unprocessed). Any of `update_vals` after this
-                        // point, and this attempt's own trailing
-                        // `update_control` (if UPDATE itself also partially
-                        // failed), are both abandoned in favor of the next
-                        // alternative's fresh UPDATE-then-EXTRACT run --
-                        // matching the doc comment's oracle repro, where the
-                        // retry re-runs UPDATE wholesale rather than
-                        // resuming this attempt's own remaining outputs.
-                        Control::Error(_) | Control::Break(_) if !is_last => {
-                            state = update_val.clone();
-                            continue 'alternatives;
-                        }
-                        control => return (state, Some(control)),
+                match ext_control {
+                    None => {}
+                    // #1458: real jq retries here too, but with a state-
+                    // threading rule found nowhere else in this file -- the
+                    // *next* alternative's UPDATE resumes from this failed
+                    // EXTRACT call's own input (`update_val`), not the pre-
+                    // attempt state and not `update_vals.last()` (this same
+                    // attempt's own final UPDATE output, which may not even
+                    // be `update_val` -- the failure can land on an earlier
+                    // one while later ones sit unprocessed). Any of
+                    // `update_vals` after this point, and this attempt's
+                    // own trailing `update_control` (if UPDATE itself also
+                    // partially failed), are both abandoned in favor of the
+                    // next alternative's fresh UPDATE-then-EXTRACT run --
+                    // matching the doc comment's oracle repro, where the
+                    // retry re-runs UPDATE wholesale rather than resuming
+                    // this attempt's own remaining outputs.
+                    Some(control) if is_retryable_control(&control, is_last) => {
+                        state = update_val.clone();
+                        continue 'alternatives;
                     }
+                    Some(control) => return (state, Some(control)),
                 }
             } else {
                 outputs.push(update_val.clone());
@@ -21346,7 +21364,7 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
 
         match update_control {
             None => return (state, None),
-            Some(Control::Error(_) | Control::Break(_)) if !is_last => continue,
+            Some(control) if is_retryable_control(&control, is_last) => continue,
             Some(control) => return (state, Some(control)),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21225,20 +21225,24 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ///
 /// EXTRACT runs only once UPDATE has picked a winning alternative, fanning
 /// out over every one of UPDATE's (possibly multiple) outputs using that
-/// same alternative's bindings; an EXTRACT error/break/halt propagates
-/// directly, without retrying a different alternative. This is a
-/// deliberately narrower scope than real jq's own behavior: live-probing
-/// found that when EXTRACT itself errors, real jq retries by re-running
-/// UPDATE *again* with the next alternative, feeding it the failed EXTRACT
-/// call's own input as UPDATE's new state (`foreach .[] as {a:$x} ?//
-/// {a:$y} (0; .+1, .+2; if . == 2 then error("boom") else [$x,$y,.] end)`
-/// on `[{"a":1}]` is `[[1,null,1],[null,1,3],[null,1,4]]` -- the `3`/`4`
-/// only make sense as `.+1, .+2` re-run against state `2`, the failed
-/// EXTRACT call's own input). That interaction is substantially stranger
-/// than anything else `?//` does elsewhere in this codebase and reads as
-/// an accidental byproduct of jq's bytecode compilation rather than a
-/// designed behavior; reproducing it is left as a follow-up (#1458) rather
-/// than blocking this one on fully reverse-engineering it.
+/// same alternative's bindings. Unlike UPDATE's own retry above, an EXTRACT
+/// error/break (on a non-last alternative) doesn't resume the *same*
+/// attempt or reuse the pre-attempt state -- it abandons this attempt's
+/// remaining UPDATE outputs entirely and retries the *next* alternative's
+/// whole UPDATE-then-EXTRACT sequence from scratch, seeded with the failed
+/// EXTRACT call's own input as UPDATE's new state (#1458; live-verified
+/// against real jq 1.7.1): `foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2;
+/// if . == 2 then error("boom") else [$x,$y,.] end)` on `[{"a":1}]` is
+/// `[[1,null,1],[null,1,3],[null,1,4]]` -- the `3`/`4` only make sense as
+/// `.+1, .+2` re-run against state `2`, the failed EXTRACT call's own
+/// input, not `4`, this attempt's own final UPDATE output. That state-
+/// threading rule is substantially stranger than anything else `?//` does
+/// elsewhere in this codebase and reads as an accidental byproduct of jq's
+/// bytecode compilation rather than a designed behavior -- reproduced here
+/// bug-for-bug anyway, per ADR-0018, rather than "fixed" into a cleaner
+/// model that doesn't match. `Halt`, and any EXTRACT failure on the *last*
+/// alternative, still propagate immediately -- unretryable, same as
+/// UPDATE's own rule.
 ///
 /// Appends every EXTRACT (or bare UPDATE, when EXTRACT is absent) output
 /// straight into `outputs` (mirroring `eval_foreach`'s own "the steps
@@ -21265,7 +21269,7 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
     let last_idx = substituted_steps.len() - 1;
     let mut state = state_input;
 
-    for (i, step) in substituted_steps.iter().enumerate() {
+    'alternatives: for (i, step) in substituted_steps.iter().enumerate() {
         let is_last = i == last_idx;
 
         let (substituted_update, substituted_extract) = match step {
@@ -21311,7 +21315,29 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
                     eval_owned_expr_fork::<S>(ext_expr, update_val, optional);
                 outputs.extend(ext_vals);
                 if let Some(control) = ext_control {
-                    return (state, Some(control));
+                    match control {
+                        // #1458: real jq retries here too, but with a state-
+                        // threading rule found nowhere else in this file --
+                        // the *next* alternative's UPDATE resumes from this
+                        // failed EXTRACT call's own input (`update_val`), not
+                        // the pre-attempt state and not `update_vals.last()`
+                        // (this same attempt's own final UPDATE output,
+                        // which may not even be `update_val` -- the failure
+                        // can land on an earlier one while later ones sit
+                        // unprocessed). Any of `update_vals` after this
+                        // point, and this attempt's own trailing
+                        // `update_control` (if UPDATE itself also partially
+                        // failed), are both abandoned in favor of the next
+                        // alternative's fresh UPDATE-then-EXTRACT run --
+                        // matching the doc comment's oracle repro, where the
+                        // retry re-runs UPDATE wholesale rather than
+                        // resuming this attempt's own remaining outputs.
+                        Control::Error(_) | Control::Break(_) if !is_last => {
+                            state = update_val.clone();
+                            continue 'alternatives;
+                        }
+                        control => return (state, Some(control)),
+                    }
                 }
             } else {
                 outputs.push(update_val.clone());

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21224,7 +21224,7 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// own copy of this same predicate already once did (#1457).
 /// [`try_reduce_step_alternatives`] hand-rolls an equivalent match rather
 /// than calling this, since its single UPDATE-only retry predates this
-/// helper; consolidating it too is tracked separately (#1571) rather than
+/// helper; consolidating it too is tracked separately (#1570) rather than
 /// attempted here, to keep this fix scoped to the bug it's actually fixing.
 fn is_retryable_control(control: &Control, is_last: bool) -> bool {
     !is_last && matches!(control, Control::Error(_) | Control::Break(_))
@@ -21252,10 +21252,11 @@ fn is_retryable_control(control: &Control, is_last: bool) -> bool {
 /// whole UPDATE-then-EXTRACT sequence from scratch, seeded with the failed
 /// EXTRACT call's own input as UPDATE's new state (#1458; live-verified
 /// against real jq 1.7.1): `foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2;
-/// if . == 2 then error("boom") else [$x,$y,.] end)` on `[{"a":1}]` is
-/// `[[1,null,1],[null,1,3],[null,1,4]]` -- the `3`/`4` only make sense as
-/// `.+1, .+2` re-run against state `2`, the failed EXTRACT call's own
-/// input, not `4`, this attempt's own final UPDATE output. That state-
+/// if . == 2 then error("boom") else [$x,$y,.] end)` on `[{"a":1}]` prints
+/// three separate top-level outputs -- `[1,null,1]`, then `[null,1,3]`,
+/// then `[null,1,4]` -- and the `3`/`4` only make sense as `.+1, .+2`
+/// re-run against state `2`, the failed EXTRACT call's own input, not `4`,
+/// this attempt's own final UPDATE output. That state-
 /// threading rule is substantially stranger than anything else `?//` does
 /// elsewhere in this codebase and reads as an accidental byproduct of jq's
 /// bytecode compilation rather than a designed behavior -- reproduced here

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15931,6 +15931,26 @@ fn test_foreach_alt_extract_success_survives_when_alt_later_falls_through_1458()
     Ok(())
 }
 
+#[test]
+fn test_foreach_alt_extract_error_on_middle_output_abandons_later_ones_1458() -> Result<()> {
+    // A 3-output UPDATE fan-out (.+1, .+2, .+3), EXTRACT erroring on the
+    // *middle* one -- the third output (5, from alt1's own UPDATE) is never
+    // reached by alt1's EXTRACT at all: it's abandoned along with the
+    // failure, not merely skipped-and-resumed. Alt2's fresh UPDATE re-run
+    // from state 2 produces 3,4,5 -- the doc comment's own claim ("the
+    // failure can land on an earlier one while later ones sit unprocessed").
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2, .+3; if . == 2 then error(\"boom\") else [$x,$y,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[1,null,1]\n[null,1,3]\n[null,1,4]\n[null,1,5]");
+    Ok(())
+}
+
 // =============================================================================
 // #1164: a builtin argument generator that produces a value and *then*
 // breaks/errors no longer silently continues past that escape once the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15818,6 +15818,120 @@ fn test_reduce_foreach_accept_pattern_alternatives_1365() -> Result<()> {
 }
 
 // =============================================================================
+// #1458: `foreach ?//`'s EXTRACT retry. Real jq's own oracle-verified
+// behavior when EXTRACT (not UPDATE) errors mid-stream on a non-last
+// alternative: it abandons the rest of that attempt's own UPDATE outputs
+// and retries the *next* alternative's whole UPDATE-then-EXTRACT sequence,
+// seeded with the failed EXTRACT call's own input as UPDATE's new state --
+// not the pre-attempt state, and not this attempt's own final UPDATE
+// output. All cases below live-verified against pinned jq 1.7.1.
+// =============================================================================
+
+#[test]
+fn test_foreach_alt_extract_error_retries_next_alt_from_failed_input_1458() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2; if . == 2 then error(\"boom\") else [$x,$y,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "[1,null,1]\n[null,1,3]\n[null,1,4]",
+        "the 3/4 only make sense as .+1,.+2 re-run against state 2 (the failed EXTRACT's own input), not 4 (this attempt's own final UPDATE output)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_foreach_alt_extract_break_also_retries_like_error_1458() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2; if . == 2 then break $out else [$x,$y,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[1,null,1]\n[null,1,3]\n[null,1,4]");
+    Ok(())
+}
+
+#[test]
+fn test_foreach_alt_extract_error_on_last_alt_still_propagates_1458() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "foreach .[] as {a:$x} (0; .+1, .+2; if . == 2 then error(\"boom\") else [$x,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    // Single alternative -- no next one to retry -- so the error propagates
+    // after the already-produced prefix (#494), same as pre-#1458.
+    assert_eq!(code, 5, "should error; out={out}");
+    assert!(err.contains("boom"), "err={err}");
+    assert_eq!(out.trim(), "[1,1]");
+    Ok(())
+}
+
+#[test]
+fn test_foreach_alt_extract_halt_never_retries_1458() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2; if . == 2 then halt else [$x,$y,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    // `halt` bypasses try/catch, label/break, AND this retry mechanism --
+    // stops the whole process at the first successful output.
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "[1,null,1]");
+    Ok(())
+}
+
+#[test]
+fn test_foreach_alt_extract_retry_cascades_through_three_alternatives_1458() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "foreach .[] as {a:$x} ?// {a:$y} ?// {a:$z} (0; .+1, .+2; if . == 2 or . == 4 then error(\"boom \\(.)\") else [$x,$y,$z,.] end)",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "[1,null,null,1]\n[null,1,null,3]\n[null,null,1,5]\n[null,null,1,6]"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_foreach_alt_extract_success_survives_when_alt_later_falls_through_1458() -> Result<()> {
+    // The already-successfully-extracted output from the failed alternative
+    // (`[1,null,1]`) is NOT discarded when that alternative later fails and
+    // falls through -- confirmed via `try`/`catch` capturing only the error,
+    // with the earlier output already collected into the array.
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            "[foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2; if . == 2 then error(\"boom\") else [$x,$y,.] end)]",
+        ],
+        Some(r#"[{"a":1}]"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "[[1,null,1],[null,1,3],[null,1,4]]",
+        "the first alternative's own successful [1,null,1] output must survive"
+    );
+    Ok(())
+}
+
+// =============================================================================
 // #1164: a builtin argument generator that produces a value and *then*
 // breaks/errors no longer silently continues past that escape once the
 // builtin has finished using the value -- `result_to_owned`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15913,8 +15913,10 @@ fn test_foreach_alt_extract_retry_cascades_through_three_alternatives_1458() -> 
 fn test_foreach_alt_extract_success_survives_when_alt_later_falls_through_1458() -> Result<()> {
     // The already-successfully-extracted output from the failed alternative
     // (`[1,null,1]`) is NOT discarded when that alternative later fails and
-    // falls through -- confirmed via `try`/`catch` capturing only the error,
-    // with the earlier output already collected into the array.
+    // falls through -- collecting into `[...]` succeeds with all three
+    // outputs present (no error escapes to the top level at all, since the
+    // retry handles EXTRACT's failure internally), confirming the earlier
+    // output was already collected rather than discarded on retry.
     let (out, err, code) = run_jq_full(
         &[
             "-c",


### PR DESCRIPTION
## Summary

PR #1455 (#1365) added `?//`-separated pattern alternatives to `reduce`/`foreach`'s
`as` clause. For `foreach`, only UPDATE participated in the retry: when the winning
alternative's EXTRACT call itself errored/broke, succinctly propagated that directly
instead of retrying a different alternative — a deliberate scope-narrowing documented
in `try_foreach_step_alternatives`'s own doc comment, left as this follow-up.

Real jq's actual behavior is stranger than a simple "retry from pre-attempt state"
model: when EXTRACT errors on one of UPDATE's outputs, it retries by re-running UPDATE
**again** with the next alternative, feeding it **the failed EXTRACT call's own input**
as UPDATE's new state — not the pre-attempt state, and not this attempt's own final
UPDATE output.

```bash
$ echo '[{"a":1}]' | jq -c 'foreach .[] as {a:$x} ?// {a:$y} (0; .+1, .+2; if . == 2 then error("boom") else [$x,$y,.] end)'
[[1,null,1],[null,1,3],[null,1,4]]
```

The `3`/`4` only make sense as `.+1, .+2` re-run against state `2` — the value EXTRACT
choked on — with alt2's bindings.

## Change

`try_foreach_step_alternatives` (`src/jq/eval.rs`) now: on an EXTRACT
error/break on a non-last alternative, abandons the rest of that attempt's own
UPDATE outputs (and its own trailing `update_control`, if any), sets `state` to the
specific value EXTRACT failed on, and continues the outer alternatives loop — so the
next alternative's UPDATE-then-EXTRACT sequence runs fresh from there. This naturally
cascades through further alternatives if they also fail, since it's the same loop.
`Halt`, and a failure on the *last* alternative, still propagate immediately, matching
UPDATE's own existing rule.

Confirmed `?//` isn't parseable in yq mode at all (`as {a:$x} ?// ...` errors
`expected '|', found '?'`), so this is jq-mode-only in practice — no yq-side testing
needed.

## Verification against pinned jq 1.7.1

- The oracle example above, byte-for-byte.
- `try`/`catch` wrapping (rules out a stray-uncaught-error explanation).
- EXTRACT failure on the *last* alternative still propagates (single-alternative
  regression check).
- `halt` inside EXTRACT on a non-last alternative still stops the whole process
  immediately, no retry.
- `break $label` inside EXTRACT retries the same as `error`.
- 3-alternative cascade: first two alternatives' EXTRACT both fail, falls through to
  the third.
- The already-successfully-extracted output from a failing alternative
  (`[1,null,1]`) survives in the final output, not discarded.
- 2-arg `foreach` (no EXTRACT) and UPDATE-level retries unaffected (regression checks).

All six cases now have dedicated regression tests in `tests/jq_cli_tests.rs`.

Fixes #1458

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — 0 failures, all 54 groups green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's 2nd clippy leg)
- [x] `cargo build --no-default-features` (no_std) — warnings identical to main, pre-existing
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo fmt --check`
- [x] Live-verified every scenario above against `/usr/bin/jq` 1.7.1