### PR TITLE
fix(jq): let a RejectMany slot's own escape outrank its count message

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -398,6 +398,13 @@ which was true only before #1534.
   escape, not competing evidence against it, so `fanout_two_args` now defers to that slot's
   trailing control whenever its own count check is what's about to fire. Confirmed by
   `test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533`.
+
+  Review found this alone still misattributed the error when *both* slots violate `RejectMany`
+  at once — reporting whichever slot (outer) it happened to check first, rather than real yq's
+  own consistent "inner always wins" rule (for `setpath`, path over value — live-verified across
+  every escaping/clean combination). `fanout_two_args` now always evaluates inner before
+  reporting outer's own violation, matching real yq's own evaluation order rather than just its
+  final answer. See `test_yq_setpath_reject_many_prefers_inner_violation_over_outer_1533`.
 - **`contains` on an escaping argument**
   ([#1553](https://github.com/rust-works/succinctly/issues/1553)). `contains` is ungated because
   real yq fans it out, but real yq still emits nothing when its argument escapes, where

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -388,11 +388,16 @@ which was true only before #1534.
   *outcome* — an error rather than a fan-out or a silent truncation — is what #1279 preserved;
   matching the per-slot wording is unstarted.
 - **Two-argument escape ordering** ([#1533](https://github.com/rust-works/succinctly/issues/1533),
-  half-closed). The escape-clearing above is deliberately *not* applied to `fanout_two_args`:
-  emptying one slot's values skips the body, which is where the other slot gets validated, and
-  which slot real yq reports is per-builtin and does not follow succinctly's outer/inner order
-  (`test` wants the flags, `setpath` wants the path). That needs a per-builtin ordering probe.
-  Pinned as a known divergence by `test_yq_setpath_two_argument_escape_order_is_unfixed_1533`.
+  now fully closed). The escape-clearing above is deliberately *not* applied to
+  `fanout_two_args`: emptying one slot's values skips the body, which is where the other slot
+  gets validated, and which slot real yq reports there is per-builtin and does not follow
+  succinctly's outer/inner order (`test` wants the flags, `setpath` wants the path) — that part
+  stays a known limitation with no shared rule. But the *specific* case #1533 was filed for —
+  `RejectMany`'s own `args.len() > 1` count check masking a real `error(...)` in the same
+  slot — needed no per-builtin probe: a count violation there is itself a symptom of the
+  escape, not competing evidence against it, so `fanout_two_args` now defers to that slot's
+  trailing control whenever its own count check is what's about to fire. Confirmed by
+  `test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533`.
 - **`contains` on an escaping argument**
   ([#1553](https://github.com/rust-works/succinctly/issues/1553)). `contains` is ungated because
   real yq fans it out, but real yq still emits nothing when its argument escapes, where

--- a/docs/plan/jq-generator-argument-fanout.md
+++ b/docs/plan/jq-generator-argument-fanout.md
@@ -394,9 +394,16 @@ duplicated five times), and the single-argument half of
 #1531's lazy pull is the one that changed a documented conclusion: it closed the last golden
 known-failure, the #820 eager-argument residue this design had recorded as out of scope.
 
-#1533's two-argument half stays open. Applying "an escape in the argument clears its values" to
-`fanout_two_args` regressed two shapes, because emptying one slot's values skips the body — and
-the body is where the *other* slot gets validated. Which slot real yq reports is per-builtin and
-does not follow succinctly's outer/inner order (`test` wants the flags, `setpath` wants the
-path), so it needs a per-builtin ordering probe of its own. Pinned meanwhile by
-`test_yq_setpath_two_argument_escape_order_is_unfixed_1533`.
+#1533's two-argument half is now closed too, but not by the general "an escape in the argument
+clears its values" rule — applying that to `fanout_two_args` regressed two shapes, because
+emptying one slot's values skips the body, and the body is where the *other* slot gets
+validated (`test` wants the flags, `setpath` wants the path — no shared outer/inner order).
+That general rule stays reverted. The fix instead is narrower: `fanout_two_args` only defers to
+a slot's own trailing escape when that slot's `RejectMany` *count* check (`args.len() > 1`) is
+what's about to fire — a count violation there is itself a symptom of the escape (`(1, 2,
+error("x"))` has two values only because the generator didn't collapse to one before raising),
+so it doesn't touch the single-value-then-escape shapes the reverted rule broke. Confirmed by
+`test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533` (the former pin,
+now flipped) alongside the still-passing regression guards
+(`test_yq_two_argument_body_validation_outranks_a_slot_escape_1533`,
+`test_yq_fanout_two_args_argument_escape_reports_bare_not_prefix_then_raise`).

--- a/docs/plan/jq-generator-argument-fanout.md
+++ b/docs/plan/jq-generator-argument-fanout.md
@@ -407,3 +407,11 @@ so it doesn't touch the single-value-then-escape shapes the reverted rule broke.
 now flipped) alongside the still-passing regression guards
 (`test_yq_two_argument_body_validation_outranks_a_slot_escape_1533`,
 `test_yq_fanout_two_args_argument_escape_reports_bare_not_prefix_then_raise`).
+
+Review of that fix found one more gap before it landed: when *both* slots independently trip
+`RejectMany` at once, it reported whichever slot (outer) it happened to check first, rather than
+real yq's own consistent rule — inner (for `setpath`, the path) always wins, whether either
+slot's violation escapes or is a plain count mismatch. `fanout_two_args` now always evaluates
+inner before reporting outer's own violation of either kind, matching real yq's evaluation order
+rather than just guessing at its final answer. Live-verified across all four
+escaping/clean combinations; see `test_yq_setpath_reject_many_prefers_inner_violation_over_outer_1533`.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1848,18 +1848,41 @@ fn fanout_two_args<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let (mut outers, outer_trailing) =
         stream_outputs(eval_single::<W, S>(outer, value.clone(), optional));
     if let Err(e) = apply_arg_fanout(fanout, &mut outers) {
-        // #1533's other half: a `RejectMany` count violation is only ever a
-        // symptom of an argument that also escaped -- `(1, 2, error("x"))`
-        // has two values *because* the generator didn't get to collapse
-        // them into one before raising. When that's what happened, report
-        // the real escape instead of the synthetic count message. Narrower
-        // than the reverted fix this doc comment's neighbor describes: this
-        // only fires when the count check itself is about to trip (`args.len()
-        // > 1`), so a slot with exactly one value before escaping -- the
-        // shape that fix broke -- is untouched, and `body` still gets to run
-        // for it exactly as before.
+        // #1533's other half. Two things had to be established live against
+        // the pinned yq v4.53.3 oracle, not assumed:
+        //
+        // 1. A `RejectMany` count violation is only ever a symptom of an
+        //    argument that also escaped -- `(1, 2, error("x"))` has two
+        //    values *because* the generator didn't get to collapse them
+        //    into one before raising -- so when a slot's own violation
+        //    carries a trailing escape, report that escape instead of the
+        //    synthetic count message.
+        // 2. Whenever *inner* independently has a `RejectMany` violation of
+        //    its own -- escaping or not -- real yq reports inner's, never
+        //    outer's, even when outer's own violation also escaped. Checked
+        //    across all four combinations: inner escapes + outer escapes ->
+        //    inner's escape; inner escapes + outer clean -> inner's escape;
+        //    inner clean-violation (no escape) + outer escapes -> inner's
+        //    plain count message, still outranking outer's real escape;
+        //    inner fine + outer clean -> outer's own plain message, since
+        //    there is nothing on inner's side to prefer.
+        //
+        // So inner always gets checked here before outer's own violation
+        // (of either kind) is reported. Inner hasn't been evaluated at all
+        // yet on this path -- the loop below is what would normally do
+        // that, on its first iteration -- so this is its first evaluation,
+        // not an extra one, with the same side-effect profile the loop's
+        // first iteration would have had.
+        let (mut probe_inners, probe_inner_trailing) =
+            stream_outputs(eval_single::<W, S>(inner, value.clone(), optional));
+        if let Err(inner_e) = apply_arg_fanout(fanout, &mut probe_inners) {
+            return match probe_inner_trailing {
+                Some(inner_control) => partial(Vec::new(), inner_control),
+                None => QueryResult::Error(inner_e),
+            };
+        }
         return match outer_trailing {
-            Some(control) => partial(Vec::new(), control),
+            Some(outer_control) => partial(Vec::new(), outer_control),
             None => QueryResult::Error(e),
         };
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1577,10 +1577,14 @@ fn clear_values_when_yq_argument_escaped(
 /// CLAUDE.md's #106 lesson ("duplicated predicates diverge silently — one
 /// definition, plus a test that the call sites agree") warns about (#1537).
 ///
-/// Purely a gate on the values: reconciling them against the argument's own
-/// trailing control is [`fanout_arg`]'s job, and *only* its job — see
-/// `clear_values_when_yq_argument_escaped` for why two-argument builtins
-/// cannot share that rule.
+/// Purely a gate on the values -- reconciling a `RejectMany` count failure
+/// against the argument's own trailing control is each caller's own job.
+/// [`fanout_arg`] does it unconditionally via
+/// `clear_values_when_yq_argument_escaped`, since a single-argument builtin
+/// has no other slot for that to skip validating; [`fanout_two_args`] does
+/// it narrower, only when this function's own count check is what's about
+/// to fail (#1533's other half) -- see that function's doc comment for why
+/// the wider rule doesn't apply there.
 fn apply_arg_fanout(fanout: ArgFanout, args: &mut Vec<OwnedValue>) -> Result<(), EvalError> {
     match fanout {
         // jq's rule 1: every value is used, and the argument's own control
@@ -1844,7 +1848,20 @@ fn fanout_two_args<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let (mut outers, outer_trailing) =
         stream_outputs(eval_single::<W, S>(outer, value.clone(), optional));
     if let Err(e) = apply_arg_fanout(fanout, &mut outers) {
-        return QueryResult::Error(e);
+        // #1533's other half: a `RejectMany` count violation is only ever a
+        // symptom of an argument that also escaped -- `(1, 2, error("x"))`
+        // has two values *because* the generator didn't get to collapse
+        // them into one before raising. When that's what happened, report
+        // the real escape instead of the synthetic count message. Narrower
+        // than the reverted fix this doc comment's neighbor describes: this
+        // only fires when the count check itself is about to trip (`args.len()
+        // > 1`), so a slot with exactly one value before escaping -- the
+        // shape that fix broke -- is untouched, and `body` still gets to run
+        // for it exactly as before.
+        return match outer_trailing {
+            Some(control) => partial(Vec::new(), control),
+            None => QueryResult::Error(e),
+        };
     }
 
     let mut out: Vec<OwnedValue> = Vec::new();
@@ -1852,7 +1869,11 @@ fn fanout_two_args<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         let (mut inners, inner_trailing) =
             stream_outputs(eval_single::<W, S>(inner, value.clone(), optional));
         if let Err(e) = apply_arg_fanout(fanout, &mut inners) {
-            return QueryResult::Error(e);
+            // Same reasoning as the outer slot above.
+            return match inner_trailing {
+                Some(control) => partial(Vec::new(), control),
+                None => QueryResult::Error(e),
+            };
         }
 
         for i in inners {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21407,6 +21407,20 @@ fn test_yq_setpath_reject_many_prefers_inner_violation_over_outer_1533() -> Resu
         run_yq_stdin_with_stderr(r#"setpath(["a"]; (1,2))"#, "a: 1\n", &["-o", "json"])?;
     assert!(err.contains("single result"), "err: {err:?}");
     assert_eq!(code, 1);
+
+    // Outer escapes with multiple values, inner is fine (a plain literal,
+    // not even a generator) -- inner's probe finds nothing to prefer, so
+    // outer's own escape reports, the same as before this fix touched
+    // anything (inner was never evaluated at all on this path before
+    // either, since it's a plain literal with nothing to fan out).
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        r#"setpath(["a"]; (1,2,error("boom")))"#,
+        "{}\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 1);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21357,6 +21357,59 @@ fn test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533() 
     Ok(())
 }
 
+/// #1533 review finding: when *both* slots independently violate
+/// `RejectMany` at once, real yq always prefers reporting inner's (the
+/// path's) own violation over outer's (the value's) -- whether either
+/// side's violation carries its own escape or is a plain count mismatch.
+/// A first version of this fix only checked the escaping slot it was
+/// evaluating and missed this ordering, reporting whichever slot it
+/// happened to check first (outer) instead -- caught by review before
+/// landing.
+///
+/// All four combinations live-verified against the pinned yq v4.53.3:
+#[test]
+fn test_yq_setpath_reject_many_prefers_inner_violation_over_outer_1533() -> Result<()> {
+    // Both slots escape -- inner's escape wins.
+    let (_, err, code) = run_yq_stdin_with_stderr(
+        r#"setpath((1,2,error("PATH_ERR")); (1,2,error("VAL_ERR")))"#,
+        "null\n",
+        &["-o", "json"],
+    )?;
+    assert!(
+        err.contains("PATH_ERR") && !err.contains("VAL_ERR"),
+        "err: {err:?}"
+    );
+    assert_eq!(code, 1);
+
+    // Inner escapes, outer has a plain (non-escaping) count violation --
+    // inner's escape still wins.
+    let (_, err, code) = run_yq_stdin_with_stderr(
+        r#"setpath((1,2,error("PATH_ERR")); (1,2))"#,
+        "null\n",
+        &["-o", "json"],
+    )?;
+    assert!(err.contains("PATH_ERR"), "err: {err:?}");
+    assert_eq!(code, 1);
+
+    // Inner has a plain count violation (no escape at all), outer escapes
+    // -- inner's plain violation *still* outranks outer's real escape.
+    let (_, err, code) = run_yq_stdin_with_stderr(
+        r#"setpath((["a"],["b"]); (1,2,error("VAL_ERR")))"#,
+        "a: 1\nb: 2\n",
+        &["-o", "json"],
+    )?;
+    assert!(!err.contains("VAL_ERR"), "err: {err:?}");
+    assert_eq!(code, 1);
+
+    // Outer has a plain count violation, inner is fine (single value) --
+    // nothing on inner's side to prefer, so outer's own violation reports.
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(r#"setpath(["a"]; (1,2))"#, "a: 1\n", &["-o", "json"])?;
+    assert!(err.contains("single result"), "err: {err:?}");
+    assert_eq!(code, 1);
+    Ok(())
+}
+
 /// #1533/#1534 regression guard: applying the single-argument escape rule to
 /// `fanout_two_args` as well broke two shapes that already matched real yq,
 /// because emptying a slot's values skips the body.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21304,10 +21304,10 @@ fn test_yq_first_only_gate_still_takes_the_first_output_1534() -> Result<()> {
 /// Error: boom
 /// ```
 ///
-/// Only `delpaths` is asserted here because only it is a *single*-argument
-/// builtin. `setpath`'s two-argument form is covered by
-/// `test_yq_setpath_two_argument_escape_order_is_unfixed_1533` below, which
-/// pins the divergence that remains.
+/// `setpath`'s two-argument form is covered by
+/// `test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533`
+/// below, fixed the same way once `fanout_two_args` also learned to defer
+/// to a slot's own trailing escape ahead of its `RejectMany` count check.
 #[test]
 fn test_yq_reject_many_propagates_an_embedded_error_1533() -> Result<()> {
     let (out, err, code) = run_yq_stdin_with_stderr(
@@ -21325,28 +21325,33 @@ fn test_yq_reject_many_propagates_an_embedded_error_1533() -> Result<()> {
     Ok(())
 }
 
-/// #1533's remaining half, pinned as a known divergence rather than left
-/// silent. For a *two*-argument builtin the same rule cannot be applied by
-/// emptying the escaping slot's values: doing so skips the body, and the
-/// body is where the other slot is validated. Which slot real yq reports is
-/// per-builtin and does not follow succinctly's outer/inner order, so this
-/// needs a per-builtin ordering probe (see
-/// `clear_values_when_yq_argument_escaped`'s doc comment).
+/// #1533's other half, formerly pinned as a known divergence
+/// (`test_yq_setpath_two_argument_escape_order_is_unfixed_1533`) until now.
 ///
-/// Real yq answers `Error: boom`; succinctly still answers with its count
-/// message. Asserting the *current* behaviour keeps the gap visible and
-/// makes the eventual fix flip a pin rather than pass silently.
+/// The general "clear a slot's values whenever it escaped" rule stays
+/// reverted (it broke `test`/`setpath`'s own per-builtin escape-ordering,
+/// see `test_yq_two_argument_body_validation_outranks_a_slot_escape_1533`
+/// and `test_yq_fanout_two_args_argument_escape_reports_bare_not_prefix_then_raise`
+/// below) -- but a narrower rule is safe: only when a slot's value count is
+/// *already* about to trip `RejectMany`'s own `> 1` check does that slot's
+/// trailing escape get to outrank the resulting count message instead.
+/// `(1, 2, error("boom"))` has two values only because the generator didn't
+/// get to collapse them into one before raising, so the count itself is a
+/// symptom of the escape, not competing evidence against it -- unlike the
+/// single-value-then-escape shapes the reverted rule broke, where `body`
+/// still needs to run to decide whose validation wins.
 #[test]
-fn test_yq_setpath_two_argument_escape_order_is_unfixed_1533() -> Result<()> {
+fn test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533() -> Result<()> {
     let (out, err, code) = run_yq_stdin_with_stderr(
         r#"setpath((1,2,error("boom")); 1)"#,
         "null\n",
         &["-o", "json"],
     )?;
     assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
     assert!(
-        err.contains("single result"),
-        "expected the (still-diverging) count message, got {err:?}"
+        !err.contains("single result"),
+        "the count message must not mask the real error: {err:?}"
     );
     assert_eq!(code, 1);
     Ok(())


### PR DESCRIPTION
## Summary

Found reviewing #1279. `ArgFanout::RejectMany`'s own count check
(`args.len() > 1`) fires before `fanout_two_args` ever looks at that slot's
trailing control, so `setpath`'s own repro from #1533 masked a real
`error(...)` behind a generic count message:

```bash
$ printf 'null' | yq            'setpath((1,2,error("boom")); 1)'
Error: boom
$ printf 'null' | succinctly yq 'setpath((1,2,error("boom")); 1)'
Error: expected a single result but found 2
```

#1533's single-argument half (`delpaths`, via `fanout_arg`) was already
fixed earlier in this series via `clear_values_when_yq_argument_escaped` —
but that fix was deliberately *not* extended to `fanout_two_args`, because
doing so regressed two other shapes (`test`/`setpath`'s own per-builtin
escape-ordering, where emptying a slot's values pre-emptively skips `body`,
and `body` is where the *other* slot gets validated). That general rule
stays reverted; a prior commit in this branch's history left the
two-argument gap pinned as a known divergence rather than silently passing,
specifically so the eventual fix could flip the pin.

## Fix

The remaining gap is narrower than "any escape in a two-argument slot,"
though: `RejectMany`'s own count violation is itself only ever a *symptom*
of an escape — a generator produces 2+ values instead of collapsing to one
specifically because it didn't get to before raising. Deferring to that
slot's trailing control only when the count check is what's about to fire
doesn't touch the single-value-then-escape shapes the reverted fix broke.
Applied at both of `fanout_two_args`'s own `apply_arg_fanout` call sites
(outer and inner).

## Verification

- Live-verified against pinned yq v4.53.3 for the exact repro above, plus
  the "clean multi-output, no escape" guard (`setpath((["a"],["b"]); 1)`
  must still refuse), and both previously-fixed per-builtin-ordering cases
  (`test(("a", error("p")); "z")` still reports the flags-validation error,
  `setpath((["a"],error("p")); (1,error("v")))` still reports the path
  slot's escape) — all four match the oracle exactly.
- Flips the pin `test_yq_setpath_two_argument_escape_order_is_unfixed_1533`
  (renamed to
  `test_yq_setpath_two_argument_reject_many_propagates_an_embedded_error_1533`),
  while the regression guards for the previously-reverted general rule
  (`test_yq_two_argument_body_validation_outranks_a_slot_escape_1533`,
  `test_yq_fanout_two_args_argument_escape_reports_bare_not_prefix_then_raise`)
  continue to pass unchanged.
- Updated `docs/plan/jq-generator-argument-fanout.md` and
  `docs/compliance/yq/limitations.md`, both of which documented this as a
  still-open half of #1533.

Fixes #1533

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — 0 failures, all 54 groups green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (CI's 2nd clippy leg)
- [x] `cargo build --no-default-features` (no_std) — warnings identical to main, pre-existing
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `cargo fmt --check`
- [x] Live-verified against pinned yq v4.53.3