### PR TITLE
perf(jq): build the owned rest-pipe once per driver, not per element (#1598)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3114,9 +3114,21 @@ fn eval_each_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // to stop stage 1 too -- that is the whole point of the lazy `Pipe` arm --
     // but the two cases surface differently to our own caller.
     let mut downstream: Option<Flow> = None;
-    // Built once, outside the driver closure, so an Owned item mid-pipe
-    // doesn't re-clone `rest` per value.
-    let rest_pipe = Expr::Pipe(rest.to_vec());
+    // Built at most once, and only if an `Owned` item actually arrives
+    // (#1598). This used to be unconditional, so an all-`Borrowed` chain --
+    // the common case -- allocated a `Vec` and deep-cloned every remaining
+    // stage that nothing then read, once per call, and this function is
+    // itself the per-item recursion below.
+    //
+    // Measured neutral (Apple M5 Max, 200k elements, 1/4/8-stage borrowed
+    // chains: -0.4% / +0.7% / -0.3%), so this is dead-work removal for
+    // clarity, not a speed fix -- do not cite it as one. The superlinear
+    // cost curve those chains do show is the per-stage evaluation itself,
+    // not this clone: rebuilding with the allocation gone moves nothing.
+    // `eval_generic`'s twin of this driver carries the same cache as a
+    // `RestPipe`; here the `Owned` arm is the only reader, so a plain
+    // `Option` is enough.
+    let mut rest_pipe: Option<Expr> = None;
     let upstream = {
         let mut driver = |item: Item<'a, W>| -> Demand {
             let flow = match item {
@@ -3129,7 +3141,8 @@ fn eval_each_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // (#820: an eager fallback here silently drained inputs a
                 // downstream sink never asked for).
                 Item::Owned(v) => {
-                    eval_each_owned::<S>(&rest_pipe, &v, optional, &mut |o| sink(Item::Owned(o)))
+                    let rest_pipe = rest_pipe.get_or_insert_with(|| Expr::Pipe(rest.to_vec()));
+                    eval_each_owned::<S>(rest_pipe, &v, optional, &mut |o| sink(Item::Owned(o)))
                 }
             };
             match flow {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3036,22 +3036,17 @@ fn drive_pipe_elements_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    // One cache for the whole drive, so a `rest` pipe that has to be owned
-    // for an `Owned` element is built on the first one and reused by every
-    // element after it (#1598).
-    let mut rest_pipe: Option<Expr> = None;
+    // One `RestPipe` for the whole drive, so an owned copy is built on the
+    // first `Owned` element and reused by every element after it (#1598).
+    let mut rest = RestPipe::new(rest);
     for element in elements {
         match element {
-            Ok(item) => match continue_pipe_element_generic::<S, V>(
-                item,
-                rest,
-                optional,
-                &mut rest_pipe,
-                sink,
-            ) {
-                Flow::Exhausted => continue,
-                other => return other,
-            },
+            Ok(item) => {
+                match continue_pipe_element_generic::<S, V>(item, &mut rest, optional, sink) {
+                    Flow::Exhausted => continue,
+                    other => return other,
+                }
+            }
             Err(Control::Error(e)) => return drain_result_generic(GenericResult::Error(e), sink),
             Err(Control::Break(label)) => {
                 return drain_result_generic(GenericResult::Break(label), sink);
@@ -3946,6 +3941,48 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// The stages after the current one, plus the owned `Expr::Pipe` copy an
+/// `Owned` element needs -- built at most once, and only if such an element
+/// actually arrives (#1598).
+///
+/// `eval_each_owned` takes an `&Expr`, and the only way to present a `rest`
+/// *slice* as one is to own a copy: a `Vec` allocation plus a recursive
+/// `Expr` clone per stage. Doing that inside the per-element call meant
+/// paying it once per element; a driver builds one of these instead and
+/// reuses it for its whole loop.
+///
+/// The slice and its owned copy are one value rather than two parameters on
+/// purpose. Correctness requires that a cached pipe is only ever used with
+/// the `rest` it was built from -- a mismatch would evaluate elements
+/// against the wrong stages, which is a wrong answer rather than a crash.
+/// Pairing them here makes that mismatch unrepresentable instead of relying
+/// on every call site to keep two arguments in step.
+struct RestPipe<'a> {
+    stages: &'a [Expr],
+    owned: Option<Expr>,
+}
+
+impl<'a> RestPipe<'a> {
+    fn new(stages: &'a [Expr]) -> Self {
+        Self {
+            stages,
+            owned: None,
+        }
+    }
+
+    /// The stages themselves, for the arms that can consume a slice.
+    fn stages(&self) -> &'a [Expr] {
+        self.stages
+    }
+
+    /// The same stages as one owned `Expr`, cloning on first use only.
+    fn owned(&mut self) -> &Expr {
+        let stages = self.stages;
+        self.owned
+            .get_or_insert_with(|| Expr::Pipe(stages.to_vec()))
+    }
+}
+
 /// Continue a pipe through one already-produced item: recurse the *rest* of
 /// the pipe against it, honoring `sink`'s `Demand` throughout. Shared by
 /// [`eval_each_pipe_generic`]'s own driver and [`fold_pipe_stages_sink`]'s
@@ -3964,34 +4001,35 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
 /// dispatch below.
 fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
     item: GenericItem<V>,
-    rest: &[Expr],
+    rest: &mut RestPipe<'_>,
     optional: bool,
-    rest_pipe: &mut Option<Expr>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     match item {
-        GenericItem::One(v) => eval_each_pipe_generic::<S, V>(rest, v, optional, None, sink),
+        GenericItem::One(v) => {
+            eval_each_pipe_generic::<S, V>(rest.stages(), v, optional, None, sink)
+        }
         GenericItem::OneCursor(c) => {
-            eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
+            eval_each_pipe_generic::<S, V>(rest.stages(), c.value(), optional, Some(c), sink)
         }
-        GenericItem::Owned(o) => {
-            // Built once per driver, not once per element (#1598).
-            // `eval_each_owned` needs an `&Expr`, and the only way to
-            // present a `rest` *slice* as one is to own a copy -- which is
-            // a `Vec` allocation plus a recursive `Expr` clone per stage.
-            // Callers hand in the cache so it survives their whole loop;
-            // it stays `None` on the cursor arms above, which never need
-            // it, so a path that yields no `Owned` item still allocates
-            // nothing.
-            let rest_pipe = rest_pipe.get_or_insert_with(|| Expr::Pipe(rest.to_vec()));
-            eval_each_owned::<S>(rest_pipe, &o, optional, &mut |o| {
-                sink(GenericItem::Owned(o))
-            })
-        }
+        GenericItem::Owned(o) => eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
+            sink(GenericItem::Owned(o))
+        }),
         item @ (GenericItem::LazyKeys { .. }
         | GenericItem::LazyIndexRange(_)
         | GenericItem::LazySeq(_)) => {
-            fold_pipe_stages_sink::<S, V>(generic_item_to_result(item), rest, optional, sink)
+            // Note: this arm cannot use the cache -- `fold_pipe_stages_sink`
+            // owns its own stage cursor and rebuilds a pipe from
+            // `stages[j..]`, a different slice than `rest`. It is documented
+            // as reachable only once per pulled element, so it is not a
+            // per-element clone today; #1611 tracks folding it in if that
+            // ever changes.
+            fold_pipe_stages_sink::<S, V>(
+                generic_item_to_result(item),
+                rest.stages(),
+                optional,
+                sink,
+            )
         }
     }
 }
@@ -4047,17 +4085,11 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
 
     let mut downstream: Option<Flow> = None;
     // Same once-per-driver cache as `drive_pipe_elements_generic` (#1598):
-    // this closure also runs once per element of `first`'s output.
-    let mut rest_pipe: Option<Expr> = None;
+    // this closure also runs once per item stage 1 produces.
+    let mut rest = RestPipe::new(rest);
     let upstream = {
         let mut driver = |item: GenericItem<V>| -> Demand {
-            let flow = continue_pipe_element_generic::<S, V>(
-                item,
-                rest,
-                optional,
-                &mut rest_pipe,
-                &mut *sink,
-            );
+            let flow = continue_pipe_element_generic::<S, V>(item, &mut rest, optional, &mut *sink);
             match flow {
                 Flow::Exhausted => Demand::Continue,
                 other => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3036,9 +3036,19 @@ fn drive_pipe_elements_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
+    // One cache for the whole drive, so a `rest` pipe that has to be owned
+    // for an `Owned` element is built on the first one and reused by every
+    // element after it (#1598).
+    let mut rest_pipe: Option<Expr> = None;
     for element in elements {
         match element {
-            Ok(item) => match continue_pipe_element_generic::<S, V>(item, rest, optional, sink) {
+            Ok(item) => match continue_pipe_element_generic::<S, V>(
+                item,
+                rest,
+                optional,
+                &mut rest_pipe,
+                sink,
+            ) {
                 Flow::Exhausted => continue,
                 other => return other,
             },
@@ -3956,6 +3966,7 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
     item: GenericItem<V>,
     rest: &[Expr],
     optional: bool,
+    rest_pipe: &mut Option<Expr>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     match item {
@@ -3964,8 +3975,16 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
             eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
         }
         GenericItem::Owned(o) => {
-            let rest_pipe = Expr::Pipe(rest.to_vec());
-            eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
+            // Built once per driver, not once per element (#1598).
+            // `eval_each_owned` needs an `&Expr`, and the only way to
+            // present a `rest` *slice* as one is to own a copy -- which is
+            // a `Vec` allocation plus a recursive `Expr` clone per stage.
+            // Callers hand in the cache so it survives their whole loop;
+            // it stays `None` on the cursor arms above, which never need
+            // it, so a path that yields no `Owned` item still allocates
+            // nothing.
+            let rest_pipe = rest_pipe.get_or_insert_with(|| Expr::Pipe(rest.to_vec()));
+            eval_each_owned::<S>(rest_pipe, &o, optional, &mut |o| {
                 sink(GenericItem::Owned(o))
             })
         }
@@ -4027,9 +4046,18 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     }
 
     let mut downstream: Option<Flow> = None;
+    // Same once-per-driver cache as `drive_pipe_elements_generic` (#1598):
+    // this closure also runs once per element of `first`'s output.
+    let mut rest_pipe: Option<Expr> = None;
     let upstream = {
         let mut driver = |item: GenericItem<V>| -> Demand {
-            let flow = continue_pipe_element_generic::<S, V>(item, rest, optional, &mut *sink);
+            let flow = continue_pipe_element_generic::<S, V>(
+                item,
+                rest,
+                optional,
+                &mut rest_pipe,
+                &mut *sink,
+            );
             match flow {
                 Flow::Exhausted => Demand::Continue,
                 other => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3071,6 +3071,62 @@ fn test_lazy_keys_streaming_reports_first_occurrence_cursor_1599() -> Result<()>
     Ok(())
 }
 
+/// #1598: `continue_pipe_element_generic` used to rebuild the remaining
+/// pipe as an owned `Expr` for *every* element it was handed. The owned
+/// pipe is now built once per driver and cached, which makes correctness
+/// depend on something it did not before: that the cache never outlives
+/// the `rest` slice it was built from.
+///
+/// It cannot, because both drivers hold `rest` fixed for their whole loop
+/// — but nothing in the type system says so, so these pin it. The rows
+/// that matter are the ones with *two* `first(...)` calls carrying
+/// different trailing pipes: a cache leaking from the first driver into
+/// the second would answer the second query with the first one's stages,
+/// which is exactly the silent wrong answer this shape would produce.
+///
+/// `keys` (sorted) is the spelling that reaches the `Owned` arm — its
+/// branch yields each key as an owned string rather than a cursor — and a
+/// predicate that does not match keeps the driver pulling, so the loop
+/// runs once per key instead of stopping at the first. Every expectation
+/// is jq 1.7.1's own output.
+#[test]
+fn test_pipe_element_rest_cache_survives_multiple_drivers_1598() -> Result<()> {
+    let input = r#"{"b":1,"a":2,"c":3}"#;
+    for (filter, expected) in [
+        // Never matches: the driver walks every key through the `Owned`
+        // arm and still yields nothing.
+        (r#"[first(keys | .[] | select(. == "zzz"))]"#, "[]"),
+        // Matches only the last key, so the loop runs to the end.
+        (r#"first(keys | .[] | select(. == "c"))"#, r#""c""#),
+        // Two drivers, different trailing pipes, in one program.
+        (
+            r#"[first(keys | .[] | select(. == "c")), first(keys | .[] | ascii_upcase)]"#,
+            r#"["c","A"]"#,
+        ),
+        // Same, but both trailing pipes are multi-stage and differ in
+        // both length and content.
+        (
+            r#"[first(keys | .[] | select(. == "c") | ascii_upcase), first(keys | .[] | select(. == "b"))]"#,
+            r#"["C","b"]"#,
+        ),
+        // A longer trailing pipe: more stages is a bigger owned `Expr`,
+        // and the stage order still has to be preserved exactly.
+        (
+            r#"first(keys | .[] | tostring | select(. == "c") | ascii_upcase)"#,
+            r#""C""#,
+        ),
+        // The non-`first` spelling, which drives the same arm without an
+        // early stop.
+        (r#"[keys | .[] | select(. == "c")]"#, r#"["c"]"#),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    Ok(())
+}
+
 #[test]
 fn test_jq_compat_default() -> Result<()> {
     // Test that jq-compat is now the default behavior

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3071,30 +3071,41 @@ fn test_lazy_keys_streaming_reports_first_occurrence_cursor_1599() -> Result<()>
     Ok(())
 }
 
-/// #1598: `continue_pipe_element_generic` used to rebuild the remaining
-/// pipe as an owned `Expr` for *every* element it was handed. The owned
-/// pipe is now built once per driver and cached, which makes correctness
-/// depend on something it did not before: that the cache never outlives
-/// the `rest` slice it was built from.
+/// #1598: the shapes that drive `continue_pipe_element_generic`'s `Owned`
+/// arm, which now reads its owned copy of the remaining pipe from a
+/// `RestPipe` cache instead of rebuilding one per element.
 ///
-/// It cannot, because both drivers hold `rest` fixed for their whole loop
-/// — but nothing in the type system says so, so these pin it. The rows
-/// that matter are the ones with *two* `first(...)` calls carrying
-/// different trailing pipes: a cache leaking from the first driver into
-/// the second would answer the second query with the first one's stages,
-/// which is exactly the silent wrong answer this shape would produce.
+/// **What these do and do not prove.** They are a behavioural guard, not a
+/// regression pin: every row below passes identically on the pre-change
+/// binary, because the mispairing the cache could in principle suffer --
+/// a cached pipe used with a `rest` it was not built from -- is not
+/// expressible once `RestPipe` owns both halves as one value. That is the
+/// real protection; these rows exist so that a future change widening the
+/// cache's scope (sharing one across drivers, or hoisting it above a loop
+/// that varies `rest`) fails visibly here rather than silently evaluating
+/// elements against the wrong stages.
 ///
-/// `keys` (sorted) is the spelling that reaches the `Owned` arm — its
-/// branch yields each key as an owned string rather than a cursor — and a
-/// predicate that does not match keeps the driver pulling, so the loop
-/// runs once per key instead of stopping at the first. Every expectation
-/// is jq 1.7.1's own output.
+/// Reaching the arm at all takes care, so the rows are chosen to spread
+/// across the drivers that get there, not just the convenient one:
+///
+/// - `keys` (sorted) yields each key as an owned string, driving
+///   `each_lazy_keys_iterate_sink` -> `drive_pipe_elements_generic`. A
+///   predicate that does not match keeps the driver pulling, so the loop
+///   runs once per key rather than stopping at the first element.
+/// - a bare comma stream (`(1,2,3) | f`) drives `eval_each_pipe_generic`'s
+///   own closure, which carries the *second* cache the change adds -- the
+///   `keys` rows leave it untouched, because stage 1 there hands back a
+///   single `LazyKeys` item.
+/// - `keys` over an array reaches `each_lazy_index_range_iterate_sink`,
+///   and `map(f) | .[] | g` reaches `each_lazy_seq_iterate_sink`; both
+///   land on the same cached arm by a different route.
+///
+/// Every expectation is jq 1.7.1's own output.
 #[test]
-fn test_pipe_element_rest_cache_survives_multiple_drivers_1598() -> Result<()> {
-    let input = r#"{"b":1,"a":2,"c":3}"#;
+fn test_pipe_element_rest_cache_across_drivers_1598() -> Result<()> {
+    let object = r#"{"b":1,"a":2,"c":3}"#;
     for (filter, expected) in [
-        // Never matches: the driver walks every key through the `Owned`
-        // arm and still yields nothing.
+        // Never matches: walks every key through the `Owned` arm.
         (r#"[first(keys | .[] | select(. == "zzz"))]"#, "[]"),
         // Matches only the last key, so the loop runs to the end.
         (r#"first(keys | .[] | select(. == "c"))"#, r#""c""#),
@@ -3103,23 +3114,41 @@ fn test_pipe_element_rest_cache_survives_multiple_drivers_1598() -> Result<()> {
             r#"[first(keys | .[] | select(. == "c")), first(keys | .[] | ascii_upcase)]"#,
             r#"["c","A"]"#,
         ),
-        // Same, but both trailing pipes are multi-stage and differ in
-        // both length and content.
+        // Both trailing pipes multi-stage, differing in length and content.
         (
             r#"[first(keys | .[] | select(. == "c") | ascii_upcase), first(keys | .[] | select(. == "b"))]"#,
             r#"["C","b"]"#,
         ),
-        // A longer trailing pipe: more stages is a bigger owned `Expr`,
-        // and the stage order still has to be preserved exactly.
+        // A longer trailing pipe: stage order must survive the caching.
         (
             r#"first(keys | .[] | tostring | select(. == "c") | ascii_upcase)"#,
             r#""C""#,
         ),
-        // The non-`first` spelling, which drives the same arm without an
-        // early stop.
+        // The non-`first` spelling, driving the arm without an early stop.
         (r#"[keys | .[] | select(. == "c")]"#, r#"["c"]"#),
     ] {
-        let (out, _, code) = run_jq_full(&["-c", filter], Some(input))?;
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(object))?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    // The other three drivers. `(1,2,3) | f` is the one that exercises
+    // `eval_each_pipe_generic`'s own cache with more than one `Owned` item.
+    let array = "[1,2,3]";
+    for (filter, expected) in [
+        (r"[(1,2,3) | tostring]", r#"["1","2","3"]"#),
+        (r#"[("a","b") | ascii_upcase]"#, r#"["A","B"]"#),
+        // Two comma-stream drivers with different trailing pipes.
+        (
+            r#"[first((1,2,3) | tostring), first(("x","y") | ascii_upcase)]"#,
+            r#"["1","X"]"#,
+        ),
+        // `keys` over an array -> index-range driver, owned integer items.
+        (r"[[10,20,30] | keys | .[] | . + 1]", "[1,2,3]"),
+        // `map(f) | .[] | g` -> lazy-seq driver.
+        (r"[map(.+1) | .[] | tostring]", r#"["2","3","4"]"#),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(array))?;
         assert_eq!(code, 0, "filter {filter}");
         assert_eq!(out.trim(), expected, "filter {filter}");
     }


### PR DESCRIPTION
## Summary

`continue_pipe_element_generic`'s `Owned` arm rebuilt the remaining pipe as an owned AST for **every item handed to it** — `Expr::Pipe(rest.to_vec())` is a `Vec` allocation plus a recursive `Expr` clone per stage. Before #1565 that arm ran once per pipe; #1565 moved it onto a per-*element* path, so both drivers that reach it pay the clone once per element.

The slice and its owned copy are now one `RestPipe` value, built at most once per driver and only if an `Owned` element actually arrives. Pairing them removes a hazard as well as the cost: correctness requires that a cached pipe is only ever used with the `rest` it was built from, and as two loose parameters that mispairing compiled cleanly and produced a wrong answer rather than a crash.

`eval.rs::eval_each_pipe` — the twin driver, and the function this arm hands off to — had the same eager clone and is made lazy the same way. This repo has previously fixed one of these two evaluators and missed the other, so they move together.

## This is not latent — it is measurable today

The issue filed this as latent, reasoning that no query drives the loop more than once and therefore offering no measurement. That holds only for a **bare** `first(...)`. A `first(...)` whose predicate never matches keeps pulling, and `keys` (sorted) yields every key as an `Owned` — so `first(keys | .[] | select(. == "zzz"))` already pays one clone per key on current `main`.

**Apple M5 Max (arm64)**, 200,000-key object, release builds, interleaved within each repetition **with the order flipped every rep**, 5 reps (min / median):

| shape | before | after | delta |
|---|---|---|---|
| owned driver, `rest` = 1 stage | 0.132s | 0.110s | **-16.8% / -16.5%** |
| owned driver, `rest` = 7 stages | 0.148s | 0.112s | **-24.6% / -25.7%** |
| borrowed chain, 1 / 4 / 8 stages | 0.107 / 0.251 / 0.474s | — | -0.4% / +0.7% / -0.3% (neutral) |

The gain **growing with stage count** is the mechanism's own signature — a longer `rest` is a bigger tree to clone per element.

⚠️ **Single-architecture result.** `docs/STYLE_GUIDE.md` STYLE-0008 and CLAUDE.md both require naming the chip and measuring ARM *and* x86_64; the first revision of this PR named neither, which the review flagged. The chip is named now, but these are ARM-only — the x86_64 leg needs one of the pinned benchmark hosts, which this run did not have. Treat the magnitudes as ARM figures pending an x86 confirmation. The change removes an allocation, and allocator behaviour is exactly the class CLAUDE.md warns can differ across architectures.

## Two proposals measured and *not* taken

Both came from review, both were implemented and benchmarked rather than accepted on the reasoning:

1. **`eval.rs` lazy clone** — kept, but **measured neutral** (numbers above). The review attributed the superlinear cost curve on borrowed chains to this clone; rebuilding with the allocation gone moves nothing, so that curve is the per-stage evaluation itself. Kept as dead-work removal, and its comment says so explicitly so nobody later cites it as a speed fix.
2. **Empty-`rest` shortcut** (skip the serialize-and-reindex bridge when `Expr::Iterate` is the pipe's last stage) — **implemented, measured, dropped.** Neutral on every shape that should reach it: `[map({a:.,b:.,c:.,d:.}) | .[]] | length` +1.6%, `[keys | .[]] | length` +0.6%, index-range -2.0%. The 0.196s-vs-0.360s gap that motivated it is real but is not this bridge, since removing the bridge does not close it. Its fidelity was also checked properly first — the review verified number spelling *with* the round trip in place, which does not show that removing it preserves representation; implementing it and diffing `2.50`, `1.0`, `-0.0`, `1e1000`, `1e-1000`, `4e4`, 20-digit integers, unicode and escapes against jq 1.7.1 does, and it did.

## Test

Rewritten to say what it actually establishes. The previous doc claimed to pin the cache-leak invariant; **every row passes identically on the pre-change binary**, because that leak is not expressible once `RestPipe` owns both halves. It is a forward guard against someone widening the cache's scope, not a regression pin, and it now says so.

Widened from one driver to four, since the original covered only the convenient one: the sorted-`keys` driver, a bare comma stream (the only shape that exercises the *second* cache, in `eval_each_pipe_generic` — the `keys` rows leave it untouched), the index-range driver, and the lazy-seq driver. All expectations are jq 1.7.1's own output.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — **8989 passed, 0 failed** (63 binaries)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] Behaviour diffed against the pinned oracle `/usr/bin/jq` 1.7.1 directly, not just goldens
- [x] Output identity gated before trusting any timing

Fixes #1598
