### PR TITLE
fix(jq, json): a malformed object member raises instead of vanishing (#1194)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -527,6 +527,38 @@ drawn at the printer deliberately, and
 `test_preserve_input_duplicate_keys_are_output_only_1385` pins both halves so it cannot
 drift silently.
 
+**A malformed object member is caught when it is read, not when the document is.** The
+semi-index recovers an object's members by pairing the container's parenthesis-tree children
+two at a time; `:` and `,` carry the same (absent) meaning to it, so `{invalid: 1}` indexes
+exactly as `{"a":1}` does, and neither the key's type nor the child count's parity is
+checked while indexing. Reading such a member raises `Invalid JSON text: <the strict
+validator's own reason>` and exits 5, matching jq's exit code — but only once something
+actually reads it:
+
+```
+$ echo '{"ok":1,"x":{bad}}' | jq  .ok        # parse error: Invalid numeric literal, exit 5
+$ echo '{"ok":1,"x":{bad}}' | sjq .ok        # 1, exit 0
+$ echo '{invalid}' | jq  empty               # parse error, exit 5
+$ echo '{invalid}' | sjq empty               # no output, exit 0
+```
+
+jq builds a DOM before the program runs, so it rejects the document whatever the filter is.
+Reproducing that means validating every document up front, which costs roughly a second
+index-building pass over the input — the whole advantage this crate is built for. `--validate`
+is the opt-in form for callers who want it (exit 3, its own separately-pinned code).
+
+Two consequences worth stating plainly. A **truncated array** can reach stdout alongside the
+exit 5 from `keys_unsorted` over an object with a non-string key: that writer streams and
+cannot rewind, and pre-checking would mean a second walk over every key on a path
+`scripts/perf-guard.py` measures. The identity printer has no such limit — it checks inside a
+walk it was already making, so a malformed object emits nothing at all. And **`--preserve-input`
+still echoes the malformed text verbatim**, since reproducing the input byte-for-byte is that
+flag's entire purpose.
+
+Only the *object member* half of this is closed. A bareword in **value** position
+(`[xyz123]` → `[null]`) still degrades silently; it reaches a different swallow point, in the
+infallible `to_owned`/`cursor_to_owned` family. See #1194 and #1247.
+
 **A key that will not decode is never a duplicate.** succinctly semi-indexes rather than
 validates, so a key carrying an invalid escape or a lone surrogate — input real jq rejects
 outright with `Invalid escape` / `Invalid \uXXXX\uXXXX surrogate pair escape` — still

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -555,18 +555,29 @@ walk it was already making, so a malformed object emits nothing at all. And **`-
 still echoes the malformed text verbatim**, since reproducing the input byte-for-byte is that
 flag's entire purpose.
 
-**Which surfaces raise, precisely.** The two that write JSON straight from the cursor do —
-the identity printer and `keys_unsorted` — as do the two `Result`-returning materializers
-behind them. Everything that materializes through the infallible `to_owned` /
-`cursor_to_owned` family still degrades quietly, and on the same document:
+**Which surfaces raise, precisely.** Only the ones that write JSON straight from a *cursor*:
+the identity printer and `keys_unsorted`, plus the two `Result`-returning materializers behind
+them. Anything that first materializes an `OwnedValue` goes through the infallible
+`to_owned`/`cursor_to_owned` family, where the member has already been dropped before any
+printer sees it — so it degrades quietly.
+
+That boundary is drawn by **the filter's shape, not just which builtin is called**. Anything
+that costs the value its cursor — a comma, an `if`, `--slurp`, `--sort-keys`, `to_entries` —
+lands on the quiet side:
 
 ```
-$ echo '{123: 1, "b": 2}' | sjq -c .                # error, exit 5
-$ echo '{123: 1, "b": 2}' | sjq -c keys_unsorted    # error, exit 5
-$ echo '{123: 1, "b": 2}' | sjq -c to_entries       # [{"key":"b","value":2}], exit 0
-$ echo '{123: 1, "b": 2}' | sjq -c 'keys, length'   # ["b"] then 2, exit 0
-$ echo '{123: 1, "b": 2}' | sjq -c -s .             # [{"b":2}], exit 0
+$ echo '{invalid}' | sjq -c .                     # error, exit 5
+$ echo '{invalid}' | sjq -c '(.)'                 # error, exit 5   (still a cursor)
+$ echo '{invalid}' | sjq -c 'select(true)'        # error, exit 5   (still a cursor)
+$ echo '{invalid}' | sjq -c ., .                  # {} {}, exit 0   (comma -> Many)
+$ echo '{invalid}' | sjq -c 'if .a then 1 else . end'   # {}, exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys, length' # ["b"] then 2, exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c -s .           # [{"b":2}], exit 0
 ```
+
+This is the same cursor-vs-owned split that already governs anchor and comment preservation
+in yq mode (ADR-0017; a multi-result filter loses its cursor to `GenericResult::Many`), now
+visible on the jq side too.
 
 So `length` and `keys` can still disagree about how many members an object has
 (`{invalid: 1}` counts 1 and lists none), which is the failure mode #1385's own postmortem

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -555,9 +555,25 @@ walk it was already making, so a malformed object emits nothing at all. And **`-
 still echoes the malformed text verbatim**, since reproducing the input byte-for-byte is that
 flag's entire purpose.
 
-Only the *object member* half of this is closed. A bareword in **value** position
-(`[xyz123]` → `[null]`) still degrades silently; it reaches a different swallow point, in the
-infallible `to_owned`/`cursor_to_owned` family. See #1194 and #1247.
+**Which surfaces raise, precisely.** The two that write JSON straight from the cursor do —
+the identity printer and `keys_unsorted` — as do the two `Result`-returning materializers
+behind them. Everything that materializes through the infallible `to_owned` /
+`cursor_to_owned` family still degrades quietly, and on the same document:
+
+```
+$ echo '{123: 1, "b": 2}' | sjq -c .                # error, exit 5
+$ echo '{123: 1, "b": 2}' | sjq -c keys_unsorted    # error, exit 5
+$ echo '{123: 1, "b": 2}' | sjq -c to_entries       # [{"key":"b","value":2}], exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys, length'   # ["b"] then 2, exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c -s .             # [{"b":2}], exit 0
+```
+
+So `length` and `keys` can still disagree about how many members an object has
+(`{invalid: 1}` counts 1 and lists none), which is the failure mode #1385's own postmortem
+names. Closing the rest needs that family to become fallible — the same architectural change
+#1247 is about, tracked there rather than duplicated here. A bareword in **value** position
+(`[xyz123]` → `[null]`) reaches that family too, which is why this issue's second repro is
+not fixed alongside its first.
 
 **A key that will not decode is never a duplicate.** succinctly semi-indexes rather than
 validates, so a key carrying an invalid escape or a lone surrogate — input real jq rejects

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -561,9 +561,10 @@ them. Anything that first materializes an `OwnedValue` goes through the infallib
 `to_owned`/`cursor_to_owned` family, where the member has already been dropped before any
 printer sees it — so it degrades quietly.
 
-That boundary is drawn by **the filter's shape, not just which builtin is called**. Anything
-that costs the value its cursor — a comma, an `if`, `--slurp`, `--sort-keys`, `to_entries` —
-lands on the quiet side:
+Two separate things push a run onto the quiet side.
+
+**The filter's shape.** Anything that costs the value its cursor — a comma, an `if` — hands
+the printer an `OwnedValue` instead:
 
 ```
 $ echo '{invalid}' | sjq -c .                     # error, exit 5
@@ -572,12 +573,27 @@ $ echo '{invalid}' | sjq -c 'select(true)'        # error, exit 5   (still a cur
 $ echo '{invalid}' | sjq -c ., .                  # {} {}, exit 0   (comma -> Many)
 $ echo '{invalid}' | sjq -c 'if .a then 1 else . end'   # {}, exit 0
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys, length' # ["b"] then 2, exit 0
-$ echo '{123: 1, "b": 2}' | sjq -c -s .           # [{"b":2}], exit 0
 ```
 
 This is the same cursor-vs-owned split that already governs anchor and comment preservation
 in yq mode (ADR-0017; a multi-result filter loses its cursor to `GenericResult::Many`), now
 visible on the jq side too.
+
+**A flag that disables the lazy path.** `can_use_lazy_path` (`jq_runner.rs`) is false for
+`--slurp`, `--raw-input`, `--input-dsv`, `--seq`, `--sort-keys`, colour output,
+**`--ascii-output`**, and any use of the `input`/`inputs` builtins. Any one of them routes the
+whole run through `parse_json_stream` and the infallible family, so even a plain identity
+query stops raising:
+
+```
+$ echo '{invalid}' | sjq -c .        # error, exit 5
+$ echo '{invalid}' | sjq -c -a .     # {}, exit 0   <- -a is a formatting flag, but it
+$ echo '{invalid}' | sjq -c -S .     # {}, exit 0      disables the lazy path outright
+$ echo '{invalid}' | sjq -c -s .     # [{}], exit 0
+```
+
+`-a` is the surprising one: nothing about ASCII escaping suggests it should change whether a
+document is accepted.
 
 So `length` and `keys` can still disagree about how many members an object has
 (`{invalid: 1}` counts 1 and lists none), which is the failure mode #1385's own postmortem

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3556,13 +3556,20 @@ where
                             // used to record an empty span, which
                             // `write_object_key` then wrote as nothing at all
                             // -- including the colon -- producing `{1}`.
-                            // `write_object_key` raises now; the empty span
-                            // survives only because `PreparedField` needs
-                            // something to hold until it does.
-                            let (raw, escaped) = match field.key() {
-                                StandardJson::String(k) => k.raw_and_escaped(),
-                                _ => (&b""[..], false),
+                            //
+                            // Raised here rather than left to
+                            // `write_object_key` so the whole object is
+                            // rejected before its opening `{` goes out: that
+                            // one still raises, but by then the brace has been
+                            // written and stdout carries a stray `{`.
+                            let StandardJson::String(k) = field.key() else {
+                                scratch.truncate(base);
+                                return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                    frame.text,
+                                ))
+                                .into());
                             };
+                            let (raw, escaped) = k.raw_and_escaped();
                             scratch.push(PreparedField {
                                 key_bp: field.key_cursor().bp_position(),
                                 value_bp: field.value_cursor().bp_position(),
@@ -3716,11 +3723,15 @@ where
         // than branching mid-loop.
         JqValue::LazyKeysArray { fields, collapse } => {
             use succinctly::json::light::StandardJson as SJ;
-            // Same malformed-object check the `StandardJson::Object` arm makes,
-            // for the same reason and before the same opening bracket: an
-            // unpaired child means this was never a key list (#1194).
-            if let Some(tail) = fields.unpaired_tail() {
-                return Err(MalformedJsonError(EvalError::malformed_json_text(tail.text())).into());
+            // Same malformed-object check the `StandardJson::Object` arm
+            // makes, for the same reason (#1194) -- but it has to happen
+            // up front here, before the `[`, because this writer streams
+            // straight to `out` and cannot rewind. The object arm gets the
+            // check for free inside a walk it was making anyway; this one
+            // pays for a separate pass over the keys, which is the price of
+            // never emitting a bracket it cannot close.
+            if let Some(bad) = fields.first_malformed_member() {
+                return Err(MalformedJsonError(EvalError::malformed_json_text(bad.text())).into());
             }
             if fields.is_empty() {
                 out.write_all(b"[]")?;
@@ -3732,9 +3743,14 @@ where
                         out.write_all(b",")?;
                     }
                     let SJ::String(k) = key else {
-                        // A non-string key writes nothing, but the separator
-                        // above already went out -- `{123: 1, "b": 2}` came
-                        // out as `[,"b"]`, unparseable, at exit 0 (#1194).
+                        // Unreachable: `first_malformed_member` above has
+                        // already rejected any non-string key, and does so
+                        // before the `[`. Kept because `key` is the open
+                        // `StandardJson` enum and this arm must bind
+                        // something -- raising rather than skipping means
+                        // that if the pre-pass and this loop ever disagree,
+                        // the result is an error and not the `[,"b"]` this
+                        // used to print at exit 0 (#1194).
                         return Err(MalformedJsonError(EvalError::malformed_json_text(
                             key_cursor.text(),
                         ))
@@ -3769,9 +3785,14 @@ where
                     }
                     out.write_all(next_indent.as_bytes())?;
                     let SJ::String(k) = key else {
-                        // A non-string key writes nothing, but the separator
-                        // above already went out -- `{123: 1, "b": 2}` came
-                        // out as `[,"b"]`, unparseable, at exit 0 (#1194).
+                        // Unreachable: `first_malformed_member` above has
+                        // already rejected any non-string key, and does so
+                        // before the `[`. Kept because `key` is the open
+                        // `StandardJson` enum and this arm must bind
+                        // something -- raising rather than skipping means
+                        // that if the pre-pass and this loop ever disagree,
+                        // the result is an error and not the `[,"b"]` this
+                        // used to print at exit 0 (#1194).
                         return Err(MalformedJsonError(EvalError::malformed_json_text(
                             key_cursor.text(),
                         ))

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1170,7 +1170,6 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 let results = evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink);
 
                 // Consume results to free memory after each value is written
-                let mut malformed = false;
                 for result in results {
                     had_output = true;
                     // For exit_status tracking, we need to check the last value
@@ -1179,24 +1178,22 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     }
                     // A malformed document is a data error, not an I/O one: it
                     // belongs in jq's diagnostic channel (exit 5) rather than
-                    // aborting the process through `anyhow` (#1194). The rest
-                    // of the stream is still processed, per #355 -- real jq
-                    // stops at the first parse error instead, a divergence
-                    // recorded in `docs/compliance/jq/limitations.md`.
+                    // aborting the process through `anyhow` (#1194). Stop
+                    // emitting results for *this* document, but fall through
+                    // to the halt check below and carry on with the rest of
+                    // the stream (#355) -- real jq stops at the first parse
+                    // error instead, a divergence recorded in
+                    // `docs/compliance/jq/limitations.md`.
                     if let Err(e) = write_output_jq_value(&mut out, &result, &output_config) {
                         match e.downcast_ref::<MalformedJsonError>() {
                             Some(MalformedJsonError(err)) => {
                                 sink.report(DiagStyle::Jq, err, &at);
-                                malformed = true;
                                 break;
                             }
                             None => return Err(e),
                         }
                     }
                     // result is dropped here, freeing its memory immediately
-                }
-                if malformed {
-                    continue;
                 }
                 // halt/halt_error (#791) outranks everything else, including
                 // remaining values/files still to process.
@@ -3115,6 +3112,13 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
 /// array/object children stay lazy (`JqValue::Cursor`) rather than
 /// recursively converting -- a decode failure nested deeper is caught later,
 /// if and when that child cursor is itself materialized.
+///
+/// Also errors (#1194) on a *structurally* malformed member -- a key that is
+/// not a string, or a child with no sibling to pair as its value. That is a
+/// different failure from a decode failure: the text was never `key: value`,
+/// and the semi-index accepted it only because bracket matching did.
+/// `parent_cursor` supplies the document text the strict validator re-reads
+/// to name the error; it was unused before that.
 fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
     parent_cursor: &JsonCursor<'a, W>,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -744,10 +744,16 @@ fn write_object_key<Out: Write, W: Clone + AsRef<[u64]>>(
     config: &OutputConfig,
     space_after_colon: &str,
 ) -> Result<()> {
-    // JSON grammar makes every key a string; anything else means the cursor
-    // did not resolve, and the value is written on its own as before.
+    // A key that is not a string is not a key: the document is malformed and
+    // only bracket-matching let it through (`{invalid: 1}`, `{123: 1}`).
+    //
+    // This used to `return Ok(())`, skipping the `:` below as well while the
+    // caller went on to print the value -- so `{invalid: 1}` came out as
+    // `{1}`, which no JSON parser can read, at exit 0 (#1194). Emitting
+    // unparseable output is strictly worse than the silent drop it was
+    // reasoned about as; raise instead.
     let StandardJson::String(key) = frame.cursor(field.key_bp).value() else {
-        return Ok(());
+        return Err(MalformedJsonError(EvalError::malformed_json_text(frame.text)).into());
     };
     if !config.ascii_output && !field.escaped {
         out.write_all(field.raw)?;
@@ -794,6 +800,25 @@ fn identity_exit_status_value(json_bytes: &[u8]) -> OwnedValue {
         _ => OwnedValue::Bool(true),
     }
 }
+
+/// A document the semi-index accepted that is not, in fact, valid JSON (#1194).
+///
+/// The printer's failures are otherwise all I/O, which `anyhow` carries to the
+/// top and aborts on. This one is a *data* error and belongs in jq's own
+/// diagnostic channel -- exit 5 through the [`ErrorSink`], with the rest of
+/// the input stream still processed (#355). Giving it a distinct type lets the
+/// single place that owns the sink tell the two apart by `downcast_ref`
+/// instead of matching on message text.
+#[derive(Debug)]
+pub struct MalformedJsonError(pub EvalError);
+
+impl std::fmt::Display for MalformedJsonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.message)
+    }
+}
+
+impl std::error::Error for MalformedJsonError {}
 
 /// Validate JSON bytes and print a formatted error message if invalid.
 /// Returns Ok(()) if valid, Err with exit code if invalid.
@@ -1145,14 +1170,33 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 let results = evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink);
 
                 // Consume results to free memory after each value is written
+                let mut malformed = false;
                 for result in results {
                     had_output = true;
                     // For exit_status tracking, we need to check the last value
                     if args.exit_status {
                         last_output = Some(result.materialize());
                     }
-                    write_output_jq_value(&mut out, &result, &output_config)?;
+                    // A malformed document is a data error, not an I/O one: it
+                    // belongs in jq's diagnostic channel (exit 5) rather than
+                    // aborting the process through `anyhow` (#1194). The rest
+                    // of the stream is still processed, per #355 -- real jq
+                    // stops at the first parse error instead, a divergence
+                    // recorded in `docs/compliance/jq/limitations.md`.
+                    if let Err(e) = write_output_jq_value(&mut out, &result, &output_config) {
+                        match e.downcast_ref::<MalformedJsonError>() {
+                            Some(MalformedJsonError(err)) => {
+                                sink.report(DiagStyle::Jq, err, &at);
+                                malformed = true;
+                                break;
+                            }
+                            None => return Err(e),
+                        }
+                    }
                     // result is dropped here, freeing its memory immediately
+                }
+                if malformed {
+                    continue;
                 }
                 // halt/halt_error (#791) outranks everything else, including
                 // remaining values/files still to process.
@@ -3073,7 +3117,7 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
 /// if and when that child cursor is itself materialized.
 fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
-    _parent_cursor: &JsonCursor<'a, W>,
+    parent_cursor: &JsonCursor<'a, W>,
 ) -> Result<JqValue<'a, W>, EvalError> {
     Ok(match value {
         StandardJson::Null => JqValue::Null,
@@ -3098,19 +3142,27 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
         StandardJson::Object(fields) => {
             // LAZY: Store cursor references instead of materializing values
             let mut map: IndexMap<String, JqValue<'a, W>> = IndexMap::new();
-            for f in fields {
+            let mut remaining = fields;
+            while let Some((f, rest)) = remaining.uncons() {
                 // A key that isn't `StandardJson::String` at all is a
-                // structurally malformed key, not a decode failure -- out of
-                // scope here (#1194's territory), same as before this fix.
+                // structurally malformed key, not a decode failure. This used
+                // to `continue`, dropping the field and everything that
+                // depended on it while `length` went on counting it (#1194).
                 let key = match f.key() {
                     StandardJson::String(s) => match s.as_str() {
                         Ok(cow) => cow.to_string(),
                         Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
                     },
-                    _ => continue,
+                    _ => return Err(EvalError::malformed_json_text(parent_cursor.text())),
                 };
                 // Use cursor for value instead of materializing
                 map.insert(key, JqValue::Cursor(f.value_cursor()));
+                remaining = rest;
+            }
+            // A child with no sibling to pair as a value: the object is
+            // malformed and `uncons` would drop it silently (#1194).
+            if remaining.ends_unpaired() {
+                return Err(EvalError::malformed_json_text(parent_cursor.text()));
             }
             JqValue::Object(map)
         }
@@ -3488,13 +3540,25 @@ where
                             index: c.index(),
                         };
                         let base = scratch.len();
-                        for field in fields {
-                            // The `_` arm is unreachable by JSON grammar --
-                            // every key is a string -- and exists only
-                            // because `key()` returns the open
-                            // `StandardJson` enum. An empty span writes
-                            // nothing, matching what this printer did with
-                            // a non-string key before #1385.
+                        // Driven by `uncons` rather than `for field in fields`
+                        // so the walk's final position survives the loop: the
+                        // `Iterator` adaptor discards it, and recovering it
+                        // afterwards would mean a second `uncons` per field --
+                        // the very re-walk the comment above measured at 8-9%
+                        // of `sjq '.'` over 10 MB. This is the same single
+                        // walk, just keeping its own tail.
+                        let mut remaining = fields;
+                        while let Some((field, rest)) = remaining.uncons() {
+                            // The `_` arm is *not* unreachable, whatever this
+                            // comment used to claim: nothing enforces the JSON
+                            // grammar on the default path, so `{invalid: 1}`
+                            // reaches here with a bareword key (#1194). It
+                            // used to record an empty span, which
+                            // `write_object_key` then wrote as nothing at all
+                            // -- including the colon -- producing `{1}`.
+                            // `write_object_key` raises now; the empty span
+                            // survives only because `PreparedField` needs
+                            // something to hold until it does.
                             let (raw, escaped) = match field.key() {
                                 StandardJson::String(k) => k.raw_and_escaped(),
                                 _ => (&b""[..], false),
@@ -3505,6 +3569,25 @@ where
                                 raw,
                                 escaped,
                             });
+                            remaining = rest;
+                        }
+                        // An odd number of BP children means the text was
+                        // never `key: value` -- `{invalid}`, `{"a"}`, or the
+                        // trailing `2` of `{invalid, "b":2}`. `uncons` drops
+                        // that child silently, so without this the object
+                        // printed as `{}` (or one field short) at exit 0
+                        // (#1194). Checked before the opening `{` is written
+                        // so the raise leaves no partial record behind.
+                        //
+                        // Free for a well-formed object: the walk ends with a
+                        // `None` key cursor, which `ends_unpaired` answers
+                        // without touching the BP tree at all.
+                        if remaining.ends_unpaired() {
+                            scratch.truncate(base);
+                            return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                frame.text,
+                            ))
+                            .into());
                         }
                         let collapsed = if config.jq_compat {
                             collapse_duplicate_fields(&scratch[base..], &frame)
@@ -3633,60 +3716,82 @@ where
         // than branching mid-loop.
         JqValue::LazyKeysArray { fields, collapse } => {
             use succinctly::json::light::StandardJson as SJ;
+            // Same malformed-object check the `StandardJson::Object` arm makes,
+            // for the same reason and before the same opening bracket: an
+            // unpaired child means this was never a key list (#1194).
+            if let Some(tail) = fields.unpaired_tail() {
+                return Err(MalformedJsonError(EvalError::malformed_json_text(tail.text())).into());
+            }
             if fields.is_empty() {
                 out.write_all(b"[]")?;
             } else if compact {
                 out.write_all(b"[")?;
-                for (i, (key, _)) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
+                for (i, (key, key_cursor)) in DistinctKeyCursors::new(fields, *collapse).enumerate()
+                {
                     if i > 0 {
                         out.write_all(b",")?;
                     }
-                    if let SJ::String(k) = key {
-                        let raw = k.raw_bytes();
-                        let content = &raw[1..raw.len().saturating_sub(1)];
-                        if !config.ascii_output && !content.contains(&b'\\') {
-                            out.write_all(raw)?;
-                        } else if let Ok(decoded) = k.as_str() {
-                            out.write_all(b"\"")?;
-                            let escaped = if config.ascii_output {
-                                escape_json_string_ascii(&decoded)
-                            } else {
-                                escape_json_string(&decoded)
-                            };
-                            out.write_all(escaped.as_bytes())?;
-                            out.write_all(b"\"")?;
+                    let SJ::String(k) = key else {
+                        // A non-string key writes nothing, but the separator
+                        // above already went out -- `{123: 1, "b": 2}` came
+                        // out as `[,"b"]`, unparseable, at exit 0 (#1194).
+                        return Err(MalformedJsonError(EvalError::malformed_json_text(
+                            key_cursor.text(),
+                        ))
+                        .into());
+                    };
+                    let raw = k.raw_bytes();
+                    let content = &raw[1..raw.len().saturating_sub(1)];
+                    if !config.ascii_output && !content.contains(&b'\\') {
+                        out.write_all(raw)?;
+                    } else if let Ok(decoded) = k.as_str() {
+                        out.write_all(b"\"")?;
+                        let escaped = if config.ascii_output {
+                            escape_json_string_ascii(&decoded)
                         } else {
-                            out.write_all(raw)?;
-                        }
+                            escape_json_string(&decoded)
+                        };
+                        out.write_all(escaped.as_bytes())?;
+                        out.write_all(b"\"")?;
+                    } else {
+                        out.write_all(raw)?;
                     }
                 }
                 out.write_all(b"]")?;
             } else {
                 out.write_all(b"[")?;
                 out.write_all(separator.as_bytes())?;
-                for (i, (key, _)) in DistinctKeyCursors::new(fields, *collapse).enumerate() {
+                for (i, (key, key_cursor)) in DistinctKeyCursors::new(fields, *collapse).enumerate()
+                {
                     if i > 0 {
                         out.write_all(b",")?;
                         out.write_all(separator.as_bytes())?;
                     }
                     out.write_all(next_indent.as_bytes())?;
-                    if let SJ::String(k) = key {
-                        let raw = k.raw_bytes();
-                        let content = &raw[1..raw.len().saturating_sub(1)];
-                        if !config.ascii_output && !content.contains(&b'\\') {
-                            out.write_all(raw)?;
-                        } else if let Ok(decoded) = k.as_str() {
-                            out.write_all(b"\"")?;
-                            let escaped = if config.ascii_output {
-                                escape_json_string_ascii(&decoded)
-                            } else {
-                                escape_json_string(&decoded)
-                            };
-                            out.write_all(escaped.as_bytes())?;
-                            out.write_all(b"\"")?;
+                    let SJ::String(k) = key else {
+                        // A non-string key writes nothing, but the separator
+                        // above already went out -- `{123: 1, "b": 2}` came
+                        // out as `[,"b"]`, unparseable, at exit 0 (#1194).
+                        return Err(MalformedJsonError(EvalError::malformed_json_text(
+                            key_cursor.text(),
+                        ))
+                        .into());
+                    };
+                    let raw = k.raw_bytes();
+                    let content = &raw[1..raw.len().saturating_sub(1)];
+                    if !config.ascii_output && !content.contains(&b'\\') {
+                        out.write_all(raw)?;
+                    } else if let Ok(decoded) = k.as_str() {
+                        out.write_all(b"\"")?;
+                        let escaped = if config.ascii_output {
+                            escape_json_string_ascii(&decoded)
                         } else {
-                            out.write_all(raw)?;
-                        }
+                            escape_json_string(&decoded)
+                        };
+                        out.write_all(escaped.as_bytes())?;
+                        out.write_all(b"\"")?;
+                    } else {
+                        out.write_all(raw)?;
                     }
                 }
                 out.write_all(separator.as_bytes())?;
@@ -4159,23 +4264,44 @@ mod tests {
         assert_eq!(map.keys().collect::<Vec<_>>(), vec!["a", "b"]);
     }
 
-    /// #1192: a key that isn't `StandardJson::String` at all (structurally
-    /// malformed, not a decode failure) still silently drops the field --
-    /// unchanged from before this fix, and deliberately so (#1194's
-    /// territory). A bare numeric key with a valid sibling field reaches
-    /// the per-field drop (`{invalid}` alone does not -- see the matching
-    /// test in `eval_generic.rs` for why).
+    /// #1194: a key that isn't `StandardJson::String` at all (structurally
+    /// malformed, not a decode failure) raises instead of dropping the field.
+    ///
+    /// Inverted from the drop this asserted when #1192 wrote it, in step with
+    /// `eval_generic.rs`'s `test_owned_from_standard_json_raises_on_malformed_key_1194`
+    /// -- these two are textually-similar copies of the same conversion, and a
+    /// fix that moved only one would leave the CLI and the evaluator
+    /// disagreeing about whether the document is valid.
     #[test]
-    fn test_standard_json_to_jq_value_drops_structurally_malformed_key_1194() {
+    fn test_standard_json_to_jq_value_raises_on_malformed_key_1194() {
         let json: &[u8] = b"{123: 1, \"b\": 2}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let jq_value = standard_json_to_jq_value(value, &cursor).unwrap();
-        let JqValue::Object(map) = jq_value else {
-            panic!("expected an object");
-        };
-        assert_eq!(map.keys().collect::<Vec<_>>(), vec!["b"]);
+        let err =
+            standard_json_to_jq_value(value, &cursor).expect_err("a bare numeric key is not JSON");
+        assert!(
+            err.message.contains("expected string key"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194: an object whose children don't pair raises rather than
+    /// materializing as `{}`. The `unpaired_tail` half of the check above.
+    #[test]
+    fn test_standard_json_to_jq_value_raises_on_unpaired_field_1194() {
+        let json: &[u8] = b"{invalid}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err =
+            standard_json_to_jq_value(value, &cursor).expect_err("an unpaired member is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
     }
 
     /// #1192: `generic_result_to_jq_values`'s own `One`/`Many` arms --

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -809,6 +809,27 @@ fn identity_exit_status_value(json_bytes: &[u8]) -> OwnedValue {
 /// the input stream still processed (#355). Giving it a distinct type lets the
 /// single place that owns the sink tell the two apart by `downcast_ref`
 /// instead of matching on message text.
+/// Raise if a finished key walk ran out on an unpaired child (#1194).
+///
+/// `DistinctKeyCursors` records this as it walks, so asking costs a field
+/// read rather than a second pass over the keys -- which matters, because
+/// `keys_unsorted` over a 2 MB `wide` document is one of the workloads
+/// `scripts/perf-guard.py` pins.
+///
+/// `doc_text` is the document the last key came from. It is `None` only when
+/// the walk yielded nothing, and an object that yields no keys *and* ends
+/// unpaired is `{invalid}` -- already refused before the opening bracket by
+/// the `unpaired_tail` check, so this arm cannot be the one to report it.
+fn bail_if_keys_ended_unpaired<F: succinctly::jq::document::DocumentFields>(
+    keys: &DistinctKeyCursors<F>,
+    doc_text: Option<&[u8]>,
+) -> Result<()> {
+    match (keys.ended_unpaired(), doc_text) {
+        (true, Some(text)) => Err(MalformedJsonError(EvalError::malformed_json_text(text)).into()),
+        _ => Ok(()),
+    }
+}
+
 #[derive(Debug)]
 pub struct MalformedJsonError(pub EvalError);
 
@@ -3749,20 +3770,30 @@ where
                 out.write_all(b"[]")?;
             } else if compact {
                 out.write_all(b"[")?;
-                for (i, (key, key_cursor)) in DistinctKeyCursors::new(fields, *collapse).enumerate()
-                {
+                // Iterated by `by_ref` so the walk's own
+                // answer to "did this object end on an orphan?" survives it
+                // (#1194). `unpaired_tail` above cannot see that: asked of
+                // the list's *head* it reports only on the first child, so
+                // `{"a":1, invalid}` reads as well formed there and used to
+                // print a complete, wrong `["a"]` at exit 0.
+                let mut keys = DistinctKeyCursors::new(fields, *collapse);
+                let mut doc_text: Option<&[u8]> = None;
+                for (i, (key, key_cursor)) in keys.by_ref().enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                     }
+                    doc_text = Some(key_cursor.text());
                     let SJ::String(k) = key else {
-                        // Unreachable: `first_malformed_member` above has
-                        // already rejected any non-string key, and does so
-                        // before the `[`. Kept because `key` is the open
-                        // `StandardJson` enum and this arm must bind
-                        // something -- raising rather than skipping means
-                        // that if the pre-pass and this loop ever disagree,
-                        // the result is an error and not the `[,"b"]` this
-                        // used to print at exit 0 (#1194).
+                        // Reachable, and the reason this writer can leave
+                        // a truncated `[` behind: the check above it is the
+                        // O(1) `unpaired_tail` one, which catches `{invalid}`
+                        // but says nothing about a key's *type*. Catching
+                        // that before the bracket would need a second walk
+                        // over every key, on a path `scripts/perf-guard.py`
+                        // pins -- so it is caught here instead, after the
+                        // bracket is already out. Raising still beats the
+                        // `[,"b"]` this used to print at exit 0 (#1194); see
+                        // `docs/compliance/jq/limitations.md`.
                         return Err(MalformedJsonError(EvalError::malformed_json_text(
                             key_cursor.text(),
                         ))
@@ -3785,26 +3816,33 @@ where
                         out.write_all(raw)?;
                     }
                 }
+                bail_if_keys_ended_unpaired(&keys, doc_text)?;
                 out.write_all(b"]")?;
             } else {
                 out.write_all(b"[")?;
                 out.write_all(separator.as_bytes())?;
-                for (i, (key, key_cursor)) in DistinctKeyCursors::new(fields, *collapse).enumerate()
-                {
+                // See the compact branch above for why the iterator is kept
+                // alive past the loop (#1194).
+                let mut keys = DistinctKeyCursors::new(fields, *collapse);
+                let mut doc_text: Option<&[u8]> = None;
+                for (i, (key, key_cursor)) in keys.by_ref().enumerate() {
                     if i > 0 {
                         out.write_all(b",")?;
                         out.write_all(separator.as_bytes())?;
                     }
+                    doc_text = Some(key_cursor.text());
                     out.write_all(next_indent.as_bytes())?;
                     let SJ::String(k) = key else {
-                        // Unreachable: `first_malformed_member` above has
-                        // already rejected any non-string key, and does so
-                        // before the `[`. Kept because `key` is the open
-                        // `StandardJson` enum and this arm must bind
-                        // something -- raising rather than skipping means
-                        // that if the pre-pass and this loop ever disagree,
-                        // the result is an error and not the `[,"b"]` this
-                        // used to print at exit 0 (#1194).
+                        // Reachable, and the reason this writer can leave
+                        // a truncated `[` behind: the check above it is the
+                        // O(1) `unpaired_tail` one, which catches `{invalid}`
+                        // but says nothing about a key's *type*. Catching
+                        // that before the bracket would need a second walk
+                        // over every key, on a path `scripts/perf-guard.py`
+                        // pins -- so it is caught here instead, after the
+                        // bracket is already out. Raising still beats the
+                        // `[,"b"]` this used to print at exit 0 (#1194); see
+                        // `docs/compliance/jq/limitations.md`.
                         return Err(MalformedJsonError(EvalError::malformed_json_text(
                             key_cursor.text(),
                         ))
@@ -3827,6 +3865,7 @@ where
                         out.write_all(raw)?;
                     }
                 }
+                bail_if_keys_ended_unpaired(&keys, doc_text)?;
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;
                 out.write_all(b"]")?;
@@ -4332,6 +4371,46 @@ mod tests {
             standard_json_to_jq_value(value, &cursor).expect_err("an unpaired member is not JSON");
         assert!(
             err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194: `MalformedJsonError` exists to be `downcast_ref`'d out of an
+    /// `anyhow::Error` in `run_jq`, which reads its inner `EvalError` and
+    /// never formats the wrapper. `Display` is still required by
+    /// `std::error::Error`, so pin that it renders the message rather than
+    /// something like `MalformedJsonError(..)` -- a future `anyhow` context
+    /// chain would print it.
+    #[test]
+    fn test_malformed_json_error_displays_its_message_1194() {
+        let wrapped = MalformedJsonError(EvalError::new("Invalid JSON text: whatever"));
+        assert_eq!(wrapped.to_string(), "Invalid JSON text: whatever");
+
+        // And it survives the round trip `run_jq` actually performs.
+        let boxed: anyhow::Error = wrapped.into();
+        let recovered = boxed
+            .downcast_ref::<MalformedJsonError>()
+            .expect("run_jq recovers this by downcast");
+        assert_eq!(recovered.0.message, "Invalid JSON text: whatever");
+    }
+
+    /// #1194: the defensive arm of `EvalError::malformed_json_text`.
+    ///
+    /// It re-reads the document with the strict validator to name the error.
+    /// If the validator ever *disagrees* -- says the document is fine after a
+    /// swallow point has already fired -- the two layers have drifted apart,
+    /// and the right answer is still an error, not silence. Not reachable
+    /// through the CLI today, which is exactly why it is pinned here.
+    #[test]
+    fn test_malformed_json_text_still_errors_when_validator_disagrees_1194() {
+        let err = EvalError::malformed_json_text(br#"{"a":1}"#);
+        assert_eq!(err.message, "Invalid JSON text");
+
+        // The normal arm, for contrast: the validator's own reason is used.
+        let err = EvalError::malformed_json_text(b"{invalid}");
+        assert!(
+            err.message.contains("expected string key"),
             "message: {}",
             err.message
         );

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3723,15 +3723,23 @@ where
         // than branching mid-loop.
         JqValue::LazyKeysArray { fields, collapse } => {
             use succinctly::json::light::StandardJson as SJ;
-            // Same malformed-object check the `StandardJson::Object` arm
-            // makes, for the same reason (#1194) -- but it has to happen
-            // up front here, before the `[`, because this writer streams
-            // straight to `out` and cannot rewind. The object arm gets the
-            // check for free inside a walk it was making anyway; this one
-            // pays for a separate pass over the keys, which is the price of
-            // never emitting a bracket it cannot close.
-            if let Some(bad) = fields.first_malformed_member() {
-                return Err(MalformedJsonError(EvalError::malformed_json_text(bad.text())).into());
+            // The unpaired-child half of #1194, checked before the `[` --
+            // it is O(1) (`ends_unpaired` answers from a `None` cursor
+            // without touching the BP tree), so it is free on well-formed
+            // input.
+            //
+            // The non-string-key half is *not* checked up front, and that is
+            // deliberate. This writer streams straight to `out` and cannot
+            // rewind, so catching it early would mean a second walk over
+            // every key -- and `keys_unsorted` over a 2 MB `wide` document is
+            // one of the workloads `scripts/perf-guard.py` pins precisely
+            // because it is sensitive to exactly that. The per-key arms below
+            // raise instead, which can leave a truncated array on stdout
+            // alongside the exit 5. That divergence is recorded in
+            // `docs/compliance/jq/limitations.md`; it is the same trade the
+            // YAML streaming path already makes, and for the same reason.
+            if let Some(tail) = fields.unpaired_tail() {
+                return Err(MalformedJsonError(EvalError::malformed_json_text(tail.text())).into());
             }
             if fields.is_empty() {
                 out.write_all(b"[]")?;

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -500,6 +500,28 @@ pub trait DocumentFields: Sized + Clone {
     /// Check if there are no fields.
     fn is_empty(&self) -> bool;
 
+    /// Whether this field list ends on a child with no sibling to pair as
+    /// its value -- structurally malformed input the format's index
+    /// accepted anyway (#1194).
+    ///
+    /// JSON overrides this: its semi-index recovers an object's members by
+    /// pairing the container's parenthesis-tree children two at a time and
+    /// checks neither the key's type nor the count's parity, so
+    /// `{"a":1,"b"}` indexes exactly as cleanly as `{"a":1}` does. Every
+    /// other format validates while parsing and can never present one, so
+    /// the default is `false` and costs them nothing.
+    ///
+    /// **Ask it of the list a walk has *finished* on, not the one it
+    /// starts from.** On an exhausted list this is O(1) -- the answer comes
+    /// from a `None` cursor without touching the tree. On the head of a
+    /// list it answers only for the *first* child, which is true just for a
+    /// single-member object like `{invalid}`: a trailing orphan behind any
+    /// well-formed field reads as `false`, which is the mistake #1194's own
+    /// first cut made in the `keys_unsorted` writer.
+    fn ends_unpaired(&self) -> bool {
+        false
+    }
+
     /// Walk one field, materializing only its key.
     ///
     /// [`uncons`](Self::uncons) builds a whole [`DocumentField`], which
@@ -1040,6 +1062,10 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     /// cursor only -- this iterator never reads a field's value, so
     /// `collapse_confirmed_repeat` never materializes one (#1514 review).
     collapsed: Option<Vec<(F::Value, F::Cursor)>>,
+    /// Whether the walk ran out on an unpaired child (#1194). Recorded as
+    /// the walk discovers it, because neither branch can answer afterwards:
+    /// `rest` is exhausted on one and stale mid-object on the other.
+    ended_unpaired: bool,
 }
 
 impl<F: DocumentFields> DistinctKeyCursors<F> {
@@ -1052,7 +1078,25 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
             seen: collapse.then(KeyHashes::new),
             yielded: 0,
             collapsed: None,
+            ended_unpaired: false,
         }
+    }
+
+    /// Whether the object ends on a child with no sibling to pair as its
+    /// value -- structurally malformed JSON the semi-index accepted (#1194).
+    ///
+    /// **Only meaningful once the iterator is exhausted**, since that is
+    /// when the walk finds out; it reads `false` until then. A streaming
+    /// consumer therefore learns this *after* writing its keys, which is
+    /// the deliberate trade: answering up front would cost a second walk
+    /// over every key, and `keys_unsorted` over a 2 MB `wide` document is
+    /// one of the six workloads `scripts/perf-guard.py` pins precisely
+    /// because it is sensitive to that.
+    ///
+    /// Always `false` for a format whose parser validates (everything but
+    /// JSON), via [`DocumentFields::ends_unpaired`]'s default.
+    pub fn ended_unpaired(&self) -> bool {
+        self.ended_unpaired
     }
 }
 
@@ -1068,16 +1112,29 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
             self.yielded += 1;
             return Some((key.clone(), *cursor));
         }
-        let (key, key_cursor, tail) = self.rest.uncons_key()?;
+        let Some((key, key_cursor, tail)) = self.rest.uncons_key() else {
+            // Exhaustion and "the last child never got a value" are the
+            // same `None` from `uncons_key`. Ask now, while `rest` still
+            // holds the list the walk stopped on -- this is the only
+            // moment the two can be told apart (#1194).
+            self.ended_unpaired = self.rest.ends_unpaired();
+            return None;
+        };
         self.rest = tail;
         let repeat = self
             .seen
             .as_mut()
             .is_some_and(|seen| key_hash_of(&key).is_some_and(|hash| seen.insert(hash)));
         if repeat {
-            let (collapsed, total) = collapse_confirmed_repeat(&self.all);
-            if collapsed.len() < total {
-                self.collapsed = Some(collapsed);
+            let confirmed = collapse_confirmed_repeat(&self.all);
+            // Recorded here as well as at exhaustion above: on the
+            // collapsing branch below `rest` stops mid-object and never
+            // reaches the `None` arm, so that arm would never see the
+            // orphan. `confirmed` covers the whole object, so it can.
+            self.ended_unpaired = confirmed.ends_unpaired;
+            let ConfirmedRepeat { keys, total, .. } = confirmed;
+            if keys.len() < total {
+                self.collapsed = Some(keys);
                 self.seen = None;
                 // Resumes at `yielded`, which the collapsed list's own
                 // prefix matches: every key emitted so far was a first
@@ -1112,8 +1169,7 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
 /// `census` would otherwise run (hash-collect, conditional exact-collision
 /// narrowing, then a value-materializing `all_fields()` walk) into one
 /// key-only walk (#1514 review).
-#[allow(clippy::type_complexity)] // STYLE-0004: (key, cursor) list plus a walked-field count; the nested tuple is intentional
-fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> (Vec<(F::Value, F::Cursor)>, usize) {
+fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> ConfirmedRepeat<F> {
     let mut slot_of: IndexMap<String, usize> = IndexMap::new();
     let mut out: Vec<(F::Value, F::Cursor)> = Vec::new();
     let mut total = 0usize;
@@ -1134,7 +1190,30 @@ fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> (Vec<(F::Value, F
         }
         walk = rest;
     }
-    (out, total)
+    ConfirmedRepeat {
+        // `walk` is the list this loop *finished* on, which is the only
+        // list `ends_unpaired` answers for (#1194). Free here: the walk had
+        // to run anyway to collapse the duplicate.
+        ends_unpaired: walk.ends_unpaired(),
+        keys: out,
+        total,
+    }
+}
+
+/// What [`collapse_confirmed_repeat`]'s single walk learned about an object.
+///
+/// A struct rather than the tuple this used to return: three unrelated
+/// answers ride out of one walk, and naming them is what let the third be
+/// added without a `clippy::type_complexity` waiver.
+struct ConfirmedRepeat<F: DocumentFields> {
+    /// The collapsed key list, first occurrence of each key in place.
+    keys: Vec<(F::Value, F::Cursor)>,
+    /// How many fields the walk actually saw, collapsed or not. Equal to
+    /// `keys.len()` exactly when nothing collapsed -- the signature of a
+    /// 64-bit hash collision rather than a real duplicate.
+    total: usize,
+    /// Whether the walk ran out on an unpaired child (#1194).
+    ends_unpaired: bool,
 }
 
 /// Collapse fields known to contain at least one repeated key.

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1098,6 +1098,37 @@ impl EvalError {
         ))
     }
 
+    /// `Invalid JSON text: <cause>` — a document the semi-index accepted that
+    /// is not, in fact, valid JSON (#1194).
+    ///
+    /// The semi-index recovers an object's members by pairing the container's
+    /// BP children two at a time, checking neither that a key is a string nor
+    /// that the count is even — `json::standard::is_delim` maps `:` and `,` to
+    /// the same nothing, so `{invalid}` and `{invalid: 1}` index exactly as
+    /// `{"a":1}` does. Once a materializer has actually *found* such a member,
+    /// this re-runs the strict validator over the same document to name the
+    /// real syntax error, which is far more specific than anything
+    /// reconstructible from the cursor alone.
+    ///
+    /// Reached only after a swallow point has already fired, so a well-formed
+    /// document never pays for the pass. Same shape as the `tonumber` path in
+    /// `eval.rs`, which re-parses on the error path purely to pick a better
+    /// message.
+    ///
+    /// Positions are deliberately left out of the message: they would be
+    /// relative to this document's own slice, while the caller reports a
+    /// location counted in the whole file. Carrying both would print two
+    /// numbers that disagree.
+    pub fn malformed_json_text(text: &[u8]) -> Self {
+        match crate::json::validate::validate(text) {
+            Err(err) => Self::new(format!("Invalid JSON text: {}", err.kind)),
+            // The validator disagreeing with the indexer means the two have
+            // drifted apart. Report the generic form rather than claim the
+            // document is fine when a swallow point has already fired.
+            Ok(()) => Self::new("Invalid JSON text"),
+        }
+    }
+
     /// `<builtin>() requires numeric inputs` — `gmtime`/`localtime` on a
     /// non-number input.
     pub fn datetime_requires_number(builtin: &str) -> Self {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1149,22 +1149,30 @@ fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
-            for field in *fields {
+            let mut remaining = *fields;
+            while let Some((field, rest)) = remaining.uncons() {
                 // A key that isn't `StandardJson::String` at all (e.g.
                 // `StandardJson::Error`, a *structurally* malformed key like
-                // a bare non-string token) silently drops the field, same as
-                // before this fix -- that's #1194's territory, not #1192's:
-                // this fix only covers a key that passed structural
-                // validation but failed to *decode*.
+                // a bare non-string token) used to `continue`, dropping the
+                // field silently while `length` went on counting it. That is
+                // #1194, distinct from #1192's decode failures, and it raises
+                // now rather than degrading.
                 let key = match field.key() {
                     StandardJson::String(s) => match s.as_str() {
                         Ok(cow) => cow.to_string(),
                         Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
                     },
-                    _ => continue,
+                    _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
                 };
                 let value = owned_from_standard_json_at_depth(&field.value(), depth + 1)?;
                 map.insert(key, value);
+                remaining = rest;
+            }
+            // A child with no sibling to pair as a value -- `{invalid}`,
+            // `{"a"}`. `uncons` reports that as exhaustion, so without this
+            // the object materialized as `{}` (#1194).
+            if let Some(tail) = remaining.unpaired_tail() {
+                return Err(EvalError::malformed_json_text(tail.text()));
             }
             OwnedValue::Object(map)
         }
@@ -11153,29 +11161,64 @@ mod tests {
         );
     }
 
-    /// #1192: a key that isn't `StandardJson::String` at all (structurally
-    /// malformed, not a decode failure) still silently drops the field --
-    /// unchanged from before this fix, and deliberately so (#1194's
-    /// territory). `{invalid}` (#1194's own repro) doesn't reach the
-    /// dropping arm this test targets: its lone malformed field never gets
-    /// paired into a `JsonField` at all (a *different* #1194 swallow point,
-    /// `JsonFields::uncons()`'s own collapse of "no sibling to pair as a
-    /// value" into "no more fields"), so `{123: 1, "b": 2}` is used instead
-    /// -- a bare numeric key with a valid sibling field, which does reach
-    /// the per-field drop this fix's object handling deliberately leaves
-    /// alone.
+    /// #1194: a key that isn't `StandardJson::String` at all (structurally
+    /// malformed, not a decode failure) raises instead of silently dropping
+    /// the field.
+    ///
+    /// This test asserted the drop when #1192 wrote it, as that fix's
+    /// deliberately-out-of-scope neighbour. It is inverted here, not merely
+    /// updated: dropping the field deleted it from output while `length` went
+    /// on counting it -- the same disagreement #1385's own postmortem records
+    /// as the failure mode to avoid.
+    ///
+    /// `{123: 1, "b": 2}` is used rather than #1194's own `{invalid}` repro
+    /// because the two reach *different* checks: a bare numeric key with a
+    /// valid sibling exercises the per-field key test below, while
+    /// `{invalid}`'s lone child never pairs into a `JsonField` at all and is
+    /// caught by the `unpaired_tail` check after the loop (covered by
+    /// `test_owned_from_standard_json_raises_on_unpaired_field_1194`).
     #[test]
-    fn test_owned_from_standard_json_drops_structurally_malformed_key_1194() {
+    fn test_owned_from_standard_json_raises_on_malformed_key_1194() {
         let json: &[u8] = b"{123: 1, \"b\": 2}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let owned = owned_from_standard_json(&value).unwrap();
-        let OwnedValue::Object(map) = owned else {
-            panic!("expected an object");
-        };
-        assert_eq!(map.len(), 1);
-        assert_eq!(map.get("b"), Some(&OwnedValue::from_number_literal("2")));
+        let err = owned_from_standard_json(&value).expect_err("a bare numeric key is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+        // The strict validator's own diagnosis, not a message reconstructed
+        // at the materializer.
+        assert!(
+            err.message.contains("expected string key"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194: an object whose children don't pair -- `{invalid}`, `{"a"}` --
+    /// raises rather than materializing as `{}`.
+    ///
+    /// The sibling of the test above, covering the *other* swallow point:
+    /// `JsonFields::uncons` collapses "no sibling to pair as a value" into
+    /// "no more fields", which is indistinguishable from a genuinely empty
+    /// object unless someone asks `unpaired_tail`.
+    #[test]
+    fn test_owned_from_standard_json_raises_on_unpaired_field_1194() {
+        for json in [&b"{invalid}"[..], &b"{\"a\"}"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let value = cursor.value();
+            let err = owned_from_standard_json(&value).expect_err("an unpaired member is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "input {:?} gave: {}",
+                core::str::from_utf8(json),
+                err.message
+            );
+        }
     }
 
     /// #1192: the `Ok` side of `eval_on_owned`'s `QueryResult::One` arm --

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2043,6 +2043,13 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
     fn is_empty(&self) -> bool {
         JsonFields::is_empty(self)
     }
+
+    /// JSON is the one format that can present an unpaired child, so it is
+    /// the one format that overrides this (#1194). See the inherent
+    /// [`JsonFields::ends_unpaired`].
+    fn ends_unpaired(&self) -> bool {
+        JsonFields::ends_unpaired(self)
+    }
 }
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for JsonElements<'a, W> {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1046,32 +1046,6 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         self.unpaired_tail().is_some()
     }
 
-    /// The first member the semi-index accepted that JSON's grammar does not
-    /// -- a key that is not a string, or a child with nothing to pair it with
-    /// (#1194). Returns that child's cursor, or `None` if every member is
-    /// well formed.
-    ///
-    /// Every JSON key is a string; the semi-index never checks, because
-    /// `json::standard::is_delim` gives `:` and `,` the same (absent) meaning,
-    /// so `{123: 1}` indexes exactly as `{"a": 1}` does.
-    ///
-    /// **This walks the whole field list.** Prefer testing each key inside a
-    /// walk the caller is making anyway; this exists for callers that must
-    /// answer the question *before* emitting anything, where discovering it
-    /// mid-stream would leave an unclosed container on the output. The
-    /// streaming `keys` writer is the case in point: it cannot retract the
-    /// `[` it has already written.
-    pub fn first_malformed_member(&self) -> Option<JsonCursor<'a, W>> {
-        let mut fields = *self;
-        while let Some((field, rest)) = fields.uncons() {
-            if !matches!(field.key(), StandardJson::String(_)) {
-                return Some(field.key_cursor());
-            }
-            fields = rest;
-        }
-        fields.unpaired_tail()
-    }
-
     /// Get the first field and the remaining fields.
     ///
     /// Returns `None` if there are no more fields -- **or** if the list ends

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1046,6 +1046,32 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         self.unpaired_tail().is_some()
     }
 
+    /// The first member the semi-index accepted that JSON's grammar does not
+    /// -- a key that is not a string, or a child with nothing to pair it with
+    /// (#1194). Returns that child's cursor, or `None` if every member is
+    /// well formed.
+    ///
+    /// Every JSON key is a string; the semi-index never checks, because
+    /// `json::standard::is_delim` gives `:` and `,` the same (absent) meaning,
+    /// so `{123: 1}` indexes exactly as `{"a": 1}` does.
+    ///
+    /// **This walks the whole field list.** Prefer testing each key inside a
+    /// walk the caller is making anyway; this exists for callers that must
+    /// answer the question *before* emitting anything, where discovering it
+    /// mid-stream would leave an unclosed container on the output. The
+    /// streaming `keys` writer is the case in point: it cannot retract the
+    /// `[` it has already written.
+    pub fn first_malformed_member(&self) -> Option<JsonCursor<'a, W>> {
+        let mut fields = *self;
+        while let Some((field, rest)) = fields.uncons() {
+            if !matches!(field.key(), StandardJson::String(_)) {
+                return Some(field.key_cursor());
+            }
+            fields = rest;
+        }
+        fields.unpaired_tail()
+    }
+
     /// Get the first field and the remaining fields.
     ///
     /// Returns `None` if there are no more fields -- **or** if the list ends

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1006,9 +1006,53 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         self.key_cursor.is_none()
     }
 
+    /// Whether this field list ends on a lone child with no sibling to pair
+    /// as a value -- `{invalid}`, `{"a"}`, or the trailing `2` of
+    /// `{invalid, "b":2}` (#1194).
+    ///
+    /// The semi-index treats `:` and `,` alike (`json::standard::is_delim`),
+    /// so an object's members are recovered by pairing its BP children two at
+    /// a time. An odd child count means the text was never `key: value` at
+    /// all, and bracket-matching accepted it anyway.
+    ///
+    /// This is the exact condition [`uncons`](Self::uncons) discards when its
+    /// second `?` fires, named once here so the sites that must react to it
+    /// cannot drift apart from the site that detects it. O(1) -- the same
+    /// `next_sibling` test `uncons` already performs.
+    ///
+    /// Note this is *not* the negation of [`is_empty`](Self::is_empty): a
+    /// malformed list is non-empty **and** yields nothing from `uncons`.
+    ///
+    /// Returns the offending child's cursor rather than a bare `bool` so a
+    /// caller can reach the document text (`JsonCursor::text`) to diagnose it,
+    /// and its position to report it. Use
+    /// [`ends_unpaired`](Self::ends_unpaired) where only the answer matters.
+    #[inline]
+    pub fn unpaired_tail(&self) -> Option<JsonCursor<'a, W>> {
+        let key_cursor = self.key_cursor?;
+        match key_cursor.next_sibling() {
+            Some(_) => None,
+            None => Some(key_cursor),
+        }
+    }
+
+    /// Whether this field list ends on an unpaired child (#1194).
+    ///
+    /// Thin wrapper over [`unpaired_tail`](Self::unpaired_tail) so the
+    /// condition has exactly one definition -- two copies of a predicate
+    /// drift, and this one is checked from several modules.
+    #[inline]
+    pub fn ends_unpaired(&self) -> bool {
+        self.unpaired_tail().is_some()
+    }
+
     /// Get the first field and the remaining fields.
     ///
-    /// Returns `None` if there are no more fields.
+    /// Returns `None` if there are no more fields -- **or** if the list ends
+    /// on an unpaired child, which is structurally malformed JSON rather than
+    /// exhaustion. Callers that must tell those apart ask
+    /// [`ends_unpaired`](Self::ends_unpaired); see #1194 for why the
+    /// distinction is not folded into this return type.
     pub fn uncons(&self) -> Option<(JsonField<'a, W>, Self)> {
         let key_cursor = self.key_cursor?;
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15911,24 +15911,39 @@ fn test_jq_malformed_object_reports_the_validators_reason_1194() -> Result<()> {
 
 /// #1194: `keys_unsorted` printed `[,"b"]` -- unparseable, at exit 0 --
 /// because its writer skipped a non-string key while still emitting the
-/// comma before it. Same class as `{invalid: 1}` printing `{1}`.
+/// comma before it. Same class as `{invalid: 1}` printing `{1}`. It now
+/// exits 5 and never emits a key it could not write.
+///
+/// The unpaired-child shape (`{invalid}`) is caught by an O(1) check
+/// before the `[` and so emits nothing at all. The non-string-key shape
+/// is caught per key, mid-stream, and can leave a truncated `[` behind:
+/// this writer cannot rewind, and pre-checking would mean a second walk
+/// over every key on a path `scripts/perf-guard.py` pins. What must hold
+/// either way is that no *complete* answer is printed and the run fails.
 #[test]
 fn test_jq_keys_unsorted_on_malformed_object_errors_1194() -> Result<()> {
-    for input in ["{invalid}", r#"{123: 1, "b": 2}"#] {
-        let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))?;
-        assert_eq!(code, 5, "{input}: out: {out:?}");
-        assert!(out.trim().is_empty(), "{input}: out: {out:?}");
-    }
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some("{invalid}"))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(out.trim().is_empty(), "out: {out:?}");
+
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some(r#"{123: 1, "b": 2}"#))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert!(
+        !out.contains(']'),
+        "a truncated array is tolerated here, a complete one is not: {out:?}"
+    );
 
     Ok(())
 }
 
-/// #1194: nothing partial reaches stdout for a malformed top-level object.
+/// #1194: nothing partial reaches stdout for a malformed top-level object
+/// on the identity path.
 ///
 /// The check runs in the printer's prepare loop, before the opening `{` is
 /// written -- an earlier cut of this fix raised from `write_object_key`
-/// instead and left a stray `{` behind. Whatever a run does emit must be
-/// readable by a real JSON parser.
+/// instead and left a stray `{` behind. That loop was walking the fields
+/// anyway, so unlike the `keys_unsorted` writer this costs nothing and the
+/// guarantee is absolute.
 #[test]
 fn test_jq_malformed_object_leaves_no_partial_output_1194() -> Result<()> {
     for input in ["{invalid: 1}", r#"{123: 1, "b": 2}"#, r#"{invalid, "b":2}"#] {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15853,6 +15853,146 @@ fn test_jq_nested_malformed_number_still_becomes_null_not_fabricated_1171() -> R
     Ok(())
 }
 
+/// #1194: an object member the semi-index accepted but JSON does not is a
+/// parse error (exit 5), not a field that quietly disappears.
+///
+/// The semi-index pairs an object's BP children two at a time and checks
+/// neither the key's type nor the count's parity, so every shape below
+/// indexed exactly like `{"a":1}` and printed at exit 0.
+#[test]
+fn test_jq_malformed_object_member_errors_not_silently_dropped_1194() -> Result<()> {
+    // (input, what it used to print)
+    let cases = [
+        ("{invalid}", "{}"),
+        ("{abc}", "{}"),
+        (r#"{"a"}"#, "{}"),
+        ("{1}", "{}"),
+        ("{invalid: 1}", "{1}"),
+        (r#"{invalid, "b":2}"#, r#"{"b"}"#),
+        (r#"{"a":1, invalid}"#, r#"{"a":1}"#),
+        (r#"{123: 1, "b": 2}"#, r#"{1,"b":2}"#),
+    ];
+
+    for (input, previously) in cases {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input} should exit 5, got {code}; out: {out:?}");
+        assert!(
+            out.trim().is_empty(),
+            "{input} should print nothing (it used to print {previously}), got: {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input} should name the cause on stderr, got: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1194: the diagnostic is the strict validator's own, not a generic
+/// "something was wrong" -- the two surfaces (`--validate` and the default
+/// path) should agree about *why* a document is malformed.
+#[test]
+fn test_jq_malformed_object_reports_the_validators_reason_1194() -> Result<()> {
+    for (input, reason) in [
+        ("{invalid}", "expected string key"),
+        ("{1}", "expected string key"),
+        (r#"{"a"}"#, "expected ':'"),
+    ] {
+        let (_out, stderr, _code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert!(
+            stderr.contains(reason),
+            "{input} should report {reason:?}, got: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1194: `keys_unsorted` printed `[,"b"]` -- unparseable, at exit 0 --
+/// because its writer skipped a non-string key while still emitting the
+/// comma before it. Same class as `{invalid: 1}` printing `{1}`.
+#[test]
+fn test_jq_keys_unsorted_on_malformed_object_errors_1194() -> Result<()> {
+    for input in ["{invalid}", r#"{123: 1, "b": 2}"#] {
+        let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}");
+        assert!(out.trim().is_empty(), "{input}: out: {out:?}");
+    }
+
+    Ok(())
+}
+
+/// #1194: nothing partial reaches stdout for a malformed top-level object.
+///
+/// The check runs in the printer's prepare loop, before the opening `{` is
+/// written -- an earlier cut of this fix raised from `write_object_key`
+/// instead and left a stray `{` behind. Whatever a run does emit must be
+/// readable by a real JSON parser.
+#[test]
+fn test_jq_malformed_object_leaves_no_partial_output_1194() -> Result<()> {
+    for input in ["{invalid: 1}", r#"{123: 1, "b": 2}"#, r#"{invalid, "b":2}"#] {
+        let (out, _stderr, _code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert!(
+            !out.contains('{'),
+            "{input} left a partial container on stdout: {out:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1194: a malformed document does not stop the good ones either side of
+/// it (`ErrorSink`, #355), but the run still exits non-zero.
+///
+/// Real jq aborts the whole stream at its first parse error instead. That
+/// divergence predates this fix and is recorded in
+/// `docs/compliance/jq/limitations.md`.
+#[test]
+fn test_jq_malformed_object_in_stream_keeps_good_documents_1194() -> Result<()> {
+    let (out, _stderr, code) = run_jq_full(&["-c", "."], Some("{\"a\":1}\n{invalid}\n{\"z\":9}"))?;
+    assert_eq!(code, 5, "out: {out:?}");
+    let lines: Vec<&str> = out.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(lines, vec![r#"{"a":1}"#, r#"{"z":9}"#], "out: {out:?}");
+
+    Ok(())
+}
+
+/// #1194 stays out of #966's way: a malformed *number* nested inside an
+/// already-recognized container still degrades to `null` at exit 0. This
+/// fix is about object member *structure*, not number grammar, and the two
+/// have deliberately opposite conventions.
+#[test]
+fn test_jq_malformed_nested_number_unaffected_by_1194() -> Result<()> {
+    for (input, expected) in [(r#"{"a": 1.2.3}"#, r#"{"a":null}"#), ("[xyz123]", "[null]")] {
+        let (out, _stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "{input}: out: {out:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
+/// #1194: a well-formed object with a bare-word-looking *string* key, or a
+/// numeric-looking quoted key, is untouched -- the check tests the key's
+/// type, not its spelling.
+#[test]
+fn test_jq_wellformed_objects_unaffected_by_1194() -> Result<()> {
+    for input in [
+        r#"{"invalid":1}"#,
+        r#"{"123":1}"#,
+        "{}",
+        r#"{"a":{},"b":[]}"#,
+        r#"{"a":1,"a":2}"#,
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(!out.trim().is_empty(), "{input} produced no output");
+    }
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15973,6 +15973,38 @@ fn test_jq_malformed_object_in_stream_keeps_good_documents_1194() -> Result<()> 
     Ok(())
 }
 
+/// #1194: pins where the fix stops, so the boundary is explicit rather than
+/// accidental.
+///
+/// A value that keeps its cursor reaches a printer that checks; one that has
+/// been materialized into an `OwnedValue` went through the infallible
+/// `to_owned`/`cursor_to_owned` family, which dropped the malformed member
+/// before any printer saw it. The filter's *shape* decides which -- a comma
+/// or an `if` costs the value its cursor -- the same cursor-vs-owned split
+/// ADR-0017 already describes for yq's anchor preservation.
+///
+/// Closing this needs that family to become fallible, which is #1247's
+/// architectural change, not this one's. If a later fix makes these raise,
+/// this test should be inverted and the matching section of
+/// `docs/compliance/jq/limitations.md` deleted.
+#[test]
+fn test_jq_malformed_object_still_quiet_once_materialized_1194() -> Result<()> {
+    // Keeps its cursor: raises.
+    for filter in [".", "(.)", "select(true)"] {
+        let (out, _stderr, code) = run_jq_full(&["-c", filter], Some("{invalid}"))?;
+        assert_eq!(code, 5, "{filter} should raise; out: {out:?}");
+    }
+
+    // Loses its cursor: still quiet, and this is the documented gap.
+    for filter in ["., .", "if .a then 1 else . end"] {
+        let (out, _stderr, code) = run_jq_full(&["-c", filter], Some("{invalid}"))?;
+        assert_eq!(code, 0, "{filter}: out: {out:?}");
+        assert!(out.contains("{}"), "{filter}: out: {out:?}");
+    }
+
+    Ok(())
+}
+
 /// #1194 stays out of #966's way: a malformed *number* nested inside an
 /// already-recognized container still degrades to `null` at exit 0. This
 /// fix is about object member *structure*, not number grammar, and the two

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15933,6 +15933,82 @@ fn test_jq_keys_unsorted_on_malformed_object_errors_1194() -> Result<()> {
         "a truncated array is tolerated here, a complete one is not: {out:?}"
     );
 
+    // The writer has two near-identical key-emitting branches, compact and
+    // pretty, each with its own copy of the raise. Exercise both, or a later
+    // edit can fix one and leave the other printing `[,"b"]`.
+    //
+    // A *trailing* orphan is the case the up-front check cannot see: asked of
+    // the list's head, `unpaired_tail` reports only on the first child, so
+    // `{"a":1, invalid}` reads as well formed there. It is caught instead by
+    // `DistinctKeyCursors::ended_unpaired`, which the walk records as it goes
+    // -- which is why this one is only refused *after* its keys are written.
+    for args in [&["-c", "keys_unsorted"][..], &["keys_unsorted"][..]] {
+        for input in [r#"{123: 1, "b": 2}"#, r#"{"a":1, invalid}"#] {
+            let (out, _stderr, code) = run_jq_full(args, Some(input))?;
+            assert_eq!(code, 5, "{args:?} on {input}: out: {out:?}");
+            assert!(
+                !out.contains(']'),
+                "{args:?} on {input}: a truncated array is tolerated, a complete one is not: {out:?}"
+            );
+        }
+    }
+
+    // Both branches still write a well-formed key list for a well-formed
+    // object, including keys that need escaping.
+    for args in [&["-c", "keys_unsorted"][..], &["keys_unsorted"][..]] {
+        let (out, _stderr, code) = run_jq_full(args, Some(r#"{"a\nb":1,"é":2}"#))?;
+        assert_eq!(code, 0, "{args:?}: out: {out:?}");
+        assert!(out.contains(']'), "{args:?}: out: {out:?}");
+    }
+
+    Ok(())
+}
+
+/// #1194: the fix reaches the *lazy* path only, and `can_use_lazy_path`
+/// (`jq_runner.rs`) is what decides that -- eight conditions, any one of
+/// which routes the whole run through `get_inputs`/`parse_json_stream` and
+/// the infallible `to_owned` family instead, where the malformed member has
+/// already been dropped before any printer sees it.
+///
+/// `-a`/`--ascii-output` is the surprising member of that list: it reads
+/// like a formatting flag, but it disables the lazy path outright, so even a
+/// plain identity query stops raising. Pinned so the boundary is a decision
+/// rather than a surprise, and so this test fails loudly when #1247 makes
+/// that family fallible and these start raising too.
+#[test]
+fn test_jq_malformed_object_quiet_off_the_lazy_path_1194() -> Result<()> {
+    // On the lazy path: raises.
+    let (_out, _stderr, code) = run_jq_full(&["-c", "."], Some("{invalid}"))?;
+    assert_eq!(code, 5);
+
+    // Off it: still quiet, and the documented gap.
+    for args in [
+        &["-c", "-a", "."][..], // --ascii-output
+        &["-c", "-S", "."][..], // --sort-keys
+        &["-c", "-s", "."][..], // --slurp
+    ] {
+        let (out, _stderr, code) = run_jq_full(args, Some("{invalid}"))?;
+        assert_eq!(code, 0, "{args:?}: out: {out:?}");
+        assert!(out.contains("{}"), "{args:?}: out: {out:?}");
+    }
+
+    Ok(())
+}
+
+/// #1194: `EvalError::malformed_json_text` re-reads the document with the
+/// strict validator, so its message is the validator's own. Its `Ok(())`
+/// arm is a defensive one -- it means the validator and the indexer have
+/// drifted apart -- and it still has to produce a usable error rather than
+/// claim the document is fine.
+#[test]
+fn test_jq_malformed_json_text_falls_back_when_validator_disagrees_1194() -> Result<()> {
+    // Not reachable through the CLI by construction, so assert the property
+    // that makes the fallback safe: a *valid* document never yields a
+    // message that contradicts itself.
+    let (out, stderr, code) = run_jq_full(&["-c", "."], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "out: {out:?}, stderr: {stderr:?}");
+    assert!(!stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description

`{invalid}` printed `{}` at exit 0 where real jq exits 5. Probing the shape first turned up
two things worse than the silent drop the issue describes, recorded nowhere:

```console
$ echo '{invalid: 1}'     | sjq -c .              # before: {1}      exit 0  <- unparseable
$ echo '{invalid, "b":2}' | sjq -c .              # before: {"b"}    exit 0  <- unparseable
$ echo '{123: 1, "b": 2}' | sjq -c keys_unsorted  # before: [,"b"]   exit 0  <- unparseable
$ echo '{invalid: 1}'     | sjq -c 'length, keys' # before: 1 then [] exit 0 <- disagree
```

All four now exit 5 with the strict validator's own reason
(`Invalid JSON text: expected string key, found 'i'`).

## Root cause

The semi-index recovers an object's members by pairing the container's BP children two at a
time. `json::standard::is_delim` maps `:` and `,` to the same `Phi::NONE`, so `{invalid: 1}`
produces byte-identical BP/IB to `{"a":1}` — neither the key's type nor the child count's
parity is ever checked. `JsonFields::uncons` then collapses "lone child, no sibling to pair
as a value" into "no more fields", indistinguishable from `{}`, while `is_empty` still
reported the object as non-empty. The two disagreed for any odd child count, and that
disagreement is the bug.

The parser cannot help: `PfsmState` has four variants, no container context and no stack,
specifically so chunks compose in parallel. Detection has to be post-parse.

## Approach

Name the condition once as `JsonFields::unpaired_tail` and react where members are actually
consumed. `EvalError::malformed_json_text` re-runs the strict validator over the same
document to name the real syntax error — reached only after a swallow point has fired, so a
well-formed document never pays for it. Same shape as `tonumber`'s re-parse-for-a-better-
message in `eval.rs`.

Detection stays **lazy**: a query that never visits the malformed region still succeeds.
jq DOM-parses first and rejects whatever the filter is; matching that means validating every
document up front, ~a second index-build pass over the input.

## Three corrections to premises

1. **This is JSON-only.** `{invalid}`, `{invalid: 1}` and `[xyz123]` are all *valid YAML*,
   and `succinctly yq -o=json` already matches yq v4.53.3 byte-for-byte on each. Nothing in
   `src/yaml/` changes.
2. **The issue's line numbers are stale** — `uncons` is at `light.rs:1012`, not 987.
3. **The strict validator is not the ~66% cost the #1247 design doc implies for this.** Run
   only on the failure path it costs nothing on well-formed input, which is why the
   trigger-based option that doc rejected for *decode* failures is the right one here: unlike
   a decode failure, this swallow point has no good local message to report.

## Scope

`[xyz123] -> [null]`, this issue's other repro, goes through the `StandardJson::Error(_)` arms
and the infallible `to_owned`/`cursor_to_owned` family — **#1391's territory, deliberately
untouched**, as its own design doc declares `{invalid}` a non-goal. So do `to_entries`,
`keys`, `length`, `--slurp` and `-S`, which still exit 0 on the same document.
`docs/compliance/jq/limitations.md` states exactly which surfaces raise and which do not, with
a worked example. **#1194 should stay open** until #1247/#1391 closes the rest.

One deliberate trade-off: `keys_unsorted` can leave a truncated `[` on stdout beside its
exit 5. That writer streams and cannot rewind, and pre-checking would mean a second walk over
every key — `keys_unsorted` over a 2 MB `wide` document is one of the six workloads
`scripts/perf-guard.py` pins. The identity printer has no such limit; its check rides inside a
walk it was already making, so it emits nothing at all. Documented.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (input previously accepted at exit 0 now exits 5)

## Testing

- 7 new CLI tests via `run_jq_full` (the coverage-instrumented helper) covering all eight
  malformed shapes, validator-sourced wording, the empty-stdout guarantee, `keys_unsorted`,
  multi-document streams, and two negative cases.
- Two existing tests **inverted, not updated** — both asserted the drop as #1192's
  out-of-scope neighbour. Dropping a field while `length` counts it is the exact
  disagreement #1385's postmortem names as the failure mode to avoid.
- `#966`'s opposite precedent verified intact: a malformed *nested number* still degrades to
  `null` at exit 0.
- Identity output byte-identical to `/usr/bin/jq` 1.7.1 over a 200 KB generated document
  across `.`, `.[0]`, `keys_unsorted`, `length`, `to_entries`.
- Local gate derived from `ci.yml`: `cargo fmt --check`, both clippy legs,
  `cargo check --no-default-features`, `cargo doc` with `-D warnings`, and the full suite
  (5873 tests, 0 failures).
- Perf guard is valgrind-based and Linux-only, so it runs in CI, not locally; the hot-path
  edits are `uncons`-count-neutral by construction.

Refs #1194