### PR TITLE
fix(jq): keep the cursor for position builtins under #1504's bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#1461, #1481) — those never touch `input`/`inputs`, so this fix's guard
   never fires for them; they remain open under their own issues.
 
+  Two things the bridge deliberately does *not* do. It is **carved back out
+  for cursor-metadata builtins**: `eval.rs` answers `line`/`column`/
+  `document_index`/`anchor`/`style`/`line_comment` from fixed-default stubs
+  and rejects `at_offset`/`at_position` outright, so a program mixing an
+  input builtin with one of those keeps the eager, cursor-carrying path and
+  keeps its answer, forgoing the interleave. Re-indexing could not have
+  rescued them — `eval_each_owned` rebuilds from re-serialised text, so any
+  offset it reported would describe that text, not the user's file — and a
+  confidently wrong position is worse than a divergence. That carve-out is
+  also why `eval_first_or_last_generic` keeps its own #1309 guard rather than
+  deferring to the top-level one: `first(inputs), line` reaches it down the
+  carved-out path with the queue still live, and `each_take_first_generic`
+  has no `Builtin::Inputs` lazy arm to stop the drain. And it is **not free**
+  — it re-serialises and re-indexes each document on top of the index the
+  caller already built, a per-document penalty that grows with document size
+  (an interleaved spot check put it near 1.7x, though on hardware the
+  benchmarking guide rules out for a quotable figure); a filter with no input
+  builtin is untouched. Both are written up in
+  `docs/compliance/jq/limitations.md`.
+
 - **`yq`: `split_doc` hidden inside twelve builtins is detected** (#1309):
   `contains_split_doc` was exhaustive over `Expr` but ended its inner
   `Builtin` match in `_ => false`, so `any`/`all` (both arities), `IN`/`INDEX`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -770,6 +770,41 @@ raises once per top-level document, matching jq — see
 [`docs/plan/jq-lazy-generator-consumers.md`](../../plan/jq-lazy-generator-consumers.md) for
 the mechanism.
 
+**The bridge is not free, and it is not universal.** It re-serialises and re-indexes each
+document on top of the index `evaluate_input` already built, so its cost scales with
+document size. An interleaved wall-clock spot check with
+`[.[] | select(.id != null) | .id], (input | [.[] | .id])` over two copies of one generated
+file, outputs byte-identical either way, put the penalty near **1.7x** and growing linearly:
+1 MB 0.06 s → 0.10 s, 2 MB 0.12 s → 0.23 s, 4 MB 0.24 s → 0.43 s. A filter with no input
+builtin is untouched (0.01 s on both), so the guard itself is free — only the programs it
+fires for pay.
+
+Treat that ratio as indicative, not as a benchmark result: it is `/usr/bin/time` over three
+interleaved repetitions on an Apple M5 Max **laptop running on battery**, which
+[the benchmarking guide](../../guides/benchmarking.md#ab-benchmarking-method) rules out for
+a number worth quoting, and x86_64 was not measured at all. What the check does establish is
+the shape — a per-document, size-proportional penalty, matching the mechanism — and that it
+is confined to filters using an input builtin. Re-measure on pinned hardware before treating
+1.7x as the figure.
+
+It is also **carved back out for cursor-metadata builtins**. `eval.rs` has no cursor to
+answer position questions from: `line`/`column`/`document_index`/`anchor`/`style`/
+`line_comment` are fixed-default stubs there and `at_offset`/`at_position` are
+unconditional `requires document cursor context` errors. So a program mixing an input
+builtin with one of those keeps the eager, cursor-carrying path and keeps its answer,
+forgoing the interleave:
+
+```
+$ echo '{"a":1}' | succinctly jq -c 'at_offset(1), input_line_number'   # "a"  1
+$ echo '{"a":1}' | succinctly jq -c 'line, column, input_line_number'   # 1  1  1
+```
+
+Re-indexing could not have rescued them: `eval_each_owned` rebuilds from re-serialised
+text, so any offset or line/column it reported would describe that text rather than the
+file the user passed. A confidently wrong position is worse than the divergence, so the
+divergence is what these filters get. `at_offset`/`at_position`/`line`/`column` are
+succinctly extensions, so no jq-compliance question arises either way.
+
 One divergence remains, unrelated to the eager-evaluator root cause above.
 
 **`input_line_number` keeps its line after a failed read.** jq resets it to 0 after an

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2343,16 +2343,47 @@ pub fn eval<V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
 /// queue behaves identically either way, so the eager `eval_single` path
 /// (and its cursor/zero-copy fast paths) stays the default; only a filter
 /// that actually shares state with `jq_runner`'s input queue pays for the
-/// re-index round trip through `eval_each_owned_collect`. Supersedes the
-/// narrower guard `eval_first_or_last_generic` used to run per `first(...)`
-/// call site (#1309) -- this check covers the whole expression up front, so
-/// that guard was dead code and has been removed.
+/// re-index round trip through `eval_each_owned_collect`, which re-serialises
+/// and re-indexes on top of the index the caller already built. That cost is
+/// per document and scales with document size -- an interleaved spot check
+/// put it near 1.7x wall clock; see `docs/compliance/jq/limitations.md` for
+/// the numbers and what they are and aren't worth.
+///
+/// **Carved back out for cursor-metadata builtins.** The bridge hands the
+/// program to `eval.rs`, which answers `line`/`column`/`document_index`/
+/// `anchor`/`style`/`line_comment` from fixed-default stubs and rejects
+/// `at_offset`/`at_position` outright -- all eight answers live only in this
+/// module's `Option<V::Cursor>` threading. Re-indexing cannot rescue
+/// them either: `eval_each_owned` rebuilds from re-serialised text, so any
+/// offset or line/column it could report would describe that text rather
+/// than the file the user passed. So a program that mixes an input builtin
+/// with a cursor-metadata builtin keeps the eager path and keeps its cursor,
+/// at the cost of #1504's interleave -- a divergence, where the bridge would
+/// instead give a wrong answer or an error. See
+/// [`crate::jq::walk::uses_cursor_metadata_builtins`].
 pub fn eval_using<S: EvalSemantics, V: DocumentValue>(expr: &Expr, value: V) -> GenericResult<V> {
-    if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(expr) {
+    if takes_input_queue_bridge(expr) {
         let owned = to_owned_with_cursor(&value, None);
         return eval_each_owned_collect::<S, V>(expr, &owned, false);
     }
     eval_single::<S, V>(expr, value, false, None)
+}
+
+/// Whether `expr` should be handed to `eval.rs`'s demand-driven evaluator
+/// instead of this module's eager `eval_single` (#1504).
+///
+/// One definition shared by [`eval_using`] and [`eval_with_cursor_using`], so
+/// the two top-level entry points cannot drift apart on which programs take
+/// the bridge. `input_queue_is_active` (one TLS load) comes first so yq mode,
+/// library embedders and every jq filter that never mentions an input builtin
+/// pay nothing for the two AST walks behind it.
+///
+/// See [`eval_using`]'s doc comment for why the cursor-metadata carve-out is
+/// part of the condition rather than something the bridge could handle.
+fn takes_input_queue_bridge(expr: &Expr) -> bool {
+    crate::jq::input_queue_is_active()
+        && crate::jq::walk::uses_input_builtins(expr)
+        && !crate::jq::walk::uses_cursor_metadata_builtins(expr)
 }
 
 /// Evaluate an expression against a cursor.
@@ -2369,16 +2400,18 @@ pub fn eval_with_cursor<C: DocumentCursor>(expr: &Expr, cursor: C) -> GenericRes
 /// Like [`eval_with_cursor`] but arithmetic follows `S` (jq vs yq), so yq's
 /// modulo/division/overflow behavior is preserved on the cursor path.
 ///
-/// Same `input`/`inputs`/`input_line_number` guard as [`eval_using`] (#1504);
-/// see its doc comment for why this is gated rather than unconditional.
+/// Same `takes_input_queue_bridge` condition as [`eval_using`] (#1504),
+/// cursor-metadata carve-out included; see its doc comment for why the
+/// bridge is gated rather than unconditional.
 pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
     expr: &Expr,
     cursor: C,
 ) -> GenericResult<C::Value> {
-    if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(expr) {
-        let value = cursor.value();
-        let owned = to_owned_with_cursor(&value, Some(cursor));
-        return eval_each_owned_collect::<S, C::Value>(expr, &owned, false);
+    if takes_input_queue_bridge(expr) {
+        // `to_owned_cursor` directly rather than `to_owned_with_cursor`: the
+        // latter ignores its value argument whenever the cursor is `Some`, so
+        // routing through it would compute a `cursor.value()` only to drop it.
+        return eval_each_owned_collect::<S, C::Value>(expr, &to_owned_cursor(&cursor), false);
     }
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
@@ -4034,16 +4067,41 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     want_last: bool,
 ) -> GenericResult<V> {
     // `first(f)` where `f` can consume input documents must not run `f` to
-    // completion -- previously handled by a guard here (#1309) that bridged
-    // just this subtree through `eval_on_owned`. #1504 moved that same
-    // `input_queue_is_active` + `uses_input_builtins` check to `eval_using`/
-    // `eval_with_cursor_using`, covering the *whole* expression up front
-    // rather than each `first(...)` call site individually; since `inner` is
-    // always a subterm of whatever tree that top-level check already walked,
-    // it can never satisfy the condition the top-level guard didn't. This
-    // function is only ever reached once that check has already cleared the
-    // whole expression, so the per-call guard was dead code and has been
-    // removed.
+    // completion. [`eval_each_generic`] (#1461) is only a native lazy arm for
+    // `Comma`/`Pipe`/`Paren` -- it has no `Builtin::Inputs`-aware arm of its
+    // own, so a bare `first(inputs)`/`first(inputs, 1)`/`first(inputs | f)`
+    // would still fall to its eager `_` fallback and drain the shared queue.
+    // `eval::eval_first_expr` has been wired to `eval.rs`'s own sink since
+    // #820 Stage 2, so hand the whole `first(...)` over rather than
+    // evaluating `inner` here (#1309) -- one guard covering every shape
+    // `inputs` can appear in, rather than one `eval_each_generic` arm per
+    // shape.
+    //
+    // **Why this is not dead code under #1504's top-level bridge.** That
+    // bridge does subsume this guard for most programs -- `inner` is always a
+    // subterm of the tree `takes_input_queue_bridge` already walked -- but
+    // only for the programs it actually takes. Its cursor-metadata carve-out
+    // deliberately declines it for a program that mixes an input builtin with
+    // `line`/`at_offset`/..., and such a program reaches `eval_single` and
+    // then this function with the shared queue still live:
+    // `first(inputs), line` is the shape. Without this guard that
+    // `first(inputs)` falls to the eager `_` fallback described above and
+    // drains the queue -- exactly #1309's silent data loss, reintroduced
+    // through the carve-out. Pinned by
+    // `test_jq_cursor_metadata_carve_out_keeps_first_inputs_lazy_1504`.
+    //
+    // Gated rather than unconditional because the bridge costs this subtree
+    // its cursor, and with it #607's duplicate-key fidelity. The one-load
+    // `input_queue_is_active` check comes first specifically so yq mode,
+    // library embedders and the common `first(.[])` never pay for the AST
+    // walk.
+    if !want_last
+        && crate::jq::input_queue_is_active()
+        && crate::jq::walk::uses_input_builtins(inner)
+    {
+        let owned = to_owned_with_cursor(&value, cursor);
+        return eval_on_owned::<S, _>(&Expr::FirstExpr(Box::new(inner.clone())), owned, optional);
+    }
 
     // `first` stops pulling from `inner` as soon as it has one output, so
     // anything past that point -- a later comma sibling, a later pipe stage's

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -775,6 +775,41 @@ pub fn uses_input_builtins(expr: &Expr) -> bool {
     })
 }
 
+/// Whether `expr` references a builtin whose answer comes from the *cursor*
+/// rather than from the value, anywhere (#1504).
+///
+/// These eight are the ones `eval_generic.rs` answers from `Option<V::Cursor>`
+/// and `eval.rs` cannot answer at all: `line`/`column`/`document_index`/
+/// `anchor`/`style`/`line_comment` are fixed-default stubs there, and
+/// `at_offset`/`at_position` are unconditional "requires document cursor
+/// context" errors. Any bridge from `eval_generic.rs` into `eval.rs` therefore
+/// silently downgrades or breaks them, which is what this predicate exists to
+/// let a caller avoid.
+///
+/// Re-indexing cannot rescue them: `eval_each_owned` rebuilds its index from
+/// `to_json_for_reindex`'s *re-serialized* text, so byte offsets and
+/// line/column on that document describe the re-serialization, not the file
+/// the user passed. A cursor-aware `eval.rs` would answer confidently and
+/// wrongly; declining the bridge is the only answer that stays true.
+///
+/// Same expanded-program requirement as [`uses_input_builtins`] — a call
+/// reachable only through an imported module body still counts.
+pub fn uses_cursor_metadata_builtins(expr: &Expr) -> bool {
+    contains_builtin(expr, |b| {
+        matches!(
+            b,
+            Builtin::Line
+                | Builtin::Column
+                | Builtin::DocumentIndex
+                | Builtin::Anchor
+                | Builtin::Style
+                | Builtin::LineComment
+                | Builtin::AtOffset(_)
+                | Builtin::AtPosition(_, _)
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -787,6 +822,10 @@ mod tests {
     fn has_split_doc(filter: &str) -> bool {
         let expr = parse(filter).expect("filter should parse");
         contains_builtin(&expr, |b| matches!(b, Builtin::SplitDoc))
+    }
+
+    fn uses_cursor_meta(filter: &str) -> bool {
+        uses_cursor_metadata_builtins(&parse(filter).expect("filter should parse"))
     }
 
     #[test]
@@ -875,6 +914,50 @@ mod tests {
             then: Box::new(program.expr),
         };
         assert!(uses_input_builtins(&expanded));
+    }
+
+    #[test]
+    fn detects_every_cursor_metadata_builtin() {
+        // The six `eval.rs` answers from a fixed default...
+        assert!(uses_cursor_meta("line"));
+        assert!(uses_cursor_meta("column"));
+        assert!(uses_cursor_meta("document_index"));
+        assert!(uses_cursor_meta("anchor"));
+        assert!(uses_cursor_meta("style"));
+        assert!(uses_cursor_meta("line_comment"));
+        // ...and the two it rejects outright.
+        assert!(uses_cursor_meta("at_offset(0)"));
+        assert!(uses_cursor_meta("at_position(1; 1)"));
+    }
+
+    #[test]
+    fn cursor_metadata_check_reaches_nested_and_argument_positions() {
+        assert!(uses_cursor_meta("inputs | line"));
+        assert!(uses_cursor_meta("(., at_offset(0))"));
+        assert!(uses_cursor_meta("first(line)"));
+        assert!(uses_cursor_meta("[at_position(1; 1)]"));
+        assert!(uses_cursor_meta("def f: line; f"));
+        assert!(uses_cursor_meta("at_offset(line)")); // nested in an argument
+    }
+
+    #[test]
+    fn cursor_metadata_check_does_not_fire_on_lookalikes() {
+        assert!(!uses_cursor_meta("."));
+        assert!(!uses_cursor_meta(".line"));
+        assert!(!uses_cursor_meta(".column"));
+        assert!(!uses_cursor_meta("\"line\""));
+        assert!(!uses_cursor_meta("inputs | input_line_number"));
+        assert!(!uses_cursor_meta("{line: 1}"));
+    }
+
+    /// The two predicates are independent: #1504's carve-out is the
+    /// *conjunction* of them, so neither may imply the other.
+    #[test]
+    fn input_and_cursor_metadata_checks_are_independent() {
+        assert!(uses_inputs("inputs") && !uses_cursor_meta("inputs"));
+        assert!(uses_cursor_meta("line") && !uses_inputs("line"));
+        assert!(uses_inputs("inputs, line") && uses_cursor_meta("inputs, line"));
+        assert!(!uses_inputs(".a") && !uses_cursor_meta(".a"));
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17671,6 +17671,72 @@ fn test_jq_comma_pipe_error_raises_once_per_document_1504() -> Result<()> {
     Ok(())
 }
 
+/// #1504's bridge hands the whole program to `eval.rs`, which has no cursor
+/// to answer position questions from: `line`/`column` are permanent-`0`
+/// stubs there and `at_offset`/`at_position` are unconditional "requires
+/// document cursor context" errors. So a program that mixes an input builtin
+/// with one of those must keep `eval_generic.rs`'s eager, cursor-carrying
+/// path instead. Without the carve-out every filter below either errored
+/// (exit 5) or silently answered `0` -- all four worked before #1504 and
+/// work again with it.
+///
+/// Re-indexing could not have rescued them: `eval_each_owned` rebuilds its
+/// index from re-serialised text, so any offset it reported would describe
+/// that text rather than the file the user passed.
+#[test]
+fn test_jq_cursor_metadata_builtins_survive_an_input_builtin_1504() -> Result<()> {
+    for (filter, expected) in [
+        ("at_offset(1), input_line_number", "\"a\"\n1\n"),
+        ("at_position(1; 2), input_line_number", "\"a\"\n1\n"),
+        ("line, column, input_line_number", "1\n1\n1\n"),
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-c", filter], Some("{\"a\":1}\n")).expect("cursor-metadata repro runs");
+        assert_eq!(code, 0, "{filter}: stdout: {stdout}\nstderr: {stderr}");
+        assert_eq!(stdout, expected, "{filter}");
+    }
+    Ok(())
+}
+
+/// The carve-out above sends `first(inputs), line` back down the eager path
+/// with the shared queue still live, which is exactly the situation #1309's
+/// own `eval_first_or_last_generic` guard exists for: `each_take_first_generic`
+/// has no `Builtin::Inputs` lazy arm, so an unguarded `first(inputs)` there
+/// falls to its eager fallback and drains the queue. Dropping that guard as
+/// "dead code" is safe only while the top-level bridge is unconditional --
+/// it is not, so this pins that `[inputs]` still sees documents 2 and 3.
+#[test]
+fn test_jq_cursor_metadata_carve_out_keeps_first_inputs_lazy_1504() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", "[first(inputs)], line, [inputs]"],
+        Some("1\n2\n3\n"),
+    )
+    .expect("carve-out laziness repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    // `[1]` and `[2,3]` are jq 1.7.1's own answer for the same filter with
+    // `line` removed (`line` is a succinctly extension jq cannot parse).
+    assert_eq!(stdout, "[1]\n1\n[2,3]\n");
+    Ok(())
+}
+
+/// The carve-out keys off the `line`/`at_offset`/... *builtins*, so a field
+/// or key that merely spells one of their names must not trip it -- that
+/// would quietly switch a filter back to the eager path and undo #1504's own
+/// interleave fix for it. `.line` here is a plain field access: the bridge is
+/// still taken, so `input_line_number` reports each document's own line
+/// (`1`, then `2`) rather than the last one twice.
+#[test]
+fn test_jq_carve_out_does_not_fire_on_a_field_named_like_a_builtin_1504() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", "inputs | [.line, input_line_number]"],
+        Some("{\"line\":9}\n{\"line\":8}\n"),
+    )
+    .expect("carve-out lookalike repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[9,1]\n[8,2]\n");
+    Ok(())
+}
+
 /// The gate on #1309's `first(...)` delegation must not fire for a filter
 /// that cannot consume inputs -- the bridge costs the subtree its cursor, and
 /// with it #607's duplicate-key fidelity. Pinned as a behavioural check on the


### PR DESCRIPTION
Follow-up to #1593, which merged while this commit was still in flight — the
queue rebased and took only its first two commits, leaving this one stranded on
the branch. The regression below is live on `main` today, verified against a
build of `9a6ce7a57`.

## The bug

#1504's top-level bridge hands any program mentioning `input`/`inputs`/
`input_line_number` to `eval.rs`, which has no cursor to answer position
questions from: `line`/`column` are permanent-`0` stubs there and
`at_offset`/`at_position` are unconditional `requires document cursor context`
errors. All four worked before #1504.

```
$ echo '{"a":1}' | succinctly jq -c 'at_offset(1), input_line_number'
jq: error (at <stdin>:1): at_offset requires document cursor context   # exit 5
$ echo '{"a":1}' | succinctly jq -c 'line, column, input_line_number'
0 0 1
```

`at_offset(1)` on its own still works, so it is specifically the combination
with an input builtin.

Re-indexing could not have rescued them: `eval_each_owned` rebuilds its index
from `to_json_for_reindex`'s re-serialised text, so any offset or line/column it
reported would describe that text rather than the file the user passed. A
confidently wrong position is worse than a divergence.

## The fix

Add `walk::uses_cursor_metadata_builtins` over the eight cursor-answered
builtins and carve them out of the bridge condition, now shared by `eval_using`
and `eval_with_cursor_using` as `takes_input_queue_bridge` so the two entry
points cannot drift apart. Such a program keeps the eager, cursor-carrying path
and its answer, forgoing #1504's interleave.

**That carve-out makes `eval_first_or_last_generic`'s #1309 guard reachable
again, so this restores it.** #1593's second commit removed it as dead code,
correct while the bridge was unconditional. It is not any more:
`first(inputs), line` now reaches that function down the carved-out path with
the queue still live, and `each_take_first_generic` has no `Builtin::Inputs`
lazy arm to stop the drain — #1309's silent data loss, reintroduced sideways.
Verified live by instrumenting the guard with a `panic!`: **reached** via the
carve-out, **still dead** via the bridge, which is exactly the split its removal
assumed.

Also drops a `cursor.value()` that `to_owned_with_cursor` discards whenever the
cursor is `Some`.

## Behaviour

| probe | `main` today | this PR |
|---|---|---|
| `at_offset(1), input_line_number` | error, exit 5 | `"a" 1` |
| `at_position(1;2), input_line_number` | error, exit 5 | `"a" 1` |
| `line, column, input_line_number` | `0 0 1` | `1 1 1` |
| `inputs \| input_line_number` (#1504) | `1 2 3` | `1 2 3` — preserved |
| `[first(inputs)], line, [inputs]` | `[1] 0 [2,3]` | `[1] 1 [2,3]` |
| `inputs \| [.line, input_line_number]` | `[9,1] [8,2]` | `[9,1] [8,2]` — preserved |

The last row is the predicate not over-firing on a field that merely spells a
builtin's name, which would have switched that filter back to the eager path
and quietly undone #1504's own fix for it.

## Tests

Four new tests: cursor-metadata builtins survive an input builtin; the carve-out
keeps `first(inputs)` lazy; the predicate does not fire on a `.line` field; plus
unit tests for the new predicate, including that it and `uses_input_builtins`
are independent (the carve-out is their conjunction, so neither may imply the
other).

`cargo test --features cli,simd,regex,serde --workspace` — **5853 passed, 0
failed** on top of the current `main`, including the five jq-laziness commits
that landed alongside #1593 and touch the same neighbourhood
(`fold_pipe_stages_sink`, `first(try/label/as/limit)`, `fold_lazy_*_stage`).
`fmt --check`, both CI clippy legs, `cargo doc` under `-D warnings`, and
`--no-default-features` all clean.

## Also recorded

`docs/compliance/jq/limitations.md` gains the carve-out rationale and a note
that the bridge costs roughly 1.7x wall clock per document, growing with
document size. That ratio is written up as an **indicative spot check, not a
benchmark result** — it was `/usr/bin/time` over three interleaved repetitions
on an Apple M5 Max laptop running on battery, which the benchmarking guide rules
out for a quotable figure, and x86_64 was never measured. What it does establish
is the shape (per-document, size-proportional, matching the mechanism) and that
it is confined to filters using an input builtin.