### PR TITLE
fix(jq): stop string-repeat panicking, add yq's own allocation cap

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -627,6 +627,22 @@ refuses with `Cannot grow array to <n> elements` — succinctly's own wording, s
 no jq sentence to copy. Only the impossible is refused; every length that fits in memory
 still pads, so `[1,2] | setpath([5]; 9)` still agrees with jq.
 
+String repetition (`s * n`) has the identical shape (#1612): `n` comes from the document, so
+`"ab" * 1e30` asks for a byte length `String::repeat` cannot even represent, which used to
+panic with `capacity overflow` rather than the `EvalError` `setpath`'s own case above already
+gets. Confirmed live, jq itself does not error on this filter at all — it just keeps running
+rather than answering promptly (never observed to terminate one way or the other; there is no
+jq sentence to reproduce because no output was ever captured to reproduce). succinctly now
+refuses with `Cannot repeat string to <n> bytes` — succinctly's own wording — once the
+requested allocation cannot actually be made, checked via `String::try_reserve_exact` rather
+than the infallible `String::repeat` (the same technique the `setpath` case above already
+uses): this covers both an unrepresentable byte length (past `isize::MAX`) and a
+representable-but-genuinely-unallocatable one alike, in one guard. Every length that fits
+still repeats, so `"ab" * 3` and #1230's float-count cases are unaffected.
+
+This guard is jq-mode-only. See [yq Limitations](../yq/limitations.md) for `succinctly yq`
+mode, which refuses much earlier via its own, separate cap.
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -658,7 +658,7 @@ conversion).
 Not divergences — these are ADR-0018 rule 2 working correctly. The same filter text means
 different things in `sjq` and `syq` because the two reference tools disagree, and succinctly
 follows each one in its own mode. The behavioural axis is `EvalSemantics`
-([src/jq/eval.rs](../../../src/jq/eval.rs)) — eleven `const`s plus an `EvalTag` identity tag
+([src/jq/eval.rs](../../../src/jq/eval.rs)) — twelve `const`s plus an `EvalTag` identity tag
 — together with a handful of `S::TAG` tests at individual call sites:
 
 | Behaviour | `succinctly jq` (jq 1.7.1) | `succinctly yq` (yq v4.53.3) |
@@ -677,9 +677,10 @@ follows each one in its own mode. The behavioural axis is `EvalSemantics`
 | `2.0 == 2` | `true` | `false` (strict int/float distinction) |
 | Bare `halt_error` exit code | `5` | `1` |
 | `7 + null` / `null - 7` | `7` / error | error / `7` |
+| String-repeat (`s * n`) allocation limit | none — refuses only once the allocation genuinely can't be made (#1612) | explicit ~10MiB cap (`MAX_STRING_REPEAT_BYTES`), matching real yq's own deliberate refusal before any allocation is attempted |
 
-Ten of these rows are `EvalSemantics` constants, each carrying its live-verification note in
-the trait's doc comments — `7 + null` / `null - 7` is one row over two constants,
+Eleven of these rows are `EvalSemantics` constants, each carrying its live-verification note
+in the trait's doc comments — `7 + null` / `null - 7` is one row over two constants,
 `ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE` and `SUB_LEFT_NULL_IS_IDENTITY`. **Four are not.**
 Bare `sub`, container `@uri`/`@base64`, and `@base64d`'s malformed-padding strictness are all
 `S::TAG == EvalTag::Yq` tests at their call sites in

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -147,6 +147,31 @@ pub trait EvalSemantics: Copy + Default {
     /// The jq CLI's `--preserve-input` extension keeps every occurrence
     /// regardless, via its own `jq_compat` gate -- ADR-0018 rule 5.
     const COLLAPSE_DUPLICATE_KEYS: bool;
+    /// A deliberate, artificial byte-length cap string-repeat (`s * n`)
+    /// refuses past, entirely separate from whatever the host can actually
+    /// allocate — `None` for jq, which has no such cap and lets any count
+    /// through to a real allocation attempt, exactly as jq does. `arith_mul`'s
+    /// own string-repeat arm still guards *that* attempt itself, via
+    /// `try_reserve_exact` rather than an infallible `String::repeat`
+    /// (#1612, same technique #1017's own `pad_with_nulls` already
+    /// established for this bug class) — so jq mode refusing past this
+    /// cap is not the only thing standing between a huge `n` and the
+    /// embedder's process going down; it is jq mode's *only* refusal, but
+    /// yq mode's own cap fires first, well before its own `try_reserve_exact`
+    /// call would ever have anything to say.
+    ///
+    /// yq is different: real yq v4.53.3 refuses *before* attempting the
+    /// allocation at all, with its own explicit, deliberate safety cap.
+    /// Confirmed live: `"ab" * 5242880` (10485760 bytes) succeeds; `"ab" *
+    /// 5242881` (10485762 bytes) refuses with `result of repeating string
+    /// (2 bytes) by 5242881 would exceed 10485760 bytes` — the boundary is
+    /// an exact `10 * 1024 * 1024`, not an approximation. Matching this
+    /// (rather than relying solely on `try_reserve_exact` catching a real
+    /// allocation failure) keeps `succinctly yq` bug-for-bug faithful to
+    /// yq's own deliberately conservative behavior, not just crash-free —
+    /// a count `try_reserve_exact` alone would happily allocate (a few
+    /// hundred MB, say) still must refuse in yq mode, since real yq does.
+    const MAX_STRING_REPEAT_BYTES: Option<u128>;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -171,6 +196,7 @@ impl EvalSemantics for JqSemantics {
     const ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE: bool = false;
     const SUB_LEFT_NULL_IS_IDENTITY: bool = false;
     const COLLAPSE_DUPLICATE_KEYS: bool = true;
+    const MAX_STRING_REPEAT_BYTES: Option<u128> = None;
 }
 
 /// yq-compatible evaluation semantics.
@@ -197,6 +223,7 @@ impl EvalSemantics for YqSemantics {
     const ADD_RIGHT_NULL_REQUIRES_CONCAT_TYPE: bool = true;
     const SUB_LEFT_NULL_IS_IDENTITY: bool = true;
     const COLLAPSE_DUPLICATE_KEYS: bool = false;
+    const MAX_STRING_REPEAT_BYTES: Option<u128> = Some(10 * 1024 * 1024);
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -4309,7 +4336,50 @@ fn arith_mul<S: EvalSemantics>(
                     if n < 0 {
                         Ok(OwnedValue::Null)
                     } else {
-                        Ok(OwnedValue::String(s.repeat(n as usize)))
+                        // `n` comes from the document, so an absurd count
+                        // asks for an absurd allocation (#1612, same class
+                        // as `cannot_grow_array`/#1017). `u128` for the
+                        // product avoids overflow happening a second time,
+                        // in the multiplication used to compute *whether*
+                        // it overflows.
+                        let total = s.len() as u128 * n as u128;
+                        // yq mode refuses outright past its own deliberate
+                        // cap, before ever attempting an allocation -- see
+                        // `MAX_STRING_REPEAT_BYTES`'s own doc comment.
+                        if let Some(max) = S::MAX_STRING_REPEAT_BYTES {
+                            if total > max {
+                                return Err(string_repeat_would_exceed_cap(s.len(), n, max));
+                            }
+                        }
+                        // jq mode has no cap of its own and simply attempts
+                        // the allocation, exactly as jq does -- but
+                        // `try_reserve_exact`, not `String::repeat`
+                        // directly, same technique #1017's own
+                        // `pad_with_nulls` already established for this bug
+                        // class. `String::repeat` answers *either* an
+                        // unrepresentable byte length (past what an
+                        // allocator `Layout` permits: `isize::MAX`, not
+                        // `usize::MAX` -- Rust's own allocator API requires
+                        // every layout's size to fit an `isize`) *or* a
+                        // representable-but-actually-unallocatable one
+                        // (genuine OOM) the same unconditional way: a panic
+                        // for the former, an abort for the latter -- both
+                        // take the embedder's process down regardless.
+                        // `try_reserve_exact` reports *both* as an
+                        // `Err(TryReserveError)` instead, so this closes the
+                        // whole class in one guard rather than only the
+                        // Layout-overflow half of it.
+                        let Ok(len) = usize::try_from(total) else {
+                            return Err(cannot_repeat_string(total));
+                        };
+                        let mut result = String::new();
+                        if result.try_reserve_exact(len).is_err() {
+                            return Err(cannot_repeat_string(total));
+                        }
+                        for _ in 0..n {
+                            result.push_str(&s);
+                        }
+                        Ok(OwnedValue::String(result))
                     }
                 }
                 // Type mismatch -- `left`/`right` were never consumed by
@@ -4321,6 +4391,29 @@ fn arith_mul<S: EvalSemantics>(
             }
         }
     }
+}
+
+/// Refusal for a string-repeat byte length that cannot be allocated (jq
+/// mode only reaches this — yq mode's own `MAX_STRING_REPEAT_BYTES` cap
+/// always refuses first, well before this bound).
+///
+/// Not a jq sentence: confirmed live, jq does not error on any filter that
+/// reaches this — it just keeps running rather than answering promptly
+/// (`"ab" * 1e30` was still running after several seconds, never observed
+/// to terminate one way or the other) — so there is no wording to
+/// reproduce here. See `docs/compliance/jq/limitations.md`.
+fn cannot_repeat_string(total: u128) -> EvalError {
+    EvalError::new(format!("Cannot repeat string to {total} bytes"))
+}
+
+/// Real yq v4.53.3's own wording for its `MAX_STRING_REPEAT_BYTES` cap,
+/// reproduced verbatim (confirmed live) — `s_len`/`n` name the *inputs*
+/// (the string's own byte length and the repeat count), not `total`, which
+/// yq's own message doesn't otherwise mention.
+fn string_repeat_would_exceed_cap(s_len: usize, n: i64, max: u128) -> EvalError {
+    EvalError::new(format!(
+        "result of repeating string ({s_len} bytes) by {n} would exceed {max} bytes"
+    ))
 }
 
 /// Merge two values for `*`/`*=` where `right` merges into a position
@@ -35231,6 +35324,102 @@ mod tests {
         // (jqlang/jq#1593).
         query!(br#"{"s": "ab", "n": -1.5}"#, ".s * .n",
             QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    /// #1612: a repeat count from the document can ask for a byte length
+    /// no allocation can ever satisfy -- either because it doesn't even fit
+    /// an allocator `Layout` (past `isize::MAX`, not `usize::MAX`), which
+    /// used to make `String::repeat` answer with an unconditional
+    /// `capacity overflow` *panic*, or because it's representable but the
+    /// host genuinely has no that much memory, which used to abort the
+    /// process on real allocation failure -- `try_reserve_exact` (not
+    /// `String::repeat` directly) reports both the same way, as a catchable
+    /// `EvalError`. jq mode has no cap of its own beyond what can actually
+    /// be allocated; ordinary large-but-representable counts still succeed
+    /// exactly as before
+    /// (`test_arithmetic_mul_string_repetition_float_count_1230`'s own
+    /// cases are unaffected by this fix). Both operand orderings share the
+    /// same match arm (`s * n` and `n * s`), so both are exercised here.
+    #[test]
+    fn test_arithmetic_mul_string_repetition_overflow_1612() {
+        query!(br#"{"s": "ab", "n": 123456789012345678901234567890}"#, ".s * .n",
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("Cannot repeat string to"), "{}", e.message);
+            }
+        );
+        // The other operand ordering (`n * s`) is a *different* match-arm
+        // pattern, not just a swapped argument to the same code -- must be
+        // exercised on its own.
+        query!(br#"{"s": "ab", "n": 123456789012345678901234567890}"#, ".n * .s",
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("Cannot repeat string to"), "{}", e.message);
+            }
+        );
+        // A product that overflows `usize` itself (not just `isize`) --
+        // needs a 3+ byte string, since `2 * i64::MAX` alone still (just)
+        // fits a 64-bit `usize`.
+        query!(br#"{"s": "abc", "n": 123456789012345678901234567890}"#, ".s * .n",
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("Cannot repeat string to"), "{}", e.message);
+            }
+        );
+        // A count that fits `usize` but not `isize` (`Layout`'s own
+        // requirement) still refuses -- not just counts that overflow
+        // `usize` outright.
+        query!(br#"{"s": "ab", "n": 9223372036854775807}"#, ".s * .n",
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("Cannot repeat string to"), "{}", e.message);
+            }
+        );
+        // Positive `infinite` truncates (via `as i64`) to the same
+        // `i64::MAX` saturation, previously an unguarded hang/OOM hazard
+        // (#1199's own review found and deliberately left this uncovered);
+        // now refuses cleanly like any other unrepresentable count.
+        query!(br#"{"s": "ab"}"#, ".s * infinite",
+            QueryResult::Error(e) => {
+                assert!(e.message.starts_with("Cannot repeat string to"), "{}", e.message);
+            }
+        );
+        // Ordinary large-but-representable counts are unaffected.
+        query!(br#"{"s": "ab", "n": 1000000}"#, ".s * .n",
+            QueryResult::Owned(OwnedValue::String(s)) if s.len() == 2_000_000 => {}
+        );
+    }
+
+    /// #1612: real yq v4.53.3 never relies on the OS at all -- it refuses
+    /// with its own explicit, deliberate cap (confirmed live: exactly
+    /// `10 * 1024 * 1024` bytes succeeds, one more refuses), which is *far*
+    /// below `isize::MAX` and so a genuine additional divergence beyond
+    /// jq mode's own capacity-overflow guard: without this, `succinctly yq`
+    /// still crashed (a real allocator abort, not a Rust panic, but the
+    /// same "takes the embedder's process down" outcome) on a count well
+    /// under `isize::MAX` but past what any real machine can allocate.
+    #[test]
+    fn test_yq_arithmetic_mul_string_repetition_cap_1612() {
+        // Exactly at the cap: succeeds.
+        yq_query!(br#"{"s": "ab", "n": 5242880}"#, ".s * .n",
+            QueryResult::Owned(OwnedValue::String(s)) if s.len() == 10_485_760 => {}
+        );
+        // One byte over: refuses, with real yq's own exact wording.
+        yq_query!(br#"{"s": "ab", "n": 5242881}"#, ".s * .n",
+            QueryResult::Error(e) => {
+                assert_eq!(
+                    e.message,
+                    "result of repeating string (2 bytes) by 5242881 would exceed 10485760 bytes"
+                );
+            }
+        );
+        // A count nowhere near `isize::MAX` still refuses in yq mode --
+        // the case that used to reach a real allocator abort.
+        yq_query!(br#"{"s": "ab", "n": 999999999999999999}"#, ".s * .n",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("would exceed 10485760 bytes"), "{}", e.message);
+            }
+        );
+        // jq mode's own cases are unaffected by the yq-only cap.
+        query!(br#"{"s": "ab", "n": 5242881}"#, ".s * .n",
+            QueryResult::Owned(OwnedValue::String(s)) if s.len() == 10_485_762 => {}
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15861,15 +15861,16 @@ fn test_jq_binary_op_success_paths_unaffected_1199() -> Result<()> {
 /// negative, so it takes the existing negative-count-returns-null branch
 /// instead).
 ///
-/// Positive `infinite` (and a very large finite magnitude like `1e10`) are
-/// deliberately not covered here: truncating either yields a huge repeat
-/// count fed to `String::repeat`, an unbounded-allocation hang/OOM hazard,
-/// not a panic -- and that exact hazard already exists, unguarded, for a
-/// same-magnitude `Int` operand (`"ab" * 10000000000`) on `main` today, so
-/// it's a pre-existing characteristic of this arm rather than something
-/// #1230 introduced. Live-verified against real jq: `timeout 3 jq -cn
-/// '(infinite) * "ab"'` hangs (no output, no error) rather than rejecting
-/// the input, so there's no clean "must error" behavior to pin here either.
+/// Positive `infinite` used to be deliberately uncovered here: truncating it
+/// saturates to `i64::MAX`, a huge repeat count that used to reach
+/// `String::repeat` unguarded (an unbounded-allocation hang/OOM hazard, not
+/// a panic -- confirmed live against real jq at the time: `timeout 3 jq -cn
+/// '(infinite) * "ab"'` hangs, no output, no error). #1612 closed that
+/// hazard (`try_reserve_exact` instead of `String::repeat` directly), so
+/// this is now exactly the same "byte length no allocator can satisfy"
+/// case as the huge-`Int`-operand cases pinned in
+/// `test_arithmetic_mul_string_repetition_overflow_1612` (`src/jq/eval.rs`)
+/// -- covered by name there instead of duplicated here.
 ///
 /// Note real jq's own `nan * "ab"` returns `null` (verified: jq-1.7.1),
 /// not `""` -- but that's `(int)NaN` C-cast undefined behavior (platform-
@@ -21870,6 +21871,60 @@ fn test_jq_reduce_reconstruction_step_no_longer_promotes_next_step_write_1590() 
     assert_eq!(stdout, "", "must not write: stderr: {stderr:?}");
     assert!(
         stderr.contains(r#"Invalid path expression with result {"a":1}"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1612's own repro, run through the real CLI process end-to-end (not
+/// just the library-level `EvalError` path) -- the whole point of the fix
+/// is that this no longer panics with a Rust `capacity overflow` message
+/// and `RUST_BACKTRACE` note (exit 101), but exits cleanly with a jq-style
+/// error (exit 5) instead. Confirmed live against jq 1.7.1: jq itself does
+/// not error on this filter at all -- it just keeps running rather than
+/// answering promptly (never observed to terminate one way or the other),
+/// so there is no oracle wording to match here, only the requirement that
+/// succinctly dies cleanly instead of with a panic.
+#[test]
+fn test_jq_string_repeat_huge_count_does_not_panic_1612() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".s * .n"],
+        Some(r#"{"s":"ab","n":123456789012345678901234567890}"#),
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Cannot repeat string to"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1612's guard is shared by the compound-assignment route too
+/// (`.path *= n` desugars through `eval_compound_assign` into
+/// `eval_update`, a textually distinct evaluator path from the bare `*`
+/// above) -- confirmed here rather than assumed, since a future change to
+/// `eval_update`'s own error handling could regress this route
+/// independently of `arith_mul` itself while the bare-`*` test above stays
+/// green.
+#[test]
+fn test_jq_string_repeat_huge_count_compound_assign_does_not_panic_1612() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".s *= .n"],
+        Some(r#"{"s":"ab","n":123456789012345678901234567890}"#),
+    )?;
+    assert_eq!(stdout, "", "must not write: stderr: {stderr:?}");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Cannot repeat string to"),
         "stderr: {stderr:?}"
     );
     assert_eq!(code, 5, "stderr: {stderr:?}");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21989,3 +21989,48 @@ fn test_yq_accepts_multibyte_utf8_1242() -> Result<()> {
     assert_eq!(output.trim(), r#"{"a":"café","b":"日本語","c":"😀"}"#);
     Ok(())
 }
+
+/// #1612's yq-mode cap, run through the real CLI process end-to-end --
+/// real yq's own explicit ~10MiB safety cap means `succinctly yq` must
+/// answer with yq's own specific wording (`would exceed 10485760 bytes`),
+/// not jq mode's generic `Cannot repeat string to <n> bytes` -- confirming
+/// the cap fires *before* any allocation is even attempted, the same way
+/// real yq's own refusal does, rather than happening to produce the same
+/// outcome by coincidentally also failing a real allocation attempt.
+#[test]
+fn test_yq_string_repeat_cap_does_not_abort_1612() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".s * .n", "s: ab\nn: 999999999999999999\n", &[])?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("memory allocation"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("would exceed 10485760 bytes"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1612's yq-mode cap is shared by the compound-assignment route too
+/// (`.path *= n`, a textually distinct evaluator path from the bare `*`
+/// above) -- see the sibling jq-mode test's own doc comment for why this
+/// is checked independently rather than assumed.
+#[test]
+fn test_yq_string_repeat_cap_compound_assign_does_not_abort_1612() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".s *= .n", "s: ab\nn: 999999999999999999\n", &[])?;
+    assert_eq!(stdout, "", "must not write: stderr: {stderr:?}");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("memory allocation"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("would exceed 10485760 bytes"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`arith_mul`'s string-repetition arm (`"s" * n`) ended in an unguarded `s.repeat(n as usize)`. `n` comes from the document, so an absurd count asks for an absurd allocation — same class as #1017's `setpath` fix (`cannot_grow_array`), at a different site:

```
$ echo '{"s":"ab","n":123456789012345678901234567890}' | jq -c '.s * .n'
                                                              # grinds; no panic
$ echo '{"s":"ab","n":123456789012345678901234567890}' | succinctly jq -c '.s * .n'
thread 'main' panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow                                            # exit 101
```

## Fix

Same technique #1017's own `pad_with_nulls` already established for this bug class: `String::try_reserve_exact` instead of the infallible `String::repeat`. This closes the **whole** crash class in one guard, not just the Layout-overflow half of it — a representable-but-genuinely-unallocatable byte length (real OOM, no overflow involved) used to abort the process too, and the issue's own acceptance criteria had explicitly left that direction unfixed as "matches jq's own OOM-kill." `try_reserve_exact` reports both failure modes as a catchable `EvalError` uniformly, so this covers strictly more than the issue's own minimum bar with no extra guard logic to maintain. jq mode has no cap of its own beyond what can actually be allocated; every length that fits still repeats, so `"ab" * 3` and #1230's float-count cases are unaffected.

**yq mode:** while verifying the dual-mode acceptance criterion, found real yq v4.53.3 never relies on the OS at all — it refuses *before* attempting the allocation, with its own explicit, deliberate ~10MiB cap:

```
$ echo '{"s":"ab","n":999999999999999999}' | yq -c '.s * .n'
Error: result of repeating string (2 bytes) by 999999999999999999 would exceed 10485760 bytes
```

Confirmed live: exactly `10 * 1024 * 1024` bytes succeeds, one more refuses — and the cap applies even to an already-large *input* string times `1`, not just a large repeat count. Added `MAX_STRING_REPEAT_BYTES` to `EvalSemantics` (`None` for jq, `Some(10 * 1024 * 1024)` for yq, checked before the allocation attempt) and reproduced yq's own wording verbatim — full parity, recorded in `docs/compliance/yq/limitations.md`'s mode-difference table rather than as a divergence, since it isn't one.

## Caught mid-fix

An earlier version of this patch passed the byte-length *product* to `String::repeat` instead of the repeat *count* itself, silently **doubling** every result. `"ab" * 3` gave 12 characters instead of 6. The huge-count acceptance criteria alone would never have exposed this — only live-testing the ordinary small-`n` case caught it before it went out.

## Code review

A `high`-effort, six-agent `/code-review` pass found real issues in the first version of this fix, all addressed:

- The jq-mode guard as first written only closed the Layout-overflow half of the crash class (a hand-derived `isize::MAX` check) — replaced with `try_reserve_exact` outright, closing the full class (see above).
- The yq-cap documentation had landed in the jq-mode limitations page instead of yq's own — moved, and the mode-difference table gained a row.
- A few claims about real jq's own behavior overclaimed beyond what was actually live-observed ("OOM-killed by the OS" where only "keeps running, never observed to terminate" was confirmed) — reworded throughout.
- Test coverage was missing for the `n * s` operand ordering, the `.path *= n` compound-assignment route in both modes, the exact `usize`-overflow boundary (needs a 3+ byte string), and positive `infinite` (a hazard #1199's own review had explicitly left uncovered — now closed by this fix) — all added.
- A fifth finding — unguarded `keys.len() * targets.len()` capacity multiplications at several unrelated computed-index call sites, the identical bug class at different sites — filed separately as #1634, since it needs its own live repro and oracle check per site.

## Result

Both modes verified against their own pinned oracle (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4.53.3) for the fix's own cases and #1230's existing float-count cases (unaffected).

Fixes #1612

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] Diffed output against pinned real `jq` 1.7.1 and Homebrew `yq` v4.53.3 directly (10-shape oracle probe + boundary/cap checks, including the large-string-times-1 yq shape)
- [x] `high`-effort, six-agent `/code-review` pass; all findings addressed (see above)
- [x] New unit tests: `test_arithmetic_mul_string_repetition_overflow_1612` (jq mode, both operand orderings, `usize`/`isize` boundaries, positive `infinite`), `test_yq_arithmetic_mul_string_repetition_cap_1612` (yq mode, exact cap boundary)
- [x] New CLI tests: `test_jq_string_repeat_huge_count_does_not_panic_1612`, `test_jq_string_repeat_huge_count_compound_assign_does_not_panic_1612`, `test_yq_string_repeat_cap_does_not_abort_1612`, `test_yq_string_repeat_cap_compound_assign_does_not_abort_1612`
- [x] `docs/compliance/jq/limitations.md` and `docs/compliance/yq/limitations.md` updated (ADR-0018)
- [x] Patch coverage: 100% (53/53 new lines)
