### PR TITLE
perf(jq): make the duplicate-key detector cheap on documents with no duplicates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,7 +617,7 @@ For detailed documentation on optimization techniques used in this project, see 
 - **Verify the box is idle; macOS load average lies** (read 1.4 on a machine using 2.4% CPU — it counts uninterruptible-wait threads). Never benchmark a laptop on battery.
 - **A benchmark cannot measure a shape it does not generate** — "all neutral" is not evidence. Add the generator pattern first.
 - **A share of runtime is not a comparison.** Name a baseline commit that predates the change being judged — not a sibling from the same series (#1514: "cut the probe from 10.4% to 3.9%" shipped inside a 2-3x regression).
-- **Measure a precheck where the guarded code is already fastest.** It is charged to every input including the ones it cannot help, so the workload with least work to save is where its cost shows (#1514: the same detector read +8% on record-shaped input and +134% on one wide object).
+- **Measure a precheck where the guarded code is already fastest.** It is charged to every input including the ones it cannot help, so the workload with least work to save is where its cost shows (#1514: the same detector read +14% on record-shaped input and +141% on one wide object).
 
 **Recent YAML optimizations:**
 - ✅ P2.5 (Cached Type Checking): 1-17% improvement depending on nesting depth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -602,6 +602,8 @@ For detailed documentation on optimization techniques used in this project, see 
 - Duplicated predicates diverge silently — one definition, plus a test that the call sites agree (#106: three copies of one predicate, one of them quadratic)
 - Check where data physically lives before proposing to tag it (#106: the proposal assumed a `Vec<u32>`; no real file has one)
 - Re-derive a break-even before trusting it (#106: the issue's stated 12.5% dropped a bits-to-bytes conversion; the real gate was 3.125%)
+- A hash table is not automatically cheaper than a sort — above L3 a sort streams and a table does not, and which wins is architecture-dependent (#1514: the same table beat the sort on an M4 Pro and lost 24% to it on a 7950X at 7.1M keys)
+- To attribute a cost, build the binary again with the feature *disabled* and measure that — timings alone cannot separate what a check costs from what the code around it costs (#1514: it proved #1385's cost was 100% its probe, and caught a larger regression introduced by the fix)
 
 ### Benchmarking Discipline
 
@@ -614,6 +616,8 @@ For detailed documentation on optimization techniques used in this project, see 
 - **Memory-bound effects do not port across architectures** — measure ARM *and* x86_64, and name the chip in every table. #106 was 6.1x on M4 Pro, 16.4x on Zen 4.
 - **Verify the box is idle; macOS load average lies** (read 1.4 on a machine using 2.4% CPU — it counts uninterruptible-wait threads). Never benchmark a laptop on battery.
 - **A benchmark cannot measure a shape it does not generate** — "all neutral" is not evidence. Add the generator pattern first.
+- **A share of runtime is not a comparison.** Name a baseline commit that predates the change being judged — not a sibling from the same series (#1514: "cut the probe from 10.4% to 3.9%" shipped inside a 2-3x regression).
+- **Measure a precheck where the guarded code is already fastest.** It is charged to every input including the ones it cannot help, so the workload with least work to save is where its cost shows (#1514: the same detector read +8% on record-shaped input and +134% on one wide object).
 
 **Recent YAML optimizations:**
 - ✅ P2.5 (Cached Type Checking): 1-17% improvement depending on nesting depth

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -877,6 +877,34 @@ Before trusting a neutral result, confirm the suite contains the shape the chang
 does not, add a pattern to `src/bin/succinctly/yaml_generators.rs` (or the JSON/DSV equivalent)
 and regenerate.
 
+### 8. A share of runtime is not a comparison, and one signal finds one regression
+
+`b6c0c3ca` was titled *"cut the duplicate-key probe from 10.4% to 3.9%"* and shipped inside the
+very series that #1514 later bisected as a 2-3x regression. Both figures are shares of the
+*post-change* runtime. They say the probe got cheaper relative to a binary that was already
+much slower than the baseline; they cannot say whether it got closer to it. Measured against
+the pre-change commit, that same commit recovered part of one regression and left the other
+slightly worse.
+
+A perf claim needs a **named baseline commit that predates the change being judged** — not a
+sibling from the same series, and not the current tip. "A benchmark claim is only as fresh as
+its baseline" is already on record for the broadword UTF-8 reversal, where a clean rebase
+silently improved the control side; this is the same failure with the staleness chosen rather
+than inherited.
+
+**Corollary for a detector** — anything that decides whether a fast path applies. Measure it on
+the workload where the guarded code was *already fastest*, not the one where it was slowest: a
+precheck is charged to every input including the ones it cannot help, so the input with the
+least work to save is where its cost shows most. #1514's duplicate-key detector cost ~3% of
+`sjq '.'` over a document of small objects and doubled `sjq keys_unsorted` over one holding a
+single wide object.
+
+**And pick more than one signal.** #1385 shipped two regressions on two paths. A `git bisect`
+on `keys_unsorted` found the evaluator commit and stepped straight over the print-path one,
+because `.` had barely moved at that commit; a second bisect on `.` was needed to find it. One
+signal proves one thing. Before believing a bisect result, ask which paths the suspected change
+touches and whether the signal is sensitive to each of them.
+
 ### Building both halves on a remote box
 
 A source-only tarball plus a reverse patch of the commit under test is enough, with no pushing:

--- a/docs/plan/jq-duplicate-key-collapse.md
+++ b/docs/plan/jq-duplicate-key-collapse.md
@@ -389,13 +389,165 @@ why patch coverage on `src/json/light.rs` read 15%. `raw_and_escaped`, from the 
 genuinely used and stays. Deleting them also left exactly one pairwise-scan threshold in the
 tree rather than three.
 
+## What the detector cost, and how it was made cheap (#1514)
+
+Open risk 1 above asked for the 4-6% to be confirmed on the pinned hosts. It was not 4-6%.
+Measured against `40c5ff93` on both boxes — interleaved, identity-gated, `codegen-units=1` (see
+"The measurement had a hole in it" below) — the detector cost up to **+141%** on a document
+holding one wide object, and *no object in that document carries a repeated key*.
+
+Two corrections to what this document says above, both of which it had the information to avoid:
+
+- **"The residue is the printer's alone."** It was not. The printer's share (`.`) was the smaller
+  half; `keys_unsorted` — the path that had no probe at all before this series and gained a whole
+  `census` walk — more than doubled, and `keys_unsorted | length` with it.
+- **The numbers came from `succinctly json generate`'s default shape.** A detector's cost shows
+  most on the workload where the guarded code is *already fastest*, which here is a single wide
+  object (82K keys at 1 MB, 7.1M at 100 MB). On the record-shaped `users` pattern the same
+  detector reads +14%, which is why it shipped.
+
+### Finding the cost: disable the detector, then measure
+
+Timings alone cannot separate "what the detector costs" from "what the code around it costs".
+Building each binary a second time with the detector *forcibly disabled* can, and the whole
+investigation turned on it:
+
+| `wide` `keys_unsorted`, Apple M4 Pro | 10 MB | 100 MB |
+|---|---|---|
+| `main`, probe disabled | **−1.1%** | **−0.7%** |
+| an intermediate fix, dedup disabled | +89.4% | +100.0% |
+| the same intermediate, dedup on | +112.3% | +154.2% |
+
+Row 1 proves #1514's premise: with the probe gone, `main` sits exactly on the pre-#1385
+baseline, so on that path the detector was the entire cost. Row 2 caught a regression introduced
+*by the fix* — see "The mistake the fix made".
+
+### Where the cost sat
+
+Three separate passes, which is why one bisect signal only ever revealed one of them:
+
+1. **The printer** (`spans_repeat`) sorted the key *spans*, so every comparison chased a pointer
+   into a random offset of the document text.
+2. **The evaluator** ran a second full cons-list walk (`census`), `key_str()`-decoding every field
+   — `as_str` scans for the closing quote, scans again for a backslash, then validates UTF-8 —
+   before sorting anything.
+3. **The probe ran in guard position**, ahead of the arm match, so `select(true)` and `map(.)`
+   paid a full census and discarded the answer.
+
+### The fix
+
+- Hash with eight bytes per multiply and a splitmix64 finalizer, not byte-at-a-time FNV-1a.
+- Hash the key's **raw span** when it is escape-free and ASCII, instead of decoding it. ASCII is
+  what makes the substitution sound, not just fast: it is valid UTF-8, so `key_string` would have
+  answered `Some` with those exact bytes, which keeps the keyed/unkeyed split `census` counts on.
+- Run the probe **only where the answer is read positionally** (`.[n]`, `last`). `length` asks
+  `effective_len`; `.[]` and `map` dedup during the walk they were already making; `first` needs
+  nothing, because collapsing keeps a key at its first position and the first field is nobody's
+  repeat; the materializing fallback applies the rule itself.
+- **Walk keys without materializing values.** `DocumentFields::uncons_key` exists because `uncons`
+  builds a whole `DocumentField`, constructing the value a key walk never looks at.
+- Sort hashes; do not probe a table — except in `DistinctKeyCursors`, which answers per key as it
+  streams and has nothing to sort yet.
+
+### The mistake the fix made
+
+Removing the probe walk from `keys_unsorted` did not make it faster, and the dedup-disabled build
+said why: the replacement walk cost **+89% at 10 MB and +100% at 100 MB on its own**. Routing the
+writer through the generic `DocumentFields::uncons` materialized each field's value as well as its
+key, and the consumer then called `cursor.value()` to rebuild the key the walk had just dropped —
+two wasted materializations per key, worth about what the probe had cost.
+
+Local sanity checks did not catch it: the same binary measured 21% apart between two runs on a
+laptop. Only a pinned box, with the detector disabled, separated the two effects.
+
+### The table was the wrong structure, and only one architecture said so
+
+An open-addressed hash set replaced every sort first. On an M4 Pro that was right. On a 7950X it
+cost **24% on the identity path**, where at 7.1M keys the table is 134 MB against 32 MB of L3 per
+CCD: a sort streams, a table does not. Sorting `u64` hashes instead is better than both on both
+boxes — it keeps the printer's real win (registers, not pointer-chasing memcmp) without the
+random access.
+
+Two further findings, recorded so they are not re-derived:
+
+- **Size the table; never let it grow into a wide object.** Shipped growing first and measured:
+  `keys_unsorted` on `wide/10mb` went from +110% to +146% — the sort it replaced was *faster*.
+  Seventeen doublings each rehash everything held.
+- **Rejected: quadrupling instead of doubling.** Cuts rehashed entries to about a third and moved
+  `wide/100mb` from +108.5% to +108.2%, with 10 MB flat. Growth was not where the money was: a
+  rehash reads the old table sequentially and writes into one it is filling, so those inserts
+  pipeline; live inserts do not.
+
+### The measurement had a hole in it
+
+`succinctly jq type` — which reports the root's type and touches no keys — measured **+12% on an
+M4 Pro and +27% on a 7950X** between binaries in this series, scaling with input size (~0.19
+ms/MB, so it is index build). It did not bisect to the same commit on the two machines. At
+`codegen-units=1` it is **+0.2%**.
+
+The crate has no `[profile.release]`, so it builds at `codegen-units = 16` with no LTO, and adding
+code to one module changes how unrelated modules are optimized. Every CLI A/B this project has
+recorded carries that component, this document's own figures included. All numbers below were
+re-measured with `codegen-units=1` on both sides.
+
+### What it costs now
+
+`codegen-units=1`, median of 7, against `40c5ff93`. Control bands: M4 Pro −0.7%..+0.4%, 7950X
+−2.8%..+0.8%. Identity: 25 configurations, 0 differences on each box.
+
+| `wide` | M4 Pro `main` | M4 Pro tip | 7950X `main` | 7950X tip |
+|---|---|---|---|---|
+| `.` 1/10/100 MB | +24 / +30 / +34% | **+16 / +19 / +24%** | +39 / +46 / +49% | **+24 / +28 / +30%** |
+| `keys_unsorted` | +88 / +123 / +136% | **+50 / +57 / +96%** | +129 / +137 / +141% | **+78 / +97 / +142%** |
+| `\| select(true)` | +27 / +32 / +37% | **+4 / +4 / +5%** | +32 / +39 / +52% | **+2 / +4 / +3%** |
+| `\| map(.)` | +20 / +25 / +30% | **+4 / +6 / +12%** | +38 / +39 / +38% | **+16 / +23 / +36%** |
+| `\| length` | +77 / +105 / +119% | **+22 / +29 / +25%** | +98 / +106 / +107% | **+23 / +22 / +21%** |
+
+Median across all 25 configurations: M4 Pro **+25.1% → +4.8%**, 7950X **+38.1% → +12.2%**. Head to
+head against `main` on the 7950X: **median −12.0%, 24 of 25 rows faster**; the exception is
+`keys_unsorted` at 100 MB (+3.8%). yq is flat on both (median −0.3%, every row inside ±1.6%).
+
+### The floor
+
+At 7.1M keys in one object the streaming table is 134 MB and every live insert is a DRAM round
+trip — ~87 ns per key against a 670 ms baseline query. That is why `keys_unsorted` at 100 MB is
+the one row that does not improve on a 7950X. Identity `.` pays the same absolute cost and reads
+as +30% only because it has an order of magnitude more work to hide it behind: the
+"measure a precheck where the guarded code is already fastest" rule, demonstrated rather than
+argued.
+
+### Memory
+
+Peak RSS, Apple M4 Pro, MiB:
+
+| workload | `40c5ff93` | `main` | tip |
+|---|---|---|---|
+| `wide/10mb` `.` | 20.8 | 63.0 | **57.1** |
+| `wide/10mb` `keys_unsorted` | 20.8 | 29.7 | 52.9 |
+| `wide/10mb` `\| length` | 20.8 | 29.8 | 29.8 |
+| `wide/100mb` `.` | 132.5 | 514.0 | **459.7** |
+| `wide/100mb` `keys_unsorted` | 132.5 | 188.9 | 388.7 |
+| `wide/100mb` `\| length` | 132.5 | 189.0 | 189.0 |
+| `users/10mb`, every filter | 16.4 | 16.5 | 16.5 |
+
+`.` improves on `main` (the printer's `Vec<u64>` is half the width of the `Vec<&[u8]>` it
+replaced) and `length` is identical. Only the streaming `keys_unsorted` path doubles: an
+open-addressed table keeps 16 bytes per key at its half-load point where a sorted `Vec<u64>` keeps
+8. That is the trade for the time above, and defect 4 in this document is the precedent for
+reporting both rather than one.
+
 ## Open risks for an implementer to sanity-check
 
-1. **The 4-6% wants confirming on the pinned hosts.** Everything above was measured on a
-   laptop under someone else's load. Re-run `succinctly bench run jq_bench` interleaved on the
-   M4 Pro and the 7950X before treating the figure as settled — and note the cost is
-   memory-traffic-shaped (a per-field buffer), which is exactly the kind that does not port
-   between architectures.
+1. ~~**The 4-6% wants confirming on the pinned hosts.**~~ **Closed by
+   [#1514](https://github.com/rust-works/succinctly/issues/1514), and the answer was not 4-6%.**
+   On both pinned hosts the detector cost up to **+134%** on a document holding one wide
+   object — none of whose objects carries a repeated key. The laptop figure was low for two
+   reasons this risk named only half of: the machine, and the *workload*. See "What the
+   detector cost, and how it was made cheap" below.
+
+   The prediction that the cost is memory-traffic-shaped and would not port between
+   architectures was right, and mattered more than expected: the fix's first structure won on
+   an M4 Pro and lost 24% on a 7950X.
 2. **Shared-evaluator hazard.** ADR-0018 rule 2's standing warning, and a repeated failure in this
    repo: a builtin generic over `S` serves *both* modes, so a jq-motivated rewrite can silently
    regress yq. Every touched arm needs a yq-mode check.
@@ -434,3 +586,5 @@ tree rather than three.
 - Symptom issues: #443, #442, #478, #1251, #1170 (jq), #1342/#1343/#1344 (yq)
 - [#1377](https://github.com/rust-works/succinctly/issues/1377) — #820's design doc, where this
   was first surfaced as Open Risk 7
+- [#1514](https://github.com/rust-works/succinctly/issues/1514) — what the detector cost once it
+  was measured on the pinned hosts, and the work that made it cheap

--- a/docs/plan/jq-duplicate-key-collapse.md
+++ b/docs/plan/jq-duplicate-key-collapse.md
@@ -540,7 +540,7 @@ reporting both rather than one.
 
 1. ~~**The 4-6% wants confirming on the pinned hosts.**~~ **Closed by
    [#1514](https://github.com/rust-works/succinctly/issues/1514), and the answer was not 4-6%.**
-   On both pinned hosts the detector cost up to **+134%** on a document holding one wide
+   On both pinned hosts the detector cost up to **+141%** on a document holding one wide
    object — none of whose objects carries a repeated key. The laptop figure was low for two
    reasons this risk named only half of: the machine, and the *workload*. See "What the
    detector cost, and how it was made cheap" below.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -10,7 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
-use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors, KeyHashes};
+use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors};
 use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
@@ -634,14 +634,21 @@ fn span_fingerprint(raw: &[u8]) -> u64 {
 ///
 /// Small objects -- nearly every object in a real document -- take the
 /// pairwise branch, which allocates nothing. Above the threshold the
-/// pairwise loop is quadratic, so the wide case probes a [`KeyHashes`]
-/// table instead: one hash and about 1.5 slot reads per key, against the
-/// `Vec<&[u8]>`-plus-`sort_unstable` this replaced, whose every comparison
-/// chased a pointer into a random offset of the document text. That sort
-/// was the whole of #1514's identity-path regression -- 59 ns per key on a
-/// 10 MB document with a wide root object.
+/// pairwise loop is quadratic, so the wide case sorts one 64-bit hash per
+/// key and looks for an adjacent pair.
 ///
-/// Above the threshold the answer is conservative: two distinct keys
+/// It sorts *hashes*, not the spans it used to (#1514). Sorting `&[u8]`
+/// meant every comparison chased a pointer into a random offset of the
+/// document text, which cost 59-85 ns per key on a 10 MB document with a
+/// wide root object. Sorting `u64`s compares registers over one contiguous
+/// array, half the width of the fat pointers it replaces.
+///
+/// An open-addressed table was tried here and is *not* what shipped: it
+/// beat the sort on an M4 Pro and lost to it by 24% on a 7950X at 100 MB,
+/// where 7.1M keys make the table 134 MB against 32 MB of L3 per CCD. A
+/// sort streams; a table does not. See `docs/plan/jq-duplicate-key-collapse.md`.
+///
+/// The answer above the threshold is conservative: two distinct keys
 /// sharing a 64-bit hash report `true`. [`collapse_duplicate_fields`]
 /// resolves it on the spans themselves and returns `None` when nothing
 /// actually collapsed, so a collision costs one exact rebuild.
@@ -656,10 +663,9 @@ fn spans_repeat(prepared: &[PreparedField<'_>]) -> bool {
                 .any(|j| marks[i] == marks[j] && prepared[i].raw == prepared[j].raw)
         });
     }
-    let mut seen = KeyHashes::with_capacity(prepared.len());
-    prepared
-        .iter()
-        .any(|field| seen.insert(key_hash(field.raw)))
+    let mut hashes: Vec<u64> = prepared.iter().map(|field| key_hash(field.raw)).collect();
+    hashes.sort_unstable();
+    hashes.windows(2).any(|pair| pair[0] == pair[1])
 }
 
 /// jq's duplicate-key rule over an object's already-walked fields (#1385):

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -10,7 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
-use succinctly::jq::document::{collapsed_fields, effective_keys};
+use succinctly::jq::document::{collapsed_fields, effective_keys, key_hash, KeyHashes};
 use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
@@ -630,7 +630,21 @@ fn span_fingerprint(raw: &[u8]) -> u64 {
     ((n as u64) << 16) | ((first as u64) << 8) | last as u64
 }
 
-/// Whether any two key spans are byte-identical.
+/// Whether any two key spans *may* be byte-identical.
+///
+/// Small objects -- nearly every object in a real document -- take the
+/// pairwise branch, which allocates nothing. Above the threshold the
+/// pairwise loop is quadratic, so the wide case probes a [`KeyHashes`]
+/// table instead: one hash and about 1.5 slot reads per key, against the
+/// `Vec<&[u8]>`-plus-`sort_unstable` this replaced, whose every comparison
+/// chased a pointer into a random offset of the document text. That sort
+/// was the whole of #1514's identity-path regression -- 59 ns per key on a
+/// 10 MB document with a wide root object.
+///
+/// Above the threshold the answer is conservative: two distinct keys
+/// sharing a 64-bit hash report `true`. [`collapse_duplicate_fields`]
+/// resolves it on the spans themselves and returns `None` when nothing
+/// actually collapsed, so a collision costs one exact rebuild.
 fn spans_repeat(prepared: &[PreparedField<'_>]) -> bool {
     if prepared.len() <= PAIRWISE_SPAN_SCAN_LIMIT {
         let mut marks = [0u64; PAIRWISE_SPAN_SCAN_LIMIT];
@@ -642,12 +656,10 @@ fn spans_repeat(prepared: &[PreparedField<'_>]) -> bool {
                 .any(|j| marks[i] == marks[j] && prepared[i].raw == prepared[j].raw)
         });
     }
-    // Sorting keeps the wide case out of the quadratic loop: on a 10 MB
-    // document whose root object is wide, an unbounded pairwise scan
-    // measured 1240% slower than not collapsing at all.
-    let mut spans: Vec<&[u8]> = prepared.iter().map(|field| field.raw).collect();
-    spans.sort_unstable();
-    spans.windows(2).any(|w| w[0] == w[1])
+    let mut seen = KeyHashes::with_capacity(prepared.len());
+    prepared
+        .iter()
+        .any(|field| seen.insert(key_hash(field.raw)))
 }
 
 /// jq's duplicate-key rule over an object's already-walked fields (#1385):

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -10,7 +10,7 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
-use succinctly::jq::document::{collapsed_fields, effective_keys, key_hash, KeyHashes};
+use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors, KeyHashes};
 use succinctly::jq::eval_generic::{
     eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
 };
@@ -2966,28 +2966,20 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         // sorted `keys` result must never be routed there (#683) — it
         // materializes and sorts here instead, same as eager `Keys` always
         // did.
-        // #1385: a duplicate key would be emitted twice by the lazy
-        // writer, which streams raw key bytes without a collapse step. Probe
-        // first and stay lazy only when the object is clean -- a repeated
-        // key materializes the collapsed list instead, keeping the fast path
-        // for every ordinary document.
+        // #1385: a duplicate key would be emitted twice by a writer that
+        // streams raw key bytes with no collapse step. #1514: the rule
+        // travels with the value instead of being settled here. Probing
+        // first cost a whole extra cons-list walk, `key_str()`-decoding
+        // every field, ahead of the walk that writes the output -- 96 ns
+        // per key on `wide/10mb`, against an 87 ns/key baseline for the
+        // entire query. `LazyKeysArray`'s consumers apply the rule as they
+        // walk, which is sound because "first occurrence wins" needs no
+        // lookahead.
         GenericResult::LazyKeys {
             fields,
             sorted: false,
             collapse,
-        } if !collapse || collapsed_fields(&fields).is_none() => {
-            vec![JqValue::LazyKeysArray(fields)]
-        }
-        GenericResult::LazyKeys {
-            fields,
-            sorted: false,
-            collapse,
-        } => vec![JqValue::from_owned(OwnedValue::Array(
-            effective_keys(&fields, collapse)
-                .into_iter()
-                .map(OwnedValue::String)
-                .collect(),
-        ))],
+        } => vec![JqValue::LazyKeysArray { fields, collapse }],
         GenericResult::LazyKeys {
             fields,
             sorted: true,
@@ -3633,17 +3625,17 @@ where
         // first. Compact/pretty duplicated as two full loops, matching the
         // `StandardJson::Array`/`StandardJson::Object` arms above rather
         // than branching mid-loop.
-        JqValue::LazyKeysArray(fields) => {
+        JqValue::LazyKeysArray { fields, collapse } => {
             use succinctly::json::light::StandardJson as SJ;
             if fields.is_empty() {
                 out.write_all(b"[]")?;
             } else if compact {
                 out.write_all(b"[")?;
-                for (i, field) in (*fields).enumerate() {
+                for (i, key_cursor) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                     }
-                    if let SJ::String(k) = field.key() {
+                    if let SJ::String(k) = key_cursor.value() {
                         let raw = k.raw_bytes();
                         let content = &raw[1..raw.len().saturating_sub(1)];
                         if !config.ascii_output && !content.contains(&b'\\') {
@@ -3666,13 +3658,13 @@ where
             } else {
                 out.write_all(b"[")?;
                 out.write_all(separator.as_bytes())?;
-                for (i, field) in (*fields).enumerate() {
+                for (i, key_cursor) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                         out.write_all(separator.as_bytes())?;
                     }
                     out.write_all(next_indent.as_bytes())?;
-                    if let SJ::String(k) = field.key() {
+                    if let SJ::String(k) = key_cursor.value() {
                         let raw = k.raw_bytes();
                         let content = &raw[1..raw.len().saturating_sub(1)];
                         if !config.ascii_output && !content.contains(&b'\\') {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3631,11 +3631,11 @@ where
                 out.write_all(b"[]")?;
             } else if compact {
                 out.write_all(b"[")?;
-                for (i, key_cursor) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
+                for (i, (key, _)) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                     }
-                    if let SJ::String(k) = key_cursor.value() {
+                    if let SJ::String(k) = key {
                         let raw = k.raw_bytes();
                         let content = &raw[1..raw.len().saturating_sub(1)];
                         if !config.ascii_output && !content.contains(&b'\\') {
@@ -3658,13 +3658,13 @@ where
             } else {
                 out.write_all(b"[")?;
                 out.write_all(separator.as_bytes())?;
-                for (i, key_cursor) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
+                for (i, (key, _)) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                         out.write_all(separator.as_bytes())?;
                     }
                     out.write_all(next_indent.as_bytes())?;
-                    if let SJ::String(k) = key_cursor.value() {
+                    if let SJ::String(k) = key {
                         let raw = k.raw_bytes();
                         let content = &raw[1..raw.len().saturating_sub(1)];
                         if !config.ascii_output && !content.contains(&b'\\') {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -5,6 +5,8 @@
 //! intermediate conversion.
 
 #[cfg(not(test))]
+use alloc::vec;
+#[cfg(not(test))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use indexmap::{IndexMap, IndexSet};
@@ -526,42 +528,153 @@ pub trait DocumentFields: Sized + Clone {
     }
 }
 
-/// A 64-bit fingerprint of a key, for grouping candidates cheaply.
+/// A 64-bit hash of a key, for grouping candidates cheaply.
 ///
-/// FNV-1a: no dependency, no `HashMap` (this module is `no_std` + `alloc`),
-/// and deterministic across runs. Fingerprint quality only affects *speed*
-/// -- every routine below resolves a shared fingerprint by comparing the
-/// keys themselves, so a collision costs work, never a wrong answer.
-fn key_fingerprint(key: &str) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in key.as_bytes() {
-        hash ^= *byte as u64;
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+/// Mixes eight bytes per multiply rather than one, then runs a
+/// splitmix64 finalizer so the low bits [`KeyHashes`] indexes on are as
+/// well distributed as the high ones. No dependency and no `HashMap`
+/// (this module is `no_std` + `alloc`), and deterministic across runs.
+///
+/// Hash quality only affects *speed* -- every routine below resolves a
+/// shared hash by comparing the keys themselves, so a collision costs
+/// work, never a wrong answer.
+pub fn key_hash(key: &[u8]) -> u64 {
+    const PRIME: u64 = 0x9e37_79b9_7f4a_7c15;
+    let mut acc = 0xcbf2_9ce4_8422_2325 ^ (key.len() as u64);
+    let mut chunks = key.chunks_exact(8);
+    for chunk in &mut chunks {
+        let mut word = [0u8; 8];
+        word.copy_from_slice(chunk);
+        acc = (acc ^ u64::from_le_bytes(word))
+            .wrapping_mul(PRIME)
+            .rotate_left(31);
     }
-    hash
+    let tail = chunks.remainder();
+    if !tail.is_empty() {
+        let mut word = [0u8; 8];
+        word[..tail.len()].copy_from_slice(tail);
+        acc = (acc ^ u64::from_le_bytes(word))
+            .wrapping_mul(PRIME)
+            .rotate_left(31);
+    }
+    // splitmix64 finalizer: without it the low bits carry too little of
+    // the input, and `& mask` would cluster short keys into one run.
+    acc ^= acc >> 33;
+    acc = acc.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    acc ^= acc >> 33;
+    acc = acc.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    acc ^ (acc >> 33)
 }
 
-/// The sorted, deduplicated fingerprints that occur more than once in
-/// `sorted`, plus how many distinct fingerprint values it holds in total.
+/// An open-addressed set of key hashes: "has any key repeated?" in one
+/// pass, no sort, no key text kept.
 ///
-/// `sorted` must already be sorted ascending; the returned list is too, so
-/// callers can `binary_search` it.
-fn shared_fingerprints(sorted: &[u64]) -> (Vec<u64>, usize) {
-    let mut shared = Vec::new();
-    let mut distinct = 0usize;
-    let mut i = 0usize;
-    while i < sorted.len() {
-        let mut j = i + 1;
-        while j < sorted.len() && sorted[j] == sorted[i] {
-            j += 1;
+/// This replaces the sort-then-scan shape #1385 shipped (#1514). Sorting
+/// is O(n log n) with a comparison per step; on a wide object it dominated
+/// the walk it was guarding -- and the printer's variant sorted *byte
+/// slices*, chasing a pointer into a random offset of the document on
+/// every comparison. Probing costs one hash and about 1.5 slot reads per
+/// key, and the slots are one contiguous array.
+///
+/// The table holds hashes only -- 8 bytes per slot, never a key -- so it
+/// stays a fraction of what materializing the fields would cost, and it
+/// can grow by rehashing what it already has.
+///
+/// [`insert`](Self::insert) is deliberately **conservative**: it reports a
+/// repeat when two keys merely share a 64-bit hash, which for distinct
+/// keys happens about `n^2 / 2^64` of the time. Every caller resolves a
+/// reported repeat against the keys themselves, so a false report costs
+/// one exact pass and still answers correctly.
+pub struct KeyHashes {
+    /// Open-addressed slots. `0` marks an empty slot, so a key hashing to
+    /// zero is stored as `1` -- folding two hash values together, which
+    /// the exact resolution above already tolerates.
+    slots: Vec<u64>,
+    mask: usize,
+    len: usize,
+}
+
+impl KeyHashes {
+    /// Smallest table built, in slots. Below this the pairwise scans the
+    /// callers keep for small objects are cheaper anyway.
+    const MIN_SLOTS: usize = 16;
+
+    /// A table sized for `keys` insertions without a rehash: capacity is
+    /// the next power of two at or above `2 * keys`, keeping the load
+    /// factor at or below one half.
+    pub fn with_capacity(keys: usize) -> Self {
+        let slots = keys
+            .saturating_mul(2)
+            .next_power_of_two()
+            .max(Self::MIN_SLOTS);
+        Self {
+            slots: vec![0; slots],
+            mask: slots - 1,
+            len: 0,
         }
-        distinct += 1;
-        if j - i > 1 {
-            shared.push(sorted[i]);
-        }
-        i = j;
     }
-    (shared, distinct)
+
+    /// Record `hash`, answering whether an equal hash was already present.
+    ///
+    /// `true` means "these keys may be the same" -- see the type's note on
+    /// conservatism.
+    pub fn insert(&mut self, hash: u64) -> bool {
+        // Grow before inserting so the load factor never exceeds one half;
+        // past that, linear probing's run lengths climb sharply.
+        if (self.len + 1) * 2 > self.slots.len() {
+            self.grow();
+        }
+        let hash = if hash == 0 { 1 } else { hash };
+        let mut at = (hash as usize) & self.mask;
+        loop {
+            match self.slots[at] {
+                0 => {
+                    self.slots[at] = hash;
+                    self.len += 1;
+                    return false;
+                }
+                seen if seen == hash => return true,
+                _ => at = (at + 1) & self.mask,
+            }
+        }
+    }
+
+    /// Distinct hashes recorded so far.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether nothing has been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Double the table and re-place what it holds.
+    ///
+    /// Rehashing needs no keys: the slots *are* the hashes, which is the
+    /// whole reason a caller that cannot count its keys up front (the
+    /// streaming `keys_unsorted` writer) can still use this.
+    fn grow(&mut self) {
+        let slots = (self.slots.len() * 2).max(Self::MIN_SLOTS);
+        let old = core::mem::replace(&mut self.slots, vec![0; slots]);
+        self.mask = slots - 1;
+        for hash in old {
+            if hash == 0 {
+                continue;
+            }
+            let mut at = (hash as usize) & self.mask;
+            while self.slots[at] != 0 {
+                at = (at + 1) & self.mask;
+            }
+            self.slots[at] = hash;
+        }
+    }
+}
+
+impl Default for KeyHashes {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
 }
 
 /// Number of distinct values in an already-sorted slice, and whether any
@@ -609,37 +722,53 @@ impl KeyCensus {
 }
 
 /// Take the census of `fields` (see [`KeyCensus`]).
+///
+/// The walk collects hashes into a `Vec` and the table is built afterwards,
+/// rather than probing as the walk goes, purely so the table can be sized
+/// exactly. A [`KeyHashes`] left to grow into a wide object rehashes
+/// everything it holds at every doubling -- roughly as many extra
+/// random-access inserts as there are keys, plus zeroing each intermediate
+/// table -- and measured *slower* than the sort it replaces: `keys_unsorted`
+/// on `wide/10mb` went +110% to +146% against the pre-#1385 baseline instead
+/// of improving. The `Vec` was already here before this change, so sizing
+/// the table off it costs nothing new.
 fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
-    let mut prints: Vec<u64> = Vec::new();
+    let mut hashes: Vec<u64> = Vec::new();
     let mut unkeyed = 0usize;
     let mut walk = fields.clone();
     while let Some((field, rest)) = walk.uncons() {
         match field.key_str() {
-            Some(key) => prints.push(key_fingerprint(&key)),
+            Some(key) => hashes.push(key_hash(key.as_bytes())),
             None => unkeyed += 1,
         }
         walk = rest;
     }
-    let keyed = prints.len();
-    prints.sort_unstable();
-    let (shared, distinct_prints) = shared_fingerprints(&prints);
+    let mut seen = KeyHashes::with_capacity(hashes.len());
+    let mut shared: Vec<u64> = Vec::new();
+    for hash in hashes {
+        if seen.insert(hash) {
+            shared.push(hash);
+        }
+    }
     if shared.is_empty() {
         return KeyCensus {
-            distinct: keyed,
+            distinct: seen.len(),
             unkeyed,
             repeated: false,
         };
     }
+    shared.sort_unstable();
+    shared.dedup();
 
-    // A shared fingerprint is nearly always a genuine repeat, but two
-    // different keys can collide, and counting those as one would be
-    // wrong. Re-walk owning *only* the colliding keys -- on an ordinary
-    // duplicate that is a handful of strings, not one per field.
+    // A shared hash is nearly always a genuine repeat, but two different
+    // keys can collide, and counting those as one would be wrong. Re-walk
+    // owning *only* the colliding keys -- on an ordinary duplicate that is
+    // a handful of strings, not one per field.
     let mut colliding: Vec<String> = Vec::new();
     let mut walk = fields.clone();
     while let Some((field, rest)) = walk.uncons() {
         if let Some(key) = field.key_str() {
-            if shared.binary_search(&key_fingerprint(&key)).is_ok() {
+            if shared.binary_search(&key_hash(key.as_bytes())).is_ok() {
                 colliding.push(key.into_owned());
             }
         }
@@ -648,18 +777,26 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     colliding.sort_unstable();
     let (distinct_colliding, repeated) = distinct_sorted(&colliding);
     KeyCensus {
-        distinct: distinct_prints - shared.len() + distinct_colliding,
+        // `seen.len()` counts distinct *hashes*; every colliding group
+        // contributed exactly one of them, so swap each group's single
+        // hash for however many distinct keys it actually held.
+        distinct: seen.len() - shared.len() + distinct_colliding,
         unkeyed,
         repeated,
     }
 }
 
-/// Whether any key occurs more than once among already-walked fields.
+/// Whether any key *may* occur more than once among already-walked fields.
 ///
 /// The slice counterpart of [`census`], for callers that have had to
-/// materialize the fields anyway. Same fingerprint-then-verify shape, so it
-/// is linear in the field count and keeps 8 bytes per field rather than a
-/// borrowed-key `Cow` (32).
+/// materialize the fields anyway. One [`KeyHashes`] probe per key, no sort.
+///
+/// Deliberately conservative, as [`KeyHashes::insert`] is: two distinct
+/// keys sharing a 64-bit hash answer `true` here. The only caller,
+/// [`effective_fields`], responds by running [`collapse_repeated`], which
+/// decides on the keys themselves and returns the same field list when
+/// nothing actually repeated -- so a collision costs one rebuild, never a
+/// wrong answer.
 ///
 /// A field whose key does not stringify (`key_str` answers `None`) never
 /// compares equal to anything, including another such field.
@@ -667,22 +804,11 @@ fn keys_repeat<V: DocumentValue, C: DocumentCursor>(fields: &[DocumentField<V, C
     if fields.len() < 2 {
         return false;
     }
-    let mut prints: Vec<(u64, usize)> = Vec::with_capacity(fields.len());
-    for (i, field) in fields.iter().enumerate() {
-        if let Some(key) = field.key_str() {
-            prints.push((key_fingerprint(&key), i));
-        }
-    }
-    prints.sort_unstable();
-    prints.windows(2).any(|w| {
-        w[0].0 == w[1].0 && {
-            // Same fingerprint: decide it on the keys themselves.
-            let (a, b) = (fields[w[0].1].key_str(), fields[w[1].1].key_str());
-            match (a, b) {
-                (Some(a), Some(b)) => a == b,
-                _ => false,
-            }
-        }
+    let mut seen = KeyHashes::with_capacity(fields.len());
+    fields.iter().any(|field| {
+        field
+            .key_str()
+            .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
     })
 }
 
@@ -778,12 +904,22 @@ pub fn effective_len<F: DocumentFields>(fields: &F, collapse: bool) -> usize {
 /// An object's field names under the mode's duplicate-key rule, in
 /// document order (first position of each key).
 ///
-/// `IndexSet::insert` keeps the first occurrence's position and discards
-/// later equal ones -- which is the whole rule, since a key array carries
+/// Probes with [`KeyHashes`] first and returns the walked keys untouched
+/// when nothing repeats, which is the overwhelmingly common case (#1514).
+/// Only a document that actually carries a repeat pays for the
+/// `IndexSet`, whose `insert` keeps the first occurrence's position and
+/// discards later equal ones -- the whole rule, since a key array carries
 /// no values for "last value wins" to choose between.
 pub fn effective_keys<F: DocumentFields>(fields: &F, collapse: bool) -> Vec<String> {
     let keys = fields.keys();
     if !collapse {
+        return keys;
+    }
+    let mut probe = KeyHashes::with_capacity(keys.len());
+    if !keys
+        .iter()
+        .any(|key| probe.insert(key_hash(key.as_bytes())))
+    {
         return keys;
     }
     let mut seen: IndexSet<String> = IndexSet::with_capacity(keys.len());
@@ -880,5 +1016,87 @@ pub trait DocumentElements: Sized + Copy + Clone {
             elems = rest;
         }
         cursors
+    }
+}
+
+#[cfg(test)]
+mod key_hash_tests {
+    use super::{key_hash, KeyHashes};
+
+    /// The set answers "already seen" exactly for repeated hashes, and
+    /// `len` counts distinct ones — the two properties `census` derives
+    /// its whole answer from.
+    #[test]
+    fn key_hashes_reports_repeats_and_counts_distinct_1514() {
+        let mut seen = KeyHashes::with_capacity(4);
+        assert!(!seen.insert(key_hash(b"a")));
+        assert!(!seen.insert(key_hash(b"b")));
+        assert!(seen.insert(key_hash(b"a")), "second `a` is a repeat");
+        assert!(!seen.insert(key_hash(b"c")));
+        assert_eq!(seen.len(), 3);
+    }
+
+    /// A table built with no capacity hint must grow correctly, because
+    /// the streaming callers cannot count their keys up front. Growing
+    /// rehashes from the stored hashes, so nothing may be lost or
+    /// duplicated across the resize.
+    #[test]
+    fn key_hashes_grows_without_losing_entries_1514() {
+        const N: usize = 5_000;
+        let mut seen = KeyHashes::default();
+        assert!(seen.is_empty());
+        for i in 0..N {
+            let key = alloc::format!("k{i}");
+            assert!(
+                !seen.insert(key_hash(key.as_bytes())),
+                "{key} is the first of its kind"
+            );
+        }
+        assert_eq!(seen.len(), N, "every distinct key survived the growth");
+        for i in 0..N {
+            let key = alloc::format!("k{i}");
+            assert!(seen.insert(key_hash(key.as_bytes())), "{key} repeats");
+        }
+        assert_eq!(seen.len(), N, "a repeat adds nothing");
+    }
+
+    /// Zero is the empty-slot marker, so a key hashing to zero has to be
+    /// folded onto another value rather than read back as "empty" — which
+    /// would let it repeat forever undetected.
+    #[test]
+    fn key_hashes_handles_a_zero_hash_1514() {
+        let mut seen = KeyHashes::with_capacity(2);
+        assert!(!seen.insert(0));
+        assert!(seen.insert(0), "a zero hash must still register as seen");
+        assert_eq!(seen.len(), 1);
+    }
+
+    /// The hash must depend on length as well as content, or `"ab"` and
+    /// `"ab\0"` would collide constantly through the tail path and turn
+    /// every wide object into an exact-resolution pass.
+    #[test]
+    fn key_hash_separates_length_from_content_1514() {
+        assert_ne!(key_hash(b"ab"), key_hash(b"ab\0"));
+        assert_ne!(key_hash(b""), key_hash(b"\0"));
+        assert_eq!(key_hash(b"abcdefghij"), key_hash(b"abcdefghij"));
+    }
+
+    /// Low bits carry the index, so a run of keys differing only in their
+    /// last byte must not pile into one probe chain. Without the
+    /// splitmix64 finalizer this distribution collapses.
+    #[test]
+    fn key_hash_spreads_the_low_bits_1514() {
+        let mut buckets = [0usize; 16];
+        for i in 0..4096u32 {
+            let key = alloc::format!("field_{i:06}");
+            buckets[(key_hash(key.as_bytes()) & 15) as usize] += 1;
+        }
+        let (lo, hi) = (
+            *buckets.iter().min().expect("16 buckets"),
+            *buckets.iter().max().expect("16 buckets"),
+        );
+        // Perfectly uniform is 256 per bucket; allow a wide margin so this
+        // pins "not degenerate", not the exact hash function.
+        assert!(lo > 150 && hi < 400, "buckets {buckets:?}");
     }
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -877,6 +877,94 @@ pub fn collapsed_fields<F: DocumentFields>(
     Some(collapse_repeated(fields.all_fields()))
 }
 
+/// An object's key cursors under the mode's duplicate-key rule, produced
+/// one at a time (#1514).
+///
+/// "First occurrence wins" is an *online* rule -- every key already yielded
+/// was a first occurrence -- so a consumer that only moves forward (the
+/// `keys_unsorted` writers, `map`'s lazy pull, `.[]`) can stream straight
+/// through instead of running the whole-object probe those paths used to
+/// run before producing anything. On a wide object that probe was a second
+/// full cons-list walk, and `uncons` is two BP sibling hops per field.
+///
+/// The [`KeyHashes`] probe rides along with the walk. A repeated hash hands
+/// the object to [`collapsed_fields`], which decides on the keys
+/// themselves:
+///
+/// - `Some` — a real duplicate. The remainder switches to the exact
+///   collapsed list, resuming at the count already yielded, which lines up
+///   because the collapsed list opens with those same first occurrences.
+/// - `None` — a 64-bit hash collision, and the answer covers the whole
+///   object, so the probe retires rather than firing again at the next one.
+///
+/// `collapse` false (yq) carries no probe state at all and is the plain
+/// cons-list walk it always was.
+#[derive(Clone)]
+pub struct DistinctKeyCursors<F: DocumentFields> {
+    /// The fields still to walk.
+    rest: F,
+    /// The object as a whole, for the exact resolution above. A `F` is a
+    /// cursor position, so this is a copy of a couple of machine words.
+    all: F,
+    /// Hashes of the keys yielded so far, while the rule is in force and
+    /// the object is not yet proved clean.
+    seen: Option<KeyHashes>,
+    /// How many cursors have gone out, which is where `collapsed` resumes.
+    yielded: usize,
+    /// The exact collapsed key cursors, once a repeat is confirmed.
+    collapsed: Option<Vec<F::Cursor>>,
+}
+
+impl<F: DocumentFields> DistinctKeyCursors<F> {
+    /// Walk `fields`, collapsing a repeated key onto its first occurrence
+    /// when `collapse`.
+    pub fn new(fields: &F, collapse: bool) -> Self {
+        Self {
+            rest: fields.clone(),
+            all: fields.clone(),
+            seen: collapse.then(KeyHashes::new),
+            yielded: 0,
+            collapsed: None,
+        }
+    }
+}
+
+impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
+    type Item = F::Cursor;
+
+    fn next(&mut self) -> Option<F::Cursor> {
+        if let Some(cursors) = &self.collapsed {
+            let cursor = cursors.get(self.yielded).copied()?;
+            self.yielded += 1;
+            return Some(cursor);
+        }
+        let (field, tail) = self.rest.uncons()?;
+        self.rest = tail;
+        let repeat = self.seen.as_mut().is_some_and(|seen| {
+            field
+                .key_str()
+                .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
+        });
+        if repeat {
+            match collapsed_fields(&self.all) {
+                Some(fields) => {
+                    let cursors: Vec<F::Cursor> =
+                        fields.into_iter().map(|f| f.key_cursor).collect();
+                    let cursor = cursors.get(self.yielded).copied();
+                    self.collapsed = Some(cursors);
+                    self.seen = None;
+                    let cursor = cursor?;
+                    self.yielded += 1;
+                    return Some(cursor);
+                }
+                None => self.seen = None,
+            }
+        }
+        self.yielded += 1;
+        Some(field.key_cursor)
+    }
+}
+
 /// Collapse fields known to contain at least one repeated key.
 ///
 /// Linear in the field count: the surviving slot for each key is looked up

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -585,10 +585,15 @@ pub fn key_hash(key: &[u8]) -> u64 {
 /// keys happens about `n^2 / 2^64` of the time. Every caller resolves a
 /// reported repeat against the keys themselves, so a false report costs
 /// one exact pass and still answers correctly.
+#[derive(Clone)]
 pub struct KeyHashes {
     /// Open-addressed slots. `0` marks an empty slot, so a key hashing to
     /// zero is stored as `1` -- folding two hash values together, which
     /// the exact resolution above already tolerates.
+    ///
+    /// Empty until the first insertion, so a caller that constructs one
+    /// per object and never uses it -- yq, where `collapse` is false --
+    /// allocates nothing.
     slots: Vec<u64>,
     mask: usize,
     len: usize,
@@ -599,10 +604,25 @@ impl KeyHashes {
     /// callers keep for small objects are cheaper anyway.
     const MIN_SLOTS: usize = 16;
 
+    /// An empty table that allocates on its first insertion.
+    ///
+    /// For callers that cannot count their keys up front, and for the ones
+    /// that may never insert at all.
+    pub fn new() -> Self {
+        Self {
+            slots: Vec::new(),
+            mask: 0,
+            len: 0,
+        }
+    }
+
     /// A table sized for `keys` insertions without a rehash: capacity is
     /// the next power of two at or above `2 * keys`, keeping the load
     /// factor at or below one half.
     pub fn with_capacity(keys: usize) -> Self {
+        if keys == 0 {
+            return Self::new();
+        }
         let slots = keys
             .saturating_mul(2)
             .next_power_of_two()
@@ -673,7 +693,7 @@ impl KeyHashes {
 
 impl Default for KeyHashes {
     fn default() -> Self {
-        Self::with_capacity(0)
+        Self::new()
     }
 }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -396,6 +396,19 @@ pub trait DocumentValue: Sized + Clone {
         self.as_str()
     }
 
+    /// This value's raw source bytes when it is a string key whose span
+    /// needs no decoding -- byte-identical to what
+    /// [`key_string`](Self::key_string) would return.
+    ///
+    /// Lets the duplicate-key probe hash a key without decoding it (#1514);
+    /// see `ascii_key_hash` for why that substitution is sound. Defaults to
+    /// `None`, which sends the caller to `key_string`. JSON overrides it for
+    /// an escape-free string span; YAML does not -- yq keeps every
+    /// occurrence, so no probe runs there at all.
+    fn key_raw_unescaped(&self) -> Option<&[u8]> {
+        None
+    }
+
     /// Try to get as object fields.
     fn as_object(&self) -> Option<Self::Fields>;
 
@@ -528,34 +541,40 @@ pub trait DocumentFields: Sized + Clone {
     }
 }
 
-/// A 64-bit hash of a key, for grouping candidates cheaply.
+/// A 64-bit hash of a key, and whether every byte of it was ASCII.
 ///
-/// Mixes eight bytes per multiply rather than one, then runs a
-/// splitmix64 finalizer so the low bits [`KeyHashes`] indexes on are as
-/// well distributed as the high ones. No dependency and no `HashMap`
-/// (this module is `no_std` + `alloc`), and deterministic across runs.
+/// Mixes eight bytes per multiply rather than one, then runs a splitmix64
+/// finalizer so the low bits [`KeyHashes`] indexes on are as well
+/// distributed as the high ones. No dependency and no `HashMap` (this
+/// module is `no_std` + `alloc`), and deterministic across runs.
 ///
 /// Hash quality only affects *speed* -- every routine below resolves a
 /// shared hash by comparing the keys themselves, so a collision costs
 /// work, never a wrong answer.
-pub fn key_hash(key: &[u8]) -> u64 {
+///
+/// The ASCII flag rides the same loop: `high` accumulates every word and
+/// one test at the end reads its `0x80` bits, so there is no branch per
+/// word. [`ascii_key_hash`] is what needs it.
+fn key_hash_checked(key: &[u8]) -> (u64, bool) {
     const PRIME: u64 = 0x9e37_79b9_7f4a_7c15;
+    const HIGH_BITS: u64 = 0x8080_8080_8080_8080;
     let mut acc = 0xcbf2_9ce4_8422_2325 ^ (key.len() as u64);
+    let mut high = 0u64;
     let mut chunks = key.chunks_exact(8);
     for chunk in &mut chunks {
-        let mut word = [0u8; 8];
-        word.copy_from_slice(chunk);
-        acc = (acc ^ u64::from_le_bytes(word))
-            .wrapping_mul(PRIME)
-            .rotate_left(31);
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(chunk);
+        let word = u64::from_le_bytes(bytes);
+        high |= word;
+        acc = (acc ^ word).wrapping_mul(PRIME).rotate_left(31);
     }
     let tail = chunks.remainder();
     if !tail.is_empty() {
-        let mut word = [0u8; 8];
-        word[..tail.len()].copy_from_slice(tail);
-        acc = (acc ^ u64::from_le_bytes(word))
-            .wrapping_mul(PRIME)
-            .rotate_left(31);
+        let mut bytes = [0u8; 8];
+        bytes[..tail.len()].copy_from_slice(tail);
+        let word = u64::from_le_bytes(bytes);
+        high |= word;
+        acc = (acc ^ word).wrapping_mul(PRIME).rotate_left(31);
     }
     // splitmix64 finalizer: without it the low bits carry too little of
     // the input, and `& mask` would cluster short keys into one run.
@@ -563,7 +582,50 @@ pub fn key_hash(key: &[u8]) -> u64 {
     acc = acc.wrapping_mul(0xff51_afd7_ed55_8ccd);
     acc ^= acc >> 33;
     acc = acc.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
-    acc ^ (acc >> 33)
+    (acc ^ (acc >> 33), high & HIGH_BITS == 0)
+}
+
+/// A 64-bit hash of a key, for grouping candidates cheaply.
+pub fn key_hash(key: &[u8]) -> u64 {
+    key_hash_checked(key).0
+}
+
+/// The hash of a key's *raw source span*, or `None` if the span is not
+/// pure ASCII.
+///
+/// A JSON key whose span carries no escape decodes to its own bytes, so
+/// hashing the span directly skips `JsonString::as_str`'s two extra scans
+/// (closing quote, then backslash) and its UTF-8 validation, plus the
+/// `Cow` around the result. On `wide/10mb` that decode is most of what the
+/// probe costs per key once the walk itself is gone (#1514).
+///
+/// The ASCII test is what makes the substitution *safe*, not just fast.
+/// Two guarantees have to hold, and ASCII gives both: an ASCII span is
+/// valid UTF-8, so [`DocumentValue::key_string`] would have answered
+/// `Some` with these exact bytes -- keeping the keyed/unkeyed split
+/// [`census`] counts on identical -- and equal decoded keys still hash
+/// equal, because a non-ASCII or escaped key takes the `key_string`
+/// fallback and can never decode to the same bytes as an ASCII span
+/// without being that span. It is free: [`key_hash_checked`] already
+/// computes it.
+fn ascii_key_hash(key: &[u8]) -> Option<u64> {
+    let (hash, ascii) = key_hash_checked(key);
+    ascii.then_some(hash)
+}
+
+/// The hash a field's key compares under, or `None` when the key does not
+/// stringify at all (a YAML alias or complex key, or a JSON escape that
+/// will not decode).
+///
+/// Prefers the raw span (see [`ascii_key_hash`]) and falls back to the
+/// decoded key, which is what every exact resolution downstream uses.
+fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, C>) -> Option<u64> {
+    if let Some(raw) = field.key.key_raw_unescaped() {
+        if let Some(hash) = ascii_key_hash(raw) {
+            return Some(hash);
+        }
+    }
+    field.key_str().map(|key| key_hash(key.as_bytes()))
 }
 
 /// An open-addressed set of key hashes: "has any key repeated?" in one
@@ -757,8 +819,8 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     let mut unkeyed = 0usize;
     let mut walk = fields.clone();
     while let Some((field, rest)) = walk.uncons() {
-        match field.key_str() {
-            Some(key) => hashes.push(key_hash(key.as_bytes())),
+        match field_key_hash(&field) {
+            Some(hash) => hashes.push(hash),
             None => unkeyed += 1,
         }
         walk = rest;
@@ -787,9 +849,14 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     let mut colliding: Vec<String> = Vec::new();
     let mut walk = fields.clone();
     while let Some((field, rest)) = walk.uncons() {
-        if let Some(key) = field.key_str() {
-            if shared.binary_search(&key_hash(key.as_bytes())).is_ok() {
-                colliding.push(key.into_owned());
+        // `field_key_hash` answers `Some` only for a key that stringifies,
+        // so the inner `key_str` is how the owned spelling is obtained
+        // here, not a second filter that could drop a counted field.
+        if let Some(hash) = field_key_hash(&field) {
+            if shared.binary_search(&hash).is_ok() {
+                if let Some(key) = field.key_str() {
+                    colliding.push(key.into_owned());
+                }
             }
         }
         walk = rest;
@@ -825,11 +892,9 @@ fn keys_repeat<V: DocumentValue, C: DocumentCursor>(fields: &[DocumentField<V, C
         return false;
     }
     let mut seen = KeyHashes::with_capacity(fields.len());
-    fields.iter().any(|field| {
-        field
-            .key_str()
-            .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
-    })
+    fields
+        .iter()
+        .any(|field| field_key_hash(field).is_some_and(|hash| seen.insert(hash)))
 }
 
 /// Apply the evaluation mode's duplicate-key rule to an object's fields.
@@ -940,11 +1005,10 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
         }
         let (field, tail) = self.rest.uncons()?;
         self.rest = tail;
-        let repeat = self.seen.as_mut().is_some_and(|seen| {
-            field
-                .key_str()
-                .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
-        });
+        let repeat = self
+            .seen
+            .as_mut()
+            .is_some_and(|seen| field_key_hash(&field).is_some_and(|hash| seen.insert(hash)));
         if repeat {
             match collapsed_fields(&self.all) {
                 Some(fields) => {
@@ -1206,5 +1270,46 @@ mod key_hash_tests {
         // Perfectly uniform is 256 per bucket; allow a wide margin so this
         // pins "not degenerate", not the exact hash function.
         assert!(lo > 150 && hi < 400, "buckets {buckets:?}");
+    }
+}
+
+#[cfg(test)]
+mod raw_key_hash_tests {
+    use super::{ascii_key_hash, key_hash};
+
+    /// The raw-span shortcut must agree with the decoded path exactly, or
+    /// two spellings of one key would land in different buckets and the
+    /// probe would miss a real duplicate.
+    #[test]
+    fn ascii_key_hash_agrees_with_key_hash_1514() {
+        for key in [
+            &b""[..],
+            b"a",
+            b"key",
+            b"exactly8",
+            b"nine_char",
+            b"a rather longer key than one word",
+            b"k1234567",
+        ] {
+            assert_eq!(
+                ascii_key_hash(key),
+                Some(key_hash(key)),
+                "{:?}",
+                core::str::from_utf8(key)
+            );
+        }
+    }
+
+    /// A non-ASCII span declines the shortcut, so the caller falls back to
+    /// the decoded key. Without this the keyed/unkeyed split `census`
+    /// counts on could shift on input a validating parser would reject.
+    #[test]
+    fn ascii_key_hash_declines_non_ascii_1514() {
+        assert_eq!(ascii_key_hash("café".as_bytes()), None);
+        assert_eq!(ascii_key_hash("日本".as_bytes()), None);
+        assert_eq!(ascii_key_hash(&[b'a', 0x80, b'b']), None);
+        // The high byte in the *tail* word, past the 8-byte stride, is the
+        // case a chunk-only check would miss.
+        assert_eq!(ascii_key_hash("aaaaaaaaé".as_bytes()), None);
     }
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -986,6 +986,20 @@ pub fn collapsed_fields<F: DocumentFields>(
     Some(collapse_repeated(fields.all_fields()))
 }
 
+/// [`collapsed_fields`], but skipped outright when the mode doesn't
+/// collapse (yq) -- the single guard the two positional `LazyKeys` arms
+/// (`Index`/`IndexNumber`, `Last`) both need before they can answer.
+pub fn collapsed_fields_if<F: DocumentFields>(
+    fields: &F,
+    collapse: bool,
+) -> Option<Vec<DocumentField<F::Value, F::Cursor>>> {
+    if collapse {
+        collapsed_fields(fields)
+    } else {
+        None
+    }
+}
+
 /// An object's key cursors under the mode's duplicate-key rule, produced
 /// one at a time (#1514).
 ///

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -870,8 +870,8 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     let mut hashes: Vec<u64> = Vec::new();
     let mut unkeyed = 0usize;
     let mut walk = fields.clone();
-    while let Some((field, rest)) = walk.uncons() {
-        match field_key_hash(&field) {
+    while let Some((key, _cursor, rest)) = walk.uncons_key() {
+        match key_hash_of(&key) {
             Some(hash) => hashes.push(hash),
             None => unkeyed += 1,
         }
@@ -890,17 +890,18 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     // A shared hash is nearly always a genuine repeat, but two different
     // keys can collide, and counting those as one would be wrong. Re-walk
     // owning *only* the colliding keys -- on an ordinary duplicate that is
-    // a handful of strings, not one per field.
+    // a handful of strings, not one per field. `uncons_key` (#1514), same
+    // as the first walk above: a census never looks at values.
     let mut colliding: Vec<String> = Vec::new();
     let mut walk = fields.clone();
-    while let Some((field, rest)) = walk.uncons() {
-        // `field_key_hash` answers `Some` only for a key that stringifies,
-        // so the inner `key_str` is how the owned spelling is obtained
+    while let Some((key, _cursor, rest)) = walk.uncons_key() {
+        // `key_hash_of` answers `Some` only for a key that stringifies,
+        // so the inner `key_string` is how the owned spelling is obtained
         // here, not a second filter that could drop a counted field.
-        if let Some(hash) = field_key_hash(&field) {
+        if let Some(hash) = key_hash_of(&key) {
             if shared.binary_search(&hash).is_ok() {
-                if let Some(key) = field.key_str() {
-                    colliding.push(key.into_owned());
+                if let Some(k) = key.key_string() {
+                    colliding.push(k.into_owned());
                 }
             }
         }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1012,14 +1012,15 @@ pub fn collapsed_fields_if<F: DocumentFields>(
 /// full cons-list walk, and `uncons` is two BP sibling hops per field.
 ///
 /// The [`KeyHashes`] probe rides along with the walk. A repeated hash hands
-/// the object to [`collapsed_fields`], which decides on the keys
+/// the object to `collapse_confirmed_repeat`, which decides on the keys
 /// themselves:
 ///
-/// - `Some` — a real duplicate. The remainder switches to the exact
-///   collapsed list, resuming at the count already yielded, which lines up
-///   because the collapsed list opens with those same first occurrences.
-/// - `None` — a 64-bit hash collision, and the answer covers the whole
-///   object, so the probe retires rather than firing again at the next one.
+/// - A genuine collapse — the remainder switches to the exact collapsed
+///   list, resuming at the count already yielded, which lines up because
+///   the collapsed list opens with those same first occurrences.
+/// - A 64-bit hash collision, no real duplicate — the answer covers the
+///   whole object, so the probe retires rather than firing again at the
+///   next one.
 ///
 /// `collapse` false (yq) carries no probe state at all and is the plain
 /// cons-list walk it always was.
@@ -1035,8 +1036,10 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     seen: Option<KeyHashes>,
     /// How many cursors have gone out, which is where `collapsed` resumes.
     yielded: usize,
-    /// The exact collapsed fields, once a repeat is confirmed.
-    collapsed: Option<Vec<DocumentField<F::Value, F::Cursor>>>,
+    /// The exact collapsed key list, once a repeat is confirmed. Key and
+    /// cursor only -- this iterator never reads a field's value, so
+    /// `collapse_confirmed_repeat` never materializes one (#1514 review).
+    collapsed: Option<Vec<(F::Value, F::Cursor)>>,
 }
 
 impl<F: DocumentFields> DistinctKeyCursors<F> {
@@ -1061,9 +1064,9 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(collapsed) = &self.collapsed {
-            let field = collapsed.get(self.yielded)?;
+            let (key, cursor) = collapsed.get(self.yielded)?;
             self.yielded += 1;
-            return Some((field.key.clone(), field.key_cursor));
+            return Some((key.clone(), *cursor));
         }
         let (key, key_cursor, tail) = self.rest.uncons_key()?;
         self.rest = tail;
@@ -1072,21 +1075,66 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
             .as_mut()
             .is_some_and(|seen| key_hash_of(&key).is_some_and(|hash| seen.insert(hash)));
         if repeat {
-            match collapsed_fields(&self.all) {
-                Some(fields) => {
-                    self.collapsed = Some(fields);
-                    self.seen = None;
-                    // Resumes at `yielded`, which the collapsed list's own
-                    // prefix matches: every key emitted so far was a first
-                    // occurrence, and collapsing keeps those in place.
-                    return self.next();
-                }
-                None => self.seen = None,
+            let (collapsed, total) = collapse_confirmed_repeat(&self.all);
+            if collapsed.len() < total {
+                self.collapsed = Some(collapsed);
+                self.seen = None;
+                // Resumes at `yielded`, which the collapsed list's own
+                // prefix matches: every key emitted so far was a first
+                // occurrence, and collapsing keeps those in place.
+                return self.next();
             }
+            // A 64-bit hash collision, not a real duplicate: nothing
+            // collapsed, so the answer covers the whole object and the
+            // probe retires rather than firing again at the next one.
+            self.seen = None;
         }
         self.yielded += 1;
         Some((key, key_cursor))
     }
+}
+
+/// The exact collapsed key list for an object [`DistinctKeyCursors`] has
+/// already flagged as a probable repeat via its hash probe.
+///
+/// Unlike [`collapsed_fields`] (used by the `.[] | map` collapse path in
+/// `eval_generic.rs`, which needs `value_cursor` too), this never
+/// materializes a field's value -- `DistinctKeyCursors` only ever reads the
+/// key -- and it skips `collapsed_fields`'s own [`census`] pre-check
+/// entirely: the caller already knows a repeat is likely, so re-deriving
+/// "is this object actually repeated?" first is redundant work whose answer
+/// this caller doesn't need. A genuine hash collision (no real repeat)
+/// still resolves correctly here -- the caller sees `collapsed.len() ==
+/// total` in that case, exactly what `census`'s own exact check would have
+/// reported, just discovered post hoc instead of as a separate pass.
+///
+/// This turns the up-to-three full-object walks `collapsed_fields` +
+/// `census` would otherwise run (hash-collect, conditional exact-collision
+/// narrowing, then a value-materializing `all_fields()` walk) into one
+/// key-only walk (#1514 review).
+#[allow(clippy::type_complexity)] // STYLE-0004: (key, cursor) list plus a walked-field count; the nested tuple is intentional
+fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> (Vec<(F::Value, F::Cursor)>, usize) {
+    let mut slot_of: IndexMap<String, usize> = IndexMap::new();
+    let mut out: Vec<(F::Value, F::Cursor)> = Vec::new();
+    let mut total = 0usize;
+    let mut walk = fields.clone();
+    while let Some((key, key_cursor, rest)) = walk.uncons_key() {
+        total += 1;
+        match key.key_string().map(Cow::into_owned) {
+            Some(k) => match slot_of.get(&k) {
+                Some(&slot) => out[slot] = (key, key_cursor),
+                None => {
+                    slot_of.insert(k, out.len());
+                    out.push((key, key_cursor));
+                }
+            },
+            // Same "no name to collapse on, keep it where it stands"
+            // handling as `collapse_repeated` (#1385 review).
+            None => out.push((key, key_cursor)),
+        }
+        walk = rest;
+    }
+    (out, total)
 }
 
 /// Collapse fields known to contain at least one repeated key.

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -650,19 +650,21 @@ fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, 
     key_hash_of(&field.key)
 }
 
-/// An open-addressed set of key hashes: "has any key repeated?" in one
-/// pass, no sort, no key text kept.
+/// An open-addressed set of key hashes: "have I seen this one?" answered
+/// as a walk goes, without holding the keys.
 ///
-/// This replaces the sort-then-scan shape #1385 shipped (#1514). Sorting
-/// is O(n log n) with a comparison per step; on a wide object it dominated
-/// the walk it was guarding -- and the printer's variant sorted *byte
-/// slices*, chasing a pointer into a random offset of the document on
-/// every comparison. Probing costs one hash and about 1.5 slot reads per
-/// key, and the slots are one contiguous array.
+/// **Only for a caller that cannot sort.** Every batch site here hashes
+/// into a `Vec<u64>` and sorts instead, because a sort streams and a table
+/// does not: at 7.1M keys the table is 134 MB, and on a 7950X -- 32 MB of
+/// L3 per CCD -- that cost 24% on the identity path where the sort cost
+/// nothing. An M4 Pro absorbed it and preferred the table, which is the
+/// architecture split CLAUDE.md warns memory-bound results carry. The one
+/// caller that keeps it is [`DistinctKeyCursors`], which must answer per
+/// key as it streams and has nothing to sort yet.
 ///
 /// The table holds hashes only -- 8 bytes per slot, never a key -- so it
-/// stays a fraction of what materializing the fields would cost, and it
-/// can grow by rehashing what it already has.
+/// can grow by rehashing what it already has, which is what a streaming
+/// caller with no count up front needs.
 ///
 /// [`insert`](Self::insert) is deliberately **conservative**: it reports a
 /// repeat when two keys merely share a 64-bit hash, which for distinct
@@ -781,6 +783,34 @@ impl Default for KeyHashes {
     }
 }
 
+/// The sorted, deduplicated hashes that occur more than once in `sorted`,
+/// plus how many distinct hash values it holds in total.
+///
+/// `sorted` must already be sorted ascending; the returned list is too, so
+/// callers can `binary_search` it.
+fn shared_hashes(sorted: &[u64]) -> (Vec<u64>, usize) {
+    let mut shared = Vec::new();
+    let mut distinct = 0usize;
+    let mut i = 0usize;
+    while i < sorted.len() {
+        let mut j = i + 1;
+        while j < sorted.len() && sorted[j] == sorted[i] {
+            j += 1;
+        }
+        distinct += 1;
+        if j - i > 1 {
+            shared.push(sorted[i]);
+        }
+        i = j;
+    }
+    (shared, distinct)
+}
+
+/// Whether an already-sorted hash list holds the same value twice.
+fn hashes_repeat(sorted: &[u64]) -> bool {
+    sorted.windows(2).any(|pair| pair[0] == pair[1])
+}
+
 /// Number of distinct values in an already-sorted slice, and whether any
 /// value occurs more than once.
 fn distinct_sorted(sorted: &[String]) -> (usize, bool) {
@@ -847,22 +877,15 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
         }
         walk = rest;
     }
-    let mut seen = KeyHashes::with_capacity(hashes.len());
-    let mut shared: Vec<u64> = Vec::new();
-    for hash in hashes {
-        if seen.insert(hash) {
-            shared.push(hash);
-        }
-    }
+    hashes.sort_unstable();
+    let (shared, distinct_hashes) = shared_hashes(&hashes);
     if shared.is_empty() {
         return KeyCensus {
-            distinct: seen.len(),
+            distinct: distinct_hashes,
             unkeyed,
             repeated: false,
         };
     }
-    shared.sort_unstable();
-    shared.dedup();
 
     // A shared hash is nearly always a genuine repeat, but two different
     // keys can collide, and counting those as one would be wrong. Re-walk
@@ -886,10 +909,10 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     colliding.sort_unstable();
     let (distinct_colliding, repeated) = distinct_sorted(&colliding);
     KeyCensus {
-        // `seen.len()` counts distinct *hashes*; every colliding group
-        // contributed exactly one of them, so swap each group's single
-        // hash for however many distinct keys it actually held.
-        distinct: seen.len() - shared.len() + distinct_colliding,
+        // `distinct_hashes` counts distinct *hashes*; every colliding
+        // group contributed exactly one of them, so swap each group's
+        // single hash for however many distinct keys it actually held.
+        distinct: distinct_hashes - shared.len() + distinct_colliding,
         unkeyed,
         repeated,
     }
@@ -913,10 +936,9 @@ fn keys_repeat<V: DocumentValue, C: DocumentCursor>(fields: &[DocumentField<V, C
     if fields.len() < 2 {
         return false;
     }
-    let mut seen = KeyHashes::with_capacity(fields.len());
-    fields
-        .iter()
-        .any(|field| field_key_hash(field).is_some_and(|hash| seen.insert(hash)))
+    let mut hashes: Vec<u64> = fields.iter().filter_map(field_key_hash).collect();
+    hashes.sort_unstable();
+    hashes_repeat(&hashes)
 }
 
 /// Apply the evaluation mode's duplicate-key rule to an object's fields.
@@ -1110,11 +1132,9 @@ pub fn effective_keys<F: DocumentFields>(fields: &F, collapse: bool) -> Vec<Stri
     if !collapse {
         return keys;
     }
-    let mut probe = KeyHashes::with_capacity(keys.len());
-    if !keys
-        .iter()
-        .any(|key| probe.insert(key_hash(key.as_bytes())))
-    {
+    let mut hashes: Vec<u64> = keys.iter().map(|key| key_hash(key.as_bytes())).collect();
+    hashes.sort_unstable();
+    if !hashes_repeat(&hashes) {
         return keys;
     }
     let mut seen: IndexSet<String> = IndexSet::with_capacity(keys.len());

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -500,6 +500,23 @@ pub trait DocumentFields: Sized + Clone {
     /// Check if there are no fields.
     fn is_empty(&self) -> bool;
 
+    /// Walk one field, materializing only its key.
+    ///
+    /// [`uncons`](Self::uncons) builds a whole [`DocumentField`], which
+    /// means constructing the field's *value* as well -- wasted for a
+    /// caller that only ever looks at keys, and not cheap. Routing the
+    /// `keys_unsorted` writer through `uncons` rather than a key-only walk
+    /// measured **+89% at 10 MB and +100% at 100 MB** on a wide object
+    /// with duplicate detection switched off entirely (#1514) -- it was the
+    /// whole of that path's cost, dwarfing the detector it was carrying.
+    ///
+    /// The default delegates to `uncons`, so a format pays nothing to
+    /// ignore it; JSON overrides it.
+    fn uncons_key(&self) -> Option<(Self::Value, Self::Cursor, Self)> {
+        let (field, rest) = self.uncons()?;
+        Some((field.key, field.key_cursor, rest))
+    }
+
     /// Walk every field, keeping every occurrence of a repeated key in
     /// document order.
     ///
@@ -619,13 +636,18 @@ fn ascii_key_hash(key: &[u8]) -> Option<u64> {
 ///
 /// Prefers the raw span (see [`ascii_key_hash`]) and falls back to the
 /// decoded key, which is what every exact resolution downstream uses.
-fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, C>) -> Option<u64> {
-    if let Some(raw) = field.key.key_raw_unescaped() {
+fn key_hash_of<V: DocumentValue>(key: &V) -> Option<u64> {
+    if let Some(raw) = key.key_raw_unescaped() {
         if let Some(hash) = ascii_key_hash(raw) {
             return Some(hash);
         }
     }
-    field.key_str().map(|key| key_hash(key.as_bytes()))
+    key.key_string().map(|key| key_hash(key.as_bytes()))
+}
+
+/// [`key_hash_of`] for a caller holding a whole field.
+fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, C>) -> Option<u64> {
+    key_hash_of(&field.key)
 }
 
 /// An open-addressed set of key hashes: "has any key repeated?" in one
@@ -976,8 +998,8 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     seen: Option<KeyHashes>,
     /// How many cursors have gone out, which is where `collapsed` resumes.
     yielded: usize,
-    /// The exact collapsed key cursors, once a repeat is confirmed.
-    collapsed: Option<Vec<F::Cursor>>,
+    /// The exact collapsed fields, once a repeat is confirmed.
+    collapsed: Option<Vec<DocumentField<F::Value, F::Cursor>>>,
 }
 
 impl<F: DocumentFields> DistinctKeyCursors<F> {
@@ -995,37 +1017,38 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
 }
 
 impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
-    type Item = F::Cursor;
+    /// The key *and* a cursor to it. Both, because every consumer wants
+    /// the key itself, and re-deriving it from the cursor materializes a
+    /// second time what the walk has already built (#1514).
+    type Item = (F::Value, F::Cursor);
 
-    fn next(&mut self) -> Option<F::Cursor> {
-        if let Some(cursors) = &self.collapsed {
-            let cursor = cursors.get(self.yielded).copied()?;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(collapsed) = &self.collapsed {
+            let field = collapsed.get(self.yielded)?;
             self.yielded += 1;
-            return Some(cursor);
+            return Some((field.key.clone(), field.key_cursor));
         }
-        let (field, tail) = self.rest.uncons()?;
+        let (key, key_cursor, tail) = self.rest.uncons_key()?;
         self.rest = tail;
         let repeat = self
             .seen
             .as_mut()
-            .is_some_and(|seen| field_key_hash(&field).is_some_and(|hash| seen.insert(hash)));
+            .is_some_and(|seen| key_hash_of(&key).is_some_and(|hash| seen.insert(hash)));
         if repeat {
             match collapsed_fields(&self.all) {
                 Some(fields) => {
-                    let cursors: Vec<F::Cursor> =
-                        fields.into_iter().map(|f| f.key_cursor).collect();
-                    let cursor = cursors.get(self.yielded).copied();
-                    self.collapsed = Some(cursors);
+                    self.collapsed = Some(fields);
                     self.seen = None;
-                    let cursor = cursor?;
-                    self.yielded += 1;
-                    return Some(cursor);
+                    // Resumes at `yielded`, which the collapsed list's own
+                    // prefix matches: every key emitted so far was a first
+                    // occurrence, and collapsing keeps those in place.
+                    return self.next();
                 }
                 None => self.seen = None,
             }
         }
         self.yielded += 1;
-        Some(field.key_cursor)
+        Some((key, key_cursor))
     }
 }
 
@@ -1102,6 +1125,7 @@ pub fn effective_keys<F: DocumentFields>(fields: &F, collapse: bool) -> Vec<Stri
 }
 
 /// A single field from an object.
+#[derive(Clone)]
 pub struct DocumentField<V, C> {
     /// The field key.
     pub key: V,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1927,7 +1927,7 @@ impl<V: DocumentValue> GenericResult<V> {
                     // `Builtin::KeysUnsorted`. `sort_keys` (`-S`) is a no-op
                     // here: this is a flat array of key names, not a
                     // mapping, so there's nothing for `-S` to reorder.
-                    crate::jq::stream::stream_lazy_keys_json(fields, out, indent)?;
+                    crate::jq::stream::stream_lazy_keys_json(fields, *collapse, out, indent)?;
                 }
                 on_value(out)?;
                 stats.count = 1;
@@ -2131,7 +2131,7 @@ impl<V: DocumentValue> GenericResult<V> {
                 } else {
                     // Genuinely lazy (#685): see `stream_json`'s
                     // `LazyKeys` arm above — same reasoning, YAML target.
-                    crate::jq::stream::stream_lazy_keys_yaml(fields, out, indent)?;
+                    crate::jq::stream::stream_lazy_keys_yaml(fields, *collapse, out, indent)?;
                 }
                 on_value(out)?;
                 stats.count = 1;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5,8 +5,6 @@
 //! JSON and YAML without intermediate conversion.
 
 #[cfg(not(test))]
-use alloc::borrow::Cow;
-#[cfg(not(test))]
 use alloc::boxed::Box;
 #[cfg(not(test))]
 use alloc::format;
@@ -19,15 +17,13 @@ use alloc::vec;
 #[cfg(not(test))]
 use alloc::vec::Vec;
 #[cfg(test)]
-use std::borrow::Cow;
-#[cfg(test)]
 use std::rc::Rc;
 
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, effective_fields, effective_keys, effective_len, DocumentCursor,
-    DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
+    collapsed_fields, effective_fields, effective_keys, effective_len, key_hash, DocumentCursor,
+    DocumentElements, DocumentFields, DocumentValue, IndentSpec, KeyHashes,
 };
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, eval_each_owned, format_owned,
@@ -687,74 +683,45 @@ fn materialize_lazy_keys<V: DocumentValue>(
     OwnedValue::Array(keys.into_iter().map(OwnedValue::String).collect())
 }
 
-/// The `LazyKeys` `Pipe` fast-path arms, over an object whose repeated keys
-/// have already been collapsed (#1385).
+/// An object's key cursors in document order, with a repeated key dropped
+/// after its first occurrence when the mode collapses (#1514).
 ///
-/// Mirrors the cons-list arms in `eval_single`'s `LazyKeys` dispatch
-/// one-for-one, reading from the collapsed field list instead of walking
-/// `V::Fields`. It is reached only when the object genuinely carries a
-/// duplicate, so allocating here costs nothing on ordinary documents.
+/// One walk. The [`KeyHashes`] probe rides along with the walk that was
+/// happening anyway, so a duplicate-free object -- the overwhelmingly
+/// common case -- pays one hash per key and nothing else. Before this the
+/// caller ran a whole separate `document::census` first, then walked again
+/// to build this list.
 ///
-/// `map` has no collapsed counterpart -- `LazySource::Keys` holds a
-/// `V::Fields`, not a slice -- so it joins the materializing fallback rather
-/// than staying lazy. That trades #724's laziness for correctness on an
-/// input that cannot use it anyway.
-///
-/// The empty-`fields` arms below are unreachable rather than dead: this
-/// function is only called once `collapsed_fields` has answered `Some`,
-/// which needs a key to have repeated, which needs at least two fields.
-/// They cannot be deleted -- `Vec::into_iter().next()` is an `Option`, and
-/// the cons-list arms they mirror do have to handle an empty object.
-fn lazy_keys_collapsed<S: EvalSemantics, V: DocumentValue>(
-    expr: &Expr,
-    fields: Vec<DocumentField<V, V::Cursor>>,
-    sorted: bool,
-    optional: bool,
-) -> GenericResult<V> {
-    match unwrap_paren(expr) {
-        Expr::Builtin(Builtin::Length) => {
-            GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
-        }
-        Expr::Iterate if !sorted => {
-            let cursors: Vec<V::Cursor> = fields.into_iter().map(|f| f.key_cursor).collect();
-            if cursors.is_empty() {
-                GenericResult::None
-            } else {
-                GenericResult::ManyCursor(cursors)
-            }
-        }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
-            let target = if *idx < 0 {
-                let normalized = fields.len() as i64 + idx;
-                usize::try_from(normalized).ok()
-            } else {
-                Some(*idx as usize)
+/// A repeated hash abandons the walk and settles the object exactly through
+/// `collapsed_fields`, which decides on the keys themselves. That costs one
+/// extra pass on an object that genuinely repeats a key -- and on the
+/// 1-in-2^64 collision that only looks like one, where `collapsed_fields`
+/// answers `None` and the plain walk is the right answer after all.
+fn distinct_key_cursors<V: DocumentValue>(fields: &V::Fields, collapse: bool) -> Vec<V::Cursor> {
+    let mut cursors = Vec::new();
+    let mut seen = KeyHashes::new();
+    let mut walk = fields.clone();
+    while let Some((field, rest)) = walk.uncons() {
+        if collapse
+            && field
+                .key_str()
+                .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
+        {
+            return match collapsed_fields(fields) {
+                Some(collapsed) => collapsed.into_iter().map(|f| f.key_cursor).collect(),
+                // A hash collision, not a duplicate: no key repeats
+                // anywhere in the object, so the plain walk is correct.
+                None => fields
+                    .all_fields()
+                    .into_iter()
+                    .map(|f| f.key_cursor)
+                    .collect(),
             };
-            match target.and_then(|t| fields.into_iter().nth(t)) {
-                Some(field) => GenericResult::OneCursor(field.key_cursor),
-                None => GenericResult::Owned(OwnedValue::Null),
-            }
         }
-        Expr::Builtin(Builtin::First) if !sorted => match fields.into_iter().next() {
-            Some(field) => GenericResult::OneCursor(field.key_cursor),
-            None => GenericResult::Owned(OwnedValue::Null),
-        },
-        Expr::Builtin(Builtin::Last) if !sorted => match fields.into_iter().next_back() {
-            Some(field) => GenericResult::OneCursor(field.key_cursor),
-            None => GenericResult::Owned(OwnedValue::Null),
-        },
-        _ => {
-            let mut keys: Vec<String> = fields
-                .iter()
-                .filter_map(|f| f.key_str().map(Cow::into_owned))
-                .collect();
-            if sorted {
-                keys.sort();
-            }
-            let owned = OwnedValue::Array(keys.into_iter().map(OwnedValue::String).collect());
-            eval_on_owned::<S, _>(expr, owned, optional)
-        }
+        cursors.push(field.key_cursor);
+        walk = rest;
     }
+    cursors
 }
 
 /// Materialize a `GenericResult::LazyIndexRange` fallback: build the
@@ -818,7 +785,30 @@ enum LazySource<V: DocumentValue> {
     /// Bare `obj | map(f)` (#725).
     Values(V::Fields),
     /// `keys_unsorted | map(f)` (#724).
-    Keys(V::Fields),
+    ///
+    /// Carries the mode's duplicate-key rule into the pull itself (#1514)
+    /// instead of probing the whole object before the first element is
+    /// asked for. "First occurrence wins" is an *online* rule: every key
+    /// already emitted was a first occurrence, so a repeat discovered
+    /// later means "skip this one" and never invalidates what went out.
+    Keys {
+        /// The fields still to pull from.
+        rest: V::Fields,
+        /// The object as a whole, kept only for the exact resolution in
+        /// `advance` -- `V::Fields` is a cursor position, so this is a
+        /// copy of two machine words, not of the object.
+        all: V::Fields,
+        /// Hashes of the keys emitted so far, in jq mode. `None` in yq
+        /// mode, where every occurrence is kept, and `None` again once
+        /// the object has been *proved* free of duplicates.
+        seen: Option<KeyHashes>,
+        /// How many elements have gone out, which is where `collapsed`
+        /// resumes.
+        emitted: usize,
+        /// Set once a repeat is confirmed: the exact collapsed key
+        /// cursors, which the pull reads from for the remainder.
+        collapsed: Option<Vec<V::Cursor>>,
+    },
     /// Array `keys_unsorted | map(f)` (#724) — synthetic `[0, 1, ..., len-1]`,
     /// no cursor to point at.
     IndexRange { next: usize, len: usize },
@@ -843,7 +833,7 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
         match self {
             Self::Elements(_) => f.write_str("LazySource::Elements(..)"),
             Self::Values(_) => f.write_str("LazySource::Values(..)"),
-            Self::Keys(_) => f.write_str("LazySource::Keys(..)"),
+            Self::Keys { .. } => f.write_str("LazySource::Keys(..)"),
             Self::IndexRange { next, len } => f
                 .debug_struct("LazySource::IndexRange")
                 .field("next", next)
@@ -859,6 +849,21 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
 }
 
 impl<V: DocumentValue> LazySource<V> {
+    /// A `keys_unsorted` source that honours the mode's duplicate-key
+    /// rule as it pulls (#1514).
+    ///
+    /// `collapse` false -- yq -- keeps every occurrence, so no probe state
+    /// is carried at all and the pull is the plain cons-list walk it was.
+    fn keys(fields: V::Fields, collapse: bool) -> Self {
+        Self::Keys {
+            rest: fields.clone(),
+            all: fields,
+            seen: collapse.then(KeyHashes::new),
+            emitted: 0,
+            collapsed: None,
+        }
+    }
+
     /// Pull one element forward, storing "the rest" back into `self`. Once a
     /// variant's underlying cons-list is empty (or `next == len`), every
     /// subsequent call returns `None` forever.
@@ -874,9 +879,49 @@ impl<V: DocumentValue> LazySource<V> {
                 *fields = rest;
                 Some(LazyElem::Cursor(field.value_cursor))
             }
-            Self::Keys(fields) => {
-                let (field, rest) = fields.uncons()?;
-                *fields = rest;
+            Self::Keys {
+                rest,
+                all,
+                seen,
+                emitted,
+                collapsed,
+            } => {
+                if let Some(cursors) = collapsed {
+                    let cursor = cursors.get(*emitted).copied()?;
+                    *emitted += 1;
+                    return Some(LazyElem::Cursor(cursor));
+                }
+                let (field, tail) = rest.uncons()?;
+                *rest = tail;
+                let repeat = seen.as_mut().is_some_and(|seen| {
+                    field
+                        .key_str()
+                        .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
+                });
+                if repeat {
+                    // Settle it on the keys themselves. `collapsed_fields`
+                    // answers `None` when nothing actually repeats -- a
+                    // 64-bit hash collision -- and that answer covers the
+                    // whole object, so the probe is dropped for good
+                    // rather than re-run at the next collision.
+                    match collapsed_fields(all) {
+                        Some(fields) => {
+                            let cursors: Vec<V::Cursor> =
+                                fields.into_iter().map(|f| f.key_cursor).collect();
+                            // The collapsed list opens with the same
+                            // first occurrences already emitted, so the
+                            // remainder resumes at `emitted`.
+                            let cursor = cursors.get(*emitted).copied();
+                            *collapsed = Some(cursors);
+                            *seen = None;
+                            let cursor = cursor?;
+                            *emitted += 1;
+                            return Some(LazyElem::Cursor(cursor));
+                        }
+                        None => *seen = None,
+                    }
+                }
+                *emitted += 1;
                 Some(LazyElem::Cursor(field.key_cursor))
             }
             Self::IndexRange { next, len } => {
@@ -2688,118 +2733,153 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     optional: bool,
 ) -> GenericResult<V> {
-    match if collapse {
-        // #1385: in jq mode a repeated key collapses, so
-        // these count- and order-sensitive arms cannot
-        // answer from the raw walk -- the collapsed object
-        // has fewer members, and `.[n]`/`last` land
-        // elsewhere. Probe once: an object with no repeat
-        // (the common case) keeps the zero-allocation
-        // cons-list arms below exactly as they were, and in
-        // yq mode `collapse` is a `false` const, so the
-        // probe itself compiles away.
-        collapsed_fields(&fields)
-    } else {
-        None
-    } {
-        Some(eff) => lazy_keys_collapsed::<S, V>(expr, eff, sorted, optional),
-        None => match unwrap_paren(expr) {
-            // Order-independent for both `keys` and
-            // `keys_unsorted` — the one fast path #683 adds for
-            // sorted `keys`.
-            Expr::Builtin(Builtin::Length) => {
-                GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
+    match unwrap_paren(expr) {
+        // #1514: the collapse probe used to run in guard
+        // position, ahead of this match, so every arm paid a
+        // full `document::census` -- including the ones that
+        // never needed the answer (`first`, and the
+        // materializing fallback, which applies the rule
+        // itself through `effective_keys`) and the ones that
+        // can settle it during a walk they were making
+        // anyway. It now runs only where the answer is read
+        // *positionally*, which is the only shape that cannot
+        // be decided as the walk goes.
+        //
+        // Order-independent for both `keys` and
+        // `keys_unsorted` — the one fast path #683 adds for
+        // sorted `keys`. `effective_len` counts distinct keys
+        // in one walk without materializing the field list,
+        // and is `fields.len()` outright when `collapse` is
+        // false.
+        Expr::Builtin(Builtin::Length) => {
+            GenericResult::Owned(OwnedValue::Int(effective_len(&fields, collapse) as i64))
+        }
+        // Document order is a valid answer only for
+        // `keys_unsorted`. `keys` needs lexicographic order
+        // for these and falls through to the shared
+        // materialize-(and-sort) fallback below. Do not drop
+        // the `if !sorted` guard on a new arm here without
+        // re-deriving why document order would still be a
+        // correct answer.
+        Expr::Iterate if !sorted => {
+            let cursors = distinct_key_cursors::<V>(&fields, collapse);
+            if cursors.is_empty() {
+                GenericResult::None
+            } else {
+                GenericResult::ManyCursor(cursors)
             }
-            // Document order is a valid answer only for
-            // `keys_unsorted`. `keys` needs lexicographic order
-            // for these and falls through to the shared
-            // materialize-(and-sort) fallback below. Do not drop
-            // the `if !sorted` guard on a new arm here without
-            // re-deriving why document order would still be a
-            // correct answer.
-            Expr::Iterate if !sorted => {
-                let mut cursors = Vec::new();
-                let mut current = fields;
-                while let Some((field, rest)) = current.uncons() {
-                    cursors.push(field.key_cursor);
-                    current = rest;
-                }
-                if cursors.is_empty() {
-                    GenericResult::None
-                } else {
-                    GenericResult::ManyCursor(cursors)
-                }
-            }
-            Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
-                // Negative indices need the length to normalize
-                // against, same as `Expr::Index`'s array arm
-                // above; positive indices skip straight to the
-                // walk. Out-of-bounds is `null`, never an error
-                // (#307), matching that same arm.
+        }
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
+            // Positional: a collapsed object has fewer
+            // members, so `.[n]` lands elsewhere. This is one
+            // of the two arms that still has to know the
+            // whole answer before it can pick an element.
+            //
+            // Negative indices need the length to normalize
+            // against, same as `Expr::Index`'s array arm
+            // above; positive indices skip straight to the
+            // walk. Out-of-bounds is `null`, never an error
+            // (#307), matching that same arm.
+            let collapsed = if collapse {
+                collapsed_fields(&fields)
+            } else {
+                None
+            };
+            if let Some(eff) = collapsed {
                 let target = if *idx < 0 {
-                    let len = fields.len();
-                    let normalized = len as i64 + idx;
-                    if normalized < 0 {
-                        None
-                    } else {
-                        Some(normalized as usize)
-                    }
+                    usize::try_from(eff.len() as i64 + idx).ok()
                 } else {
                     Some(*idx as usize)
                 };
-                match target {
-                    Some(target) => {
-                        let mut current = fields;
-                        let mut found = None;
-                        let mut i = 0usize;
-                        while let Some((field, rest)) = current.uncons() {
-                            if i == target {
-                                found = Some(field.key_cursor);
-                                break;
-                            }
-                            current = rest;
-                            i += 1;
+                return match target.and_then(|t| eff.into_iter().nth(t)) {
+                    Some(field) => GenericResult::OneCursor(field.key_cursor),
+                    None => GenericResult::Owned(OwnedValue::Null),
+                };
+            }
+            let target = if *idx < 0 {
+                let len = fields.len();
+                let normalized = len as i64 + idx;
+                if normalized < 0 {
+                    None
+                } else {
+                    Some(normalized as usize)
+                }
+            } else {
+                Some(*idx as usize)
+            };
+            match target {
+                Some(target) => {
+                    let mut current = fields;
+                    let mut found = None;
+                    let mut i = 0usize;
+                    while let Some((field, rest)) = current.uncons() {
+                        if i == target {
+                            found = Some(field.key_cursor);
+                            break;
                         }
-                        match found {
-                            Some(c) => GenericResult::OneCursor(c),
-                            None => GenericResult::Owned(OwnedValue::Null),
-                        }
+                        current = rest;
+                        i += 1;
                     }
-                    None => GenericResult::Owned(OwnedValue::Null),
+                    match found {
+                        Some(c) => GenericResult::OneCursor(c),
+                        None => GenericResult::Owned(OwnedValue::Null),
+                    }
                 }
-            }
-            Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
-                Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
                 None => GenericResult::Owned(OwnedValue::Null),
-            },
-            Expr::Builtin(Builtin::Last) if !sorted => {
-                let mut current = fields;
-                let mut last_cursor = None;
-                while let Some((field, rest)) = current.uncons() {
-                    last_cursor = Some(field.key_cursor);
-                    current = rest;
-                }
-                match last_cursor {
-                    Some(c) => GenericResult::OneCursor(c),
-                    None => GenericResult::Owned(OwnedValue::Null),
-                }
             }
-            // Slice 1 (#724): stay lazy instead of falling
-            // through to the `_` materializing fallback below —
-            // reuses the composability arm (`GenericResult::LazySeq`
-            // below) for everything past this first `map` stage.
-            // Same `!sorted` guard as the other fast-path arms
-            // above: sorted `keys` still needs a full decode+sort
-            // first.
-            Expr::Builtin(Builtin::Map(f)) if !sorted => {
-                GenericResult::LazySeq(LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG))
-            }
-            _ => eval_on_owned::<S, _>(
-                expr,
-                materialize_lazy_keys::<V>(&fields, sorted, collapse),
-                optional,
-            ),
+        }
+        // No probe: collapsing keeps every key at its *first*
+        // position, and the first field is nobody's repeat, so
+        // it survives whatever the rest of the object does.
+        Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
+            Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
+            None => GenericResult::Owned(OwnedValue::Null),
         },
+        // The other positional arm: the last field *is*
+        // droppable — if its key repeats an earlier one it
+        // collapses away and some other field ends up last.
+        Expr::Builtin(Builtin::Last) if !sorted => {
+            let collapsed = if collapse {
+                collapsed_fields(&fields)
+            } else {
+                None
+            };
+            if let Some(eff) = collapsed {
+                return match eff.into_iter().next_back() {
+                    Some(field) => GenericResult::OneCursor(field.key_cursor),
+                    None => GenericResult::Owned(OwnedValue::Null),
+                };
+            }
+            let mut current = fields;
+            let mut last_cursor = None;
+            while let Some((field, rest)) = current.uncons() {
+                last_cursor = Some(field.key_cursor);
+                current = rest;
+            }
+            match last_cursor {
+                Some(c) => GenericResult::OneCursor(c),
+                None => GenericResult::Owned(OwnedValue::Null),
+            }
+        }
+        // Slice 1 (#724): stay lazy instead of falling
+        // through to the `_` materializing fallback below —
+        // reuses the composability arm (`GenericResult::LazySeq`
+        // below) for everything past this first `map` stage.
+        // Same `!sorted` guard as the other fast-path arms
+        // above: sorted `keys` still needs a full decode+sort
+        // first. `LazySource::keys` carries the collapse rule
+        // into the pull itself (#1514), so no probe runs here
+        // either.
+        Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
+            LazySeq::new(LazySource::keys(fields, collapse)).push_map(f, S::TAG),
+        ),
+        // No probe: `materialize_lazy_keys` applies the
+        // collapse rule itself, through `effective_keys`.
+        _ => eval_on_owned::<S, _>(
+            expr,
+            materialize_lazy_keys::<V>(&fields, sorted, collapse),
+            optional,
+        ),
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -691,7 +691,9 @@ fn materialize_lazy_keys<V: DocumentValue>(
 /// the single walk that collects them -- where before, the caller ran a
 /// whole separate `document::census` and then walked again to build this.
 fn distinct_key_cursors<V: DocumentValue>(fields: &V::Fields, collapse: bool) -> Vec<V::Cursor> {
-    DistinctKeyCursors::new(fields, collapse).collect()
+    DistinctKeyCursors::new(fields, collapse)
+        .map(|(_, cursor)| cursor)
+        .collect()
 }
 
 /// Materialize a `GenericResult::LazyIndexRange` fallback: build the
@@ -821,7 +823,7 @@ impl<V: DocumentValue> LazySource<V> {
                 *fields = rest;
                 Some(LazyElem::Cursor(field.value_cursor))
             }
-            Self::Keys(keys) => Some(LazyElem::Cursor(keys.next()?)),
+            Self::Keys(keys) => Some(LazyElem::Cursor(keys.next()?.1)),
             Self::IndexRange { next, len } => {
                 if *next >= *len {
                     return None;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,8 +22,8 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, effective_fields, effective_keys, effective_len, key_hash, DocumentCursor,
-    DocumentElements, DocumentFields, DocumentValue, IndentSpec, KeyHashes,
+    collapsed_fields, effective_fields, effective_keys, effective_len, DistinctKeyCursors,
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, eval_each_owned, format_owned,
@@ -686,42 +686,12 @@ fn materialize_lazy_keys<V: DocumentValue>(
 /// An object's key cursors in document order, with a repeated key dropped
 /// after its first occurrence when the mode collapses (#1514).
 ///
-/// One walk. The [`KeyHashes`] probe rides along with the walk that was
-/// happening anyway, so a duplicate-free object -- the overwhelmingly
-/// common case -- pays one hash per key and nothing else. Before this the
-/// caller ran a whole separate `document::census` first, then walked again
-/// to build this list.
-///
-/// A repeated hash abandons the walk and settles the object exactly through
-/// `collapsed_fields`, which decides on the keys themselves. That costs one
-/// extra pass on an object that genuinely repeats a key -- and on the
-/// 1-in-2^64 collision that only looks like one, where `collapsed_fields`
-/// answers `None` and the plain walk is the right answer after all.
+/// Materializes what [`DistinctKeyCursors`] streams. `.[]` over a key array
+/// has to hand back every cursor at once, but the dedup still happens during
+/// the single walk that collects them -- where before, the caller ran a
+/// whole separate `document::census` and then walked again to build this.
 fn distinct_key_cursors<V: DocumentValue>(fields: &V::Fields, collapse: bool) -> Vec<V::Cursor> {
-    let mut cursors = Vec::new();
-    let mut seen = KeyHashes::new();
-    let mut walk = fields.clone();
-    while let Some((field, rest)) = walk.uncons() {
-        if collapse
-            && field
-                .key_str()
-                .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
-        {
-            return match collapsed_fields(fields) {
-                Some(collapsed) => collapsed.into_iter().map(|f| f.key_cursor).collect(),
-                // A hash collision, not a duplicate: no key repeats
-                // anywhere in the object, so the plain walk is correct.
-                None => fields
-                    .all_fields()
-                    .into_iter()
-                    .map(|f| f.key_cursor)
-                    .collect(),
-            };
-        }
-        cursors.push(field.key_cursor);
-        walk = rest;
-    }
-    cursors
+    DistinctKeyCursors::new(fields, collapse).collect()
 }
 
 /// Materialize a `GenericResult::LazyIndexRange` fallback: build the
@@ -788,27 +758,9 @@ enum LazySource<V: DocumentValue> {
     ///
     /// Carries the mode's duplicate-key rule into the pull itself (#1514)
     /// instead of probing the whole object before the first element is
-    /// asked for. "First occurrence wins" is an *online* rule: every key
-    /// already emitted was a first occurrence, so a repeat discovered
-    /// later means "skip this one" and never invalidates what went out.
-    Keys {
-        /// The fields still to pull from.
-        rest: V::Fields,
-        /// The object as a whole, kept only for the exact resolution in
-        /// `advance` -- `V::Fields` is a cursor position, so this is a
-        /// copy of two machine words, not of the object.
-        all: V::Fields,
-        /// Hashes of the keys emitted so far, in jq mode. `None` in yq
-        /// mode, where every occurrence is kept, and `None` again once
-        /// the object has been *proved* free of duplicates.
-        seen: Option<KeyHashes>,
-        /// How many elements have gone out, which is where `collapsed`
-        /// resumes.
-        emitted: usize,
-        /// Set once a repeat is confirmed: the exact collapsed key
-        /// cursors, which the pull reads from for the remainder.
-        collapsed: Option<Vec<V::Cursor>>,
-    },
+    /// asked for -- see [`DistinctKeyCursors`] for why that is sound on a
+    /// forward-only consumer.
+    Keys(DistinctKeyCursors<V::Fields>),
     /// Array `keys_unsorted | map(f)` (#724) — synthetic `[0, 1, ..., len-1]`,
     /// no cursor to point at.
     IndexRange { next: usize, len: usize },
@@ -833,7 +785,7 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
         match self {
             Self::Elements(_) => f.write_str("LazySource::Elements(..)"),
             Self::Values(_) => f.write_str("LazySource::Values(..)"),
-            Self::Keys { .. } => f.write_str("LazySource::Keys(..)"),
+            Self::Keys(_) => f.write_str("LazySource::Keys(..)"),
             Self::IndexRange { next, len } => f
                 .debug_struct("LazySource::IndexRange")
                 .field("next", next)
@@ -851,19 +803,9 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
 impl<V: DocumentValue> LazySource<V> {
     /// A `keys_unsorted` source that honours the mode's duplicate-key
     /// rule as it pulls (#1514).
-    ///
-    /// `collapse` false -- yq -- keeps every occurrence, so no probe state
-    /// is carried at all and the pull is the plain cons-list walk it was.
     fn keys(fields: V::Fields, collapse: bool) -> Self {
-        Self::Keys {
-            rest: fields.clone(),
-            all: fields,
-            seen: collapse.then(KeyHashes::new),
-            emitted: 0,
-            collapsed: None,
-        }
+        Self::Keys(DistinctKeyCursors::new(&fields, collapse))
     }
-
     /// Pull one element forward, storing "the rest" back into `self`. Once a
     /// variant's underlying cons-list is empty (or `next == len`), every
     /// subsequent call returns `None` forever.
@@ -879,51 +821,7 @@ impl<V: DocumentValue> LazySource<V> {
                 *fields = rest;
                 Some(LazyElem::Cursor(field.value_cursor))
             }
-            Self::Keys {
-                rest,
-                all,
-                seen,
-                emitted,
-                collapsed,
-            } => {
-                if let Some(cursors) = collapsed {
-                    let cursor = cursors.get(*emitted).copied()?;
-                    *emitted += 1;
-                    return Some(LazyElem::Cursor(cursor));
-                }
-                let (field, tail) = rest.uncons()?;
-                *rest = tail;
-                let repeat = seen.as_mut().is_some_and(|seen| {
-                    field
-                        .key_str()
-                        .is_some_and(|key| seen.insert(key_hash(key.as_bytes())))
-                });
-                if repeat {
-                    // Settle it on the keys themselves. `collapsed_fields`
-                    // answers `None` when nothing actually repeats -- a
-                    // 64-bit hash collision -- and that answer covers the
-                    // whole object, so the probe is dropped for good
-                    // rather than re-run at the next collision.
-                    match collapsed_fields(all) {
-                        Some(fields) => {
-                            let cursors: Vec<V::Cursor> =
-                                fields.into_iter().map(|f| f.key_cursor).collect();
-                            // The collapsed list opens with the same
-                            // first occurrences already emitted, so the
-                            // remainder resumes at `emitted`.
-                            let cursor = cursors.get(*emitted).copied();
-                            *collapsed = Some(cursors);
-                            *seen = None;
-                            let cursor = cursor?;
-                            *emitted += 1;
-                            return Some(LazyElem::Cursor(cursor));
-                        }
-                        None => *seen = None,
-                    }
-                }
-                *emitted += 1;
-                Some(LazyElem::Cursor(field.key_cursor))
-            }
+            Self::Keys(keys) => Some(LazyElem::Cursor(keys.next()?)),
             Self::IndexRange { next, len } => {
                 if *next >= *len {
                     return None;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,8 +22,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, effective_fields, effective_keys, effective_len, DistinctKeyCursors,
-    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    collapsed_fields, collapsed_fields_if, effective_fields, effective_keys, effective_len,
+    DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields, DocumentValue,
+    IndentSpec,
 };
 use super::eval::{
     apply_compare_op, collapse_vec, eval as full_eval, eval_each_owned, format_owned,
@@ -2680,52 +2681,49 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
             // above; positive indices skip straight to the
             // walk. Out-of-bounds is `null`, never an error
             // (#307), matching that same arm.
-            let collapsed = if collapse {
-                collapsed_fields(&fields)
-            } else {
-                None
-            };
+            let collapsed = collapsed_fields_if(&fields, collapse);
             if let Some(eff) = collapsed {
                 let target = if *idx < 0 {
                     usize::try_from(eff.len() as i64 + idx).ok()
                 } else {
                     Some(*idx as usize)
                 };
-                return match target.and_then(|t| eff.into_iter().nth(t)) {
+                match target.and_then(|t| eff.into_iter().nth(t)) {
                     Some(field) => GenericResult::OneCursor(field.key_cursor),
                     None => GenericResult::Owned(OwnedValue::Null),
-                };
-            }
-            let target = if *idx < 0 {
-                let len = fields.len();
-                let normalized = len as i64 + idx;
-                if normalized < 0 {
-                    None
-                } else {
-                    Some(normalized as usize)
                 }
             } else {
-                Some(*idx as usize)
-            };
-            match target {
-                Some(target) => {
-                    let mut current = fields;
-                    let mut found = None;
-                    let mut i = 0usize;
-                    while let Some((field, rest)) = current.uncons() {
-                        if i == target {
-                            found = Some(field.key_cursor);
-                            break;
+                let target = if *idx < 0 {
+                    let len = fields.len();
+                    let normalized = len as i64 + idx;
+                    if normalized < 0 {
+                        None
+                    } else {
+                        Some(normalized as usize)
+                    }
+                } else {
+                    Some(*idx as usize)
+                };
+                match target {
+                    Some(target) => {
+                        let mut current = fields;
+                        let mut found = None;
+                        let mut i = 0usize;
+                        while let Some((field, rest)) = current.uncons() {
+                            if i == target {
+                                found = Some(field.key_cursor);
+                                break;
+                            }
+                            current = rest;
+                            i += 1;
                         }
-                        current = rest;
-                        i += 1;
+                        match found {
+                            Some(c) => GenericResult::OneCursor(c),
+                            None => GenericResult::Owned(OwnedValue::Null),
+                        }
                     }
-                    match found {
-                        Some(c) => GenericResult::OneCursor(c),
-                        None => GenericResult::Owned(OwnedValue::Null),
-                    }
+                    None => GenericResult::Owned(OwnedValue::Null),
                 }
-                None => GenericResult::Owned(OwnedValue::Null),
             }
         }
         // No probe: collapsing keeps every key at its *first*
@@ -2739,26 +2737,23 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // droppable — if its key repeats an earlier one it
         // collapses away and some other field ends up last.
         Expr::Builtin(Builtin::Last) if !sorted => {
-            let collapsed = if collapse {
-                collapsed_fields(&fields)
-            } else {
-                None
-            };
+            let collapsed = collapsed_fields_if(&fields, collapse);
             if let Some(eff) = collapsed {
-                return match eff.into_iter().next_back() {
+                match eff.into_iter().next_back() {
                     Some(field) => GenericResult::OneCursor(field.key_cursor),
                     None => GenericResult::Owned(OwnedValue::Null),
-                };
-            }
-            let mut current = fields;
-            let mut last_cursor = None;
-            while let Some((field, rest)) = current.uncons() {
-                last_cursor = Some(field.key_cursor);
-                current = rest;
-            }
-            match last_cursor {
-                Some(c) => GenericResult::OneCursor(c),
-                None => GenericResult::Owned(OwnedValue::Null),
+                }
+            } else {
+                let mut current = fields;
+                let mut last_cursor = None;
+                while let Some((field, rest)) = current.uncons() {
+                    last_cursor = Some(field.key_cursor);
+                    current = rest;
+                }
+                match last_cursor {
+                    Some(c) => GenericResult::OneCursor(c),
+                    None => GenericResult::Owned(OwnedValue::Null),
+                }
             }
         }
         // Slice 1 (#724): stay lazy instead of falling

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -25,7 +25,7 @@ use std::borrow::Cow;
 
 use crate::json::light::{JsonCursor, StandardJson};
 
-use super::document::DistinctKeyCursors;
+use super::document::{effective_len, DistinctKeyCursors};
 
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
@@ -376,9 +376,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             // No wildcard covers this case: without this arm,
             // `keys_unsorted | length` reaching `JqValue` directly would
             // silently answer `None` instead of the field count.
-            JqValue::LazyKeysArray { fields, collapse } => {
-                Some(DistinctKeyCursors::new(fields, *collapse).count())
-            }
+            JqValue::LazyKeysArray { fields, collapse } => Some(effective_len(fields, *collapse)),
             // No wildcard covers this case either, for the same reason as
             // `LazyKeysArray` above: without it, `keys_unsorted | length` on
             // an array reaching `JqValue` directly would silently answer

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -609,7 +609,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::LazyKeysArray { fields, collapse } => {
                 out.write_char('[')?;
                 let mut first = true;
-                for key_cursor in DistinctKeyCursors::new(fields, *collapse) {
+                for (key, key_cursor) in DistinctKeyCursors::new(fields, *collapse) {
                     if !first {
                         out.write_char(',')?;
                     }
@@ -623,7 +623,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                         // string tokens with a text range, so this is not
                         // expected to be reached.
                         None => {
-                            if let StandardJson::String(k) = key_cursor.value() {
+                            if let StandardJson::String(k) = key {
                                 out.write_char('"')?;
                                 if let Ok(s) = k.as_str() {
                                     write_json_body_jq(out, &s)?;
@@ -673,8 +673,8 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
     collapse: bool,
 ) -> OwnedValue {
     let mut keys = Vec::new();
-    for key_cursor in DistinctKeyCursors::new(fields, collapse) {
-        if let StandardJson::String(k) = key_cursor.value() {
+    for (key, _) in DistinctKeyCursors::new(fields, collapse) {
+        if let StandardJson::String(k) = key {
             if let Ok(s) = k.as_str() {
                 keys.push(OwnedValue::String(s.into_owned()));
             }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -25,6 +25,8 @@ use std::borrow::Cow;
 
 use crate::json::light::{JsonCursor, StandardJson};
 
+use super::document::DistinctKeyCursors;
+
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
 use super::value::{assert_value_tree_depth, infinite_float_preview_text, OwnedValue};
@@ -91,7 +93,20 @@ pub enum JqValue<'a, W = Vec<u64>> {
     /// iterator — not yet decoded into `String`s (#140). `write_json` and
     /// `print_json` stream each key's raw bytes straight from its cursor,
     /// so a bare `keys_unsorted` output never materializes a `Vec<String>`.
-    LazyKeysArray(crate::json::light::JsonFields<'a, W>),
+    ///
+    /// `collapse` is the evaluation mode's duplicate-key rule, carried here
+    /// rather than settled before construction (#1514). #1385 built this
+    /// variant only for objects a `collapsed_fields` probe had already
+    /// declared clean, which meant a whole extra cons-list walk -- with a
+    /// `key_str()` decode per field -- ahead of the walk that writes the
+    /// output. Every consumer below now applies the rule through
+    /// `DistinctKeyCursors` during the walk it was making anyway.
+    LazyKeysArray {
+        /// The object whose keys this array presents.
+        fields: crate::json::light::JsonFields<'a, W>,
+        /// Whether a repeated key collapses onto its first occurrence.
+        collapse: bool,
+    },
 
     /// Lazy array-index range: `keys`/`keys_unsorted` on an array (#684).
     /// `[0, 1, ..., len-1]` is fully determined by `len` alone, so
@@ -274,7 +289,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::String(_) => "string",
             JqValue::Array(_) => "array",
             JqValue::Object(_) => "object",
-            JqValue::LazyKeysArray(_) => "array",
+            JqValue::LazyKeysArray { .. } => "array",
             JqValue::LazyIndexRange(_) => "array",
         }
     }
@@ -361,7 +376,9 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             // No wildcard covers this case: without this arm,
             // `keys_unsorted | length` reaching `JqValue` directly would
             // silently answer `None` instead of the field count.
-            JqValue::LazyKeysArray(fields) => Some((*fields).count()),
+            JqValue::LazyKeysArray { fields, collapse } => {
+                Some(DistinctKeyCursors::new(fields, *collapse).count())
+            }
             // No wildcard covers this case either, for the same reason as
             // `LazyKeysArray` above: without it, `keys_unsorted | length` on
             // an array reaching `JqValue` directly would silently answer
@@ -434,7 +451,9 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     .map(|(k, v)| (k.clone(), v.materialize_at_depth(depth + 1)))
                     .collect(),
             ),
-            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(fields),
+            JqValue::LazyKeysArray { fields, collapse } => {
+                lazy_keys_array_to_owned(fields, *collapse)
+            }
             JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(*len),
         }
     }
@@ -469,7 +488,9 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                     .map(|(k, v)| (k, v.into_owned_at_depth(depth + 1)))
                     .collect(),
             ),
-            JqValue::LazyKeysArray(fields) => lazy_keys_array_to_owned(&fields),
+            JqValue::LazyKeysArray { fields, collapse } => {
+                lazy_keys_array_to_owned(&fields, collapse)
+            }
             JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(len),
         }
     }
@@ -585,16 +606,15 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             // cursor — already a valid, already-escaped JSON string token —
             // so this never allocates a `String` per key, unlike
             // `JqValue::Object`/`Array` above.
-            JqValue::LazyKeysArray(fields) => {
+            JqValue::LazyKeysArray { fields, collapse } => {
                 out.write_char('[')?;
-                let mut current = *fields;
                 let mut first = true;
-                while let Some((field, rest)) = current.uncons() {
+                for key_cursor in DistinctKeyCursors::new(fields, *collapse) {
                     if !first {
                         out.write_char(',')?;
                     }
                     first = false;
-                    match field.key_cursor().raw_bytes() {
+                    match key_cursor.raw_bytes() {
                         Some(bytes) => {
                             let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
                             out.write_str(s)?;
@@ -603,7 +623,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                         // string tokens with a text range, so this is not
                         // expected to be reached.
                         None => {
-                            if let StandardJson::String(k) = field.key() {
+                            if let StandardJson::String(k) = key_cursor.value() {
                                 out.write_char('"')?;
                                 if let Ok(s) = k.as_str() {
                                     write_json_body_jq(out, &s)?;
@@ -614,7 +634,6 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                             }
                         }
                     }
-                    current = rest;
                 }
                 out.write_char(']')
             }
@@ -651,16 +670,15 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
 /// materialized value (`sort_keys`, color output, etc.).
 fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
     fields: &crate::json::light::JsonFields<'_, W>,
+    collapse: bool,
 ) -> OwnedValue {
     let mut keys = Vec::new();
-    let mut current = *fields;
-    while let Some((field, rest)) = current.uncons() {
-        if let StandardJson::String(k) = field.key() {
+    for key_cursor in DistinctKeyCursors::new(fields, collapse) {
+        if let StandardJson::String(k) = key_cursor.value() {
             if let Ok(s) = k.as_str() {
                 keys.push(OwnedValue::String(s.into_owned()));
             }
         }
-        current = rest;
     }
     OwnedValue::Array(keys)
 }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -23,7 +23,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use super::document::{DocumentFields, IndentSpec};
+use super::document::{DistinctKeyCursors, DocumentFields, DocumentValue, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
@@ -527,13 +527,19 @@ fn stream_json_string<W: core::fmt::Write>(
 /// an intermediate `Vec<String>`/`OwnedValue::Array` (#685).
 ///
 /// The lazy counterpart of `stream_owned_value_json_with`'s `Array` arm
-/// above, pulling one key at a time from `uncons()` instead of walking a
-/// materialized slice. `GenericResult::LazyKeys { sorted: false, .. }` is
-/// always the entire top-level result (never nested inside another
-/// container), so unlike the function it mirrors this has no
-/// `current_indent` parameter — it's always 0.
+/// above, pulling one key at a time from `DistinctKeyCursors` instead of
+/// walking a materialized slice. `collapse` is threaded through to it so a
+/// repeated key collapses onto its first occurrence here too, same as every
+/// other `LazyKeys` consumer (#1514) — this path is reachable from
+/// `yq_runner.rs`'s M2 fast path, where `collapse` is always `false` today,
+/// but the rule must still hold if a jq-mode caller ever reaches it.
+/// `GenericResult::LazyKeys { sorted: false, .. }` is always the entire
+/// top-level result (never nested inside another container), so unlike the
+/// function it mirrors this has no `current_indent` parameter — it's always
+/// 0.
 pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
+    collapse: bool,
     out: &mut W,
     indent: IndentSpec,
 ) -> core::fmt::Result {
@@ -541,13 +547,13 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
         return out.write_str("[]");
     }
     out.write_char('[')?;
-    let mut current = fields.clone();
     let mut i = 0usize;
-    while let Some((field, rest)) = current.uncons() {
-        // `key_str()` is expected to always return `Some` (see its doc
-        // comment on `DocumentField`); a field with no stringifiable key is
-        // silently skipped, matching `DocumentFields::keys()`'s default walk.
-        if let Some(key) = field.key_str() {
+    for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
+        // `key_string()` is expected to always return `Some` (see
+        // `DocumentField::key_str`'s doc comment); a key with no
+        // stringifiable spelling is silently skipped, matching
+        // `DocumentFields::keys()`'s default walk.
+        if let Some(key) = key.key_string() {
             if i > 0 {
                 out.write_char(',')?;
             }
@@ -558,7 +564,6 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
             stream_json_string(out, &key, write_json_body_yq)?;
             i += 1;
         }
-        current = rest;
     }
     if indent.width > 0 {
         out.write_char('\n')?;
@@ -854,35 +859,37 @@ pub fn stream_yaml_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fm
 /// never nested containers, so this omits that arm's "nested container gets
 /// its own indented line" branch, and — like `stream_lazy_keys_json` — has no
 /// `current_indent` parameter, since `LazyKeys { sorted: false, .. }` is
-/// always the entire top-level result.
+/// always the entire top-level result. `collapse` is threaded through for
+/// the same reason as `stream_lazy_keys_json` (#1514): yq's own
+/// `COLLAPSE_DUPLICATE_KEYS` is always `false`, so this is a no-op today,
+/// but the rule must still hold if a jq-mode caller ever reaches it.
 pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
+    collapse: bool,
     out: &mut W,
     indent: IndentSpec,
 ) -> core::fmt::Result {
     if fields.is_empty() {
         return out.write_str("[]");
     }
-    let mut current = fields.clone();
     let mut i = 0usize;
     if indent.is_compact() {
         // Flow style
         out.write_char('[')?;
-        while let Some((field, rest)) = current.uncons() {
-            if let Some(key) = field.key_str() {
+        for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
+            if let Some(key) = key.key_string() {
                 if i > 0 {
                     out.write_str(", ")?;
                 }
                 stream_yaml_string(out, &key)?;
                 i += 1;
             }
-            current = rest;
         }
         out.write_char(']')
     } else {
         // Block style
-        while let Some((field, rest)) = current.uncons() {
-            if let Some(key) = field.key_str() {
+        for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
+            if let Some(key) = key.key_string() {
                 if i > 0 {
                     out.write_char('\n')?;
                 }
@@ -890,7 +897,6 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
                 stream_yaml_string(out, &key)?;
                 i += 1;
             }
-            current = rest;
         }
         Ok(())
     }
@@ -1097,6 +1103,51 @@ mod tests {
             .stream_json(&mut buf, IndentSpec::COMPACT, false)
             .unwrap();
         assert_eq!(buf, "3.125");
+    }
+
+    /// #1514 review: `stream_lazy_keys_json`/`stream_lazy_keys_yaml` are the
+    /// M2 fast path's key-array writers. They used to walk `fields.uncons()`
+    /// directly with no dedup logic at all -- every other `LazyKeys`
+    /// consumer touched by #1514 was rewired through `DistinctKeyCursors`,
+    /// but these two were missed, so a `collapse: true` caller would have
+    /// printed a repeated key twice. Reachable today only from
+    /// `yq_runner.rs`, where `collapse` is always `false`, so this is
+    /// unexercised by any CLI test; pinned directly here so the rule holds
+    /// if a jq-mode caller ever reaches this path.
+    #[test]
+    fn test_stream_lazy_keys_honors_collapse_1514() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        let json = br#"{"b":1,"a":2,"b":3}"#;
+        let index = JsonIndex::build(json);
+        let StandardJson::Object(fields) = index.root(json).value() else {
+            panic!("expected object");
+        };
+
+        let mut collapsed = String::new();
+        stream_lazy_keys_json(&fields, true, &mut collapsed, IndentSpec::COMPACT).unwrap();
+        assert_eq!(
+            collapsed, r#"["b","a"]"#,
+            "collapse: true drops the repeat of \"b\""
+        );
+
+        let mut uncollapsed = String::new();
+        stream_lazy_keys_json(&fields, false, &mut uncollapsed, IndentSpec::COMPACT).unwrap();
+        assert_eq!(
+            uncollapsed, r#"["b","a","b"]"#,
+            "collapse: false (yq) keeps every occurrence"
+        );
+
+        let mut collapsed_yaml = String::new();
+        stream_lazy_keys_yaml(&fields, true, &mut collapsed_yaml, IndentSpec::COMPACT).unwrap();
+        assert_eq!(
+            collapsed_yaml, "[b, a]",
+            "the YAML writer applies the same rule"
+        );
+
+        let mut uncollapsed_yaml = String::new();
+        stream_lazy_keys_yaml(&fields, false, &mut uncollapsed_yaml, IndentSpec::COMPACT).unwrap();
+        assert_eq!(uncollapsed_yaml, "[b, a, b]");
     }
 
     /// The `yq` JSON convention (what the M2 fast path for `.field`/`.[0]`/

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1902,6 +1902,28 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
         }
     }
 
+    /// The span's content bytes, quotes stripped, when it carries no
+    /// escape -- in which case they *are* the decoded key, so the
+    /// duplicate-key probe can hash them without going through `as_str`
+    /// (#1514). `raw_and_escaped` reports both from the one scan it makes
+    /// for the closing quote, so the escape test is free.
+    fn key_raw_unescaped(&self) -> Option<&[u8]> {
+        match self {
+            StandardJson::String(s) => {
+                let (raw, escaped) = s.raw_and_escaped();
+                // A well-formed span is `"..."`; anything shorter than the
+                // two quotes is a truncated document, and has no content to
+                // hand back.
+                if escaped || raw.len() < 2 {
+                    None
+                } else {
+                    Some(&raw[1..raw.len() - 1])
+                }
+            }
+            _ => None,
+        }
+    }
+
     fn as_object(&self) -> Option<Self::Fields> {
         match self {
             StandardJson::Object(fields) => Some(*fields),

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1979,6 +1979,15 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
         ))
     }
 
+    /// The inherent `JsonFields::uncons` builds a `JsonField` of two
+    /// cursors and materializes nothing, so a key-only walk pays for one
+    /// `key()` and no `value()` -- which is the difference between this
+    /// and the trait default (#1514).
+    fn uncons_key(&self) -> Option<(Self::Value, Self::Cursor, Self)> {
+        let (field, rest) = JsonFields::uncons(self)?;
+        Some((field.key(), field.key_cursor(), rest))
+    }
+
     fn find(&self, name: &str) -> Option<Self::Value> {
         JsonFields::find(self, name)
     }

--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,18 +1,18 @@
 {
   "ARM64-Linux": {
-    "arrays_identity": 1441480786,
-    "users_identity": 330130356,
-    "users_keys_unsorted": 43261762,
-    "users_yq_keys_unsorted": 72626751,
-    "wide_identity": 736876694,
-    "wide_keys_unsorted": 478638146
+    "arrays_identity": 1486074505,
+    "users_identity": 337129160,
+    "users_keys_unsorted": 43388740,
+    "users_yq_keys_unsorted": 72762888,
+    "wide_identity": 668045547,
+    "wide_keys_unsorted": 289871551
   },
   "x86_64": {
-    "arrays_identity": 1496423517,
-    "users_identity": 372062228,
-    "users_keys_unsorted": 67471861,
-    "users_yq_keys_unsorted": 82680144,
-    "wide_identity": 821574633,
-    "wide_keys_unsorted": 573924928
+    "arrays_identity": 1506416474,
+    "users_identity": 375956384,
+    "users_keys_unsorted": 67388453,
+    "users_yq_keys_unsorted": 82548670,
+    "wide_identity": 742550939,
+    "wide_keys_unsorted": 351802447
   }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2787,6 +2787,51 @@ fn test_lazy_keys_dedup_switches_on_the_second_field_1514() -> Result<()> {
     Ok(())
 }
 
+/// #1514 review: `keys_unsorted | .[n]` and `keys_unsorted | last` must keep
+/// folding the *rest* of the pipe once they've resolved positionally against
+/// the collapsed list on a duplicate-keyed object. Both arms briefly used
+/// `return` inside `fold_pipe_stages`'s per-stage `match`, which exits the
+/// whole function instead of handing the value to the next stage — silently
+/// dropping every filter chained after the index/`last`. Only reachable when
+/// the object has a genuine duplicate key: the collapsed branch is untaken
+/// otherwise, which is why the plain no-duplicate case must be pinned here
+/// too, not just the buggy one.
+#[test]
+fn test_lazy_keys_index_and_last_continue_the_pipe_on_duplicates_1514() -> Result<()> {
+    let dup = r#"{"b":1,"a":2,"b":3}"#;
+    for (filter, expected) in [
+        ("keys_unsorted|.[0]|length", "1"),
+        ("keys_unsorted|.[-1]|length", "1"),
+        ("keys_unsorted|last|length", "1"),
+        ("keys_unsorted|.[0]|ascii_upcase", r#""B""#),
+        ("keys_unsorted|last|ascii_upcase", r#""A""#),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(dup))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(
+            out.trim(),
+            expected,
+            "filter {filter}, duplicate-keyed input"
+        );
+    }
+
+    let clean = r#"{"x":1,"y":2}"#;
+    for (filter, expected) in [
+        ("keys_unsorted|.[0]|length", "1"),
+        ("keys_unsorted|last|length", "1"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(clean))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(
+            out.trim(),
+            expected,
+            "filter {filter}, no-duplicate control"
+        );
+    }
+
+    Ok(())
+}
+
 /// #1385 review: `--preserve-input` preserves duplicate keys on *output*
 /// and nowhere else. The exemption ADR-0018 rule 5 grants that extension
 /// reaches the printer, which is gated on `jq_compat`; the evaluator is

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2708,6 +2708,85 @@ fn test_undecodable_keys_are_not_duplicates_1385() -> Result<()> {
     Ok(())
 }
 
+/// #1514: `keys_unsorted | map(f)` and `keys_unsorted | .[]` no longer probe
+/// the whole object before the first key comes out — they dedup as they walk
+/// and switch to the exact collapsed list only once a hash repeats. That
+/// switch has to resume at the right offset, so a duplicate in the *middle*
+/// of a wide object is the shape that matters: keys before it have already
+/// been emitted and must not repeat, keys after it must all still arrive.
+///
+/// The object is wider than the printer's `PAIRWISE_SPAN_SCAN_LIMIT` so the
+/// hash-table branch is the one under test, not the small-object pairwise
+/// scan.
+#[test]
+fn test_lazy_keys_dedup_switches_mid_walk_1514() -> Result<()> {
+    const HEAD: usize = 30;
+    const TAIL: usize = 30;
+    let mut input = String::from("{");
+    for i in 0..HEAD {
+        input.push_str(&format!("\"m{i}\":{i},"));
+    }
+    input.push_str("\"m5\":-1,");
+    for i in 0..TAIL {
+        input.push_str(&format!("\"n{i}\":{i},"));
+    }
+    input.pop();
+    input.push('}');
+
+    let expected_keys: Vec<String> = (0..HEAD)
+        .map(|i| format!("\"m{i}\""))
+        .chain((0..TAIL).map(|i| format!("\"n{i}\"")))
+        .collect();
+    let expected_array = format!("[{}]", expected_keys.join(","));
+
+    for filter in ["keys_unsorted|map(.)", "[keys_unsorted[]]"] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(&input))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(
+            out.trim(),
+            expected_array,
+            "filter {filter}: the repeat of m5 collapses to its first position \
+             and every later key still arrives"
+        );
+    }
+
+    // The positional and counting arms have to agree with the streamed ones.
+    for (filter, expected) in [
+        ("keys_unsorted|length", (HEAD + TAIL).to_string()),
+        ("keys_unsorted|first", "\"m0\"".to_string()),
+        ("keys_unsorted|last", format!("\"n{}\"", TAIL - 1)),
+        ("keys_unsorted[5]", "\"m5\"".to_string()),
+        ("keys_unsorted[-1]", format!("\"n{}\"", TAIL - 1)),
+        (".m5", "-1".to_string()),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(&input))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    Ok(())
+}
+
+/// #1514: an object whose keys *all* repeat drives the mid-walk switch on
+/// the very first duplicate, when exactly one key has gone out. Guards the
+/// resume offset against an off-by-one that a tail-duplicate case cannot
+/// see.
+#[test]
+fn test_lazy_keys_dedup_switches_on_the_second_field_1514() -> Result<()> {
+    let input = r#"{"a":1,"a":2,"a":3,"b":4}"#;
+    for (filter, expected) in [
+        ("keys_unsorted|map(.)", r#"["a","b"]"#),
+        ("[keys_unsorted[]]", r#"["a","b"]"#),
+        ("keys_unsorted|length", "2"),
+        (".", r#"{"a":3,"b":4}"#),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+    Ok(())
+}
+
 /// #1385 review: `--preserve-input` preserves duplicate keys on *output*
 /// and nowhere else. The exemption ADR-0018 rule 5 grants that extension
 /// reaches the printer, which is gated on `jq_compat`; the evaluator is
@@ -2757,10 +2836,12 @@ fn test_preserve_input_duplicate_keys_are_output_only_1385() -> Result<()> {
     Ok(())
 }
 
-/// #1385 review: the `LazyKeys` collapsed fast path (`lazy_keys_collapsed`
-/// in `eval_generic.rs`) mirrors the cons-list arms one-for-one, and every
-/// one of its arms was reached only when the object carries a duplicate --
-/// so none of them was covered. Each filter here lands on a different arm.
+/// #1385 review: every `LazyKeys` arm in `eval_generic.rs`'s `Expr::Pipe`
+/// dispatch answers differently once the object carries a duplicate, and
+/// none of those answers was covered. Each filter here lands on a different
+/// arm. (#1514 folded the separate `lazy_keys_collapsed` mirror this
+/// originally covered back into the arms themselves; the filters are
+/// unchanged because the answers are.)
 #[test]
 fn test_duplicate_keys_lazy_keys_fast_paths_1385() -> Result<()> {
     let input = r#"{"b":1,"a":2,"b":3}"#;


### PR DESCRIPTION
Fixes #1514.

#1385's duplicate-key collapse is correct and stays; its **cost** was the problem. On a document
holding one wide object — none of whose objects carries a repeated key — the detector cost up to
**+141%** against the pre-#1385 baseline `40c5ff93`.

## Result

`codegen-units=1` on both sides (see #1587 for why that matters), median of 7, interleaved,
against `40c5ff93`. Control bands: M4 Pro −0.7%..+0.4%, 7950X −2.8%..+0.8%. Identity: **25
configurations, 0 differences on each box.**

| `wide`, 1 / 10 / 100 MB | M4 Pro `main` | M4 Pro this PR | 7950X `main` | 7950X this PR |
|---|---|---|---|---|
| `.` | +24 / +30 / +34% | **+16 / +19 / +24%** | +39 / +46 / +49% | **+24 / +28 / +30%** |
| `keys_unsorted` | +88 / +123 / +136% | **+50 / +57 / +96%** | +129 / +137 / +141% | **+78 / +97 / +142%** |
| `keys_unsorted \| select(true)` | +27 / +32 / +37% | **+4 / +4 / +5%** | +32 / +39 / +52% | **+2 / +4 / +3%** |
| `keys_unsorted \| map(.)` | +20 / +25 / +30% | **+4 / +6 / +12%** | +38 / +39 / +38% | **+16 / +23 / +36%** |
| `keys_unsorted \| length` | +77 / +105 / +119% | **+22 / +29 / +25%** | +98 / +106 / +107% | **+23 / +22 / +21%** |

Median across all 25 configurations: M4 Pro **+25.1% → +4.8%**, 7950X **+38.1% → +12.2%**.
Head to head against `main`: **M4 Pro −8.5% median, 7950X −12.0% median (24 of 25 rows faster)**.
`users` and `arrays` sit inside ±2%. yq is flat on both boxes (median −0.2%, every row within
±1.8%) — `collapse` is `false` there and the gates compile away.

## What changed

| commit | |
|---|---|
| `f46866f8e` | one hash-set primitive replaces three sorts — including the correction that it must be *sized*, since shipping it growing was slower than the sort it replaced |
| `2c3aa652a` | the probe runs only in the two arms that read the answer positionally; `select`/`map`/the fallback stop paying for an answer they discard |
| `ecde8a7b4` | bare `keys_unsorted` dedups as it writes — "first occurrence wins" needs no lookahead |
| `c3108c9e3` | hash the key's raw span instead of decoding it through `as_str`'s two scans and a UTF-8 validation |
| `b0ddbbe35` | `uncons_key`: walk keys without materializing every value — fixes a regression `ecde8a7b4` introduced |
| `5e6a0ddb2` | sort `u64` hashes rather than probe a table, except where the walk streams |
| `b19c73b36` | the record, in `docs/plan/jq-duplicate-key-collapse.md` |

## Three things measurement overturned

- **The table was the wrong structure, and only one machine said so.** An open-addressed set
  replaced every sort first. On an M4 Pro that was right; on a 7950X it cost 24% on the identity
  path, where 7.1M keys make the table 134 MB against 32 MB of L3 per CCD. Sorting hashes beats
  both on both boxes. `f46866f8e`'s own message records the earlier sizing correction for the
  same reason.
- **The fix introduced a bigger regression than the one it removed.** With dedup forcibly
  disabled, `ecde8a7b4`'s walk cost +89%/+100% on its own — it routed the writer through a
  generic walk that materialized each field's *value*, then re-derived the key from a cursor.
  Building the binary a second time with the feature disabled is what found it; timings alone
  could not.
- **The measurement had a hole in it.** `jq type`, which touches no keys, moved 12-27% between
  binaries and did not bisect to the same commit on the two machines. At `codegen-units=1` it is
  +0.2%. Filed as #1587; every figure above was re-measured accordingly.

## Correctness

- Identity-gated against the pre-change binary over a 16-input duplicate-key corpus (escaped
  spellings both ways, a `\u`-escaped spelling of an ASCII key, an undecodable key, non-ASCII
  keys, all-duplicates, duplicates at head/middle/tail of an object wider than the printer's
  pairwise limit, nested and inside arrays) × 30 filters × 4 flag sets: **1984 configurations, 0
  differences**, at every commit.
- Spot-checked against `/usr/bin/jq` 1.7.1: the only divergence is the invalid-escape input jq
  rejects as a parse error, which is #1385's documented semi-indexing case and unchanged here.
- Full `cargo test` 54/54, both clippy legs, `cargo fmt --check`, `cargo check
  --no-default-features`, `cargo doc` with `-D warnings`.
- Two new tests pin the mid-walk switch to the exact collapsed list, whose resume offset a
  tail-duplicate case cannot exercise; five pin the hash primitive.

## Known trade

Bare `keys_unsorted` over a wide object roughly doubles peak RSS against `main` (100 MB: 189 →
389 MiB) — the streaming detector keeps 16 bytes per key where a sorted `Vec` keeps 8. `.` is
*better* than `main` (514 → 460 MiB), `length` is identical, `users`-shaped documents are
unchanged. Filed as #1588.

## Not fixed

`keys_unsorted` on a single 7.1M-key object stays ~+96% (ARM) / +142% (x86). At that width the
streaming table is 134 MB and every insert is a DRAM round trip — ~87 ns/key against a 670 ms
baseline query. Exact detection has no cheaper structure here; the sort is worse. Recorded in the
design doc as the floor.
