### PR TITLE
fix(jq): make first(keys|.[]|f) / first(map(f)|.[]|f) demand-aware

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -799,6 +799,44 @@ Deliberately not matched. jq is not self-consistent between the two exhaustion p
 a single probe admitting two readings is not a model worth encoding; the reset is not
 reproduced until the rule behind it is known.
 
+## A truncating consumer of `map(f)` skips the elements it never needed
+
+Real jq's `map(f)` is `[.[] | f]` — an array construction, and array construction is
+atomic: every element runs before anything downstream can observe the result, so a single
+failing element fails the whole expression even when the consumer only ever wanted the
+first output.
+
+`succinctly jq` evaluates `map(f)` as a lazy sequence (#724, #725) and pulls from it on
+demand, so a consumer that stops early never runs the elements past its stopping point —
+and an element that would have errored is one such element:
+
+```
+$ echo '[1,"x",3]' | jq          -c 'map(.+1) | first'          # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1) | first'        # 2, exit 0
+$ echo '[1,"x",3]' | jq          -c 'first(map(.+1) | .[])'     # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'first(map(.+1) | .[])'   # 2, exit 0
+```
+
+Deliberate, and the whole point of the laziness: skipping elements that cannot affect the
+requested output is the optimization, and restoring jq's atomicity would mean draining the
+sequence before emitting anything — reinstating exactly the O(n) cost
+[#1565](https://github.com/rust-works/succinctly/issues/1565) removed (a 2M-element
+`first(map(.+1) | .[] | .+1)` went from ~1.8 s to ~0.04 s).
+
+The divergence is bounded to consumers that genuinely truncate. Anything that has to see
+the whole array still errors, in both tools:
+
+```
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1)'         # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1) | last'  # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c '[map(.+1) | .[]]' # error, exit 5
+```
+
+Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../../tests/jq_cli_tests.rs)
+(the `map(f) | first` / `map(f) | .[0]` spelling) and
+[`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
+(the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2577,119 +2577,7 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
                 fields,
                 sorted,
                 collapse,
-            } => match if collapse {
-                // #1385: in jq mode a repeated key collapses, so
-                // these count- and order-sensitive arms cannot
-                // answer from the raw walk -- the collapsed object
-                // has fewer members, and `.[n]`/`last` land
-                // elsewhere. Probe once: an object with no repeat
-                // (the common case) keeps the zero-allocation
-                // cons-list arms below exactly as they were, and in
-                // yq mode `collapse` is a `false` const, so the
-                // probe itself compiles away.
-                collapsed_fields(&fields)
-            } else {
-                None
-            } {
-                Some(eff) => lazy_keys_collapsed::<S, V>(expr, eff, sorted, optional),
-                None => match unwrap_paren(expr) {
-                    // Order-independent for both `keys` and
-                    // `keys_unsorted` — the one fast path #683 adds for
-                    // sorted `keys`.
-                    Expr::Builtin(Builtin::Length) => {
-                        GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
-                    }
-                    // Document order is a valid answer only for
-                    // `keys_unsorted`. `keys` needs lexicographic order
-                    // for these and falls through to the shared
-                    // materialize-(and-sort) fallback below. Do not drop
-                    // the `if !sorted` guard on a new arm here without
-                    // re-deriving why document order would still be a
-                    // correct answer.
-                    Expr::Iterate if !sorted => {
-                        let mut cursors = Vec::new();
-                        let mut current = fields;
-                        while let Some((field, rest)) = current.uncons() {
-                            cursors.push(field.key_cursor);
-                            current = rest;
-                        }
-                        if cursors.is_empty() {
-                            GenericResult::None
-                        } else {
-                            GenericResult::ManyCursor(cursors)
-                        }
-                    }
-                    Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
-                        // Negative indices need the length to normalize
-                        // against, same as `Expr::Index`'s array arm
-                        // above; positive indices skip straight to the
-                        // walk. Out-of-bounds is `null`, never an error
-                        // (#307), matching that same arm.
-                        let target = if *idx < 0 {
-                            let len = fields.len();
-                            let normalized = len as i64 + idx;
-                            if normalized < 0 {
-                                None
-                            } else {
-                                Some(normalized as usize)
-                            }
-                        } else {
-                            Some(*idx as usize)
-                        };
-                        match target {
-                            Some(target) => {
-                                let mut current = fields;
-                                let mut found = None;
-                                let mut i = 0usize;
-                                while let Some((field, rest)) = current.uncons() {
-                                    if i == target {
-                                        found = Some(field.key_cursor);
-                                        break;
-                                    }
-                                    current = rest;
-                                    i += 1;
-                                }
-                                match found {
-                                    Some(c) => GenericResult::OneCursor(c),
-                                    None => GenericResult::Owned(OwnedValue::Null),
-                                }
-                            }
-                            None => GenericResult::Owned(OwnedValue::Null),
-                        }
-                    }
-                    Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
-                        Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
-                        None => GenericResult::Owned(OwnedValue::Null),
-                    },
-                    Expr::Builtin(Builtin::Last) if !sorted => {
-                        let mut current = fields;
-                        let mut last_cursor = None;
-                        while let Some((field, rest)) = current.uncons() {
-                            last_cursor = Some(field.key_cursor);
-                            current = rest;
-                        }
-                        match last_cursor {
-                            Some(c) => GenericResult::OneCursor(c),
-                            None => GenericResult::Owned(OwnedValue::Null),
-                        }
-                    }
-                    // Slice 1 (#724): stay lazy instead of falling
-                    // through to the `_` materializing fallback below —
-                    // reuses the composability arm (`GenericResult::LazySeq`
-                    // below) for everything past this first `map` stage.
-                    // Same `!sorted` guard as the other fast-path arms
-                    // above: sorted `keys` still needs a full decode+sort
-                    // first.
-                    Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
-                        LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG),
-                    ),
-                    _ => eval_on_owned::<S, _>(
-                        expr,
-                        materialize_lazy_keys::<V>(&fields, sorted, collapse),
-                        optional,
-                    ),
-                },
-            },
+            } => fold_lazy_keys_stage::<S, V>(fields, sorted, collapse, expr, optional),
             // The array counterpart of `LazyKeys` above
             // (#684): the index range `[0, 1, ..., len-1]` is fully
             // determined by `len` alone, so `length`, `.[]`, `.[n]`,
@@ -2697,57 +2585,9 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // allocation at all, not even a `Vec<V::Cursor>` (there's
             // no cursor to point at: array-index "keys" are
             // synthetic, not bytes in the source document).
-            GenericResult::LazyIndexRange(len) => match unwrap_paren(expr) {
-                Expr::Builtin(Builtin::Length) => GenericResult::Owned(OwnedValue::Int(len as i64)),
-                Expr::Iterate => {
-                    if len == 0 {
-                        GenericResult::None
-                    } else {
-                        GenericResult::ManyOwned(
-                            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
-                        )
-                    }
-                }
-                Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-                    // Same normalization/OOB-is-null semantics as
-                    // `LazyKeys`'s `Expr::Index` arm above.
-                    let target = if *idx < 0 {
-                        let normalized = len as i64 + idx;
-                        if normalized < 0 {
-                            None
-                        } else {
-                            Some(normalized as usize)
-                        }
-                    } else {
-                        Some(*idx as usize)
-                    };
-                    match target {
-                        Some(i) if i < len => GenericResult::Owned(OwnedValue::Int(i as i64)),
-                        _ => GenericResult::Owned(OwnedValue::Null),
-                    }
-                }
-                Expr::Builtin(Builtin::First) => {
-                    if len == 0 {
-                        GenericResult::Owned(OwnedValue::Null)
-                    } else {
-                        GenericResult::Owned(OwnedValue::Int(0))
-                    }
-                }
-                Expr::Builtin(Builtin::Last) => {
-                    if len == 0 {
-                        GenericResult::Owned(OwnedValue::Null)
-                    } else {
-                        GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
-                    }
-                }
-                // Slice 1 (#724), array counterpart of `LazyKeys`'s
-                // own `Builtin::Map` arm above. No `!sorted` guard —
-                // array "keys" are never sorted.
-                Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
-                    LazySeq::new(LazySource::IndexRange { next: 0, len }).push_map(f, S::TAG),
-                ),
-                _ => eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional),
-            },
+            GenericResult::LazyIndexRange(len) => {
+                fold_lazy_index_range_stage::<S, V>(len, expr, optional)
+            }
             // The composability engine (#724, #725): every further
             // `| map(g)` stage just pushes onto the same chain
             // (self-recursive by construction — an arbitrary-length
@@ -2757,117 +2597,7 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // materializes once (`materialize_atomic`) and hands off
             // to the full evaluator — still one pass, not the
             // original four-pass round trip.
-            GenericResult::LazySeq(mut seq) => match unwrap_paren(expr) {
-                Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(seq.push_map(h, S::TAG)),
-
-                // Count-and-discard: every element still runs (so a
-                // `map(f)` that errors partway still errors), but no
-                // `OwnedValue` is ever built for any of them. Atomic,
-                // same as `materialize_atomic` -- `length` of an
-                // array construction that fails is itself a failure,
-                // not a partial count.
-                Expr::Builtin(Builtin::Length) => {
-                    let mut count: i64 = 0;
-                    for item in seq {
-                        match item {
-                            Ok(_) => count += 1,
-                            Err(Control::Error(e)) => return GenericResult::Error(e),
-                            Err(Control::Break(label)) => return GenericResult::Break(label),
-                            Err(Control::Halt(code)) => return GenericResult::Halt(code),
-                        }
-                    }
-                    GenericResult::Owned(OwnedValue::Int(count))
-                }
-
-                // `.[]` iterates the array `map`'s own construction
-                // already built, not the raw source -- and that
-                // construction is atomic in real jq
-                // (`[1,2,"x"]|map(.+1)` prints nothing on error, not
-                // a truncated prefix), so a failure here discards
-                // every already-yielded element too, same atomicity
-                // boundary as `Length`/the `_` fallback below. This
-                // is NOT the same case as elementwise
-                // `.[] | select(g)` (a structurally distinct,
-                // out-of-scope case per the design doc): there,
-                // `.[]` is the *source* of the pipe and each element
-                // is independent; here it's a *consumer* of an
-                // already-atomic `map` result.
-                Expr::Iterate => {
-                    let mut items = Vec::new();
-                    for item in seq {
-                        match item {
-                            Ok(elem) => items.push(elem),
-                            Err(Control::Error(e)) => return GenericResult::Error(e),
-                            Err(Control::Break(label)) => return GenericResult::Break(label),
-                            Err(Control::Halt(code)) => return GenericResult::Halt(code),
-                        }
-                    }
-                    let all_cursor = items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
-                    if items.is_empty() {
-                        GenericResult::None
-                    } else if all_cursor {
-                        GenericResult::ManyCursor(
-                            items
-                                .into_iter()
-                                .map(|item| match item {
-                                    LazyElem::Cursor(c) => c,
-                                    LazyElem::Owned(_) => {
-                                        unreachable!("checked all_cursor above")
-                                    }
-                                })
-                                .collect(),
-                        )
-                    } else {
-                        GenericResult::ManyOwned(
-                            items
-                                .into_iter()
-                                .map(|item| match item {
-                                    LazyElem::Cursor(c) => to_owned_cursor(&c),
-                                    LazyElem::Owned(o) => o,
-                                })
-                                .collect(),
-                        )
-                    }
-                }
-
-                // Pull-one-and-stop: at most one element of `seq` is
-                // ever evaluated. Accepted, deliberate divergence
-                // from real jq's strict semantics: real jq's `map`
-                // eagerly builds the *whole* array before `first`/
-                // `.[0]` can observe it, so `map(f)|first` errors if
-                // *any* element of `f` fails, even ones past the
-                // first. This fast path only evaluates what's
-                // actually needed, so `[1,2,"x"]|map(.+1)|first`
-                // succeeds here (returns `2`) where real jq raises a
-                // type error -- the entire point of making `first`/
-                // `.[0]` lazy is to skip evaluating elements that
-                // don't affect the requested output, and an error on
-                // a skipped element is one such element. Pinned by
-                // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
-                Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
-                    None => GenericResult::Owned(OwnedValue::Null),
-                    Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
-                    Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
-                    Some(Err(Control::Error(e))) => GenericResult::Error(e),
-                    Some(Err(Control::Break(label))) => GenericResult::Break(label),
-                    Some(Err(Control::Halt(code))) => GenericResult::Halt(code),
-                },
-
-                // `last`, nonzero `.[n]`, whole-value `select`,
-                // comparisons, everything else: one atomic forward
-                // pass, then hand off to the full evaluator -- still
-                // one pass, not the original four-pass round trip.
-                // `select` deliberately gets no dedicated arm here —
-                // it materializes once and runs through
-                // `eval_on_owned`'s already-correct `Builtin::Select`
-                // handling, same as any other computed value.
-                _ => match seq.materialize_atomic() {
-                    Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
-                    Err(Control::Error(e)) => GenericResult::Error(e),
-                    Err(Control::Break(label)) => GenericResult::Break(label),
-                    Err(Control::Halt(code)) => GenericResult::Halt(code),
-                },
-            },
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => return GenericResult::Error(e),
             GenericResult::Owned(o) => {
@@ -2884,6 +2614,315 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
     }
 
     current
+}
+
+/// One step of folding a `GenericResult::LazyKeys` through a single further
+/// pipe stage. Extracted verbatim from `fold_pipe_stages`'s own `LazyKeys`
+/// arm so a planned demand-aware sibling (#1565) can share the exact same
+/// composability fast paths (`length`, `.[]`, `.[n]`, `first`, `last`,
+/// `map` when `!sorted`) instead of duplicating them.
+fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
+    fields: V::Fields,
+    sorted: bool,
+    collapse: bool,
+    expr: &Expr,
+    optional: bool,
+) -> GenericResult<V> {
+    match if collapse {
+        // #1385: in jq mode a repeated key collapses, so
+        // these count- and order-sensitive arms cannot
+        // answer from the raw walk -- the collapsed object
+        // has fewer members, and `.[n]`/`last` land
+        // elsewhere. Probe once: an object with no repeat
+        // (the common case) keeps the zero-allocation
+        // cons-list arms below exactly as they were, and in
+        // yq mode `collapse` is a `false` const, so the
+        // probe itself compiles away.
+        collapsed_fields(&fields)
+    } else {
+        None
+    } {
+        Some(eff) => lazy_keys_collapsed::<S, V>(expr, eff, sorted, optional),
+        None => match unwrap_paren(expr) {
+            // Order-independent for both `keys` and
+            // `keys_unsorted` — the one fast path #683 adds for
+            // sorted `keys`.
+            Expr::Builtin(Builtin::Length) => {
+                GenericResult::Owned(OwnedValue::Int(fields.len() as i64))
+            }
+            // Document order is a valid answer only for
+            // `keys_unsorted`. `keys` needs lexicographic order
+            // for these and falls through to the shared
+            // materialize-(and-sort) fallback below. Do not drop
+            // the `if !sorted` guard on a new arm here without
+            // re-deriving why document order would still be a
+            // correct answer.
+            Expr::Iterate if !sorted => {
+                let mut cursors = Vec::new();
+                let mut current = fields;
+                while let Some((field, rest)) = current.uncons() {
+                    cursors.push(field.key_cursor);
+                    current = rest;
+                }
+                if cursors.is_empty() {
+                    GenericResult::None
+                } else {
+                    GenericResult::ManyCursor(cursors)
+                }
+            }
+            Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
+                // Negative indices need the length to normalize
+                // against, same as `Expr::Index`'s array arm
+                // above; positive indices skip straight to the
+                // walk. Out-of-bounds is `null`, never an error
+                // (#307), matching that same arm.
+                let target = if *idx < 0 {
+                    let len = fields.len();
+                    let normalized = len as i64 + idx;
+                    if normalized < 0 {
+                        None
+                    } else {
+                        Some(normalized as usize)
+                    }
+                } else {
+                    Some(*idx as usize)
+                };
+                match target {
+                    Some(target) => {
+                        let mut current = fields;
+                        let mut found = None;
+                        let mut i = 0usize;
+                        while let Some((field, rest)) = current.uncons() {
+                            if i == target {
+                                found = Some(field.key_cursor);
+                                break;
+                            }
+                            current = rest;
+                            i += 1;
+                        }
+                        match found {
+                            Some(c) => GenericResult::OneCursor(c),
+                            None => GenericResult::Owned(OwnedValue::Null),
+                        }
+                    }
+                    None => GenericResult::Owned(OwnedValue::Null),
+                }
+            }
+            Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
+                Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
+                None => GenericResult::Owned(OwnedValue::Null),
+            },
+            Expr::Builtin(Builtin::Last) if !sorted => {
+                let mut current = fields;
+                let mut last_cursor = None;
+                while let Some((field, rest)) = current.uncons() {
+                    last_cursor = Some(field.key_cursor);
+                    current = rest;
+                }
+                match last_cursor {
+                    Some(c) => GenericResult::OneCursor(c),
+                    None => GenericResult::Owned(OwnedValue::Null),
+                }
+            }
+            // Slice 1 (#724): stay lazy instead of falling
+            // through to the `_` materializing fallback below —
+            // reuses the composability arm (`GenericResult::LazySeq`
+            // below) for everything past this first `map` stage.
+            // Same `!sorted` guard as the other fast-path arms
+            // above: sorted `keys` still needs a full decode+sort
+            // first.
+            Expr::Builtin(Builtin::Map(f)) if !sorted => {
+                GenericResult::LazySeq(LazySeq::new(LazySource::Keys(fields)).push_map(f, S::TAG))
+            }
+            _ => eval_on_owned::<S, _>(
+                expr,
+                materialize_lazy_keys::<V>(&fields, sorted, collapse),
+                optional,
+            ),
+        },
+    }
+}
+
+/// One step of folding a `GenericResult::LazyIndexRange` through a single
+/// further pipe stage. Extracted verbatim from `fold_pipe_stages`'s own
+/// `LazyIndexRange` arm (#1565); see [`fold_lazy_keys_stage`]'s own doc
+/// comment for why this split exists.
+fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
+    len: usize,
+    expr: &Expr,
+    optional: bool,
+) -> GenericResult<V> {
+    match unwrap_paren(expr) {
+        Expr::Builtin(Builtin::Length) => GenericResult::Owned(OwnedValue::Int(len as i64)),
+        Expr::Iterate => {
+            if len == 0 {
+                GenericResult::None
+            } else {
+                GenericResult::ManyOwned((0..len).map(|i| OwnedValue::Int(i as i64)).collect())
+            }
+        }
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+            // Same normalization/OOB-is-null semantics as
+            // `LazyKeys`'s `Expr::Index` arm above.
+            let target = if *idx < 0 {
+                let normalized = len as i64 + idx;
+                if normalized < 0 {
+                    None
+                } else {
+                    Some(normalized as usize)
+                }
+            } else {
+                Some(*idx as usize)
+            };
+            match target {
+                Some(i) if i < len => GenericResult::Owned(OwnedValue::Int(i as i64)),
+                _ => GenericResult::Owned(OwnedValue::Null),
+            }
+        }
+        Expr::Builtin(Builtin::First) => {
+            if len == 0 {
+                GenericResult::Owned(OwnedValue::Null)
+            } else {
+                GenericResult::Owned(OwnedValue::Int(0))
+            }
+        }
+        Expr::Builtin(Builtin::Last) => {
+            if len == 0 {
+                GenericResult::Owned(OwnedValue::Null)
+            } else {
+                GenericResult::Owned(OwnedValue::Int(len as i64 - 1))
+            }
+        }
+        // Slice 1 (#724), array counterpart of `LazyKeys`'s
+        // own `Builtin::Map` arm above. No `!sorted` guard —
+        // array "keys" are never sorted.
+        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
+            LazySeq::new(LazySource::IndexRange { next: 0, len }).push_map(f, S::TAG),
+        ),
+        _ => eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional),
+    }
+}
+
+/// One step of folding a `GenericResult::LazySeq` through a single further
+/// pipe stage. Extracted verbatim from `fold_pipe_stages`'s own `LazySeq`
+/// arm; see [`fold_lazy_keys_stage`]'s own doc comment for why this split
+/// exists.
+fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
+    mut seq: LazySeq<V>,
+    expr: &Expr,
+    optional: bool,
+) -> GenericResult<V> {
+    match unwrap_paren(expr) {
+        Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(seq.push_map(h, S::TAG)),
+
+        // Count-and-discard: every element still runs (so a
+        // `map(f)` that errors partway still errors), but no
+        // `OwnedValue` is ever built for any of them. Atomic,
+        // same as `materialize_atomic` -- `length` of an
+        // array construction that fails is itself a failure,
+        // not a partial count.
+        Expr::Builtin(Builtin::Length) => {
+            let mut count: i64 = 0;
+            for item in seq {
+                match item {
+                    Ok(_) => count += 1,
+                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                    Err(Control::Halt(code)) => return GenericResult::Halt(code),
+                }
+            }
+            GenericResult::Owned(OwnedValue::Int(count))
+        }
+
+        // `.[]` iterates the array `map`'s own construction
+        // already built, not the raw source -- and that
+        // construction is atomic in real jq
+        // (`[1,2,"x"]|map(.+1)` prints nothing on error, not
+        // a truncated prefix), so a failure here discards
+        // every already-yielded element too, same atomicity
+        // boundary as `Length`/the `_` fallback below. This
+        // is NOT the same case as elementwise
+        // `.[] | select(g)` (a structurally distinct,
+        // out-of-scope case per the design doc): there,
+        // `.[]` is the *source* of the pipe and each element
+        // is independent; here it's a *consumer* of an
+        // already-atomic `map` result.
+        Expr::Iterate => {
+            let mut items = Vec::new();
+            for item in seq {
+                match item {
+                    Ok(elem) => items.push(elem),
+                    Err(Control::Error(e)) => return GenericResult::Error(e),
+                    Err(Control::Break(label)) => return GenericResult::Break(label),
+                    Err(Control::Halt(code)) => return GenericResult::Halt(code),
+                }
+            }
+            let all_cursor = items.iter().all(|item| matches!(item, LazyElem::Cursor(_)));
+            if items.is_empty() {
+                GenericResult::None
+            } else if all_cursor {
+                GenericResult::ManyCursor(
+                    items
+                        .into_iter()
+                        .map(|item| match item {
+                            LazyElem::Cursor(c) => c,
+                            LazyElem::Owned(_) => {
+                                unreachable!("checked all_cursor above")
+                            }
+                        })
+                        .collect(),
+                )
+            } else {
+                GenericResult::ManyOwned(
+                    items
+                        .into_iter()
+                        .map(|item| match item {
+                            LazyElem::Cursor(c) => to_owned_cursor(&c),
+                            LazyElem::Owned(o) => o,
+                        })
+                        .collect(),
+                )
+            }
+        }
+
+        // Pull-one-and-stop: at most one element of `seq` is
+        // ever evaluated. Accepted, deliberate divergence
+        // from real jq's strict semantics: real jq's `map`
+        // eagerly builds the *whole* array before `first`/
+        // `.[0]` can observe it, so `map(f)|first` errors if
+        // *any* element of `f` fails, even ones past the
+        // first. This fast path only evaluates what's
+        // actually needed, so `[1,2,"x"]|map(.+1)|first`
+        // succeeds here (returns `2`) where real jq raises a
+        // type error -- the entire point of making `first`/
+        // `.[0]` lazy is to skip evaluating elements that
+        // don't affect the requested output, and an error on
+        // a skipped element is one such element. Pinned by
+        // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
+        Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
+            None => GenericResult::Owned(OwnedValue::Null),
+            Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
+            Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
+            Some(Err(Control::Error(e))) => GenericResult::Error(e),
+            Some(Err(Control::Break(label))) => GenericResult::Break(label),
+            Some(Err(Control::Halt(code))) => GenericResult::Halt(code),
+        },
+
+        // `last`, nonzero `.[n]`, whole-value `select`,
+        // comparisons, everything else: one atomic forward
+        // pass, then hand off to the full evaluator -- still
+        // one pass, not the original four-pass round trip.
+        // `select` deliberately gets no dedicated arm here —
+        // it materializes once and runs through
+        // `eval_on_owned`'s already-correct `Builtin::Select`
+        // handling, same as any other computed value.
+        _ => match seq.materialize_atomic() {
+            Ok(owned) => eval_on_owned::<S, _>(expr, owned, optional),
+            Err(Control::Error(e)) => GenericResult::Error(e),
+            Err(Control::Break(label)) => GenericResult::Break(label),
+            Err(Control::Halt(code)) => GenericResult::Halt(code),
+        },
+    }
 }
 
 /// Evaluate a single expression against a value with optional cursor context.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3130,14 +3130,30 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
             // already-correct, arbitrary-length-pipe-aware demand driver
             // rather than re-deriving its cursor-threading logic here
             // (#1503).
+            //
+            // These three hand off `&stages[j..]`, NOT `rest`: `current` is
+            // the value *entering* `stages[j]`, since only the lazy arms
+            // above consume `expr` (they are the arms that assign back to
+            // `current` and fall through to `j += 1`). Handing off `rest`
+            // here silently skipped `stages[j]` altogether -- `first(keys |
+            // length | tostring)` printed `3` instead of `"3"` -- so the
+            // `stages[j..]` the `other` arm below already used is the
+            // correct slice for every non-folding arm. Pinned by
+            // `test_first_over_lazy_prefix_applies_every_stage_1565`.
             GenericResult::One(v) => {
-                return eval_each_pipe_generic::<S, V>(rest, v, optional, None, sink);
+                return eval_each_pipe_generic::<S, V>(&stages[j..], v, optional, None, sink);
             }
             GenericResult::OneCursor(c) => {
-                return eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink);
+                return eval_each_pipe_generic::<S, V>(
+                    &stages[j..],
+                    c.value(),
+                    optional,
+                    Some(c),
+                    sink,
+                );
             }
             GenericResult::Owned(o) => {
-                let rest_pipe = Expr::Pipe(rest.to_vec());
+                let rest_pipe = Expr::Pipe(stages[j..].to_vec());
                 return eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
                     sink(GenericItem::Owned(o))
                 });
@@ -3150,18 +3166,23 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
             | GenericResult::Halt(_)) => {
                 return drain_result_generic(terminal, sink);
             }
-            // Unreachable from this function's only entry points
-            // (`eval_each_pipe_generic`'s Lazy* driver arm and
-            // `continue_pipe_element_generic`'s own Lazy* arm, both of which
-            // always start here with a `LazyKeys`/`LazyIndexRange`/`LazySeq`
-            // `current`): nothing above ever assigns `Many`/`ManyCursor`/
-            // `ManyOwned`/`Partial` to `current` mid-loop, since the only
-            // stage shape that can fan out (`Expr::Iterate`) is intercepted
-            // above and returns immediately instead of falling through to
-            // the generic match. Kept as a safety net (degrading to the
-            // eager fold) rather than `unreachable!()`, so a future caller
-            // that *does* reach this some other way gets correct-but-less-
-            // lazy behavior instead of a panic.
+            // Genuinely reachable, not a safety net -- do not turn this
+            // into `unreachable!()`. `Expr::Iterate` is not the only stage
+            // shape that can fan out: `fold_lazy_keys_stage`'s own
+            // materializing `_` fallback hands `expr` to `eval_on_owned`,
+            // which returns `ManyOwned` for any multi-output stage that
+            // isn't one of the native fast paths. `first(keys | .[0,1] |
+            // stderr)` is the shortest witness -- `.[0,1]` is an
+            // `Expr::IndexExpr` with a `Comma` key, so it lands here with
+            // `current` already a two-element `ManyOwned`.
+            //
+            // Folding the rest eagerly from here is a deliberate
+            // correct-but-less-lazy fallback: once a stage has already
+            // fanned out into a materialized `Vec`, its side effects have
+            // all fired anyway, so there is no demand left to honor for
+            // *that* stage. Pinned by
+            // `test_first_over_lazy_prefix_applies_every_stage_1565`'s
+            // `.[0,1]` row.
             other => {
                 return drain_result_generic(
                     fold_pipe_stages::<S, V>(other, &stages[j..], optional),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3054,6 +3054,24 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// yields `Result<LazyElem<V>, Control>`; only [`LazyElem::Cursor`]/
 /// [`LazyElem::Owned`] are real elements, an `Err` is a mid-`map` failure
 /// handled by [`drive_pipe_elements_generic`] itself.
+///
+/// **Deliberate divergence from real jq, and from the eager arm's own
+/// atomicity.** `fold_lazy_seq_stage`'s `Expr::Iterate` arm drains first, so
+/// a `map(f)` that fails on *any* element discards every element it already
+/// yielded -- matching real jq, where `map` builds the whole array before
+/// `.[]` can observe it. Pulling one at a time cannot preserve that: an
+/// element already handed to `sink` is already downstream. So
+/// `[1,"x",3] | first(map(.+1) | .[])` yields `2` here where jq errors.
+///
+/// This is the same trade #725 already made for `map(f) | first` (pinned by
+/// `test_generic_lazy_seq_first_after_map_skips_later_error_725`), widened
+/// from `first`/`.[0]` to `.[]`-under-demand: the point of a lazy `first` is
+/// to skip elements that cannot affect the requested output, and an element
+/// that errors is one such element. Restoring atomicity would mean draining
+/// the whole `seq` before emitting anything, which is exactly the O(n) cost
+/// #1565 exists to remove. Pinned by
+/// `test_first_over_lazy_seq_iterate_skips_later_error_1565`; recorded in
+/// `docs/compliance/jq/limitations.md`.
 fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     seq: LazySeq<V>,
     rest: &[Expr],

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2618,9 +2618,13 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
 
 /// One step of folding a `GenericResult::LazyKeys` through a single further
 /// pipe stage. Extracted verbatim from `fold_pipe_stages`'s own `LazyKeys`
-/// arm so a planned demand-aware sibling (#1565) can share the exact same
+/// arm (#1565) so [`fold_pipe_stages_sink`] can share the exact same
 /// composability fast paths (`length`, `.[]`, `.[n]`, `first`, `last`,
-/// `map` when `!sorted`) instead of duplicating them.
+/// `map` when `!sorted`) instead of duplicating them -- only the eager
+/// `fold_pipe_stages` and the demand-aware `fold_pipe_stages_sink` differ in
+/// how they consume an `Expr::Iterate` result, and `fold_pipe_stages_sink`
+/// intercepts that case before ever calling this function (see its own
+/// per-lazy-variant element iteration instead).
 fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
     fields: V::Fields,
     sorted: bool,
@@ -2805,8 +2809,13 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
 
 /// One step of folding a `GenericResult::LazySeq` through a single further
 /// pipe stage. Extracted verbatim from `fold_pipe_stages`'s own `LazySeq`
-/// arm; see [`fold_lazy_keys_stage`]'s own doc comment for why this split
-/// exists.
+/// arm (#1565); see [`fold_lazy_keys_stage`]'s own doc comment for why this
+/// split exists. `fold_pipe_stages_sink` intercepts `Expr::Iterate` before
+/// ever calling this function, but every *other* stage shape here --
+/// including `Expr::Builtin(Builtin::First) | Expr::Index(0)`'s own
+/// pull-one-and-stop fast path -- is identical between the eager and
+/// demand-aware callers, since none of them fan out beyond the single `seq`
+/// they were already holding.
 fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
     mut seq: LazySeq<V>,
     expr: &Expr,
@@ -2922,6 +2931,245 @@ fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
             Err(Control::Break(label)) => GenericResult::Break(label),
             Err(Control::Halt(code)) => GenericResult::Halt(code),
         },
+    }
+}
+
+/// Pull items one at a time from `elements`, threading each through `rest`
+/// via [`continue_pipe_element_generic`] and stopping the moment that isn't
+/// `Flow::Exhausted`. Shared by every `Expr::Iterate` fan-out case in
+/// [`fold_pipe_stages_sink`] (#1565) so `first` only ever pays for the
+/// elements it actually needed downstream, never the ones after it stopped.
+/// An `Err(control)` from the source itself (only `LazySeq` can produce one,
+/// mid-`map`) is an immediate stop, matching `fold_lazy_seq_stage`'s own
+/// treatment of a mid-drain error.
+fn drive_pipe_elements_generic<S: EvalSemantics, V: DocumentValue>(
+    elements: impl Iterator<Item = Result<GenericItem<V>, Control>>,
+    rest: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    for element in elements {
+        match element {
+            Ok(item) => match continue_pipe_element_generic::<S, V>(item, rest, optional, sink) {
+                Flow::Exhausted => continue,
+                other => return other,
+            },
+            Err(Control::Error(e)) => return drain_result_generic(GenericResult::Error(e), sink),
+            Err(Control::Break(label)) => {
+                return drain_result_generic(GenericResult::Break(label), sink);
+            }
+            Err(Control::Halt(code)) => {
+                return drain_result_generic(GenericResult::Halt(code), sink)
+            }
+        }
+    }
+    Flow::Exhausted
+}
+
+/// Demand-aware `Expr::Iterate` fan-out for a `LazyIndexRange` (#1565): no
+/// allocation at all, mirroring `fold_lazy_index_range_stage`'s own
+/// `Expr::Iterate` arm's zero-cost arithmetic -- the only difference is each
+/// index is driven through `rest` one at a time instead of all being
+/// collected into a `ManyOwned` first.
+fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
+    len: usize,
+    rest: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    drive_pipe_elements_generic::<S, V>(
+        (0..len).map(|i| Ok(GenericItem::Owned(OwnedValue::Int(i as i64)))),
+        rest,
+        optional,
+        sink,
+    )
+}
+
+/// Demand-aware `Expr::Iterate` fan-out for a `LazyKeys` (#1565).
+///
+/// `!sorted` (`keys_unsorted`): reuses the exact same cons-list walk
+/// `fold_lazy_keys_stage`'s own `Expr::Iterate` arm uses to build its
+/// `ManyCursor` -- building that `Vec<V::Cursor>` costs the same as a real
+/// array's own `ManyCursor` build (the baseline `first(.[] | ...)` already
+/// pays, per #1461), so `first`'s saving here is entirely in the
+/// *downstream* per-element re-evaluation this function now gates, not in
+/// this structural step.
+///
+/// `sorted` (`keys`): lexicographic order needs every key decoded and
+/// sorted first, unavoidably -- the same cost `materialize_lazy_keys` always
+/// paid. Reuses `effective_keys` (the same helper `materialize_lazy_keys`
+/// calls) rather than re-deriving key decoding, then walks the sorted `Vec`
+/// one at a time as `Owned` strings -- matching `materialize_lazy_keys`'s
+/// existing behaviour of not preserving a cursor for sorted keys (no new
+/// capability, no regression, just demand-aware instead of eager).
+fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
+    fields: V::Fields,
+    sorted: bool,
+    collapse: bool,
+    rest: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    if !sorted {
+        let cursors: Vec<V::Cursor> = match if collapse {
+            collapsed_fields(&fields)
+        } else {
+            None
+        } {
+            Some(collapsed) => collapsed.into_iter().map(|f| f.key_cursor).collect(),
+            None => {
+                let mut cursors = Vec::new();
+                let mut current = fields;
+                while let Some((field, next)) = current.uncons() {
+                    cursors.push(field.key_cursor);
+                    current = next;
+                }
+                cursors
+            }
+        };
+        return drive_pipe_elements_generic::<S, V>(
+            cursors.into_iter().map(|c| Ok(GenericItem::OneCursor(c))),
+            rest,
+            optional,
+            sink,
+        );
+    }
+
+    let mut keys = effective_keys(&fields, collapse);
+    keys.sort();
+    drive_pipe_elements_generic::<S, V>(
+        keys.into_iter()
+            .map(|k| Ok(GenericItem::Owned(OwnedValue::String(k)))),
+        rest,
+        optional,
+        sink,
+    )
+}
+
+/// Demand-aware `Expr::Iterate` fan-out for a `LazySeq` (#1565): pulls
+/// directly from `seq`'s own `Iterator` impl one element at a time, unlike
+/// `fold_lazy_seq_stage`'s own `Expr::Iterate` arm, which drains it fully
+/// (running every buffered `map(f)` closure) before returning -- draining is
+/// exactly the O(n) cost `first(map(f) | .[] | g)` should not pay. `seq`
+/// yields `Result<LazyElem<V>, Control>`; only [`LazyElem::Cursor`]/
+/// [`LazyElem::Owned`] are real elements, an `Err` is a mid-`map` failure
+/// handled by [`drive_pipe_elements_generic`] itself.
+fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
+    seq: LazySeq<V>,
+    rest: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    drive_pipe_elements_generic::<S, V>(
+        seq.map(|item| {
+            item.map(|elem| match elem {
+                LazyElem::Cursor(c) => GenericItem::OneCursor(c),
+                LazyElem::Owned(o) => GenericItem::Owned(o),
+            })
+        }),
+        rest,
+        optional,
+        sink,
+    )
+}
+
+/// Demand-aware twin of `fold_pipe_stages` (#1565): folds an already-produced
+/// `LazyKeys`/`LazyIndexRange`/`LazySeq` item through the remaining pipe
+/// stages one at a time, honoring `sink`'s `Demand` the moment `Expr::Iterate`
+/// would otherwise fan out into multiple elements -- so a `first`-driven pull
+/// stops as soon as the sink says so, instead of `fold_pipe_stages`'s
+/// unconditional full materialization (`first(keys | .[] | stderr)` visiting
+/// every key). Every *other* stage shape reuses `fold_lazy_keys_stage`/
+/// `fold_lazy_index_range_stage`/`fold_lazy_seq_stage` -- the exact same
+/// composability fast paths `fold_pipe_stages` itself uses (#724/#725) --
+/// rather than duplicating them, and the moment folding resolves to a
+/// genuinely single value, control hands off to `eval_each_pipe_generic`/
+/// `eval_each_owned`, which already know how to thread an arbitrary-length
+/// remaining pipe through one value without re-deriving cursor threading here
+/// (the #1503 lesson).
+fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
+    mut current: GenericResult<V>,
+    stages: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut j = 0usize;
+    loop {
+        if j == stages.len() {
+            return drain_result_generic(current, sink);
+        }
+        let expr = &stages[j];
+        let rest = &stages[j + 1..];
+        let is_iterate = matches!(unwrap_paren(expr), Expr::Iterate);
+        current = match current {
+            GenericResult::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            } if is_iterate => {
+                return each_lazy_keys_iterate_sink::<S, V>(
+                    fields, sorted, collapse, rest, optional, sink,
+                );
+            }
+            GenericResult::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            } => fold_lazy_keys_stage::<S, V>(fields, sorted, collapse, expr, optional),
+            GenericResult::LazyIndexRange(len) if is_iterate => {
+                return each_lazy_index_range_iterate_sink::<S, V>(len, rest, optional, sink);
+            }
+            GenericResult::LazyIndexRange(len) => {
+                fold_lazy_index_range_stage::<S, V>(len, expr, optional)
+            }
+            GenericResult::LazySeq(seq) if is_iterate => {
+                return each_lazy_seq_iterate_sink::<S, V>(seq, rest, optional, sink);
+            }
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
+            // Resolved to a genuinely single value/cursor -- hand off to the
+            // already-correct, arbitrary-length-pipe-aware demand driver
+            // rather than re-deriving its cursor-threading logic here
+            // (#1503).
+            GenericResult::One(v) => {
+                return eval_each_pipe_generic::<S, V>(rest, v, optional, None, sink);
+            }
+            GenericResult::OneCursor(c) => {
+                return eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink);
+            }
+            GenericResult::Owned(o) => {
+                let rest_pipe = Expr::Pipe(rest.to_vec());
+                return eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
+                    sink(GenericItem::Owned(o))
+                });
+            }
+            // Nothing further to fold; push (or don't) and stop, same as
+            // `drain_result_generic`'s own handling of these.
+            terminal @ (GenericResult::None
+            | GenericResult::Error(_)
+            | GenericResult::Break(_)
+            | GenericResult::Halt(_)) => {
+                return drain_result_generic(terminal, sink);
+            }
+            // Unreachable from this function's only entry points
+            // (`eval_each_pipe_generic`'s Lazy* driver arm and
+            // `continue_pipe_element_generic`'s own Lazy* arm, both of which
+            // always start here with a `LazyKeys`/`LazyIndexRange`/`LazySeq`
+            // `current`): nothing above ever assigns `Many`/`ManyCursor`/
+            // `ManyOwned`/`Partial` to `current` mid-loop, since the only
+            // stage shape that can fan out (`Expr::Iterate`) is intercepted
+            // above and returns immediately instead of falling through to
+            // the generic match. Kept as a safety net (degrading to the
+            // eager fold) rather than `unreachable!()`, so a future caller
+            // that *does* reach this some other way gets correct-but-less-
+            // lazy behavior instead of a panic.
+            other => {
+                return drain_result_generic(
+                    fold_pipe_stages::<S, V>(other, &stages[j..], optional),
+                    sink,
+                );
+            }
+        };
+        j += 1;
     }
 }
 
@@ -3540,6 +3788,47 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// Continue a pipe through one already-produced item: recurse the *rest* of
+/// the pipe against it, honoring `sink`'s `Demand` throughout. Shared by
+/// [`eval_each_pipe_generic`]'s own driver and [`fold_pipe_stages_sink`]'s
+/// per-element fan-out handling (#1565), so "thread one pulled value through
+/// an arbitrary-length remaining pipe" exists in exactly one place.
+///
+/// An `Owned` item bridges to the already-lazy `eval::eval_each_owned` so
+/// laziness (and thus `input`/`inputs` demand) continues through the rest of
+/// the pipe instead of stopping at the owned/cursor boundary, mirroring
+/// `eval_each_pipe`'s own `Item::Owned` arm (PR #1450 fixed the equivalent
+/// bug on the `eval.rs` side). A `LazyKeys`/`LazyIndexRange`/`LazySeq` item
+/// (never produced for a single pulled element by either caller today, but
+/// handled for robustness) folds through the remaining stages via
+/// [`fold_pipe_stages_sink`] rather than being decomposed or materialized
+/// here -- the #1503-safe move, same rationale as the top-level `Pipe`
+/// dispatch below.
+fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
+    item: GenericItem<V>,
+    rest: &[Expr],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match item {
+        GenericItem::One(v) => eval_each_pipe_generic::<S, V>(rest, v, optional, None, sink),
+        GenericItem::OneCursor(c) => {
+            eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
+        }
+        GenericItem::Owned(o) => {
+            let rest_pipe = Expr::Pipe(rest.to_vec());
+            eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
+                sink(GenericItem::Owned(o))
+            })
+        }
+        item @ (GenericItem::LazyKeys { .. }
+        | GenericItem::LazyIndexRange(_)
+        | GenericItem::LazySeq(_)) => {
+            fold_pipe_stages_sink::<S, V>(generic_item_to_result(item), rest, optional, sink)
+        }
+    }
+}
+
 /// Generic-evaluator twin of `eval::eval_each_pipe` (#1461): the "stop
 /// pulling from stage 1 once the rest of the pipe has enough" mechanism.
 ///
@@ -3549,30 +3838,21 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
 /// see a stubbed-zero default. Otherwise: evaluate stage 1 lazily via
 /// [`eval_each_generic`], and for every item it produces, recursively drive
 /// the *whole remaining pipe* (not just one more stage) through a driver
-/// closure that forwards items to the outer `sink` and translates whatever
-/// `Flow` that recursive call terminates in back into a `Demand` for stage
-/// 1's own generator. Recursing on the full remaining slice, rather than one
-/// stage at a time, is what lets cursor threading (`.[] | select(...) |
-/// line`) survive an arbitrary-length remaining pipe -- the exact property a
-/// narrower, 2-stage-only attempt lost (#1503 review).
+/// closure that forwards items to the outer `sink` (via
+/// [`continue_pipe_element_generic`]) and translates whatever `Flow` that
+/// recursive call terminates in back into a `Demand` for stage 1's own
+/// generator. Recursing on the full remaining slice, rather than one stage at
+/// a time, is what lets cursor threading (`.[] | select(...) | line`) survive
+/// an arbitrary-length remaining pipe -- the exact property a narrower,
+/// 2-stage-only attempt lost (#1503 review).
 ///
-/// An `Owned` item bridges to the already-lazy `eval::eval_each_owned` so
-/// laziness (and thus `input`/`inputs` demand) continues through the rest of
-/// the pipe instead of stopping at the owned/cursor boundary, mirroring
-/// `eval_each_pipe`'s own `Item::Owned` arm (PR #1450 fixed the equivalent
-/// bug on the `eval.rs` side). A `LazyKeys`/`LazyIndexRange`/`LazySeq` item
-/// folds through the remaining stages via [`fold_pipe_stages`] -- the same
-/// per-variant switch `eval_single`'s own `Expr::Pipe` arm uses, including
-/// its `map`/`select`/`first`/`.[n]` composability fast paths (#724/#725) --
-/// rather than being decomposed or materialized here, which is exactly what
-/// regressed #1503's own broader attempt.
-///
-/// **Known gap (#1565):** `fold_pipe_stages` itself is a plain eager fold
-/// with no demand check, so a `LazyKeys`/`LazyIndexRange`/`LazySeq` item
-/// folded through it this way does not get `first`'s early-stop benefit --
-/// `first(keys | .[] | stderr)` still visits every key, unlike the sibling
-/// `first(.[] | stderr)` shape #1461 fixed. Pre-existing (unchanged from the
-/// old eager fallback this function replaced), not a regression from #1461.
+/// A `LazyKeys`/`LazyIndexRange`/`LazySeq` item folds through the remaining
+/// stages via [`fold_pipe_stages_sink`] (#1565) -- demand-aware from the
+/// stage it was produced at, so `first(keys | .[] | stderr)` stops after one
+/// key instead of visiting every one, unlike the eager `fold_pipe_stages`
+/// this replaced for this call site. `fold_pipe_stages_sink` itself reuses
+/// `fold_pipe_stages`'s own per-variant composability fast paths (#724/#725)
+/// rather than duplicating them -- see its own doc comment.
 fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     value: V,
@@ -3599,34 +3879,9 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     }
 
     let mut downstream: Option<Flow> = None;
-    let rest_pipe = Expr::Pipe(rest.to_vec());
     let upstream = {
         let mut driver = |item: GenericItem<V>| -> Demand {
-            let flow = match item {
-                GenericItem::One(v) => {
-                    eval_each_pipe_generic::<S, V>(rest, v, optional, None, &mut *sink)
-                }
-                GenericItem::OneCursor(c) => {
-                    eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), &mut *sink)
-                }
-                GenericItem::Owned(o) => eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
-                    sink(GenericItem::Owned(o))
-                }),
-                // These three carry a deferred computation `fold_pipe_stages`
-                // already knows how to thread through the rest of the pipe
-                // (its `map`/`select`/`first`/`.[n]` composability fast
-                // paths, #724/#725) without decomposing it -- so convert
-                // back to the `GenericResult` shape it came from via
-                // `generic_item_to_result` (the exact inverse of
-                // `drain_result_generic`'s own construction of these items)
-                // rather than re-deriving that conversion by hand here.
-                item @ (GenericItem::LazyKeys { .. }
-                | GenericItem::LazyIndexRange(_)
-                | GenericItem::LazySeq(_)) => drain_result_generic(
-                    fold_pipe_stages::<S, V>(generic_item_to_result(item), rest, optional),
-                    &mut *sink,
-                ),
-            };
+            let flow = continue_pipe_element_generic::<S, V>(item, rest, optional, &mut *sink);
             match flow {
                 Flow::Exhausted => Demand::Continue,
                 other => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6690,6 +6690,73 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_first_pipe_iterate_after_lazy_stops_at_one_element_1565() {
+        // Durable, non-flaky proxy for #1565's perf claim: a later element
+        // that would *error* if evaluated proves it was never pulled, the
+        // same technique `test_generic_lazy_seq_first_after_map_skips_later_error_725`
+        // uses -- a wall-clock assertion would be flaky, this instead pins
+        // the *shape* of laziness. Covers all three lazy sources
+        // `fold_pipe_stages_sink` fans out over, plus the `keys` (sorted)
+        // case, which routes through owned strings instead of cursors.
+
+        // `LazySeq` (`map(f)`, #724/#725): `"x" + 1` on the second element
+        // would error if `first`'s `.[] | ...` tail ever pulled past the
+        // first mapped element.
+        let json = br#"[1, "x", "y"]"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse("first(map(. + 1) | .[] | (. + 100))").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Int(102)
+        );
+
+        // `LazyIndexRange` (an array's own `keys`/`keys_unsorted`, #684):
+        // `error` on index `2` would fire if the iterate-after-`keys` tail
+        // ever pulled past the first index.
+        let json = br"[10, 20, 30]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr =
+            crate::jq::parse(r#"first(keys | .[] | (if . == 2 then error("touched") else . end))"#)
+                .unwrap();
+        assert_eq!(eval(&expr, value).into_owned().unwrap(), OwnedValue::Int(0));
+
+        // `LazyKeys { sorted: false }` (`keys_unsorted`): document order is
+        // `"z"`, `"a"` -- `error` on `"a"` would fire if the tail pulled
+        // past the first (document-order-first) key.
+        let json = br#"{"z": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse(
+            r#"first(keys_unsorted | .[] | (if . == "a" then error("touched") else . end))"#,
+        )
+        .unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("z".to_string())
+        );
+
+        // `LazyKeys { sorted: true }` (`keys`): lexicographic order is
+        // `"a"`, `"z"` -- `error` on `"z"` would fire if the tail pulled
+        // past the first (lexicographically-first) key. Exercises the
+        // owned-string element path (`keys` doesn't preserve a cursor for
+        // sorted keys, matching `materialize_lazy_keys`'s existing
+        // behaviour), not the cursor path the other three cases exercise.
+        let json = br#"{"z": 1, "a": 2}"#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let expr = crate::jq::parse(
+            r#"first(keys | .[] | (if . == "z" then error("touched") else . end))"#,
+        )
+        .unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::String("a".to_string())
+        );
+    }
+
+    #[test]
     fn test_generic_lazy_seq_composability_keys_unsorted_map_select_724() {
         // The actual point of this design: `keys_unsorted | map(f) | select(g)`
         // stays lazy through the `map` stage, materializes once at `select`.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18989,14 +18989,59 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             "B",
             0,
         ),
-        // Same class as the `Compare` row above (#1565): `Expr::If` has no
-        // native `eval_each_generic` arm either, so `first(if ...)` falls
-        // through to eager `eval_single` and the discarded `else` branch's
-        // sibling side effect still fires. Out of #1461's scope by design,
-        // same as `Compare`; pre-existing on `main` before #1461 too. jq: no
-        // stderr.
+        // Same class as the `Compare` row above: `Expr::If`/`Try`/`Label`/
+        // `As`/`Limit` have no native `eval_each_generic` arm either
+        // (#1461's own doc comment scopes it to `Comma`/`Pipe`/`Paren`
+        // only), so when one of these is `first`'s argument's top-level
+        // shape, evaluation falls through to eager `eval_single` and a
+        // sibling branch's side effect fires even though `first` never
+        // needed it. Out of scope by design -- fixing `fold_pipe_stages`'s
+        // `LazyKeys`/`LazyIndexRange`/`LazySeq` gap (#1565) does not touch
+        // this; these five shapes are pinned as an explicit, documented
+        // known gap rather than fixed, matching how `Compare` was already
+        // pinned. jq: no stderr.
         (
             &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
+            None,
+            "1\n",
+            "B",
+            0,
+        ),
+        // `try EXPR` with nothing erroring is just `EXPR`'s own laziness --
+        // still eager here, same root cause as the `If` row above.
+        (
+            &["-cn", r#"first(try (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "B",
+            0,
+        ),
+        // `label $out | EXPR` with no `break` reached is just `EXPR`'s own
+        // laziness -- same root cause as the `If` row above.
+        (
+            &["-cn", r#"first(label $out | (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "B",
+            0,
+        ),
+        // `EXPR as $x | BODY` should stop after `BODY`'s first output for
+        // the first `$x` binding, never touching the second `(1,2)`
+        // binding at all -- same root cause as the `If` row above, but
+        // doubly eager here since both bindings' `BODY` runs to completion.
+        // jq: writes `B` once (never reaches the `$x = 2` binding).
+        (
+            &["-cn", r#"first((1,2) as $x | ($x, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "BB",
+            0,
+        ),
+        // `limit(2; f)` should stop pulling from `f` after `first` takes
+        // `limit`'s own first output, never evaluating `f`'s second output
+        // -- same root cause as the `If` row above.
+        (
+            &["-cn", r#"first(limit(2; (1, ("B"|stderr))))"#],
             None,
             "1\n",
             "B",

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18430,6 +18430,40 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
         // `stderr` fires once per element pulled, not once per element that
         // exists -- `first` pulls exactly one.
         (&["-c", "first(.[] | stderr)"], Some("[1,2]"), "1\n", "1", 0),
+        // #1565 (moved from the leaks table below): when the pipe's *first*
+        // stage evaluates to `GenericResult::LazyKeys`/`LazyIndexRange`/
+        // `LazySeq` (`keys`, `keys_unsorted`, `map(f)`) and 2+ further
+        // stages follow, `eval_each_pipe_generic`'s driver now folds through
+        // `fold_pipe_stages_sink` instead of the eager `fold_pipe_stages` --
+        // demand-aware from the stage the lazy value was produced at, so
+        // `.[] | stderr` after a `keys` prefix fires once, same as the bare
+        // `first(.[] | stderr)` row above.
+        (
+            &["-c", "first(keys | .[] | stderr)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"a\"\n",
+            "a",
+            0,
+        ),
+        // Same #1565 fix, `keys_unsorted`/`LazyKeys{sorted:false}` flavor --
+        // the cons-list-walk fast path rather than `keys`'s decode+sort one.
+        (
+            &["-c", "first(keys_unsorted | .[] | stderr)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"a\"\n",
+            "a",
+            0,
+        ),
+        // Same #1565 fix, `LazySeq` (`map(f)`, #724/#725) flavor -- pulls
+        // `seq.next()` one at a time instead of draining the whole `map`
+        // chain before `first` gets a chance to stop.
+        (
+            &["-c", "first(map(.+1) | .[] | stderr)"],
+            Some("[1,2,3]"),
+            "2\n",
+            "2",
+            0,
+        ),
         // `n == 0` must not evaluate the operand at all.
         (&["-cn", r#"[limit(0; ("B"|stderr))]"#], None, "[]\n", "", 0),
         // Array construction is atomic in jq; laziness must not leak into it.
@@ -18953,33 +18987,6 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             None,
             "[false]\n",
             "B",
-            0,
-        ),
-        // Code review of #1461, filed as #1565: when the pipe's *first*
-        // stage evaluates to `GenericResult::LazyKeys` (`keys`,
-        // `keys_unsorted`) and 2+ further stages follow, the driver hands
-        // the whole remaining pipe to `fold_pipe_stages` -- the plain eager
-        // fold, with no demand check -- rather than continuing through
-        // `eval_each_pipe_generic`'s own sink. So `.[] | stderr` after a
-        // `keys` prefix still fires for every key, unlike the bare
-        // `first(.[] | stderr)` #1461 itself fixed. Confirmed pre-existing
-        // (identical on `main` before #1461, via the old 2-stage-only
-        // `first_over_comma_generic`), so not a regression here -- pinned so
-        // a fix for #1565 has a red test to turn green. jq: writes `a` once.
-        (
-            &["-c", "first(keys | .[] | stderr)"],
-            Some(r#"{"a":1,"b":2,"c":3}"#),
-            "\"a\"\n",
-            "abc",
-            0,
-        ),
-        // Same #1565 gap, `LazySeq` (`map(f)`, #724/#725) flavor instead of
-        // `LazyKeys`. jq: writes `2` once.
-        (
-            &["-c", "first(map(.+1) | .[] | stderr)"],
-            Some("[1,2,3]"),
-            "2\n",
-            "234",
             0,
         ),
         // Same class as the `Compare` row above (#1565): `Expr::If` has no

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19028,8 +19028,11 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
         // `EXPR as $x | BODY` should stop after `BODY`'s first output for
         // the first `$x` binding, never touching the second `(1,2)`
         // binding at all -- same root cause as the `If` row above, but
-        // doubly eager here since both bindings' `BODY` runs to completion.
-        // jq: writes `B` once (never reaches the `$x = 2` binding).
+        // doubly eager here since both bindings' `BODY` runs to completion,
+        // hence `BB` rather than the other rows' single `B`. jq: no stderr
+        // at all (captured from jq 1.7.1), same as every other row here --
+        // it stops at `$x`'s own first output, before `("B"|stderr)` is
+        // ever reached under either binding.
         (
             &["-cn", r#"first((1,2) as $x | ($x, ("B"|stderr)))"#],
             None,
@@ -19393,6 +19396,57 @@ fn test_first_over_lazy_prefix_applies_every_stage_1565() -> Result<()> {
             (stdout.as_str(), code),
             (*want_out, 0),
             "`{}` -- stderr: {stderr}",
+            args.join(" ")
+        );
+    }
+    Ok(())
+}
+
+/// #1565 made `first(map(f) | .[] | g)` pull one element at a time, which
+/// necessarily gives up the atomicity `fold_lazy_seq_stage`'s eager
+/// `Expr::Iterate` arm has: an element already handed to the sink is already
+/// downstream, so a later element that would error can no longer retract it.
+///
+/// That is the same deliberate trade #725 already made for `map(f) | first`
+/// (see `docs/compliance/jq/limitations.md`), widened from `first`/`.[0]` to
+/// `.[]`-under-demand -- pinned here so the divergence stays a decision
+/// rather than drifting, together with the draining counter-cases that must
+/// keep matching jq exactly. All expectations captured from jq 1.7.1.
+#[test]
+fn test_first_over_lazy_seq_iterate_skips_later_error_1565() -> Result<()> {
+    // Diverges from jq: jq errors (exit 5) because `map` builds the whole
+    // array first; succinctly stops after the element `first` needed.
+    for (args, want_out) in [
+        (&["-c", "first(map(.+1) | .[])"][..], "2\n"),
+        (&["-c", "first(map(.+1) | .[] | . + 10)"][..], "12\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(args, Some(r#"[1,"x",3]"#))?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            (want_out, 0),
+            "`{}` -- stderr: {stderr}",
+            args.join(" ")
+        );
+    }
+
+    // Matches jq: every one of these has to see the whole array, so the
+    // failing element is never skipped and the error still surfaces.
+    for args in [
+        &["-c", "map(.+1)"][..],
+        &["-c", "map(.+1) | last"][..],
+        &["-c", "[map(.+1) | .[]]"][..],
+        &["-c", "[first(map(.+1) | .[] | select(. > 100))]"][..],
+    ] {
+        let (stdout, stderr, code) = run_jq_full(args, Some(r#"[1,"x",3]"#))?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            ("", 5),
+            "`{}` -- stderr: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            stderr.contains("cannot be added"),
+            "`{}` -- unexpected stderr: {stderr}",
             args.join(" ")
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19286,6 +19286,119 @@ fn test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451() -> R
     Ok(())
 }
 
+/// #1565 review: `fold_pipe_stages_sink`'s `One`/`OneCursor`/`Owned` arms
+/// handed the remaining pipe off as `stages[j + 1..]` while `current` was
+/// still the value *entering* `stages[j]`, so the stage that produced that
+/// single value was silently dropped -- wrong output, no error, in both
+/// modes (`first(keys | length | tostring)` printed `3`, not `"3"`).
+///
+/// Nothing in the suite caught it: #1565's own rows all end in a fan-out
+/// (`.[] | stderr`), which the `Expr::Iterate` interception handles before
+/// the buggy arms are ever reached. Each row here instead makes the *middle*
+/// stage collapse a lazy prefix to a single value, then puts a further stage
+/// behind it whose output differs observably from its input -- a stage that
+/// merely passed its input through would not distinguish "applied" from
+/// "skipped".
+///
+/// Covers all three collapsing arms (`Owned` via `length`, `OneCursor` via
+/// `first`/`last`/`.[n]`, and the `ManyOwned` fall-through to the eager
+/// `fold_pipe_stages`) across all three lazy sources (`LazyKeys` sorted and
+/// unsorted, `LazyIndexRange`, `LazySeq`). Every expectation is jq 1.7.1's.
+#[test]
+fn test_first_over_lazy_prefix_applies_every_stage_1565() -> Result<()> {
+    let cases: &[(&[&str], Option<&str>, &str)] = &[
+        // `LazyKeys{sorted}` -> `Owned` (`length`) -> a further stage.
+        (
+            &["-c", "first(keys | length | tostring)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"3\"\n",
+        ),
+        // `LazyKeys{sorted}` -> `OneCursor` (`first`) -> a further stage.
+        (
+            &["-c", "first(keys | first | ascii_upcase)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"A\"\n",
+        ),
+        // `LazyKeys{sorted}` -> `OneCursor` (`last`) -> a further stage.
+        (
+            &["-c", "first(keys | last | ascii_upcase)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"C\"\n",
+        ),
+        // `LazyKeys{sorted}` -> `OneCursor` (`.[n]`) -> a further stage.
+        (
+            &["-c", "first(keys | .[1] | ascii_upcase)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"B\"\n",
+        ),
+        // `LazyKeys{!sorted}`: the cons-list walk rather than decode+sort.
+        (
+            &["-c", "first(keys_unsorted | first | ascii_upcase)"],
+            Some(r#"{"b":1,"a":2}"#),
+            "\"B\"\n",
+        ),
+        // Four stages, so the hand-off target is itself a multi-stage pipe
+        // rather than a single trailing expression.
+        (
+            &["-c", "first(keys | first | ascii_upcase | . + \"!\")"],
+            Some(r#"{"a":1,"b":2}"#),
+            "\"A!\"\n",
+        ),
+        // `LazyIndexRange` (an array's own `keys`, #684) -> `Owned`.
+        (
+            &["-c", "first(keys | length | . + 1)"],
+            Some("[9,9,9]"),
+            "4\n",
+        ),
+        // `LazyIndexRange` -> `Owned` (`.[n]`, synthetic index, no cursor).
+        (
+            &["-c", "first(keys | .[0] | . + 1)"],
+            Some("[9,9,9]"),
+            "1\n",
+        ),
+        // `LazySeq` (#724/#725) -> `Owned` via the pull-one-and-stop
+        // `first` fast path -> a further stage.
+        (
+            &["-c", "first(map(.+1) | first | . + 100)"],
+            Some("[1,2,3]"),
+            "102\n",
+        ),
+        // `LazySeq` -> `Owned` via `length`'s count-and-discard arm.
+        (
+            &["-c", "first(map(.+1) | length | tostring)"],
+            Some("[1,2,3]"),
+            "\"3\"\n",
+        ),
+        // Two collapsing stages back to back, so the second one folds from
+        // a `current` the first already replaced.
+        (
+            &["-c", "first(keys | map(.) | length | tostring)"],
+            Some(r#"{"a":1,"b":2}"#),
+            "\"2\"\n",
+        ),
+        // The `other` arm: `.[0,1]` is an `Expr::IndexExpr` with a `Comma`
+        // key, so `fold_lazy_keys_stage`'s materializing fallback returns
+        // `ManyOwned` mid-loop -- the shape that arm's comment once called
+        // unreachable. It must still apply the trailing stage.
+        (
+            &["-c", "[first(keys | .[0,1] | ascii_upcase)]"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "[\"A\"]\n",
+        ),
+    ];
+
+    for (args, stdin, want_out) in cases {
+        let (stdout, stderr, code) = run_jq_full(args, *stdin)?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            (*want_out, 0),
+            "`{}` -- stderr: {stderr}",
+            args.join(" ")
+        );
+    }
+    Ok(())
+}
+
 /// #1519, found while implementing #1462's own oracle sweep: real jq's
 /// short-circuiting builtins are macro-expanded `label $out | ... break
 /// $out` definitions, and its `?//`-alternatives operator retries the next

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21720,3 +21720,42 @@ fn test_map_multidoc_separator_matches_other_m2_expressions_757() -> Result<()> 
     assert_eq!(code, 1);
     Ok(())
 }
+
+/// #1565's stage-skipping regression reached `succinctly yq` too:
+/// `eval_generic.rs` is the shared engine, so `fold_pipe_stages_sink` sits on
+/// both modes' path and its `One`/`OneCursor`/`Owned` arms dropped the stage
+/// that produced the single value they were folding from.
+///
+/// The jq-mode twin, with the full arm/source matrix and the reasoning behind
+/// each row, is `test_first_over_lazy_prefix_applies_every_stage_1565` in
+/// `tests/jq_cli_tests.rs`; this pins that the shared engine's fix reaches yq
+/// mode rather than re-deriving that matrix.
+#[test]
+fn test_first_over_lazy_prefix_applies_every_stage_1565() -> Result<()> {
+    let cases: &[(&str, &str, &str)] = &[
+        // `Owned` arm, via `length`.
+        (
+            "first(keys | length | tostring)",
+            "a: 1\nb: 2\nc: 3\n",
+            "\"3\"\n",
+        ),
+        // `OneCursor` arm, via `first` over a `LazyKeys` cons-list walk.
+        (
+            "first(keys | first | ascii_upcase)",
+            "a: 1\nb: 2\n",
+            "\"A\"\n",
+        ),
+        // `Owned` arm again, but from a `LazySeq` (`map(f)`) source.
+        (
+            "first(map(.+1) | first | . + 100)",
+            "- 1\n- 2\n- 3\n",
+            "102\n",
+        ),
+    ];
+
+    for (filter, input, want_out) in cases {
+        let (stdout, code) = run_yq_stdin(filter, input, &["--jq-extensions", "-o=json", "-I=0"])?;
+        assert_eq!((stdout.as_str(), code), (*want_out, 0), "`{filter}`");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `first(keys | .[] | f)` and `first(map(f) | .[] | f)` evaluated every element instead of stopping after one, leaking side effects (stderr firing for every element, not just the first) and costing ~12x/~28x over the already-fixed `first(.[] | .+1)` baseline on a 2M-element input.
- Root cause: when a pipe's first stage produced a `LazyKeys`/`LazyIndexRange`/`LazySeq` value and 2+ stages followed, `eval_each_pipe_generic`'s driver folded them through the eager `fold_pipe_stages`, only checking the sink's `Demand` after every element had already run.
- Adds `fold_pipe_stages_sink`, a demand-aware twin that reuses the existing `map`/`select`/`first`/`.[n]` composability fast paths (#724/#725) for every non-fan-out stage, and for `Expr::Iterate` on a lazy source, pulls elements one at a time and stops the instant `first` has what it needs.
- Preserves the #1503 lesson: a `LazyKeys`/`LazyIndexRange`/`LazySeq` is never collapsed to `Owned`/`One` before its own composability fast paths run, and cursor threading for an arbitrary-length remaining pipe is delegated to the existing `eval_each_pipe_generic`/`eval_each_owned` rather than re-derived.
- `first(try/label/as/limit ...)` still leak side effects the same way `Compare`/`If` already did (no native `eval_each_generic` arm) — pinned as an explicit known gap rather than natively fixed, matching the existing `Compare` precedent.

Split into 3 commits: a pure extraction refactor, the actual fix, and the remaining test coverage (known-gap pins + a durable laziness regression test).

Fixes #1565

## Test plan

- [x] Full test suite (`cargo test --features cli,simd,regex,serde`) green at every commit
- [x] All 3 CI clippy legs clean (`--all-features`, and the two narrower feature-set legs)
- [x] `cargo fmt --check` / `cargo doc --no-deps` clean
- [x] `cargo build --no-default-features` still compiles
- [x] Live-probed against pinned jq 1.7.1 (`/usr/bin/jq`) — byte-identical stdout/stderr for `first(keys | .[] | stderr)`, `first(keys_unsorted | .[] | stderr)`, `first(map(.+1) | .[] | stderr)`
- [x] Verified `succinctly yq --jq-extensions` picks up the fix (shared `eval_generic.rs` engine)
- [x] 2M-element timing: `map(.+1)` case lands within noise of the already-fixed baseline; `keys`/`keys_unsorted` downstream re-evaluation now costs the same as a bare `first(keys | length)` (the fix's target), with a separate pre-existing, unrelated cost in constructing `LazyKeys` for a 2M-field object left as-is (out of scope)