### PR TITLE
perf(jq): stop cloning builtin_del's own resolved paths into rewritten

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25124,8 +25124,8 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `yq_del_slice_outcome` instead of being cloned -- a real allocation
     // win at scale (a `k`-branch computed key ahead of an `n`-element
     // trailing `[]` resolves to `k*n` paths here, each a multi-component
-    // `Expr` tree), measured at roughly a 19-31% peak-RSS reduction for
-    // `del()` on `.items[(0,1)].foo[]` across 100k/400k/800k elements.
+    // `Expr` tree), measured at an 18-28% peak-RSS reduction for `del()`
+    // on `.items[(0,1)].foo[]` across 100k/400k/800k elements.
     let rewritten: Vec<Expr> = paths
         .into_iter()
         .filter_map(|path| {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25118,16 +25118,24 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // empty path list as a no-op (its own `paths.is_empty()` guard), so
     // this composes cleanly even when every sibling turns out to be a
     // no-op.
+    //
+    // `paths.into_iter()` (#1384): `paths` is never read again after this
+    // loop, so `path` can be moved into `rewritten`/passed by reference to
+    // `yq_del_slice_outcome` instead of being cloned -- a real allocation
+    // win at scale (a `k`-branch computed key ahead of an `n`-element
+    // trailing `[]` resolves to `k*n` paths here, each a multi-component
+    // `Expr` tree), measured at roughly a 19-31% peak-RSS reduction for
+    // `del()` on `.items[(0,1)].foo[]` across 100k/400k/800k elements.
     let rewritten: Vec<Expr> = paths
-        .iter()
+        .into_iter()
         .filter_map(|path| {
             if S::TAG != EvalTag::Yq {
-                return Some(path.clone());
+                return Some(path);
             }
-            match yq_del_slice_outcome(path, &result, false) {
+            match yq_del_slice_outcome(&path, &result, false) {
                 YqDelSliceOutcome::DropParent(rewritten) => Some(rewritten),
                 YqDelSliceOutcome::Noop => None,
-                YqDelSliceOutcome::NotApplicable => Some(path.clone()),
+                YqDelSliceOutcome::NotApplicable => Some(path),
             }
         })
         .collect();


### PR DESCRIPTION
Addresses #1384's acceptance criteria (measurement + decision; narrower fix implemented).

## Summary

#1384 tracked the allocation-volume cost of `resolve_dynamic_indexes`'s
`defer_trailing_iterate: false` call from `eval_assign`/`eval_update`/`builtin_del`:
a `k`-branch computed key ahead of an `n`-element trailing `[]` resolves to `k*n`
static `Expr` paths, where `path()` (which defers) gets only `k`. Issue #1384's
own acceptance criteria asked for (1) a peak-RSS measurement across 100k/400k/800k
elements and (2) a decision on whether resolving the full "four divergence
families" (path()'s deferral model) is justified, or whether "a narrower fix
(e.g. sharing path prefixes rather than deferring at all) gets most of it."

## Measurement (criterion 1)

Peak RSS (`/usr/bin/time -l`), `.items[(0,1)].foo[]` (`k=2`, `n` = trailing
array length), gated on output identity against real jq at every size:

| n       | `path()` (control) | `del()` before | `assign =` | `update \|=` |
|---------|--------------------:|----------------:|------------:|-------------:|
| 100,000 | 212.3 MB            | 485.6 MB         | 278.3 MB    | 278.4 MB     |
| 400,000 | 768.8 MB            | 1850.8 MB        | 992.1 MB    | 992.1 MB     |
| 800,000 | 1518.5 MB           | 3823.7 MB        | 1988.0 MB   | 2014.0 MB    |

`del()` runs ~2.3-2.5x `path()`'s memory; `assign`/`update` run ~1.3x. Tracing
the extra cost: `assign`/`update` pay only the shared `resolve_seq` fan-out cost
`path()` also pays (just over `k*n` branches instead of `k`) — no separate
Rust-level fix available there without touching the deferral model itself.
`del()` pays that *plus* an extra, avoidable clone layer specific to its own
`rewritten` builder (`builtin_del`, `src/jq/eval.rs`): `paths.iter().filter_map(|path|
... Some(path.clone()) ...)` clones every one of the `k*n` resolved paths into a
new `Vec`, even though `paths` is never read again afterward.

## Decision (criterion 2)

**Narrower fix, not full deferral.** Resolving the four divergence families
(making `del`/`=`/`\|=` defer like `path()` does) is exactly what
`test_trailing_iterate_deferral_is_read_only_888`'s own history warns against —
a first attempt at deferring for all four callers found **186 divergences** in a
1,680-case sweep against jq 1.7.1 (per that test's doc comment). That's a real,
proven correctness risk for a **Low-severity**, allocation-volume-only issue with
no crash/scaling/data-loss angle (#1379 already ruled out the scaling explanation).
Not worth it here.

The narrower alternative the issue itself suggested — reduce clone volume without
touching deferral — *is* available for `del()` specifically: `paths` is provably
dead after the `rewritten` builder runs (confirmed by reading every line after it
in `builtin_del`), so `paths.into_iter()` lets each path move into `rewritten`
(or borrow-then-move through `yq_del_slice_outcome`'s `NotApplicable`/jq-mode
arms) instead of being cloned. `assign`/`update` have no equivalent avoidable
clone — their own per-path walk already borrows through `set_path`/`update_path`
without a second collecting `Vec`.

## Result

Peak RSS for `del()`, before → after this fix:

| n       | before    | after     | reduction |
|---------|----------:|----------:|----------:|
| 100,000 | 485.6 MB  | 351.7 MB  | -27.6%    |
| 400,000 | 1850.8 MB | 1510.5 MB | -18.4%    |
| 800,000 | 3823.7 MB | 3017.4 MB | -21.1%    |

Output identity confirmed unchanged at every size (jq mode) and against every
`YqDelSliceOutcome` arm (`DropParent`/`Noop`/`NotApplicable`, all three exercised
by existing tests plus live oracle checks in this PR).

Third acceptance-criteria checkbox ("if pursued: all four families resolved") is
N/A — the decision above is explicitly not to pursue that.

## Testing

- Full suite green locally (`cargo test --features cli,simd,regex,serde`, 0 failures).
- Both required clippy legs clean, `cargo build --no-default-features` (no_std)
  clean, `cargo doc --all-features` clean.
- `del`-specific and computed-key test suites re-run directly
  (`test_trailing_iterate_deferral_is_read_only_888`,
  `test_del_sibling_grouping_preserves_source_order_1301`, all 55 yq `del` tests
  including the `Noop`-arm tests) — all pass unchanged.
- Manually cross-checked jq-mode multi-value `del()` output and yq-mode slice-del
  rewrite (`DropParent`/`NotApplicable`) against pinned oracles.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features`
- [x] Peak-RSS measurement before/after, output identity gated