### PR TITLE
fix(jq, test, docs): pull range()'s bound arguments lazily

### DIFF
--- a/docs/plan/jq-range-lazy-bounds.md
+++ b/docs/plan/jq-range-lazy-bounds.md
@@ -1,0 +1,327 @@
+# Lazy bound resolution for `range()` (#1556)
+
+[Home](../../) > [Docs](../) > [Plan](./) > Range lazy bounds
+
+**Status: implemented.** This document is the
+deliverable for [#1556](https://github.com/rust-works/succinctly/issues/1556),
+whose own tier review classified it Tier 3 — "changes evaluation shape rather
+than fixing a local mistake... wants a design doc first" — and which a prior
+agent explicitly declined to implement without one, per that same reasoning.
+
+## Problem
+
+`eval_range` (`src/jq/eval.rs`) resolves `range`'s `from`/`to`/`step` bound
+expressions eagerly, via three nested `stream_outputs(eval_single(...))`
+loops — one per bound, `from` outer, `to` middle, `step` inner. `eval_each`,
+the demand-driven dispatch table [#820](https://github.com/rust-works/succinctly/issues/820)
+and [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md) built so
+a wrapping consumer (`first`, `limit(1;...)`, `isempty`, `path(...)`) can stop
+a generator argument mid-stream, has no `Expr::Range` arm, so it falls to the
+catch-all `_ => drain_result(eval_single(expr, value, optional), sink)`. That
+fallback requires `eval_single` to run to completion — meaning the *entire*
+triple-nested eager bound resolution — before the sink ever sees a value.
+
+When a bound is itself a multi-output generator, this means later comma
+branches get evaluated even when an earlier one already satisfies the
+consumer — including branches with side effects (`input`, `stderr`,
+`halt_error`) that real jq's lazy generator semantics would never reach:
+
+```
+$ printf '5\n99\n' | jq -c 'first(range(1, input)), input'
+0
+99
+$ printf '5\n99\n' | succinctly jq -c 'first(range(1, input)), input'
+jq: error (at <stdin>:2): break
+0
+```
+
+`first(range(1, input))`'s bound is `(1, input)`. Its first branch (`1`)
+already produces `range(0;1) = [0]`, a non-empty result, so real jq's
+`label $out | (f, break $out)` desugaring for `first` never asks the
+generator for a second value — `input` is never evaluated, and the trailing
+`, input` at the top level reads the second document (`99`) cleanly.
+succinctly's eager `stream_outputs` call drains `(1, input)` in full before
+`eval_range` produces anything, consuming the second document as a side
+effect of computing a bound the caller never needed past its first value.
+That leaves the top-level `input` queue empty, so the trailing `, input`
+raises the same `break` exhaustion error real jq's own `input` raises when
+the queue genuinely runs dry (`eval.rs`'s `builtin_input`) — misleadingly,
+since here the queue was emptied by an evaluation-order bug, not by the
+program's own request.
+
+## Root cause: confirmed single-evaluator scope
+
+This codebase has two evaluators — `src/jq/eval.rs` (the `QueryResult`/
+`StandardJson` cursor-based one) and `src/jq/eval_generic.rs` (the generic,
+YAML-capable one) — and a fix that only reaches one of them is a documented
+recurring trap ([#1054](https://github.com/rust-works/succinctly/issues/1054)
+missed a reindex-bridge fix this same way). Traced end-to-end for this issue:
+
+- `eval_generic.rs` has **zero** `Expr::Range` handling anywhere — no native
+  arm, no separate range implementation. Every `Range` node it encounters
+  bridges into `eval.rs`'s `eval_single`/`eval_range` via `eval_on_owned` or
+  the top-level `input`-queue bridge (`takes_input_queue_bridge`,
+  `eval_with_cursor_using`).
+- `eval_generic.rs`'s own demand-driven mechanism, `eval_each_generic`, is
+  explicitly scoped (by its own doc comment) to only `Comma`/`Pipe`/`Paren`
+  — it was never meant to mirror `eval.rs`'s wider arm set, and needs no
+  change here.
+- For the exact CLI repro above, tracing the call chain confirms
+  `eval.rs`'s `eval_each` is the evaluator that actually runs:
+  `eval_with_cursor` → (`input`-queue bridge, since the query uses `input`)
+  → `eval_each_owned_collect` → `eval::eval_each_owned` →
+  `eval::eval_each` (`Comma` arm) → `eval_each` on `FirstExpr(Range)` →
+  catch-all → `eval_first_expr` → `each_take_first` → `eval_each` on
+  `Range` → catch-all → `eval_range` (eager). `eval_generic.rs`'s own
+  `each_take_first_generic`/`eval_each_generic` are never entered.
+
+So this is not a repeat of #1054's shape: there is exactly one `range`
+implementation to fix, and it lives entirely in `src/jq/eval.rs`.
+
+## The two questions this design settles
+
+The issue asked for a design pass to settle two things before any code is
+written.
+
+### 1. Reuse `fanout_two_args_lazy`'s shape, not the function
+
+[`fanout_two_args_lazy`](../../src/jq/eval.rs) (#1531,
+[jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)) already
+drives two generator arguments through `eval_each`, nested, with a shared
+`escape: Option<Control>` variable capturing whichever control should
+terminate the whole thing. It is the closest existing precedent for
+"multiple nested lazy pulls, one escape". But it cannot be reused directly:
+it is hardcoded to exactly two arguments, and it returns a `QueryResult`
+rather than a `Flow` — it is itself an ordinary builtin-body helper called
+from `eval_single`-reachable code, not a dispatch-table arm. Only inserting
+an actual `Expr::Range` arm into `eval_each`'s match closes the gap, and
+that arm must be `Flow`/`Demand`-shaped.
+
+`range` needs **three** nested pulls (`from` outer, `to` middle, `step`
+inner — jq's own leftmost-outermost `$`-bound order for its `def range($from;
+$upto; $by)`, already established correctly by the current eager code's
+oracle-verified doc comment, unaffected by this change). The answer: a new
+function, `each_range`, built on `fanout_two_args_lazy`'s nesting/escape
+pattern one level deeper. It stays a bespoke function rather than a
+generalized N-argument helper, for the same reason `eval_range` itself is
+bespoke today
+([Stage 6](jq-generator-argument-fanout.md#L23), verbatim): *"the three
+arities differ enough that a generic 3-argument helper would be all glue."*
+
+### 2. What the new arm owes the dispatch table: the fallback invariant, satisfied by construction
+
+[jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md#the-fallback-invariant-state-it-then-test-it)
+states the obligation every dispatch-table arm has: *for a sink that always
+returns `Demand::Continue`, `eval_each` must deliver exactly the values
+`push_owned_values(eval_single(...), ...)` would collect, in the same order,
+with the same terminal `Control`. A lazy arm can only shrink which
+sub-expressions get evaluated — never change which values are delivered or
+their order.*
+
+Rather than writing `each_range` and keeping `eval_range`'s existing
+triple-nested-loop body as two independently-maintained implementations that
+could silently drift (the recurring lesson behind
+[#106](https://github.com/rust-works/succinctly/issues/106): "duplicated
+predicates diverge silently"), `eval_range` becomes a **thin wrapper** over
+`each_range`: it drives `each_range` with a sink that always answers
+`Demand::Continue`, collecting into a `Vec`, then converts the terminal
+`Flow` back into a `QueryResult`. This is exactly the relationship
+`fanout_two_args` already has with `fanout_two_args_lazy`. The invariant
+holds by construction — there is one implementation of bound resolution and
+value generation, not two.
+
+## Mechanism
+
+```rust
+fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    from: &Expr,
+    to: Option<&Expr>,
+    step: Option<&Expr>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow
+```
+
+Drives `from` through `eval_each` (outer closure); per from-item, drives `to`
+through `eval_each` (middle closure) — except the structurally unreachable
+`to: None` case (the parser always desugars `range(n)` to
+`Range { from: Literal(0), to: Some(n), step: None }`; `to: None` is kept in
+lockstep with `eval_range`'s existing dead branch rather than deleted, per
+that branch's own comment about the `Option` field rippling through six
+rebuild sites for no behavioural gain). Per to-item, if `step` is `Some`,
+drives it through `eval_each` (inner closure); if `step` is `None`, uses the
+literal default `1` directly with no evaluation — matching current behavior,
+since there is nothing to pull.
+
+An `emit` closure turns each fully-resolved `(from_val, to_val, step_val)`
+triple into its value sequence via the existing, unmodified
+`eval_range_values`/`eval_range_values_f64`, and forwards it to `sink` via
+`drain_result(one, sink)` directly rather than a hand-rolled loop.
+`owned_vec_to_result`'s three-variant range (`None`/`Owned`/`ManyOwned`)
+means `drain_result` can only answer `Exhausted` or `Stopped { pending: None
+}` here, so its `Escaped` arm is `unreachable!()` — the same defensive
+pattern `drain_result` itself uses for `QueryResult::OneCursor`.
+
+### Two ways to stop, tracked out-of-band
+
+The driving closures can only answer `Demand`, so two `bool`/`Option`
+locals in `each_range` carry *why* a stop happened, checked in priority
+order once the outer `eval_each(from, ...)` call returns:
+
+- **`sink_stopped: bool`** — set only when the innermost value-emission call
+  reports back that the *wrapping* `sink` returned `Demand::Stop`: the
+  consumer has what it wants, and every remaining bound value at every
+  nesting level is left unevaluated. Collapses to
+  `Flow::Stopped { pending: None }`.
+- **`escape: Option<Control>`** — set when a bound value fails
+  [`range_num`]'s numeric check (Rule 3 below), or when a nested
+  `eval_each(to_expr/step_expr, ...)` call itself returns `Flow::Escaped`
+  (Rule 4 below — some control, e.g. a `halt`, surfaced from inside a
+  bound's own generator). Collapses to `Flow::Escaped(control)`.
+
+These are mutually exclusive by construction: `sink_stopped` is set only
+inside `emit`, and once `escape` is set a closure always returns
+`Demand::Stop` immediately without reaching `emit` again.
+
+### Dropping `pending`, and why that's the right precedent
+
+Whenever a nested `eval_each(to_expr, ...)` or `eval_each(step_expr, ...)`
+call returns `Flow::Stopped { pending }`, the enclosing closure returns
+`Demand::Stop` via `Flow::Stopped { .. } => Demand::Stop` — **without
+reading `pending`**, at every nesting level. `Flow`'s own doc comment
+records that every dispatch-table arm added so far drops `pending` on its
+own local stop except `binary_fanout_each` (which has two operands and must
+pick one — not applicable here, `each_range` has one linear escape chain).
+
+The precedent to cite for this is **`fanout_two_args_lazy`**, not
+`each_limit`. `each_limit` wraps only *one* level of `eval_each` with the
+*ultimate* sink passed straight through, so it must stay transparent to its
+own caller and keeps `pending` verbatim. `fanout_two_args_lazy` is the one
+other function in this file that nests multiple `eval_each` calls under a
+shared `escape`, one level shallower than `each_range` needs — and it
+already drops `pending` unconditionally at both of its own nesting levels.
+(An earlier draft of this design cited `each_limit`; that was corrected
+during review.)
+
+### Confirmed no `escape.is_some()` guard is needed
+
+A closure never needs to check `escape.is_some()` before returning — it is
+provably redundant. `escape` can only be set either directly inside a
+closure immediately before that closure returns `Demand::Stop` (no further
+code in it runs), or via a `match nested_flow { Flow::Escaped(c) => ... }`
+arm, which by construction only fires when the nested call's own `Flow` is
+genuinely `Escaped` — which itself only happens when *no* deeper closure
+decided to stop it (a closure-caused stop always yields `Flow::Stopped`,
+never `Escaped`). So `escape` being set by a deeper frame always surfaces as
+`Flow::Stopped` one level up, which the `Stopped => Demand::Stop` arm
+already handles without consulting `escape` again.
+
+## Behaviour, oracle-verified
+
+Rules 3 and 4 are the two escape-priority rules already established (and
+tested) for the *eager* `eval_range`, from
+[jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)'s rules 3
+and 4, restated here because `each_range` must reproduce them exactly:
+
+| Rule | Query | Result |
+|---|---|---|
+| 3 — failure aborts the loop, keeps the prefix | `jq -cn 'range((1,"x"))'` | `0` on stdout, then `Range bounds must be numeric`, exit 5 |
+| 4 — the builtin's own error can outrank a trailing halt | `jq -cn 'range((1, halt_error(4)); 10)'` | `1` through `9` on stdout, exit 4 |
+
+Both hand-traced through `each_range`'s proposed control flow and confirmed
+to reproduce identically (see `git log`/PR discussion for the full trace);
+both already pass on the current eager binary, so neither regresses.
+
+**A third, previously-undetected divergence, found while validating this
+design and fixed as a side effect** — `path()` around a `range` whose `to`
+bound contains a `halt_error` behind values `path()` never needs:
+
+```
+$ jq -cn 'path(range(1; (2,3,halt_error(9)) + 0))'
+jq: error (at <unknown>): Invalid path expression with result 1   (exit 5)
+$ succinctly jq -cn 'path(range(1; (2,3,halt_error(9)) + 0))'
+(exit 9 — halted, no output)
+```
+
+Today, `eval_range`'s eager `stream_outputs` on the `to` bound fully
+materializes `(2,3,halt_error(9)) + 0` up front as
+`QueryResult::Partial([2,3], Halt(9))`, and that `Partial` reaches
+`resolve_leaf`'s stop-after-first sink directly — one nesting level away —
+which is exactly the shallow shape `resolve_leaf`'s halt-preserving check
+(`eval.rs`, the one path-context consumer that reads `pending` to avoid
+downgrading an already-triggered halt into a catchable path error) is
+designed for, so it fires the halt. Real jq's `path()` is satisfied by the
+very first candidate (`1`) and never asks the `to` generator for a second
+value, so `halt_error(9)` is never reached and jq raises its own path error
+instead. With `each_range`, the same `Partial` is consumed and its
+`pending` dropped *inside* the `to`-level `eval_each` call — three closures
+away from `resolve_leaf` — matching real jq's laziness. `resolve_leaf`'s
+own doc comment already states the general principle this now correctly
+extends to `range`'s bounds (*"`path(range(3))` raises on `0` alone, never
+reaching `1`/`2`"*).
+
+This is a genuine, user-visible exit-code change (9 → 5) on an existing
+construct, in the direction of correctness — recorded here explicitly
+rather than left to be discovered later, and pinned as its own regression
+test.
+
+## Verification
+
+- `eval.rs`'s existing `collect_each` differential-invariant corpus gets new
+  rows: `range(3)`, `range(1;5)`, `range(1;5;2)`, a multi-output-bound row
+  (`range((0,1);(2,3);(1,2))`, matching `eval_range`'s own oracle table),
+  and `range` nested inside `limit`/`if`/`try`.
+- New `tests/jq_cli_tests.rs` cases, via `run_jq_full` (not the
+  `cargo run`-based stdin helper, which builds an uninstrumented binary
+  invisible to coverage):
+  - The headline repro, modeled on
+    `test_compare_operand_consuming_input_documents_1459`: two documents, a
+    control run proving both are seen absent a consumer, then
+    `first(range(1, input)), input` proving the second is never popped.
+  - A negative control: `[range(1, input)]` (no `first`) over two documents
+    still consumes both — the fix must not over-lazify.
+  - Rules 3 and 4 above, and the `resolve_leaf`/`path()` bonus fix.
+  - A `sink_stopped`-via-intermediate-consumer case
+    (`isempty(range(1, ("B"|stderr)))`-shaped), confirming demand
+    propagates correctly when the stopping consumer is not the immediate
+    caller of `range`.
+- One `tests/jq_evaluator_parity_tests.rs` row, per that file's own
+  convention, so a future native `eval_generic.rs` arm cannot silently
+  bypass this fix; plus a yq-mode CLI test confirming `range` still fans
+  out with laziness intact under yq's "unopposed extension" gate.
+
+## Blast radius
+
+Single file: `src/jq/eval.rs`. No `eval_generic.rs` change (confirmed
+above). No `#[cfg]` matrix concerns — `range` has no regex/`no_std` gating
+of its own. yq mode shares the same `<S: EvalSemantics>`-generic evaluator,
+so no separate yq-mode implementation is needed, only parity test coverage.
+One deliberate, documented exit-code change (`path(range(...))` with an
+unreached trailing halt in a bound: 9 → 5), in the direction of jq
+fidelity.
+
+## Follow-ups (explicit non-goals)
+
+- **`MAX_RANGE` (100,000) per-combination cap is unaffected.** This fix
+  lazifies which `(from, to, step)` *combinations* get tried — not how many
+  values one combination can produce. `eval_range_values`/`_f64` are reused
+  unmodified, so each combination still eagerly builds one capped `Vec`
+  before any of its values reach `sink`, exactly as the eager path already
+  does. Out of scope for #1556 (its title and branch name are about bound
+  *arguments*), noted here so it doesn't read as an oversight.
+
+## Related
+
+- [#1556](https://github.com/rust-works/succinctly/issues/1556) — this
+  document's subject.
+- [#1279](https://github.com/rust-works/succinctly/issues/1279),
+  [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md) —
+  `range`'s existing fan-out (Stage 6) and `fanout_two_args_lazy` (#1531),
+  the structural precedent this design extends one level deeper.
+- [#820](https://github.com/rust-works/succinctly/issues/820),
+  [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md) — the
+  `Flow`/`Demand`/`eval_each` machinery and the fallback invariant this
+  design is bound by.
+- [#1054](https://github.com/rust-works/succinctly/issues/1054) — the "two
+  evaluators" trap this design confirms it does not repeat.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2491,9 +2491,10 @@ fn drain_result<'a, W: Clone + AsRef<[u64]>>(
 /// Push every output of `expr` into `sink`, stopping as soon as `sink` says to.
 ///
 /// Native lazy arms: `Comma`, `Pipe`, `Paren`, `Builtin::PathsFilter`
-/// (#987, Stage 3), `Compare` (#1459, Stage 4), and -- #1462, Stage 5 --
-/// `If`, `Try`/`Optional`, `Label`, `As`, `AsPattern`, `FuncDef` and `Limit`.
-/// Everything else falls back to `eval_single` + [`drain_result`]. `Paren`
+/// (#987, Stage 3), `Compare` (#1459, Stage 4), -- #1462, Stage 5 --
+/// `If`, `Try`/`Optional`, `Label`, `As`, `AsPattern`, `FuncDef` and `Limit`,
+/// and -- #1556 -- `Range`. Everything else falls back to `eval_single` +
+/// [`drain_result`]. `Paren`
 /// is not optional cosmetics: `isempty(...)` consumes only its own
 /// parentheses, so `isempty((1, stderr))` is `IsEmpty(Paren(Comma(..)))` and
 /// without this arm the fix would be a coin flip on spelling.
@@ -2654,6 +2655,14 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `each_limit` below forwards every output straight to `sink` and
         // stops on whichever comes first, `n` or `sink` itself.
         Expr::Limit { n, expr } => each_limit::<W, S>(n, expr, value, optional, sink),
+
+        // #1556: `range`'s `from`/`to`/`step` bounds are generator arguments
+        // like any other -- see `each_range`'s own doc comment and
+        // `docs/plan/jq-range-lazy-bounds.md` for why this needs a bespoke
+        // arm rather than reusing `fanout_two_args_lazy`.
+        Expr::Range { from, to, step } => {
+            each_range::<W, S>(from, to.as_deref(), step.as_deref(), value, optional, sink)
+        }
 
         _ => drain_result(eval_single::<W, S>(expr, value, optional), sink),
     }
@@ -3077,6 +3086,152 @@ fn each_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // what `limit` reaches -- same policy as `eval_limit`'s `Escaped`
         // arm (`[limit(3; 1,2,error("x"),4)]` raises).
         Flow::Escaped(control) => Flow::Escaped(control),
+    }
+}
+
+/// Demand-driven twin of [`eval_range`] (#1556): drives `from`, `to`, and
+/// `step` through [`eval_each`] instead of `stream_outputs`, so a wrapping
+/// consumer's [`Demand::Stop`] reaches *inside* the bound expressions
+/// themselves, not just the values `range` finally emits. Nesting order is
+/// unchanged from `eval_range`'s own doc comment: `from` outer, `to`
+/// middle, `step` inner, mirroring jq's own `def range($from; $upto; $by)`.
+///
+/// Two distinct reasons the nest can stop, tracked out-of-band (the driving
+/// closures can only answer `Demand`) -- the same shape
+/// [`fanout_two_args_lazy`]'s `escape` uses, one level deeper:
+///
+/// * `sink_stopped` -- the *wrapping* `sink` returned [`Demand::Stop`] after
+///   receiving a generated value: the consumer has what it wants, so every
+///   remaining bound value at every nesting level is left unevaluated.
+///   Always collapses to `Flow::Stopped { pending: None }`.
+/// * `escape` -- a bound value failed [`range_num`]'s numeric check (rule 3:
+///   `range((1,"x"))` prints `0` then raises), or a nested `eval_each` call
+///   on `to`/`step` itself returned `Flow::Escaped` (rule 4: a `halt`/
+///   `break`/`error` from inside a bound's own generator, deferred until
+///   the prefix already produced is delivered).
+///
+/// Both cases drop any `pending` a nested `to`/`step` call's own
+/// `Flow::Stopped` carries, exactly as [`fanout_two_args_lazy`] already does
+/// at both of *its* nesting levels -- the closest existing precedent for a
+/// multi-level nested-generator combinator in this file, not [`each_limit`]
+/// (which wraps only one level with the ultimate sink passed straight
+/// through, so it has to stay transparent). Live-verified this is what real
+/// jq does even through `path(...)`, where `resolve_leaf` would otherwise be
+/// the one consumer to notice: `path(range(1; (2,3,halt_error(9)) + 0))`
+/// raises "Invalid path expression" in real jq, not halt 9 -- jq never asks
+/// the `to` generator for its second value once `path()`'s first candidate
+/// is enough. See `docs/plan/jq-range-lazy-bounds.md`.
+fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    from: &Expr,
+    to: Option<&Expr>,
+    step: Option<&Expr>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let mut escape: Option<Control> = None;
+    let mut sink_stopped = false;
+
+    // One (from, to, step) combination's values, forwarded to the wrapping
+    // `sink`. Reuses `eval_range_values`/`_f64` and `drain_result` verbatim
+    // -- `MAX_RANGE` is unaffected: each combination still eagerly builds
+    // one capped `Vec` exactly as the eager path does (#1556 is scoped to
+    // the bound expressions, not that pre-existing cap).
+    let mut emit = |from_val: RangeNum, to_val: RangeNum, step_val: RangeNum| -> Demand {
+        let one = match (from_val, to_val, step_val) {
+            (RangeNum::Int(f), RangeNum::Int(t), RangeNum::Int(st)) => {
+                eval_range_values::<W>(f, t, st)
+            }
+            (f, t, st) => eval_range_values_f64::<W>(f.as_f64(), t.as_f64(), st.as_f64()),
+        };
+        match drain_result(one, sink) {
+            Flow::Exhausted => Demand::Continue,
+            Flow::Stopped { .. } => {
+                sink_stopped = true;
+                Demand::Stop
+            }
+            // `owned_vec_to_result` only ever yields `None`/`Owned`/
+            // `ManyOwned`, so `drain_result` can only answer `Exhausted` or
+            // `Stopped { pending: None }` here.
+            Flow::Escaped(_) => unreachable!(
+                "eval_range_values(_f64) never produces an Error/Break/Halt/Partial result"
+            ),
+        }
+    };
+
+    let from_flow = eval_each::<W, S>(from, value.clone(), optional, &mut |from_item| {
+        let from_val = match range_num(&item_to_owned(from_item)) {
+            Ok(n) => n,
+            Err(e) => {
+                escape = Some(Control::Error(e));
+                return Demand::Stop;
+            }
+        };
+
+        let Some(to_expr) = to else {
+            // range(n) -- unreachable from any query today; see
+            // `eval_range`'s own doc comment on this branch.
+            return match from_val {
+                RangeNum::Int(t) => emit(RangeNum::Int(0), RangeNum::Int(t), RangeNum::Int(1)),
+                RangeNum::Float(t) => emit(
+                    RangeNum::Float(0.0),
+                    RangeNum::Float(t),
+                    RangeNum::Float(1.0),
+                ),
+            };
+        };
+
+        let to_flow = eval_each::<W, S>(to_expr, value.clone(), optional, &mut |to_item| {
+            let to_val = match range_num(&item_to_owned(to_item)) {
+                Ok(n) => n,
+                Err(e) => {
+                    escape = Some(Control::Error(e));
+                    return Demand::Stop;
+                }
+            };
+
+            match step {
+                None => emit(from_val, to_val, RangeNum::Int(1)),
+                Some(step_expr) => {
+                    let step_flow =
+                        eval_each::<W, S>(step_expr, value.clone(), optional, &mut |step_item| {
+                            let step_val = match range_num(&item_to_owned(step_item)) {
+                                Ok(n) => n,
+                                Err(e) => {
+                                    escape = Some(Control::Error(e));
+                                    return Demand::Stop;
+                                }
+                            };
+                            emit(from_val, to_val, step_val)
+                        });
+                    match step_flow {
+                        Flow::Exhausted => Demand::Continue,
+                        Flow::Stopped { .. } => Demand::Stop,
+                        Flow::Escaped(control) => {
+                            escape = Some(control);
+                            Demand::Stop
+                        }
+                    }
+                }
+            }
+        });
+
+        match to_flow {
+            Flow::Exhausted => Demand::Continue,
+            Flow::Stopped { .. } => Demand::Stop,
+            Flow::Escaped(control) => {
+                escape = Some(control);
+                Demand::Stop
+            }
+        }
+    });
+
+    if sink_stopped {
+        return Flow::Stopped { pending: None };
+    }
+    match escape {
+        Some(control) => Flow::Escaped(control),
+        None => from_flow,
     }
 }
 
@@ -22569,6 +22724,24 @@ fn range_num(value: &OwnedValue) -> Result<RangeNum, EvalError> {
 }
 
 /// Evaluate `range(n)`, `range(a;b)`, or `range(a;b;step)`.
+///
+/// Every bound is a generator argument, and jq nests them leftmost-outermost
+/// -- `range` is a jq-level `def range($from; $upto; $by)` with all three
+/// `$`-bound, unlike the C builtins that nest rightmost-outermost.
+/// Live-verified against jq 1.7.1:
+///
+///   [range((1,2))]             => [0,0,1]
+///   [range((0,1);(2,3))]       => [0,1,0,1,2,1,1,2]
+///   [range(0;6;(2,3))]         => [0,2,4,0,3]
+///   [range((0,1);(2,3);(1,2))] => [0,1,0,0,1,2,0,2,1,1,1,2,1]
+///
+/// Thin wrapper over [`each_range`] (#1556): drives it with a sink that
+/// always answers `Demand::Continue`, appending every value to `out`, then
+/// converts the terminal `Flow` back into a `QueryResult`. Kept as the
+/// entry point for `eval_single`'s `Expr::Range` arm and every other
+/// non-demand-driven caller (`eval_generic.rs`'s bridge included), so the
+/// bound-resolution/value-generation logic has exactly one implementation
+/// rather than two that can drift -- see `docs/plan/jq-range-lazy-bounds.md`.
 fn eval_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     from: &Expr,
     to: Option<&Expr>,
@@ -22576,97 +22749,19 @@ fn eval_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Every bound is a generator argument, and jq nests them leftmost-outermost
-    // -- `range` is a jq-level `def range($from; $upto; $by)` with all three
-    // `$`-bound, unlike the C builtins that nest rightmost-outermost.
-    // Live-verified against jq 1.7.1:
-    //
-    //   [range((1,2))]             => [0,0,1]
-    //   [range((0,1);(2,3))]       => [0,1,0,1,2,1,1,2]
-    //   [range(0;6;(2,3))]         => [0,2,4,0,3]
-    //   [range((0,1);(2,3);(1,2))] => [0,1,0,0,1,2,0,2,1,1,1,2,1]
-    //
-    // Before this every one of those reported "Range bounds must be numeric",
-    // because `range_arg` matched the whole `QueryResult` and sent
-    // `Many`/`ManyOwned` to its catch-all (#1279).
     let mut out: Vec<OwnedValue> = Vec::new();
+    let flow = each_range::<W, S>(from, to, step, value, optional, &mut |item| {
+        out.push(item.into_owned());
+        Demand::Continue
+    });
 
-    // A bound that is not numeric aborts the remaining loops but keeps the
-    // outputs already produced -- `jq -cn 'range((1,"x"))'` prints `0` and
-    // then raises. Same "abort, keep the prefix" rule `fanout_arg` applies.
-    macro_rules! bound {
-        ($v:expr) => {
-            match range_num($v) {
-                Ok(n) => n,
-                Err(e) => return partial(out, Control::Error(e)),
-            }
-        };
-    }
-
-    let (from_vals, from_ctrl) = stream_outputs(eval_single::<W, S>(from, value.clone(), optional));
-    for from_owned in &from_vals {
-        let from_val = bound!(from_owned);
-
-        let Some(to_expr) = to else {
-            // range(n) means range(0; n).
-            //
-            // Unreachable from any query, and was before #1279 too: the parser
-            // desugars the one-argument form itself, emitting
-            // `Range { from: Literal(0), to: Some(n), step: None }`
-            // (`parse_range_expr`), and every other `Expr::Range` construction
-            // in the tree is a rebuild that threads an existing `to` through.
-            // So nothing ever sets `to: None`, and llvm-cov reports 0 hits
-            // here while the line above it has 65. Kept rather than deleted
-            // because narrowing the AST field to a non-`Option` would ripple
-            // through the parser and six rebuild sites for no behavioural
-            // gain -- noted so a reader does not go looking for the test that
-            // would cover it.
-            let one = match from_val {
-                RangeNum::Int(to) => eval_range_values::<W>(0, to, 1),
-                RangeNum::Float(to) => eval_range_values_f64::<W>(0.0, to, 1.0),
-            };
-            if let Some(control) = push_owned_values(one, &mut out) {
-                return partial(out, control);
-            }
-            continue;
-        };
-
-        let (to_vals, to_ctrl) =
-            stream_outputs(eval_single::<W, S>(to_expr, value.clone(), optional));
-        for to_owned in &to_vals {
-            let to_val = bound!(to_owned);
-
-            // The absent-`step` case is one implicit `1`, so it runs the same
-            // innermost loop once rather than needing a branch of its own.
-            let (step_vals, step_ctrl) = match step {
-                Some(step_expr) => {
-                    stream_outputs(eval_single::<W, S>(step_expr, value.clone(), optional))
-                }
-                None => (vec![OwnedValue::Int(1)], None),
-            };
-            for step_owned in &step_vals {
-                let step_val = bound!(step_owned);
-                let one = match (from_val, to_val, step_val) {
-                    (RangeNum::Int(f), RangeNum::Int(t), RangeNum::Int(st)) => {
-                        eval_range_values::<W>(f, t, st)
-                    }
-                    (f, t, st) => eval_range_values_f64::<W>(f.as_f64(), t.as_f64(), st.as_f64()),
-                };
-                if let Some(control) = push_owned_values(one, &mut out) {
-                    return partial(out, control);
-                }
-            }
-            if let Some(control) = step_ctrl {
-                return partial(out, control);
-            }
-        }
-        if let Some(control) = to_ctrl {
-            return partial(out, control);
-        }
-    }
-    match from_ctrl {
-        Some(control) => partial(out, control),
-        None => owned_vec_to_result(out),
+    match flow {
+        Flow::Escaped(control) => partial(out, control),
+        // This sink never answers `Stop`, so `Stopped` cannot actually
+        // occur -- folded with `Exhausted` rather than `unreachable!()`, the
+        // same defensive choice `any_all_gen_cond`/`binary_fanout_core` make
+        // for the identical impossible-`Stopped` shape.
+        Flow::Exhausted | Flow::Stopped { .. } => owned_vec_to_result(out),
     }
 }
 
@@ -33989,6 +34084,41 @@ mod tests {
             (b"null", "limit(2; 1, 2, 3)"),
             (b"null", "limit(5; 1, 2)"),
             (b"null", "limit(3; 1, 2, error(\"x\"), 4)"),
+            // #1556: `Expr::Range` gained a native lazy arm (`each_range`).
+            // This differential is what guards it against drifting from
+            // `eval_range`'s own bound resolution -- `eval_range` is now
+            // itself a thin wrapper over `each_range`, so in practice this
+            // also exercises that the wrapper's `Flow` -> `QueryResult`
+            // conversion agrees with a bare `eval_single` call, but the
+            // pairing is kept so a future refactor that breaks that
+            // relationship still gets caught here.
+            (b"null", "range(3)"),
+            (b"null", "range(1;5)"),
+            (b"null", "range(1;5;2)"),
+            (b"null", "range(5;1;-1)"),
+            (b"null", "[range(0)]"),
+            (b"null", "range(1.5;4.5)"),
+            // Multi-output bounds -- the leftmost-outermost `$`-bound
+            // nesting order `eval_range`'s own doc comment establishes,
+            // live-verified against jq 1.7.1.
+            (b"null", "range((1,2))"),
+            (b"null", "range((0,1);(2,3))"),
+            (b"null", "range(0;6;(2,3))"),
+            (b"null", "range((0,1);(2,3);(1,2))"),
+            // Error/break/halt terminators from within a bound, side-effect
+            // free so the always-`Continue` sink must still agree exactly.
+            (b"null", "range((1,\"x\"))"),
+            (b"null", "range(\"x\")"),
+            (b"null", "range(1; \"x\")"),
+            (b"null", "range(1; 10; \"x\")"),
+            (b"null", "range((1, error(\"x\")); 10)"),
+            (b"null", "label $o | range((1, break $o); 10)"),
+            // Nested inside the other lazy arms, so `each_range` is also
+            // reached indirectly, mirroring the `limit`/`if`/`try` coverage
+            // pattern established above for the other Stage 5 arms.
+            (b"null", "[limit(2; range(1;10))]"),
+            (b"null", "if true then range(1;4) else 9 end"),
+            (b"null", "try range(1; \"x\") catch 9"),
         ];
 
         for (json, src) in cases {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10106,6 +10106,66 @@ fn test_range_step_bound_propagates_halt() -> Result<()> {
     Ok(())
 }
 
+/// #1556's rule 3: a bound value that fails `range_num`'s numeric check
+/// aborts the remaining loops but keeps the prefix already produced --
+/// `test_range_bound_non_numeric_value_rejected` covers the single-value
+/// case; this is its comma-fanout sibling, distinct because `each_range`
+/// must deliver the `1` branch's full output through a nested `eval_each`
+/// call *before* the `"x"` branch's failure is even reached, not just
+/// reject a single already-materialized value. Live-verified against jq
+/// 1.7.1: `jq -n 'range((1,"x"))'` prints `0` then raises "Range bounds
+/// must be numeric", exit 5.
+#[test]
+fn test_range_bound_fanout_prefix_then_raises_1556() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "range((1,\"x\"))"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("Range bounds must be numeric"), "{stderr}");
+    Ok(())
+}
+
+/// `each_range`'s `from`-closure has its own `range_num` failure arm,
+/// distinct from `to`'s (exercised above) and `step`'s
+/// (`test_range_bound_non_numeric_value_rejected` only ever reaches `to`,
+/// since `range(n)` desugars to `from: Literal(0)`). Covers both the plain
+/// single-value case and the fanout case, where the failure is the *second*
+/// `from` branch and must still abort before `to`/`step` are ever pulled
+/// for it. Live-verified against jq 1.7.1: both exit 5, no stdout.
+#[test]
+fn test_range_from_bound_non_numeric_value_rejected_1556() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "range(\"x\"; 5)"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("Range bounds must be numeric"), "{stderr}");
+
+    let (stdout, stderr, code) = run_jq_full(&["-n", "range((\"x\",1); 5)"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("Range bounds must be numeric"), "{stderr}");
+
+    Ok(())
+}
+
+/// #1556's bonus fix: `path(...)` around a `range` whose `to` bound has a
+/// `halt_error` behind values `path()`'s stop-after-first sink never
+/// demands. Before this fix, `eval_range`'s eager `stream_outputs` fully
+/// materialized the `to` bound as a single `QueryResult::Partial` one
+/// nesting level from `resolve_leaf`'s halt-preserving check, so the halt
+/// fired even though real jq's laziness never reaches it -- `path()` is
+/// already satisfied by the first candidate. With `each_range`, that same
+/// `Partial` is consumed and its `pending` dropped three closures away from
+/// `resolve_leaf`, matching jq. Live-verified against jq 1.7.1: exit 5,
+/// "Invalid path expression with result 1" -- not exit 9.
+#[test]
+fn test_range_bound_path_context_halt_laziness_1556() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "path(range(1; (2,3,halt_error(9)) + 0))"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("Invalid path expression"), "{stderr}");
+    Ok(())
+}
+
 #[test]
 fn test_recurse_cond_propagates_halt_from_f() -> Result<()> {
     // `builtin_recurse_cond`'s `f`-evaluation match, `Err(e) => return
@@ -20607,6 +20667,71 @@ fn test_compare_operand_consuming_input_documents_1459() -> Result<()> {
         "limit over a compare must not pop a document"
     );
 
+    Ok(())
+}
+
+/// `range`'s bound arguments, closed by #1556. `Expr::Range` had no
+/// `eval_each` arm, so a wrapping `first`/`isempty`/`limit(1;...)` could only
+/// drain whatever `eval_range`'s eager `stream_outputs` had already fully
+/// computed -- an `input` in a later comma branch of a bound got popped even
+/// when an earlier branch already satisfied the consumer. Same shape as
+/// `test_compare_operand_consuming_input_documents_1459`, one `Expr` variant
+/// over. Live against jq 1.7.1.
+#[test]
+fn test_range_bound_consuming_input_documents_1556() -> Result<()> {
+    const DOCS: &str = "5\n99\n";
+
+    // Control: every document is processed when nothing consumes the queue.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(DOCS))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "5\n99\n", "control run must see both documents");
+
+    // `first` is satisfied by `range(1, input)`'s first comma branch
+    // (`1` alone gives `range(0;1) = [0]`, non-empty), so `input` in the
+    // second branch is never evaluated and never pops -- the trailing
+    // `, input` reads document 2 cleanly. Before #1556 this raised `break`
+    // at document 2 (already eaten by the bound) and printed only `0`.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(range(1, input)), input"], Some(DOCS))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "0\n99\n",
+        "first(range(...)) must not pop a document its bound never needed"
+    );
+
+    // Negative control: without `first`, jq's own laziness does not apply --
+    // every comma branch of the bound is genuinely needed to enumerate all
+    // of `range`'s outputs, so `input` is consumed and both documents feed
+    // the range. Confirms the fix does not over-lazify.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[range(1, input)] | length"], Some(DOCS))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "100\n",
+        "without a stopping consumer, both branches of the bound must still run"
+    );
+
+    Ok(())
+}
+
+/// `isempty` around `range`: the consumer that stops `range` is reached
+/// through another already-lazy arm, not `range`'s immediate caller.
+/// Confirms `each_range`'s `sink_stopped` signal propagates out through
+/// `isempty`'s own stop-after-first sink, not just a bare `first`. `range`'s
+/// first bound branch (`1`) already gives a non-empty `range(0;1) = [0]`, so
+/// `isempty` is `false` without ever evaluating the `stderr`-writing second
+/// branch. Live-verified identical against jq 1.7.1: `false` then
+/// `"after"` on stdout, nothing on stderr.
+#[test]
+fn test_range_bound_sink_stopped_via_intermediate_consumer_1556() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "isempty(range(1, (\"B\" | stderr))), \"after\""],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "false\n\"after\"\n");
+    assert_eq!(
+        stderr, "",
+        "isempty must stop range before its bound's second comma branch runs"
+    );
     Ok(())
 }
 

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -893,6 +893,37 @@ fn test_parity_number_literal_reaches_more_numeric_arg_builtins_387() {
     assert_parity(br"[2020.0,0,1,0,0,0,3,0]", r#"strftime("%Y-%m-%d")"#);
 }
 
+/// #1556: `range`'s bound resolution moved from a bespoke triple-nested
+/// `stream_outputs` loop to `each_range` (a native `eval_each` lazy arm),
+/// with `eval_range` itself becoming a thin wrapper over it. `eval_generic.rs`
+/// has no `Expr::Range` handling of its own and always bridges into
+/// `eval.rs` for this builtin, so this pins that relationship: a future
+/// native `eval_generic.rs` arm for `Range` cannot silently diverge in the
+/// *values* it produces without this test catching it (laziness itself --
+/// which document `input` pops -- is a CLI-level, not a values-only,
+/// concern, and is covered by `tests/jq_cli_tests.rs` instead).
+#[test]
+fn test_parity_range_multi_output_bounds_1556() {
+    for (json, filter, expected) in [
+        (br"null".as_slice(), "range((1,2))", "[0,0,1]"),
+        (br"null", "range((0,1);(2,3))", "[0,1,0,1,2,1,1,2]"),
+        (br"null", "range(0;6;(2,3))", "[0,2,4,0,3]"),
+        (
+            br"null",
+            "range((0,1);(2,3);(1,2))",
+            "[0,1,0,0,1,2,0,2,1,1,1,2,1]",
+        ),
+    ] {
+        let full = full_outputs(json, &format!("[{filter}]"));
+        assert_eq!(
+            as_strs(&full),
+            [expected],
+            "full evaluator disagrees with jq for `{filter}`"
+        );
+        assert_parity(json, &format!("[{filter}]"));
+    }
+}
+
 /// A slice is a path component (#366), so it reaches `path()`, `getpath`,
 /// `setpath`, `delpaths`, `=`, `|=` and `del()`. The CLI drives the generic
 /// evaluator, which has no `Expr::Slice` arm of its own and round-trips to the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1143,6 +1143,40 @@ fn test_yq_paths_preserves_nested_duplicate_mapping_keys_868() -> Result<()> {
     Ok(())
 }
 
+/// #1556: `range`'s bound resolution moved to a native `eval_each` lazy arm
+/// (`each_range`), shared unmodified with yq mode via `<S: EvalSemantics>`.
+/// yq mode has no `input` builtin at all, so the jq-mode headline repro
+/// (`first(range(1, input)), input`) doesn't apply here -- this instead
+/// pins the two things that do: multi-output bound fan-out still produces
+/// the same values (Stage 6, unaffected by this refactor), and a wrapping
+/// `isempty` still stops `range` before a later comma branch's `stderr`
+/// write runs (`isempty`/`range` are both succinctly extensions in yq mode,
+/// gated behind `--jq-extensions`).
+#[test]
+fn test_yq_range_multi_output_bound_fanout_and_laziness_1556() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        "[range((0,1);(2,3))]",
+        "null\n",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
+    assert_eq!(code, 0, "out: {output:?}");
+    assert_eq!(output.trim(), "[0,1,0,1,2,1,1,2]");
+
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        "isempty(range(1, (\"B\" | stderr))), \"after\"",
+        "null\n",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
+    assert_eq!(code, 0, "out: {output:?} stderr: {stderr:?}");
+    assert_eq!(output, "false\n\"after\"\n");
+    assert_eq!(
+        stderr, "",
+        "isempty must stop range before its bound's second comma branch runs"
+    );
+
+    Ok(())
+}
+
 /// Updated for #1398: `paths` on `--input-format json` input must now agree
 /// with YAML input (both preserve every duplicate-key occurrence, matching
 /// `to_entries`'s own format-independent behavior) rather than applying


### PR DESCRIPTION
## Summary

- `eval_range`'s `from`/`to`/`step` bound expressions were resolved eagerly via `stream_outputs`, and `Expr::Range` had no arm in `eval_each`'s demand-driven dispatch table — so a wrapping `first()`/`limit(1;...)`/`isempty()`/`path()` could only drain whatever the eager triple-nested loop had already fully computed, not intervene early. A multi-output bound containing a side-effecting generator (e.g. `input`) got drained past the point real jq's own laziness would ever reach it.
- Adds `each_range`, a native `eval_each` arm that pulls `from`/`to`/`step` through `eval_each` instead of `stream_outputs`, nested in the same leftmost-outermost order already established for the eager fan-out (`fanout_two_args_lazy`'s escape/stop-tracking shape, one level deeper). `eval_range` becomes a thin wrapper over `each_range` so bound-resolution logic has exactly one implementation rather than two that could drift.
- Fixes a bonus divergence found while validating the design: `path(range(...))` around a bound with an unreached trailing `halt_error` used to fire the halt anyway; now matches jq (exit 5, "Invalid path expression", not exit 9).
- Full design rationale in [`docs/plan/jq-range-lazy-bounds.md`](docs/plan/jq-range-lazy-bounds.md).

Fixes #1556.

## Test plan

- [x] `cargo test --features cli,regex` — 0 failures across the full suite (unit, CLI, golden, evaluator-parity, doctests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (CI's second leg)
- [x] `cargo build --no-default-features` — builds (no_std)
- [x] Every oracle claim in the diff (rule 3/4 escape priority, the `input`-consuming repro, the `path()`/`halt_error` exit-code change, multi-output bound fan-out values) independently re-verified live against pinned `jq` 1.7.1 and cross-checked against the built `succinctly` binary — byte-identical output in every case