### PR TITLE
fix(jq): input_line_number reports 0, not the raw sentinel, for a dropped --seq -s record

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1742,7 +1742,15 @@ fn json_seq_ends(raw: &[u8]) -> Vec<usize> {
 /// straight from [`per_value`](InputLocations::per_value) -- answers
 /// `<unknown>` the same way, rather than only the direct-lookup path
 /// checking a side flag `resolve` itself didn't know about.
-const UNKNOWN_LINE: u32 = u32::MAX;
+///
+/// Value comes from the library crate's own `jq::UNKNOWN_INPUT_LINE` (#1549)
+/// rather than an independently-picked `u32::MAX` here: this same raw value
+/// also crosses into the shared `input`/`inputs`/`input_line_number` queue
+/// (`seed_remaining_inputs`, below), so `builtin_input_line_number` needs to
+/// recognize the exact sentinel this side emits -- previously it didn't,
+/// and reported the raw `u32::MAX` (`4294967295`) instead of real jq's own
+/// `0` for a dropped trailing `--seq -s` record.
+const UNKNOWN_LINE: u32 = jq::UNKNOWN_INPUT_LINE;
 
 /// Source locations for the values returned by [`get_inputs`].
 ///

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26767,8 +26767,19 @@ mod remaining_inputs {
         CURRENT.with(Cell::get)
     }
 
-    pub fn last_line() -> u32 {
-        LAST_LINE.with(Cell::get)
+    /// `None` when the last-popped document carries [`UNKNOWN_LINE`] (no
+    /// real EOF position, e.g. a dropped `--seq -s` trailing record, #1542)
+    /// instead of a real line -- checked once, here, rather than leaving it
+    /// to whichever caller remembers to compare against the sentinel (#1549:
+    /// `input_line_number` didn't, and reported the raw sentinel verbatim).
+    /// This is `last_line`'s only caller crate-wide, so folding the check in
+    /// here costs nothing and makes "unknown" a type-level fact instead of a
+    /// convention.
+    pub fn last_line() -> Option<u32> {
+        match LAST_LINE.with(Cell::get) {
+            UNKNOWN_LINE => None,
+            line => Some(line),
+        }
     }
 }
 
@@ -26975,18 +26986,13 @@ fn builtin_input_line_number<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() ->
     }
     #[cfg(feature = "std")]
     {
-        // #1549: the most recently popped document can carry
-        // `remaining_inputs::UNKNOWN_LINE` (no real EOF position at all,
-        // e.g. `--seq -s`'s trailing-record drop) rather than a real line --
-        // report real jq's own answer for "no line known yet" (`0`, the
-        // same value this builtin already reports before anything has been
-        // read) instead of the raw sentinel.
-        let line = remaining_inputs::last_line();
-        let reported = if line == remaining_inputs::UNKNOWN_LINE {
-            0
-        } else {
-            line
-        };
+        // #1549: the most recently popped document can carry no real EOF
+        // position at all (e.g. `--seq -s`'s trailing-record drop) --
+        // `last_line` already maps that to `None`; report real jq's own
+        // answer for "no line known yet" (`0`, the same value this builtin
+        // already reports before anything has been read) instead of the
+        // raw sentinel it used to leak.
+        let reported = remaining_inputs::last_line().unwrap_or(0);
         QueryResult::Owned(OwnedValue::Int(reported as i64))
     }
     #[cfg(not(feature = "std"))]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26663,6 +26663,18 @@ mod remaining_inputs {
     use std::cell::{Cell, RefCell};
     use std::collections::VecDeque;
 
+    /// Marks a queued document as having no real line to report -- jq's own
+    /// parser lost its EOF position entirely for it (e.g. `--seq -s`'s
+    /// trailing-record drop, #1542). The CLI driver (`jq_runner.rs`) owns
+    /// the *only* other place this same "no real position" concept exists
+    /// (its own `UNKNOWN_LINE`, used to resolve the `(at ...)` error marker)
+    /// -- shared here so both sides agree on one value instead of each
+    /// independently picking `u32::MAX` and hoping they never drift (#1549:
+    /// `input_line_number` used to read the raw sentinel straight off this
+    /// queue with no idea it meant "unknown," reporting `4294967295` instead
+    /// of real jq's own `0`).
+    pub const UNKNOWN_LINE: u32 = u32::MAX;
+
     thread_local! {
         // `(document, source tag, 1-based end line)`. The source tag is opaque
         // here: the CLI assigns it and resolves it back to a file name itself,
@@ -26759,6 +26771,19 @@ mod remaining_inputs {
         LAST_LINE.with(Cell::get)
     }
 }
+
+/// The line value a queued document carries when it has no real EOF
+/// position to report at all (#1549).
+///
+/// The CLI driver ([`seed_remaining_inputs`]'s caller) tags a document this
+/// way rather than with a resolvable line number, and `input_line_number`
+/// maps it back to `0` at read time instead of exposing the raw sentinel.
+/// Shared here so the CLI's own line-resolution logic (which independently
+/// needs the same "no position" concept for its `(at ...)` error marker)
+/// can reference one value instead of each side picking `u32::MAX` on its
+/// own and hoping they never drift apart.
+#[cfg(feature = "std")]
+pub const UNKNOWN_INPUT_LINE: u32 = remaining_inputs::UNKNOWN_LINE;
 
 /// Seeds the `input`/`inputs`/`input_line_number` queue (#723).
 ///
@@ -26950,7 +26975,19 @@ fn builtin_input_line_number<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() ->
     }
     #[cfg(feature = "std")]
     {
-        QueryResult::Owned(OwnedValue::Int(remaining_inputs::last_line() as i64))
+        // #1549: the most recently popped document can carry
+        // `remaining_inputs::UNKNOWN_LINE` (no real EOF position at all,
+        // e.g. `--seq -s`'s trailing-record drop) rather than a real line --
+        // report real jq's own answer for "no line known yet" (`0`, the
+        // same value this builtin already reports before anything has been
+        // read) instead of the raw sentinel.
+        let line = remaining_inputs::last_line();
+        let reported = if line == remaining_inputs::UNKNOWN_LINE {
+            0
+        } else {
+            line
+        };
+        QueryResult::Owned(OwnedValue::Int(reported as i64))
     }
     #[cfg(not(feature = "std"))]
     {

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -93,7 +93,9 @@ pub use eval::{
 // backing store needs `std`, and there is no meaningful "remaining input
 // stream" to seed under a `no_std` embedding with no CLI driver anyway).
 #[cfg(feature = "std")]
-pub use eval::{current_input_location, pop_remaining_input, seed_remaining_inputs};
+pub use eval::{
+    current_input_location, pop_remaining_input, seed_remaining_inputs, UNKNOWN_INPUT_LINE,
+};
 // `input_queue_is_active` exists under both gates (a `const fn` returning
 // `false` without `std`), so `eval_generic` can consult it unconditionally.
 pub use eval::input_queue_is_active;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18008,6 +18008,26 @@ fn test_jq_seq_slurp_trailing_record_unknown_location_1542() -> Result<()> {
     Ok(())
 }
 
+/// #1549: `input_line_number`'s own *value* (not just the `(at ...)` error
+/// marker #1542 already covers) must report real jq's own answer for "no
+/// line known yet" (`0`) for a dropped `--seq -s` trailing record, not the
+/// raw internal sentinel line the CLI driver tags it with. Verified live
+/// against jq 1.7.1 (`0`, confirmed against a fresh probe -- not carried over
+/// from #1542's own suite, which only ever checked the error marker).
+#[test]
+fn test_jq_input_line_number_after_seq_slurp_dropped_trailing_record_1549() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["--seq", "-c", "-s", "input_line_number"],
+        Some("\x1e1\n\x1e{\"a\":1"),
+    )
+    .expect("input_line_number after a dropped --seq -s trailing record still runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    // `--seq` RS-prefixes output too (RFC 7464), not just input.
+    assert_eq!(stdout, "\x1e0\n", "{stderr}");
+
+    Ok(())
+}
+
 /// #1550: #1542's drop check only ever inspected `raw_inputs.last()` -- the
 /// *physically* last file on the command line. Real jq's `-s` reader treats
 /// every file as one continuous byte stream, so a truncated record's own


### PR DESCRIPTION
Fixes #1549.

`remaining_inputs::pop` (`src/jq/eval.rs`) sets `LAST_LINE` directly from the raw per-value `line` the CLI driver seeds the queue with, with no concept of "no real position." For #1542's `UNKNOWN_LINE` sentinel (`u32::MAX`, used when a `--seq -s` trailing record real jq's own incremental parser never resolves), that meant `input_line_number` returned the raw sentinel cast to `i64` (`4294967295`) instead of jq's own answer of `0`.

The `(at ...)` error marker already handled this correctly — `jq_runner.rs`'s `InputLocations::resolve` centrally checks for its own private `UNKNOWN_LINE` constant — but `input_line_number` reads `LAST_LINE` through a completely different path (`remaining_inputs::last_line()`) that never went through that check, and the CLI's sentinel was private to the binary crate, invisible to the library-crate code that actually needed to recognize it.

## Fix

Added `pub const UNKNOWN_INPUT_LINE` to the library crate (`src/jq/eval.rs`'s `remaining_inputs` module, re-exported via `src/jq/mod.rs`), so both sides agree on one sentinel instead of independently picking `u32::MAX`:
- `builtin_input_line_number` now maps the sentinel back to `0` at read time.
- `jq_runner.rs`'s own `UNKNOWN_LINE` now derives its value from the shared library constant instead of defining `u32::MAX` a second time.

```
$ jq --seq -s 'input_line_number, error("x")' <<< $'\x1e1\n\x1e{"a":1'
jq: ignoring parse error: Unfinished JSON term at EOF at line 2, column 7
jq: error (at <unknown>): x
0

$ succinctly jq --seq -s 'input_line_number, error("x")' <<< $'\x1e1\n\x1e{"a":1'
jq: error (at <unknown>): x
0   # was 4294967295 before this fix
```

No new divergence — this fix removes one, bringing `input_line_number` in line with jq's own answer.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, no regressions; one unrelated flake — `test_short_circuit_side_effect_shapes_already_match_jq_820` killed by SIGKILL under this machine's heavy concurrent load — reran alone and clean, then reran the full suite clean)
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (workspace)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] New fix verified live against pinned jq 1.7.1 for the reported repro; verified normal (non-sentinel) `input_line_number` cases and #1520's own empty-last-file case are unaffected