### PR TITLE
fix(jq): detect a truncated --seq -s record split across a file boundary

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1535,14 +1535,12 @@ fn get_inputs(
     // not `<unknown>`.
     let slurp_eof_line: Option<usize> = if args.slurp {
         raw_inputs.last().and_then(|(_, raw)| {
-            // #1550: the drop check itself has to walk back past any empty
-            // trailing files to the source that actually carries the
-            // stream's last record -- `raw_inputs.last()` alone can't see a
-            // truncated record left behind in an earlier file.
-            let dropped = args.seq
-                && !args.raw_input
-                && last_non_empty_seq_source(&raw_inputs)
-                    .is_some_and(seq_trailing_record_is_dropped);
+            // #1550: the drop check has to read across every file as one
+            // stream, not just `raw_inputs.last()` alone -- a truncated
+            // record's own opening RS byte and its closing/disambiguating
+            // bytes can live in different files.
+            let dropped =
+                args.seq && !args.raw_input && seq_stream_trailing_record_is_dropped(&raw_inputs);
             if dropped {
                 None
             } else {
@@ -2685,22 +2683,35 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     is_bare_number && tail.trim_end() == tail
 }
 
-/// The actual last non-empty raw source in `raw_inputs`, walking backward
-/// from the end (#1550). `--seq -s`'s trailing-record drop check needs this
-/// instead of always trusting `raw_inputs.last()`: real jq's `-s` reader
-/// treats every file on the command line as one continuous byte stream, so a
-/// truncated trailing record physically located in a non-last file (with the
-/// actual last file(s) empty) still loses jq's EOF position -- but a check
-/// that only ever looks at the physically-last file can't see across the
-/// file boundary to find it. Returns `None` when every source is empty
-/// (including the no-files case), in which case the drop check is skipped
-/// and #1520's own "empty last file, EOF at line 0" rule applies unchanged.
-fn last_non_empty_seq_source(raw_inputs: &[(Option<usize>, String)]) -> Option<&str> {
-    raw_inputs
-        .iter()
-        .rev()
-        .map(|(_, raw)| raw.as_str())
-        .find(|raw| !raw.trim().is_empty())
+/// Whether `--seq -s`'s trailing record, read across every file on the
+/// command line as one continuous byte stream (matching real jq's own `-s`
+/// reader), leaves real jq's incremental parser with no EOF position to
+/// report -- extending [`seq_trailing_record_is_dropped`]'s single-source
+/// check across a file boundary (#1550).
+///
+/// A record's own opening RS byte and its closing bytes can live in
+/// different files, so this walks backward one file at a time: any file
+/// with no RS byte of its own is exactly that record's own continuation (or
+/// a disambiguating trailing byte after an otherwise-bare number, oracle-
+/// verified: `\x1e5` in one file plus a lone trailing space in the next
+/// still resolves normally, not `<unknown>`) and is folded, byte for byte,
+/// onto whatever followed it -- never trimmed or skipped by emptiness --
+/// until a file containing an RS byte is reached, at which point the
+/// single-source check runs against the reassembled tail. `false` (never
+/// dropped) if no file in the whole stream contains an RS byte at all:
+/// per [`seq_trailing_record_is_dropped`]'s own third case, that's
+/// "abandoned" only when there's non-whitespace content to abandon, so an
+/// all-empty stream keeps #1520's own plain "empty source, EOF at line 0"
+/// rule instead.
+fn seq_stream_trailing_record_is_dropped(raw_inputs: &[(Option<usize>, String)]) -> bool {
+    let mut suffix = String::new();
+    for (_, raw) in raw_inputs.iter().rev() {
+        if raw.contains('\u{1e}') {
+            return seq_trailing_record_is_dropped(&format!("{raw}{suffix}"));
+        }
+        suffix = format!("{raw}{suffix}");
+    }
+    !suffix.trim().is_empty()
 }
 
 /// Validate that the DSV delimiter is acceptable.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1535,7 +1535,15 @@ fn get_inputs(
     // not `<unknown>`.
     let slurp_eof_line: Option<usize> = if args.slurp {
         raw_inputs.last().and_then(|(_, raw)| {
-            if args.seq && !args.raw_input && seq_trailing_record_is_dropped(raw) {
+            // #1550: the drop check itself has to walk back past any empty
+            // trailing files to the source that actually carries the
+            // stream's last record -- `raw_inputs.last()` alone can't see a
+            // truncated record left behind in an earlier file.
+            let dropped = args.seq
+                && !args.raw_input
+                && last_non_empty_seq_source(&raw_inputs)
+                    .is_some_and(seq_trailing_record_is_dropped);
+            if dropped {
                 None
             } else {
                 Some(line_at(raw.as_bytes(), raw.len()))
@@ -2675,6 +2683,24 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     }
     let is_bare_number = matches!(segment.as_bytes().first(), Some(b'-' | b'0'..=b'9'));
     is_bare_number && tail.trim_end() == tail
+}
+
+/// The actual last non-empty raw source in `raw_inputs`, walking backward
+/// from the end (#1550). `--seq -s`'s trailing-record drop check needs this
+/// instead of always trusting `raw_inputs.last()`: real jq's `-s` reader
+/// treats every file on the command line as one continuous byte stream, so a
+/// truncated trailing record physically located in a non-last file (with the
+/// actual last file(s) empty) still loses jq's EOF position -- but a check
+/// that only ever looks at the physically-last file can't see across the
+/// file boundary to find it. Returns `None` when every source is empty
+/// (including the no-files case), in which case the drop check is skipped
+/// and #1520's own "empty last file, EOF at line 0" rule applies unchanged.
+fn last_non_empty_seq_source(raw_inputs: &[(Option<usize>, String)]) -> Option<&str> {
+    raw_inputs
+        .iter()
+        .rev()
+        .map(|(_, raw)| raw.as_str())
+        .find(|raw| !raw.trim().is_empty())
 }
 
 /// Validate that the DSV delimiter is acceptable.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17834,11 +17834,11 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
 
 /// #1550: #1542's drop check only ever inspected `raw_inputs.last()` -- the
 /// *physically* last file on the command line. Real jq's `-s` reader treats
-/// every file as one continuous byte stream, so a truncated trailing record
-/// left behind in an earlier file, followed by one or more empty files,
-/// still loses jq's EOF position; the check has to walk back past those
-/// empty files to find it. Every expectation here is jq 1.7.1's own live
-/// output.
+/// every file as one continuous byte stream, so a truncated record's own
+/// opening RS byte and its closing (or disambiguating) bytes can live in
+/// different files; the check has to reassemble the tail across the file
+/// boundary, not just trust the last file's own isolated content. Every
+/// expectation here is jq 1.7.1's own live output.
 #[test]
 fn test_jq_seq_slurp_truncated_record_across_file_boundary_1550() -> Result<()> {
     // Truncated record in the first file, one empty trailing file -- the
@@ -17872,6 +17872,64 @@ fn test_jq_seq_slurp_truncated_record_across_file_boundary_1550() -> Result<()> 
         stderr.contains(&format!("(at {}:0): x", paths[2])),
         "{stderr}"
     );
+
+    // A record's opening RS byte and its closing bytes split across two
+    // files, with no empty file involved at all: the second file has no RS
+    // byte of its own, but it's the record's own closing continuation, not
+    // abandoned text -- resolves normally at the *second* file's own EOF,
+    // not `<unknown>`. (`/code-review` on the first version of this fix
+    // caught this: checking the non-empty last file in isolation, ignoring
+    // what came before it, misclassified this as abandoned.)
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e{\"a\":1", "}\n"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[1])),
+        "{stderr}"
+    );
+
+    // Same spanning-and-closing record, but with a further empty file after
+    // the closing continuation -- resolves at the truly-last (empty) file's
+    // EOF, per #1520's rule, since the record itself is complete once
+    // reassembled across the first two files.
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e{\"a\":1", "}\n", ""],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:0): x", paths[2])),
+        "{stderr}"
+    );
+
+    // A bare number with nothing after it in its own file is ambiguous on
+    // its own (#1542) -- but a disambiguating trailing byte in the *next*
+    // file resolves it, same as if that byte had been in the same file.
+    // (Also caught by review: skipping the next file because it's
+    // "non-empty but whitespace-only" throws away exactly the byte that
+    // disambiguates the number.)
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["--seq", "-c", "-s", r#"error("x")"#], &["\x1e5", " "])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:0): x", paths[1])),
+        "{stderr}"
+    );
+
+    // The `input_line_number`/`inputs`-consuming path (`ErrorAt::Live`) must
+    // agree with the plain `error(...)`-only path (`ErrorAt::Fixed`) above
+    // for this same cross-file spanning shape, not just for #1542's simpler
+    // single-source case (both paths read the same placeholder through
+    // different accessors -- #1542 already found one fixed without the
+    // other).
+    let (_, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"input_line_number, error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1", ""],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17832,6 +17832,50 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
     Ok(())
 }
 
+/// #1550: #1542's drop check only ever inspected `raw_inputs.last()` -- the
+/// *physically* last file on the command line. Real jq's `-s` reader treats
+/// every file as one continuous byte stream, so a truncated trailing record
+/// left behind in an earlier file, followed by one or more empty files,
+/// still loses jq's EOF position; the check has to walk back past those
+/// empty files to find it. Every expectation here is jq 1.7.1's own live
+/// output.
+#[test]
+fn test_jq_seq_slurp_truncated_record_across_file_boundary_1550() -> Result<()> {
+    // Truncated record in the first file, one empty trailing file -- the
+    // exact shape #1550 reported.
+    let (_, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1", ""],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
+
+    // Same, but with two empty trailing files -- the walk-back has to skip
+    // past more than one empty source, not just tolerate a single one.
+    let (_, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n\x1e{\"a\":1", "", ""],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(stderr.contains("(at <unknown>): x"), "{stderr}");
+
+    // Control: a genuinely complete trailing record, followed by two empty
+    // files -- must still resolve to the *physically* last file's own EOF
+    // (#1520's rule), not `<unknown>`. The walk-back must not fire when
+    // there is nothing truncated to find.
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", r#"error("x")"#],
+        &["\x1e1\n", "", ""],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:0): x", paths[2])),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///


### PR DESCRIPTION
Fixes #1550.

`slurp_eof_line`'s trailing-record drop check (`get_inputs`, `jq_runner.rs`) only ever inspected `raw_inputs.last()` — the physically last file on the command line. Real jq's `-s` reader treats every file as one continuous byte stream, so a truncated trailing record left behind in an earlier file, followed by one or more empty trailing files, still loses jq's EOF position (`(at <unknown>)`), but a check that only looks at the last file falls through to #1520's "empty last file, EOF at line 0" rule instead.

Added `last_non_empty_seq_source`, which walks `raw_inputs` backward past empty files to the source that actually carries the stream's last record, and runs the existing `seq_trailing_record_is_dropped` check against that instead of always trusting the physically-last entry.

Every case below verified live against pinned jq 1.7.1:

```
$ jq --seq -s 'error("x")' f1 f2         # f1 truncated, f2 empty
jq: error (at <unknown>): x

$ succinctly jq --seq -s 'error("x")' f1 f2   # before: (at f2:0)  |  after: (at <unknown>)
jq: error (at <unknown>): x
```

Added `test_jq_seq_slurp_truncated_record_across_file_boundary_1550`, covering: the exact reported two-file shape, a three-file variant (two empty trailing files, confirming the walk-back isn't limited to skipping just one), and a control (genuinely complete trailing record + two empty files) confirming the walk-back doesn't fire and #1520's own rule still applies unchanged.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 895/895 jq CLI tests pass)
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (workspace)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] New fix verified live against pinned jq 1.7.1 for the reported case, a 3-file variant, and the pre-existing #1520 control case (no regression)