### PR TITLE
perf(jq): stream the lazy-keys fan-out instead of census-then-collect (#1599)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2703,6 +2703,22 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::ManyCursor(cursors)
             }
         }
+        // `.[0]` is `first` by another spelling, so it takes
+        // the `Builtin::First` arm's reasoning below rather
+        // than the general positional one: collapsing keeps a
+        // repeated key at its *first* position, so field 0 in
+        // document order is the answer whatever the rest of
+        // the object turns out to hold. Only a *non-zero*
+        // index can be displaced by an earlier key collapsing
+        // away, which is why the arm below still probes
+        // (#1599 -- #1514 moved the probe off the guard, but
+        // left this spelling paying it).
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted && *idx == 0 => {
+            match fields.uncons_key() {
+                Some((_, key_cursor, _)) => GenericResult::OneCursor(key_cursor),
+                None => GenericResult::Owned(OwnedValue::Null),
+            }
+        }
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
             // Positional: a collapsed object has fewer
             // members, so `.[n]` lands elsewhere. This is one
@@ -3052,8 +3068,7 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// Demand-aware `Expr::Iterate` fan-out for a `LazyKeys` (#1565).
 ///
 /// `!sorted` (`keys_unsorted`): streams [`DistinctKeyCursors`] straight
-/// into the driver, so a consumer that stops early walks only the fields it
-/// actually reached. This arm used to run `document::collapsed_fields`
+/// into the driver. This arm used to run `document::collapsed_fields`
 /// (whose probe is a whole-object `census`: decode and fingerprint every
 /// key, then sort the fingerprints) and then collect every key cursor into
 /// a `Vec`, both *before* handing the first element downstream -- so
@@ -3067,14 +3082,34 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// every cursor at once to build a `ManyCursor`, so it collects; this one
 /// drives elements one at a time and can consume the iterator directly.
 ///
-/// The yielded sequence is identical either way, which is why this is a
-/// cost change and not a behaviour change: `DistinctKeyCursors` emits first
-/// occurrences in document order, and on confirming a real repeat switches
-/// to the exact collapsed list resuming at the count already yielded --
-/// which lines up, because that list opens with those same first
-/// occurrences. Unlike the `LazySeq` arm below, streaming raises no
-/// atomicity question: producing a key cursor runs no user filter, so there
-/// is no per-element failure that eager collection would have masked.
+/// **The early exit is not unconditional.** It holds until a repeated key
+/// is *reached*: at that point `DistinctKeyCursors` calls
+/// `collapse_confirmed_repeat`, which walks the rest of the object and
+/// owns a `String` per distinct key. So `first` over an object whose
+/// second field repeats its first still pays a full walk. That is never
+/// worse than the old path, which paid `census` plus `collapse_repeated`
+/// unconditionally -- but it is not O(1) either, and sizing this arm's
+/// worst case from the paragraph above alone would get it wrong.
+///
+/// The *sequence* of keys is identical to what collecting produced, and
+/// for the same reason the resume is sound: `DistinctKeyCursors` emits
+/// first occurrences in document order, and on confirming a real repeat
+/// switches to the exact collapsed list resuming at the count already
+/// yielded -- which lines up, because that list opens with those same
+/// first occurrences. Unlike the `LazySeq` arm below, streaming raises no
+/// atomicity question: producing a key cursor runs no user filter, so
+/// there is no per-element failure that eager collection would have
+/// masked.
+///
+/// **The cursor a collapsed key carries did change**, which is why this is
+/// not purely a cost change. `collapse_repeated` overwrites the surviving
+/// slot with the *last* occurrence's `key_cursor`, so the old path
+/// reported the later position; streaming reports the first occurrence.
+/// Observable through the position builtins and through `anchor`/`style`
+/// in yq mode. The new answer is the one the collecting path has always
+/// given and the one jq's first-occurrence-wins rule points at, so this
+/// settles a disagreement between two spellings rather than creating one
+/// -- pinned by `test_lazy_keys_streaming_reports_first_occurrence_cursor_1599`.
 ///
 /// `sorted` (`keys`): lexicographic order needs every key decoded and
 /// sorted first, unavoidably -- the same cost `materialize_lazy_keys` always
@@ -3084,7 +3119,7 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// existing behaviour of not preserving a cursor for sorted keys (no new
 /// capability, no regression, just demand-aware instead of eager).
 fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
-    fields: V::Fields,
+    fields: &V::Fields,
     sorted: bool,
     collapse: bool,
     rest: &[Expr],
@@ -3093,7 +3128,7 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 ) -> Flow {
     if !sorted {
         return drive_pipe_elements_generic::<S, V>(
-            DistinctKeyCursors::new(&fields, collapse)
+            DistinctKeyCursors::new(fields, collapse)
                 .map(|(_, cursor)| Ok(GenericItem::OneCursor(cursor))),
             rest,
             optional,
@@ -3101,7 +3136,7 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
         );
     }
 
-    let mut keys = effective_keys(&fields, collapse);
+    let mut keys = effective_keys(fields, collapse);
     keys.sort();
     drive_pipe_elements_generic::<S, V>(
         keys.into_iter()
@@ -3192,7 +3227,7 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
                 collapse,
             } if is_iterate => {
                 return each_lazy_keys_iterate_sink::<S, V>(
-                    fields, sorted, collapse, rest, optional, sink,
+                    &fields, sorted, collapse, rest, optional, sink,
                 );
             }
             GenericResult::LazyKeys {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3051,13 +3051,30 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 
 /// Demand-aware `Expr::Iterate` fan-out for a `LazyKeys` (#1565).
 ///
-/// `!sorted` (`keys_unsorted`): reuses the exact same cons-list walk
-/// `fold_lazy_keys_stage`'s own `Expr::Iterate` arm uses to build its
-/// `ManyCursor` -- building that `Vec<V::Cursor>` costs the same as a real
-/// array's own `ManyCursor` build (the baseline `first(.[] | ...)` already
-/// pays, per #1461), so `first`'s saving here is entirely in the
-/// *downstream* per-element re-evaluation this function now gates, not in
-/// this structural step.
+/// `!sorted` (`keys_unsorted`): streams [`DistinctKeyCursors`] straight
+/// into the driver, so a consumer that stops early walks only the fields it
+/// actually reached. This arm used to run `document::collapsed_fields`
+/// (whose probe is a whole-object `census`: decode and fingerprint every
+/// key, then sort the fingerprints) and then collect every key cursor into
+/// a `Vec`, both *before* handing the first element downstream -- so
+/// `first(keys_unsorted | .[] | f)` on a wide object paid O(n log n) plus a
+/// full cons-list walk to produce one key (#1599).
+///
+/// Neither is needed here. "First occurrence wins" is an *online* rule, so
+/// the dedup rides along with the walk instead of preceding it -- exactly
+/// what `fold_lazy_keys_stage`'s own `Expr::Iterate` arm switched to in
+/// #1514, via the `distinct_key_cursors` wrapper. That arm has to hand back
+/// every cursor at once to build a `ManyCursor`, so it collects; this one
+/// drives elements one at a time and can consume the iterator directly.
+///
+/// The yielded sequence is identical either way, which is why this is a
+/// cost change and not a behaviour change: `DistinctKeyCursors` emits first
+/// occurrences in document order, and on confirming a real repeat switches
+/// to the exact collapsed list resuming at the count already yielded --
+/// which lines up, because that list opens with those same first
+/// occurrences. Unlike the `LazySeq` arm below, streaming raises no
+/// atomicity question: producing a key cursor runs no user filter, so there
+/// is no per-element failure that eager collection would have masked.
 ///
 /// `sorted` (`keys`): lexicographic order needs every key decoded and
 /// sorted first, unavoidably -- the same cost `materialize_lazy_keys` always
@@ -3075,24 +3092,9 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     if !sorted {
-        let cursors: Vec<V::Cursor> = match if collapse {
-            collapsed_fields(&fields)
-        } else {
-            None
-        } {
-            Some(collapsed) => collapsed.into_iter().map(|f| f.key_cursor).collect(),
-            None => {
-                let mut cursors = Vec::new();
-                let mut current = fields;
-                while let Some((field, next)) = current.uncons() {
-                    cursors.push(field.key_cursor);
-                    current = next;
-                }
-                cursors
-            }
-        };
         return drive_pipe_elements_generic::<S, V>(
-            cursors.into_iter().map(|c| Ok(GenericItem::OneCursor(c))),
+            DistinctKeyCursors::new(&fields, collapse)
+                .map(|(_, cursor)| Ok(GenericItem::OneCursor(cursor))),
             rest,
             optional,
             sink,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6432,6 +6432,15 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for YamlFields<'a, W> {
         ))
     }
 
+    /// The key-only walk (#1514), which until #1599 only JSON overrode --
+    /// so every YAML key walk went through the trait default, which calls
+    /// `uncons` and therefore builds the field's *value* as well. The
+    /// `keys`/`keys_unsorted` walkers never look at it.
+    fn uncons_key(&self) -> Option<(Self::Value, Self::Cursor, Self)> {
+        let (field, rest) = YamlFields::uncons(self)?;
+        Some((field.key(), field.key_cursor(), rest))
+    }
+
     fn find(&self, name: &str) -> Option<Self::Value> {
         YamlFields::find(self, name)
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2930,57 +2930,130 @@ fn test_duplicate_keys_lazy_keys_fast_paths_1385() -> Result<()> {
     Ok(())
 }
 
-/// #1599: `each_lazy_keys_iterate_sink`'s `keys_unsorted` arm streams
-/// `DistinctKeyCursors` rather than running a whole-object `census` and
-/// collecting every key cursor before driving the first element. The
-/// sequence must be unchanged, which is what these pin -- the arm is only
-/// reachable through a *demand-aware* fan-out (`first`/`limit` wrapping
-/// `keys_unsorted | .[] | f`), so `test_duplicate_keys_lazy_keys_fast_paths_1385`
-/// above, which drives `fold_lazy_keys_stage`'s collecting arms, does not
-/// cover it.
+/// #1599: the `keys_unsorted` arms that no longer run a whole-object
+/// `census` before answering -- `each_lazy_keys_iterate_sink` (which now
+/// streams `DistinctKeyCursors` instead of collapsing-then-collecting) and
+/// `fold_lazy_keys_stage`'s new `.[0]` arm.
 ///
-/// `mid` is the case that matters: its duplicate sits at the *fourth*
-/// field, past three distinct keys already yielded. Streaming only learns
-/// of it on reaching it, and `DistinctKeyCursors` responds by switching to
-/// the exact collapsed list and resuming at the count already emitted -- so
-/// a consumer that stops before the repeat, exactly at it, or past it must
-/// all agree with jq. Every expectation below is jq 1.7.1's own output.
+/// **Reaching the streaming arm takes care.** It is used only for a
+/// `.[]` stage driven by a *demand-aware* consumer, which in practice
+/// means `first(...)`: `limit(n; ...)` does not route through it (its
+/// elements arrive as owned strings, not cursors), and a collecting
+/// `[keys_unsorted | .[]]` takes `fold_lazy_keys_stage`'s `Expr::Iterate`
+/// arm instead. So only the `first(...)` rows below actually exercise the
+/// rewrite; the others are here to pin that the *other* paths kept their
+/// answers, which is the property that makes this a cost change.
+///
+/// The `select(...)` rows are the ones that matter most: a bare
+/// `first(keys_unsorted | .[])` stops after a single element, so it never
+/// reaches `DistinctKeyCursors`'s repeat handling at all. A predicate that
+/// does not match until *after* the duplicate forces the walk through
+/// `collapse_confirmed_repeat` and its resume-at-`yielded` path -- the one
+/// branch of the rewrite that can reorder or drop a key if it is wrong.
+///
+/// Every expectation is jq 1.7.1's own output.
 #[test]
 fn test_lazy_keys_demand_sink_streams_collapse_1599() -> Result<()> {
     // Duplicate at the head: the very first key is the repeated one.
     let head = r#"{"b":1,"a":2,"b":3}"#;
     for (filter, expected) in [
+        // -- reaches the streaming arm --
         ("first(keys_unsorted | .[])", r#""b""#),
-        ("[limit(1; keys_unsorted | .[])]", r#"["b"]"#),
+        // Walks the whole object without matching: the repeat is reached
+        // and resolved, and still nothing is emitted.
+        ("[first(keys_unsorted | .[] | select(. == \"zzz\"))]", "[]"),
+        // Matches only the key *after* the duplicate.
+        ("first(keys_unsorted | .[] | select(. == \"a\"))", r#""a""#),
+        // -- other paths, pinned to the same answers --
         ("[limit(2; keys_unsorted | .[])]", r#"["b","a"]"#),
-        // Past the end of the collapsed object: still only two keys.
         ("[limit(9; keys_unsorted | .[])]", r#"["b","a"]"#),
         ("[keys_unsorted | .[] | .]", r#"["b","a"]"#),
-        // A non-empty `rest` after the iterate, so the driver threads each
-        // streamed cursor through a real downstream stage.
-        ("first(keys_unsorted | .[] | ascii_downcase)", r#""b""#),
+        // `.[0]`'s own no-census arm, and the neighbours that must keep
+        // paying for one: a repeated key makes them differ.
+        ("keys_unsorted | .[0]", r#""b""#),
+        ("keys_unsorted | .[1]", r#""a""#),
+        ("keys_unsorted | .[-1]", r#""a""#),
+        ("keys_unsorted | .[9]", "null"),
+        ("keys | .[0]", r#""a""#),
     ] {
         let (out, _, code) = run_jq_full(&["-c", filter], Some(head))?;
         assert_eq!(code, 0, "filter {filter}");
         assert_eq!(out.trim(), expected, "filter {filter}");
     }
 
-    // Duplicate mid-stream: "a" repeats only as the fourth field.
+    // Duplicate mid-stream: "a" repeats only as the fourth field, so a
+    // consumer has already been handed three keys before the collapse is
+    // discovered.
     let mid = r#"{"a":1,"b":2,"c":3,"a":4,"d":5}"#;
     for (filter, expected) in [
         ("first(keys_unsorted | .[])", r#""a""#),
-        // Stops before the repeat is ever reached.
-        ("[limit(3; keys_unsorted | .[])]", r#"["a","b","c"]"#),
-        // Crosses it: this is the switch-and-resume branch.
-        ("[limit(4; keys_unsorted | .[])]", r#"["a","b","c","d"]"#),
-        ("[limit(5; keys_unsorted | .[])]", r#"["a","b","c","d"]"#),
+        // Stops before the repeat is reached.
+        ("first(keys_unsorted | .[] | select(. == \"b\"))", r#""b""#),
+        // Lands exactly on the field that repeats.
+        ("first(keys_unsorted | .[] | select(. == \"c\"))", r#""c""#),
+        // Past it: this is the switch-and-resume branch. "d" is only
+        // reachable by continuing correctly *through* the collapse.
+        ("first(keys_unsorted | .[] | select(. == \"d\"))", r#""d""#),
+        // Never matches, so the walk runs to completion through the repeat.
+        ("[first(keys_unsorted | .[] | select(. == \"zzz\"))]", "[]"),
+        // A downstream stage that actually transforms, so an empty or
+        // dropped `rest` could not pass: the key is a string, not a number.
+        ("first(keys_unsorted | .[] | length)", "1"),
         ("[keys_unsorted | .[] | .]", r#"["a","b","c","d"]"#),
+        ("keys_unsorted | .[0]", r#""a""#),
+        ("keys_unsorted | .[3]", r#""d""#),
         ("keys_unsorted | length", "4"),
     ] {
         let (out, _, code) = run_jq_full(&["-c", filter], Some(mid))?;
         assert_eq!(code, 0, "filter {filter}");
         assert_eq!(out.trim(), expected, "filter {filter}");
     }
+
+    // An uppercase key proves the trailing stage is really applied, which
+    // a lowercase one could not: without `rest` the answer would be "B".
+    let upper = r#"{"B":1,"a":2}"#;
+    let (out, _, code) = run_jq_full(
+        &["-c", "first(keys_unsorted | .[] | ascii_downcase)"],
+        Some(upper),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#""b""#);
+
+    Ok(())
+}
+
+/// #1599: the cursor a collapsed duplicate key reports moved, and this
+/// pins where it landed.
+///
+/// The old collapse-then-collect path built its cursors from
+/// `collapse_repeated`, which overwrites the surviving slot with the
+/// *last* occurrence's `key_cursor`, so `first(keys_unsorted | .[] |
+/// column)` on `{"b":1,"a":2,"b":3}` reported column 14 -- the second
+/// `"b"`. Streaming emits the first occurrence, so it now reports 2.
+///
+/// 2 is the answer the collecting path (`[keys_unsorted | .[] | column]`
+/// => `[2,8]`) has always given, so this removes a disagreement between
+/// two spellings of the same query rather than introducing one; it is also
+/// the position jq's own first-occurrence-wins rule points at. Recorded as
+/// a deliberate change because the value is observable through the
+/// position builtins (`column`/`line`) and through `anchor`/`style` in yq
+/// mode, and nothing else pins it.
+#[test]
+fn test_lazy_keys_streaming_reports_first_occurrence_cursor_1599() -> Result<()> {
+    let head = r#"{"b":1,"a":2,"b":3}"#;
+    let (out, _, code) = run_jq_full(&["-c", "first(keys_unsorted | .[] | column)"], Some(head))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2", "streamed cursor is the first occurrence");
+
+    // The collecting path agrees, and always did.
+    let (out, _, code) = run_jq_full(&["-c", "[keys_unsorted | .[] | column]"], Some(head))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[2,8]");
+
+    // `.[0]`'s no-census arm reports the same position.
+    let (out, _, code) = run_jq_full(&["-c", "keys_unsorted | .[0] | column"], Some(head))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2930,6 +2930,61 @@ fn test_duplicate_keys_lazy_keys_fast_paths_1385() -> Result<()> {
     Ok(())
 }
 
+/// #1599: `each_lazy_keys_iterate_sink`'s `keys_unsorted` arm streams
+/// `DistinctKeyCursors` rather than running a whole-object `census` and
+/// collecting every key cursor before driving the first element. The
+/// sequence must be unchanged, which is what these pin -- the arm is only
+/// reachable through a *demand-aware* fan-out (`first`/`limit` wrapping
+/// `keys_unsorted | .[] | f`), so `test_duplicate_keys_lazy_keys_fast_paths_1385`
+/// above, which drives `fold_lazy_keys_stage`'s collecting arms, does not
+/// cover it.
+///
+/// `mid` is the case that matters: its duplicate sits at the *fourth*
+/// field, past three distinct keys already yielded. Streaming only learns
+/// of it on reaching it, and `DistinctKeyCursors` responds by switching to
+/// the exact collapsed list and resuming at the count already emitted -- so
+/// a consumer that stops before the repeat, exactly at it, or past it must
+/// all agree with jq. Every expectation below is jq 1.7.1's own output.
+#[test]
+fn test_lazy_keys_demand_sink_streams_collapse_1599() -> Result<()> {
+    // Duplicate at the head: the very first key is the repeated one.
+    let head = r#"{"b":1,"a":2,"b":3}"#;
+    for (filter, expected) in [
+        ("first(keys_unsorted | .[])", r#""b""#),
+        ("[limit(1; keys_unsorted | .[])]", r#"["b"]"#),
+        ("[limit(2; keys_unsorted | .[])]", r#"["b","a"]"#),
+        // Past the end of the collapsed object: still only two keys.
+        ("[limit(9; keys_unsorted | .[])]", r#"["b","a"]"#),
+        ("[keys_unsorted | .[] | .]", r#"["b","a"]"#),
+        // A non-empty `rest` after the iterate, so the driver threads each
+        // streamed cursor through a real downstream stage.
+        ("first(keys_unsorted | .[] | ascii_downcase)", r#""b""#),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(head))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    // Duplicate mid-stream: "a" repeats only as the fourth field.
+    let mid = r#"{"a":1,"b":2,"c":3,"a":4,"d":5}"#;
+    for (filter, expected) in [
+        ("first(keys_unsorted | .[])", r#""a""#),
+        // Stops before the repeat is ever reached.
+        ("[limit(3; keys_unsorted | .[])]", r#"["a","b","c"]"#),
+        // Crosses it: this is the switch-and-resume branch.
+        ("[limit(4; keys_unsorted | .[])]", r#"["a","b","c","d"]"#),
+        ("[limit(5; keys_unsorted | .[])]", r#"["a","b","c","d"]"#),
+        ("[keys_unsorted | .[] | .]", r#"["a","b","c","d"]"#),
+        ("keys_unsorted | length", "4"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(mid))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    Ok(())
+}
+
 #[test]
 fn test_jq_compat_default() -> Result<()> {
     // Test that jq-compat is now the default behavior

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3009,6 +3009,19 @@ fn test_lazy_keys_demand_sink_streams_collapse_1599() -> Result<()> {
         assert_eq!(out.trim(), expected, "filter {filter}");
     }
 
+    // An empty object has no field 0, so the new `.[0]` arm's `uncons_key`
+    // answers `None`. jq returns null rather than erroring here, same as
+    // for an out-of-range index (#307).
+    for (filter, expected) in [
+        ("keys_unsorted | .[0]", "null"),
+        ("keys_unsorted | first", "null"),
+        ("keys_unsorted | .[1]", "null"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some("{}"))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
     // An uppercase key proves the trailing stage is really applied, which
     // a lowercase one could not: without `rest` the answer would be "B".
     let upper = r#"{"B":1,"a":2}"#;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21759,3 +21759,65 @@ fn test_first_over_lazy_prefix_applies_every_stage_1565() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1599: the yq half of `each_lazy_keys_iterate_sink`'s rewrite.
+///
+/// The streaming arm is generic over `S: EvalSemantics` and
+/// `each_lazy_keys_iterate_sink::<YqSemantics, YamlValue>` is a live
+/// monomorphization, so yq exercises it with `collapse = false` -- the
+/// branch where `DistinctKeyCursors` carries no dedup probe at all and
+/// every occurrence of a repeated mapping key must survive. That is the
+/// opposite of jq's rule, and nothing else in the suite pins it through
+/// this path, so a future change that made the streaming arm collapse
+/// unconditionally would pass every jq test while silently dropping YAML
+/// duplicate keys.
+///
+/// `first(...)` is what routes a `.[]` stage into the streaming arm; the
+/// `select(...)` rows keep the walk going past the duplicate rather than
+/// stopping on the first element.
+#[test]
+fn test_lazy_keys_streaming_preserves_yaml_duplicates_1599() -> Result<()> {
+    let dup = "b: 1\na: 2\nb: 3\n";
+
+    // yq keeps every occurrence, unlike jq's first-wins collapse.
+    let (out, code) = run_yq_stdin("[keys | .[]]", dup, &["--jq-extensions", "-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","a","b"]"#);
+
+    // Through the streaming arm: stops at the first key.
+    let (out, code) = run_yq_stdin(
+        "first(keys | .[])",
+        dup,
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#""b""#);
+
+    // Through the streaming arm, walking the whole mapping without
+    // matching -- so the repeated key is reached, and must not end the
+    // walk early or be treated as a collapse.
+    let (out, code) = run_yq_stdin(
+        "[first(keys | .[] | select(. == \"zzz\"))]",
+        dup,
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[]");
+
+    // A mapping whose duplicate sits mid-stream: "d" is only reachable by
+    // continuing correctly through the repeated "a".
+    let mid = "a: 1\nb: 2\nc: 3\na: 4\nd: 5\n";
+    let (out, code) = run_yq_stdin(
+        "first(keys | .[] | select(. == \"d\"))",
+        mid,
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#""d""#);
+
+    let (out, code) = run_yq_stdin("[keys | .[]]", mid, &["--jq-extensions", "-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["a","b","c","a","d"]"#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Two `keys_unsorted` shapes ran a whole-object `census` — decode and fingerprint every key, then sort the fingerprints — before they could answer, even though neither needs it under jq's first-occurrence-wins collapse rule.

**1. The demand-aware fan-out** (`each_lazy_keys_iterate_sink`). It ran `document::collapsed_fields` and then collected every key cursor into a `Vec`, *both before handing the first element downstream*, so `first(keys_unsorted | .[] | f)` on a wide object paid O(n log n) plus a full cons-list walk to produce one key. It now streams `DistinctKeyCursors` straight into the driver: "first occurrence wins" is an *online* rule, so the dedup rides along with the walk instead of preceding it — exactly what `fold_lazy_keys_stage`'s `Expr::Iterate` arm switched to in #1514.

**2. `keys_unsorted | .[0]`** (`fold_lazy_keys_stage`). `.[0]` is `first` by another spelling — collapsing keeps a repeated key at its *first* position, so document-order field 0 is the answer whatever the rest of the object holds. It was still taking the general positional arm and probing. A non-zero index genuinely can be displaced by an earlier key collapsing away, so that arm still probes, as do `length`, `last`, and sorted `keys`.

**3. `YamlFields::uncons_key`.** #1514 added the key-only walk but only JSON overrode it, so every YAML key walk went through the trait default — which calls `uncons` and therefore builds each field's *value* too. Added the override; this is what makes the streaming arm's cost model actually true on the yq path.

## Measurements

Release builds, the two binaries **interleaved within each repetition with the order flipped every rep**, min of 9 (min/median agree throughout), Apple M-series. jq: 2,000,000-key flat object. yq: 1,000,000-key mapping (15.7 MB).

| shape | before | after | delta |
|---|---|---|---|
| jq `first(keys_unsorted \| .[])` — early exit | 0.336s | 0.061s | **-81.8%** |
| jq `keys_unsorted \| .[0]` | 0.194s | 0.060s | **-69.0%** |
| jq `first(keys_unsorted \| .[] \| select(...))` — walks all, no early exit | 0.843s | 0.830s | -1.5% |
| yq `first(keys \| .[])` — early exit | 0.140s | 0.093s | **-34.0%** |
| yq `first(keys \| .[] \| select(...))` — walks all | 0.463s | 0.486s | **+5.0%** |

`keys_unsorted | .[0]` now matches `keys_unsorted | first` (0.060s vs 0.061s); `.[1]`, `length` and `last` are unchanged, still correctly paying for a census.

**The +5.0% is a real regression and the one deliberate trade here.** Full consumption through the streaming arm interleaves the walk with downstream evaluation instead of building a `Vec` in a tight loop first, which costs locality. The `YamlFields::uncons_key` override already halved it (+11.1% → +5.0%); the residue is inherent to streaming. Accepted because the same mode's early-exit shape gains 34%, but it is a judgement call rather than a free win — flagging it explicitly rather than burying it.

## Behaviour change (one, deliberate)

**The cursor a collapsed duplicate key carries moved from the last occurrence to the first.** `collapse_repeated` overwrote the surviving slot with the *last* occurrence's `key_cursor`, so `first(keys_unsorted | .[] | column)` on `{"b":1,"a":2,"b":3}` reported `14`; it now reports `2`. This is observable through the position builtins and through `anchor`/`style` in yq mode.

`2` is what the collecting path (`[keys_unsorted | .[] | column]` => `[2,8]`) has always reported and what jq's first-occurrence-wins rule points at, so this removes a disagreement between two spellings of the same query rather than creating one. Pinned by a dedicated test, since nothing else did.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — full suite
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] All 22 new jq expectations diffed against the pinned oracle `/usr/bin/jq` 1.7.1
- [x] Output identity gated before believing any timing
- [x] Dual-mode: a committed `yq_cli_tests` case now covers the `collapse = false` branch (duplicates preserved: `["b","a","b"]`)

### On the tests, specifically

The first version of this PR's test was largely ineffective and the review caught it. Reaching the streaming arm is narrow: `limit(n; ...)` does **not** route through it (its elements arrive as owned strings, not cursors) and a collecting `[keys_unsorted | .[]]` takes `fold_lazy_keys_stage` instead — so 9 of 12 original rows never executed the changed code, and because a bare `first(...)` stops after one element, none reached `DistinctKeyCursors`'s repeat handling either. The rewritten test uses `first(keys_unsorted | .[] | select(...))` with predicates that match before, exactly at, and after a mid-stream duplicate, which forces the walk through `collapse_confirmed_repeat` and its resume-at-`yielded` path — the one branch that could reorder or drop a key. I verified reachability independently of the review: on the pre-PR binary the arm reports column `14` and the collecting path `2`, so a row that changes across the two binaries provably went through it.

Fixes #1599
