### PR TITLE
jq: mirror Demand/Item/Flow into eval_generic for Comma/Pipe/Paren

### DIFF
--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -21,7 +21,7 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | 3     | `paths(f)` producer + `resolve_leaf` sink           | ✅ merged — closes #987     |
 | 4     | `Expr::Compare`'s outer loop                        | ✅ merged — closes #1459    |
 | 5     | Widen the lazy arm set                              | ✅ merged — closes #1462    |
-| (c)   | Mirror the sink into `eval_generic` for `Pipe`      | 🟡 partial — #1451, rest #1461 |
+| (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ✅ merged — #1451, #1461    |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2276,7 +2276,7 @@ fn push_owned_values<W: Clone + AsRef<[u64]>>(
 /// has what it came for, and jq's generator would never have been asked for
 /// another value".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Demand {
+pub(crate) enum Demand {
     Continue,
     Stop,
 }
@@ -2313,7 +2313,7 @@ impl<W: Clone + AsRef<[u64]>> Item<'_, W> {
 /// gives for splitting `Error`/`Break`/`Halt` — it makes "escaped" and
 /// "stopped, with a control the consumer must still rule on" structurally
 /// distinct, so the wrong one cannot be written by accident.
-enum Flow {
+pub(crate) enum Flow {
     /// Ran to exhaustion; every output was delivered.
     Exhausted,
     /// A sink returned [`Demand::Stop`].
@@ -2346,6 +2346,12 @@ enum Flow {
     /// delivered to the sink.
     Escaped(Control),
 }
+
+// `Demand`/`Flow` above have no generic parameters and nothing not already
+// crate-visible (`Control` is `pub`), so `eval_generic.rs`'s own mirror of
+// this sink (#1461) reuses them directly via `pub(crate)` rather than
+// duplicating two parameter-free enums. `Item<'a, W>` is JSON/cursor-specific
+// by design and stays private -- `eval_generic.rs` has its own `GenericItem`.
 
 /// Drain an already-materialized [`QueryResult`] into a sink, checking demand
 /// between values. The fallback for every `Expr` variant with no lazy arm.
@@ -3213,7 +3219,7 @@ fn each_take_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `eval_owned_input` normalizes `One`/`Many` to `Owned`/`ManyOwned`. This is
 /// what lets one primitive serve the owned-surface consumers (`any`/`all`,
 /// `IN`) as well as the cursor ones.
-fn eval_each_owned<S: EvalSemantics>(
+pub(crate) fn eval_each_owned<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     optional: bool,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3475,28 +3475,18 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
                 GenericItem::Owned(o) => eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
                     sink(GenericItem::Owned(o))
                 }),
-                GenericItem::LazyKeys {
-                    fields,
-                    sorted,
-                    collapse,
-                } => drain_result_generic(
-                    fold_pipe_stages::<S, V>(
-                        GenericResult::LazyKeys {
-                            fields,
-                            sorted,
-                            collapse,
-                        },
-                        rest,
-                        optional,
-                    ),
-                    &mut *sink,
-                ),
-                GenericItem::LazyIndexRange(len) => drain_result_generic(
-                    fold_pipe_stages::<S, V>(GenericResult::LazyIndexRange(len), rest, optional),
-                    &mut *sink,
-                ),
-                GenericItem::LazySeq(seq) => drain_result_generic(
-                    fold_pipe_stages::<S, V>(GenericResult::LazySeq(seq), rest, optional),
+                // These three carry a deferred computation `fold_pipe_stages`
+                // already knows how to thread through the rest of the pipe
+                // (its `map`/`select`/`first`/`.[n]` composability fast
+                // paths, #724/#725) without decomposing it -- so convert
+                // back to the `GenericResult` shape it came from via
+                // `generic_item_to_result` (the exact inverse of
+                // `drain_result_generic`'s own construction of these items)
+                // rather than re-deriving that conversion by hand here.
+                item @ (GenericItem::LazyKeys { .. }
+                | GenericItem::LazyIndexRange(_)
+                | GenericItem::LazySeq(_)) => drain_result_generic(
+                    fold_pipe_stages::<S, V>(generic_item_to_result(item), rest, optional),
                     &mut *sink,
                 ),
             };

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3436,6 +3436,13 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
 /// its `map`/`select`/`first`/`.[n]` composability fast paths (#724/#725) --
 /// rather than being decomposed or materialized here, which is exactly what
 /// regressed #1503's own broader attempt.
+///
+/// **Known gap (#1565):** `fold_pipe_stages` itself is a plain eager fold
+/// with no demand check, so a `LazyKeys`/`LazyIndexRange`/`LazySeq` item
+/// folded through it this way does not get `first`'s early-stop benefit --
+/// `first(keys | .[] | stderr)` still visits every key, unlike the sibling
+/// `first(.[] | stderr)` shape #1461 fixed. Pre-existing (unchanged from the
+/// old eager fallback this function replaced), not a regression from #1461.
 fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     value: V,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2290,6 +2290,510 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
 
+/// Fold an already-evaluated first pipe stage through every remaining stage,
+/// eagerly. Extracted verbatim from `eval_single`'s own `Expr::Pipe` arm
+/// (`current` is `exprs[0]`'s own result, `stages` is `exprs[1..]`) so a
+/// future lazy `Pipe` mirror (#1461) can reuse this per-`GenericResult`-
+/// variant switch -- including its `map`/`select`/`first`/`.[n]`
+/// composability fast paths (#724/#725) -- instead of duplicating it.
+fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
+    mut current: GenericResult<V>,
+    stages: &[Expr],
+    optional: bool,
+) -> GenericResult<V> {
+    for (j, expr) in stages.iter().enumerate() {
+        current = match current {
+            // The previous stage produced `vs` before terminating in
+            // `outer_control` (#400, #494): pipe that prefix through
+            // this stage first — `eval_on_many_owned` already
+            // propagates any control the piping itself hits — and
+            // only attach `outer_control` once that's done cleanly.
+            GenericResult::Partial(vs, outer_control) => {
+                match eval_on_many_owned::<S, _>(expr, vs, optional) {
+                    p @ (GenericResult::Partial(..)
+                    | GenericResult::Error(_)
+                    | GenericResult::Break(_)
+                    | GenericResult::Halt(_)) => p,
+                    GenericResult::None => partial_generic(Vec::new(), outer_control),
+                    GenericResult::ManyOwned(results) => partial_generic(results, outer_control),
+                    _ => unreachable!(
+                        "eval_on_many_owned only returns None/ManyOwned/Error/Break/Halt/Partial"
+                    ),
+                }
+            }
+            GenericResult::One(v) => eval_single::<S, _>(expr, v, optional, None),
+            GenericResult::OneCursor(c) => eval_single::<S, _>(expr, c.value(), optional, Some(c)),
+            GenericResult::Many(vs) => {
+                let mut results = Vec::new();
+                for v in vs {
+                    match eval_single::<S, _>(expr, v, optional, None).materialize_lazy() {
+                        GenericResult::One(r) => results.push(to_owned(&r)),
+                        GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
+                        GenericResult::Many(rs) => {
+                            results.extend(rs.iter().map(to_owned));
+                        }
+                        GenericResult::ManyCursor(cs) => {
+                            results.extend(cs.iter().map(to_owned_cursor));
+                        }
+                        GenericResult::None => {}
+                        // The outputs already piped through no longer
+                        // vanish (#400, #494).
+                        GenericResult::Error(e) => {
+                            return partial_generic(results, Control::Error(e));
+                        }
+                        GenericResult::Owned(o) => results.push(o),
+                        GenericResult::ManyOwned(os) => results.extend(os),
+                        GenericResult::Break(label) => {
+                            return partial_generic(results, Control::Break(label));
+                        }
+                        GenericResult::Halt(code) => {
+                            return partial_generic(results, Control::Halt(code));
+                        }
+                        GenericResult::Partial(vs2, control) => {
+                            results.extend(vs2);
+                            return partial_generic(results, control);
+                        }
+                        GenericResult::LazyKeys { .. }
+                        | GenericResult::LazyIndexRange(_)
+                        | GenericResult::LazySeq(_) => {
+                            unreachable!("materialize_lazy() already normalized every lazy variant")
+                        }
+                    }
+                }
+                if results.is_empty() {
+                    GenericResult::None
+                } else {
+                    GenericResult::ManyOwned(results)
+                }
+            }
+            // Unlike the `Many` arm above, don't flatten after just
+            // this one stage: a flattened `ManyOwned` can't carry a
+            // per-element cursor into any *further* stage — including
+            // one in an *enclosing* pipe, since a dot-chain like
+            // `.a[].b` parses as its own nested `Pipe` (see
+            // `parse_postfix`), so `.a[].b | line` only reaches
+            // `line` after this whole inner pipe returns. Instead,
+            // run the rest of the pipe (`expr` and everything after
+            // it) against each cursor independently and, when every
+            // element's result is itself a single cursor (the common
+            // `.[] | .foo` / nested dot-chain shape), stay as
+            // `ManyCursor` so an enclosing pipe or `line`/`column`
+            // can still resolve a position. Only degrade to
+            // materialized `ManyOwned` when a result is
+            // heterogeneous (multiple values, filtered out, or a
+            // computed value).
+            GenericResult::ManyCursor(cs) => {
+                let rest = Expr::Pipe(stages[j..].to_vec());
+                let mut per_element = Vec::with_capacity(cs.len());
+                for c in cs {
+                    match eval_single::<S, _>(&rest, c.value(), optional, Some(c)) {
+                        // The elements already piped through no
+                        // longer vanish (#400, #494). If an earlier
+                        // element's own buffered `LazySeq` also fails
+                        // once `flatten_generic_results` materializes
+                        // it, that earlier failure wins -- it's
+                        // chronologically first in evaluation order.
+                        GenericResult::Error(e) => {
+                            return match flatten_generic_results(per_element) {
+                                Ok(prefix) => partial_generic(prefix, Control::Error(e)),
+                                Err(Control::Error(earlier)) => GenericResult::Error(earlier),
+                                Err(Control::Break(label)) => GenericResult::Break(label),
+                                Err(Control::Halt(code)) => GenericResult::Halt(code),
+                            };
+                        }
+                        GenericResult::Break(label) => {
+                            return match flatten_generic_results(per_element) {
+                                Ok(prefix) => partial_generic(prefix, Control::Break(label)),
+                                Err(Control::Error(earlier)) => GenericResult::Error(earlier),
+                                Err(Control::Break(earlier_label)) => {
+                                    GenericResult::Break(earlier_label)
+                                }
+                                Err(Control::Halt(code)) => GenericResult::Halt(code),
+                            };
+                        }
+                        // Same immediate-stop treatment as `Error`/`Break`
+                        // above — halt is an opaque terminal signal, not
+                        // catchable by anything downstream, so this must
+                        // not fall through to the `other => ...` wildcard
+                        // below (which would keep evaluating later cursor
+                        // elements instead of stopping immediately).
+                        GenericResult::Halt(code) => {
+                            return match flatten_generic_results(per_element) {
+                                Ok(prefix) => partial_generic(prefix, Control::Halt(code)),
+                                Err(Control::Error(earlier)) => GenericResult::Error(earlier),
+                                Err(Control::Break(label)) => GenericResult::Break(label),
+                                Err(Control::Halt(earlier_code)) => {
+                                    GenericResult::Halt(earlier_code)
+                                }
+                            };
+                        }
+                        GenericResult::Partial(vs, control) => {
+                            return match flatten_generic_results(per_element) {
+                                Ok(mut prefix) => {
+                                    prefix.extend(vs);
+                                    partial_generic(prefix, control)
+                                }
+                                Err(Control::Error(earlier)) => GenericResult::Error(earlier),
+                                Err(Control::Break(label)) => GenericResult::Break(label),
+                                Err(Control::Halt(code)) => GenericResult::Halt(code),
+                            };
+                        }
+                        other => per_element.push(other),
+                    }
+                }
+
+                let all_single_cursor = !per_element.is_empty()
+                    && per_element
+                        .iter()
+                        .all(|r| matches!(r, GenericResult::OneCursor(_)));
+
+                return if all_single_cursor {
+                    GenericResult::ManyCursor(
+                        per_element
+                            .into_iter()
+                            .map(|r| match r {
+                                GenericResult::OneCursor(c) => c,
+                                _ => unreachable!("checked all_single_cursor above"),
+                            })
+                            .collect(),
+                    )
+                } else {
+                    match flatten_generic_results(per_element) {
+                        Ok(results) if results.is_empty() => GenericResult::None,
+                        Ok(results) => GenericResult::ManyOwned(results),
+                        Err(Control::Error(e)) => GenericResult::Error(e),
+                        Err(Control::Break(label)) => GenericResult::Break(label),
+                        Err(Control::Halt(code)) => GenericResult::Halt(code),
+                    }
+                };
+            }
+            // The whole point of `LazyKeys`: `length` always, and
+            // `.[]`, `.[n]`, `first`, and `last` when `!sorted`, all
+            // answer directly from the field iterator (no decode, no
+            // `Vec`, no reserialize/reindex round-trip) by mirroring
+            // the same shapes' handling for real arrays elsewhere in
+            // this file (`Expr::Index`/`Expr::Iterate` above,
+            // `Builtin::First`/`Builtin::Last`/`Builtin::Length` in
+            // `eval_builtin`). `map`/`select` and everything else
+            // fall back to materializing exactly as eager `keys`/
+            // `keys_unsorted` did — `eval_generic.rs` has no native
+            // lazy `map`/`select` for *any* value today (even a
+            // materialized array's `map` round-trips through
+            // `eval_on_owned`), so there's no cheap win available
+            // here without a broader, unrelated architecture change.
+            GenericResult::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            } => match if collapse {
+                // #1385: in jq mode a repeated key collapses, so
+                // these count- and order-sensitive arms cannot
+                // answer from the raw walk -- the collapsed object
+                // has fewer members, and `.[n]`/`last` land
+                // elsewhere. Probe once: an object with no repeat
+                // (the common case) keeps the zero-allocation
+                // cons-list arms below exactly as they were, and in
+                // yq mode `collapse` is a `false` const, so the
+                // probe itself compiles away.
+                collapsed_fields(&fields)
+            } else {
+                None
+            } {
+                Some(eff) => lazy_keys_collapsed::<S, V>(expr, eff, sorted, optional),
+                None => match unwrap_paren(expr) {
+                    // Order-independent for both `keys` and
+                    // `keys_unsorted` — the one fast path #683 adds for
+                    // sorted `keys`.
+                    Expr::Builtin(Builtin::Length) => {
+                        GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
+                    }
+                    // Document order is a valid answer only for
+                    // `keys_unsorted`. `keys` needs lexicographic order
+                    // for these and falls through to the shared
+                    // materialize-(and-sort) fallback below. Do not drop
+                    // the `if !sorted` guard on a new arm here without
+                    // re-deriving why document order would still be a
+                    // correct answer.
+                    Expr::Iterate if !sorted => {
+                        let mut cursors = Vec::new();
+                        let mut current = fields;
+                        while let Some((field, rest)) = current.uncons() {
+                            cursors.push(field.key_cursor);
+                            current = rest;
+                        }
+                        if cursors.is_empty() {
+                            GenericResult::None
+                        } else {
+                            GenericResult::ManyCursor(cursors)
+                        }
+                    }
+                    Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
+                        // Negative indices need the length to normalize
+                        // against, same as `Expr::Index`'s array arm
+                        // above; positive indices skip straight to the
+                        // walk. Out-of-bounds is `null`, never an error
+                        // (#307), matching that same arm.
+                        let target = if *idx < 0 {
+                            let len = fields.len();
+                            let normalized = len as i64 + idx;
+                            if normalized < 0 {
+                                None
+                            } else {
+                                Some(normalized as usize)
+                            }
+                        } else {
+                            Some(*idx as usize)
+                        };
+                        match target {
+                            Some(target) => {
+                                let mut current = fields;
+                                let mut found = None;
+                                let mut i = 0usize;
+                                while let Some((field, rest)) = current.uncons() {
+                                    if i == target {
+                                        found = Some(field.key_cursor);
+                                        break;
+                                    }
+                                    current = rest;
+                                    i += 1;
+                                }
+                                match found {
+                                    Some(c) => GenericResult::OneCursor(c),
+                                    None => GenericResult::Owned(OwnedValue::Null),
+                                }
+                            }
+                            None => GenericResult::Owned(OwnedValue::Null),
+                        }
+                    }
+                    Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
+                        Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
+                        None => GenericResult::Owned(OwnedValue::Null),
+                    },
+                    Expr::Builtin(Builtin::Last) if !sorted => {
+                        let mut current = fields;
+                        let mut last_cursor = None;
+                        while let Some((field, rest)) = current.uncons() {
+                            last_cursor = Some(field.key_cursor);
+                            current = rest;
+                        }
+                        match last_cursor {
+                            Some(c) => GenericResult::OneCursor(c),
+                            None => GenericResult::Owned(OwnedValue::Null),
+                        }
+                    }
+                    // Slice 1 (#724): stay lazy instead of falling
+                    // through to the `_` materializing fallback below —
+                    // reuses the composability arm (`GenericResult::LazySeq`
+                    // below) for everything past this first `map` stage.
+                    // Same `!sorted` guard as the other fast-path arms
+                    // above: sorted `keys` still needs a full decode+sort
+                    // first.
+                    Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
+                        LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG),
+                    ),
+                    _ => eval_on_owned::<S, _>(
+                        expr,
+                        materialize_lazy_keys::<V>(&fields, sorted, collapse),
+                        optional,
+                    ),
+                },
+            },
+            // The array counterpart of `LazyKeys` above
+            // (#684): the index range `[0, 1, ..., len-1]` is fully
+            // determined by `len` alone, so `length`, `.[]`, `.[n]`,
+            // `first`, and `last` are plain arithmetic on `len` — no
+            // allocation at all, not even a `Vec<V::Cursor>` (there's
+            // no cursor to point at: array-index "keys" are
+            // synthetic, not bytes in the source document).
+            GenericResult::LazyIndexRange(len) => match unwrap_paren(expr) {
+                Expr::Builtin(Builtin::Length) => GenericResult::Owned(OwnedValue::Int(len as i64)),
+                Expr::Iterate => {
+                    if len == 0 {
+                        GenericResult::None
+                    } else {
+                        GenericResult::ManyOwned(
+                            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+                        )
+                    }
+                }
+                Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+                    // Same normalization/OOB-is-null semantics as
+                    // `LazyKeys`'s `Expr::Index` arm above.
+                    let target = if *idx < 0 {
+                        let normalized = len as i64 + idx;
+                        if normalized < 0 {
+                            None
+                        } else {
+                            Some(normalized as usize)
+                        }
+                    } else {
+                        Some(*idx as usize)
+                    };
+                    match target {
+                        Some(i) if i < len => GenericResult::Owned(OwnedValue::Int(i as i64)),
+                        _ => GenericResult::Owned(OwnedValue::Null),
+                    }
+                }
+                Expr::Builtin(Builtin::First) => {
+                    if len == 0 {
+                        GenericResult::Owned(OwnedValue::Null)
+                    } else {
+                        GenericResult::Owned(OwnedValue::Int(0))
+                    }
+                }
+                Expr::Builtin(Builtin::Last) => {
+                    if len == 0 {
+                        GenericResult::Owned(OwnedValue::Null)
+                    } else {
+                        GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
+                    }
+                }
+                // Slice 1 (#724), array counterpart of `LazyKeys`'s
+                // own `Builtin::Map` arm above. No `!sorted` guard —
+                // array "keys" are never sorted.
+                Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
+                    LazySeq::new(LazySource::IndexRange { next: 0, len }).push_map(f, S::TAG),
+                ),
+                _ => eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional),
+            },
+            // The composability engine (#724, #725): every further
+            // `| map(g)` stage just pushes onto the same chain
+            // (self-recursive by construction — an arbitrary-length
+            // `map(f) | map(g) | map(h)` stays one `LazySeq`, not one
+            // type per depth). A handful of consumers get a genuine
+            // single-forward-pass native fast path; everything else
+            // materializes once (`materialize_atomic`) and hands off
+            // to the full evaluator — still one pass, not the
+            // original four-pass round trip.
+            GenericResult::LazySeq(mut seq) => match unwrap_paren(expr) {
+                Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(seq.push_map(h, S::TAG)),
+
+                // Count-and-discard: every element still runs (so a
+                // `map(f)` that errors partway still errors), but no
+                // `OwnedValue` is ever built for any of them. Atomic,
+                // same as `materialize_atomic` -- `length` of an
+                // array construction that fails is itself a failure,
+                // not a partial count.
+                Expr::Builtin(Builtin::Length) => {
+                    let mut count: i64 = 0;
+                    for item in seq {
+                        match item {
+                            Ok(_) => count += 1,
+                            Err(Control::Error(e)) => return GenericResult::Error(e),
+                            Err(Control::Break(label)) => return GenericResult::Break(label),
+                            Err(Control::Halt(code)) => return GenericResult::Halt(code),
+                        }
+                    }
+                    GenericResult::Owned(OwnedValue::Int(count))
+                }
+
+                // `.[]` iterates the array `map`'s own construction
+                // already built, not the raw source -- and that
+                // construction is atomic in real jq
+                // (`[1,2,"x"]|map(.+1)` prints nothing on error, not
+                // a truncated prefix), so a failure here discards
+                // every already-yielded element too, same atomicity
+                // boundary as `Length`/the `_` fallback below. This
+                // is NOT the same case as elementwise
+                // `.[] | select(g)` (a structurally distinct,
+                // out-of-scope case per the design doc): there,
+                // `.[]` is the *source* of the pipe and each element
+                // is independent; here it's a *consumer* of an
+                // already-atomic `map` result.
+                Expr::Iterate => {
+                    let mut items = Vec::new();
+                    for item in seq {
+                        match item {
+                            Ok(elem) => items.push(elem),
+                            Err(Control::Error(e)) => return GenericResult::Error(e),
+                            Err(Control::Break(label)) => return GenericResult::Break(label),
+                            Err(Control::Halt(code)) => return GenericResult::Halt(code),
+                        }
+                    }
+                    let all_cursor = items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
+                    if items.is_empty() {
+                        GenericResult::None
+                    } else if all_cursor {
+                        GenericResult::ManyCursor(
+                            items
+                                .into_iter()
+                                .map(|item| match item {
+                                    LazyElem::Cursor(c) => c,
+                                    LazyElem::Owned(_) => {
+                                        unreachable!("checked all_cursor above")
+                                    }
+                                })
+                                .collect(),
+                        )
+                    } else {
+                        GenericResult::ManyOwned(
+                            items
+                                .into_iter()
+                                .map(|item| match item {
+                                    LazyElem::Cursor(c) => to_owned_cursor(&c),
+                                    LazyElem::Owned(o) => o,
+                                })
+                                .collect(),
+                        )
+                    }
+                }
+
+                // Pull-one-and-stop: at most one element of `seq` is
+                // ever evaluated. Accepted, deliberate divergence
+                // from real jq's strict semantics: real jq's `map`
+                // eagerly builds the *whole* array before `first`/
+                // `.[0]` can observe it, so `map(f)|first` errors if
+                // *any* element of `f` fails, even ones past the
+                // first. This fast path only evaluates what's
+                // actually needed, so `[1,2,"x"]|map(.+1)|first`
+                // succeeds here (returns `2`) where real jq raises a
+                // type error -- the entire point of making `first`/
+                // `.[0]` lazy is to skip evaluating elements that
+                // don't affect the requested output, and an error on
+                // a skipped element is one such element. Pinned by
+                // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
+                Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
+                    None => GenericResult::Owned(OwnedValue::Null),
+                    Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
+                    Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
+                    Some(Err(Control::Error(e))) => GenericResult::Error(e),
+                    Some(Err(Control::Break(label))) => GenericResult::Break(label),
+                    Some(Err(Control::Halt(code))) => GenericResult::Halt(code),
+                },
+
+                // `last`, nonzero `.[n]`, whole-value `select`,
+                // comparisons, everything else: one atomic forward
+                // pass, then hand off to the full evaluator -- still
+                // one pass, not the original four-pass round trip.
+                // `select` deliberately gets no dedicated arm here —
+                // it materializes once and runs through
+                // `eval_on_owned`'s already-correct `Builtin::Select`
+                // handling, same as any other computed value.
+                _ => match seq.materialize_atomic() {
+                    Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
+                    Err(Control::Error(e)) => GenericResult::Error(e),
+                    Err(Control::Break(label)) => GenericResult::Break(label),
+                    Err(Control::Halt(code)) => GenericResult::Halt(code),
+                },
+            },
+            GenericResult::None => GenericResult::None,
+            GenericResult::Error(e) => return GenericResult::Error(e),
+            GenericResult::Owned(o) => {
+                // Continue piping from owned value via JSON round-trip
+                eval_on_owned::<S, _>(expr, o, optional)
+            }
+            GenericResult::ManyOwned(os) => {
+                // Continue piping from owned values via JSON round-trip
+                eval_on_many_owned::<S, _>(expr, os, optional)
+            }
+            GenericResult::Break(label) => return GenericResult::Break(label),
+            GenericResult::Halt(code) => return GenericResult::Halt(code),
+        };
+    }
+
+    current
+}
+
 /// Evaluate a single expression against a value with optional cursor context.
 fn eval_single<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
@@ -2508,529 +3012,8 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 return GenericResult::One(value);
             }
 
-            let mut current = eval_single::<S, _>(&exprs[0], value, optional, cursor);
-
-            for (i, expr) in exprs.iter().enumerate().skip(1) {
-                current = match current {
-                    // The previous stage produced `vs` before terminating in
-                    // `outer_control` (#400, #494): pipe that prefix through
-                    // this stage first — `eval_on_many_owned` already
-                    // propagates any control the piping itself hits — and
-                    // only attach `outer_control` once that's done cleanly.
-                    GenericResult::Partial(vs, outer_control) => {
-                        match eval_on_many_owned::<S, _>(expr, vs, optional) {
-                            p @ (GenericResult::Partial(..)
-                            | GenericResult::Error(_)
-                            | GenericResult::Break(_)
-                            | GenericResult::Halt(_)) => p,
-                            GenericResult::None => partial_generic(Vec::new(), outer_control),
-                            GenericResult::ManyOwned(results) => {
-                                partial_generic(results, outer_control)
-                            }
-                            _ => unreachable!(
-                                "eval_on_many_owned only returns None/ManyOwned/Error/Break/Halt/Partial"
-                            ),
-                        }
-                    }
-                    GenericResult::One(v) => eval_single::<S, _>(expr, v, optional, None),
-                    GenericResult::OneCursor(c) => {
-                        eval_single::<S, _>(expr, c.value(), optional, Some(c))
-                    }
-                    GenericResult::Many(vs) => {
-                        let mut results = Vec::new();
-                        for v in vs {
-                            match eval_single::<S, _>(expr, v, optional, None).materialize_lazy() {
-                                GenericResult::One(r) => results.push(to_owned(&r)),
-                                GenericResult::OneCursor(c) => results.push(to_owned_cursor(&c)),
-                                GenericResult::Many(rs) => {
-                                    results.extend(rs.iter().map(to_owned));
-                                }
-                                GenericResult::ManyCursor(cs) => {
-                                    results.extend(cs.iter().map(to_owned_cursor));
-                                }
-                                GenericResult::None => {}
-                                // The outputs already piped through no longer
-                                // vanish (#400, #494).
-                                GenericResult::Error(e) => {
-                                    return partial_generic(results, Control::Error(e));
-                                }
-                                GenericResult::Owned(o) => results.push(o),
-                                GenericResult::ManyOwned(os) => results.extend(os),
-                                GenericResult::Break(label) => {
-                                    return partial_generic(results, Control::Break(label));
-                                }
-                                GenericResult::Halt(code) => {
-                                    return partial_generic(results, Control::Halt(code));
-                                }
-                                GenericResult::Partial(vs2, control) => {
-                                    results.extend(vs2);
-                                    return partial_generic(results, control);
-                                }
-                                GenericResult::LazyKeys { .. }
-                                | GenericResult::LazyIndexRange(_)
-                                | GenericResult::LazySeq(_) => {
-                                    unreachable!(
-                                        "materialize_lazy() already normalized every lazy variant"
-                                    )
-                                }
-                            }
-                        }
-                        if results.is_empty() {
-                            GenericResult::None
-                        } else {
-                            GenericResult::ManyOwned(results)
-                        }
-                    }
-                    // Unlike the `Many` arm above, don't flatten after just
-                    // this one stage: a flattened `ManyOwned` can't carry a
-                    // per-element cursor into any *further* stage — including
-                    // one in an *enclosing* pipe, since a dot-chain like
-                    // `.a[].b` parses as its own nested `Pipe` (see
-                    // `parse_postfix`), so `.a[].b | line` only reaches
-                    // `line` after this whole inner pipe returns. Instead,
-                    // run the rest of the pipe (`expr` and everything after
-                    // it) against each cursor independently and, when every
-                    // element's result is itself a single cursor (the common
-                    // `.[] | .foo` / nested dot-chain shape), stay as
-                    // `ManyCursor` so an enclosing pipe or `line`/`column`
-                    // can still resolve a position. Only degrade to
-                    // materialized `ManyOwned` when a result is
-                    // heterogeneous (multiple values, filtered out, or a
-                    // computed value).
-                    GenericResult::ManyCursor(cs) => {
-                        let rest = Expr::Pipe(exprs[i..].to_vec());
-                        let mut per_element = Vec::with_capacity(cs.len());
-                        for c in cs {
-                            match eval_single::<S, _>(&rest, c.value(), optional, Some(c)) {
-                                // The elements already piped through no
-                                // longer vanish (#400, #494). If an earlier
-                                // element's own buffered `LazySeq` also fails
-                                // once `flatten_generic_results` materializes
-                                // it, that earlier failure wins -- it's
-                                // chronologically first in evaluation order.
-                                GenericResult::Error(e) => {
-                                    return match flatten_generic_results(per_element) {
-                                        Ok(prefix) => partial_generic(prefix, Control::Error(e)),
-                                        Err(Control::Error(earlier)) => {
-                                            GenericResult::Error(earlier)
-                                        }
-                                        Err(Control::Break(label)) => GenericResult::Break(label),
-                                        Err(Control::Halt(code)) => GenericResult::Halt(code),
-                                    };
-                                }
-                                GenericResult::Break(label) => {
-                                    return match flatten_generic_results(per_element) {
-                                        Ok(prefix) => {
-                                            partial_generic(prefix, Control::Break(label))
-                                        }
-                                        Err(Control::Error(earlier)) => {
-                                            GenericResult::Error(earlier)
-                                        }
-                                        Err(Control::Break(earlier_label)) => {
-                                            GenericResult::Break(earlier_label)
-                                        }
-                                        Err(Control::Halt(code)) => GenericResult::Halt(code),
-                                    };
-                                }
-                                // Same immediate-stop treatment as `Error`/`Break`
-                                // above — halt is an opaque terminal signal, not
-                                // catchable by anything downstream, so this must
-                                // not fall through to the `other => ...` wildcard
-                                // below (which would keep evaluating later cursor
-                                // elements instead of stopping immediately).
-                                GenericResult::Halt(code) => {
-                                    return match flatten_generic_results(per_element) {
-                                        Ok(prefix) => partial_generic(prefix, Control::Halt(code)),
-                                        Err(Control::Error(earlier)) => {
-                                            GenericResult::Error(earlier)
-                                        }
-                                        Err(Control::Break(label)) => GenericResult::Break(label),
-                                        Err(Control::Halt(earlier_code)) => {
-                                            GenericResult::Halt(earlier_code)
-                                        }
-                                    };
-                                }
-                                GenericResult::Partial(vs, control) => {
-                                    return match flatten_generic_results(per_element) {
-                                        Ok(mut prefix) => {
-                                            prefix.extend(vs);
-                                            partial_generic(prefix, control)
-                                        }
-                                        Err(Control::Error(earlier)) => {
-                                            GenericResult::Error(earlier)
-                                        }
-                                        Err(Control::Break(label)) => GenericResult::Break(label),
-                                        Err(Control::Halt(code)) => GenericResult::Halt(code),
-                                    };
-                                }
-                                other => per_element.push(other),
-                            }
-                        }
-
-                        let all_single_cursor = !per_element.is_empty()
-                            && per_element
-                                .iter()
-                                .all(|r| matches!(r, GenericResult::OneCursor(_)));
-
-                        return if all_single_cursor {
-                            GenericResult::ManyCursor(
-                                per_element
-                                    .into_iter()
-                                    .map(|r| match r {
-                                        GenericResult::OneCursor(c) => c,
-                                        _ => unreachable!("checked all_single_cursor above"),
-                                    })
-                                    .collect(),
-                            )
-                        } else {
-                            match flatten_generic_results(per_element) {
-                                Ok(results) if results.is_empty() => GenericResult::None,
-                                Ok(results) => GenericResult::ManyOwned(results),
-                                Err(Control::Error(e)) => GenericResult::Error(e),
-                                Err(Control::Break(label)) => GenericResult::Break(label),
-                                Err(Control::Halt(code)) => GenericResult::Halt(code),
-                            }
-                        };
-                    }
-                    // The whole point of `LazyKeys`: `length` always, and
-                    // `.[]`, `.[n]`, `first`, and `last` when `!sorted`, all
-                    // answer directly from the field iterator (no decode, no
-                    // `Vec`, no reserialize/reindex round-trip) by mirroring
-                    // the same shapes' handling for real arrays elsewhere in
-                    // this file (`Expr::Index`/`Expr::Iterate` above,
-                    // `Builtin::First`/`Builtin::Last`/`Builtin::Length` in
-                    // `eval_builtin`). `map`/`select` and everything else
-                    // fall back to materializing exactly as eager `keys`/
-                    // `keys_unsorted` did — `eval_generic.rs` has no native
-                    // lazy `map`/`select` for *any* value today (even a
-                    // materialized array's `map` round-trips through
-                    // `eval_on_owned`), so there's no cheap win available
-                    // here without a broader, unrelated architecture change.
-                    GenericResult::LazyKeys {
-                        fields,
-                        sorted,
-                        collapse,
-                    } => match if collapse {
-                        // #1385: in jq mode a repeated key collapses, so
-                        // these count- and order-sensitive arms cannot
-                        // answer from the raw walk -- the collapsed object
-                        // has fewer members, and `.[n]`/`last` land
-                        // elsewhere. Probe once: an object with no repeat
-                        // (the common case) keeps the zero-allocation
-                        // cons-list arms below exactly as they were, and in
-                        // yq mode `collapse` is a `false` const, so the
-                        // probe itself compiles away.
-                        collapsed_fields(&fields)
-                    } else {
-                        None
-                    } {
-                        Some(eff) => lazy_keys_collapsed::<S, V>(expr, eff, sorted, optional),
-                        None => match unwrap_paren(expr) {
-                            // Order-independent for both `keys` and
-                            // `keys_unsorted` — the one fast path #683 adds for
-                            // sorted `keys`.
-                            Expr::Builtin(Builtin::Length) => {
-                                GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
-                            }
-                            // Document order is a valid answer only for
-                            // `keys_unsorted`. `keys` needs lexicographic order
-                            // for these and falls through to the shared
-                            // materialize-(and-sort) fallback below. Do not drop
-                            // the `if !sorted` guard on a new arm here without
-                            // re-deriving why document order would still be a
-                            // correct answer.
-                            Expr::Iterate if !sorted => {
-                                let mut cursors = Vec::new();
-                                let mut current = fields;
-                                while let Some((field, rest)) = current.uncons() {
-                                    cursors.push(field.key_cursor);
-                                    current = rest;
-                                }
-                                if cursors.is_empty() {
-                                    GenericResult::None
-                                } else {
-                                    GenericResult::ManyCursor(cursors)
-                                }
-                            }
-                            Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
-                                // Negative indices need the length to normalize
-                                // against, same as `Expr::Index`'s array arm
-                                // above; positive indices skip straight to the
-                                // walk. Out-of-bounds is `null`, never an error
-                                // (#307), matching that same arm.
-                                let target = if *idx < 0 {
-                                    let len = fields.len();
-                                    let normalized = len as i64 + idx;
-                                    if normalized < 0 {
-                                        None
-                                    } else {
-                                        Some(normalized as usize)
-                                    }
-                                } else {
-                                    Some(*idx as usize)
-                                };
-                                match target {
-                                    Some(target) => {
-                                        let mut current = fields;
-                                        let mut found = None;
-                                        let mut i = 0usize;
-                                        while let Some((field, rest)) = current.uncons() {
-                                            if i == target {
-                                                found = Some(field.key_cursor);
-                                                break;
-                                            }
-                                            current = rest;
-                                            i += 1;
-                                        }
-                                        match found {
-                                            Some(c) => GenericResult::OneCursor(c),
-                                            None => GenericResult::Owned(OwnedValue::Null),
-                                        }
-                                    }
-                                    None => GenericResult::Owned(OwnedValue::Null),
-                                }
-                            }
-                            Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
-                                Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
-                                None => GenericResult::Owned(OwnedValue::Null),
-                            },
-                            Expr::Builtin(Builtin::Last) if !sorted => {
-                                let mut current = fields;
-                                let mut last_cursor = None;
-                                while let Some((field, rest)) = current.uncons() {
-                                    last_cursor = Some(field.key_cursor);
-                                    current = rest;
-                                }
-                                match last_cursor {
-                                    Some(c) => GenericResult::OneCursor(c),
-                                    None => GenericResult::Owned(OwnedValue::Null),
-                                }
-                            }
-                            // Slice 1 (#724): stay lazy instead of falling
-                            // through to the `_` materializing fallback below —
-                            // reuses the composability arm (`GenericResult::LazySeq`
-                            // below) for everything past this first `map` stage.
-                            // Same `!sorted` guard as the other fast-path arms
-                            // above: sorted `keys` still needs a full decode+sort
-                            // first.
-                            Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
-                                LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG),
-                            ),
-                            _ => eval_on_owned::<S, _>(
-                                expr,
-                                materialize_lazy_keys::<V>(&fields, sorted, collapse),
-                                optional,
-                            ),
-                        },
-                    },
-                    // The array counterpart of `LazyKeys` above
-                    // (#684): the index range `[0, 1, ..., len-1]` is fully
-                    // determined by `len` alone, so `length`, `.[]`, `.[n]`,
-                    // `first`, and `last` are plain arithmetic on `len` — no
-                    // allocation at all, not even a `Vec<V::Cursor>` (there's
-                    // no cursor to point at: array-index "keys" are
-                    // synthetic, not bytes in the source document).
-                    GenericResult::LazyIndexRange(len) => match unwrap_paren(expr) {
-                        Expr::Builtin(Builtin::Length) => {
-                            GenericResult::Owned(OwnedValue::Int(len as i64))
-                        }
-                        Expr::Iterate => {
-                            if len == 0 {
-                                GenericResult::None
-                            } else {
-                                GenericResult::ManyOwned(
-                                    (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
-                                )
-                            }
-                        }
-                        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-                            // Same normalization/OOB-is-null semantics as
-                            // `LazyKeys`'s `Expr::Index` arm above.
-                            let target = if *idx < 0 {
-                                let normalized = len as i64 + idx;
-                                if normalized < 0 {
-                                    None
-                                } else {
-                                    Some(normalized as usize)
-                                }
-                            } else {
-                                Some(*idx as usize)
-                            };
-                            match target {
-                                Some(i) if i < len => {
-                                    GenericResult::Owned(OwnedValue::Int(i as i64))
-                                }
-                                _ => GenericResult::Owned(OwnedValue::Null),
-                            }
-                        }
-                        Expr::Builtin(Builtin::First) => {
-                            if len == 0 {
-                                GenericResult::Owned(OwnedValue::Null)
-                            } else {
-                                GenericResult::Owned(OwnedValue::Int(0))
-                            }
-                        }
-                        Expr::Builtin(Builtin::Last) => {
-                            if len == 0 {
-                                GenericResult::Owned(OwnedValue::Null)
-                            } else {
-                                GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
-                            }
-                        }
-                        // Slice 1 (#724), array counterpart of `LazyKeys`'s
-                        // own `Builtin::Map` arm above. No `!sorted` guard —
-                        // array "keys" are never sorted.
-                        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
-                            LazySeq::new(LazySource::IndexRange { next: 0, len })
-                                .push_map(f, S::TAG),
-                        ),
-                        _ => {
-                            eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional)
-                        }
-                    },
-                    // The composability engine (#724, #725): every further
-                    // `| map(g)` stage just pushes onto the same chain
-                    // (self-recursive by construction — an arbitrary-length
-                    // `map(f) | map(g) | map(h)` stays one `LazySeq`, not one
-                    // type per depth). A handful of consumers get a genuine
-                    // single-forward-pass native fast path; everything else
-                    // materializes once (`materialize_atomic`) and hands off
-                    // to the full evaluator — still one pass, not the
-                    // original four-pass round trip.
-                    GenericResult::LazySeq(mut seq) => match unwrap_paren(expr) {
-                        Expr::Builtin(Builtin::Map(h)) => {
-                            GenericResult::LazySeq(seq.push_map(h, S::TAG))
-                        }
-
-                        // Count-and-discard: every element still runs (so a
-                        // `map(f)` that errors partway still errors), but no
-                        // `OwnedValue` is ever built for any of them. Atomic,
-                        // same as `materialize_atomic` -- `length` of an
-                        // array construction that fails is itself a failure,
-                        // not a partial count.
-                        Expr::Builtin(Builtin::Length) => {
-                            let mut count: i64 = 0;
-                            for item in seq {
-                                match item {
-                                    Ok(_) => count += 1,
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
-                                    Err(Control::Halt(code)) => return GenericResult::Halt(code),
-                                }
-                            }
-                            GenericResult::Owned(OwnedValue::Int(count))
-                        }
-
-                        // `.[]` iterates the array `map`'s own construction
-                        // already built, not the raw source -- and that
-                        // construction is atomic in real jq
-                        // (`[1,2,"x"]|map(.+1)` prints nothing on error, not
-                        // a truncated prefix), so a failure here discards
-                        // every already-yielded element too, same atomicity
-                        // boundary as `Length`/the `_` fallback below. This
-                        // is NOT the same case as elementwise
-                        // `.[] | select(g)` (a structurally distinct,
-                        // out-of-scope case per the design doc): there,
-                        // `.[]` is the *source* of the pipe and each element
-                        // is independent; here it's a *consumer* of an
-                        // already-atomic `map` result.
-                        Expr::Iterate => {
-                            let mut items = Vec::new();
-                            for item in seq {
-                                match item {
-                                    Ok(elem) => items.push(elem),
-                                    Err(Control::Error(e)) => return GenericResult::Error(e),
-                                    Err(Control::Break(label)) => {
-                                        return GenericResult::Break(label)
-                                    }
-                                    Err(Control::Halt(code)) => return GenericResult::Halt(code),
-                                }
-                            }
-                            let all_cursor =
-                                items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
-                            if items.is_empty() {
-                                GenericResult::None
-                            } else if all_cursor {
-                                GenericResult::ManyCursor(
-                                    items
-                                        .into_iter()
-                                        .map(|item| match item {
-                                            LazyElem::Cursor(c) => c,
-                                            LazyElem::Owned(_) => {
-                                                unreachable!("checked all_cursor above")
-                                            }
-                                        })
-                                        .collect(),
-                                )
-                            } else {
-                                GenericResult::ManyOwned(
-                                    items
-                                        .into_iter()
-                                        .map(|item| match item {
-                                            LazyElem::Cursor(c) => to_owned_cursor(&c),
-                                            LazyElem::Owned(o) => o,
-                                        })
-                                        .collect(),
-                                )
-                            }
-                        }
-
-                        // Pull-one-and-stop: at most one element of `seq` is
-                        // ever evaluated. Accepted, deliberate divergence
-                        // from real jq's strict semantics: real jq's `map`
-                        // eagerly builds the *whole* array before `first`/
-                        // `.[0]` can observe it, so `map(f)|first` errors if
-                        // *any* element of `f` fails, even ones past the
-                        // first. This fast path only evaluates what's
-                        // actually needed, so `[1,2,"x"]|map(.+1)|first`
-                        // succeeds here (returns `2`) where real jq raises a
-                        // type error -- the entire point of making `first`/
-                        // `.[0]` lazy is to skip evaluating elements that
-                        // don't affect the requested output, and an error on
-                        // a skipped element is one such element. Pinned by
-                        // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
-                        Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
-                            None => GenericResult::Owned(OwnedValue::Null),
-                            Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
-                            Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
-                            Some(Err(Control::Error(e))) => GenericResult::Error(e),
-                            Some(Err(Control::Break(label))) => GenericResult::Break(label),
-                            Some(Err(Control::Halt(code))) => GenericResult::Halt(code),
-                        },
-
-                        // `last`, nonzero `.[n]`, whole-value `select`,
-                        // comparisons, everything else: one atomic forward
-                        // pass, then hand off to the full evaluator -- still
-                        // one pass, not the original four-pass round trip.
-                        // `select` deliberately gets no dedicated arm here —
-                        // it materializes once and runs through
-                        // `eval_on_owned`'s already-correct `Builtin::Select`
-                        // handling, same as any other computed value.
-                        _ => match seq.materialize_atomic() {
-                            Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
-                            Err(Control::Error(e)) => GenericResult::Error(e),
-                            Err(Control::Break(label)) => GenericResult::Break(label),
-                            Err(Control::Halt(code)) => GenericResult::Halt(code),
-                        },
-                    },
-                    GenericResult::None => GenericResult::None,
-                    GenericResult::Error(e) => return GenericResult::Error(e),
-                    GenericResult::Owned(o) => {
-                        // Continue piping from owned value via JSON round-trip
-                        eval_on_owned::<S, _>(expr, o, optional)
-                    }
-                    GenericResult::ManyOwned(os) => {
-                        // Continue piping from owned values via JSON round-trip
-                        eval_on_many_owned::<S, _>(expr, os, optional)
-                    }
-                    GenericResult::Break(label) => return GenericResult::Break(label),
-                    GenericResult::Halt(code) => return GenericResult::Halt(code),
-                };
-            }
-
-            current
+            let current = eval_single::<S, _>(&exprs[0], value, optional, cursor);
+            fold_pipe_stages::<S, V>(current, &exprs[1..], optional)
         }
 
         // Handled natively rather than through the `_` fallback below: the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -30,11 +30,11 @@ use super::document::{
     DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, collapse_vec, eval as full_eval, format_owned,
+    apply_compare_op, collapse_vec, eval as full_eval, eval_each_owned, format_owned,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
-    slice_owned_value_read, tonumber_from_str, Control, EvalError, EvalSemantics, EvalTag,
-    JqSemantics, QueryResult, YqSemantics,
+    slice_owned_value_read, tonumber_from_str, Control, Demand, EvalError, EvalSemantics, EvalTag,
+    Flow, JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -2292,10 +2292,11 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
 
 /// Fold an already-evaluated first pipe stage through every remaining stage,
 /// eagerly. Extracted verbatim from `eval_single`'s own `Expr::Pipe` arm
-/// (`current` is `exprs[0]`'s own result, `stages` is `exprs[1..]`) so a
-/// future lazy `Pipe` mirror (#1461) can reuse this per-`GenericResult`-
-/// variant switch -- including its `map`/`select`/`first`/`.[n]`
-/// composability fast paths (#724/#725) -- instead of duplicating it.
+/// (`current` is `exprs[0]`'s own result, `stages` is `exprs[1..]`) so
+/// `eval_each_pipe_generic`'s lazy `LazyKeys`/`LazyIndexRange`/`LazySeq`
+/// items (#1461) can reuse this per-`GenericResult`-variant switch --
+/// including its `map`/`select`/`first`/`.[n]` composability fast paths
+/// (#724/#725) -- instead of duplicating it.
 fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
     mut current: GenericResult<V>,
     stages: &[Expr],
@@ -3255,6 +3256,313 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// One output on its way to the sink installed by [`eval_each_generic`]
+/// (#1461, mirroring `eval::Item`).
+///
+/// Six variants, matching the six single-output shapes of [`GenericResult`]
+/// -- `None`/`Error`/`Break`/`Halt`/`Partial`/`Many`/`ManyCursor`/`ManyOwned`
+/// are multi-output or terminal and are never represented as one item;
+/// [`drain_result_generic`] handles those directly. `LazyKeys`/
+/// `LazyIndexRange`/`LazySeq` are carried opaque rather than decomposed:
+/// only [`fold_pipe_stages`]'s own per-variant switch knows how to thread
+/// one of them through a *further* pipe stage (its `map`/`select`/`first`/
+/// `.[n]` composability fast paths, #724/#725) -- collapsing one to
+/// `Owned`/`One` before that switch runs is exactly the regression #1503
+/// review found and reverted. No `Debug` derive, matching `eval::Item`'s own
+/// omission: `V::Cursor` has no guaranteed `Debug` bound (see `LazyElem`'s
+/// own comment above for why that is deliberate here too).
+enum GenericItem<V: DocumentValue> {
+    One(V),
+    OneCursor(V::Cursor),
+    Owned(OwnedValue),
+    LazyKeys {
+        fields: V::Fields,
+        sorted: bool,
+        collapse: bool,
+    },
+    LazyIndexRange(usize),
+    LazySeq(LazySeq<V>),
+}
+
+/// Push one item to `sink`, translating its `Demand` into a terminal `Flow`.
+fn push_one_generic<V: DocumentValue>(
+    item: GenericItem<V>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match sink(item) {
+        Demand::Continue => Flow::Exhausted,
+        Demand::Stop => Flow::Stopped { pending: None },
+    }
+}
+
+/// Push a sequence of already-materialized items to `sink`, stopping as soon
+/// as it says to. Shared by [`drain_result_generic`]'s `Many`/`ManyCursor`/
+/// `ManyOwned`/`Partial` arms, which only differ in how the `Vec` they
+/// already hold gets wrapped into a `GenericItem`.
+fn push_many_generic<V: DocumentValue>(
+    items: impl Iterator<Item = GenericItem<V>>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    for item in items {
+        if sink(item) == Demand::Stop {
+            return Flow::Stopped { pending: None };
+        }
+    }
+    Flow::Exhausted
+}
+
+/// Generic-evaluator twin of `eval::drain_result` (#1461): adapt an
+/// already-computed [`GenericResult`] into one-at-a-time sink pushes,
+/// checking `Demand` between values. The fallback for every `Expr` shape
+/// [`eval_each_generic`] has no dedicated lazy arm for.
+///
+/// `Many`/`ManyCursor`/`ManyOwned` are already a `Vec` by the time
+/// `eval_single` returns them (e.g. `.[]`'s cursor enumeration is cheap
+/// navigation, not evaluation of side-effecting code), so iterating with an
+/// early `Demand::Stop` check is correct and sufficient -- only feeding an
+/// element to `sink`, which may recurse into more of the pipe, can run
+/// side-effecting code, and that is demand-checked per element.
+/// `LazyKeys`/`LazyIndexRange`/`LazySeq` are pushed as one opaque item each,
+/// never decomposed here -- see [`GenericItem`]'s own doc comment for why.
+fn drain_result_generic<V: DocumentValue>(
+    result: GenericResult<V>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match result {
+        GenericResult::None => Flow::Exhausted,
+        GenericResult::One(v) => push_one_generic(GenericItem::One(v), sink),
+        GenericResult::OneCursor(c) => push_one_generic(GenericItem::OneCursor(c), sink),
+        GenericResult::Owned(o) => push_one_generic(GenericItem::Owned(o), sink),
+        GenericResult::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        } => push_one_generic(
+            GenericItem::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            },
+            sink,
+        ),
+        GenericResult::LazyIndexRange(len) => {
+            push_one_generic(GenericItem::LazyIndexRange(len), sink)
+        }
+        GenericResult::LazySeq(seq) => push_one_generic(GenericItem::LazySeq(seq), sink),
+        GenericResult::Many(vs) => push_many_generic(vs.into_iter().map(GenericItem::One), sink),
+        GenericResult::ManyCursor(cs) => {
+            push_many_generic(cs.into_iter().map(GenericItem::OneCursor), sink)
+        }
+        GenericResult::ManyOwned(os) => {
+            push_many_generic(os.into_iter().map(GenericItem::Owned), sink)
+        }
+        GenericResult::Error(e) => Flow::Escaped(Control::Error(e)),
+        GenericResult::Break(label) => Flow::Escaped(Control::Break(label)),
+        GenericResult::Halt(code) => Flow::Escaped(Control::Halt(code)),
+        // `vs` is delivered first, exactly as `push_generic_owned_values`
+        // already delivers it; a sink that stops part-way carries `control`
+        // forward as `pending` rather than dropping it, same as
+        // `eval::drain_result`'s own `Partial` arm.
+        GenericResult::Partial(vs, control) => {
+            match push_many_generic(vs.into_iter().map(GenericItem::Owned), sink) {
+                Flow::Exhausted => Flow::Escaped(control),
+                Flow::Stopped { .. } => Flow::Stopped {
+                    pending: Some(control),
+                },
+                Flow::Escaped(_) => unreachable!("push_many_generic never returns Escaped"),
+            }
+        }
+    }
+}
+
+/// Generic-evaluator twin of `eval::eval_each` (#1461): a demand-driven sink
+/// over `Comma`/`Pipe`/`Paren`, so a consumer like `first` can stop pulling
+/// from the *rest* of one of these shapes as soon as it has what it needs,
+/// instead of `eval_single`'s own eager, always-materialize-everything
+/// dispatch for the same three variants.
+///
+/// Scoped to exactly these three, matching the issue's own stated scope --
+/// mirroring `eval.rs`'s wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/
+/// `Compare`/...) is out of scope here; those shapes still fall to the `_`
+/// fallback below, unchanged from before.
+fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match expr {
+        // Mirrors `eval::eval_each`'s own `Comma` arm exactly: the sink *is*
+        // the accumulator, so there is nothing to promote/collect here.
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                match eval_each_generic::<S, V>(e, value.clone(), optional, cursor, sink) {
+                    Flow::Exhausted => {}
+                    stopped_or_escaped => return stopped_or_escaped,
+                }
+            }
+            Flow::Exhausted
+        }
+        Expr::Pipe(exprs) => eval_each_pipe_generic::<S, V>(exprs, value, optional, cursor, sink),
+        Expr::Paren(inner) => eval_each_generic::<S, V>(inner, value, optional, cursor, sink),
+        _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
+    }
+}
+
+/// Generic-evaluator twin of `eval::eval_each_pipe` (#1461): the "stop
+/// pulling from stage 1 once the rest of the pipe has enough" mechanism.
+///
+/// `needs_path_context` bridges the whole remaining pipe eagerly, exactly
+/// matching `eval_single`'s own `Expr::Pipe` arm's guard (#554) -- reused
+/// directly rather than re-derived, so `path`/`parent`/`key` never silently
+/// see a stubbed-zero default. Otherwise: evaluate stage 1 lazily via
+/// [`eval_each_generic`], and for every item it produces, recursively drive
+/// the *whole remaining pipe* (not just one more stage) through a driver
+/// closure that forwards items to the outer `sink` and translates whatever
+/// `Flow` that recursive call terminates in back into a `Demand` for stage
+/// 1's own generator. Recursing on the full remaining slice, rather than one
+/// stage at a time, is what lets cursor threading (`.[] | select(...) |
+/// line`) survive an arbitrary-length remaining pipe -- the exact property a
+/// narrower, 2-stage-only attempt lost (#1503 review).
+///
+/// An `Owned` item bridges to the already-lazy `eval::eval_each_owned` so
+/// laziness (and thus `input`/`inputs` demand) continues through the rest of
+/// the pipe instead of stopping at the owned/cursor boundary, mirroring
+/// `eval_each_pipe`'s own `Item::Owned` arm (PR #1450 fixed the equivalent
+/// bug on the `eval.rs` side). A `LazyKeys`/`LazyIndexRange`/`LazySeq` item
+/// folds through the remaining stages via [`fold_pipe_stages`] -- the same
+/// per-variant switch `eval_single`'s own `Expr::Pipe` arm uses, including
+/// its `map`/`select`/`first`/`.[n]` composability fast paths (#724/#725) --
+/// rather than being decomposed or materialized here, which is exactly what
+/// regressed #1503's own broader attempt.
+fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    if exprs.iter().any(needs_path_context) {
+        return drain_result_generic(
+            eval_single::<S, _>(&Expr::Pipe(exprs.to_vec()), value, optional, cursor),
+            sink,
+        );
+    }
+
+    let Some((first, rest)) = exprs.split_first() else {
+        // Same behaviour as `eval_single`'s own empty-pipe short-circuit:
+        // `value`'s cursor, if any, is not preserved -- an empty `Expr::Pipe`
+        // is not a shape real syntax produces, only a synthesized "rest"
+        // slice that never actually reaches zero length in practice.
+        return push_one_generic(GenericItem::One(value), sink);
+    };
+    if rest.is_empty() {
+        return eval_each_generic::<S, V>(first, value, optional, cursor, sink);
+    }
+
+    let mut downstream: Option<Flow> = None;
+    let rest_pipe = Expr::Pipe(rest.to_vec());
+    let upstream = {
+        let mut driver = |item: GenericItem<V>| -> Demand {
+            let flow = match item {
+                GenericItem::One(v) => {
+                    eval_each_pipe_generic::<S, V>(rest, v, optional, None, &mut *sink)
+                }
+                GenericItem::OneCursor(c) => {
+                    eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), &mut *sink)
+                }
+                GenericItem::Owned(o) => eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
+                    sink(GenericItem::Owned(o))
+                }),
+                GenericItem::LazyKeys {
+                    fields,
+                    sorted,
+                    collapse,
+                } => drain_result_generic(
+                    fold_pipe_stages::<S, V>(
+                        GenericResult::LazyKeys {
+                            fields,
+                            sorted,
+                            collapse,
+                        },
+                        rest,
+                        optional,
+                    ),
+                    &mut *sink,
+                ),
+                GenericItem::LazyIndexRange(len) => drain_result_generic(
+                    fold_pipe_stages::<S, V>(GenericResult::LazyIndexRange(len), rest, optional),
+                    &mut *sink,
+                ),
+                GenericItem::LazySeq(seq) => drain_result_generic(
+                    fold_pipe_stages::<S, V>(GenericResult::LazySeq(seq), rest, optional),
+                    &mut *sink,
+                ),
+            };
+            match flow {
+                Flow::Exhausted => Demand::Continue,
+                other => {
+                    downstream = Some(other);
+                    Demand::Stop
+                }
+            }
+        };
+        eval_each_generic::<S, V>(first, value, optional, cursor, &mut driver)
+    };
+
+    match downstream {
+        Some(flow) => flow,
+        None => upstream,
+    }
+}
+
+/// Generic-evaluator twin of `eval::each_take_first` (#1461): pull at most
+/// one output of `inner` via [`eval_each_generic`], then stop the generator
+/// -- jq's `def first(f): label $out | (f, break $out);`.
+fn each_take_first_generic<S: EvalSemantics, V: DocumentValue>(
+    inner: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> Result<Option<GenericItem<V>>, Control> {
+    let mut first: Option<GenericItem<V>> = None;
+    let flow = eval_each_generic::<S, V>(inner, value, optional, cursor, &mut |item| {
+        first = Some(item);
+        Demand::Stop
+    });
+    match flow {
+        Flow::Stopped { .. } | Flow::Exhausted => Ok(first),
+        // The sink always stops on its first item, so an escape can only
+        // mean nothing was ever produced.
+        Flow::Escaped(control) => match first {
+            Some(item) => Ok(Some(item)),
+            None => Err(control),
+        },
+    }
+}
+
+/// Convert a captured [`GenericItem`] back to the [`GenericResult`] shape it
+/// came from -- the inverse of [`drain_result_generic`]'s single-item arms.
+fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResult<V> {
+    match item {
+        GenericItem::One(v) => GenericResult::One(v),
+        GenericItem::OneCursor(c) => GenericResult::OneCursor(c),
+        GenericItem::Owned(o) => GenericResult::Owned(o),
+        GenericItem::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        } => GenericResult::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        },
+        GenericItem::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+        GenericItem::LazySeq(seq) => GenericResult::LazySeq(seq),
+    }
+}
+
 /// Evaluate `first(inner)`/`last(inner)` (and the `Builtin::FirstStream`/
 /// `LastStream` spelling the parser sometimes produces for the same syntax --
 /// see the call sites in `eval_single`/`eval_builtin`), preserving a cursor
@@ -3274,15 +3582,15 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     want_last: bool,
 ) -> GenericResult<V> {
     // `first(f)` where `f` can consume input documents must not run `f` to
-    // completion. This module has no demand-driven sink, but `eval.rs` does,
-    // and `eval::eval_first_expr` has been wired to it since #820 Stage 2 --
-    // so hand the whole `first(...)` over rather than evaluating `inner`
-    // eagerly here (#1309).
-    //
-    // The whole node, not a `Builtin::Inputs` special case inside
-    // `first_over_comma_generic`: that would still drain for
-    // `first(inputs, 1)`, `first(1, inputs)` and `first(inputs | f)`, which
-    // this covers for free.
+    // completion. [`eval_each_generic`] (#1461) is only a native lazy arm for
+    // `Comma`/`Pipe`/`Paren` -- it has no `Builtin::Inputs`-aware arm of its
+    // own, so a bare `first(inputs)`/`first(inputs, 1)`/`first(inputs | f)`
+    // would still fall to its eager `_` fallback and drain the shared queue.
+    // `eval::eval_first_expr` has been wired to `eval.rs`'s own sink since
+    // #820 Stage 2, so hand the whole `first(...)` over rather than
+    // evaluating `inner` here (#1309) -- one guard covering every shape
+    // `inputs` can appear in, rather than one `eval_each_generic` arm per
+    // shape.
     //
     // Gated rather than unconditional because the bridge costs this subtree
     // its cursor, and with it #607's duplicate-key fidelity. Nothing is
@@ -3300,14 +3608,20 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         return eval_on_owned::<S, _>(&Expr::FirstExpr(Box::new(inner.clone())), owned, optional);
     }
 
-    // `first` over a comma stops at the first sibling that yields an output,
-    // so later siblings are never evaluated (#820 Stage 2b). `last` cannot
-    // short-circuit -- it does not know a value is the last until the stream
-    // is exhausted -- so it keeps the eager path below.
+    // `first` stops pulling from `inner` as soon as it has one output, so
+    // anything past that point -- a later comma sibling, a later pipe stage's
+    // continuation, an unpulled element of a `.[]` -- is never evaluated
+    // (#820, #1461). `last` cannot short-circuit -- it does not know a value
+    // is the last until the stream is exhausted -- so it keeps the eager
+    // path below.
     if !want_last {
-        if let Some(result) = first_over_comma_generic::<S, V>(inner, &value, optional, cursor) {
-            return result;
-        }
+        return match each_take_first_generic::<S, V>(inner, value, optional, cursor) {
+            Ok(Some(item)) => generic_item_to_result(item),
+            Ok(None) => GenericResult::None,
+            Err(Control::Error(e)) => GenericResult::Error(e),
+            Err(Control::Break(label)) => GenericResult::Break(label),
+            Err(Control::Halt(code)) => GenericResult::Halt(code),
+        };
     }
 
     // No local `optional` handling is needed for `last(f)?` here: post-#693,
@@ -3317,347 +3631,55 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     // always `false` on every dispatch path that reaches this function
     // today, and `last(empty)?` (`null`) vs. `last(error("x"))?` (empty)
     // stays correct entirely via that outer boundary, not anything here.
-    let result = eval_single::<S, V>(inner, value, optional, cursor);
-    if want_last {
-        match result {
-            GenericResult::One(v) => GenericResult::One(v),
-            GenericResult::OneCursor(c) => GenericResult::OneCursor(c),
-            GenericResult::Many(vs) => match vs.into_iter().next_back() {
-                Some(v) => GenericResult::One(v),
-                None => GenericResult::Owned(OwnedValue::Null),
-            },
-            GenericResult::ManyCursor(cs) => match cs.into_iter().next_back() {
-                Some(c) => GenericResult::OneCursor(c),
-                None => GenericResult::Owned(OwnedValue::Null),
-            },
-            GenericResult::Owned(v) => GenericResult::Owned(v),
-            GenericResult::ManyOwned(vs) => match vs.into_iter().next_back() {
-                Some(v) => GenericResult::Owned(v),
-                None => GenericResult::Owned(OwnedValue::Null),
-            },
-            // `inner`'s stream has exactly one output (the whole `keys`/
-            // `keys_unsorted` result) — forward it unchanged, same as
-            // `Owned`/`OneCursor` above, so laziness survives `last(...)`.
-            GenericResult::LazyKeys {
-                fields,
-                sorted,
-                collapse,
-            } => GenericResult::LazyKeys {
-                fields,
-                sorted,
-                collapse,
-            },
-            GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
-            // Same forwarding, same reasoning: `first(inner)`/`last(inner)`
-            // only need to know *which* of `inner`'s outputs this is, never
-            // inspect the value itself, so forwarding doesn't swallow
-            // anything -- whoever consumes the returned `LazySeq` next
-            // materializes it, and any error surfaces there.
-            GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
-            // jq's `last(f)` is `reduce f as $x (null; $x)`, which always
-            // produces exactly one output -- an empty operand answers the
-            // seed. `first` is deliberately not symmetric (#1521).
-            GenericResult::None => GenericResult::Owned(OwnedValue::Null),
-            GenericResult::Error(e) => GenericResult::Error(e),
-            GenericResult::Break(label) => GenericResult::Break(label),
-            GenericResult::Halt(code) => GenericResult::Halt(code),
-            // `last` cannot short-circuit -- it doesn't know a value is the
-            // last one until the stream is exhausted -- so a `Partial` just
-            // surfaces its trailing control, dropping the prefix (matches
-            // `eval::eval_last_expr`).
-            GenericResult::Partial(_, Control::Error(e)) => GenericResult::Error(e),
-            GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
-            GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),
-        }
-    } else {
-        take_first_generic(result).unwrap_or(GenericResult::None)
-    }
-}
-
-/// The first output of `result`, or `None` if it produced none.
-///
-/// Extracted from `eval_first_or_last_generic`'s own `first` branch so that
-/// [`first_over_comma_generic`] can reuse it per comma sibling. `None` means
-/// "this stream was empty" — which for a bare `first(f)` is `GenericResult::None`,
-/// but for one sibling of `first(a, b)` means "try `b`".
-fn take_first_generic<V: DocumentValue>(result: GenericResult<V>) -> Option<GenericResult<V>> {
-    match result {
-        GenericResult::One(v) => Some(GenericResult::One(v)),
-        GenericResult::OneCursor(c) => Some(GenericResult::OneCursor(c)),
-        GenericResult::Many(vs) => vs.into_iter().next().map(GenericResult::One),
-        GenericResult::ManyCursor(cs) => cs.into_iter().next().map(GenericResult::OneCursor),
-        GenericResult::Owned(v) => Some(GenericResult::Owned(v)),
-        GenericResult::ManyOwned(vs) => vs.into_iter().next().map(GenericResult::Owned),
-        // Each of these is exactly one output of `inner`'s stream, forwarded
-        // unchanged so laziness survives `first(...)`; `first` only needs to
-        // know *which* output this is, never to inspect it.
+    match eval_single::<S, V>(inner, value, optional, cursor) {
+        GenericResult::One(v) => GenericResult::One(v),
+        GenericResult::OneCursor(c) => GenericResult::OneCursor(c),
+        GenericResult::Many(vs) => match vs.into_iter().next_back() {
+            Some(v) => GenericResult::One(v),
+            None => GenericResult::Owned(OwnedValue::Null),
+        },
+        GenericResult::ManyCursor(cs) => match cs.into_iter().next_back() {
+            Some(c) => GenericResult::OneCursor(c),
+            None => GenericResult::Owned(OwnedValue::Null),
+        },
+        GenericResult::Owned(v) => GenericResult::Owned(v),
+        GenericResult::ManyOwned(vs) => match vs.into_iter().next_back() {
+            Some(v) => GenericResult::Owned(v),
+            None => GenericResult::Owned(OwnedValue::Null),
+        },
+        // `inner`'s stream has exactly one output (the whole `keys`/
+        // `keys_unsorted` result) — forward it unchanged, same as
+        // `Owned`/`OneCursor` above, so laziness survives `last(...)`.
         GenericResult::LazyKeys {
             fields,
             sorted,
             collapse,
-        } => Some(GenericResult::LazyKeys {
+        } => GenericResult::LazyKeys {
             fields,
             sorted,
             collapse,
-        }),
-        GenericResult::LazyIndexRange(len) => Some(GenericResult::LazyIndexRange(len)),
-        GenericResult::LazySeq(seq) => Some(GenericResult::LazySeq(seq)),
-        GenericResult::None => None,
-        GenericResult::Error(e) => Some(GenericResult::Error(e)),
-        GenericResult::Break(label) => Some(GenericResult::Break(label)),
-        GenericResult::Halt(code) => Some(GenericResult::Halt(code)),
-        // jq's generator-based `first` never asks for values past the first
-        // (verified: `first(1,2,error("x"))` is `1`, exit 0 -- the error is
-        // never reached), so a non-empty prefix always satisfies it and the
-        // trailing control is dropped. `Partial`'s prefix is never empty by
-        // construction (matches `eval::eval_first_expr`).
-        GenericResult::Partial(vs, _control) => Some(GenericResult::Owned(
-            vs.into_iter().next().expect("Partial prefix non-empty"),
-        )),
-    }
-}
-
-/// `first(a, b, ...)` evaluated one comma sibling at a time, stopping at the
-/// first that yields an output — #820 Stage 2b — and, since #1451, composing
-/// through `Pipe`/`Paren` too: a comma reached through a pipe stage (`first(1
-/// | (1, stderr))`), or nested inside one sibling of an outer comma
-/// (`first((1, stderr), 2)`), recurses back into this same function instead
-/// of falling through to the eager per-expression evaluator that started
-/// this whole gap.
-///
-/// Returns `None` when `inner` is neither a comma nor a (non-path-context)
-/// pipe, leaving the caller on its existing eager path.
-///
-/// **Why this exists at all.** Stage 2 made `eval::eval_first_expr` lazy, but
-/// the CLI never reaches it for a bare `first(...)`: `jq_runner` enters
-/// `eval_generic::eval_with_cursor`, and `Expr::FirstExpr` has a native arm
-/// here (kept cursor-preserving for #607), so the subtree never crosses into
-/// `eval.rs`. `limit`/`nth`/`isempty` have no native arm and do bounce, which
-/// is exactly why Stage 2 fixed them and left `first` leaking.
-///
-/// The original (#820 Stage 2b) fix was deliberately the *narrow* option
-/// (b) from the design doc: closing `first(1, stderr)` and — the reason it
-/// was not merely cosmetic — `first(1, input)`, where the discarded branch
-/// was **consuming a document** the CLI's driver loop then never processed.
-/// #1451 widens it to also recurse through `Pipe`'s own prefix stages: the
-/// prefix is evaluated once via the ordinary eager `eval_single` (a pipe's
-/// leading stages must run to produce the values that feed the tail either
-/// way, so this is no more eager than before), then [`first_over_pipe_prefix_result`]
-/// dispatches on every possible shape of that one evaluation's result
-/// without ever redoing it -- see its own doc comment for the full model,
-/// including why a *computed* prefix (`GenericResult::Owned`, the common
-/// case for a literal/arithmetic leading stage) needs its own
-/// `OwnedValue`-flavored twin ([`first_over_comma_owned_generic`]) rather
-/// than reusing this function directly. `needs_path_context` is checked
-/// across the *whole* pipe up front, matching the eager `Expr::Pipe` arm's
-/// own guard, so `path`/`parent`/`key` never silently see a stubbed-zero
-/// default (#715/#1302) -- a path-context pipe simply isn't attempted here
-/// and falls through to the existing bridge instead.
-fn first_over_comma_generic<S: EvalSemantics, V: DocumentValue>(
-    inner: &Expr,
-    value: &V,
-    optional: bool,
-    cursor: Option<V::Cursor>,
-) -> Option<GenericResult<V>> {
-    match unwrap_paren(inner) {
-        Expr::Comma(exprs) => {
-            for e in exprs {
-                // Each sibling is evaluated only once the previous one has
-                // been shown to produce nothing -- so a side-effecting or
-                // input-consuming sibling past the answer is never reached,
-                // matching jq's `label $out | (f, break $out)`.
-                if let Some(first) = try_lazy_first_generic::<S, V>(e, value, optional, cursor) {
-                    return Some(first);
-                }
-            }
-            // Every sibling was empty, so the comma as a whole produced
-            // nothing.
-            Some(GenericResult::None)
-        }
-        // Exactly 2 stages only, not `>= 2`: for 3+ stages, evaluating
-        // `exprs[..len-1]` as its own synthesized sub-pipe truncates the
-        // pipe one stage short of `last`, which can silently defeat
-        // `eval_single`'s own multi-stage `ManyCursor` handling -- that
-        // logic threads a cursor through the *entire* remaining pipe
-        // together, recursing into "the rest of the pipe" as one unit per
-        // cursor, not stage-by-stage; truncating the view it's given loses
-        // that (a `.[] | select(...) | line`-shaped query lost its `line`
-        // cursor this way -- #1503 review). Restricting to a single prefix
-        // stage sidesteps this: `eval_single(&exprs[0], ...)` is exactly
-        // what `eval_single`'s own `Expr::Pipe` arm evaluates as *its own*
-        // first fold step, so there is no truncation to reason about.
-        Expr::Pipe(exprs) if exprs.len() == 2 && !exprs.iter().any(needs_path_context) => {
-            let prefix_result = eval_single::<S, V>(&exprs[0], value.clone(), optional, cursor);
-            first_over_pipe_prefix_result::<S, V>(prefix_result, &exprs[1], optional)
-        }
-        _ => None,
-    }
-}
-
-/// Try to get the first lazily-recognized output of `e` against `(value,
-/// cursor)`: recurse into [`first_over_comma_generic`] first, and fall back
-/// to one eager `eval_single` call only when `e` has no further
-/// `Comma`/`Pipe`/`Paren` structure of its own to be lazy about. Returns
-/// `None` when `e` produces literally nothing, so the caller (a comma
-/// sibling loop, or a pipe's per-prefix-value tail attempt) can move on to
-/// the next candidate rather than mistaking "no output" for "stop, this is
-/// the answer" -- the same normalization `first_over_comma_generic`'s own
-/// `Comma` arm already needed, factored out so the `Pipe` arm can reuse it.
-fn try_lazy_first_generic<S: EvalSemantics, V: DocumentValue>(
-    e: &Expr,
-    value: &V,
-    optional: bool,
-    cursor: Option<V::Cursor>,
-) -> Option<GenericResult<V>> {
-    match first_over_comma_generic::<S, V>(e, value, optional, cursor) {
-        Some(GenericResult::None) => None,
-        Some(other) => Some(other),
-        None => take_first_generic(eval_single::<S, V>(e, value.clone(), optional, cursor)),
-    }
-}
-
-/// `OwnedValue`-input twin of [`first_over_comma_generic`], for a pipe
-/// prefix stage that evaluates to a *computed* value
-/// (`GenericResult::Owned`/`ManyOwned`/`Partial`) rather than one derived
-/// from the input document. A bare literal or arithmetic result has no
-/// cursor to preserve, so `eval_single` returns it this way -- and that is
-/// the *common* case for a pipe's leading stage, not a rare one: #1451's own
-/// `first(1 | (1, stderr))` repro has an `Owned` prefix (the literal `1`),
-/// not a `One`. Mirrors `first_over_comma_generic` exactly, substituting
-/// `eval_on_owned` for `eval_single` as the base-case evaluator, and mutually
-/// recurses with the `V`-flavored functions above through
-/// [`first_over_pipe_prefix_result`] so a pipe can freely mix
-/// document-derived and computed stages without losing laziness at the
-/// boundary.
-fn first_over_comma_owned_generic<S: EvalSemantics, V: DocumentValue>(
-    inner: &Expr,
-    owned: &OwnedValue,
-    optional: bool,
-) -> Option<GenericResult<V>> {
-    match unwrap_paren(inner) {
-        Expr::Comma(exprs) => {
-            for e in exprs {
-                if let Some(first) = try_lazy_first_owned_generic::<S, V>(e, owned, optional) {
-                    return Some(first);
-                }
-            }
-            Some(GenericResult::None)
-        }
-        // Exactly 2 stages only -- same reasoning as
-        // `first_over_comma_generic`'s own `Pipe` arm: kept symmetric even
-        // though `eval_on_owned` never carries a `V::Cursor` to lose, since
-        // there's no evidence its own multi-stage threading is free of an
-        // analogous "must see the whole remaining pipe" dependency, and
-        // #1451's own repros never needed more than 2 stages here either.
-        Expr::Pipe(exprs) if exprs.len() == 2 && !exprs.iter().any(needs_path_context) => {
-            let prefix_result = eval_on_owned::<S, V>(&exprs[0], owned.clone(), optional);
-            first_over_pipe_prefix_result::<S, V>(prefix_result, &exprs[1], optional)
-        }
-        _ => None,
-    }
-}
-
-/// `OwnedValue`-input twin of [`try_lazy_first_generic`] — see there for the
-/// full rationale; identical shape, `eval_on_owned` in place of
-/// `eval_single`.
-fn try_lazy_first_owned_generic<S: EvalSemantics, V: DocumentValue>(
-    e: &Expr,
-    owned: &OwnedValue,
-    optional: bool,
-) -> Option<GenericResult<V>> {
-    match first_over_comma_owned_generic::<S, V>(e, owned, optional) {
-        Some(GenericResult::None) => None,
-        Some(other) => Some(other),
-        None => take_first_generic(eval_on_owned::<S, V>(e, owned.clone(), optional)),
-    }
-}
-
-/// Shared continuation for both [`first_over_comma_generic`]'s and
-/// [`first_over_comma_owned_generic`]'s `Pipe` arm: dispatch on an
-/// already-computed prefix-stage result and try `last` (the pipe's own
-/// final stage) against it, without ever redoing the prefix evaluation
-/// itself when doing so could double-fire a side effect the prefix has.
-///
-/// A `One`/`OneCursor`/`Owned` prefix (exactly one value, safe by
-/// construction -- it's already in hand, nothing to redo) recurses lazily
-/// into whichever of the two `try_lazy_first_*_generic` twins matches that
-/// value's own kind. A `ManyOwned`/`Partial` prefix (an already-computed,
-/// already-materialized *value* set -- no document cursor, no deferred
-/// generator) tries each of its values against `last` in turn, stopping at
-/// the first that yields anything; `Partial`'s trailing control only
-/// surfaces if none of its values' own tails produced anything, matching
-/// `take_first_generic`'s own "a non-empty prefix always satisfies `first`"
-/// rule.
-///
-/// A `Many`/`ManyCursor` prefix (document-derived navigation, e.g. `.[]`)
-/// or a `LazyKeys`/`LazyIndexRange`/`LazySeq` prefix (a deferred
-/// computation that hasn't *run* yet, so reconstructing it is free) is
-/// instead handed back as `None`, deferring to the caller's own fallback of
-/// evaluating the *whole* pipe as one eager `eval_single`/`eval_on_owned`
-/// call -- redoing the prefix stage(s) that way is side-effect-free for
-/// both cases, and, critically, it is what keeps this function from
-/// regressing two properties only a *whole-pipe* evaluation preserves
-/// (#1503 review): `eval_single`'s own `ManyCursor` handling threads a
-/// cursor through the *entire* remaining pipe together, which per-value
-/// dispatch to `last` alone cannot reproduce for a multi-stage tail (a
-/// `.[] | select(...) | line`-shaped query lost its `line` cursor under the
-/// naive per-value split); and a `LazySeq` (`map(f)`'s own composability
-/// engine, #724/#725) must stay lazy until something actually indexes into
-/// it, not be forced through `materialize_lazy()` up front (`first(map(f) |
-/// .[0])` errored on a later element `f` was never supposed to reach).
-/// `GenericResult::None` is likewise handed back directly rather than via
-/// the fallback -- it's already known with certainty, so redoing the whole
-/// pipe just to re-derive the same "produces nothing" answer would be pure
-/// waste, not a correctness concern either way.
-///
-/// This means a `Many`/`ManyCursor` prefix's own per-value backtracking
-/// (which would additionally close `first(.[] | stderr)`, a harder case
-/// #820 Stage 2b explicitly could not close) is deliberately not attempted
-/// here -- doing so is what caused the cursor/`LazySeq` regressions above,
-/// so `first(.[] | stderr)` remains a known, pinned divergence rather than
-/// being closed by this function.
-fn first_over_pipe_prefix_result<S: EvalSemantics, V: DocumentValue>(
-    prefix_result: GenericResult<V>,
-    last: &Expr,
-    optional: bool,
-) -> Option<GenericResult<V>> {
-    match prefix_result {
-        GenericResult::None => Some(GenericResult::None),
-        GenericResult::Error(e) => Some(GenericResult::Error(e)),
-        GenericResult::Break(label) => Some(GenericResult::Break(label)),
-        GenericResult::Halt(code) => Some(GenericResult::Halt(code)),
-        GenericResult::One(v) => Some(
-            try_lazy_first_generic::<S, V>(last, &v, optional, None).unwrap_or(GenericResult::None),
-        ),
-        GenericResult::OneCursor(c) => {
-            let v = c.value();
-            Some(
-                try_lazy_first_generic::<S, V>(last, &v, optional, Some(c))
-                    .unwrap_or(GenericResult::None),
-            )
-        }
-        GenericResult::Owned(o) => Some(
-            try_lazy_first_owned_generic::<S, V>(last, &o, optional).unwrap_or(GenericResult::None),
-        ),
-        GenericResult::ManyOwned(os) => Some(
-            os.into_iter()
-                .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
-                .unwrap_or(GenericResult::None),
-        ),
-        GenericResult::Partial(vs, control) => Some(
-            vs.into_iter()
-                .find_map(|o| try_lazy_first_owned_generic::<S, V>(last, &o, optional))
-                .unwrap_or_else(|| match control {
-                    Control::Error(e) => GenericResult::Error(e),
-                    Control::Break(label) => GenericResult::Break(label),
-                    Control::Halt(code) => GenericResult::Halt(code),
-                }),
-        ),
-        GenericResult::Many(_)
-        | GenericResult::ManyCursor(_)
-        | GenericResult::LazyKeys { .. }
-        | GenericResult::LazyIndexRange(_)
-        | GenericResult::LazySeq(_) => None,
+        },
+        GenericResult::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
+        // Same forwarding, same reasoning: `first(inner)`/`last(inner)`
+        // only need to know *which* of `inner`'s outputs this is, never
+        // inspect the value itself, so forwarding doesn't swallow
+        // anything -- whoever consumes the returned `LazySeq` next
+        // materializes it, and any error surfaces there.
+        GenericResult::LazySeq(seq) => GenericResult::LazySeq(seq),
+        // jq's `last(f)` is `reduce f as $x (null; $x)`, which always
+        // produces exactly one output -- an empty operand answers the
+        // seed. `first` is deliberately not symmetric (#1521).
+        GenericResult::None => GenericResult::Owned(OwnedValue::Null),
+        GenericResult::Error(e) => GenericResult::Error(e),
+        GenericResult::Break(label) => GenericResult::Break(label),
+        GenericResult::Halt(code) => GenericResult::Halt(code),
+        // `last` cannot short-circuit -- it doesn't know a value is the
+        // last one until the stream is exhausted -- so a `Partial` just
+        // surfaces its trailing control, dropping the prefix (matches
+        // `eval::eval_last_expr`).
+        GenericResult::Partial(_, Control::Error(e)) => GenericResult::Error(e),
+        GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
+        GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19474,6 +19474,76 @@ fn test_owned_pipe_stage_ahead_of_comma_stays_lazy() -> Result<()> {
     Ok(())
 }
 
+/// Code review of #1461: `eval_each_pipe_generic`'s own doc comment justifies
+/// recursing on the *whole* remaining-pipe slice (rather than one stage at a
+/// time) specifically to preserve cursor threading through an arbitrary-
+/// length tail -- the exact property a narrower attempt lost (#1503 review).
+/// The only test the PR itself added for the new mechanism
+/// (`first(.[] | stderr)`) is a 2-stage tail, so this pins the property the
+/// doc comment claims for a genuine 3-stage one: `.[]` (`ManyCursor`) into
+/// `select` into a cursor-only builtin (`line`, a succinctly extension with
+/// no jq equivalent, so this checks internal consistency against the
+/// non-`first` form rather than jq).
+#[test]
+fn test_first_over_manycursor_preserves_cursor_through_three_stage_tail_1461() -> Result<()> {
+    let input = "[\n  1,\n  2,\n  3\n]";
+
+    // Control: the same 3-stage tail without `first` reaches elements 2 and
+    // 3 (lines 3 and 4) -- confirms the input/query shape actually exercises
+    // `select` filtering before `line` runs.
+    let (stdout, _, code) = run_jq_full(&["-c", ".[] | select(.>1) | line"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "3\n4\n");
+
+    // `first` must stop at the first passing element (`2`, on line 3) and
+    // its cursor must survive the two further stages (`select`, `line`)
+    // undamaged -- a lost cursor would report `0` (no position), not `3`.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "first(.[] | select(.>1) | line)"], Some(input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "3\n");
+
+    // Same shape, but with the stage 2 (`select`) firing a side effect of
+    // its own once a cursor element reaches it -- confirms the element that
+    // fails `select` (`1`) is visited (as `eval_each_pipe_generic` must, to
+    // even test the predicate) while the element after the accepted one
+    // (`3`) never is, matching jq exactly.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "first(.[] | select(.>1) | (tostring|stderr))"],
+        Some(input),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "\"2\"\n");
+    assert_eq!(stderr, "2", "must not visit element 3 past the first match");
+
+    Ok(())
+}
+
+/// Code review of #1461: the deleted `first_over_comma_owned_generic`
+/// deliberately capped itself at exactly 2 pipe stages, with its own author's
+/// comment admitting the multi-stage case was unverified ("there's no
+/// evidence its own multi-stage threading is free of an analogous
+/// dependency"). The replacement (`eval_each_pipe_generic`'s `Owned` arm,
+/// bridging unconditionally to `eval::eval_each_owned`) lifts that cap --
+/// this pins the shape that would have been rejected before, with a *flat*
+/// (not nested-in-parens) 3- and 4-stage pipe, matching jq exactly.
+#[test]
+fn test_first_over_owned_pipe_beyond_two_stages_matches_jq_1461() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", r#"first(1 | 2 | (3, ("X"|stderr)))"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "3\n");
+    assert_eq!(stderr, "", "the discarded 4th comma sibling must not fire");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", r#"first(1 | 2 | 3 | (4, ("X"|stderr)))"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "4\n");
+    assert_eq!(stderr, "", "the discarded 5th comma sibling must not fire");
+
+    Ok(())
+}
+
 /// `first((1,2) | input)` -- issue #1461's third reported symptom (a
 /// spurious `jq: error (at <stdin>:0): break`, exit 5) -- already matches jq
 /// exactly by the time #1461's `eval_each_generic` mirror landed, confirmed

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18422,6 +18422,14 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // #1461: `.[]`'s multiple *document-derived* (`ManyCursor`) values
+        // tried against the pipe's tail one at a time -- the harder case
+        // #1451 deliberately did not attempt (its own comment named this
+        // exact shape as the residual it left pinned). `eval_each_generic`'s
+        // `Pipe` arm now drives `.[]` lazily via `drain_result_generic`, so
+        // `stderr` fires once per element pulled, not once per element that
+        // exists -- `first` pulls exactly one.
+        (&["-c", "first(.[] | stderr)"], Some("[1,2]"), "1\n", "1", 0),
         // `n == 0` must not evaluate the operand at all.
         (&["-cn", r#"[limit(0; ("B"|stderr))]"#], None, "[]\n", "", 0),
         // Array construction is atomic in jq; laziness must not leak into it.
@@ -18928,30 +18936,16 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // `first(.[] | stderr)` is a *Pipe*, not a Comma, so #1451's own
-        // widening of `first_over_comma_generic` does not reach it: closing
-        // it would require the pipe's own `.[]` prefix stage's multiple
-        // *document-derived* (`ManyCursor`) values to be tried against the
-        // tail one at a time (real per-output backtracking, same as #820
-        // Stage 2b's own comma walk never attempted for a `Pipe`) -- #1451
-        // deliberately does not attempt this, since doing so broke
-        // `eval_single`'s own multi-stage `ManyCursor` cursor-preservation
-        // for a longer remaining pipe (`.[] | select(...) | line`) when
-        // tried during review (#1503). jq writes exactly one `1`.
-        (
-            &["-c", "first(.[] | stderr)"],
-            Some("[1,2]"),
-            "1\n",
-            "12",
-            0,
-        ),
-        // Same residual as the row above, found by Stage 4's own oracle
-        // sweep (#1459): a bare `first(...)` is intercepted by
-        // `eval_generic`'s native `first`/`last` arm, whose Stage 2b
-        // short-circuit only walks *comma* siblings -- an `Expr::Compare`
-        // argument falls through to eager `eval_single`, so `eval.rs`'s new
-        // lazy `Compare` arm is never reached. Wrapping the same compare in
-        // any consumer that does bounce into `eval.rs` (`isempty`, `limit`,
+        // Found by Stage 4's own oracle sweep (#1459): a bare `first(...)`
+        // is intercepted by `eval_generic`'s native `first`/`last` arm,
+        // whose lazy `eval_each_generic` (#1461) only gives `Comma`/`Pipe`/
+        // `Paren` native arms -- an `Expr::Compare` argument still falls
+        // through to eager `eval_single`, so `eval.rs`'s own lazy `Compare`
+        // arm is never reached. Out of #1461's scope by design (the issue
+        // named `Comma`/`Pipe`/`Paren` only); a `Compare`-native lazy arm
+        // here would be a separate follow-up, symmetrical to #1459/Stage 4's
+        // one on the `eval.rs` side. Wrapping the same compare in any
+        // consumer that does bounce into `eval.rs` (`isempty`, `limit`,
         // `nth`, `any`, `all`, `IN`) already matches jq -- see the table
         // above. jq: no stderr.
         (
@@ -19036,20 +19030,23 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     Ok(())
 }
 
-/// #1451: `first_over_pipe_prefix_result` dispatches on every possible
-/// shape `eval_single`/`eval_on_owned` can hand back for a pipe's prefix
-/// stage(s) -- each case here targets one specific `GenericResult` variant
-/// that dispatch has to handle without ever re-evaluating the prefix
-/// (`eval_generic.rs`).
+/// Originally #1451: pinned `first_over_pipe_prefix_result`'s dispatch over
+/// every possible shape a pipe prefix stage could hand back. #1461 replaced
+/// that hand-rolled, 2-stage-only dispatcher with `eval_each_generic`'s
+/// general `Comma`/`Pipe`/`Paren` sink (`GenericItem`/`drain_result_generic`/
+/// `eval_each_pipe_generic`, `eval_generic.rs`) -- each case here still
+/// targets one specific `GenericResult`-shaped intermediate, now threaded
+/// through arbitrary-length remaining pipes via the same mechanism, rather
+/// than one prefix stage evaluated once and dispatched on.
 #[test]
 fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> Result<()> {
     let cases: &[SideEffectCase] = &[
         // A computed prefix (`Owned`) whose tail is itself a 2-stage pipe --
-        // exercises `first_over_comma_owned_generic`'s own `Pipe` arm
-        // recursing into `try_lazy_first_generic`/`first_over_comma_generic`
-        // for the tail, one level deep. (A pipe of *3+* stages, at either
-        // level, deliberately does not take this fast path at all -- see
-        // `first_over_comma_generic`'s own `Pipe` arm comment for why.)
+        // exercises `eval_each_pipe_generic`'s `Owned` arm bridging to
+        // `eval::eval_each_owned`, which recurses into its own `Pipe`/`Comma`
+        // handling for the tail. (Unlike the old #1451-era dispatcher, this
+        // is no longer capped at a 2-stage tail -- an arbitrary-length
+        // remaining pipe threads through the same way.)
         (
             &["-cn", r#"first(1 | (2 | (1, ("B"|stderr))))"#],
             None,
@@ -19081,11 +19078,10 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
         // break must propagate to its own label, abandoning the whole
         // pipe. Verified live to match jq; a probe confirmed `break`
         // unwinds through a different path before ever reaching
-        // `first_over_pipe_prefix_result` as a `GenericResult::Break`
-        // data value at all (same for the `Partial`-then-`break` case
-        // below), so this does not exercise this function's own `Break`
-        // arms specifically -- kept as a behavioral pin either way, same
-        // as the `Halt` case below.
+        // `drain_result_generic` as a `GenericResult::Break` data value at
+        // all (same for the `Partial`-then-`break` case below), so this
+        // does not exercise that arm specifically -- kept as a behavioral
+        // pin either way, same as the `Halt` case below.
         (
             &[
                 "-cn",
@@ -19131,10 +19127,11 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
         // A prefix that errors after producing some values
         // (`GenericResult::Partial`), where a *later* one of those values'
         // own tail is what satisfies `first` -- the trailing error must be
-        // dropped, matching `take_first_generic`'s "a non-empty prefix
-        // always satisfies `first`" rule. Same context-dependent tail as
-        // above, so this also confirms dispatch doesn't stop at the first
-        // (rejected) value just because a control follows.
+        // dropped, matching `each_take_first_generic`'s "a non-empty prefix
+        // always satisfies `first`" rule (jq's own `break $out` fires the
+        // moment an output exists). Same context-dependent tail as above, so
+        // this also confirms dispatch doesn't stop at the first (rejected)
+        // value just because a control follows.
         (
             &["-cn", r#"first((1,2,error("x")) | select(.==2))"#],
             None,
@@ -19153,8 +19150,9 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
             5,
         ),
         // A computed-prefix tail whose first sibling produces nothing --
-        // `try_lazy_first_owned_generic` must fall through to the second
-        // sibling rather than stopping (or erroring) on the empty one.
+        // `eval_each_owned`'s own `Comma` arm must fall through to the
+        // second sibling rather than stopping (or erroring) on the empty
+        // one.
         (
             &["-cn", r#"first(1 | (empty, (1, ("B"|stderr))))"#],
             None,
@@ -19167,8 +19165,8 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
         // rather than the loop over-running its own bounds.
         (&["-cn", "[first(1 | (empty, empty))]"], None, "[]\n", "", 0),
         // A bare top-level comma every one of whose siblings produces
-        // nothing -- `first_over_comma_generic`'s own `Comma` arm must fall
-        // all the way through its loop to report nothing.
+        // nothing -- `eval_each_generic`'s own `Comma` arm must fall all the
+        // way through its loop to report nothing.
         (&["-cn", "[first(empty, empty)]"], None, "[]\n", "", 0),
         // A top-level comma sibling that is itself a lazily-recognized
         // (nested `Comma`) shape producing nothing -- the outer loop must

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18955,6 +18955,46 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "B",
             0,
         ),
+        // Code review of #1461, filed as #1565: when the pipe's *first*
+        // stage evaluates to `GenericResult::LazyKeys` (`keys`,
+        // `keys_unsorted`) and 2+ further stages follow, the driver hands
+        // the whole remaining pipe to `fold_pipe_stages` -- the plain eager
+        // fold, with no demand check -- rather than continuing through
+        // `eval_each_pipe_generic`'s own sink. So `.[] | stderr` after a
+        // `keys` prefix still fires for every key, unlike the bare
+        // `first(.[] | stderr)` #1461 itself fixed. Confirmed pre-existing
+        // (identical on `main` before #1461, via the old 2-stage-only
+        // `first_over_comma_generic`), so not a regression here -- pinned so
+        // a fix for #1565 has a red test to turn green. jq: writes `a` once.
+        (
+            &["-c", "first(keys | .[] | stderr)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"a\"\n",
+            "abc",
+            0,
+        ),
+        // Same #1565 gap, `LazySeq` (`map(f)`, #724/#725) flavor instead of
+        // `LazyKeys`. jq: writes `2` once.
+        (
+            &["-c", "first(map(.+1) | .[] | stderr)"],
+            Some("[1,2,3]"),
+            "2\n",
+            "234",
+            0,
+        ),
+        // Same class as the `Compare` row above (#1565): `Expr::If` has no
+        // native `eval_each_generic` arm either, so `first(if ...)` falls
+        // through to eager `eval_single` and the discarded `else` branch's
+        // sibling side effect still fires. Out of #1461's scope by design,
+        // same as `Compare`; pre-existing on `main` before #1461 too. jq: no
+        // stderr.
+        (
+            &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
+            None,
+            "1\n",
+            "B",
+            0,
+        ),
         // The eager copies of jq's right-outer/left-inner fanout loop
         // (`binary_fanout_core` via `eval_binary_fanout`,
         // `eval_binary_fanout_with_path_context`, and `eval_generic`'s own

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19457,9 +19457,43 @@ fn test_owned_pipe_stage_ahead_of_comma_stays_lazy() -> Result<()> {
         "every document must still be processed"
     );
 
-    let (stdout, _, code) = run_jq_full(&["-cn", r#"limit(1; 1 | (1, ("B"|stderr)))"#], None)?;
+    // #1461: `first` closed the same way -- `eval_each_generic`'s `Pipe` arm
+    // bridges the computed `1 |` prefix into `eval::eval_each_owned`, so the
+    // discarded `input` branch is never evaluated here either.
+    let (stdout, _, code) = run_jq_full(&["-c", "[first(1|(1,input)), .id]"], Some(DOCS))?;
     assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "[1,1]\n[1,2]\n[1,3]\n[1,4]\n",
+        "every document must still be processed"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-cn", r#"limit(1; 1 | (1, ("B"|stderr)))"#], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout, "1\n");
+
+    Ok(())
+}
+
+/// `first((1,2) | input)` -- issue #1461's third reported symptom (a
+/// spurious `jq: error (at <stdin>:0): break`, exit 5) -- already matches jq
+/// exactly by the time #1461's `eval_each_generic` mirror landed, confirmed
+/// live against jq 1.7.1. Not a shape #1461 needed to fix; pinned here so a
+/// future change to this machinery cannot silently reintroduce the leak.
+///
+/// `first` stops after its very first output: `(1,2) | input` yields `1 |
+/// input`'s pop first, which `first` accepts immediately, so `input` is
+/// popped exactly once per successful `first(...)` -- comma sibling `2` is
+/// never tried. That is one document consumed beyond the driving one, so two
+/// starting documents (1 and 3) each pull a neighbor (2 and 4) and produce a
+/// row; jq's own generator-based `first` behaves identically.
+#[test]
+fn test_first_over_comma_then_input_matches_jq_1461() -> Result<()> {
+    const DOCS: &str = r#"{"id":1} {"id":2} {"id":3} {"id":4}"#;
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[first((1,2) | input), .id]"], Some(DOCS))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"id\":2},1]\n[{\"id\":4},3]\n");
+    assert_eq!(stderr, "");
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21484,3 +21484,19 @@ fn test_yq_sub_arity3_pattern_escape_reports_bare_not_prefix_then_raise() -> Res
     assert_eq!(code, 1);
     Ok(())
 }
+
+/// #1461's `eval_each_generic`/`eval_each_pipe_generic` sink lives in
+/// `eval_generic.rs`, shared verbatim between jq and yq -- `tests/jq_cli_tests.rs`
+/// pins the fix there, but nothing pinned yq mode's own path through the same
+/// code. `first`, `.[]`, and `stderr` are all real yq builtins (no
+/// `--jq-extensions` needed), so this exercises the identical shape
+/// (`first(.[] | stderr)`) the jq-side fix closed.
+#[test]
+fn test_yq_first_over_pipe_stops_at_first_element_1461() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr("first(.[] | stderr)", "- 1\n- 2\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n");
+    assert_eq!(stderr, "1", "must not visit the second element");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements option (c) of [`docs/plan/jq-lazy-generator-consumers.md`](https://github.com/rust-works/succinctly/blob/main/docs/plan/jq-lazy-generator-consumers.md), closing #1461.

- Mirrors `eval.rs`'s `Demand`/`Item`/`Flow` sink into `eval_generic.rs` as `GenericItem`/`push_one_generic`/`push_many_generic`/`drain_result_generic`/`eval_each_generic`/`eval_each_pipe_generic`/`each_take_first_generic`, replacing the old special-cased, 2-stage-only `first_over_comma_generic` dispatcher with a general demand-driven sink for `Comma`/`Pipe`/`Paren` that can short-circuit through an arbitrary-length pipe.
- `fold_pipe_stages` is extracted verbatim from `eval_single`'s old `Expr::Pipe` arm so the new sink's `LazyKeys`/`LazyIndexRange`/`LazySeq` items can reuse its `map`/`select`/`first`/`.[n]` composability fast paths (#724/#725) without duplicating that switch.
- All of #1461's acceptance criteria verified against pinned jq 1.7.1: `[first(1 | (1, input)), .id]` now processes every document (previously silently dropped documents 2 and 4); `first((1,2) | stderr)` / `first(.[] | stderr)` write to stderr exactly once instead of leaking every candidate's side effect; the spurious `break`/exit-5 leak was already correct by the time this landed and is now pinned so it can't regress; `last` stays eager; #607's duplicate-key fidelity (`--preserve-input first(.[])`) is unaffected.
- Code review follow-ups folded in: `eval_each_pipe_generic`'s driver now reuses `generic_item_to_result` instead of hand-reconstructing `GenericResult` three times; added a genuine 3-stage `ManyCursor` cursor-threading test (`.[] | select | line`) and a flat 3/4-stage owned-pipe test, since the only test #1461 originally added for the new mechanism was a 2-stage case; added the first yq-mode regression test for this whole mechanism (previously zero coverage on that side of the shared engine).
- Filed and pinned #1565 for a related, **pre-existing** (not a regression here — confirmed identical on `main` before this PR) gap the review surfaced: `first(...)` over a `keys`/`map(f)` pipe prefix with 2+ further stages, and a `first(if ...)`-shaped argument, still evaluate/leak eagerly. Out of this issue's stated `Comma`/`Pipe`/`Paren` scope, pinned as a known gap the same way the existing `Compare`-argument gap already was.

## Test plan

- [x] `cargo test --features cli,regex` (full suite) — all green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two other CI clippy legs (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests` with and without `broadword-yaml`) — clean
- [x] `cargo check --no-default-features` (no_std) — passes
- [x] `cargo test` across every CI feature-combo leg: default, `simd`, `portable-popcount`, `simd,scalar-yaml`, `simd,broadword-yaml`, plus the pinned-tool bundle (`yq_cli_tests`, `yq_golden_tests`, `yq_path_consistency_tests`, `jq_golden_tests`, ...) — all green
- [x] New/updated behavior verified live against `/usr/bin/jq` 1.7.1 for every acceptance-criteria repro in #1461