### PR TITLE
perf(jq): reclaim the ~5% yq full-consumption cost from #1599's streaming lazy-keys arm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -806,6 +806,13 @@ For detailed documentation on optimization techniques used in this project, see 
   - Outputs byte-identical pre↔post on all 80 yq A/B configurations
   - Key insight: derive, don't store, what the text already encodes; transient build allocations can dwarf the retained structure (2-bit-per-byte scratch was 6-13× the stored bitvector)
   - See [docs/parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-](docs/parsing/yaml.md#o4-seq_items-bitvector-elimination--accepted-) for full analysis
+- ✅ O5 (Lazy-Keys Cursor+Value Reuse): **-5.3% to -8.4%** on yq/jq queries that walk every key, issues #1599/#1606/#1609
+  - `each_lazy_keys_iterate_sink`'s streaming `keys_unsorted` arm (#1599) discarded each key's already-decoded value and let downstream re-derive it via a second `V::Cursor::value()` resolve — for YAML a full scalar decode, not a cheap re-read
+  - New `GenericItem::OneCursorValue(V::Cursor, V)` variant carries the value through instead; 3 edits in `src/jq/eval_generic.rs`, no changes to `document.rs`/`yaml/light.rs`/`json/light.rs`
+  - **Measured** (Apple M4 Pro, interleaved A/B, 100K/1M-key flat mappings): walks-all shape -5.3% to -8.4% (both yq and jq), early-exit shape unchanged (within noise) — #1599's -34% early-exit win fully preserved, batching-window idea #1609 floated was not needed
+  - `size_of::<GenericItem<V>>()` measured unchanged (176/192 bytes) — the new variant fit inside the enum's existing footprint, no boxing needed
+  - Key insight: a doc comment naming a redundancy (#1514) can be verified by reading the call graph, not just profiled; format-dependent magnitude (YAML full decode vs JSON single-byte dispatch) doesn't mean the underlying inefficiency isn't present in the cheaper format too
+  - See [docs/parsing/yaml.md#o5-lazy-keys-cursorvalue-reuse--accepted-](docs/parsing/yaml.md#o5-lazy-keys-cursorvalue-reuse--accepted-) for full analysis
 - ✅ O5 (CS-Poppy Combined Sampling for BP Select): **4× smaller YAML select index**, mixed select1 speed by platform, issue #64
   - Replaced `WithSelect`'s sampled `(word, cumulative)` pairs with `WithCsPoppy`: `u32` entry points into BP's own rank directory (`rank_l1`/`rank_l2`) instead of a parallel structure
   - Step A (narrow `SelectIndex<u32>` for BP, `len <= u32::MAX` bits) + Step B (`WithCsPoppy`) together take the BP select index from 25% to 6.25% of the bitmap — a 4x reduction, measured via real `select_heap_size()`, not derived

--- a/docs/parsing/yaml.md
+++ b/docs/parsing/yaml.md
@@ -5119,6 +5119,130 @@ removed O(1) bit test.
 
 ---
 
+## O5: Lazy-Keys Cursor+Value Reuse — Accepted ✅
+
+**Issues**: [#1599](https://github.com/rust-works/succinctly/issues/1599) (streamed
+`keys_unsorted` fan-out, origin of the trade this closes),
+[#1606](https://github.com/rust-works/succinctly/pull/1606) (partial fix: `YamlFields`
+`uncons_key` override, +11.1% → +5.0%), [#1609](https://github.com/rust-works/succinctly/issues/1609)
+(this issue: the remaining ~5%)
+
+### Problem
+
+`each_lazy_keys_iterate_sink`'s `!sorted` (`keys_unsorted`/yq `keys`) arm
+([src/jq/eval_generic.rs](../../src/jq/eval_generic.rs)) streams `DistinctKeyCursors`
+directly into the pipe driver — a big win for early-exit consumers (#1599), but on a query
+that walks every key and matches none, it regressed **+5.0%** in yq mode versus the older
+collect-then-drive path. #1606 closed roughly half of that (+11.1% → +5.0%) by giving
+`YamlFields` its own `uncons_key` override; this issue is the residue.
+
+Root cause: `DistinctKeyCursors::next()` ([src/jq/document.rs](../../src/jq/document.rs))
+calls `uncons_key()`, which already decodes each key's value (needed for the duplicate-key
+hash probe) — but the construction site threw that value away and kept only the cursor:
+
+```rust
+DistinctKeyCursors::new(fields, collapse)
+    .map(|(_, cursor)| Ok(GenericItem::OneCursor(cursor)))
+```
+
+Downstream, `continue_pipe_element_generic`'s `OneCursor` arm calls `c.value()` to get the
+value back — the *same* `YamlCursor::value()` resolve `uncons_key()` already ran, a second
+time, per key. For YAML that is not a cheap re-read: root check, `is_container()`, seq-item
+unwrap, alias/anchor handling, a block-vs-scalar lookahead, and for plain scalars a `\n`
+scan. JSON's `JsonCursor::value()` is a cheap single-byte dispatch, which is why the
+equivalent JSON shape was *not* regressed by #1599 — the mechanism is real but
+format-dependent in magnitude, exactly matching what #1609 observed.
+
+### Solution
+
+A new `GenericItem` variant, `OneCursorValue(V::Cursor, V)`, carries the already-decoded
+key alongside its cursor so the second decode never happens. Three edits, all in
+`src/jq/eval_generic.rs`:
+
+1. `enum GenericItem` gains `OneCursorValue(V::Cursor, V)`, documented as a one-site-only
+   optimization — every other cursor site (`.[]` iteration via `uncons_cursor`, etc.) has no
+   value decoded yet, so pairing one in there would be new cost, not a freebie.
+2. The construction site keeps the value instead of discarding it:
+   `.map(|(value, cursor)| Ok(GenericItem::OneCursorValue(cursor, value)))`.
+3. `continue_pipe_element_generic` gets a new arm identical to `OneCursor`'s, minus the
+   `c.value()` call. `generic_item_to_result` (the only other exhaustive match the compiler
+   forces) collapses `OneCursorValue` back to plain `GenericResult::OneCursor`, deliberately
+   dropping the pre-decoded value — its only caller is `first(...)`/`last(...)`'s
+   single-item capture, once per builtin call rather than once per key, so re-deriving there
+   costs nothing that matters.
+
+No changes to `document.rs`, `yaml/light.rs`, `json/light.rs`, or the older, JSON-only,
+non-generic evaluator (`src/jq/eval.rs` — its own `keys`/`keys_unsorted` eagerly collects a
+`Vec<String>` with no cursor at all, so this fix has no counterpart to apply there).
+
+**Size**: `size_of::<GenericItem<V>>()` was measured before and after, for both `V`. It did
+not change (176 bytes for `StandardJson`, 192 for `YamlValue`, in both cases) —
+`GenericItem::LazySeq`'s payload was already the size-driving variant, so the new variant
+fits inside the existing footprint at zero cost. Confirmed empirically rather than assumed;
+no boxing was needed.
+
+### Benchmark Results
+
+Apple M4 Pro, interleaved A/B (`scripts/ab-cli.py`, 9 reps, `--control` noise floor
+±0.5%, output identity gated — 0 differences across every configuration below), flat
+mapping fixtures generated inline (~1.9 MB/100K keys, ~19 MB/1M keys):
+
+| Shape                                                    | Size | Before med | After med | Δ (median) |
+|-----------------------------------------------------------|------|-----------:|----------:|-----------:|
+| yq `first(keys \| .[] \| select(. == "zzz"))` (walks all)  | 100K |    57.6 ms |   54.6 ms | **−5.3%**  |
+| yq `first(keys \| .[] \| select(. == "zzz"))` (walks all)  | 1M   |   555.2 ms |  515.5 ms | **−7.1%**  |
+| yq `first(keys \| .[])` (early exit)                       | 100K |    12.9 ms |   12.9 ms |   −0.0%    |
+| yq `first(keys \| .[])` (early exit)                       | 1M   |   102.9 ms |  101.1 ms |   −1.8%    |
+| jq `first(keys_unsorted \| .[] \| select(. == "zzz"))`      | 1M   |   404.6 ms |  370.6 ms | **−8.4%**  |
+| jq `first(keys_unsorted \| .[])` (early exit)               | 1M   |    34.8 ms |   35.2 ms |   +0.9%    |
+
+The walks-all regression this issue tracks is fully closed and then some (−5.3% to −8.4%,
+well outside the noise floor at both sizes), the effect is flat across a 10x size range
+(consistent with an O(1)-per-key mechanism, not a curved one), and #1599's early-exit win is
+fully preserved (both early-exit deltas are within the ±0.5–1.8% noise band established by
+the control run). JSON, included as a control group since the fix applies to `StandardJson`
+too, improved rather than regressed — the redundant decode was real there too, just cheaper
+per call.
+
+Given the walks-all regression closed with early-exit preserved, the batching-window idea
+`#1609` also floated (pull N cursors, drive them, repeat) was not needed and was not built —
+the dominant cost was the redundant decode, not interleaving/locality.
+
+### Tests
+
+`tests/jq_cli_tests.rs`'s existing `test_lazy_keys_demand_sink_streams_collapse_1599` and
+`test_lazy_keys_streaming_reports_first_occurrence_cursor_1599` continue to pin the #1599
+streaming semantics unmodified. New in `tests/yq_cli_tests.rs`:
+`test_keys_unsorted_streamed_key_anchor_1609`, `test_keys_unsorted_streamed_key_style_1609`,
+and `test_keys_unsorted_streamed_key_position_1609` — confirming `anchor`/`style`/`line`/
+`column` read through a streamed key's cursor identically to before the fix (verified
+directly against a before/after binary pair, not just plausible-looking output).
+
+### Key Learnings
+
+1. **A doc-comment claim ("re-deriving the key materializes it a second time") can be
+   verified by reading the call graph, not just profiled** — `DistinctKeyCursors`'s own doc
+   comment already named this exact redundancy (#1514); #1609 rediscovered it independently
+   and confirmed it was real, not just plausible.
+2. **Enum-size-bloat risk is worth measuring, not assuming** — a naive read suggested
+   pairing a cursor with a value could grow `GenericItem` and regress every other pipe
+   stage; measuring showed the enum's size was already set by a larger variant, so the
+   worry was unfounded here, but this repo's `#[repr]`-sensitive types generally warrant the
+   same check before rather than after landing.
+3. **Format-dependent magnitude, format-independent mechanism**: the same redundant-decode
+   fix helped JSON *and* YAML, but by very different amounts (`JsonCursor::value()` is a
+   single-byte dispatch, `YamlCursor::value()` is not) — a shape reported as "not regressed"
+   for one format doesn't mean the underlying inefficiency isn't there, only that it's
+   cheap enough not to show.
+
+### Files Modified
+
+- `src/jq/eval_generic.rs` — `GenericItem::OneCursorValue` variant, construction site,
+  `continue_pipe_element_generic` arm, `generic_item_to_result` arm
+- `tests/yq_cli_tests.rs` — three new `_1609` regression tests
+
+---
+
 ## See Also
 
 - [YamlIndex wiki page](yaml-index.md) — concept overview, dependencies, and academic references

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3469,6 +3469,15 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// one at a time as `Owned` strings -- matching `materialize_lazy_keys`'s
 /// existing behaviour of not preserving a cursor for sorted keys (no new
 /// capability, no regression, just demand-aware instead of eager).
+///
+/// **`!sorted` yields `OneCursorValue`, not `OneCursor`** (#1609):
+/// `DistinctKeyCursors::next` already decodes each key's value for its own
+/// duplicate-key hashing, so throwing it away here and letting
+/// `continue_pipe_element_generic` re-derive it via `OneCursor`'s
+/// `c.value()` would decode every key twice -- for YAML a real cost (a full
+/// scalar resolve, not a cheap re-read), measurable as a ~5% regression on
+/// a query that walks every key and matches none. Carrying the value
+/// through instead removes that redundancy without changing output.
 fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     fields: &V::Fields,
     sorted: bool,
@@ -3480,7 +3489,7 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     if !sorted {
         return drive_pipe_elements_generic::<S, V>(
             DistinctKeyCursors::new(fields, collapse)
-                .map(|(_, cursor)| Ok(GenericItem::OneCursor(cursor))),
+                .map(|(value, cursor)| Ok(GenericItem::OneCursorValue(cursor, value))),
             rest,
             optional,
             sink,
@@ -4122,21 +4131,36 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 /// One output on its way to the sink installed by [`eval_each_generic`]
 /// (#1461, mirroring `eval::Item`).
 ///
-/// Six variants, matching the six single-output shapes of [`GenericResult`]
-/// -- `None`/`Error`/`Break`/`Halt`/`Partial`/`Many`/`ManyCursor`/`ManyOwned`
-/// are multi-output or terminal and are never represented as one item;
-/// [`drain_result_generic`] handles those directly. `LazyKeys`/
-/// `LazyIndexRange`/`LazySeq` are carried opaque rather than decomposed:
-/// only [`fold_pipe_stages`]'s own per-variant switch knows how to thread
-/// one of them through a *further* pipe stage (its `map`/`select`/`first`/
-/// `.[n]` composability fast paths, #724/#725) -- collapsing one to
-/// `Owned`/`One` before that switch runs is exactly the regression #1503
-/// review found and reverted. No `Debug` derive, matching `eval::Item`'s own
-/// omission: `V::Cursor` has no guaranteed `Debug` bound (see `LazyElem`'s
-/// own comment above for why that is deliberate here too).
+/// Matches the six single-output shapes of [`GenericResult`] plus one extra,
+/// `OneCursorValue` -- `None`/`Error`/`Break`/`Halt`/`Partial`/`Many`/
+/// `ManyCursor`/`ManyOwned` are multi-output or terminal and are never
+/// represented as one item; [`drain_result_generic`] handles those directly.
+/// `LazyKeys`/`LazyIndexRange`/`LazySeq` are carried opaque rather than
+/// decomposed: only [`fold_pipe_stages`]'s own per-variant switch knows how
+/// to thread one of them through a *further* pipe stage (its
+/// `map`/`select`/`first`/`.[n]` composability fast paths, #724/#725) --
+/// collapsing one to `Owned`/`One` before that switch runs is exactly the
+/// regression #1503 review found and reverted. No `Debug` derive, matching
+/// `eval::Item`'s own omission: `V::Cursor` has no guaranteed `Debug` bound
+/// (see `LazyElem`'s own comment above for why that is deliberate here too).
+///
+/// `OneCursorValue(V::Cursor, V)` has no [`GenericResult`] counterpart --
+/// it exists purely as a per-item optimization at one construction site,
+/// [`each_lazy_keys_iterate_sink`]'s `!sorted` arm. `DistinctKeyCursors`
+/// already decodes each key's value as a side effect of walking (it needs
+/// it for duplicate-key hashing), so pairing that value with its cursor
+/// here lets [`continue_pipe_element_generic`] skip a second, identical
+/// `V::Cursor::value()` resolve -- for YAML specifically not a cheap
+/// re-read but a full scalar decode (#1609). **Do not use this variant
+/// anywhere else.** Every other `OneCursor` site (`.[]` iteration via
+/// `uncons_cursor`, etc.) has no value decoded yet, so pairing one in would
+/// be new cost, not a freebie -- `OneCursor` alone stays correct there.
 enum GenericItem<V: DocumentValue> {
     One(V),
     OneCursor(V::Cursor),
+    /// See the enum doc comment -- only ever constructed by
+    /// [`each_lazy_keys_iterate_sink`]'s streaming `keys_unsorted` arm.
+    OneCursorValue(V::Cursor, V),
     Owned(OwnedValue),
     LazyKeys {
         fields: V::Fields,
@@ -4414,6 +4438,12 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
         GenericItem::OneCursor(c) => {
             eval_each_pipe_generic::<S, V>(rest.stages(), c.value(), optional, Some(c), sink)
         }
+        // Same as the `OneCursor` arm above, minus the `c.value()` resolve
+        // -- `v` was already decoded by whoever built this item (#1609), so
+        // re-deriving it here would just repeat that work.
+        GenericItem::OneCursorValue(c, v) => {
+            eval_each_pipe_generic::<S, V>(rest.stages(), v, optional, Some(c), sink)
+        }
         GenericItem::Owned(o) => eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
             sink(GenericItem::Owned(o))
         }),
@@ -4536,10 +4566,20 @@ fn each_take_first_generic<S: EvalSemantics, V: DocumentValue>(
 
 /// Convert a captured [`GenericItem`] back to the [`GenericResult`] shape it
 /// came from -- the inverse of [`drain_result_generic`]'s single-item arms.
+///
+/// `OneCursorValue` has no `GenericResult` counterpart to convert to, so it
+/// collapses to plain `OneCursor` here, dropping the pre-decoded value
+/// (#1609). That's fine: this function's only caller for a single captured
+/// item is `each_take_first_generic`'s `first(...)`/`last(...)` path, once
+/// per builtin call rather than once per key, so re-deriving the value via
+/// `GenericResult::OneCursor`'s later `.value()` costs nothing that matters
+/// -- adding a matching `GenericResult` variant just to avoid that one cold
+/// re-decode isn't worth `GenericResult`'s much larger consumer set.
 fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResult<V> {
     match item {
         GenericItem::One(v) => GenericResult::One(v),
         GenericItem::OneCursor(c) => GenericResult::OneCursor(c),
+        GenericItem::OneCursorValue(c, _v) => GenericResult::OneCursor(c),
         GenericItem::Owned(o) => GenericResult::Owned(o),
         GenericItem::LazyKeys {
             fields,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -10055,6 +10055,66 @@ fn test_style_builtin_anchor_prefix_does_not_mask_style() -> Result<()> {
     Ok(())
 }
 
+/// #1609: `each_lazy_keys_iterate_sink`'s `keys_unsorted` arm streams a
+/// `GenericItem::OneCursorValue` carrying the key's already-decoded value
+/// alongside its cursor (avoiding a redundant `YamlCursor::value()` resolve
+/// per key). `anchor`/`style` read metadata off the *cursor* half of that
+/// pair, so an anchored/styled key is the concrete check that the cursor
+/// threaded through the new variant is the same one the old
+/// `OneCursor` + `.value()` path would have produced.
+#[test]
+fn test_keys_unsorted_streamed_key_anchor_1609() -> Result<()> {
+    let input = "&x a: 1\nb: 2\n";
+    let (output, code) = run_yq_stdin("keys_unsorted | .[0] | anchor", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "x");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[1] | anchor", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "");
+
+    Ok(())
+}
+
+#[test]
+fn test_keys_unsorted_streamed_key_style_1609() -> Result<()> {
+    let cases = [
+        ("\"a\": 1\nb: 2\n", "\"double\""),
+        ("'a': 1\nb: 2\n", "\"single\""),
+        ("a: 1\nb: 2\n", "\"\""),
+    ];
+
+    for (input, expected) in cases {
+        let (output, code) = run_yq_stdin("keys_unsorted | .[0] | style", input, &["-o=json"])?;
+        assert_eq!(code, 0, "input: {input:?}");
+        assert_eq!(output.trim(), expected, "input: {input:?}");
+    }
+
+    Ok(())
+}
+
+/// #1609: `line`/`column` through a streamed `keys_unsorted` element must
+/// still report the key's own position, not something the cursor+value
+/// pairing accidentally shifted.
+#[test]
+fn test_keys_unsorted_streamed_key_position_1609() -> Result<()> {
+    let input = "a: 1\nbb: 2\nccc: 3\n";
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[2]", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "ccc");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[2] | line", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3");
+
+    let (output, code) = run_yq_stdin("keys_unsorted | .[2] | column", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1");
+
+    Ok(())
+}
+
 /// The DOM path's `evaluate_yaml_cursor` (`yq_runner.rs`) has its own
 /// `GenericResult::LazySeq` arm. `can_use_m2_streaming` rejects
 /// `Builtin::Map` outright, so any top-level `map(f)` query takes this DOM


### PR DESCRIPTION
## Summary

- #1599 made `each_lazy_keys_iterate_sink`'s `keys_unsorted`/yq `keys` arm stream `DistinctKeyCursors` one cursor at a time. `DistinctKeyCursors::next()` already decodes each key's value (needed for its own duplicate-key hashing), but the construction site discarded it, keeping only the cursor (`GenericItem::OneCursor`) — so `continue_pipe_element_generic` had to re-derive the value via a second, identical `c.value()` resolve. For YAML that's a real cost (full scalar decode: root check, `is_container()`, seq-item unwrap, alias/anchor handling, block-vs-scalar lookahead, a `\n` scan), which is why #1606's `uncons_key` override only closed the regression from +11.1% to +5.0% rather than to zero — it fixed a different redundancy and left this one.
- Adds `GenericItem::OneCursorValue(V::Cursor, V)`, constructed only at the keys-streaming site, so the already-decoded value rides along with its cursor instead of being re-derived. Two other exhaustive match sites get arms (`continue_pipe_element_generic`, `generic_item_to_result`); no changes to `document.rs`/`yaml/light.rs`/`json/light.rs`, and the older JSON-only `eval.rs` evaluator has no cursor-based keys path to touch.
- `size_of::<GenericItem<V>>()` measured unchanged before/after for both formats (176/192 bytes) — `LazySeq`'s payload was already the size-driving variant, so this costs nothing extra to carry.

## Measured (Apple M4 Pro, `scripts/ab-cli.py`, 9 reps, output identity gated, flat 100K/1M-key mappings)

| shape | 100K | 1M |
|---|---|---|
| yq `first(keys \| .[] \| select(. == "zzz"))` (walks all) | **-5.3%** | **-7.1%** |
| yq `first(keys \| .[])` (early exit) | -0.0% | -1.8% (noise) |
| jq `first(keys_unsorted \| .[] \| select(. == "zzz"))`, 1M | | **-8.4%** |
| jq `first(keys_unsorted \| .[])`, 1M (early exit) | | +0.9% (noise) |

Closes the regression with #1599's -34% early-exit win fully preserved, both formats improve, and the batching-window idea #1609 floated wasn't needed.

Closes #1609.

## Test plan

- [x] `cargo test --features cli,regex` — full suite, 5966+ passed, 0 failed
- [x] New tests in `tests/yq_cli_tests.rs` pin `anchor`/`style`/`line`/`column` through a streamed `keys_unsorted` key, verified directly against a before/after binary pair
- [x] Existing `_1599` regression tests (`jq_cli_tests.rs`, `yq_cli_tests.rs`) pass unmodified
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second (SIMD/x86) clippy leg
- [x] `cargo check --no-default-features` (no_std)
- [x] `./scripts/build.sh`
- [x] Output identity gated (0 differences) in every A/B benchmark configuration above