### PR TITLE
fix(jq): interleave binary-fanout operand evaluation to match jq (#1481)

### DIFF
--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -63,7 +63,11 @@ identically one level down, as an *operand* of a binary operator
 `binary_fanout_each_generic` is handed is `eval_each_generic` itself; the sweep script
 attributes those cases to this same entry rather than pinning 20 more rows that say what the
 five already say. Closing them means mirroring Stage 5's `eval.rs` arm set into
-`eval_generic.rs` — the natural next increment of option (c), not a new mechanism.
+`eval_generic.rs` — the natural next increment of option (c), not a new mechanism, and
+already filed as [#1596](https://github.com/rust-works/succinctly/issues/1596) (duplicate:
+[#1604](https://github.com/rust-works/succinctly/issues/1604)). Its `Compare` sibling,
+[#1592](https://github.com/rust-works/succinctly/issues/1592), is what #1481 closed here —
+together with the `Arithmetic` half #1592 did not name.
 
 **Two lessons from #1481 worth carrying to that increment.** (i) *Both* operators need an
 arm, never just the one the repro used: `Compare` and `Arithmetic` share one loop but

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -2,7 +2,7 @@
 
 [Home](../../) > [Docs](../) > [Plan](./) > Lazy generator consumers
 
-**Status: Stages 1, 2, 2b, 3, 4 and 5 implemented.** This document is the
+**Status: Stages 1, 2, 2b, 3, 4, 5 and the #1481 follow-up implemented.** This document is the
 deliverable for [#820](https://github.com/rust-works/succinctly/issues/820), which its
 own tier review (2026-08-20) classified Tier 3 — "evaluator-architecture change, design
 doc first, in the shape of #1282". It also scopes the two issues that name #820 as their
@@ -23,6 +23,7 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | 5     | Widen the lazy arm set                              | ✅ merged — closes #1462    |
 | (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ✅ merged — #1451, #1461    |
 | —     | Interleave top-level `input`/`inputs` (#1309's residue) | ✅ merged — #1504        |
+| —     | Interleave the eager binary-fanout loops            | ✅ merged — closes #1481    |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
@@ -32,18 +33,24 @@ other compare reached through a lazy consumer. Since Stage 5, `eval_each` also c
 `If`, `Try`/`Optional`, `Label`, `As`, `AsPattern` and `Limit` arms, closing the
 demand-forwarding gap for a generator nested inside any of them (`isempty(limit(3; 1,
 ("B"|stderr)))`, `isempty(if true then (1,("B"|stderr)) else 9 end)`, and the rest of the
-family the same shape). **Three** shapes remain divergent, all pinned as such in
-`test_short_circuit_side_effect_leaks_820_932_987`. Two are the bare-`first(...)` family:
-`first(.[] | stderr)` (see "Option (c), scoped" below) and
-`first((1,2) == (10, ("B"|stderr)))`, both a `first(...)` over a
-non-`Comma`, which Stage 2b's sibling walk does not reach — option (c), #1461. This is a
-*separate* obstacle from Stage 5's own arms: a bare `first(...)`/`last(...)` never even
-reaches `eval.rs` for a non-`Comma` argument, because `eval_generic.rs`'s own native
-`first`/`last` routing intercepts it first (confirmed live while implementing Stage 5, below);
-`isempty`, `limit`, `nth`, `path`, `any`, `all` and `IN` have no such native `eval_generic` arm
-and so reach every one of Stage 5's new arms correctly. The third divergent shape is
+family the same shape). Three shapes were once flagged divergent here, all pinned as such in
+`test_short_circuit_side_effect_leaks_820_932_987`: `first(.[] | stderr)`, which turned out to
+already be closed by option (c)/#1461's `Pipe` arm by the time this was written;
+`first((1,2) == (10, ("B"|stderr)))`, a `first(...)` over a non-`Comma`/`Pipe`/`Paren`
+argument (`Expr::Compare`), which Stage 2b's sibling walk does not reach; and
 `("A"|stderr) == (("B"|stderr), ("C"|stderr))`, a *top-level* compare, which never reaches
-`eval_each` at all — #1481.
+`eval_each` at all. Both compare shapes are closed as of #1481: `eval_generic.rs` gained its
+own `binary_fanout_each_generic`/`eval_each_generic`-`Expr::Compare`-arm pair, mirroring
+`eval.rs`'s `binary_fanout_each`/`eval_each` machinery, and `eval_single`'s own top-level
+`Expr::Compare` arm now routes through it instead of a standalone eager loop. #1481 also closed
+a second, distinct gap in the same family: even where a lazy arm already existed
+(`eval.rs`'s `eval_each`), the *eager* callers reaching `Expr::Compare`/`Expr::Arithmetic`
+through ordinary (non-lazy-consumer) evaluation — `eval_binary_fanout` and its path-context
+sibling — still finished the right operand to completion before starting the left, where jq
+interleaves them; with `input`/`inputs` operands this changed delivered *values*, not just
+stderr order (`(input) + (input, input)` over `"a" "b" "c" "d"` was `["ca","db"]` instead of
+jq's `["ba","dc"]`). See [issue #1481](https://github.com/rust-works/succinctly/issues/1481)
+for the full repro set and `scripts/jq-fanout-oracle-sweep.sh` for the verification sweep.
 
 **One divergence Stage 5's own oracle sweep found and did not attempt.** `?//`-alternatives
 wrapped in a short-circuiting consumer: real jq's builtins are macro-expanded `label $out |
@@ -1157,7 +1164,13 @@ the reasoning behind each placement:
    `input`/`inputs` operands it changes *values*, not just stderr ordering:
    `(input) + (input, input)` over `"a" "b" "c" "d"` is `["ba","dc"]` in jq and
    `["ca","db"]` here, so it is silent data loss rather than a cosmetic leak. **Filed as
-   #1481.**
+   #1481, implemented.** `eval_binary_fanout` now routes through `eval_each` (which also
+   gained the `Expr::Arithmetic` arm Stage 4 deliberately left out); the path-context
+   sibling uses a per-operand hybrid (`eval_each_owned` when an operand doesn't itself need
+   path context, the pre-existing eager path when it does); and `eval_generic.rs`'s own
+   `Expr::Compare` arm — finding (a) above, `first((1,2) == (10, ("B"|stderr)))` included —
+   was rewired onto a new `binary_fanout_each_generic`/`eval_each_generic`-`Expr::Compare`
+   pair mirroring `eval.rs`'s machinery, closing both findings together.
 
    **Two things review added afterwards.** (i) #1459's own severity line — "Low (stray
    stderr write; no wrong output, no data loss)" — is true of its `IN(src; s)` repro and

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -40,8 +40,9 @@ already be closed by option (c)/#1461's `Pipe` arm by the time this was written;
 argument (`Expr::Compare`), which Stage 2b's sibling walk does not reach; and
 `("A"|stderr) == (("B"|stderr), ("C"|stderr))`, a *top-level* compare, which never reaches
 `eval_each` at all. Both compare shapes are closed as of #1481: `eval_generic.rs` gained its
-own `binary_fanout_each_generic`/`eval_each_generic`-`Expr::Compare`-arm pair, mirroring
-`eval.rs`'s `binary_fanout_each`/`eval_each` machinery, and `eval_single`'s own top-level
+own `binary_fanout_each_generic`, plus native `eval_each_generic` arms for **both**
+`Expr::Compare` and `Expr::Arithmetic`, mirroring `eval.rs`'s
+`binary_fanout_each`/`eval_each` machinery, and `eval_single`'s own top-level
 `Expr::Compare` arm now routes through it instead of a standalone eager loop. #1481 also closed
 a second, distinct gap in the same family: even where a lazy arm already existed
 (`eval.rs`'s `eval_each`), the *eager* callers reaching `Expr::Compare`/`Expr::Arithmetic`
@@ -51,6 +52,28 @@ interleaves them; with `input`/`inputs` operands this changed delivered *values*
 stderr order (`(input) + (input, input)` over `"a" "b" "c" "d"` was `["ca","db"]` instead of
 jq's `["ba","dc"]`). See [issue #1481](https://github.com/rust-works/succinctly/issues/1481)
 for the full repro set and `scripts/jq-fanout-oracle-sweep.sh` for the verification sweep.
+
+**What is still divergent, and where it is pinned.** Five shapes remain, all in
+`test_short_circuit_side_effect_leaks_820_932_987`: `first(...)` over an `Expr::If`, `Try`,
+`Label`, `As` or `Limit`. Those five are the arm set `eval_each_generic` still lacks — it
+has native arms for `Comma`/`Pipe`/`Paren` (option (c)/#1461) and `Compare`/`Arithmetic`
+(#1481) only, so anything else falls to its eager `_` fallback. The same five leak
+identically one level down, as an *operand* of a binary operator
+(`first(10 == (if true then (1, ("B"|stderr)) else 9 end))`), because the operand strategy
+`binary_fanout_each_generic` is handed is `eval_each_generic` itself; the sweep script
+attributes those cases to this same entry rather than pinning 20 more rows that say what the
+five already say. Closing them means mirroring Stage 5's `eval.rs` arm set into
+`eval_generic.rs` — the natural next increment of option (c), not a new mechanism.
+
+**Two lessons from #1481 worth carrying to that increment.** (i) *Both* operators need an
+arm, never just the one the repro used: `Compare` and `Arithmetic` share one loop but
+dispatch through separate `Expr` variants, and a fix that stopped at `Compare` left
+`first(10 + (1, ("B"|stderr)))` leaking while `first(10 == (1, ("B"|stderr)))` no longer did.
+(ii) A sweep's own scaffolding can hide the site it exists to test: wrapping every generated
+filter in `label $o | ...` (so a `break $o` terminator has a target) routes the whole filter
+through `eval_generic.rs`'s wildcard into `eval.rs`, since `Expr::Label` has no native
+`eval_single` arm there — which made an entire 490-case sweep blind to the `eval_generic.rs`
+copy of the loop. The wrapper is now applied to the `break $o` terminator alone.
 
 **One divergence Stage 5's own oracle sweep found and did not attempt.** `?//`-alternatives
 wrapped in a short-circuiting consumer: real jq's builtins are macro-expanded `label $out |
@@ -1169,8 +1192,14 @@ the reasoning behind each placement:
    sibling uses a per-operand hybrid (`eval_each_owned` when an operand doesn't itself need
    path context, the pre-existing eager path when it does); and `eval_generic.rs`'s own
    `Expr::Compare` arm — finding (a) above, `first((1,2) == (10, ("B"|stderr)))` included —
-   was rewired onto a new `binary_fanout_each_generic`/`eval_each_generic`-`Expr::Compare`
-   pair mirroring `eval.rs`'s machinery, closing both findings together.
+   was rewired onto a new `binary_fanout_each_generic` plus native `eval_each_generic` arms
+   for `Expr::Compare` *and* `Expr::Arithmetic`, mirroring `eval.rs`'s machinery, closing
+   both findings together. The `Arithmetic` arm is not decoration: the two variants share
+   one loop but dispatch separately, so with only the `Compare` arm
+   `first(10 + (1, ("B"|stderr)))` still leaked while `first(10 == (1, ("B"|stderr)))` did
+   not. The single `ArithOp` → `arith_*` dispatch all four `combine` sites now share lives
+   in `eval::arith_combine`, the structural twin of `apply_compare_op`; it was written out
+   at three sites before #1481 and would have become five.
 
    **Two things review added afterwards.** (i) #1459's own severity line — "Low (stray
    stderr write; no wrong output, no data loss)" — is true of its `IN(src; s)` repro and

--- a/scripts/jq-fanout-oracle-sweep.sh
+++ b/scripts/jq-fanout-oracle-sweep.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Oracle sweep for the binary-fanout interleaving fix (#1481).
+#
+# Cross-products a set of "consumer" contexts against a set of operand shapes
+# and terminating side effects, for both `Expr::Compare` (`==`) and
+# `Expr::Arithmetic` (`+`, as the shared-loop representative), running each
+# generated filter through both the pinned jq oracle and the built succinctly
+# binary and diffing stdout/stderr/exit code. This is the sweep methodology
+# from docs/plan/jq-lazy-generator-consumers.md's "Verification approach for
+# the follow-up implementation PRs" section, scoped down from its full
+# C x G x X cross product to what #1481 specifically needs.
+#
+# This is a verification tool, not a CI gate: the pinned regression rows in
+# tests/jq_cli_tests.rs (test_short_circuit_side_effect_shapes_already_match_jq_820's
+# "closed by #1481" section) are what CI actually enforces. Run this manually
+# after touching binary-fanout evaluation order to confirm the divergence
+# count, and keep it around for the next lazy-evaluation issue instead of
+# rebuilding a sweep from scratch again.
+#
+# Usage:
+#   cargo build --release --features cli
+#   ./scripts/jq-fanout-oracle-sweep.sh [path-to-succinctly-binary]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIN="$(cat "$REPO_ROOT/tests/data/jq-golden/JQ_VERSION")"
+SUCC="${1:-$REPO_ROOT/target/release/succinctly}"
+
+if [[ ! -x "$SUCC" ]]; then
+  echo "error: succinctly binary not found at $SUCC — run: cargo build --release --features cli" >&2
+  exit 1
+fi
+
+# Prefer the pinned oracle binary directly (macOS ships jq-1.7.1 at
+# /usr/bin/jq; a PATH jq, e.g. Homebrew's, is often a newer version) — same
+# reasoning as tests/jq_cli_tests.rs's own pinned-oracle comments.
+if [[ -x /usr/bin/jq ]] && /usr/bin/jq --version | grep -q "^$PIN"; then
+  JQ=/usr/bin/jq
+elif command -v jq >/dev/null 2>&1 && jq --version | grep -q "^$PIN"; then
+  JQ="$(command -v jq)"
+else
+  echo "error: no jq matching pin $PIN found at /usr/bin/jq or on PATH" >&2
+  exit 1
+fi
+echo "oracle: $JQ ($("$JQ" --version)), succinctly: $SUCC" >&2
+
+# 14 operand shapes (docs/plan/jq-lazy-generator-consumers.md's own sweep
+# methodology), __X__ substituted with each terminator below.
+G_SHAPES=(
+  '(1, __X__)'
+  '(__X__, 1)'
+  '(empty, __X__)'
+  '(1, 2, __X__)'
+  '(1 | __X__)'
+  '((1,2) | __X__)'
+  '((1, __X__))'
+  'if true then (1, __X__) else 9 end'
+  'try (1, __X__) catch 9'
+  'label $o | (1, __X__)'
+  '1 as $v | (1, __X__)'
+  'first(1, __X__)'
+  'limit(3; 1, __X__)'
+  '[1, __X__]'
+)
+
+# 7 terminating side effects. Every generated filter is wrapped in an outer
+# `label $o | (...)` so a bare `break $o` always has a valid target, even
+# though shape 10 above nests its own `label $o` (a deliberate shadowing
+# case, not a bug in the sweep).
+X_TERMS=(
+  '("B"|stderr)'
+  '("m"|halt_error(3))'
+  'error("e")'
+  'break $o'
+  'input'
+  'debug'
+  '7'
+)
+
+# Plenty of stdin documents so an `input` terminator never runs the queue dry
+# regardless of how many times a shape evaluates it — every case gets the
+# same stdin; jq/succinctly alike leave it unread when a filter never calls
+# `input`/`inputs`.
+STDIN_DOCS='1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20'
+
+total=0
+diverged=0
+divergence_log=""
+
+run_case() {
+  local label="$1" filter="$2"
+  total=$((total + 1))
+
+  local jq_out jq_err jq_code succ_out succ_err succ_code
+  jq_out="$(printf '%s' "$STDIN_DOCS" | "$JQ" -cn "$filter" 2>/tmp/jq-fanout-sweep.err)" && jq_code=0 || jq_code=$?
+  jq_err="$(cat /tmp/jq-fanout-sweep.err)"
+  succ_out="$(printf '%s' "$STDIN_DOCS" | "$SUCC" jq -cn "$filter" 2>/tmp/succ-fanout-sweep.err)" && succ_code=0 || succ_code=$?
+  succ_err="$(cat /tmp/succ-fanout-sweep.err)"
+
+  if [[ "$jq_out" != "$succ_out" || "$jq_err" != "$succ_err" || "$jq_code" != "$succ_code" ]]; then
+    diverged=$((diverged + 1))
+    divergence_log+="[$label] $filter
+  jq:          out=$jq_out err=$jq_err exit=$jq_code
+  succinctly:  out=$succ_out err=$succ_err exit=$succ_code
+"
+  fi
+}
+
+for g in "${G_SHAPES[@]}"; do
+  for x in "${X_TERMS[@]}"; do
+    operand="${g//__X__/$x}"
+
+    compare_core="10 == ($operand)"
+    run_case "compare/bare"  "label \$o | [$compare_core]"
+    run_case "compare/first" "label \$o | [first($compare_core)]"
+    run_case "compare/IN"    "label \$o | [IN(10; $operand)]"
+
+    arith_core="10 + ($operand)"
+    run_case "arith/bare"  "label \$o | [$arith_core]"
+    run_case "arith/first" "label \$o | [first($arith_core)]"
+  done
+done
+
+rm -f /tmp/jq-fanout-sweep.err /tmp/succ-fanout-sweep.err
+
+echo "$divergence_log"
+echo "== $diverged / $total cases diverged from $JQ =="

--- a/scripts/jq-fanout-oracle-sweep.sh
+++ b/scripts/jq-fanout-oracle-sweep.sh
@@ -14,9 +14,25 @@
 # This is a verification tool, not a CI gate: the pinned regression rows in
 # tests/jq_cli_tests.rs (test_short_circuit_side_effect_shapes_already_match_jq_820's
 # "closed by #1481" section) are what CI actually enforces. Run this manually
-# after touching binary-fanout evaluation order to confirm the divergence
-# count, and keep it around for the next lazy-evaluation issue instead of
-# rebuilding a sweep from scratch again.
+# after touching binary-fanout evaluation order, and keep it around for the
+# next lazy-evaluation issue instead of rebuilding a sweep from scratch again.
+#
+# **Do not blanket-wrap the generated filters in `label $o | ...`.** An
+# earlier draft did, so that a bare `break $o` terminator always had a target.
+# `Expr::Label` has no native `eval_single` arm in `src/jq/eval_generic.rs`
+# (see the `Expr::Array` arm's own comment there), so a `label`-prefixed
+# filter falls to that module's wildcard and is bridged wholesale into
+# `src/jq/eval.rs` -- which silently routed every case away from
+# `eval_generic.rs`, the very copy of the fanout loop #1481 calls out as
+# "what a top-level `==` in the CLI actually reaches". The wrapper is
+# therefore applied to the `break $o` terminator only, and those rows alone
+# cannot speak for `eval_generic.rs`.
+#
+# **Expected result: `0 unexpected`.** Divergences attributable to an already
+# known, separately tracked gap are counted and printed separately (see
+# `classify_divergence` below) so the headline number stays a pass/fail
+# signal rather than something a reader has to re-triage by hand. The script
+# exits non-zero if any *unexpected* divergence appears.
 #
 # Usage:
 #   cargo build --release --features cli
@@ -65,10 +81,7 @@ G_SHAPES=(
   '[1, __X__]'
 )
 
-# 7 terminating side effects. Every generated filter is wrapped in an outer
-# `label $o | (...)` so a bare `break $o` always has a valid target, even
-# though shape 10 above nests its own `label $o` (a deliberate shadowing
-# case, not a bug in the sweep).
+# 7 terminating side effects.
 X_TERMS=(
   '("B"|stderr)'
   '("m"|halt_error(3))'
@@ -85,9 +98,43 @@ X_TERMS=(
 # `input`/`inputs`.
 STDIN_DOCS='1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20'
 
+# Attribute a divergence to an already-tracked gap, or return 1 for "this is
+# new, look at it". Keep every entry tied to an issue number: an unattributed
+# entry here would turn this sweep back into the unreadable count it was.
+classify_divergence() {
+  local filter="$1"
+
+  # #1594: `debug`/`debug(msg)` never write `["DEBUG:",value]` to stderr at
+  # all, so every `debug`-terminated case diverges on stderr regardless of
+  # evaluation order. Unrelated to fanout; drop this branch once #1594 lands.
+  if [[ "$filter" == *debug* ]]; then
+    echo '#1594 (debug writes nothing to stderr)'
+    return 0
+  fi
+
+  # #820's pinned leaks table: `eval_each_generic` has native lazy arms for
+  # `Comma`/`Pipe`/`Paren`/`Compare`/`Arithmetic` only, so a `first(...)`
+  # over an `If`/`Try`/`Label`/`As`/`Limit` — whether that shape is the
+  # argument itself or one of the binary operator's operands — still falls to
+  # the eager `_` fallback and runs a side effect `first` never needed. Pinned
+  # as a known gap in test_short_circuit_side_effect_leaks_820_932_987.
+  if [[ "$filter" == *'first('* ]]; then
+    case "$filter" in
+      *'if true then'*|*'try ('*|*'label $o |'*|*' as $v |'*|*'limit('*)
+        echo '#820 (If/Try/Label/As/Limit have no eval_each_generic arm)'
+        return 0
+        ;;
+    esac
+  fi
+
+  return 1
+}
+
 total=0
 diverged=0
+unexpected=0
 divergence_log=""
+declare -a known_labels=()
 
 run_case() {
   local label="$1" filter="$2"
@@ -101,6 +148,12 @@ run_case() {
 
   if [[ "$jq_out" != "$succ_out" || "$jq_err" != "$succ_err" || "$jq_code" != "$succ_code" ]]; then
     diverged=$((diverged + 1))
+    local known
+    if known="$(classify_divergence "$filter")"; then
+      known_labels+=("$known")
+      return
+    fi
+    unexpected=$((unexpected + 1))
     divergence_log+="[$label] $filter
   jq:          out=$jq_out err=$jq_err exit=$jq_code
   succinctly:  out=$succ_out err=$succ_err exit=$succ_code
@@ -112,18 +165,36 @@ for g in "${G_SHAPES[@]}"; do
   for x in "${X_TERMS[@]}"; do
     operand="${g//__X__/$x}"
 
+    # `break $o` is the one terminator that cannot stand on its own, so those
+    # cases — and only those — get an enclosing label. See the header: a
+    # blanket wrapper would divert the whole sweep away from eval_generic.rs.
+    # Shape 10 nests its own `label $o`, making that combination a deliberate
+    # shadowing case rather than a bug in the sweep.
+    if [[ "$x" == 'break $o' ]]; then
+      open='label $o | '
+    else
+      open=''
+    fi
+
     compare_core="10 == ($operand)"
-    run_case "compare/bare"  "label \$o | [$compare_core]"
-    run_case "compare/first" "label \$o | [first($compare_core)]"
-    run_case "compare/IN"    "label \$o | [IN(10; $operand)]"
+    run_case "compare/bare"  "$open[$compare_core]"
+    run_case "compare/first" "$open[first($compare_core)]"
+    run_case "compare/IN"    "$open[IN(10; $operand)]"
 
     arith_core="10 + ($operand)"
-    run_case "arith/bare"  "label \$o | [$arith_core]"
-    run_case "arith/first" "label \$o | [first($arith_core)]"
+    run_case "arith/bare"  "$open[$arith_core]"
+    run_case "arith/first" "$open[first($arith_core)]"
   done
 done
 
 rm -f /tmp/jq-fanout-sweep.err /tmp/succ-fanout-sweep.err
 
-echo "$divergence_log"
-echo "== $diverged / $total cases diverged from $JQ =="
+printf '%s' "$divergence_log"
+echo "== $total cases vs $JQ: $unexpected unexpected, $((diverged - unexpected)) known =="
+if ((diverged > unexpected)); then
+  printf '%s\n' "${known_labels[@]}" | sort | uniq -c | sed 's/^/   known: /'
+fi
+if ((unexpected > 0)); then
+  echo "FAIL: $unexpected unexpected divergence(s) — see above" >&2
+  exit 1
+fi

--- a/scripts/jq-fanout-oracle-sweep.sh
+++ b/scripts/jq-fanout-oracle-sweep.sh
@@ -96,7 +96,20 @@ X_TERMS=(
 # regardless of how many times a shape evaluates it — every case gets the
 # same stdin; jq/succinctly alike leave it unread when a filter never calls
 # `input`/`inputs`.
+#
+# **Fed from a file, never a pipe.** `printf ... | jq` looks equivalent and is
+# not: most filters here never read stdin, so the consumer exits with the
+# writer still holding data, `printf` dies of SIGPIPE, and `set -o pipefail`
+# promotes that 141 to the pipeline's status — which this script would then
+# record as the *oracle's* exit code. It is load-dependent, so it passes in
+# isolation and fails when something else is using the machine: 5 phantom
+# "divergences" whose stdout and stderr matched exactly, differing only in an
+# exit code neither binary actually returned. Same family as the
+# `cargo test | grep | tail` false-green. A redirect has no writer to kill.
 STDIN_DOCS='1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20'
+STDIN_FILE="$(mktemp -t jq-fanout-sweep-stdin)"
+trap 'rm -f "$STDIN_FILE" /tmp/jq-fanout-sweep.err /tmp/succ-fanout-sweep.err' EXIT
+printf '%s' "$STDIN_DOCS" > "$STDIN_FILE"
 
 # Attribute a divergence to an already-tracked gap, or return 1 for "this is
 # new, look at it". Keep every entry tied to an issue number: an unattributed
@@ -142,9 +155,9 @@ run_case() {
   total=$((total + 1))
 
   local jq_out jq_err jq_code succ_out succ_err succ_code
-  jq_out="$(printf '%s' "$STDIN_DOCS" | "$JQ" -cn "$filter" 2>/tmp/jq-fanout-sweep.err)" && jq_code=0 || jq_code=$?
+  jq_out="$("$JQ" -cn "$filter" <"$STDIN_FILE" 2>/tmp/jq-fanout-sweep.err)" && jq_code=0 || jq_code=$?
   jq_err="$(cat /tmp/jq-fanout-sweep.err)"
-  succ_out="$(printf '%s' "$STDIN_DOCS" | "$SUCC" jq -cn "$filter" 2>/tmp/succ-fanout-sweep.err)" && succ_code=0 || succ_code=$?
+  succ_out="$("$SUCC" jq -cn "$filter" <"$STDIN_FILE" 2>/tmp/succ-fanout-sweep.err)" && succ_code=0 || succ_code=$?
   succ_err="$(cat /tmp/succ-fanout-sweep.err)"
 
   if [[ "$jq_out" != "$succ_out" || "$jq_err" != "$succ_err" || "$jq_code" != "$succ_code" ]]; then
@@ -187,8 +200,6 @@ for g in "${G_SHAPES[@]}"; do
     run_case "arith/first" "$open[first($arith_core)]"
   done
 done
-
-rm -f /tmp/jq-fanout-sweep.err /tmp/succ-fanout-sweep.err
 
 printf '%s' "$divergence_log"
 echo "== $total cases vs $JQ: $unexpected unexpected, $((diverged - unexpected)) known =="

--- a/scripts/jq-fanout-oracle-sweep.sh
+++ b/scripts/jq-fanout-oracle-sweep.sh
@@ -112,16 +112,17 @@ classify_divergence() {
     return 0
   fi
 
-  # #820's pinned leaks table: `eval_each_generic` has native lazy arms for
-  # `Comma`/`Pipe`/`Paren`/`Compare`/`Arithmetic` only, so a `first(...)`
-  # over an `If`/`Try`/`Label`/`As`/`Limit` — whether that shape is the
-  # argument itself or one of the binary operator's operands — still falls to
-  # the eager `_` fallback and runs a side effect `first` never needed. Pinned
-  # as a known gap in test_short_circuit_side_effect_leaks_820_932_987.
+  # #1596 (dup: #1604): `eval_each_generic` has native lazy arms for
+  # `Comma`/`Pipe`/`Paren` (#1461) and `Compare`/`Arithmetic` (#1481) only,
+  # so a `first(...)` over an `If`/`Try`/`Label`/`As`/`Limit` — whether that
+  # shape is the argument itself or one of the binary operator's operands —
+  # still falls to the eager `_` fallback and runs a side effect `first`
+  # never needed. Pinned as a known gap in
+  # test_short_circuit_side_effect_leaks_820_932_987; #1596 tracks the fix.
   if [[ "$filter" == *'first('* ]]; then
     case "$filter" in
       *'if true then'*|*'try ('*|*'label $o |'*|*' as $v |'*|*'limit('*)
-        echo '#820 (If/Try/Label/As/Limit have no eval_each_generic arm)'
+        echo '#1596 (If/Try/Label/As/Limit have no eval_each_generic arm)'
         return 0
         ;;
     esac

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2551,11 +2551,11 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // path-context diversion of its own, so there is nothing to preserve
         // — and each operand's own `eval_each` re-derives exactly the routing
         // `eval_single` would (a `Pipe` operand still hits `eval_each_pipe`'s
-        // gate before anything else).
-        //
-        // `Expr::Arithmetic` shares [`binary_fanout_each`] but deliberately
-        // gets no lazy arm: Stage 4 is scoped to `Expr::Compare`, and
-        // arithmetic's `combine` can fail, which is its own risk surface.
+        // gate before anything else). `Expr::Arithmetic` shares
+        // [`binary_fanout_each`] and gets the identical arm just below —
+        // `combine`'s fallibility is not new risk, `binary_fanout_each`'s
+        // `Err` handling was written generically for it from the start
+        // (#1481).
         Expr::Compare { op, left, right } => binary_fanout_each(
             |operand, operand_sink| {
                 eval_each::<W, S>(operand, value.clone(), optional, operand_sink)
@@ -2567,6 +2567,31 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Ok(OwnedValue::Bool(apply_compare_op::<S>(
                     *op, &left_val, &right_val,
                 )))
+            },
+            sink,
+        ),
+        // #1481: the demand-aware twin of `eval_arithmetic`'s fanout, mirroring
+        // the `Expr::Compare` arm just above exactly (including the "no
+        // `needs_path_context` gate" reasoning, which applies identically
+        // here). Closes the same class of leak for `+`/`-`/`*`/`/`/`%` that
+        // `Expr::Compare` closed for comparisons at Stage 4 — e.g. a bare
+        // `(input) + (input, input)` reached through `eval_single` is fixed by
+        // `eval_binary_fanout` alone, but this arm is what keeps that fix
+        // working when arithmetic sits inside `first(...)`/`IN(...)`/another
+        // `Compare`/etc.
+        Expr::Arithmetic { op, left, right } => binary_fanout_each(
+            |operand, operand_sink| {
+                eval_each::<W, S>(operand, value.clone(), optional, operand_sink)
+            },
+            left,
+            right,
+            optional,
+            |left_val, right_val| match op {
+                ArithOp::Add => arith_add::<S>(left_val, right_val),
+                ArithOp::Sub => arith_sub::<S>(left_val, right_val),
+                ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
+                ArithOp::Div => arith_div::<S>(left_val, right_val),
+                ArithOp::Mod => arith_mod::<S>(left_val, right_val),
             },
             sink,
         ),
@@ -3428,16 +3453,19 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
 /// does not. `eval_operand` closes over whichever evaluator its caller
 /// wants; everything downstream of an operand's `QueryResult` is unchanged.
 ///
-/// **This is the eager operand strategy**, not the loop itself: the loop
-/// moved to [`binary_fanout_each`] for #1459 (Stage 4), and this is the
-/// collecting wrapper over it. `each_operand` here evaluates a whole operand
-/// up front and replays it through [`drain_result`], so both callers keep the
-/// exact "right operand evaluated to completion, *then* left re-evaluated per
-/// right value" behaviour they had when this body *was* the loop.
-/// `eval_each`'s own `Expr::Compare` arm supplies the demand-driven strategy
-/// instead — same loop, lazy operands.
+/// This is the collecting wrapper over [`binary_fanout_each`] (the loop
+/// itself, moved there for #1459/Stage 4): it just forwards whichever
+/// `each_operand` strategy its caller supplies and folds the sink's pushes
+/// back into a `QueryResult`. The strategy, not this function, decides
+/// whether operand evaluation is eager or interleaved — both
+/// [`eval_binary_fanout`] and `eval_binary_fanout_with_path_context` pass a
+/// demand-driven strategy since #1481 (respectively [`eval_each`] and a
+/// per-operand hybrid; see their own doc comments), matching `eval_each`'s
+/// own `Expr::Compare`/`Expr::Arithmetic` arms, which pass the identical
+/// [`eval_each`] strategy directly into [`binary_fanout_each`] without going
+/// through this wrapper at all.
 fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
-    eval_operand: impl Fn(&Expr) -> QueryResult<'a, W>,
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow,
     left: &Expr,
     right: &Expr,
     optional: bool,
@@ -3445,7 +3473,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'a, W> {
     let mut out: Vec<OwnedValue> = Vec::new();
     let flow = binary_fanout_each(
-        |expr, sink| drain_result(eval_operand(expr), sink),
+        each_operand,
         left,
         right,
         optional,
@@ -3472,17 +3500,24 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
 /// `docs/plan/jq-lazy-generator-consumers.md`) and parameterized over *how*
 /// an operand is enumerated.
 ///
-/// Two strategies exist, and only the strategy differs — never the loop:
+/// The strategy differs by caller, never the loop:
 ///
-/// * [`binary_fanout_core`] passes an eager `each_operand` (evaluate the
-///   whole operand, then replay it through [`drain_result`]), which is what
-///   `eval_arithmetic`/`eval_compare` and the path-context sibling have
-///   always done.
-/// * `eval_each`'s `Expr::Compare` arm passes [`eval_each`] itself, so the
-///   *right* operand — jq's outer loop — stops producing candidates the sink
-///   never asked for. That is what closes `IN(src; s)`'s side-effect leak
-///   (#932/#1459): a `stderr`/`halt_error` sitting past the matching
-///   candidate is no longer evaluated at all.
+/// * `eval_each`'s `Expr::Compare`/`Expr::Arithmetic` arms pass [`eval_each`]
+///   itself, so the *right* operand — jq's outer loop — stops producing
+///   candidates the sink never asked for, and its next candidate is only
+///   pulled once the sink actually asks for it, genuinely interleaving with
+///   the left operand's evaluation (#1481). That is what closes `IN(src;
+///   s)`'s side-effect leak (#932/#1459): a `stderr`/`halt_error` sitting
+///   past the matching candidate is no longer evaluated at all.
+/// * [`eval_binary_fanout`] (via [`binary_fanout_core`]) passes the identical
+///   [`eval_each`] strategy for ordinary, non-path-context evaluation, and
+///   `eval_binary_fanout_with_path_context` passes a per-operand hybrid
+///   (lazy via [`eval_each_owned`] when an operand doesn't itself need path
+///   context, eager via [`drain_result`] when it does) — see their own doc
+///   comments. Before #1481, both of these passed an eager `each_operand`
+///   (evaluate the whole operand, then replay it through [`drain_result`]),
+///   which is why a bare top-level `(input) + (input, input)` used to finish
+///   the right operand before starting the left, unlike jq.
 ///
 /// Keeping one loop is the whole point: #768 fixed a collapse-to-first-value
 /// bug here that the then-duplicated path-context copy independently
@@ -3722,6 +3757,12 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
+/// Backs `eval_arithmetic`/`eval_compare`. Operands are evaluated through
+/// [`eval_each`] (#1481), not [`eval_single`]: this is the same lazy strategy
+/// `eval_each`'s own `Expr::Compare`/`Expr::Arithmetic` arms use, so a plain
+/// top-level `left op right` interleaves its operands' evaluation exactly
+/// the way one reached through a lazy consumer (`first(...)`, `IN(...)`,
+/// etc.) already did.
 fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     left: &Expr,
     right: &Expr,
@@ -3730,7 +3771,7 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
-        move |expr| eval_single::<W, S>(expr, value.clone(), optional),
+        move |expr, sink| eval_each::<W, S>(expr, value.clone(), optional, sink),
         left,
         right,
         optional,
@@ -23457,12 +23498,28 @@ fn resolve_ancestor_path<'a, 'p, W: Clone + AsRef<[u64]>>(
 
 /// Path-context analog of `eval_binary_fanout` (#768/#822): evaluate `left op
 /// right` over every pairing jq's cartesian fanout produces (right operand
-/// outer / left operand inner), routed through
-/// `eval_pipe_with_path_context_internal` instead of `eval_single` so
-/// `key`/`parent`/`file_index` nested in either operand still resolve
-/// against `root`/`current_path`/`file_origin`. Structure is identical to
+/// outer / left operand inner). Structure is identical to
 /// `eval_binary_fanout`; kept separate because the two recurse through
 /// different evaluators with different parameter shapes.
+///
+/// **Per-operand hybrid strategy (#1481)**: there is no lazy/demand-driven
+/// twin of `eval_pipe_with_path_context_internal` (it is a large,
+/// exhaustive-per-`Expr`-variant function; building one is out of proportion
+/// to this fix). Instead, each operand is checked individually with
+/// [`needs_path_context`] — the *specific subexpression*, not the whole
+/// enclosing pipe, exactly the granularity
+/// `eval_pipe_with_path_context_internal`'s own `Expr::Array` arm already
+/// uses. An operand that itself resolves `key`/`parent`/`file_index` stays on
+/// the eager `eval_pipe_with_path_context_internal` + [`drain_result`] path
+/// (unavoidable without new machinery, and rare — only when *that* operand
+/// directly needs path tracking, not merely some other part of the
+/// surrounding pipe). An operand that doesn't gets the same demand-driven
+/// interleaving as [`eval_binary_fanout`], bridged through [`eval_each_owned`]
+/// — the same bridge `eval_each_pipe`'s own `Item::Owned` arm already uses to
+/// hand a path-context-tracked value to the ordinary lazy evaluator.
+/// `binary_fanout_each`'s pairing/nesting guarantees (#910/#768/#822) depend
+/// only on each operand's evaluation contract, never on whether left and
+/// right share one strategy, so mixing eager and lazy per operand is safe.
 #[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors eval_pipe_with_path_context_internal's
                                      // own root/file_origin/current_path/optional threading,
                                      // used unbundled at every one of its ~15 call sites in this
@@ -23479,15 +23536,24 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
-        |expr| {
-            eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(expr),
-                value,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            )
+        |operand: &Expr, operand_sink: &mut dyn FnMut(Item<'a, W>) -> Demand| -> Flow {
+            if needs_path_context(operand) {
+                drain_result(
+                    eval_pipe_with_path_context_internal::<W, S>(
+                        core::slice::from_ref(operand),
+                        value,
+                        root,
+                        file_origin,
+                        current_path,
+                        optional,
+                    ),
+                    operand_sink,
+                )
+            } else {
+                eval_each_owned::<S>(operand, value, optional, &mut |v| {
+                    operand_sink(Item::Owned(v))
+                })
+            }
         },
         left,
         right,
@@ -50108,6 +50174,23 @@ mod tests {
         assert_eq!(
             eval_all_outputs(b"[10]", &[0], ".[] | (((1,2) + (10,20)), file_index)"),
             vec!["11", "12", "21", "22", "0"]
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_combine_error_aborts_whole_fanout_1481() {
+        // A `combine` failure (op-application itself, not operand
+        // evaluation) still aborts the whole fanout rather than skipping
+        // just that pairing, now that `eval_each`'s new `Expr::Arithmetic`
+        // arm (#1481) is what `eval_binary_fanout` routes through: right
+        // outer (2,3), left inner (1,"a") -- `1+2=3` succeeds first, then
+        // `"a"+2` fails, so the fanout carries `[3]` as its already-produced
+        // prefix and never attempts `"a"+3` at all.
+        query!(br"null", r#"(1,"a") + (2,3)"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(3)]);
+                assert_eq!(e.message, "string (\"a\") and number (2) cannot be added");
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2586,13 +2586,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             left,
             right,
             optional,
-            |left_val, right_val| match op {
-                ArithOp::Add => arith_add::<S>(left_val, right_val),
-                ArithOp::Sub => arith_sub::<S>(left_val, right_val),
-                ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
-                ArithOp::Div => arith_div::<S>(left_val, right_val),
-                ArithOp::Mod => arith_mod::<S>(left_val, right_val),
-            },
+            |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
         // The one arm here that is a correctness fix rather than an
@@ -3779,6 +3773,37 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     )
 }
 
+/// Apply an arithmetic operator to two already-evaluated values.
+///
+/// **The one definition of this dispatch.** Every site that supplies
+/// `binary_fanout_each`'s `combine` for arithmetic used to write the match
+/// out itself: two of them before #1481, three once it added [`eval_each`]'s
+/// lazy arm, and four once `eval_generic` gained its own -- exactly the
+/// "duplicated predicates diverge silently" shape this project has already
+/// been bitten by (#106: three copies of one predicate, one of them
+/// quadratic). The four callers are [`eval_arithmetic`] (bare top-level),
+/// [`eval_each`]'s `Expr::Arithmetic` arm (lazy),
+/// `eval_pipe_with_path_context_internal`'s own arm (path-context), and
+/// `eval_generic`'s `eval_each_generic` arm (the `V: DocumentValue`
+/// evaluator) -- which is also why this is `pub(crate)` rather than private:
+/// the last of those lives in another module.
+///
+/// Structural twin of [`apply_compare_op`], which was extracted for the same
+/// reason and now backs `Expr::Compare`'s own five call sites.
+pub(crate) fn arith_combine<S: EvalSemantics>(
+    op: ArithOp,
+    left: OwnedValue,
+    right: OwnedValue,
+) -> Result<OwnedValue, EvalError> {
+    match op {
+        ArithOp::Add => arith_add::<S>(left, right),
+        ArithOp::Sub => arith_sub::<S>(left, right),
+        ArithOp::Mul(flags) => arith_mul::<S>(left, right, flags),
+        ArithOp::Div => arith_div::<S>(left, right),
+        ArithOp::Mod => arith_mod::<S>(left, right),
+    }
+}
+
 /// Evaluate arithmetic operations.
 fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     op: ArithOp,
@@ -3787,19 +3812,9 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    eval_binary_fanout::<W, S>(
-        left,
-        right,
-        value,
-        optional,
-        |left_val, right_val| match op {
-            ArithOp::Add => arith_add::<S>(left_val, right_val),
-            ArithOp::Sub => arith_sub::<S>(left_val, right_val),
-            ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, flags),
-            ArithOp::Div => arith_div::<S>(left_val, right_val),
-            ArithOp::Mod => arith_mod::<S>(left_val, right_val),
-        },
-    )
+    eval_binary_fanout::<W, S>(left, right, value, optional, |left_val, right_val| {
+        arith_combine::<S>(op, left_val, right_val)
+    })
 }
 
 /// Add two values (numbers, strings, arrays, objects).
@@ -24122,13 +24137,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 file_origin,
                 current_path,
                 optional,
-                |left_val, right_val| match op {
-                    ArithOp::Add => arith_add::<S>(left_val, right_val),
-                    ArithOp::Sub => arith_sub::<S>(left_val, right_val),
-                    ArithOp::Mul(flags) => arith_mul::<S>(left_val, right_val, *flags),
-                    ArithOp::Div => arith_div::<S>(left_val, right_val),
-                    ArithOp::Mod => arith_mod::<S>(left_val, right_val),
-                },
+                |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             );
             if rest.is_empty() {
                 return arith_result;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,8 +27,8 @@ use super::document::{
     IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, collapse_vec, eval as full_eval, eval_each_owned, format_owned,
-    index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
+    apply_compare_op, arith_combine, collapse_vec, eval as full_eval, eval_each_owned,
+    format_owned, index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, tonumber_from_str, Control, Demand, EvalError, EvalSemantics, EvalTag,
     Flow, JqSemantics, QueryResult, YqSemantics,
@@ -4179,16 +4179,30 @@ fn drain_result_generic<V: DocumentValue>(
 /// instead of `eval_single`'s own eager, always-materialize-everything
 /// dispatch for the same three variants.
 ///
-/// Scoped to `Comma`/`Pipe`/`Paren`/`Compare` -- mirroring `eval.rs`'s still
-/// wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/...) remains out of scope
-/// here; those shapes still fall to the `_` fallback below. `Compare` gained
-/// a native arm for #1481, mirroring `eval.rs`'s own `Expr::Compare` arm
-/// (#1459/Stage 4): this closes the interleaving gap both for a bare
-/// top-level compare (`eval_single`'s own arm now routes through this same
-/// machinery, see `eval_compare_generic`) and for a compare reached through
-/// this module's own lazy consumers (`first`/`last`), which previously fell
-/// through to the eager `_` fallback for any non-`Comma`/`Pipe`/`Paren`
-/// argument.
+/// Scoped to `Comma`/`Pipe`/`Paren`/`Compare`/`Arithmetic` -- mirroring
+/// `eval.rs`'s still wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/...)
+/// remains out of scope here; those shapes still fall to the `_` fallback
+/// below, and the five of them are pinned as an explicit known gap in
+/// `test_short_circuit_side_effect_leaks_820_932_987`.
+///
+/// `Compare` and `Arithmetic` both gained native arms for #1481, mirroring
+/// `eval.rs`'s own pair (#1459/Stage 4 for `Compare`, #1481 for
+/// `Arithmetic`). They close the interleaving gap both for a bare top-level
+/// binary operator (`eval_single`'s own `Expr::Compare` arm routes through
+/// this same machinery via `eval_compare_generic`; `Expr::Arithmetic` has no
+/// native `eval_single` arm and instead reaches `eval.rs`'s already-fixed
+/// `eval_binary_fanout` through the `eval_on_owned` bridge) and for one
+/// reached through this module's own lazy consumers (`first`/`last`), which
+/// previously fell through to the eager `_` fallback for any
+/// non-`Comma`/`Pipe`/`Paren` argument.
+///
+/// **Both operators need arms, not just `Compare`.** They share one loop, so
+/// a fix that stopped at `Compare` left the exactly-parallel arithmetic
+/// spelling divergent: `first(10 + (1, ("B"|stderr)))` still ran the
+/// side-effecting candidate `first` never asked for, while
+/// `first(10 == (1, ("B"|stderr)))` no longer did (both oracle-verified
+/// against pinned jq 1.7.1; pinned together in
+/// `test_short_circuit_side_effect_shapes_already_match_jq_820`).
 fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     value: V,
@@ -4236,6 +4250,28 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
                     *op, &left_val, &right_val,
                 )))
             },
+            sink,
+        ),
+        // #1481: the `Expr::Compare` arm's twin, identical but for the
+        // `combine` it supplies -- they share `binary_fanout_each_generic`
+        // the same way `eval.rs`'s `Expr::Compare`/`Expr::Arithmetic` arms
+        // share `binary_fanout_each`, so every note above (loop order,
+        // hardcoded `optional: false` on the operands, where the ambient
+        // `optional` is consulted instead) applies verbatim here.
+        //
+        // Unlike `apply_compare_op`, [`arith_combine`] is genuinely fallible
+        // (`"a" + 1`, `1 / 0`), so this is the arm that first exercises
+        // `binary_fanout_each_generic`'s `Err(e)` path -- the one its own
+        // comment said was written generically and left ready for a fallible
+        // caller.
+        Expr::Arithmetic { op, left, right } => binary_fanout_each_generic::<V>(
+            |operand, operand_sink| {
+                eval_each_generic::<S, V>(operand, value.clone(), false, cursor, operand_sink)
+            },
+            left,
+            right,
+            optional,
+            |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
         _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
@@ -4537,19 +4573,15 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             };
             match combine(left_val, right_val.clone()) {
                 Ok(v) => sink(GenericItem::Owned(v)),
-                // Unreached by any current caller, not just untested: both of
-                // this function's call sites (`eval_compare_generic` and
-                // `eval_each_generic`'s own `Expr::Compare` arm) wrap the
-                // infallible `apply_compare_op` in `Ok(...)` -- `CompareOp`
-                // has no failure mode. `combine` is still typed fallibly, not
-                // simplified to `OwnedValue`, to mirror `eval.rs`'s own
-                // `binary_fanout_each` (whose `Expr::Arithmetic` caller *can*
-                // fail here, e.g. division by zero) and stay ready for a
-                // fallible caller of its own -- `Expr::Arithmetic` has no
-                // native `eval_each_generic` arm today (see that function's
-                // doc comment), but if one is ever added, this is the arm
-                // that already handles it correctly rather than needing this
-                // whole loop's error plumbing designed from scratch.
+                // Reached by the `Expr::Arithmetic` caller only: the two
+                // `Expr::Compare` call sites wrap the infallible
+                // `apply_compare_op` in `Ok(...)` (`CompareOp` has no failure
+                // mode), while `arith_combine` fails on `"a" + 1`, `1 / 0`,
+                // and friends. Same policy as `eval.rs`'s
+                // `binary_fanout_each`: a `combine` error aborts the *whole*
+                // fanout rather than skipping just that pairing, whatever was
+                // already pushed stands, and `optional` decides whether the
+                // failure itself survives.
                 Err(e) => {
                     abort = Some(if optional {
                         Flow::Exhausted
@@ -4580,10 +4612,14 @@ fn binary_fanout_each_generic<V: DocumentValue>(
 /// Collecting wrapper over [`binary_fanout_each_generic`] for `eval_single`'s
 /// `Expr::Compare` arm (#1481) -- mirrors `eval.rs`'s
 /// `eval_binary_fanout`/`binary_fanout_core` pairing, wired directly to the
-/// lazy `eval_each_generic` operand strategy since this file has no eager
-/// sibling (`Expr::Arithmetic` has no native arm here at all, see
-/// `eval_each_generic`'s own doc comment) that still needs an eager one kept
-/// around.
+/// lazy `eval_each_generic` operand strategy since this file never had an
+/// eager sibling that still needs one kept around.
+///
+/// `Expr::Arithmetic` needs no counterpart here: it has no native
+/// `eval_single` arm at all, so a bare top-level `a + b` reaches `eval.rs`'s
+/// own (already interleaved) `eval_binary_fanout` through the `eval_on_owned`
+/// bridge. Only the *lazy* side needed an arm, and that one lives in
+/// [`eval_each_generic`].
 fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
     op: CompareOp,
     left: &Expr,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4629,6 +4629,10 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
     let mut out: Vec<OwnedValue> = Vec::new();
+    // A control raised while converting an item the sink was handed, kept
+    // out-of-band because the sink can only answer `Demand` -- same shape as
+    // `binary_fanout_each_generic`'s own `abort`.
+    let mut stray: Option<Control> = None;
     let flow = binary_fanout_each_generic::<V>(
         |operand, operand_sink| {
             eval_each_generic::<S, V>(operand, value.clone(), false, cursor, operand_sink)
@@ -4642,17 +4646,31 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
             )))
         },
         &mut |item: GenericItem<V>| {
-            match item {
-                GenericItem::Owned(v) => out.push(v),
-                // Structurally dead, not just untested: `binary_fanout_each_generic`
-                // has exactly one call to `sink` on its success path
-                // (`sink(GenericItem::Owned(v))` after a successful `combine`)
-                // -- there is no second call site that could hand this
-                // closure anything else, regardless of which `combine` a
-                // future caller passes.
-                _ => unreachable!("combine always produces GenericItem::Owned"),
+            // Total, rather than a `GenericItem::Owned` match with an
+            // `unreachable!()` fallback: `binary_fanout_each_generic` only
+            // ever calls `sink` with an `Owned` today, and for that variant
+            // `generic_item_into_owned` is an identity passthrough -- so
+            // this costs nothing on the only path that runs, and leaves no
+            // arm that could take the process down if a second `sink` call
+            // site is ever added. Same choice `eval.rs`'s
+            // `binary_fanout_core` makes for its own impossible
+            // `Flow::Stopped` ("an answer built from the outputs already
+            // produced is a better failure mode than a panic"), and
+            // deliberately *not* the choice the two `unreachable!()`s nearby
+            // make -- those enumerate a closed variant set, where this would
+            // be asserting an invariant about callers. The `Err` arm has no
+            // caller that can reach it today and so reads as uncovered;
+            // that is the accepted cost of not panicking here.
+            match generic_item_into_owned(item) {
+                Ok(v) => {
+                    out.push(v);
+                    Demand::Continue
+                }
+                Err(control) => {
+                    stray = Some(control);
+                    Demand::Stop
+                }
             }
-            Demand::Continue
         },
     );
 
@@ -4660,7 +4678,7 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
         Flow::Exhausted | Flow::Stopped { .. } => None,
         Flow::Escaped(control) => Some(control),
     };
-    finish_fork_generic(out, control, optional)
+    finish_fork_generic(out, control.or(stray), optional)
 }
 
 /// Evaluate `first(inner)`/`last(inner)` (and the `Builtin::FirstStream`/

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -11101,10 +11101,15 @@ mod tests {
         let value = index.root(json).value();
 
         let expr = crate::jq::parse("map(1/0) == 1").unwrap();
-        match eval(&expr, value) {
-            GenericResult::Error(e) => assert!(e.message.contains("divided")),
-            other => panic!("expected Error, got {other:?}"),
-        }
+        // `assert!(matches!(..))` rather than a `match` with a `panic!`
+        // fallback: the fallback arm is only ever reached by a *failing*
+        // test, so it reads as a permanently uncovered line in the coverage
+        // diff (#1601). Same style as
+        // `test_generic_compare_operand_lazy_seq_break_and_halt_propagate_1481`
+        // just above.
+        assert!(
+            matches!(eval(&expr, value), GenericResult::Error(ref e) if e.message.contains("divided"))
+        );
     }
 
     #[test]
@@ -11118,10 +11123,15 @@ mod tests {
         let value = index.root(json).value();
 
         let expr = crate::jq::parse("1 == map(1/0)").unwrap();
-        match eval(&expr, value) {
-            GenericResult::Error(e) => assert!(e.message.contains("divided")),
-            other => panic!("expected Error, got {other:?}"),
-        }
+        // `assert!(matches!(..))` rather than a `match` with a `panic!`
+        // fallback: the fallback arm is only ever reached by a *failing*
+        // test, so it reads as a permanently uncovered line in the coverage
+        // diff (#1601). Same style as
+        // `test_generic_compare_operand_lazy_seq_break_and_halt_propagate_1481`
+        // just above.
+        assert!(
+            matches!(eval(&expr, value), GenericResult::Error(ref e) if e.message.contains("divided"))
+        );
     }
 
     #[test]
@@ -11142,6 +11152,93 @@ mod tests {
 
         let expr = crate::jq::parse("map(halt_error(7)) == 1").unwrap();
         assert!(matches!(eval(&expr, value), GenericResult::Halt(7)));
+    }
+
+    #[test]
+    fn generic_arithmetic_fanout_combine_error_escapes_1481() {
+        // `binary_fanout_each_generic`'s `Err(e)` arm -- the one only the
+        // `Expr::Arithmetic` caller can reach, since both `Expr::Compare`
+        // call sites wrap the infallible `apply_compare_op` in `Ok(...)`.
+        // `first(...)` is what routes a top-level `+` through
+        // `eval_each_generic` at all (`Expr::Arithmetic` has no native
+        // `eval_single` arm, so a *bare* `("a",1) + 1` bridges out to
+        // `eval.rs`'s own fanout instead).
+        //
+        // Right is the outer loop, so the single right candidate `1` pairs
+        // with left's first candidate `"a"` -- `arith_combine` fails, and
+        // the failure aborts the whole fanout as the caller's error rather
+        // than skipping that one pairing and going on to `1 + 1`. Oracle:
+        // pinned jq 1.7.1 `jq -n 'first(("a",1) + 1)'` is exit-5 with
+        // `string ("a") and number (1) cannot be added`, *not* `2`.
+        assert!(matches!(
+            summarize(b"null", r#"first(("a",1) + 1)"#),
+            Summary::Error(ref m) if m.contains("cannot be added")
+        ));
+    }
+
+    #[test]
+    fn generic_arithmetic_fanout_combine_error_beats_later_right_candidate_1481() {
+        // The same `Err(e)` arm, this time proving the abort really is an
+        // abort of the *outer* (right) loop and not just of the inner one:
+        // right's first candidate `"a"` already fails to combine, so right's
+        // second candidate -- `error("x")`, which would report a different
+        // message -- is never pulled. Oracle: pinned jq 1.7.1
+        // `jq -n 'first(1 + ("a", error("x")))'` reports the arithmetic
+        // error, not `x`.
+        assert!(matches!(
+            summarize(b"null", r#"first(1 + ("a", error("x")))"#),
+            Summary::Error(ref m) if m.contains("cannot be added")
+        ));
+    }
+
+    #[test]
+    fn generic_arithmetic_fanout_first_stops_before_the_failing_pairing_1481() {
+        // The complement of the two above: when the *first* pairing succeeds,
+        // `first` stops the generator before the pairing that would have
+        // failed is ever combined, so the `Err(e)` arm is not reached and no
+        // error surfaces. Oracle: pinned jq 1.7.1
+        // `jq -n 'first((1,"a") + 1)'` prints `2`.
+        assert_eq!(
+            summarize(b"null", r#"first((1,"a") + 1)"#),
+            Summary::Values(vec!["2".to_string()])
+        );
+    }
+
+    #[test]
+    fn generic_arithmetic_fanout_combine_error_optional_is_unreachable_via_parser_1481() {
+        // The other half of `binary_fanout_each_generic`'s `Err(e)` arm: when
+        // `optional` is set, the failed pairing aborts the fanout as a plain
+        // `Flow::Exhausted` (empty output) instead of `Flow::Escaped`.
+        //
+        // No real query reaches it. Post-#693 the only place this module ever
+        // forces `optional = true` is `eval_single`'s
+        // `Expr::Optional(IndexExpr | SliceExpr)` special case, which threads
+        // it into `index_one_generic`/`slice_one_generic` only -- never into
+        // `eval_each_generic`. Every other caller passes the ambient
+        // `optional`, which starts `false` at every public entry point (the
+        // same observation `eval_first_or_last_generic` records for its own
+        // dispatch, and `eval_on_owned`/`eval_single`'s `_` arm for theirs).
+        // So drive the private dispatcher directly to pin the arm, exactly as
+        // `test_generic_plain_map_optional_on_non_container_is_unreachable_via_parser_725`
+        // already does for `Builtin::Map`'s matching `optional` guard.
+        let json = b"null";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse(r#"("a",1) + 1"#).unwrap();
+        assert!(matches!(expr, Expr::Arithmetic { .. }));
+
+        let mut seen = 0usize;
+        let flow = eval_each_generic::<JqSemantics, _>(&expr, value, true, None, &mut |_item| {
+            seen += 1;
+            Demand::Continue
+        });
+
+        // Swallowed, not escaped -- and swallowed *before* the second (valid)
+        // `1 + 1` pairing, since the whole fanout aborts rather than skipping
+        // just the pairing that failed.
+        assert!(matches!(flow, Flow::Exhausted));
+        assert_eq!(seen, 0);
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4478,6 +4478,17 @@ fn generic_item_into_owned<V: DocumentValue>(item: GenericItem<V>) -> Result<Own
         GenericResult::Error(e) => Err(Control::Error(e)),
         GenericResult::Break(label) => Err(Control::Break(label)),
         GenericResult::Halt(code) => Err(Control::Halt(code)),
+        // Provably dead, not just unlikely: `generic_item_to_result` can only
+        // ever produce `One`/`OneCursor`/`Owned`/`LazyKeys`/`LazyIndexRange`/
+        // `LazySeq` -- `GenericItem`'s own variant set -- and
+        // `materialize_lazy` folds the three lazy ones into
+        // `Owned`/`Error`/`Break`/`Halt`. That leaves exactly the six arms
+        // above; `GenericResult`'s other variants (`Many`/`ManyCursor`/
+        // `ManyOwned`/`None`/`Partial`) have no `GenericItem` counterpart and
+        // can never reach this match. No coverage-diff test can close this
+        // arm without adding a new `GenericItem` variant to alias into one of
+        // them -- see #1064 for the established precedent of documenting
+        // rather than forcing coverage of a structurally unreachable arm.
         _ => {
             unreachable!("a single GenericItem never materializes to a multi-output or lazy shape")
         }
@@ -4526,6 +4537,19 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             };
             match combine(left_val, right_val.clone()) {
                 Ok(v) => sink(GenericItem::Owned(v)),
+                // Unreached by any current caller, not just untested: both of
+                // this function's call sites (`eval_compare_generic` and
+                // `eval_each_generic`'s own `Expr::Compare` arm) wrap the
+                // infallible `apply_compare_op` in `Ok(...)` -- `CompareOp`
+                // has no failure mode. `combine` is still typed fallibly, not
+                // simplified to `OwnedValue`, to mirror `eval.rs`'s own
+                // `binary_fanout_each` (whose `Expr::Arithmetic` caller *can*
+                // fail here, e.g. division by zero) and stay ready for a
+                // fallible caller of its own -- `Expr::Arithmetic` has no
+                // native `eval_each_generic` arm today (see that function's
+                // doc comment), but if one is ever added, this is the arm
+                // that already handles it correctly rather than needing this
+                // whole loop's error plumbing designed from scratch.
                 Err(e) => {
                     abort = Some(if optional {
                         Flow::Exhausted
@@ -4584,7 +4608,12 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
         &mut |item: GenericItem<V>| {
             match item {
                 GenericItem::Owned(v) => out.push(v),
-                // `combine` above always produces `GenericItem::Owned`.
+                // Structurally dead, not just untested: `binary_fanout_each_generic`
+                // has exactly one call to `sink` on its success path
+                // (`sink(GenericItem::Owned(v))` after a successful `combine`)
+                // -- there is no second call site that could hand this
+                // closure anything else, regardless of which `combine` a
+                // future caller passes.
                 _ => unreachable!("combine always produces GenericItem::Owned"),
             }
             Demand::Continue
@@ -10979,6 +11008,86 @@ mod tests {
             summarize(b"null", r#"first(empty == (10, error("x")))"#),
             Summary::Error("x".to_string())
         );
+    }
+
+    #[test]
+    fn test_generic_compare_operand_bare_one_via_cursor_less_entry_1481() {
+        // Same cursor-less-entry mechanism as
+        // `test_computed_index_key_bare_one_and_many_via_cursor_less_entry`
+        // below: entering through `eval()` rather than the CLI's
+        // `eval_with_cursor()` gives `Expr::Identity` a `None` ambient
+        // cursor, so each operand of `. == .` yields `GenericItem::One`, not
+        // `OneCursor`. That's the only way to reach
+        // `generic_item_into_owned`'s `One` arm -- `jq_runner.rs` always
+        // threads a real cursor through `eval_with_cursor`, so no CLI
+        // invocation can reach it.
+        let json = b"5";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse(". == .").unwrap();
+        assert_eq!(
+            eval(&expr, value).into_owned().unwrap(),
+            OwnedValue::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_generic_compare_left_operand_lazy_seq_error_propagates_1481() {
+        // A `LazySeq` operand (`map(f)`) that errors on materialization --
+        // forced by `generic_item_into_owned`, which
+        // `binary_fanout_each_generic` calls on every pulled item -- aborts
+        // the whole fanout rather than just that pairing. On the *left*
+        // operand this exercises `binary_fanout_each_generic`'s left-error
+        // propagation (the inner sink's own `Err(control)` arm, plus the
+        // `if abort.is_some() { return Demand::Stop }` check once `inner`
+        // returns).
+        let json = b"[1,2]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(1/0) == 1").unwrap();
+        match eval(&expr, value) {
+            GenericResult::Error(e) => assert!(e.message.contains("divided")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generic_compare_right_operand_lazy_seq_error_propagates_1481() {
+        // Mirror of the above with the erroring `LazySeq` on the *right*
+        // operand, exercising `binary_fanout_each_generic`'s other
+        // error-propagation arm (`right_item`'s own `Err(control)` match,
+        // reached before `left` is ever pulled).
+        let json = b"[1,2]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("1 == map(1/0)").unwrap();
+        match eval(&expr, value) {
+            GenericResult::Error(e) => assert!(e.message.contains("divided")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generic_compare_operand_lazy_seq_break_and_halt_propagate_1481() {
+        // `generic_item_into_owned`'s `Break`/`Halt` arms: a `break`/
+        // `halt_error` inside a `map(f)` operand aborts materialization with
+        // `Control::Break`/`Control::Halt`, not `Control::Error` -- and
+        // `binary_fanout_each_generic` carries either straight out as the
+        // fanout's own `Flow::Escaped`.
+        let json = b"[1,2]";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+
+        let expr = crate::jq::parse("map(if . == 2 then break $out else . end) == 1").unwrap();
+        assert!(
+            matches!(eval(&expr, value.clone()), GenericResult::Break(ref label) if label == "out")
+        );
+
+        let expr = crate::jq::parse("map(halt_error(7)) == 1").unwrap();
+        assert!(matches!(eval(&expr, value), GenericResult::Halt(7)));
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4508,8 +4508,8 @@ fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResu
 /// `try`, not here.
 fn generic_item_into_owned<V: DocumentValue>(item: GenericItem<V>) -> Result<OwnedValue, Control> {
     match generic_item_to_result(item).materialize_lazy() {
-        GenericResult::One(v) => Ok(to_owned(&v)),
-        GenericResult::OneCursor(c) => Ok(to_owned_cursor(&c)),
+        GenericResult::One(v) => to_owned(&v).map_err(Control::Error),
+        GenericResult::OneCursor(c) => to_owned_cursor(&c).map_err(Control::Error),
         GenericResult::Owned(v) => Ok(v),
         GenericResult::Error(e) => Err(Control::Error(e)),
         GenericResult::Break(label) => Err(Control::Break(label)),
@@ -11081,7 +11081,7 @@ mod tests {
 
         let expr = crate::jq::parse(". == .").unwrap();
         assert_eq!(
-            eval(&expr, value).into_owned().unwrap(),
+            eval(&expr, value).into_owned().unwrap().unwrap(),
             OwnedValue::Bool(true)
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -33,7 +33,7 @@ use super::eval::{
     slice_owned_value_read, tonumber_from_str, Control, Demand, EvalError, EvalSemantics, EvalTag,
     Flow, JqSemantics, QueryResult, YqSemantics,
 };
-use super::expr::{Builtin, Expr, FormatType};
+use super::expr::{Builtin, CompareOp, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
 use super::value::{NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
@@ -1631,11 +1631,12 @@ macro_rules! push_or_control {
 
 /// Append every output of a `GenericResult` stream to `out`, returning any
 /// terminating `Control` instead of collapsing to the first output the way
-/// the old `Expr::Compare` arm did. Mirrors [`super::eval::push_owned_values`]
-/// for the generic evaluator's cursor-aware result type — used to fork
-/// `Expr::Compare`'s operands into every output instead of only the first
-/// (#768), the same way [`push_generic_truthiness`] already forks `select`'s
-/// condition.
+/// an earlier `Expr::Compare` arm did before #768. Mirrors
+/// [`super::eval::push_owned_values`] for the generic evaluator's
+/// cursor-aware result type — used to fork `Expr::Comma`'s operands into
+/// every output, the same way [`push_generic_truthiness`] already forks
+/// `select`'s condition. `Expr::Compare` moved off this helper for #1481
+/// (see `eval_compare_generic`).
 fn push_generic_owned_values<V: DocumentValue>(
     result: GenericResult<V>,
     out: &mut Vec<OwnedValue>,
@@ -3853,39 +3854,22 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Builtin(builtin) => eval_builtin::<S, _>(builtin, value, optional, cursor),
 
-        // Comparison operations - handle locally to preserve cursor context,
-        // over every pairing jq's cartesian fanout produces rather than just
-        // the first (#768): right operand outer, left operand inner, mirroring
-        // `eval::eval_binary_fanout`. `left`/`right` are evaluated at a
-        // hardcoded `optional: false` (unchanged from before this fix) --
-        // only the final comparison step below consults the ambient
-        // `optional`, same split as `Expr::IndexExpr`'s key/bounds above.
+        // Comparison operations: routed through the shared lazy fanout
+        // machinery (#1481) rather than a hand-rolled eager loop --
+        // `eval_compare_generic` drives `binary_fanout_each_generic` with
+        // `eval_each_generic` as the operand strategy and collects its
+        // demand-driven output into a `GenericResult`, mirroring `eval.rs`'s
+        // split between `eval_each`'s lazy `Expr::Compare` arm and a
+        // collecting wrapper over the same loop (`binary_fanout_core`/
+        // `eval_binary_fanout`). Right operand outer, left operand inner,
+        // forking over every pairing (#768) -- unchanged from before; what
+        // changes is *when* each operand runs: `right`'s next candidate is no
+        // longer pulled before `left` has fully run against the previous one,
+        // so `("A"|stderr) == (("B"|stderr), ("C"|stderr))` now writes
+        // `B A C A`, matching jq, instead of finishing right first (`B C A
+        // A`).
         Expr::Compare { op, left, right } => {
-            let mut right_vals = Vec::new();
-            let right_control = push_generic_owned_values(
-                eval_single::<S, _>(right, value.clone(), false, cursor),
-                &mut right_vals,
-            );
-
-            let mut out: Vec<OwnedValue> = Vec::new();
-            for right_val in &right_vals {
-                let mut left_vals = Vec::new();
-                let left_control = push_generic_owned_values(
-                    eval_single::<S, _>(left, value.clone(), false, cursor),
-                    &mut left_vals,
-                );
-
-                for left_val in left_vals {
-                    let result = apply_compare_op::<S>(*op, &left_val, right_val);
-                    out.push(OwnedValue::Bool(result));
-                }
-
-                if let Some(control) = left_control {
-                    return finish_fork_generic(out, Some(control), optional);
-                }
-            }
-
-            finish_fork_generic(out, right_control, optional)
+            eval_compare_generic::<S, V>(*op, left, right, value, optional, cursor)
         }
 
         // Array construction: collect every output of the inner expression
@@ -4195,10 +4179,16 @@ fn drain_result_generic<V: DocumentValue>(
 /// instead of `eval_single`'s own eager, always-materialize-everything
 /// dispatch for the same three variants.
 ///
-/// Scoped to exactly these three, matching the issue's own stated scope --
-/// mirroring `eval.rs`'s wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/
-/// `Compare`/...) is out of scope here; those shapes still fall to the `_`
-/// fallback below, unchanged from before.
+/// Scoped to `Comma`/`Pipe`/`Paren`/`Compare` -- mirroring `eval.rs`'s still
+/// wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/...) remains out of scope
+/// here; those shapes still fall to the `_` fallback below. `Compare` gained
+/// a native arm for #1481, mirroring `eval.rs`'s own `Expr::Compare` arm
+/// (#1459/Stage 4): this closes the interleaving gap both for a bare
+/// top-level compare (`eval_single`'s own arm now routes through this same
+/// machinery, see `eval_compare_generic`) and for a compare reached through
+/// this module's own lazy consumers (`first`/`last`), which previously fell
+/// through to the eager `_` fallback for any non-`Comma`/`Pipe`/`Paren`
+/// argument.
 fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     value: V,
@@ -4220,6 +4210,34 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         }
         Expr::Pipe(exprs) => eval_each_pipe_generic::<S, V>(exprs, value, optional, cursor, sink),
         Expr::Paren(inner) => eval_each_generic::<S, V>(inner, value, optional, cursor, sink),
+        // #1481: mirrors `eval.rs`'s own `eval_each` `Expr::Compare` arm
+        // (#1459, Stage 4) -- `binary_fanout_each_generic` owns the loop
+        // order; passing `eval_each_generic` as the operand strategy is what
+        // lets the *right* operand -- jq's outer loop -- stop producing
+        // candidates a consumer (e.g. `first`) never asked for.
+        //
+        // `left`/`right` are evaluated at a hardcoded `optional: false`, not
+        // the ambient `optional` -- matching this arm's pre-#1481 eager
+        // predecessor and `eval_single`'s own `Expr::IndexExpr` key/bounds
+        // split (#693): an enclosing `?` must not mask an unrelated error
+        // deep in an operand's own subtree. The ambient `optional` is still
+        // consulted, exactly once, by whichever caller collects this arm's
+        // `Flow` (`eval_compare_generic`'s `finish_fork_generic` call, or a
+        // wrapping consumer's own demand sink).
+        Expr::Compare { op, left, right } => binary_fanout_each_generic::<V>(
+            |operand, operand_sink| {
+                eval_each_generic::<S, V>(operand, value.clone(), false, cursor, operand_sink)
+            },
+            left,
+            right,
+            optional,
+            |left_val, right_val| {
+                Ok(OwnedValue::Bool(apply_compare_op::<S>(
+                    *op, &left_val, &right_val,
+                )))
+            },
+            sink,
+        ),
         _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
     }
 }
@@ -4434,6 +4452,150 @@ fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResu
         GenericItem::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
         GenericItem::LazySeq(seq) => GenericResult::LazySeq(seq),
     }
+}
+
+/// Convert a [`GenericItem`] pulled from a fanout operand into the
+/// `OwnedValue` a `combine` step needs, forcing whatever materialization a
+/// lazy variant still owes via [`generic_item_to_result`] +
+/// `GenericResult::materialize_lazy` -- the same conversion
+/// [`push_generic_owned_values`] already applies, reused here rather than
+/// re-derived.
+///
+/// Fallible, unlike `eval::Item::into_owned`: a `LazySeq` item -- a buffered
+/// `map`/`select` chain, #724/#725 -- can itself error/break/halt on the
+/// materialization this forces (e.g. `map(1/0) == 1`), where `eval.rs`'s
+/// `QueryResult` has no lazy variant to force in the first place.
+/// [`binary_fanout_each_generic`] routes that failure through the same
+/// "abort the whole fanout" `Flow::Escaped` path a `combine` error already
+/// uses, ungated by `optional` -- matching `eval.rs`'s convention that an
+/// operand-evaluation error is caught one level up, by `Expr::Optional`/
+/// `try`, not here.
+fn generic_item_into_owned<V: DocumentValue>(item: GenericItem<V>) -> Result<OwnedValue, Control> {
+    match generic_item_to_result(item).materialize_lazy() {
+        GenericResult::One(v) => Ok(to_owned(&v)),
+        GenericResult::OneCursor(c) => Ok(to_owned_cursor(&c)),
+        GenericResult::Owned(v) => Ok(v),
+        GenericResult::Error(e) => Err(Control::Error(e)),
+        GenericResult::Break(label) => Err(Control::Break(label)),
+        GenericResult::Halt(code) => Err(Control::Halt(code)),
+        _ => {
+            unreachable!("a single GenericItem never materializes to a multi-output or lazy shape")
+        }
+    }
+}
+
+/// Generic-evaluator twin of `eval::binary_fanout_each` (#1481): the one
+/// right-outer/left-inner fanout loop for the `V: DocumentValue`-generic
+/// evaluator, parameterized over *how* an operand is enumerated -- reusing
+/// `eval.rs`'s `pub(crate)` `Demand`/`Flow` directly (they carry no generic
+/// parameters), the same way this module's whole lazy-sink family already
+/// does.
+///
+/// No `'a`/`W` parameter, unlike `eval.rs`'s version: `GenericItem<V>` owns
+/// its cursor (`V::Cursor: Copy`), so nothing here borrows from an arena.
+///
+/// `each_operand` is `Fn`, not `FnMut`, for the same re-entrancy reason
+/// `eval.rs`'s `binary_fanout_each` gives: the per-right-value call on `left`
+/// happens while the call on `right` is still on the stack.
+fn binary_fanout_each_generic<V: DocumentValue>(
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
+    left: &Expr,
+    right: &Expr,
+    optional: bool,
+    mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut abort: Option<Flow> = None;
+
+    let outer = each_operand(right, &mut |right_item: GenericItem<V>| {
+        let right_val = match generic_item_into_owned(right_item) {
+            Ok(v) => v,
+            Err(control) => {
+                abort = Some(Flow::Escaped(control));
+                return Demand::Stop;
+            }
+        };
+
+        let inner = each_operand(left, &mut |left_item: GenericItem<V>| {
+            let left_val = match generic_item_into_owned(left_item) {
+                Ok(v) => v,
+                Err(control) => {
+                    abort = Some(Flow::Escaped(control));
+                    return Demand::Stop;
+                }
+            };
+            match combine(left_val, right_val.clone()) {
+                Ok(v) => sink(GenericItem::Owned(v)),
+                Err(e) => {
+                    abort = Some(if optional {
+                        Flow::Exhausted
+                    } else {
+                        Flow::Escaped(Control::Error(e))
+                    });
+                    Demand::Stop
+                }
+            }
+        });
+
+        if abort.is_some() {
+            return Demand::Stop;
+        }
+
+        match inner {
+            Flow::Exhausted => Demand::Continue,
+            other => {
+                abort = Some(other);
+                Demand::Stop
+            }
+        }
+    });
+
+    abort.unwrap_or(outer)
+}
+
+/// Collecting wrapper over [`binary_fanout_each_generic`] for `eval_single`'s
+/// `Expr::Compare` arm (#1481) -- mirrors `eval.rs`'s
+/// `eval_binary_fanout`/`binary_fanout_core` pairing, wired directly to the
+/// lazy `eval_each_generic` operand strategy since this file has no eager
+/// sibling (`Expr::Arithmetic` has no native arm here at all, see
+/// `eval_each_generic`'s own doc comment) that still needs an eager one kept
+/// around.
+fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
+    op: CompareOp,
+    left: &Expr,
+    right: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let flow = binary_fanout_each_generic::<V>(
+        |operand, operand_sink| {
+            eval_each_generic::<S, V>(operand, value.clone(), false, cursor, operand_sink)
+        },
+        left,
+        right,
+        optional,
+        |left_val, right_val| {
+            Ok(OwnedValue::Bool(apply_compare_op::<S>(
+                op, &left_val, &right_val,
+            )))
+        },
+        &mut |item: GenericItem<V>| {
+            match item {
+                GenericItem::Owned(v) => out.push(v),
+                // `combine` above always produces `GenericItem::Owned`.
+                _ => unreachable!("combine always produces GenericItem::Owned"),
+            }
+            Demand::Continue
+        },
+    );
+
+    let control = match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => None,
+        Flow::Escaped(control) => Some(control),
+    };
+    finish_fork_generic(out, control, optional)
 }
 
 /// Evaluate `first(inner)`/`last(inner)` (and the `Builtin::FirstStream`/
@@ -10791,6 +10953,31 @@ mod tests {
         assert_eq!(
             summarize(b"null", "(1,break $out) == 1"),
             partial_break(&["true"])
+        );
+    }
+
+    #[test]
+    fn generic_compare_first_stops_before_unneeded_right_candidate_1481() {
+        // `first` is satisfied by the very first pairing (`1 == 10` ->
+        // `false`), so `eval_each_generic`'s new native `Expr::Compare` arm
+        // (#1481) must never let right's generator reach its second, failing
+        // candidate -- mirrors `eval.rs`'s own `IN`/`any`/`all`-wrapped
+        // equivalents, now also true for a bare `first(...)`.
+        assert_eq!(
+            summarize(b"null", r#"first((1,2) == (10, error("x")))"#),
+            Summary::Values(vec!["false".to_string()])
+        );
+    }
+
+    #[test]
+    fn generic_compare_first_still_reaches_right_when_left_is_empty_1481() {
+        // The complementary case: `left=empty` means `combine` never runs for
+        // right's first candidate (`10`), so the fanout must still continue
+        // to right's second candidate -- confirming the new lazy arm's
+        // `Demand::Continue` path is exercised, not just its stop path.
+        assert_eq!(
+            summarize(b"null", r#"first(empty == (10, error("x")))"#),
+            Summary::Error("x".to_string())
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19751,38 +19751,15 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // Code review of #1461, filed as #1565: when the pipe's *first*
-        // stage evaluates to `GenericResult::LazyKeys` (`keys`,
-        // `keys_unsorted`) and 2+ further stages follow, the driver hands
-        // the whole remaining pipe to `fold_pipe_stages` -- the plain eager
-        // fold, with no demand check -- rather than continuing through
-        // `eval_each_pipe_generic`'s own sink. So `.[] | stderr` after a
-        // `keys` prefix still fires for every key, unlike the bare
-        // `first(.[] | stderr)` #1461 itself fixed. Confirmed pre-existing
-        // (identical on `main` before #1461, via the old 2-stage-only
-        // `first_over_comma_generic`), so not a regression here -- pinned so
-        // a fix for #1565 has a red test to turn green. jq: writes `a` once.
-        (
-            &["-c", "first(keys | .[] | stderr)"],
-            Some(r#"{"a":1,"b":2,"c":3}"#),
-            "\"a\"\n",
-            "abc",
-            0,
-        ),
-        // Same #1565 gap, `LazySeq` (`map(f)`, #724/#725) flavor instead of
-        // `LazyKeys`. jq: writes `2` once.
-        (
-            &["-c", "first(map(.+1) | .[] | stderr)"],
-            Some("[1,2,3]"),
-            "2\n",
-            "234",
-            0,
-        ),
-        // `Expr::If` has no native `eval_each_generic` arm, so `first(if
-        // ...)` falls through to eager `eval_single` and the discarded
-        // `else` branch's sibling side effect still fires -- same #1565
-        // class as the two rows above (pre-existing on `main` before #1461,
-        // unaffected by #1461/#1481). jq: no stderr.
+        // `Expr::If`/`Try`/`Label`/`As`/`Limit` have no native
+        // `eval_each_generic` arm (#1461's own doc comment scopes it to
+        // `Comma`/`Pipe`/`Paren` only), so when one of these is `first`'s
+        // argument's top-level shape, evaluation falls through to eager
+        // `eval_single` and a sibling branch's side effect fires even though
+        // `first` never needed it. Out of scope by design -- fixing
+        // `fold_pipe_stages`'s `LazyKeys`/`LazyIndexRange`/`LazySeq` gap
+        // (#1565) does not touch this; these five shapes are pinned as an
+        // explicit, documented known gap rather than fixed. jq: no stderr.
         (
             &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
             None,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19478,9 +19478,10 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
         // stays green. jq runs right's first output, then the whole left
         // operand, then right's second -- `B A C A`; the eager
         // `binary_fanout_core` finishes right first and writes `B C A A`.
-        // Distinct from the #1481 row in the leaks table below, which pins
-        // the *top-level* spelling of this same compare (it never reaches
-        // `eval_each`, so it keeps the eager order).
+        // The *bare top-level* spelling of this same compare used to diverge
+        // here (it reached `eval_generic.rs`'s own eager `Expr::Compare` arm,
+        // not `eval_each` at all) -- fixed for #1481, see the row in the
+        // "closed by #1481" section below.
         (
             &[
                 "-cn",
@@ -19638,6 +19639,66 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             r#"jq: error (at <unknown>): Cannot index array with string "b""#,
             5,
         ),
+        // ---- closed by #1481 ----
+        // The eager binary-fanout loops (`binary_fanout_core` via
+        // `eval_binary_fanout`, `eval_binary_fanout_with_path_context`, and
+        // `eval_generic`'s own `Expr::Compare` arm) now interleave their
+        // operands' evaluation instead of finishing the right one first:
+        // `eval_binary_fanout` routes through `eval_each`, the path-context
+        // sibling through a per-operand `needs_path_context` hybrid, and
+        // `eval_generic.rs`'s `Expr::Compare` arm through a new
+        // `binary_fanout_each_generic`/`eval_each_generic` pair mirroring
+        // `eval.rs`'s own machinery. A bare top-level compare now interleaves
+        // the same way the `all(...)`-wrapped spelling of this exact compare
+        // already did above (`isempty`/`limit`/etc. section) -- `B A C A`,
+        // not `B C A A`.
+        (
+            &["-cn", r#"[("A"|stderr) == (("B"|stderr), ("C"|stderr))]"#],
+            None,
+            "[false,false]\n",
+            "BACA",
+            0,
+        ),
+        // `eval_each_generic`'s new native `Expr::Compare` arm means a bare
+        // `first(...)` over a compare now stops the right operand's
+        // generator before it reaches an unneeded later candidate, closing
+        // the same gap #1461 closed for `Comma`/`Pipe`/`Paren` (this row used
+        // to live in the leaks table, blocked on exactly this arm not
+        // existing yet).
+        (
+            &["-cn", r#"[first((1,2) == (10, ("B"|stderr)))]"#],
+            None,
+            "[false]\n",
+            "",
+            0,
+        ),
+        // Acceptance-criteria repro: a bare top-level compare whose *left*
+        // operand errors before the *right* operand's later, side-effecting
+        // candidate is ever reached. `left`'s escape happens while evaluating
+        // it against right's *first* candidate (`1`), which aborts the whole
+        // fanout before right's generator ever produces its second,
+        // `stderr`-carrying candidate -- so only the error surfaces, no `B`.
+        (
+            &["-cn", r#"[error("x") == (1, ("B"|stderr))]"#],
+            None,
+            "",
+            "jq: error (at <unknown>): x",
+            5,
+        ),
+        // Acceptance-criteria repro: `input`/`inputs` pop from a
+        // process-global queue, so interleaving changes the *values*
+        // delivered, not just I/O order. jq takes right's 1st output (`a`),
+        // then runs left (`b`) -> `"ba"`; then right's 2nd (`c`), then left
+        // again (`d`) -> `"dc"`. The eager order used to take right fully
+        // first (`a`,`b`), then run left per right value (`c`,`d`) ->
+        // `"ca"`,`"db"`.
+        (
+            &["-cn", r"[(input) + (input, input)]"],
+            Some(r#""a" "b" "c" "d""#),
+            "[\"ba\",\"dc\"]\n",
+            "",
+            0,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -19690,36 +19751,38 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // Found by Stage 4's own oracle sweep (#1459): a bare `first(...)`
-        // is intercepted by `eval_generic`'s native `first`/`last` arm,
-        // whose lazy `eval_each_generic` (#1461) only gives `Comma`/`Pipe`/
-        // `Paren` native arms -- an `Expr::Compare` argument still falls
-        // through to eager `eval_single`, so `eval.rs`'s own lazy `Compare`
-        // arm is never reached. Out of #1461's scope by design (the issue
-        // named `Comma`/`Pipe`/`Paren` only); a `Compare`-native lazy arm
-        // here would be a separate follow-up, symmetrical to #1459/Stage 4's
-        // one on the `eval.rs` side. Wrapping the same compare in any
-        // consumer that does bounce into `eval.rs` (`isempty`, `limit`,
-        // `nth`, `any`, `all`, `IN`) already matches jq -- see the table
-        // above. jq: no stderr.
+        // Code review of #1461, filed as #1565: when the pipe's *first*
+        // stage evaluates to `GenericResult::LazyKeys` (`keys`,
+        // `keys_unsorted`) and 2+ further stages follow, the driver hands
+        // the whole remaining pipe to `fold_pipe_stages` -- the plain eager
+        // fold, with no demand check -- rather than continuing through
+        // `eval_each_pipe_generic`'s own sink. So `.[] | stderr` after a
+        // `keys` prefix still fires for every key, unlike the bare
+        // `first(.[] | stderr)` #1461 itself fixed. Confirmed pre-existing
+        // (identical on `main` before #1461, via the old 2-stage-only
+        // `first_over_comma_generic`), so not a regression here -- pinned so
+        // a fix for #1565 has a red test to turn green. jq: writes `a` once.
         (
-            &["-cn", r#"[first((1,2) == (10, ("B"|stderr)))]"#],
-            None,
-            "[false]\n",
-            "B",
+            &["-c", "first(keys | .[] | stderr)"],
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            "\"a\"\n",
+            "abc",
             0,
         ),
-        // Same class as the `Compare` row above: `Expr::If`/`Try`/`Label`/
-        // `As`/`Limit` have no native `eval_each_generic` arm either
-        // (#1461's own doc comment scopes it to `Comma`/`Pipe`/`Paren`
-        // only), so when one of these is `first`'s argument's top-level
-        // shape, evaluation falls through to eager `eval_single` and a
-        // sibling branch's side effect fires even though `first` never
-        // needed it. Out of scope by design -- fixing `fold_pipe_stages`'s
-        // `LazyKeys`/`LazyIndexRange`/`LazySeq` gap (#1565) does not touch
-        // this; these five shapes are pinned as an explicit, documented
-        // known gap rather than fixed, matching how `Compare` was already
-        // pinned. jq: no stderr.
+        // Same #1565 gap, `LazySeq` (`map(f)`, #724/#725) flavor instead of
+        // `LazyKeys`. jq: writes `2` once.
+        (
+            &["-c", "first(map(.+1) | .[] | stderr)"],
+            Some("[1,2,3]"),
+            "2\n",
+            "234",
+            0,
+        ),
+        // `Expr::If` has no native `eval_each_generic` arm, so `first(if
+        // ...)` falls through to eager `eval_single` and the discarded
+        // `else` branch's sibling side effect still fires -- same #1565
+        // class as the two rows above (pre-existing on `main` before #1461,
+        // unaffected by #1461/#1481). jq: no stderr.
         (
             &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
             None,
@@ -19768,24 +19831,6 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             None,
             "1\n",
             "B",
-            0,
-        ),
-        // The eager copies of jq's right-outer/left-inner fanout loop
-        // (`binary_fanout_core` via `eval_binary_fanout`,
-        // `eval_binary_fanout_with_path_context`, and `eval_generic`'s own
-        // third copy in its `Expr::Compare` arm -- which is what a top-level
-        // `==` actually reaches) still run the right operand to completion
-        // before the left, where jq interleaves them. Stage 4 made only
-        // `eval_each`'s arm demand-aware, so a top-level compare keeps the
-        // old order. jq writes `B`, `A`, `C`, `A`; succinctly writes `B`,
-        // `C`, `A`, `A`. Tracked as #1481 -- with `input` operands the same
-        // ordering changes *values*, not just stderr, and the loop it lives
-        // in is shared with `Expr::Arithmetic`.
-        (
-            &["-cn", r#"[("A"|stderr) == (("B"|stderr), ("C"|stderr))]"#],
-            None,
-            "[false,false]\n",
-            "BCAA",
             0,
         ),
         // ---- `binary_fanout_each`'s inner/outer `pending` asymmetry -------

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19839,6 +19839,9 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
         // (#1565) does not touch this; these five shapes are pinned as an
         // explicit, documented known gap rather than fixed. jq: no stderr.
         //
+        // Tracked for fixing as #1596 (duplicate: #1604), the sibling of
+        // #1592, which #1481 closed for `Compare`/`Arithmetic`.
+        //
         // The same five shapes leak identically one level down, as an
         // *operand* of a binary operator (`first(10 == (if true then (1,
         // ("B"|stderr)) else 9 end))`, and the `+` spelling of it): the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2202,13 +2202,16 @@ fn test_arithmetic_compare_cartesian_fanout_error_and_break_issue_768() -> Resul
 
 #[test]
 fn test_arithmetic_mod_reached_through_lazy_eval_each_1481() -> Result<()> {
-    // `eval_each`'s own `Expr::Arithmetic` arm (#1481) is a *second* copy of
-    // the `ArithOp` match, textually distinct from `eval_arithmetic`'s (the
-    // one a bare top-level `%` reaches) -- it only runs when arithmetic sits
-    // inside a lazy consumer built by `eval.rs`'s own evaluator, which the
-    // default CLI path only reaches once a filter touches `input`/`inputs`
-    // (`eval_generic.rs`'s `takes_input_queue_bridge` gate, #1504). Every
-    // other `ArithOp` arm there already had coverage; only `Mod` didn't.
+    // `eval_each`'s own `Expr::Arithmetic` arm (#1481) only runs when
+    // arithmetic sits inside a lazy consumer built by `eval.rs`'s own
+    // evaluator, which the default CLI path only reaches once a filter
+    // touches `input`/`inputs` (`eval_generic.rs`'s
+    // `takes_input_queue_bridge` gate, #1504) -- hence the otherwise-odd
+    // leading `input`. This pins that the lazy arm computes the same values
+    // in the same order as the eager `eval_arithmetic` a bare top-level `%`
+    // reaches; both now dispatch through the single shared `arith_combine`,
+    // so this is a route test, not a second copy of the `ArithOp` match to
+    // keep in sync (that duplication is what `arith_combine` removed).
     //
     // Ordering here is the same right-outer/left-inner fanout as `Compare`
     // (verified against the pinned oracle): `input` (bridging in and
@@ -19667,16 +19670,32 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
         // operands' evaluation instead of finishing the right one first:
         // `eval_binary_fanout` routes through `eval_each`, the path-context
         // sibling through a per-operand `needs_path_context` hybrid, and
-        // `eval_generic.rs`'s `Expr::Compare` arm through a new
-        // `binary_fanout_each_generic`/`eval_each_generic` pair mirroring
-        // `eval.rs`'s own machinery. A bare top-level compare now interleaves
-        // the same way the `all(...)`-wrapped spelling of this exact compare
-        // already did above (`isempty`/`limit`/etc. section) -- `B A C A`,
-        // not `B C A A`.
+        // `eval_generic.rs` gained a `binary_fanout_each_generic` plus
+        // native `eval_each_generic` arms mirroring `eval.rs`'s own
+        // machinery. A bare top-level compare now interleaves the same way
+        // the `all(...)`-wrapped spelling of this exact compare already did
+        // above (`isempty`/`limit`/etc. section) -- `B A C A`, not `B C A A`.
+        //
+        // `Expr::Compare` and `Expr::Arithmetic` share one loop, so every
+        // shape below is pinned in *both* spellings: fixing only the compare
+        // half is precisely the mistake that left `first(10 + ...)` leaking
+        // while `first(10 == ...)` no longer did.
         (
             &["-cn", r#"[("A"|stderr) == (("B"|stderr), ("C"|stderr))]"#],
             None,
             "[false,false]\n",
+            "BACA",
+            0,
+        ),
+        // The same top-level shape spelled with `+` instead of `==`. This is
+        // the half that reaches `eval.rs`'s `eval_binary_fanout` through
+        // `eval_generic`'s `eval_on_owned` bridge (arithmetic has no native
+        // `eval_single` arm there), so it pins a different route to the same
+        // loop than the compare row above.
+        (
+            &["-cn", r#"[("A"|stderr) + (("B"|stderr), ("C"|stderr))]"#],
+            None,
+            "[\"AB\",\"AC\"]\n",
             "BACA",
             0,
         ),
@@ -19691,6 +19710,44 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             None,
             "[false]\n",
             "",
+            0,
+        ),
+        // The `Expr::Arithmetic` twin of the row above. It is a *separate*
+        // arm on the same loop: `eval_each_generic` dispatches per `Expr`
+        // variant, so `Compare` having one said nothing about `+`, and until
+        // both existed this spelling still ran the `stderr` candidate
+        // `first` never asked for while the `==` spelling above did not.
+        (
+            &["-cn", r#"[first(10 + (1, ("B"|stderr)))]"#],
+            None,
+            "[11]\n",
+            "",
+            0,
+        ),
+        // Same arm, with a *halt* rather than a stderr write past the
+        // needed candidate -- the eager fallback used to take the whole
+        // process down at exit 3 here, which is the loudest form this leak
+        // takes.
+        (
+            &["-cn", r#"[first(10 + (1, 2, ("m"|halt_error(3))))]"#],
+            None,
+            "[11]\n",
+            "",
+            0,
+        ),
+        // Both operands generating, arithmetic spelling: pins the
+        // interleaved order (`X A`, right's first candidate then left)
+        // *and* the stop, rather than only the stop -- the compare rows
+        // above cannot show order, since `first` takes one output either
+        // way.
+        (
+            &[
+                "-cn",
+                r#"[first(("A"|stderr) + (("X"|stderr), ("Y"|stderr)))]"#,
+            ],
+            None,
+            "[\"AX\"]\n",
+            "XA",
             0,
         ),
         // Acceptance-criteria repro: a bare top-level compare whose *left*
@@ -19773,14 +19830,24 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
         // `Expr::If`/`Try`/`Label`/`As`/`Limit` have no native
-        // `eval_each_generic` arm (#1461's own doc comment scopes it to
-        // `Comma`/`Pipe`/`Paren` only), so when one of these is `first`'s
-        // argument's top-level shape, evaluation falls through to eager
-        // `eval_single` and a sibling branch's side effect fires even though
-        // `first` never needed it. Out of scope by design -- fixing
+        // `eval_each_generic` arm (#1461 scoped it to `Comma`/`Pipe`/`Paren`;
+        // #1481 added `Compare`/`Arithmetic`), so when one of these is
+        // `first`'s argument's top-level shape, evaluation falls through to
+        // eager `eval_single` and a sibling branch's side effect fires even
+        // though `first` never needed it. Out of scope by design -- fixing
         // `fold_pipe_stages`'s `LazyKeys`/`LazyIndexRange`/`LazySeq` gap
         // (#1565) does not touch this; these five shapes are pinned as an
         // explicit, documented known gap rather than fixed. jq: no stderr.
+        //
+        // The same five shapes leak identically one level down, as an
+        // *operand* of a binary operator (`first(10 == (if true then (1,
+        // ("B"|stderr)) else 9 end))`, and the `+` spelling of it): the
+        // operand strategy `binary_fanout_each_generic` is handed is
+        // `eval_each_generic` itself, so it inherits exactly this arm set.
+        // `scripts/jq-fanout-oracle-sweep.sh` attributes those 20 cases to
+        // this entry rather than reporting them as unexplained -- pinning
+        // every one of them here would be 20 more rows saying what these
+        // five already say.
         (
             &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
             None,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2201,6 +2201,27 @@ fn test_arithmetic_compare_cartesian_fanout_error_and_break_issue_768() -> Resul
 }
 
 #[test]
+fn test_arithmetic_mod_reached_through_lazy_eval_each_1481() -> Result<()> {
+    // `eval_each`'s own `Expr::Arithmetic` arm (#1481) is a *second* copy of
+    // the `ArithOp` match, textually distinct from `eval_arithmetic`'s (the
+    // one a bare top-level `%` reaches) -- it only runs when arithmetic sits
+    // inside a lazy consumer built by `eval.rs`'s own evaluator, which the
+    // default CLI path only reaches once a filter touches `input`/`inputs`
+    // (`eval_generic.rs`'s `takes_input_queue_bridge` gate, #1504). Every
+    // other `ArithOp` arm there already had coverage; only `Mod` didn't.
+    //
+    // Ordering here is the same right-outer/left-inner fanout as `Compare`
+    // (verified against the pinned oracle): `input` (bridging in and
+    // consuming the 2nd stdin document, since the 1st is already `.` for
+    // this top-level iteration) prints first, then the four `(10,7) %
+    // (3,2)` pairings.
+    let (stdout, _, code) = run_jq_full(&["-c", "input, ((10,7) % (3,2))"], Some("1\n2\n"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "2\n1\n1\n0\n1\n");
+    Ok(())
+}
+
+#[test]
 fn test_array_construction() -> Result<()> {
     let (output, code) = run_jq_stdin("[.a, .b, .c]", r#"{"a":1,"b":2,"c":3}"#, &["-c"])?;
     assert_eq!(code, 0);


### PR DESCRIPTION
## Summary

Real jq's right-outer/left-inner binary-fanout loop (arithmetic and compare
operators) genuinely interleaves its operands: pull one value from the right
generator, run the left generator fully against it, then pull the next right
value. succinctly had the pairing order right (#768/#822/#910) but not the
timing — every implementation fully materialized the right operand first.
With `input`/`inputs` operands this silently changed *values*, not just I/O
timing: `[(input) + (input, input)]` over `"a" "b" "c" "d"` was `["ca","db"]`
instead of jq's `["ba","dc"]`.

Fixes three independent eager implementations, all now reusing the one
shared `binary_fanout_each` loop (#1459) with a lazy per-operand strategy
instead of an eager one:

- `eval_binary_fanout` (`src/jq/eval.rs`) — the plain evaluator, now routed
  through `eval_each` (which also gained the `Expr::Arithmetic` arm Stage 4
  deliberately left out).
- `eval_binary_fanout_with_path_context` (`src/jq/eval.rs`) — the
  `key`/`parent`/`file_index`-tracking sibling, via a per-operand hybrid
  (lazy through the existing `eval_each_owned` when an operand doesn't
  itself need path context, eager when it does — no lazy path-context
  primitive exists to reuse otherwise).
- `eval_generic.rs`'s own hand-rolled `Expr::Compare` arm — the CLI's actual
  entry point (`eval_generic::eval_single`), which never called into
  `eval.rs` at all. Gained a new `binary_fanout_each_generic` plus native
  `eval_each_generic` arms mirroring `eval.rs`'s machinery, reusing its
  `Demand`/`Flow` types directly.

## Review round 2

Six findings from a review of the first round, all addressed in this PR.

**`eval_generic`'s lazy dispatch got `Compare` but not `Arithmetic`.** #1481
says the bug "affects `Expr::Arithmetic` as much as `Expr::Compare` (they
share the loop)", but the two dispatch through separate `Expr` variants, so
arithmetic kept falling to the eager `_` fallback and the parallel spellings
disagreed:

```
[first(10 == (1, ("B"|stderr)))]   stderr empty   (was fixed)
[first(10 + (1, ("B"|stderr)))]    stderr "B"     (still leaking)
```

Added the arm, and pinned four rows covering both spellings, the halt variant
(the eager fallback took the process down at exit 3), and the interleaved
`X A` order.

**The oracle sweep could not see the site it was written to check.** It
wrapped all 490 filters in `label $o | …` so a `break $o` terminator had a
target. `Expr::Label` has no native `eval_single` arm in `eval_generic.rs`,
so a label-prefixed filter falls to that module's wildcard and is bridged
wholesale into `eval.rs` — routing every case away from the third
implementation above. Measured on the pre-fix binary:

```
label $o | [first(10 == (1,("B"|stderr)))]   already matched jq
           [first(10 == (1,("B"|stderr)))]   diverged
```

The wrapper now applies to the `break $o` terminator alone. The unwrapped
form is what surfaced the arithmetic gap.

**The sweep's output was not a pass/fail signal.** It said "confirm the
divergence count" without stating one, and printed 49 divergences that are
all #1594. It now attributes each divergence to a tracked issue and exits
non-zero on anything unattributed: **490 cases, 0 unexpected, 69 known** —
49 #1594, 20 #1596.

**A third copy of the `ArithOp` match.** `eval_arithmetic`, the path-context
arm, and this PR's new `eval_each` arm each wrote it out, with
`eval_generic`'s about to be a fourth — the "duplicated predicates diverge
silently" shape CLAUDE.md records from #106. Extracted `arith_combine`, the
structural twin of `apply_compare_op`.

**An `unreachable!()` asserting a caller invariant.** `eval_compare_generic`'s
sink panicked on any non-`Owned` item, where its own model twenty lines away
in `eval.rs` deliberately declines to (`binary_fanout_core` folds its
impossible `Flow::Stopped` in with `Exhausted`). Made total via
`generic_item_into_owned`, an identity passthrough on the live path. The two
remaining `unreachable!()`s are untouched — those enumerate a closed variant
set, the #1064 shape.

**The plan doc dropped its residual statement.** It replaced "**Three** shapes
remain divergent" with an account of the two closed and never said what still
is, while five rows stayed pinned. Restored, and repointed at #1596 (the
specific filed issue) rather than umbrella #820.

## A latent flake in the sweep, found by making it a gate

Under load the sweep reported 5 "divergences" whose stdout and stderr matched
the oracle exactly, differing only in an exit code neither binary returned:
jq 141, succinctly 0. 141 is SIGPIPE, and it was the *writer's* — most
filters never read stdin, so `printf … | jq` leaves `printf` holding data
when the consumer exits, and `set -o pipefail` promotes its death to the
pipeline status, recorded as the oracle's exit code. Load-dependent: 12/12
clean in isolation. Stdin now comes from a file redirect, verified with three
full runs under deliberate CPU load. Latent since the script's first commit;
making it exit non-zero is what turned it from buried noise into a failing
gate.

## Verification

Current base is `origin/main` @ `1cf9bf153`, zero commits behind.

| Check | Result |
|---|---|
| `cargo test --features cli,simd,regex,serde --workspace` | 5934 passed, 0 failed |
| `./scripts/jq-fanout-oracle-sweep.sh` | 490 cases, **0 unexpected**, 69 known |
| Issue acceptance criteria ×3 | match pinned `/usr/bin/jq` 1.7.1 byte-for-byte |
| `cargo fmt --check` · clippy ×3 CI legs · `cargo doc` · `--no-default-features` | clean |

Differentials run against the pre-fix binary, all with the pinned oracle as
referee:

| Differential | Result |
|---|---|
| stderr-ordering sweep (450 cases) | 191/450 matched jq before → **450/450** after |
| jq operand cross-product (9216, 3-way) | 10 fixed, **0 regressed**, 0 otherwise changed |
| yq merge/compare + `first`/`last` (3564) | identical to `main` |
| yq path-context `key`/`parent`/`file_index` (960) | identical to `main` |
| Value fidelity, document-sourced floats/bignums (4335) | identical to `main` |

## Known gaps left open, deliberately

The sweep's 69 known divergences are both filed and both out of scope here:

- **#1596** (20 cases) — `first(...)` over an `If`/`Try`/`Label`/`As`/`Limit`,
  the arm set `eval_each_generic` still lacks. Pinned in
  `test_short_circuit_side_effect_leaks_820_932_987`; closing it means
  mirroring Stage 5's `eval.rs` arm set, which deserves its own review.
- **#1594** (49 cases) — `debug` never writes `["DEBUG:",value]` to stderr.

Three further issues were filed from this review, none caused by this PR
(all verified identical on `main`): **#1612** (`"s" * n` panics with capacity
overflow on a huge repeat count), **#1613** (`yq`'s `select(cond)` forks per
truthy output where real yq emits once if any is truthy), **#1614** (a stale
`yq-language.md` limitation contradicted by #768/#822).

Fixes #1481
Closes #1592

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] both further clippy legs from `ci.yml` (feature-set-specific)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/jq-fanout-oracle-sweep.sh` — 0 unexpected, incl. 3 runs under load
- [x] Manual repro verification against pinned `/usr/bin/jq` 1.7.1
