### PR TITLE
fix(jq, json): raise on a malformed object member wherever it materializes (#1194)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -547,15 +547,18 @@ Reproducing that means validating every document up front, which costs roughly a
 index-building pass over the input — the whole advantage this crate is built for. `--validate`
 is the opt-in form for callers who want it (exit 3, its own separately-pinned code).
 
-**What still does not raise.** Every materializing route now does — `to_entries`, `keys`,
-`length`, `--slurp`, `--sort-keys`, `--ascii-output`, and any filter shape that costs the value
-its cursor (a comma, an `if`) — because #1247 made the `to_owned`/`cursor_to_owned` family
-fallible and this check rides along with it. Two lazy routes remain, and they share one cause:
-they stream, so they have no error channel to raise into.
+**What still does not raise.** Every route that *materializes* the object now does —
+`to_entries`, `keys`, `length` (in all three of its spellings, including `keys | length`),
+`--slurp`, `--sort-keys`, `--ascii-output`, and any filter shape that costs the value its cursor
+(a comma, an `if`) — because #1247 made the `to_owned`/`cursor_to_owned` family fallible and
+this check rides along with it. Three routes remain, for two different reasons: two of them
+stream, so they have no error channel to raise into; the third never walks the whole object, so
+it is not in a position to find the malformed member at all.
 
 ```
-$ echo '{invalid}'  | sjq -c '.[]'   # no output, exit 0   <- object iteration
-$ echo '[xyz123]'   | sjq -c .       # [null],    exit 0   <- a bareword in *value* position
+$ echo '{invalid}'        | sjq -c '.[]'                 # no output, exit 0
+$ echo '[xyz123]'         | sjq -c .                     # [null],    exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'     # 123 then "b", exit 0
 ```
 
 `.[]` walks the field list through `LazySource::Values`, whose `uncons` reports an unpaired
@@ -565,14 +568,32 @@ reason: by the time a nested error is discovered the opening bracket has been wr
 there yields a truncated document where every materializing route gives a clean diagnostic.
 Both are that document's Stage 6.
 
-`keys_unsorted` sits between the two: it streams, and refuses a non-string key only once its `[`
-is out, so a **truncated** array can reach stdout beside the exit 5. Pre-checking would mean a
-second walk over every key on a path `scripts/perf-guard.py` measures. The identity printer has
-no such limit — its check rides inside a walk it was already making, so a malformed object emits
-nothing at all.
+The third is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `[n]`, `first`, `last`.
+`#1514` and `#1599` deliberately took the whole-object probe *off* these arms: `first` and `[0]`
+answer from one `uncons_key` because collapsing keeps every key at its first position, so the
+answer holds whatever the rest of the object turns out to be. Restoring a #1194 check means
+restoring exactly the walk those two issues removed, which is why it is tracked separately
+(#1629) rather than folded in here. `keys_unsorted | length` is *not* in this set — it reaches
+`effective_len`, which walks, and so carries the check for free.
 
-`--preserve-input` still echoes the malformed text verbatim, since reproducing the input
-byte-for-byte is that flag's entire purpose.
+Bare `keys_unsorted` — no stage after it — does raise, but only part-way through: it streams,
+and finds a non-string key once its `[` is already out, so a **truncated** array can reach
+stdout beside the exit 5. Pre-checking would mean a second walk over every key on a path
+`scripts/perf-guard.py` measures.
+
+The identity printer has no such limit for an object malformed at the *top* level — its check
+rides inside a walk it was already making, so nothing is emitted at all. A malformed object
+*nested* inside a well-formed one is found only once its parent's opening bytes are written, so
+that case truncates like `keys_unsorted` does:
+
+```
+$ echo '{invalid}'        | sjq -c .   # (nothing),  exit 5
+$ echo '{"a": {invalid}}' | sjq -c .   # `{"a":`,    exit 5
+```
+
+`--preserve-input` is not an exception to any of this: it changes how values are *rendered*
+(number literals and escape sequences kept as written), not whether the document is accepted,
+so a malformed member raises under it exactly as it does without it.
 
 **A key that will not decode is never a duplicate.** succinctly semi-indexes rather than
 validates, so a key carrying an invalid escape or a lone surrogate — input real jq rejects

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -547,60 +547,32 @@ Reproducing that means validating every document up front, which costs roughly a
 index-building pass over the input — the whole advantage this crate is built for. `--validate`
 is the opt-in form for callers who want it (exit 3, its own separately-pinned code).
 
-Two consequences worth stating plainly. A **truncated array** can reach stdout alongside the
-exit 5 from `keys_unsorted` over an object with a non-string key: that writer streams and
-cannot rewind, and pre-checking would mean a second walk over every key on a path
-`scripts/perf-guard.py` measures. The identity printer has no such limit — it checks inside a
-walk it was already making, so a malformed object emits nothing at all. And **`--preserve-input`
-still echoes the malformed text verbatim**, since reproducing the input byte-for-byte is that
-flag's entire purpose.
-
-**Which surfaces raise, precisely.** Only the ones that write JSON straight from a *cursor*:
-the identity printer and `keys_unsorted`, plus the two `Result`-returning materializers behind
-them. Anything that first materializes an `OwnedValue` goes through the infallible
-`to_owned`/`cursor_to_owned` family, where the member has already been dropped before any
-printer sees it — so it degrades quietly.
-
-Two separate things push a run onto the quiet side.
-
-**The filter's shape.** Anything that costs the value its cursor — a comma, an `if` — hands
-the printer an `OwnedValue` instead:
+**What still does not raise.** Every materializing route now does — `to_entries`, `keys`,
+`length`, `--slurp`, `--sort-keys`, `--ascii-output`, and any filter shape that costs the value
+its cursor (a comma, an `if`) — because #1247 made the `to_owned`/`cursor_to_owned` family
+fallible and this check rides along with it. Two lazy routes remain, and they share one cause:
+they stream, so they have no error channel to raise into.
 
 ```
-$ echo '{invalid}' | sjq -c .                     # error, exit 5
-$ echo '{invalid}' | sjq -c '(.)'                 # error, exit 5   (still a cursor)
-$ echo '{invalid}' | sjq -c 'select(true)'        # error, exit 5   (still a cursor)
-$ echo '{invalid}' | sjq -c ., .                  # {} {}, exit 0   (comma -> Many)
-$ echo '{invalid}' | sjq -c 'if .a then 1 else . end'   # {}, exit 0
-$ echo '{123: 1, "b": 2}' | sjq -c 'keys, length' # ["b"] then 2, exit 0
+$ echo '{invalid}'  | sjq -c '.[]'   # no output, exit 0   <- object iteration
+$ echo '[xyz123]'   | sjq -c .       # [null],    exit 0   <- a bareword in *value* position
 ```
 
-This is the same cursor-vs-owned split that already governs anchor and comment preservation
-in yq mode (ADR-0017; a multi-result filter loses its cursor to `GenericResult::Many`), now
-visible on the jq side too.
+`.[]` walks the field list through `LazySource::Values`, whose `uncons` reports an unpaired
+child as plain exhaustion and returns `Option`, not `Result`. `[xyz123]`'s identity path reaches
+`print_json`'s `StandardJson::Error` arm, which #1247's own design doc deferred for the same
+reason: by the time a nested error is discovered the opening bracket has been written, so bailing
+there yields a truncated document where every materializing route gives a clean diagnostic.
+Both are that document's Stage 6.
 
-**A flag that disables the lazy path.** `can_use_lazy_path` (`jq_runner.rs`) is false for
-`--slurp`, `--raw-input`, `--input-dsv`, `--seq`, `--sort-keys`, colour output,
-**`--ascii-output`**, and any use of the `input`/`inputs` builtins. Any one of them routes the
-whole run through `parse_json_stream` and the infallible family, so even a plain identity
-query stops raising:
+`keys_unsorted` sits between the two: it streams, and refuses a non-string key only once its `[`
+is out, so a **truncated** array can reach stdout beside the exit 5. Pre-checking would mean a
+second walk over every key on a path `scripts/perf-guard.py` measures. The identity printer has
+no such limit — its check rides inside a walk it was already making, so a malformed object emits
+nothing at all.
 
-```
-$ echo '{invalid}' | sjq -c .        # error, exit 5
-$ echo '{invalid}' | sjq -c -a .     # {}, exit 0   <- -a is a formatting flag, but it
-$ echo '{invalid}' | sjq -c -S .     # {}, exit 0      disables the lazy path outright
-$ echo '{invalid}' | sjq -c -s .     # [{}], exit 0
-```
-
-`-a` is the surprising one: nothing about ASCII escaping suggests it should change whether a
-document is accepted.
-
-So `length` and `keys` can still disagree about how many members an object has
-(`{invalid: 1}` counts 1 and lists none), which is the failure mode #1385's own postmortem
-names. Closing the rest needs that family to become fallible — the same architectural change
-#1247 is about, tracked there rather than duplicated here. A bareword in **value** position
-(`[xyz123]` → `[null]`) reaches that family too, which is why this issue's second repro is
-not fixed alongside its first.
+`--preserve-input` still echoes the malformed text verbatim, since reproducing the input
+byte-for-byte is that flag's entire purpose.
 
 **A key that will not decode is never a duplicate.** succinctly semi-indexes rather than
 validates, so a key carrying an invalid escape or a lone surrogate — input real jq rejects

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1287,7 +1287,25 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         );
         let (inputs, locations) = match get_inputs(&args, force_read_under_null_input) {
             Ok(Ok(inputs)) => inputs,
-            Ok(Err(e)) => return Err(e),
+            // A malformed or undecodable document is a data error, so it goes
+            // out in jq's own diagnostic shape at exit 5 rather than through
+            // `anyhow` at exit 1 with an `Error:` prefix jq never prints
+            // (#1194). Everything else here really is I/O and keeps the
+            // `anyhow` path.
+            //
+            // Line 0, the same placeholder the lazy path prints when it has
+            // no better position: this route reads the whole stream up front
+            // and fails before any per-document offset exists. Reusing the
+            // existing shape beats introducing a second rendering.
+            Ok(Err(e)) => match e.downcast::<MalformedJsonError>() {
+                Ok(MalformedJsonError(err)) => {
+                    let files = get_input_files(&args);
+                    let file = files.first().map(|p| p.to_string_lossy().to_string());
+                    sink.report(DiagStyle::Jq, &err, &InputLocation::at(file.as_deref(), 0));
+                    return Ok(DiagStyle::Jq.error_exit_code());
+                }
+                Err(e) => return Err(e),
+            },
             Err(exit_code) => return Ok(exit_code), // Validation error
         };
 
@@ -2665,8 +2683,12 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
                     .map(|(start, end)| {
                         crate::output::json_bytes_to_owned_value(&bytes[start..end])
                     })
+                    // Wrapped rather than flattened, for the same reason as
+                    // the sibling site in `parse_json_stream_strict`: the
+                    // caller reports a document error in jq's channel at
+                    // exit 5, and can only recognise it by type (#1194).
                     .collect::<core::result::Result<Vec<_>, _>>()
-                    .map_err(|de| anyhow::anyhow!("{de}")),
+                    .map_err(|de| anyhow::Error::from(MalformedJsonError(de))),
                 Err(_) => Err(e),
             }
         }
@@ -2704,8 +2726,13 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
             .position(|b| !b.is_ascii_whitespace())
             .map_or(prev_end, |offset| prev_end + offset);
         values.push(
+            // Wrapped, not flattened to an `anyhow!` string: this is a data
+            // error about the document, so the caller has to be able to tell
+            // it apart from an I/O failure and report it in jq's own channel
+            // at exit 5. Flattening lost that, and the run exited 1 with an
+            // `Error:` prefix jq never prints (#1194).
             crate::output::json_bytes_to_owned_value(&bytes[start..end])
-                .map_err(|e| anyhow::anyhow!("{e}"))?,
+                .map_err(|e| anyhow::Error::from(MalformedJsonError(e)))?,
         );
         prev_end = end;
     }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -732,6 +732,25 @@ fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, 
     key_hash_of(&field.key)
 }
 
+/// Whether this key is one the format's *grammar* never allowed -- a bare
+/// `123` or `invalid` where JSON demands a string (#1194).
+///
+/// The one definition of the #1194 key predicate, because it has to make a
+/// distinction that is easy to get wrong in only one of two places: a key
+/// that fails to *decode* also fails to stringify, but it is #1247's fault
+/// with the opposite answer -- sometimes deliberately preserved verbatim,
+/// per #1385's "a key that will not decode is never a duplicate". Testing
+/// `key_string().is_none()` alone reports an invalid escape as `expected
+/// string key`: the wrong cause, at the wrong severity.
+///
+/// `false` for every format whose parser validates, whose keys all
+/// stringify (issue #222 requires an override to answer `Some("")` rather
+/// than `None` for a key with no scalar form), so this costs YAML one
+/// predicate on a branch it never takes.
+pub(crate) fn key_is_malformed<V: DocumentValue>(key: &V) -> bool {
+    key.string_decode_error().is_none() && key.key_string().is_none()
+}
+
 /// An open-addressed set of key hashes: "have I seen this one?" answered
 /// as a walk goes, without holding the keys.
 ///
@@ -928,6 +947,16 @@ struct KeyCensus {
     unkeyed: usize,
     /// Whether any key occurred more than once.
     repeated: bool,
+    /// Whether the object holds a member the format's grammar never allowed
+    /// -- a non-string key, or a trailing child with no sibling to pair as
+    /// its value (#1194).
+    ///
+    /// Rides the census rather than taking a walk of its own: `length` is
+    /// the caller, and the census already visits every key. A separate
+    /// pre-check measured **+64%** on `length` over a 20 MB `wide`
+    /// document, which is what "only where the caller was going to walk
+    /// anyway" has to actually mean.
+    malformed: bool,
 }
 
 impl KeyCensus {
@@ -951,14 +980,24 @@ impl KeyCensus {
 fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     let mut hashes: Vec<u64> = Vec::new();
     let mut unkeyed = 0usize;
+    let mut malformed = false;
     let mut walk = fields.clone();
     while let Some((key, _cursor, rest)) = walk.uncons_key() {
         match key_hash_of(&key) {
             Some(hash) => hashes.push(hash),
-            None => unkeyed += 1,
+            // `key_hash_of` answers `None` for exactly the keys that do not
+            // stringify, so this is the only branch [`key_is_malformed`] can
+            // fire on -- and it is never taken by a well-formed document.
+            None => {
+                unkeyed += 1;
+                malformed |= key_is_malformed(&key);
+            }
         }
         walk = rest;
     }
+    // `walk` is the list this loop *finished* on, the only list
+    // `ends_unpaired` answers for (#1194), and asking it is O(1).
+    malformed |= walk.ends_unpaired();
     hashes.sort_unstable();
     let (shared, distinct_hashes) = shared_hashes(&hashes);
     if shared.is_empty() {
@@ -966,6 +1005,7 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
             distinct: distinct_hashes,
             unkeyed,
             repeated: false,
+            malformed,
         };
     }
 
@@ -998,6 +1038,7 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
         distinct: distinct_hashes - shared.len() + distinct_colliding,
         unkeyed,
         repeated,
+        malformed,
     }
 }
 
@@ -1318,6 +1359,55 @@ pub fn effective_len<F: DocumentFields>(fields: &F, collapse: bool) -> usize {
         return fields.len();
     }
     census(fields).effective_len()
+}
+
+/// [`effective_len`], refusing an object whose members the format's grammar
+/// never allowed (#1194).
+///
+/// The count and the check come out of **one** walk, which is the whole
+/// point of putting the check here rather than in front of the call: both
+/// spellings of this question -- `length` and `keys | length` -- reach
+/// `effective_len`, and a caller-side pre-check both doubled the work and
+/// covered only the first spelling, leaving `{invalid} | length` erroring
+/// while `{invalid} | keys | length` answered `0`.
+///
+/// [`effective_len`] itself stays infallible for the two `eval.rs`-side
+/// callers, which reach `length` through the other evaluator and answer for
+/// an already-materialized value.
+pub fn effective_len_checked<F: DocumentFields>(
+    fields: &F,
+    collapse: bool,
+) -> Result<usize, EvalError> {
+    if !collapse {
+        return checked_len(fields);
+    }
+    let census = census(fields);
+    if census.malformed {
+        return Err(fields.malformed_member_error());
+    }
+    Ok(census.effective_len())
+}
+
+/// The plain field count, refusing a malformed member as it goes.
+///
+/// The no-collapse counterpart of the [`census`] path above, and likewise
+/// one walk rather than two: this *replaces* [`DocumentFields::len`]'s own
+/// walk instead of preceding it, and walks with `uncons_key` where `len`
+/// walks with `uncons`, so it materializes no value cursor (#1514).
+fn checked_len<F: DocumentFields>(fields: &F) -> Result<usize, EvalError> {
+    let mut count = 0usize;
+    let mut walk = fields.clone();
+    while let Some((key, _cursor, rest)) = walk.uncons_key() {
+        if key_is_malformed(&key) {
+            return Err(walk.malformed_member_error());
+        }
+        count += 1;
+        walk = rest;
+    }
+    if walk.ends_unpaired() {
+        return Err(walk.malformed_member_error());
+    }
+    Ok(count)
 }
 
 /// An object's field names under the mode's duplicate-key rule, in

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1652,3 +1652,74 @@ mod raw_key_hash_tests {
         assert_eq!(ascii_key_hash("aaaaaaaaé".as_bytes()), None);
     }
 }
+
+#[cfg(test)]
+mod checked_len_tests {
+    use super::{effective_len_checked, DocumentValue};
+    use crate::json::JsonIndex;
+
+    /// The two arms of [`effective_len_checked`] must agree about whether a
+    /// document is well formed (#1194).
+    ///
+    /// `collapse` picks between two entirely separate implementations -- the
+    /// `census` walk and `checked_len` -- and only the first is reachable
+    /// through a shipped binary today: `collapse` is true in jq mode, and the
+    /// no-collapse arm belongs to yq mode, whose parser validates and so can
+    /// never present a malformed member. That is exactly why the arms are
+    /// driven directly here. An unexercised copy of a predicate is how two
+    /// copies drift, and the pairing is the property worth pinning: whichever
+    /// arm a future format lands on, it must give the same verdict and the
+    /// same count.
+    #[test]
+    fn both_arms_agree_on_malformed_and_well_formed_objects_1194() {
+        for (json, expected) in [
+            (&br#"{"a":1,"b":2}"#[..], Some(2)),
+            // Collapsing is the one thing the arms legitimately differ on:
+            // jq's rule folds the repeat, yq's keeps both.
+            (&br#"{"a":1,"a":2}"#[..], None),
+            (b"{}", Some(0)),
+            (b"{invalid}", None),           // orphan, post-walk check
+            (br#"{123: 1, "b": 2}"#, None), // bad key, per-field check
+            (br#"{"a":1, "b"}"#, None),     // orphan behind a good field
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let fields = cursor.value().as_object().expect("an object");
+
+            let collapsed = effective_len_checked(&fields, true);
+            let plain = effective_len_checked(&fields, false);
+
+            assert_eq!(
+                collapsed.is_ok(),
+                plain.is_ok(),
+                "the arms disagree about {}: {collapsed:?} vs {plain:?}",
+                String::from_utf8_lossy(json)
+            );
+            if let Some(len) = expected {
+                assert_eq!(collapsed.as_ref().ok(), Some(&len));
+                assert_eq!(plain.as_ref().ok(), Some(&len));
+            }
+            if let Err(err) = &plain {
+                // Same cause, not merely the same verdict -- `checked_len`
+                // asks the offending key's list while the census arm asks
+                // the head, and `malformed_member_error` is a method rather
+                // than a per-site literal precisely so those coincide.
+                assert_eq!(err.message, collapsed.unwrap_err().message);
+                assert!(err.message.contains("Invalid JSON text"));
+            }
+        }
+    }
+
+    /// A key that will not *decode* is #1247's fault, not #1194's, on the
+    /// no-collapse arm too -- the distinction `key_is_malformed` exists to
+    /// make, checked on the copy of it that no shipped binary reaches.
+    #[test]
+    fn the_plain_arm_leaves_decode_failures_alone_1194() {
+        let json: &[u8] = br#"{"a\q":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+
+        assert_eq!(effective_len_checked(&fields, false).ok(), Some(2));
+    }
+}

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -549,6 +549,25 @@ pub trait DocumentFields: Sized + Clone {
         false
     }
 
+    /// The error to raise for a member this format's index accepted but the
+    /// format's grammar does not -- an unpaired child, or a key that is not a
+    /// string (#1194).
+    ///
+    /// A method rather than a fixed string at each call site so that one
+    /// document reports the *same* cause however it is reached. JSON overrides
+    /// it to re-run its strict validator, which names the real syntax error
+    /// (`expected string key, found 'i'`); the generic evaluator cannot do
+    /// that itself, because [`DocumentCursor`] exposes `text_position` but not
+    /// the document bytes the validator needs.
+    ///
+    /// The default is unreachable for every format shipped today --
+    /// [`ends_unpaired`](Self::ends_unpaired) is `false` and every key
+    /// stringifies -- so it exists to keep a future format honest rather than
+    /// to be seen.
+    fn malformed_member_error(&self) -> EvalError {
+        EvalError::new("Invalid document text: malformed object member")
+    }
+
     /// Walk one field, materializing only its key.
     ///
     /// [`uncons`](Self::uncons) builds a whole [`DocumentField`], which
@@ -604,10 +623,18 @@ pub trait DocumentFields: Sized + Clone {
             if let Some(reason) = field.key.string_decode_error() {
                 return Err(EvalError::new(format!("{reason} in object key")));
             }
-            if let Some(key) = field.key_str() {
-                keys.push(key.into_owned());
-            }
+            // A key that will not stringify at all never allowed by the
+            // format's grammar in the first place -- structurally malformed,
+            // not a decode failure (#1194). It used to be skipped, so `keys`
+            // reported one name fewer than `length` counted members.
+            let Some(key) = field.key_str() else {
+                return Err(fields.malformed_member_error());
+            };
+            keys.push(key.into_owned());
             fields = rest;
+        }
+        if fields.ends_unpaired() {
+            return Err(fields.malformed_member_error());
         }
         Ok(keys)
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -121,6 +121,32 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_at_depth(value, 0)
 }
 
+/// The error for an object member the format's index accepted but its grammar
+/// does not -- a key that will not stringify, or a child with nothing to pair
+/// it with (#1194). `None` when every member is well formed.
+///
+/// For callers whose own return type is infallible (`DocumentFields::len`) but
+/// whose *caller* has an error channel. One key-only walk, and only where the
+/// caller was going to walk anyway -- `ends_unpaired` alone is O(1) but sees
+/// only a trailing orphan, never a bad key.
+fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
+    let mut walk = fields.clone();
+    while let Some((key, _cursor, rest)) = walk.uncons_key() {
+        // A key that fails to *decode* has no stringified name either, but it
+        // is #1247's failure, not #1194's, and the two want opposite answers:
+        // an undecodable key is deliberately preserved verbatim in places
+        // (#1385's "a key that will not decode is never a duplicate"), while a
+        // key the grammar never allowed must raise. Leave decode failures to
+        // the `string_decode_error` checks that already surround this, or this
+        // walk hijacks them and reports the wrong cause.
+        if key.string_decode_error().is_none() && key.key_string().is_none() {
+            return Some(walk.malformed_member_error());
+        }
+        walk = rest;
+    }
+    walk.ends_unpaired().then(|| walk.malformed_member_error())
+}
+
 fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedValue, EvalError> {
     assert_nesting_depth(depth);
     // Check containers first (arrays and objects have no type ambiguity)
@@ -136,13 +162,27 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             if let Some(reason) = field.key.string_decode_error() {
                 return Err(EvalError::new(format!("{reason} in object key")));
             }
-            if let Some(key) = field.key_str() {
-                map.insert(
-                    key.into_owned(),
-                    to_owned_at_depth(&field.value, depth + 1)?,
-                );
-            }
+            // A key that will not stringify at all is not a decode failure --
+            // it is a key JSON's grammar never allowed (`{123: 1}`), which
+            // the semi-index accepted because `:` and `,` mean the same
+            // nothing to it. Dropping the field silently is #1194: it
+            // vanished from output while `length` went on counting it, the
+            // disagreement #1385's postmortem names as the thing to avoid.
+            let Some(key) = field.key_str() else {
+                return Err(f.malformed_member_error());
+            };
+            map.insert(
+                key.into_owned(),
+                to_owned_at_depth(&field.value, depth + 1)?,
+            );
             f = rest;
+        }
+        // The walk ran out -- but on an unpaired child, or genuinely? Only
+        // the list it *finished* on can tell those apart, and `uncons`
+        // reports both as `None` (#1194). `false` for every format whose
+        // parser validates, so this costs YAML nothing.
+        if f.ends_unpaired() {
+            return Err(f.malformed_member_error());
         }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
@@ -226,13 +266,21 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
             if let Some(reason) = field.key.string_decode_error() {
                 return Err(EvalError::new(format!("{reason} in object key")));
             }
-            if let Some(key) = field.key_str() {
-                map.insert(
-                    key.into_owned(),
-                    to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
-                );
-            }
+            // Same two #1194 checks as `to_owned_at_depth` above, same
+            // reasons -- these two conversions are copies of each other and a
+            // fix that moved only one would leave the cursor and value
+            // domains disagreeing about whether a document is valid.
+            let Some(key) = field.key_str() else {
+                return Err(f.malformed_member_error());
+            };
+            map.insert(
+                key.into_owned(),
+                to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
+            );
             f = rest;
+        }
+        if f.ends_unpaired() {
+            return Err(f.malformed_member_error());
         }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
@@ -5690,6 +5738,15 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(elements) = value.as_array() {
                 GenericResult::Owned(OwnedValue::Int(elements.len() as i64))
             } else if let Some(fields) = value.as_object() {
+                // #1194: `effective_len` counts a member whose key never
+                // stringifies (`census`'s `unkeyed`), so `length` answered 1
+                // for `{invalid: 1}` while `keys` listed none. Refuse rather
+                // than pick one of two wrong numbers. `len` is infallible by
+                // design -- the error channel is here, where the builtin
+                // already has one.
+                if let Some(err) = malformed_object_member(&fields) {
+                    return GenericResult::Error(err);
+                }
                 // Distinct keys in jq mode (#1385) -- `{"a":1,"a":2}|length`
                 // is 1, because the object jq built only ever had one member.
                 GenericResult::Owned(OwnedValue::Int(effective_len(
@@ -5808,6 +5865,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 }
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else if let Some(fields) = value.as_object() {
+                // Up front, because `effective_fields` reports an unpaired
+                // trailing child as plain exhaustion -- the loop below would
+                // simply see one member fewer and never notice (#1194). The
+                // key-only walk is negligible here next to materializing
+                // every value, which this builtin does anyway.
+                if let Some(err) = malformed_object_member(&fields) {
+                    return GenericResult::Error(err);
+                }
                 // A loop for the same reason as the array arm above.
                 let mut entries: Vec<OwnedValue> = Vec::new();
                 for field in effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
@@ -5818,8 +5883,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                             "{reason} in object key"
                         )));
                     }
+                    // `continue` here was #1194's third drop site: an entry
+                    // vanished from the array while `length` still counted
+                    // the member it came from.
                     let Some(key) = field.key_str() else {
-                        continue;
+                        return GenericResult::Error(fields.malformed_member_error());
                     };
                     let mut entry = IndexMap::new();
                     entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
@@ -12737,38 +12805,82 @@ mod tests {
         }
     }
 
-    /// `Builtin::ToEntries`'s object branch drops a field whose key doesn't
-    /// decode to a string at all via `field.key_str()` -- not #1247's own
-    /// undecodable-*content* check just above it (`string_decode_error`,
-    /// which only fires for a string-*shaped* span), but the older, still-
-    /// open #1194-class gap for a key that isn't string-shaped in the first
-    /// place. `{123: 1, "b": 2}` isn't valid JSON (jq itself would reject
-    /// it), but this crate's lenient semi-index still represents it
-    /// structurally -- `DocumentFields::uncons` hands back a field whose
-    /// `.key` is `StandardJson::Number`, `key_str()`'s default `as_str()`
-    /// answers `None` for it, and the field is silently skipped rather than
-    /// erroring. This is a known, pre-existing gap outside this coverage
-    /// pass's scope (the fallible-conversion logic itself is not to be
-    /// touched here) -- documented as current behavior, not asserted as
-    /// correct.
+    /// `Builtin::ToEntries` raises on a key that isn't string-shaped at all,
+    /// rather than dropping the entry (#1194).
+    ///
+    /// This asserted the drop when #1247's coverage pass wrote it, as a
+    /// known gap deliberately left alone there. It is the older, distinct
+    /// sibling of #1247's own `string_decode_error` check just above it:
+    /// that one fires for a string-*shaped* span whose bytes won't decode,
+    /// while `{123: 1, "b": 2}` has a key JSON's grammar never allowed. The
+    /// lenient semi-index represents it structurally -- `uncons` hands back
+    /// a field whose `.key` is `StandardJson::Number` -- so nothing but an
+    /// explicit check can tell it from a well-formed object.
+    ///
+    /// Inverted rather than deleted: dropping the entry left `to_entries`
+    /// one shorter than `length` counted, the disagreement #1385's own
+    /// postmortem names as the failure mode to avoid.
     #[test]
-    fn test_to_entries_silently_drops_non_string_key_known_gap_1247() {
+    fn test_to_entries_raises_on_non_string_key_1194() {
         let json: &[u8] = b"{123: 1, \"b\": 2}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let result = eval_with_cursor(&crate::jq::parse("to_entries").unwrap(), cursor);
-        let entries = result.into_owned().unwrap().unwrap();
-        let OwnedValue::Array(entries) = entries else {
-            panic!("expected an array, got {entries:?}");
+        let GenericResult::Error(err) = result else {
+            panic!("expected an error, got {result:?}");
         };
-        assert_eq!(
-            entries.len(),
-            1,
-            "the malformed `123` key is dropped: {entries:?}"
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
         );
-        let OwnedValue::Object(entry) = &entries[0] else {
-            panic!("expected an object entry, got {:?}", entries[0]);
+        // The strict validator's own diagnosis, not a message invented here.
+        assert!(
+            err.message.contains("expected string key"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194: an object whose children don't pair raises from `to_entries`
+    /// too, not just one with a bad key.
+    ///
+    /// The two conditions reach different checks -- a bad key is caught
+    /// per-field, an orphan only once the walk ends -- so a fix for one can
+    /// silently miss the other.
+    #[test]
+    fn test_to_entries_raises_on_unpaired_member_1194() {
+        let json: &[u8] = b"{invalid}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("to_entries").unwrap(), cursor);
+        let GenericResult::Error(err) = result else {
+            panic!("expected an error, got {result:?}");
         };
-        assert_eq!(entry.get("key"), Some(&OwnedValue::String("b".to_string())));
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194 must not hijack #1247's decode failures: an *undecodable* key
+    /// has no stringified name either, but it is a different fault with a
+    /// different answer -- sometimes deliberately preserved verbatim
+    /// (#1385's "a key that will not decode is never a duplicate").
+    ///
+    /// Regression guard for a real bug in this fix's first cut, which tested
+    /// only `key_string().is_none()` and so reported an invalid escape as
+    /// `expected string key` -- the wrong cause, and at the wrong severity.
+    #[test]
+    fn test_malformed_member_check_leaves_decode_failures_alone_1194() {
+        let json: &[u8] = br#"{"a\q":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        assert!(
+            malformed_object_member(&fields).is_none(),
+            "an undecodable key is #1247's fault, not #1194's"
+        );
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,9 +22,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, effective_fields, effective_keys, effective_len,
-    DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields, DocumentValue,
-    IndentSpec,
+    collapsed_fields, collapsed_fields_if, effective_fields, effective_keys, effective_len_checked,
+    key_is_malformed, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, collapse_vec, eval as full_eval, eval_each_owned,
@@ -125,21 +125,28 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
 /// does not -- a key that will not stringify, or a child with nothing to pair
 /// it with (#1194). `None` when every member is well formed.
 ///
-/// For callers whose own return type is infallible (`DocumentFields::len`) but
-/// whose *caller* has an error channel. One key-only walk, and only where the
-/// caller was going to walk anyway -- `ends_unpaired` alone is O(1) but sees
-/// only a trailing orphan, never a bad key.
+/// For a caller that has an error channel but no walk of its own to hang the
+/// check on -- `to_entries`, whose `effective_fields` reports an unpaired
+/// trailing child as plain exhaustion. A key-only walk, negligible there next
+/// to materializing every value, which that builtin does anyway.
+///
+/// `length` deliberately does **not** use this: it reaches
+/// [`effective_len_checked`], which folds the same check into the walk it was
+/// already making. A pre-check in front of that call measured +64% on a 20 MB
+/// `wide` document, and answered only for the `length` spelling -- never
+/// `keys | length`, which reaches `effective_len` by a different route.
+///
+/// `ends_unpaired` alone would be O(1), but it sees only a trailing orphan,
+/// never a bad key.
 fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
     let mut walk = fields.clone();
     while let Some((key, _cursor, rest)) = walk.uncons_key() {
-        // A key that fails to *decode* has no stringified name either, but it
-        // is #1247's failure, not #1194's, and the two want opposite answers:
-        // an undecodable key is deliberately preserved verbatim in places
-        // (#1385's "a key that will not decode is never a duplicate"), while a
-        // key the grammar never allowed must raise. Leave decode failures to
-        // the `string_decode_error` checks that already surround this, or this
-        // walk hijacks them and reports the wrong cause.
-        if key.string_decode_error().is_none() && key.key_string().is_none() {
+        // `key_is_malformed` rather than a `key_string().is_none()` test
+        // written out here: it is the one definition of the distinction
+        // between #1194's structurally-impossible key and #1247's merely
+        // undecodable one, which want opposite answers and which the first
+        // cut of this function conflated. See its own doc comment.
+        if key_is_malformed(&key) {
             return Some(walk.malformed_member_error());
         }
         walk = rest;
@@ -3013,13 +3020,23 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         //
         // Order-independent for both `keys` and
         // `keys_unsorted` — the one fast path #683 adds for
-        // sorted `keys`. `effective_len` counts distinct keys
-        // in one walk without materializing the field list,
-        // and is `fields.len()` outright when `collapse` is
-        // false.
-        Expr::Builtin(Builtin::Length) => {
-            GenericResult::Owned(OwnedValue::Int(effective_len(&fields, collapse) as i64))
-        }
+        // sorted `keys`. `effective_len_checked` counts
+        // distinct keys in one walk without materializing the
+        // field list, and is a plain counting walk outright
+        // when `collapse` is false.
+        //
+        // `_checked` for the same reason `Builtin::Length`'s own object arm
+        // uses it: this is the *other* spelling of "how many members does
+        // this object have", and while it answered from the unchecked
+        // `effective_len`, `{invalid} | length` raised while `{invalid} |
+        // keys | length` said `0` -- the two-answers-for-one-document split
+        // #1385's postmortem names, reintroduced one pipe stage further
+        // along. The check costs nothing extra: it rides that same walk
+        // (#1194).
+        Expr::Builtin(Builtin::Length) => match effective_len_checked(&fields, collapse) {
+            Ok(len) => GenericResult::Owned(OwnedValue::Int(len as i64)),
+            Err(err) => GenericResult::Error(err),
+        },
         // Document order is a valid answer only for
         // `keys_unsorted`. `keys` needs lexicographic order
         // for these and falls through to the shared
@@ -5741,18 +5758,20 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // #1194: `effective_len` counts a member whose key never
                 // stringifies (`census`'s `unkeyed`), so `length` answered 1
                 // for `{invalid: 1}` while `keys` listed none. Refuse rather
-                // than pick one of two wrong numbers. `len` is infallible by
-                // design -- the error channel is here, where the builtin
-                // already has one.
-                if let Some(err) = malformed_object_member(&fields) {
-                    return GenericResult::Error(err);
-                }
+                // than pick one of two wrong numbers.
+                //
+                // `_checked` rather than a guard in front of the call: the
+                // check rides the census walk this already makes, and it is
+                // shared with the `keys | length` spelling in
+                // `fold_lazy_keys_stage`, which reaches `effective_len` by a
+                // route no guard here can see.
+                //
                 // Distinct keys in jq mode (#1385) -- `{"a":1,"a":2}|length`
                 // is 1, because the object jq built only ever had one member.
-                GenericResult::Owned(OwnedValue::Int(effective_len(
-                    &fields,
-                    S::COLLAPSE_DUPLICATE_KEYS,
-                ) as i64))
+                match effective_len_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                    Ok(len) => GenericResult::Owned(OwnedValue::Int(len as i64)),
+                    Err(err) => GenericResult::Error(err),
+                }
             } else if let Some(i) = value.as_i64() {
                 // checked_abs: i64::MIN has no i64 absolute value; use f64
                 GenericResult::Owned(match i.checked_abs() {
@@ -5886,6 +5905,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     // `continue` here was #1194's third drop site: an entry
                     // vanished from the array while `length` still counted
                     // the member it came from.
+                    //
+                    // Unreachable as it stands -- `malformed_object_member`
+                    // above has already proved every key stringifies -- but
+                    // `key_str` is an `Option` and something has to be
+                    // written here. Report the same cause rather than invent
+                    // a second one, so that if the pre-check is ever moved
+                    // this arm is still right rather than merely quiet.
                     let Some(key) = field.key_str() else {
                         return GenericResult::Error(fields.malformed_member_error());
                     };
@@ -12882,5 +12908,40 @@ mod tests {
             malformed_object_member(&fields).is_none(),
             "an undecodable key is #1247's fault, not #1194's"
         );
+    }
+
+    /// #1194: both materializing conversions raise on a non-string key.
+    ///
+    /// Driven directly rather than through a filter because these two are
+    /// copies of each other reached from different domains -- `to_owned`
+    /// from a value, `to_owned_cursor` from a cursor -- and which one a
+    /// given CLI invocation lands on depends on the filter's shape, so a
+    /// filter-level test cannot pin *both* arms on purpose. Both were
+    /// uncovered when this check was added; a fix that moved only one would
+    /// leave the value and cursor domains disagreeing about whether the same
+    /// document is valid.
+    ///
+    /// The orphan half (`{invalid}`) is exercised by the CLI tests; this is
+    /// the bad-key half, which reaches the other check entirely.
+    #[test]
+    fn test_both_owned_conversions_raise_on_non_string_key_1194() {
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+
+        let value_err = to_owned(&cursor.value()).expect_err("the value domain must raise");
+        let cursor_err = to_owned_cursor(&cursor).expect_err("the cursor domain must raise");
+
+        for err in [&value_err, &cursor_err] {
+            assert!(
+                err.message.contains("expected string key"),
+                "message: {}",
+                err.message
+            );
+        }
+        // One document, one cause, however it is reached -- the reason
+        // `malformed_member_error` is a method rather than a literal per
+        // call site.
+        assert_eq!(value_err.message, cursor_err.message);
     }
 }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1771,7 +1771,7 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
-use crate::jq::{nonfinite_display_string, YqSemantics};
+use crate::jq::{nonfinite_display_string, EvalError, YqSemantics};
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     type Value = StandardJson<'a, W>;
@@ -2073,6 +2073,25 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
 
     fn is_empty(&self) -> bool {
         JsonFields::is_empty(self)
+    }
+
+    /// Re-runs the strict validator over this object's own document to name
+    /// the real syntax error, rather than the generic wording the trait
+    /// default has to settle for (#1194).
+    ///
+    /// Reachable only once a malformed member has already been found, so a
+    /// well-formed document never pays for the pass. The cursor is what makes
+    /// this possible here and not in the generic evaluator: `JsonCursor` keeps
+    /// the document text, where `DocumentCursor` exposes only a position.
+    ///
+    /// Falls back to the trait default's shape when the list is somehow empty
+    /// -- there is no cursor to read a document from, and inventing a position
+    /// would be worse than saying less.
+    fn malformed_member_error(&self) -> EvalError {
+        match self.key_cursor {
+            Some(cursor) => EvalError::malformed_json_text(cursor.text()),
+            None => EvalError::new("Invalid JSON text"),
+        }
     }
 
     /// JSON is the one format that can present an unpaired child, so it is

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16266,6 +16266,82 @@ fn test_jq_malformed_object_raises_however_the_value_is_reached_1194() -> Result
     Ok(())
 }
 
+/// #1194: a **non-string key** raises from every route a trailing orphan
+/// does.
+///
+/// The two faults reach different checks -- a bad key is caught per field,
+/// an orphan only once the walk ends and asks `ends_unpaired` -- so the
+/// tests around this one, which all use `{invalid}`, exercise only the
+/// second. `{123: 1, "b": 2}` is the first, and it is the shape whose
+/// symptom this issue opened on: `length` said 2 while `keys` listed one
+/// name.
+#[test]
+fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()> {
+    let input = r#"{123: 1, "b": 2}"#;
+    for args in [
+        &["-c", "."][..],
+        &["-c", "length"][..],
+        &["-c", "keys"][..],
+        &["-c", "to_entries"][..],
+        &["-c", "map_values(.)"][..],
+        &["-c", "-s", "."][..], // --slurp: the owned `to_owned` family
+        &["-c", "-S", "."][..], // --sort-keys: ditto
+        &["-c", "-a", "."][..], // --ascii-output: ditto
+        &["-c", "., ."][..],    // loses its cursor to `Many`
+    ] {
+        let (out, stderr, code) = run_jq_full(args, Some(input))?;
+        assert_eq!(code, 5, "{args:?}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains("jq: error"),
+            "{args:?} must report in jq's channel: {stderr:?}"
+        );
+        // The strict validator's own diagnosis of *this* fault, not the
+        // orphan wording -- getting the cause right is half the fix.
+        assert!(
+            stderr.contains("expected string key"),
+            "{args:?}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1194: every spelling of "how many members does this object have"
+/// agrees.
+///
+/// `length` and `keys | length` reach `effective_len` by different routes
+/// -- `Builtin::Length`'s object arm and `fold_lazy_keys_stage`'s -- and
+/// while only the first was checked, `{invalid} | length` raised at exit 5
+/// while `{invalid} | keys | length` answered `0` at exit 0. That is the
+/// same one-document-two-answers split #1385's postmortem names, which is
+/// what this issue exists to remove, so a fix that leaves it standing has
+/// only moved it one pipe stage along.
+#[test]
+fn test_jq_malformed_object_length_agrees_across_spellings_1194() -> Result<()> {
+    for input in ["{invalid}", r#"{123: 1, "b": 2}"#, r#"{invalid, "b":2}"#] {
+        for filter in ["length", "keys | length", "keys_unsorted | length"] {
+            let (out, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+            assert_eq!(
+                code, 5,
+                "{input} | {filter}: out: {out:?}, stderr: {stderr:?}"
+            );
+        }
+    }
+
+    // And they still agree on a *well-formed* object, including one whose
+    // duplicate key collapses -- the check rides the census walk, so a
+    // mistake there would show up as a wrong count, not just a wrong exit.
+    for (input, expected) in [(r#"{"a":1,"b":2}"#, "2"), (r#"{"a":1,"b":2,"a":3}"#, "2")] {
+        for filter in ["length", "keys | length", "keys_unsorted | length"] {
+            let (out, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+            assert_eq!(code, 0, "{input} | {filter}: stderr: {stderr:?}");
+            assert_eq!(out.trim(), expected, "{input} | {filter}");
+        }
+    }
+
+    Ok(())
+}
+
 /// #1194 stays out of #966's way: a malformed *number* nested inside an
 /// already-recognized container still degrades to `null` at exit 0. This
 /// fix is about object member *structure*, not number grammar, and the two

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16134,33 +16134,47 @@ fn test_jq_keys_unsorted_on_malformed_object_errors_1194() -> Result<()> {
     Ok(())
 }
 
-/// #1194: the fix reaches the *lazy* path only, and `can_use_lazy_path`
-/// (`jq_runner.rs`) is what decides that -- eight conditions, any one of
-/// which routes the whole run through `get_inputs`/`parse_json_stream` and
-/// the infallible `to_owned` family instead, where the malformed member has
-/// already been dropped before any printer sees it.
+/// #1194: a malformed member raises whether or not the run takes the lazy
+/// path.
 ///
-/// `-a`/`--ascii-output` is the surprising member of that list: it reads
-/// like a formatting flag, but it disables the lazy path outright, so even a
-/// plain identity query stops raising. Pinned so the boundary is a decision
-/// rather than a surprise, and so this test fails loudly when #1247 makes
-/// that family fallible and these start raising too.
+/// `can_use_lazy_path` (`jq_runner.rs`) is false for eight flags, and each
+/// routes the whole run through `get_inputs`/`parse_json_stream` and the
+/// `to_owned` family rather than the cursor-writing printers. Until #1247
+/// made that family fallible, this test asserted those flags **stayed
+/// quiet** — `-a` being the surprising member, a formatting flag that
+/// decided whether a document was accepted. It is inverted here, which is
+/// exactly what it was written to announce.
+///
+/// Exit 5, not 1: these errors reach the `ErrorSink`, not `anyhow`. Getting
+/// that wrong is easy and invisible — the message looks right and only the
+/// exit code and the `Error:`-vs-`jq: error` prefix differ — so both are
+/// asserted.
 #[test]
-fn test_jq_malformed_object_quiet_off_the_lazy_path_1194() -> Result<()> {
-    // On the lazy path: raises.
-    let (_out, _stderr, code) = run_jq_full(&["-c", "."], Some("{invalid}"))?;
+fn test_jq_malformed_object_raises_off_the_lazy_path_1194() -> Result<()> {
+    // On the lazy path.
+    let (_out, stderr, code) = run_jq_full(&["-c", "."], Some("{invalid}"))?;
     assert_eq!(code, 5);
+    assert!(stderr.contains("jq: error"), "stderr: {stderr:?}");
 
-    // Off it: still quiet, and the documented gap.
+    // And off it.
     for args in [
         &["-c", "-a", "."][..], // --ascii-output
         &["-c", "-S", "."][..], // --sort-keys
         &["-c", "-s", "."][..], // --slurp
     ] {
-        let (out, _stderr, code) = run_jq_full(args, Some("{invalid}"))?;
-        assert_eq!(code, 0, "{args:?}: out: {out:?}");
-        assert!(out.contains("{}"), "{args:?}: out: {out:?}");
+        let (out, stderr, code) = run_jq_full(args, Some("{invalid}"))?;
+        assert_eq!(code, 5, "{args:?}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains("jq: error"),
+            "{args:?} must report in jq's channel, not anyhow's: {stderr:?}"
+        );
+        assert!(!out.contains("{}"), "{args:?}: out: {out:?}");
     }
+
+    // A genuine I/O failure still takes the `anyhow` path and exits 1 --
+    // the downcast must separate the two, not swallow everything.
+    let (_out, _stderr, code) = run_jq_full(&["-c", ".", "/nonexistent-file-1194"], None)?;
+    assert_eq!(code, 1, "a missing file is not a document error");
 
     Ok(())
 }
@@ -16219,33 +16233,34 @@ fn test_jq_malformed_object_in_stream_keeps_good_documents_1194() -> Result<()> 
     Ok(())
 }
 
-/// #1194: pins where the fix stops, so the boundary is explicit rather than
-/// accidental.
+/// #1194: the filter's shape no longer decides whether a malformed document
+/// is accepted.
 ///
-/// A value that keeps its cursor reaches a printer that checks; one that has
-/// been materialized into an `OwnedValue` went through the infallible
-/// `to_owned`/`cursor_to_owned` family, which dropped the malformed member
-/// before any printer saw it. The filter's *shape* decides which -- a comma
-/// or an `if` costs the value its cursor -- the same cursor-vs-owned split
-/// ADR-0017 already describes for yq's anchor preservation.
+/// A value that keeps its cursor reaches a printer that checks; one that a
+/// comma or an `if` has materialized into an `OwnedValue` goes through the
+/// `to_owned`/`cursor_to_owned` family instead -- the same cursor-vs-owned
+/// split ADR-0017 describes for yq's anchor preservation. While that family
+/// was infallible this test asserted the two halves **disagreed**, with the
+/// materializing side staying quiet; #1247 made it fallible and this closes
+/// the gap on both sides.
 ///
-/// Closing this needs that family to become fallible, which is #1247's
-/// architectural change, not this one's. If a later fix makes these raise,
-/// this test should be inverted and the matching section of
-/// `docs/compliance/jq/limitations.md` deleted.
+/// Kept rather than folded into the sweep above because the point is the
+/// *pairing*: these filters must agree, and a future change that makes one
+/// path fallible without the other should fail here loudly.
 #[test]
-fn test_jq_malformed_object_still_quiet_once_materialized_1194() -> Result<()> {
-    // Keeps its cursor: raises.
+fn test_jq_malformed_object_raises_however_the_value_is_reached_1194() -> Result<()> {
+    // Keeps its cursor.
     for filter in [".", "(.)", "select(true)"] {
         let (out, _stderr, code) = run_jq_full(&["-c", filter], Some("{invalid}"))?;
         assert_eq!(code, 5, "{filter} should raise; out: {out:?}");
+        assert!(out.trim().is_empty(), "{filter}: out: {out:?}");
     }
 
-    // Loses its cursor: still quiet, and this is the documented gap.
+    // Loses it to a comma or a conditional.
     for filter in ["., .", "if .a then 1 else . end"] {
         let (out, _stderr, code) = run_jq_full(&["-c", filter], Some("{invalid}"))?;
-        assert_eq!(code, 0, "{filter}: out: {out:?}");
-        assert!(out.contains("{}"), "{filter}: out: {out:?}");
+        assert_eq!(code, 5, "{filter}: out: {out:?}");
+        assert!(!out.contains("{}"), "{filter}: out: {out:?}");
     }
 
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16173,8 +16173,23 @@ fn test_jq_malformed_object_raises_off_the_lazy_path_1194() -> Result<()> {
 
     // A genuine I/O failure still takes the `anyhow` path and exits 1 --
     // the downcast must separate the two, not swallow everything.
-    let (_out, _stderr, code) = run_jq_full(&["-c", ".", "/nonexistent-file-1194"], None)?;
-    assert_eq!(code, 1, "a missing file is not a document error");
+    //
+    // `-s` is load-bearing, not decoration: the downcast being tested lives
+    // in the *materializing* branch of `run_jq`, and a bare `-c .` leaves
+    // `can_use_lazy_path` true, so it never reaches that branch at all and
+    // exits 1 from a different place entirely. Both spellings are asserted
+    // so the coincidence cannot be mistaken for coverage again.
+    for args in [
+        &["-c", ".", "/nonexistent-file-1194"][..],
+        &["-c", "-s", ".", "/nonexistent-file-1194"][..],
+    ] {
+        let (_out, stderr, code) = run_jq_full(args, None)?;
+        assert_eq!(code, 1, "{args:?}: a missing file is not a document error");
+        assert!(
+            !stderr.contains("Invalid JSON text"),
+            "{args:?} must not be reported as a malformed document: {stderr:?}"
+        );
+    }
 
     Ok(())
 }
@@ -16282,6 +16297,7 @@ fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()
         &["-c", "."][..],
         &["-c", "length"][..],
         &["-c", "keys"][..],
+        &["-c", "keys_unsorted"][..],
         &["-c", "to_entries"][..],
         &["-c", "map_values(.)"][..],
         &["-c", "-s", "."][..], // --slurp: the owned `to_owned` family
@@ -16301,6 +16317,37 @@ fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()
             stderr.contains("expected string key"),
             "{args:?}: stderr: {stderr:?}"
         );
+    }
+
+    Ok(())
+}
+
+/// #1194: `keys` raises on both fault shapes, not just the one.
+///
+/// `DocumentFields::keys` carries two separate raises -- one per field for a
+/// key that will not stringify, one after the walk for a trailing orphan --
+/// and only a document of each shape reaches both. `{invalid}` yields *no*
+/// field at all (its single child has nothing to pair with), so it exercises
+/// only the second and leaves the first cold; `{123: 1, "b": 2}` is the
+/// reverse.
+#[test]
+fn test_jq_malformed_object_keys_raises_on_both_faults_1194() -> Result<()> {
+    for input in [
+        "{invalid}",           // orphan: the post-walk check
+        r#"{123: 1, "b": 2}"#, // bad key: the per-field check
+        r#"{"a":1, "b"}"#,     // orphan *behind* a well-formed field
+    ] {
+        for filter in ["keys", "keys_unsorted"] {
+            let (out, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+            assert_eq!(
+                code, 5,
+                "{input} | {filter}: out: {out:?}, stderr: {stderr:?}"
+            );
+            assert!(
+                stderr.contains("Invalid JSON text"),
+                "{input} | {filter}: stderr: {stderr:?}"
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Description

#1247 made `to_owned`/`cursor_to_owned` return `Result` — the architectural blocker #1194 had
been waiting on since it was tiered Tier 3. This spends it.

The structural half of #1194 — a key JSON's grammar never allowed, or a child with no sibling to
pair as its value — now raises from **every route that materializes the object**, not just the
two cursor-writing printers #1608 could reach:

```console
# before this PR, on main
$ echo '{123: 1, "b": 2}' | sjq -c 'length, keys'   # 2, then ["b"]   exit 0  <- they disagree
$ echo '{invalid}'        | sjq -c to_entries       # []              exit 0
$ echo '{invalid}'        | sjq -c -s .             # [{}]            exit 0
$ echo '{invalid}'        | sjq -c ., .             # {} {}           exit 0

# after
all of the above: exit 5, `jq: error (at <stdin>:0): Invalid JSON text: expected string key, found …`
```

`--ascii-output`, `--sort-keys`, `--slurp` and any filter shape that costs the value its cursor
are all covered. That closes the "a formatting flag decides whether a document is accepted"
oddity #1611 describes, for this fault class.

## Approach

Detection reuses **`DocumentFields::ends_unpaired`**, already on `main` and defaulting to
`false`, so no format whose parser validates pays anything. The message comes from a new
companion, **`malformed_member_error`**, which JSON overrides to re-run its strict validator —
the generic evaluator cannot, because `DocumentCursor` exposes `text_position` but not the
document bytes. One method rather than a literal at each site, so a document reports the same
cause however it is reached.

## The subtle part, which broke four tests first

**Decode failures are deliberately excluded.** An undecodable key (`{"a\q":1}`) has no
stringified name either, but it is #1247's fault with the *opposite* answer — sometimes
preserved verbatim, per #1385's "a key that will not decode is never a duplicate".

The first cut of `malformed_object_member` tested only `key_string().is_none()`, so it reported
an invalid escape as `expected string key`: wrong cause, wrong severity. It broke
`test_undecodable_keys_are_not_duplicates_1385`,
`test_undecodable_object_key_does_not_hide_later_fields_1247` and two others. It now skips
anything `string_decode_error` claims, with a regression test naming why.

## A second bug this surfaced

`parse_json_stream` flattened its `EvalError` into an `anyhow!` string, so the materializing
path exited **1** with an `Error:` prefix jq never prints, where every other route gives exit 5
and `jq: error (at <stdin>:N)`. Pre-existing — reachable on `main` today via
`[xyz123] | sjq -s .` — but this PR makes it reachable for far more inputs, so it is fixed here
rather than filed. Wrapping in the existing downcastable `MalformedJsonError` keeps genuine I/O
failures on the `anyhow` path, pinned by a test that a missing file still exits 1.

## What deliberately still does not raise

Three routes, for two reasons. Two of them stream, so they have no error channel:

```console
$ echo '{invalid}' | sjq -c '.[]'   # no output, exit 0   <- LazySource::Values, `uncons` -> Option
$ echo '[xyz123]'  | sjq -c .       # [null],    exit 0   <- print_json's streaming Error arm
```

Both are what #1247's own design doc calls its **Stage 6**.

The third is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `first`, `last` — which
print a bare `123` where a key name belongs. #1514 and #1599 deliberately took the whole-object
probe *off* those arms (`first` answers from one `uncons_key`), so a check there restores
exactly the walk those issues removed. Filed as **#1629** rather than folded in.

All three are documented in `docs/compliance/jq/limitations.md`.

## Review round 2 (`0db6296ed`)

Review found the check this PR added to `Builtin::Length` answered for one *spelling* of the
question and charged every object for it. Both halves are the same mistake — a guard in front
of a walk instead of inside it — so both are fixed the same way.

**`keys | length` contradicted `length`.** `Builtin::Length`'s object arm and
`fold_lazy_keys_stage`'s both answer from `effective_len`; only the first was guarded:

```console
$ echo '{invalid}'        | sjq -c 'length'          # exit 5
$ echo '{invalid}'        | sjq -c 'keys | length'   # 0, exit 0   <- disagrees
$ echo '{123: 1, "b": 2}' | sjq -c 'keys | length'   # 2, exit 0   <- `keys` itself raised
```

That is the one-document-two-answers split #1385's postmortem names, reintroduced one pipe
stage along.

**The guard cost +64% on `length`.** Interleaved against the merge-base, release builds, 20 MB
generated `wide` document, 9 reps, medians: **0.14s → 0.23s**.

`census` now records `malformed` as it goes — one predicate on the branch `key_hash_of` already
takes for a key that will not stringify (never reached by a well-formed document), plus one O(1)
`ends_unpaired` at the end — and `effective_len_checked` reads it. Both spellings route through
it, so the check is defined once and costs nothing:

| query (20 MB `wide`, 9-15 reps, median) | merge-base | this PR |
|---|---|---|
| `length` | 0.12s | 0.12s |
| `keys \| length` | 0.12s | 0.12s |
| `.` (perf-guard) | 0.49s | 0.49s |
| `keys_unsorted` (perf-guard) | 0.31s | 0.32s |

The no-collapse arm gets `checked_len`, which *replaces* `DocumentFields::len`'s walk rather
than preceding it, and uses `uncons_key` where `len` uses `uncons` — so yq-mode `length` builds
no value cursor and is slightly cheaper than before this PR.

**Tests for the arms that had none.** Patch coverage flagged the bad-key raises in
`to_owned_at_depth`, `to_owned_cursor_at_depth`, `Builtin::Length` and `DocumentFields::keys` as
uncovered: every existing test used `{invalid}`, the *orphan* fault, while the bad-key fault
reaches different checks entirely — the split the code's own comments warn about. Added
`{123: 1, "b": 2}` across nine routes, a spelling-agreement test for all three `length` forms,
and a unit test driving both owned conversions directly (which one a filter lands on is not
something a CLI test can choose).

**Three corrections to `limitations.md`,** two of which were wrong before this branch and were
carried into its rewrite: `--preserve-input` does not echo malformed text verbatim (it raises
like everything else — it changes rendering, not acceptance), and the identity printer emits
nothing only for an object malformed at the *top* level, truncating like `keys_unsorted` when
the malformed object is nested.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (input previously accepted at exit 0 now exits 5)

## Testing

- Full suite green: **5934 passed, 0 failures**, run post-rebase with nothing else on the box.
- **Three tests inverted, not updated** — each existed to announce exactly this:
  #1247's `test_to_entries_silently_drops_non_string_key_known_gap_1247`, and #1608's two
  boundary tests pinning the quiet side of the cursor-vs-owned and lazy-path splits.
- New: `to_entries` on both fault shapes, the decode-vs-structural separation guard, and the
  I/O-still-exits-1 assertion.
- Byte-identical to `/usr/bin/jq` 1.7.1 on a 200 KB generated document across `.`, `.[0]`,
  `keys`, `keys_unsorted`, `length`, `to_entries`, `[.[]|length]`, and on duplicate-key
  collapse across four shapes × four filters.
- Local gate derived from `ci.yml`: `cargo fmt --check`, both clippy legs,
  `cargo check --no-default-features`, `cargo doc` with `-D warnings`.
- Perf guard is valgrind/Linux-only so it runs in CI. `ends_unpaired` is O(1) on an exhausted
  list; the one added walk (`malformed_object_member`) is key-only and sits on `length`/
  `to_entries`, neither of which the guard measures — its six workloads are `keys_unsorted` and
  identity, which are untouched here.

Refs #1194
