### PR TITLE
docs(plan): catalog #1556's design doc, fix its stale Range table row

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -26,6 +26,7 @@ These plans are kept for:
 | [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md)     | Partial     | `src/jq/eval.rs`                  | Demand-driven sink for short-circuiting consumers |
 | [jq-duplicate-key-collapse.md](jq-duplicate-key-collapse.md)         | Implemented | `src/jq/`, `jq_runner.rs`         | jq-mode duplicate object key collapse             |
 | [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output  |
+| [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound-argument resolution          |
 | [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                      |
 
 ## Archived Plans

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -604,22 +604,23 @@ its own captured state and returns `Demand::Stop`, then inspects that state afte
 
 Each checked against the oracle. "already correct" means succinctly matches jq today.
 
-| Arm                                        | Needed for #820/#932/#987? | Note                                                                                                    |
-|--------------------------------------------|----------------------------|---------------------------------------------------------------------------------------------------------|
-| `Iterate`, `Range`, literals, field/index  | no, ever                   | side-effect-free producers; the drain already stops per value                                           |
-| `Break`                                    | no, ever                   | a leaf returning `QueryResult::Break`; drain maps it to `Escaped`                                       |
-| `And`/`Or`/`Alternative`                   | no — already correct       | `false and ("B"\|stderr)` etc. agree today                                                              |
-| `If` (branch selection)                    | no — already correct       | `eval_fanout` evaluates only the taken branch                                                           |
-| `If` (generator inside a branch)           | no                         | but `first(if true then (1,("B"\|stderr)) else 9 end)` leaks. Stage 5                                   |
-| `Try`/`Optional`                           | no                         | but `first(try (1,("B"\|stderr)) catch 9)` leaks. Stage 5                                               |
-| `Label`                                    | no                         | but `first(label $o \| (1,("B"\|stderr)))` leaks. Stage 5                                               |
-| `AsPattern`                                | no                         | but `first(1 as $x \| (1,("B"\|stderr)))` leaks. Stage 5                                                |
-| `FuncCall`/`FuncDef`                       | no                         | but `def f: (1,("B"\|stderr)); first(f)` leaks. Stage 5                                                 |
-| `FirstExpr`/`Limit`/`NthExpr` as producers | no                         | but `isempty(limit(3; 1, ("B"\|stderr)))` leaks — demand does not forward *through* a consumer. Stage 5 |
-| `Reduce`/`Foreach`                         | no                         | `reduce` has one output; `foreach`'s #534 fork machinery is a non-goal                                  |
-| **`Compare`**                              | **yes — for #932**         | Stage 4; see below                                                                                      |
-| **`Builtin::PathsFilter`**                 | **yes — for #987**         | Stage 3                                                                                                 |
-| **`Builtin::Inputs`**                      | **yes — for #1309**        | Stage 3.5. The one arm that is a *correctness* fix, not an optimization — see below                     |
+| Arm                                        | Needed for #820/#932/#987? | Note                                                                                                                                         |
+|--------------------------------------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `Iterate`, literals, field/index           | no, ever                   | side-effect-free producers; the drain already stops per value                                                                                |
+| `Range` (own numeric output)               | no, ever                   | side-effect-free values; but its `from`/`to`/`step` *bound* expressions needed a native arm after all — #1556, see `jq-range-lazy-bounds.md` |
+| `Break`                                    | no, ever                   | a leaf returning `QueryResult::Break`; drain maps it to `Escaped`                                                                            |
+| `And`/`Or`/`Alternative`                   | no — already correct       | `false and ("B"\|stderr)` etc. agree today                                                                                                   |
+| `If` (branch selection)                    | no — already correct       | `eval_fanout` evaluates only the taken branch                                                                                                |
+| `If` (generator inside a branch)           | no                         | but `first(if true then (1,("B"\|stderr)) else 9 end)` leaks. Stage 5                                                                        |
+| `Try`/`Optional`                           | no                         | but `first(try (1,("B"\|stderr)) catch 9)` leaks. Stage 5                                                                                    |
+| `Label`                                    | no                         | but `first(label $o \| (1,("B"\|stderr)))` leaks. Stage 5                                                                                    |
+| `AsPattern`                                | no                         | but `first(1 as $x \| (1,("B"\|stderr)))` leaks. Stage 5                                                                                     |
+| `FuncCall`/`FuncDef`                       | no                         | but `def f: (1,("B"\|stderr)); first(f)` leaks. Stage 5                                                                                      |
+| `FirstExpr`/`Limit`/`NthExpr` as producers | no                         | but `isempty(limit(3; 1, ("B"\|stderr)))` leaks — demand does not forward *through* a consumer. Stage 5                                      |
+| `Reduce`/`Foreach`                         | no                         | `reduce` has one output; `foreach`'s #534 fork machinery is a non-goal                                                                       |
+| **`Compare`**                              | **yes — for #932**         | Stage 4; see below                                                                                                                           |
+| **`Builtin::PathsFilter`**                 | **yes — for #987**         | Stage 3                                                                                                                                      |
+| **`Builtin::Inputs`**                      | **yes — for #1309**        | Stage 3.5. The one arm that is a *correctness* fix, not an optimization — see below                                                          |
 
 **`Builtin::Inputs` breaks the "un-lazified is only a missed optimization" rule.**
 `drain_result`'s invariant is stated over *the values delivered to this sink*; it says


### PR DESCRIPTION
## Summary

Two small doc-only gaps found while reviewing #1556 / PR #1632, neither caught in that PR:

- `docs/plan/README.md`'s index table never got a row for `jq-range-lazy-bounds.md` — every other implemented plan doc is cataloged there.
- `docs/plan/jq-lazy-generator-consumers.md`'s "arms deliberately not lazified" table still grouped `Range` with `Iterate`/literals/field-index under "no, ever [needed]" — true of `range`'s own numeric output, but #1556 added exactly a native `Expr::Range` arm because its `from`/`to`/`step` *bound* expressions did need one. Split the row and pointed it at the new doc so a future reader isn't misled.

No code changes.

## Test plan

- Docs only — n/a