### PR TITLE
fix(yaml,json): decode the real UTF-8 char in validator error messages

### DIFF
--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -219,9 +219,9 @@ impl<'a> Validator<'a> {
             Some(b'-' | b'0'..=b'9') => self.validate_number(),
             Some(b't' | b'f' | b'n') => self.validate_keyword(),
             Some(b'+') => Err(self.error(ValidationErrorKind::LeadingPlus)),
-            Some(c) => Err(self.error(ValidationErrorKind::UnexpectedCharacter {
+            Some(_) => Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                 expected: "JSON value",
-                found: c as char,
+                found: crate::text::utf8::decode_char_at(self.input, self.offset),
             })),
             None => Err(self.error(ValidationErrorKind::UnexpectedEof {
                 expected: "JSON value",
@@ -267,7 +267,7 @@ impl<'a> Validator<'a> {
             if self.peek() != Some(b'"') {
                 return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                     expected: "string key",
-                    found: self.peek().map_or('\0', |b| b as char),
+                    found: crate::text::utf8::decode_char_at(self.input, self.offset),
                 }));
             }
             self.validate_string()?;
@@ -277,7 +277,7 @@ impl<'a> Validator<'a> {
             if self.peek() != Some(b':') {
                 return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                     expected: "':'",
-                    found: self.peek().map_or('\0', |b| b as char),
+                    found: crate::text::utf8::decode_char_at(self.input, self.offset),
                 }));
             }
             self.advance();
@@ -304,10 +304,10 @@ impl<'a> Validator<'a> {
                     self.advance();
                     return Ok(());
                 }
-                Some(c) => {
+                Some(_) => {
                     return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                         expected: "',' or '}'",
-                        found: c as char,
+                        found: crate::text::utf8::decode_char_at(self.input, self.offset),
                     }));
                 }
                 None => {
@@ -357,10 +357,10 @@ impl<'a> Validator<'a> {
                     self.advance();
                     return Ok(());
                 }
-                Some(c) => {
+                Some(_) => {
                     return Err(self.error(ValidationErrorKind::UnexpectedCharacter {
                         expected: "',' or ']'",
-                        found: c as char,
+                        found: crate::text::utf8::decode_char_at(self.input, self.offset),
                     }));
                 }
                 None => {
@@ -512,8 +512,8 @@ impl<'a> Validator<'a> {
 
                 Ok(())
             }
-            Some(c) => Err(self.error(ValidationErrorKind::InvalidEscape {
-                sequence: c as char,
+            Some(_) => Err(self.error(ValidationErrorKind::InvalidEscape {
+                sequence: crate::text::utf8::decode_char_at(self.input, self.offset),
             })),
             None => Err(self.error(ValidationErrorKind::UnclosedString)),
         }
@@ -1089,6 +1089,64 @@ mod tests {
         assert!(matches!(
             err.kind,
             ValidationErrorKind::InvalidEscape { sequence: 'q' }
+        ));
+    }
+
+    /// The byte after `\` (or at any other `UnexpectedCharacter`/`InvalidEscape`
+    /// offset) can be the lead byte of a multi-byte UTF-8 sequence; the
+    /// reported character must be the real decoded one, not a Latin-1 cast of
+    /// its lead byte (#1422).
+    #[test]
+    fn test_unexpected_character_decodes_multibyte_char_1422() {
+        let err = validate("\"\\日\"".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::InvalidEscape { sequence: '日' }
+        ));
+
+        let err = validate("{日: 1}".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "string key",
+                found: '日'
+            }
+        ));
+
+        let err = validate("{\"a\"日1}".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "':'",
+                found: '日'
+            }
+        ));
+
+        let err = validate("[1,2日".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "',' or ']'",
+                found: '日'
+            }
+        ));
+
+        let err = validate("{\"a\":1 日}".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "',' or '}'",
+                found: '日'
+            }
+        ));
+
+        let err = validate("🎉".as_bytes()).unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ValidationErrorKind::UnexpectedCharacter {
+                expected: "JSON value",
+                found: '🎉'
+            }
         ));
     }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -564,6 +564,46 @@ pub fn decode_code_point(input: &[u8]) -> Option<(u32, usize)> {
     Some((cp, len))
 }
 
+/// Decode the character at `offset` in `bytes` for embedding in an error message.
+///
+/// Three-way fallback (settled by #1187 for `yaml/parser.rs`'s
+/// `err_unexpected_char`, generalized here so `yaml/validate.rs` and
+/// `json/validate.rs` can share it instead of each re-deriving their own):
+/// a byte that starts a valid, complete UTF-8 sequence decodes to its real
+/// character; a byte that's present but doesn't decode (a bare continuation
+/// byte, an invalid lead byte, or a sequence truncated before `bytes` ends)
+/// falls back to a Latin-1 cast of that one byte, not `'\0'` -- a NUL would
+/// silently misrepresent a present-but-malformed byte as absent; only a
+/// fully out-of-bounds `offset` (true EOF) is `'\0'`.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::text::utf8::decode_char_at;
+///
+/// // ASCII
+/// assert_eq!(decode_char_at(b"abc", 1), 'b');
+///
+/// // Multi-byte
+/// assert_eq!(decode_char_at("a日b".as_bytes(), 1), '日');
+///
+/// // Truncated/invalid sequence -- Latin-1 fallback on the lead byte
+/// assert_eq!(decode_char_at(&[0x41, 0xE6], 1), 0xE6 as char);
+///
+/// // Past the end of input -- true EOF
+/// assert_eq!(decode_char_at(b"abc", 3), '\0');
+/// ```
+pub fn decode_char_at(bytes: &[u8], offset: usize) -> char {
+    match bytes.get(offset) {
+        None => '\0',
+        Some(&byte) => bytes
+            .get(offset..)
+            .and_then(decode_code_point)
+            .and_then(|(cp, _len)| char::from_u32(cp))
+            .unwrap_or(byte as char),
+    }
+}
+
 /// Encode a Unicode code point as UTF-8.
 ///
 /// Returns `None` if the code point is invalid (surrogate or > U+10FFFF).

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1018,22 +1018,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// hand, and 7 of the 8 used `self.peek().map_or('\0', |b| b as char)`
     /// -- a Latin-1 cast, not a real UTF-8 decode, so a multi-byte character
     /// at the offending position rendered as mojibake instead of itself.
-    /// Decodes via [`crate::text::utf8::decode_code_point`] instead,
+    /// Decodes via [`text::utf8::decode_char_at`] instead, which (#1422)
+    /// generalized this function's own three-way fallback logic into a
+    /// shared primitive `yaml/validate.rs` and `json/validate.rs` also use,
     /// against the byte slice starting at `offset` (not just the one byte
     /// `self.peek()`/`self.input[offset]` would give, which isn't enough to
     /// decode a multi-byte sequence).
-    ///
-    /// Three cases, matching the old per-site fallbacks exactly rather than
-    /// collapsing them together: true EOF (`offset` past the end) is `'\0'`,
-    /// same as the old `self.peek().map_or('\0', ...)`. A byte that *is*
-    /// present but doesn't decode as valid UTF-8 there (a lone continuation
-    /// byte, an invalid lead byte, or a sequence truncated by EOF) falls
-    /// back to the old Latin-1 cast of that one byte, not `'\0'` -- an
-    /// earlier version of this helper used `'\0'` for this case too, which
-    /// silently embedded a literal NUL byte into the error string for any
-    /// malformed (not just missing) input, something the old per-site code
-    /// never did (a raw byte cast never fails). Only a byte that decodes
-    /// correctly gets the real, corrected character.
     ///
     /// Takes `offset` explicitly rather than reading `self.pos`: the one
     /// site with a genuinely different call shape
@@ -1041,8 +1031,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// via a local scan cursor, before `self.pos` itself has advanced past
     /// it.
     ///
-    /// The `None` (true-EOF) arm carries no coverage from any test, before
-    /// or after this helper's own introduction: two of the 8 call sites
+    /// The `None`/true-EOF fallback inside `decode_char_at` carries no
+    /// coverage from any test reaching *this* function, before or after
+    /// #1187's introduction of it: two of the 8 call sites
     /// (`parse_flow_sequence_inner`/`parse_flow_mapping_inner`'s comma
     /// checks) have their own dedicated `self.peek().is_none()` ->
     /// `YamlError::UnexpectedEof` guard immediately before reaching this
@@ -1053,18 +1044,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// rigor as `parse_block_scalar_header`'s catch-all below, so kept as a
     /// real (not `unreachable!()`) fallback rather than a proven-dead one.
     fn err_unexpected_char(&self, offset: usize, context: &'static str) -> YamlError {
-        let char = match self.input.get(offset) {
-            None => '\0',
-            Some(&byte) => self
-                .input
-                .get(offset..)
-                .and_then(text::utf8::decode_code_point)
-                .and_then(|(cp, _len)| char::from_u32(cp))
-                .unwrap_or(byte as char),
-        };
         YamlError::UnexpectedCharacter {
             offset,
-            char,
+            char: text::utf8::decode_char_at(self.input, offset),
             context,
         }
     }

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1447,8 +1447,8 @@ impl<'a> Validator<'a> {
             b'x' => self.scan_hex_escape(2),
             b'u' => self.scan_hex_escape(4),
             b'U' => self.scan_hex_escape(8),
-            other => Err(self.error(YamlValidationErrorKind::InvalidEscape {
-                sequence: other as char,
+            _other => Err(self.error(YamlValidationErrorKind::InvalidEscape {
+                sequence: crate::text::utf8::decode_char_at(self.input, self.offset),
             })),
         }
     }
@@ -1813,6 +1813,21 @@ mod tests {
             kind(b"---\ndouble: \"quoted \\' scalar\"\n"),
             InvalidEscape { sequence: '\'' }
         )); // HRE5
+    }
+
+    #[test]
+    fn rejects_invalid_escape_decodes_multibyte_char_1422() {
+        // The byte after `\` can be the lead byte of a multi-byte UTF-8
+        // sequence; the reported `sequence` must be the real character, not
+        // a Latin-1 cast of its lead byte (#1422).
+        assert!(matches!(
+            kind("---\na: \"\\日\"\n".as_bytes()),
+            InvalidEscape { sequence: '日' }
+        ));
+        assert!(matches!(
+            kind("---\na: \"\\🎉\"\n".as_bytes()),
+            InvalidEscape { sequence: '🎉' }
+        ));
     }
 
     #[test]

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -227,6 +227,39 @@ fn test_invalid_escape_sequence() -> Result<()> {
     Ok(())
 }
 
+/// The byte an `UnexpectedCharacter`/`InvalidEscape` error reports can be the
+/// lead byte of a multi-byte UTF-8 sequence; the CLI must render the real
+/// decoded character, not a Latin-1-cast mojibake byte (#1422).
+#[test]
+fn test_invalid_escape_sequence_multibyte_char_not_mojibake_1422() -> Result<()> {
+    let (_, stderr, exit_code) = run_validate_stdin("\"\\日\"", &["--no-color"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains('日'),
+        "stderr should contain '日': {stderr}"
+    );
+    assert!(
+        !stderr.contains('æ'),
+        "stderr should not contain mojibake 'æ': {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_unexpected_character_multibyte_char_not_mojibake_1422() -> Result<()> {
+    let (_, stderr, exit_code) = run_validate_stdin("{日: 1}", &["--no-color"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        stderr.contains('日'),
+        "stderr should contain '日': {stderr}"
+    );
+    assert!(
+        !stderr.contains('æ'),
+        "stderr should not contain mojibake 'æ': {stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_invalid_control_character() -> Result<()> {
     // Tab character directly in string (should be escaped as \t)

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -273,3 +273,21 @@ fn test_yaml_validate_accepts_multibyte_utf8_1242() -> Result<()> {
     assert_eq!(code, 0, "stderr: {stderr}");
     Ok(())
 }
+
+/// The byte after `\` in a bad double-quoted escape can be the lead byte of
+/// a multi-byte UTF-8 sequence; the CLI must render the real decoded
+/// character, not a Latin-1-cast mojibake byte (#1422).
+#[test]
+fn test_yaml_validate_invalid_escape_multibyte_char_not_mojibake_1422() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("a: \"\\日\"\n", &["--no-color"])?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains('日'),
+        "stderr should contain '日': {stderr}"
+    );
+    assert!(
+        !stderr.contains('æ'),
+        "stderr should not contain mojibake 'æ': {stderr}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`src/yaml/validate.rs`'s `scan_double_quoted_escape` and five sites in
`src/json/validate.rs` (`UnexpectedCharacter`/`InvalidEscape`) construct their
error message's character via a raw `byte as char` cast on the offending
byte. When that byte is the lead byte of a multi-byte UTF-8 sequence, the
error message renders mojibake instead of the real character (e.g. `"\日"`
reports `'æ'` instead of `'日'`).

#1187 fixed the identical pattern in `src/yaml/parser.rs` via a private
`err_unexpected_char` helper that does a real UTF-8 decode with a documented
three-way fallback (decodes correctly → real char; present-but-invalid byte →
Latin-1 cast of that byte; true EOF → `'\0'`). This PR generalizes that logic
into a new public primitive, `text::utf8::decode_char_at(bytes, offset) -> char`,
and threads it through both validators' error sites instead of duplicating the
logic a second and third time.

**A sixth site, not enumerated by the issue**: `json/validate.rs`'s own
`validate_escape` catch-all (`InvalidEscape { sequence: c as char }`) has the
identical bug — the byte after `\` in a bad escape can itself be a multi-byte
lead byte. Fixed alongside the five the issue named, since it's the exact same
bug in the exact same file.

**Left alone, per the issue's own scope note** (verified against current
`main`): `yaml/validate.rs`'s bracket-related `as char` casts (`scan_flow`'s
`UnclosedFlow`/`UnbalancedFlow`, `doc_marker_char`) only ever cast a byte
already matched against a specific ASCII literal (`[`, `]`, `{`, `}`, `-`,
`.`), so the cast is always safe there — confirmed by re-reading each call
site, not just trusting the issue text.

## Verification

Manually confirmed against the built binary, contrasted with an unmodified
`main` build:

```
$ printf 'a: "\\日"\n' | main-succinctly yaml validate
error: invalid escape sequence '\æ'          # mojibake, pre-fix
$ printf 'a: "\\日"\n' | fixed-succinctly yaml validate
error: invalid escape sequence '\日'          # real character, post-fix
```

Same contrast reproduced for `json validate` on a bad object key (`{日: 1}`).

## Test plan

- [x] New unit tests: `yaml::validate::tests::rejects_invalid_escape_decodes_multibyte_char_1422`,
      `json::validate::tests::test_unexpected_character_decodes_multibyte_char_1422`
      (covers all 6 fixed json sites + the 1 yaml site, plus a 4-byte emoji case)
- [x] New CLI integration tests in `tests/json_validate_tests.rs` and
      `tests/yaml_validate_tests.rs` asserting the real character appears in
      stderr and the mojibake byte does not
- [x] New doctest on `decode_char_at`
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`): all green
- [x] Both required clippy legs (`--all-features` and the non-scalar-yaml
      feature set) clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features` (no_std) still builds

Fixes #1422