### PR TITLE
perf(jq): drop builtin_del's rewritten Vec<Expr> per-element, not at scope end

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26158,11 +26158,21 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         })
         .collect();
+    // `rewritten.into_iter()`: `rewritten` is never read again after this
+    // loop either, so each `Expr` tree can be dropped as soon as its own
+    // `flatten_delete_path` call finishes instead of staying resident until
+    // `builtin_del`'s scope ends (locals drop in reverse declaration order,
+    // not at last use -- `.iter()` alone doesn't change that). Not a clone
+    // elimination like `paths.into_iter()` above (`flatten_delete_path`
+    // still takes `&Expr` and pays the same per-leaf `component.clone()`
+    // either way); this only shrinks the window where the full `rewritten`
+    // buffer overlaps with `flatten_delete_path`'s own clone-heavy pass and
+    // the subsequent `delete_expr_paths_at` call (#1569).
     let flattened: Vec<Vec<DeleteStep>> = rewritten
-        .iter()
+        .into_iter()
         .map(|path| {
             let mut steps = Vec::new();
-            flatten_delete_path(path, false, &mut steps);
+            flatten_delete_path(&path, false, &mut steps);
             steps
         })
         .collect();


### PR DESCRIPTION
Fixes #1569.

`builtin_del`'s multi-path branch (`src/jq/eval.rs`) builds `rewritten: Vec<Expr>`, then reads it exactly once to build `flattened` via `rewritten.iter().map(|path| { flatten_delete_path(path, ...); ... })`. `rewritten` is never referenced again after that — `delete_expr_paths_at` only touches `flattened`/`refs` — but because that loop used `.iter()` rather than `.into_iter()`, Rust doesn't drop `rewritten`'s `Vec<Expr>` until `builtin_del`'s own function scope ends (locals drop in reverse declaration order, not at last use). That kept the full `k*n`-sized `Expr`-tree buffer resident through `flatten_delete_path`'s own clone-heavy pass *and* through the entirety of the subsequent `delete_expr_paths_at` call.

This is **not** a clone elimination like #1384's sibling fix one line up (`paths.into_iter()`) — `flatten_delete_path` takes `path_expr: &Expr`, so it still pays the identical per-leaf `component.clone()` cost either way. Switching to `.into_iter()` only changes *when* each `Expr` tree is freed: as soon as its own closure iteration finishes, instead of at the end of `builtin_del`.

## Measurement

Per the issue's own suggestion, since a retention-window shrink's actual peak-RSS effect isn't guaranteed to show up the same way a clone elimination's does: interleaved before/after `/usr/bin/time -l` peak-RSS, same shape and sizes #1384 used (`del(.items[(0,1)].foo[])`, 100k/400k/800k elements, 5 reps each, output identity verified first). macOS ARM64 (dev machine, under real background load — a control run of the same binary against itself showed ~5% bimodal noise, so treat the 100k number as noise-comparable and the two larger sizes as the reliable signal):

| Size | before (median) | after (median) | Δ |
|------|-----------------|-----------------|---|
| 100k | 369,459,200 | 354,566,144 | -4.0% |
| 400k | 1,583,874,048 | 1,394,294,784 | -12.0% |
| 800k | 3,164,127,232 | 2,750,791,680 | -13.1% |

The reduction scales with size, matching the mechanism (a size-proportional buffer's retention window shrinking) rather than looking like noise — the 400k/800k deltas clearly exceed the ~5% noise floor from the control run.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all `del()` tests pass, no behavioral change — output identity verified against the pre-fix binary for the benchmark shape)
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (workspace)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] Interleaved before/after peak-RSS measurement at 100k/400k/800k elements (see above), output identity gated first