### PR TITLE
docs(docs): index the range() lazy-bounds design doc, cross-link its origin

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -27,6 +27,7 @@ These plans are kept for:
 | [jq-duplicate-key-collapse.md](jq-duplicate-key-collapse.md)         | Implemented | `src/jq/`, `jq_runner.rs`         | jq-mode duplicate object key collapse             |
 | [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output  |
 | [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                      |
+| [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound resolution                   |
 
 ## Archived Plans
 

--- a/docs/plan/jq-generator-argument-fanout.md
+++ b/docs/plan/jq-generator-argument-fanout.md
@@ -356,6 +356,9 @@ run `./scripts/sync-jq-golden.sh` with the pinned jq on `PATH`.
 - [#820](https://github.com/rust-works/succinctly/issues/820) and [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md) — the opposite bug, and the source of the rule that an ordinary builtin's argument may never get a stopping sink.
 - [#840](https://github.com/rust-works/succinctly/issues/840) — `sub`/`gsub` multi-output replacement; closed by Stage 9.
 - [#1045](https://github.com/rust-works/succinctly/issues/1045), [#1164](https://github.com/rust-works/succinctly/issues/1164) — the zero-output and trailing-escape fixes this work completes.
+- [#1556](https://github.com/rust-works/succinctly/issues/1556) and
+  [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md) — the sixth review finding (below),
+  closed by its own design doc rather than branch-local like the other five.
 - [ADR-0018](../adrs/adr-0018.md) — the reference-fidelity rule the yq gates answer to.
 
 ## Follow-ups
@@ -389,7 +392,12 @@ its resolved prefix), [#1534](https://github.com/rust-works/succinctly/issues/15
 `FirstOnly` gate emitting a value it then raises over),
 [#1537](https://github.com/rust-works/succinctly/issues/1537) (the `ArgFanout` dispatch
 duplicated five times), and the single-argument half of
-[#1533](https://github.com/rust-works/succinctly/issues/1533).
+[#1533](https://github.com/rust-works/succinctly/issues/1533). The sixth,
+[#1556](https://github.com/rust-works/succinctly/issues/1556), was `range`'s own bound
+resolution — left on the eager `stream_outputs` pattern from the start (Stage 6's own
+bespoke-triple-loop decision, above), not one of #1531's shared `fanout_arg`/`fanout_two_args`
+call sites — and needed its own design pass rather than a branch-local fix; see
+[jq-range-lazy-bounds.md](jq-range-lazy-bounds.md).
 
 #1531's lazy pull is the one that changed a documented conclusion: it closed the last golden
 known-failure, the #820 eager-argument residue this design had recorded as out of scope.


### PR DESCRIPTION
## Summary

Small housekeeping follow-up to #1632 (#1556), noticed while checking for loose ends after that PR merged:

- `docs/plan/README.md`'s "Active Plans" table lists every design doc in the directory except the new `jq-range-lazy-bounds.md` — nothing in CI enforces this, so it would have silently stayed missing.
- `docs/plan/jq-generator-argument-fanout.md`'s "Review findings on this work" section says a review "found six further defects" but only names five (#1531, #1532, #1534, #1537, #1533) — the sixth was #1556, left unnamed since it hadn't been resolved yet at the time that section was written. Now names it and cross-links from the Related section too.

No code changes.

## Test plan

- [x] Doc-only change; verified the new table row's column widths match the rest of the table exactly (70/13/35/51 chars), and both new relative links (`jq-range-lazy-bounds.md`) resolve to files that exist in the same directory.