### PR TITLE
fix(jq): interleave inputs/input through top-level Comma/Pipe (#1504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,13 +301,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `empty.json:0`; both were `<unknown>`. `<unknown>` is now reserved for its
   real meaning — no read has been attempted at all.
 
-  Remaining divergences, all downstream of the evaluator's eager `Pipe`/`Comma`
-  rather than of these builtins, are recorded in
-  `docs/compliance/jq/limitations.md`: `inputs | input_line_number` does not
-  interleave, `(., input) | error(...)` raises once where jq raises twice, and
-  `input_line_number` keeps its line after a failed read (jq is not
-  self-consistent there, so the reset is deliberately not reproduced).
-  `input`/`inputs` remain unsupported in `yq` mode, reporting a clear error.
+  Two more divergences, both downstream of the evaluator's eager `Pipe`/`Comma`
+  rather than of these builtins, were found here and closed separately by
+  #1504 (below): `inputs | input_line_number` did not interleave, and
+  `(., input) | error(...)` raised once where jq raises twice. One remains,
+  recorded in `docs/compliance/jq/limitations.md`: `input_line_number` keeps
+  its line after a failed read (jq is not self-consistent there, so the reset
+  is deliberately not reproduced). `input`/`inputs` remain unsupported in `yq`
+  mode, reporting a clear error.
+
+- **`jq`: `inputs`/`input` now interleave with the rest of a top-level
+  `Pipe`/`Comma` instead of draining first** (#1504, the general fix #1309
+  left open). `eval_generic.rs`'s top-level entry points ran the whole
+  program through the eager `eval_single` (`fold_pipe_stages` for `Pipe`, a
+  plain accumulating loop for `Comma`), so a generator consumed the entire
+  shared input queue before the next pipe stage ever ran on any of it:
+  `inputs | input_line_number` reported the *last* document's line for every
+  output (`3 3 3` against jq's `1 2 3`), and `(., input) | error("boom")`
+  over two files raised once here against jq's twice (jq's lazy comma reaches
+  `error` with the first document before `input`, its right branch, is ever
+  evaluated, leaving the second document for its outer per-document loop to
+  process as a fresh top-level run; succinctly's eager comma consumed it
+  first). A program that actually touches `input`/`inputs`/
+  `input_line_number` (guarded the same way `first`/`last`'s existing bridge
+  already is, via `input_queue_is_active()` and `jq::walk::uses_input_builtins`)
+  now runs through a new `eval_each_owned_collect`, a plain "collect every
+  output" sink over `eval.rs`'s own demand-driven `eval_each_owned` — the
+  same `Demand`/`Item`/`Flow` machinery `first`/`limit`/... already use, just
+  driven to completion instead of stopped after N. The CLI's existing
+  per-document loop, unmodified, already reads from the same queue `input`
+  draws from, so the second symptom's fix falls out of the first: leaving a
+  document unconsumed is enough for the CLI to pick it up as the next
+  top-level run on its own.
+
+  This does not close `first(.[] | stderr)` or the top-level-compare shape
+  (#1461, #1481) — those never touch `input`/`inputs`, so this fix's guard
+  never fires for them; they remain open under their own issues.
 
 - **`yq`: `split_doc` hidden inside twelve builtins is detected** (#1309):
   `contains_split_doc` was exhaustive over `Expr` but ended its inner

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -759,32 +759,18 @@ walker; tracked as [#1473](https://github.com/rust-works/succinctly/issues/1473)
 #723's implementation left behind: `-L`/`import`/`include` module detection, the eager
 `inputs` drain that lost documents under `first`/`limit`/`any`/`all`/`isempty`/`nth`, the
 missing filename in error locations, and `<unknown>` where jq names an exhausted file.
-Three divergences remain, all of them consequences of the evaluator's eager `Expr::Pipe`
-and `Expr::Comma` rather than of the input builtins themselves.
+[#1504](https://github.com/rust-works/succinctly/issues/1504) closed two more — `inputs | f`
+not interleaving, and a generator branch past a raised error still consuming a document —
+both consequences of the evaluator's eager `Expr::Pipe`/`Expr::Comma` rather than of the
+input builtins themselves. A top-level program that uses `input`/`inputs`/
+`input_line_number` now runs through `eval.rs`'s demand-driven `eval_each_owned` (the same
+`Demand`/`Item`/`Flow` sink `first`/`limit`/... already used) instead of `eval_single`'s
+eager fold, so `inputs | input_line_number` reports `1 2 3` and `(., input) | error(...)`
+raises once per top-level document, matching jq — see
+[`docs/plan/jq-lazy-generator-consumers.md`](../../plan/jq-lazy-generator-consumers.md) for
+the mechanism.
 
-**`inputs | f` does not interleave.** `inputs` is a demand-driven producer now, but the
-pipe that consumes it is still eager, so the whole stream is produced before `f` runs on
-any of it. Visible through `input_line_number`, which reports the position of the last
-document read:
-
-```
-$ printf '1\n2\n3\n' | jq          -cn 'inputs | input_line_number'   # 1 2 3
-$ printf '1\n2\n3\n' | succinctly jq -cn 'inputs | input_line_number' # 3 3 3
-```
-
-The truncating consumers are unaffected — `first(inputs) | input_line_number` and
-`limit(1; inputs) | input_line_number` both answer `1`, matching jq — because those stop
-the producer rather than piping through it. Closing the general case needs the
-`Demand`/`Item`/`Flow` sink mirrored into `eval_generic`'s `Pipe` arm, which
-[`docs/plan/jq-lazy-generator-consumers.md`](../../plan/jq-lazy-generator-consumers.md)
-already scopes as option (c).
-
-**A generator branch past the answer still consumes documents.** `(., input) | error(...)`
-over two files raises once here and twice in jq: jq's lazy comma reaches `error` with the
-first document before `input` is ever evaluated, so its outer loop runs twice. succinctly's
-eager comma consumes document 2 while building the pair, leaving nothing for a second
-iteration. The location succinctly does report is correct for the position its parser
-reached. Same root cause as above, and the same fix.
+One divergence remains, unrelated to the eager-evaluator root cause above.
 
 **`input_line_number` keeps its line after a failed read.** jq resets it to 0 after an
 `input` that finds nothing, but *not* after an `[inputs]` that exhausts the same stream:

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -22,6 +22,7 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | 4     | `Expr::Compare`'s outer loop                        | ✅ merged — closes #1459    |
 | 5     | Widen the lazy arm set                              | ✅ merged — closes #1462    |
 | (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ✅ merged — #1451, #1461    |
+| —     | Interleave top-level `input`/`inputs` (#1309's residue) | ✅ merged — #1504        |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
@@ -84,6 +85,23 @@ existing whole-pipe fallback instead (safe to redo, since none of those shapes h
 side effect yet), leaving `first(.[] | stderr)` a known, still-pinned divergence rather than
 a second, deeper thing option (c) closes. The full generalized `Demand`/`Item`/`Flow` mirror
 this row originally called for remains the only way to close it soundly — filed as **#1461**.
+
+**#1504 — the other "two more owners" #1309 gave this row — closed, by a narrower fix than
+option (c)'s own full mirror.** `#1309`'s `inputs | f` (no interleave) and
+`(., input) | error(...)` (raises once, not twice) are about the CLI's *top-level* program —
+no `first`/`last`/`limit`/... wrapper in sight — so they were never reachable through
+`eval_each_generic`/`eval_each_pipe_generic` (which only `each_take_first_generic` drives) at
+all. Rather than building out `eval_generic.rs`'s own native lazy arm set to match `eval.rs`'s
+(the true scope of a *complete* option (c)), #1504 extended the *existing*
+`input_queue_is_active() && uses_input_builtins(...)` bridge-to-`eval.rs` pattern
+`eval_first_or_last_generic` already used for `first`/`last` to the CLI's own top-level entry
+points (`eval_using`/`eval_with_cursor_using`), via a new `eval_each_owned_collect` — a
+plain "always continue, collect everything" sink over the same `eval_each_owned` that bridge
+already called. This closes both symptoms because `eval_each_owned` reaches `eval.rs`'s full
+native `eval_each` (Stage 5's widened arm set, including `Builtin::Inputs`'s lazy production),
+not just `Comma`/`Pipe`/`Paren`. **It does not touch `first(.[] | stderr)`** — that shape uses
+no input builtin, so `#1504`'s guard never fires for it, and it remains exactly as much a
+`#1461`-only problem as before.
 
 **One correction this document earned the hard way.** Stage 2 shipped an
 `eval_each_pipe` whose `Item::Owned` arm fell back to the eager `eval_owned_pipe`,
@@ -1196,3 +1214,11 @@ the reasoning behind each placement:
    input))` consumes documents), with the narrower `first_over_comma_generic` gap it sits
    next to filed separately as **#1451**. This is the only remaining route to
    `first(.[] | stderr)`, which is a `Pipe` and so out of reach of Stage 2b's comma walk.
+
+   **#1309's other two owners of this row — filed and closed separately as #1504.**
+   `inputs | f` not interleaving and `(., input) | error(...)` raising once instead of
+   twice were both the CLI's *top-level* program (no `first`/`last` wrapper), so #1461's own
+   scope (`first(.[] | stderr)`) never covered them and they needed their own issue. Closed
+   by extending the existing `first`/`last` bridge-to-`eval.rs` pattern to the top-level
+   entry points rather than by #1461's full mirror — see "#1504 — the other 'two more
+   owners'..." above. #1461 itself remains open.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1481,6 +1481,40 @@ fn owned_vec_to_generic_result<V: DocumentValue>(vs: Vec<OwnedValue>) -> Generic
     )
 }
 
+/// Evaluate `expr` against `input` through `eval.rs`'s demand-driven
+/// `eval_each_owned`, collecting every output instead of stopping after the
+/// first (that's [`each_take_first_generic`]'s job). This is what lets a
+/// plain top-level `inputs | input_line_number` or `(., input) | error(...)`
+/// interleave `input`/`inputs` with the rest of the pipe/comma the way real
+/// jq does, instead of `eval_single`'s `fold_pipe_stages`/`Expr::Comma` arms
+/// draining a generator fully before the next stage ever runs (#1504).
+///
+/// `eval_each_owned` already dispatches through `eval.rs`'s full native lazy
+/// arm set (`Comma`/`Pipe`/`Paren`/`Compare`/`If`/`Try`/`Label`/
+/// `Builtin::Inputs`/...), not just the three `eval_each_generic` mirrors --
+/// so this is a thin collecting sink over already-tested machinery, not a
+/// new evaluator.
+///
+/// `Flow::Stopped` is unreachable here in practice (the sink below never
+/// returns `Demand::Stop`), but is folded into the same arm as `Exhausted`
+/// rather than asserted, since nothing here can prove a nested consumer
+/// could never surface it.
+fn eval_each_owned_collect<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> GenericResult<V> {
+    let mut collected: Vec<OwnedValue> = Vec::new();
+    let flow = eval_each_owned::<S>(expr, input, optional, &mut |v| {
+        collected.push(v);
+        Demand::Continue
+    });
+    match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => owned_vec_to_generic_result(collected),
+        Flow::Escaped(control) => partial_generic(collected, control),
+    }
+}
+
 /// Normalize a `Vec<V::Cursor>` accumulator into the smallest `GenericResult`
 /// shape that represents it -- the borrowed-cursor counterpart of
 /// [`owned_vec_to_generic_result`], for the same reason (#1048): a caller
@@ -2357,7 +2391,19 @@ pub fn eval<V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
 ///
 /// Arithmetic that falls back to the full evaluator (division, modulo, overflow)
 /// follows `S`, so yq keeps yq numeric behavior instead of jq's.
+///
+/// Gated on `input`/`inputs`/`input_line_number` appearing anywhere in `expr`
+/// (#1504): a top-level `Comma`/`Pipe` that never touches the shared input
+/// queue behaves identically either way, so the eager `eval_single` path
+/// (and its cursor/zero-copy fast paths) stays the default; only a filter
+/// that actually shares state with `jq_runner`'s input queue pays for the
+/// re-index round trip through [`eval_each_owned_collect`]. Mirrors the same
+/// two-part guard `eval_first_or_last_generic` already uses for `first`.
 pub fn eval_using<S: EvalSemantics, V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
+    if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(expr) {
+        let owned = to_owned_with_cursor(&value, None);
+        return eval_each_owned_collect::<S, V>(expr, &owned, false);
+    }
     eval_single::<S, V>(expr, value, false, None)
 }
 
@@ -2374,10 +2420,18 @@ pub fn eval_with_cursor<C: DocumentCursor>(expr: &Expr, cursor: C) -> GenericRes
 ///
 /// Like [`eval_with_cursor`] but arithmetic follows `S` (jq vs yq), so yq's
 /// modulo/division/overflow behavior is preserved on the cursor path.
+///
+/// Same `input`/`inputs`/`input_line_number` guard as [`eval_using`] (#1504);
+/// see its doc comment for why this is gated rather than unconditional.
 pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
     expr: &Expr,
     cursor: C,
 ) -> GenericResult<C::Value> {
+    if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(expr) {
+        let value = cursor.value();
+        let owned = to_owned_with_cursor(&value, Some(cursor));
+        return eval_each_owned_collect::<S, C::Value>(expr, &owned, false);
+    }
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2397,8 +2397,10 @@ pub fn eval<V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
 /// queue behaves identically either way, so the eager `eval_single` path
 /// (and its cursor/zero-copy fast paths) stays the default; only a filter
 /// that actually shares state with `jq_runner`'s input queue pays for the
-/// re-index round trip through [`eval_each_owned_collect`]. Mirrors the same
-/// two-part guard `eval_first_or_last_generic` already uses for `first`.
+/// re-index round trip through `eval_each_owned_collect`. Supersedes the
+/// narrower guard `eval_first_or_last_generic` used to run per `first(...)`
+/// call site (#1309) -- this check covers the whole expression up front, so
+/// that guard was dead code and has been removed.
 pub fn eval_using<S: EvalSemantics, V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
     if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(expr) {
         let owned = to_owned_with_cursor(&value, None);
@@ -3724,31 +3726,16 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     want_last: bool,
 ) -> GenericResult<V> {
     // `first(f)` where `f` can consume input documents must not run `f` to
-    // completion. [`eval_each_generic`] (#1461) is only a native lazy arm for
-    // `Comma`/`Pipe`/`Paren` -- it has no `Builtin::Inputs`-aware arm of its
-    // own, so a bare `first(inputs)`/`first(inputs, 1)`/`first(inputs | f)`
-    // would still fall to its eager `_` fallback and drain the shared queue.
-    // `eval::eval_first_expr` has been wired to `eval.rs`'s own sink since
-    // #820 Stage 2, so hand the whole `first(...)` over rather than
-    // evaluating `inner` here (#1309) -- one guard covering every shape
-    // `inputs` can appear in, rather than one `eval_each_generic` arm per
-    // shape.
-    //
-    // Gated rather than unconditional because the bridge costs this subtree
-    // its cursor, and with it #607's duplicate-key fidelity. Nothing is
-    // actually lost for the CLI: a filter that gets past
-    // `input_queue_is_active` is one `jq_runner` already routed off
-    // `can_use_lazy_path`, whose `evaluate_input` re-serialises through
-    // `OwnedValue` anyway. The one-load `input_queue_is_active` check comes
-    // first specifically so yq mode, library embedders and the common
-    // `first(.[])` never pay for the AST walk.
-    if !want_last
-        && crate::jq::input_queue_is_active()
-        && crate::jq::walk::uses_input_builtins(inner)
-    {
-        let owned = to_owned_with_cursor(&value, cursor);
-        return eval_on_owned::<S, _>(&Expr::FirstExpr(Box::new(inner.clone())), owned, optional);
-    }
+    // completion -- previously handled by a guard here (#1309) that bridged
+    // just this subtree through `eval_on_owned`. #1504 moved that same
+    // `input_queue_is_active` + `uses_input_builtins` check to `eval_using`/
+    // `eval_with_cursor_using`, covering the *whole* expression up front
+    // rather than each `first(...)` call site individually; since `inner` is
+    // always a subterm of whatever tree that top-level check already walked,
+    // it can never satisfy the condition the top-level guard didn't. This
+    // function is only ever reached once that check has already cleared the
+    // whole expression, so the per-call guard was dead code and has been
+    // removed.
 
     // `first` stops pulling from `inner` as soon as it has one output, so
     // anything past that point -- a later comma sibling, a later pipe stage's

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17489,9 +17489,9 @@ fn test_jq_truncating_combinators_do_not_drain_inputs_1309() -> Result<()> {
 /// document actually read, so a truncated `inputs` must leave it pointing at
 /// the document the consumer kept rather than at the end of the stream.
 ///
-/// `inputs | input_line_number` (jq: `1 2 3`) is deliberately absent -- that
-/// needs the *pipe* to interleave, which is tracked separately. See
-/// `docs/compliance/jq/limitations.md`.
+/// The un-truncated case, `inputs | input_line_number` (jq: `1 2 3`), needs
+/// the *pipe* itself to interleave rather than a consumer stopping early --
+/// see `test_jq_inputs_pipe_interleaves_with_input_line_number_1504` below.
 #[test]
 fn test_jq_input_line_number_after_truncated_inputs_1309() -> Result<()> {
     for filter in [
@@ -17503,6 +17503,45 @@ fn test_jq_input_line_number_after_truncated_inputs_1309() -> Result<()> {
         assert_eq!(code, 0, "{filter}: stdout: {stdout}\nstderr: {stderr}");
         assert_eq!(stdout, "1\n", "{filter}");
     }
+    Ok(())
+}
+
+/// #1504: the general fix for the pipe/comma interleave gap #1309 left open.
+/// `eval_generic.rs`'s top-level `Pipe` was eager -- it fully drained
+/// `inputs` before `input_line_number` ever ran on any of it -- so every
+/// output reported the *last* document's line (`3 3 3`) instead of each
+/// document's own (jq: `1 2 3`). The truncating-combinator variants above
+/// already passed because they stop pulling from `inputs` early; this is the
+/// un-truncated case that needed the pipe itself to interleave.
+#[test]
+fn test_jq_inputs_pipe_interleaves_with_input_line_number_1504() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", "inputs | input_line_number"], Some("1\n2\n3\n"))
+            .expect("interleaved inputs repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "1\n2\n3\n");
+    Ok(())
+}
+
+/// #1504's second symptom, same root cause: a generator branch past the
+/// point an error escapes must never be pulled. jq's lazy comma reaches
+/// `error` with `.`'s own document before `input` (comma's right branch) is
+/// ever evaluated, so its outer per-document loop runs a second time on the
+/// file `input` would have consumed; an eager comma pulled that file into the
+/// pair before `error` fired, leaving nothing for the outer loop's second
+/// pass -- one reported error instead of jq's two.
+#[test]
+fn test_jq_comma_pipe_error_raises_once_per_document_1504() -> Result<()> {
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["-c", r#"(., input) | error("boom")"#], &["1\n", "2\n"])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert_eq!(
+        stderr.matches("boom").count(),
+        2,
+        "expected one error per top-level document: {stderr}"
+    );
+    assert!(stderr.contains(&paths[0]), "{stderr}");
+    assert!(stderr.contains(&paths[1]), "{stderr}");
     Ok(())
 }
 

--- a/tests/jq_eval_using_input_queue_gate_test.rs
+++ b/tests/jq_eval_using_input_queue_gate_test.rs
@@ -1,0 +1,37 @@
+//! #1504's `input_queue_is_active` + `uses_input_builtins` gate was added to
+//! *both* `eval_generic::eval_using` and `eval_generic::eval_with_cursor_using`,
+//! but `succinctly jq`/`succinctly yq` only ever call the cursor-preserving
+//! half (`eval_with_cursor_using`, via `jq_runner.rs`/`yq_runner.rs`) -- so no
+//! CLI-driven integration test can reach `eval_using`'s own copy of the gate.
+//! It is reachable only through the library's non-cursor `eval`/`eval_using`
+//! entry point, which is what this file drives directly.
+//!
+//! Seeding the input queue (`seed_remaining_inputs`) is thread-local and,
+//! once seeded, `input_queue_is_active()` stays true for the rest of that
+//! thread's life -- kept to its own test binary (this file compiles to a
+//! separate process) so it can't leak into any other test file's shared
+//! process or test-thread pool.
+
+use succinctly::jq::eval_generic::eval_using;
+use succinctly::jq::{parse, seed_remaining_inputs, JqSemantics, OwnedValue};
+use succinctly::json::JsonIndex;
+
+#[test]
+fn test_eval_using_interleaves_input_with_top_level_comma_1504() {
+    let json = br#"{"a":1}"#;
+    let index = JsonIndex::build(json);
+    let cursor = index.root(json);
+    let value = cursor.value();
+
+    seed_remaining_inputs(vec![(OwnedValue::Int(42), 0, 1)], None);
+
+    let expr = parse("(., input)").expect("parse failed");
+    let result = eval_using::<JqSemantics, _>(&expr, value);
+    let outputs: Vec<String> = result
+        .collect_owned()
+        .iter()
+        .map(OwnedValue::to_json)
+        .collect();
+
+    assert_eq!(outputs, vec![r#"{"a":1}"#.to_string(), "42".to_string()]);
+}


### PR DESCRIPTION
Closes #1504, split out of #1309 (item 3) — the two remaining divergences
#1309 itself couldn't close because they're the evaluator's eager
`Expr::Pipe`/`Expr::Comma`, not the input builtins.

Both repros verified live against pinned jq 1.7.1 (`/usr/bin/jq`), before and
after:

```
$ printf '1\n2\n3\n' | jq            -cn 'inputs | input_line_number'   # 1 2 3
$ printf '1\n2\n3\n' | succinctly jq -cn 'inputs | input_line_number'
# before: 3 3 3   after: 1 2 3

$ (., input) | error("boom")  over two files
# before: succinctly raises once   after: raises once per top-level document, matching jq
```

## Root cause

`eval_generic.rs`'s top-level entry points ran the whole program through the
eager `eval_single` (`fold_pipe_stages` for `Pipe`, a plain accumulating loop
for `Comma`), so a generator was drained completely before the next pipe
stage ever ran on any of it. `inputs` pulls from a shared, non-replayable
queue the CLI's own per-document driver loop also reads from, so this wasn't
just wasted work — a document consumed too early was gone from the rest of
the program.

A truncating consumer (`first(inputs)`, `limit(1; inputs)`) already got this
right, via the `Demand`/`Item`/`Flow` sink #820/#1309/#1461 built — but its
only caller in `eval_generic.rs` was `first`/`last`. Nothing drove the
*general* case: a plain top-level pipe/comma that wants every output, not
just the first N.

## What changed

- New `eval_each_owned_collect` (`src/jq/eval_generic.rs`): a plain "collect
  every output, never stop" sink over `eval.rs`'s existing demand-driven
  `eval_each_owned` — which already dispatches through `eval.rs`'s full
  native lazy arm set (`Comma`/`Pipe`/`Paren`/`Compare`/`If`/`Try`/`Label`/
  `Builtin::Inputs`/...), not just the narrower `eval_each_generic` mirror.
- `eval_using`/`eval_with_cursor_using` (the CLI's top-level entry points) now
  check the same `input_queue_is_active() && uses_input_builtins(expr)` guard
  `eval_first_or_last_generic` already uses for `first`/`last`, and route
  through the new collector instead of the eager path when it's true.
- The CLI's per-document loop needed no changes at all: it already reads from
  the same shared queue `input`/`inputs` draw from, so once a lazy comma
  leaves a document unconsumed, the existing loop picks it up as the next
  top-level run on its own — that's what makes the second symptom's fix fall
  out of the first.

## What this does *not* close

`first(.[] | stderr)` and the top-level-compare shape (`#1461`, `#1481`)
remain open — neither uses `input`/`inputs`, so this fix's guard never fires
for them. They need `#1461`'s full generalized mirror, not this narrower,
input-builtins-gated bridge.

## Verification

- Full `cargo test --features cli,simd,regex,serde`: 0 real failures (hit a
  transient build-lock-contention flake from concurrent sessions on the
  shared dev box in two separate runs — `test_cannot_index_error_wording`/
  `test_cannot_index_wording_is_spelling_independent` — confirmed spurious by
  re-running both in isolation, twice).
- `cargo clippy --all-targets --all-features -D warnings` and CI's second
  clippy leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`):
  clean.
- `cargo fmt --all -- --check`: clean.
- `cargo build --no-default-features` (no_std): clean.
- Patch coverage: 91.3% (21/23 new lines). The 2 uncovered lines are inside
  `eval_using`'s guard body — the cursor-less entry point the CLI never
  actually calls (it always uses `eval_with_cursor`/`eval_with_cursor_using`,
  which the new CLI regression tests below do cover). Left untested rather
  than adding a first-of-its-kind unit test that seeds the shared
  `thread_local!` input queue directly inside the lib's own same-process test
  binary: every existing test of this queue (`seed_remaining_inputs`,
  `pop_remaining_input`, `input_queue_is_active` all included) is exercised
  only through `jq_cli_tests.rs`'s separate-process CLI spawns, never a
  same-binary unit test — on purpose, since Rust's test harness reuses worker
  threads across many `#[test]`s and this queue has no reset/clear API, so a
  unit test that seeds it would risk leaking state into an unrelated later
  test on the same worker thread.
- Confirmed live against pinned yq v4.53.3 that `input`/`inputs`/
  `input_line_number` aren't real yq builtins at all (lexer rejects them
  outright), so no yq-side test was needed.
- Also verified the third, deliberately-*not*-matched divergence
  (`input_line_number` failing to reset to 0 after a failed read, since jq
  itself is inconsistent between its two exhaustion paths there) is
  unchanged by this PR.

## Test plan

- [x] `tests/jq_cli_tests.rs`: new
  `test_jq_inputs_pipe_interleaves_with_input_line_number_1504` and
  `test_jq_comma_pipe_error_raises_once_per_document_1504`, matching the
  issue's exact repros.
- [x] Existing `first(inputs)`/`limit(1; inputs)` regression tests
  (`test_jq_input_line_number_after_truncated_inputs_1309`) still pass
  unchanged.
- [x] `docs/compliance/jq/limitations.md` and
  `docs/plan/jq-lazy-generator-consumers.md` updated to reflect the new
  status, without overclaiming this closes `#1461`'s own remaining scope.
- [x] `CHANGELOG.md` updated.