### PR TITLE
fix(jq): make a decode failure uncatchable by both ? and try/catch

### DIFF
--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -570,6 +570,17 @@ what Stage 6 is left with is bad escapes only.
    (it happens before the program runs). Decide explicitly whether that is acceptable or
    whether these need `Halt`-like uncatchability. This is a genuine semantic difference
    from both oracles and the design above does not resolve it.
+
+   **Resolved by #1620**: uncatchable both ways, but *not* via `Halt` -- `Halt` is
+   whole-process-fatal (aborts every remaining record in a multi-document stream), which
+   would trade this divergence for a worse one against the already-accepted "a malformed
+   value doesn't abort the rest of the stream" divergence below. Instead, `EvalError` grew a
+   `decode_failure`/`is_decode_failure` pair (`src/jq/error.rs`), mirroring the existing
+   `is_invalid_path_expression` precedent: a decode failure still travels through the
+   ordinary `Control::Error`/`GenericResult::Error`/`QueryResult::Error` channel (so it stays
+   per-record), but every `?`/`try`/`catch` boundary in both evaluators now checks
+   `is_decode_failure()` first and lets it pass through unmatched instead of suppressing or
+   catching it.
 2. **JSONTestSuite `i_` cases.** `tests/json_test_suite.rs` covers implementation-defined
    inputs; making decode failures loud can flip them in either direction. Check what the
    suite currently expects *before* regenerating anything.
@@ -626,6 +637,8 @@ what Stage 6 is left with is bad escapes only.
 
 - [#1247](https://github.com/rust-works/succinctly/issues/1247) — the issue this document
   is the deliverable for.
+- [#1620](https://github.com/rust-works/succinctly/issues/1620) (resolved) — Open Risk 1,
+  decode-failure catchability, filed and settled per this document's own follow-up list.
 - [#1192](https://github.com/rust-works/succinctly/issues/1192) (closed) — fixed two
   sibling copies and established the `EvalError` wording convention reused here.
 - [#1098](https://github.com/rust-works/succinctly/issues/1098) (closed) — the original
@@ -653,5 +666,6 @@ Not yet filed. Once this document is reviewed:
 1. One implementation issue per stage above, linking back here.
 2. **`JsonFields::uncons` cannot represent a malformed field** — #1194's headline repro
    (`{invalid} → {}`), see Correction 3.
-3. **Decide catchability of decode errors** — Open Risk 1, if it is not settled during
-   Stage 3's review.
+3. ~~**Decide catchability of decode errors** — Open Risk 1, if it is not settled during
+   Stage 3's review.~~ Filed as [#1620](https://github.com/rust-works/succinctly/issues/1620),
+   resolved there -- see Open Risk 1 above.

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -621,7 +621,7 @@ pub trait DocumentFields: Sized + Clone {
             // other key-materializing site (#1247): an undecodable key must
             // raise here, not silently vanish once `key_str` stringifies it.
             if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::new(format!("{reason} in object key")));
+                return Err(EvalError::decode_failure(format!("{reason} in object key")));
             }
             // A key that will not stringify at all never allowed by the
             // format's grammar in the first place -- structurally malformed,

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -955,6 +955,36 @@ impl EvalError {
             .starts_with(Self::INVALID_PATH_EXPRESSION_PREFIX)
     }
 
+    /// A decode failure while materializing a lazily-indexed document value
+    /// (#1247): invalid UTF-8, an unrecoverable escape, or a malformed
+    /// number literal. Unlike an ordinary type-mismatch error, this must
+    /// never be suppressed by `?` or caught by `try`/`catch` (#1620) — jq's
+    /// own equivalent is a parse-time rejection no program could ever catch
+    /// either.
+    pub fn decode_failure(reason: impl Into<String>) -> Self {
+        Self::new(reason)
+    }
+
+    /// Whether this is a [`Self::decode_failure`] — see #1620. Every
+    /// `?`/`try`/`catch` boundary consults this so a decode failure passes
+    /// through unmatched instead of being suppressed, the same way
+    /// [`Self::is_invalid_path_expression`] exempts its own narrow error
+    /// class without leaving the ordinary catchable `Error` channel.
+    pub fn is_decode_failure(&self) -> bool {
+        let base = self
+            .message
+            .strip_suffix(" in object key")
+            .unwrap_or(&self.message);
+        matches!(
+            base,
+            "invalid UTF-8 in string"
+                | "invalid number format"
+                | "invalid escape sequence in string"
+                | "invalid unicode escape sequence"
+                | "invalid escape sequence"
+        )
+    }
+
     /// `Cannot check whether <container> has a <key type> key`.
     pub fn cannot_check_has(container_type: &str, key_type: &str) -> Self {
         Self::new(format!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -736,7 +736,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             StandardJson::String(s) => {
                 let s_str = match s.as_str() {
                     Ok(s) => s,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid UTF-8 in string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 };
 
                 // Fast path: identity slice [:] returns original string without character counting
@@ -2798,6 +2798,12 @@ fn each_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
     match eval_each::<W, S>(expr, value, optional, sink) {
+        // A decode failure (#1247) must never be caught by `try`/`catch`,
+        // same #1620 exclusion as `eval_try`'s identical arm -- propagates
+        // unchanged via the `other => other` wildcard's own reasoning.
+        Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+            Flow::Escaped(Control::Error(e))
+        }
         Flow::Escaped(Control::Error(e)) => match catch {
             Some(catch_expr) => {
                 eval_each_owned::<S>(catch_expr, &e.payload(), optional, &mut |o| {
@@ -5036,6 +5042,12 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let result = eval_single::<W, S>(expr, value, optional);
 
     match result {
+        // A decode failure (#1247) must never be caught by `try`/`catch`,
+        // any more than it's suppressed by `?` (#1620) -- jq's own
+        // equivalent is a parse-time rejection no program could ever catch
+        // either. Checked before the ordinary `Error` catch below so it
+        // falls through to `other => other` instead.
+        QueryResult::Error(e) if e.is_decode_failure() => QueryResult::Error(e),
         // If error, use catch handler or return nothing. jq runs the handler
         // with the *raised value* as its input, not the original input, so
         // `try error("boom") catch .` yields "boom".
@@ -5052,6 +5064,12 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Some(catch_expr) => eval_owned_input::<W, S>(catch_expr, &OwnedValue::Null, optional),
             None => QueryResult::None,
         },
+        // Same #1620 decode-failure exclusion as the bare `Error` arm above
+        // -- a `Partial` ending in a decode failure must still propagate
+        // uncaught, not run the catch handler.
+        QueryResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+            QueryResult::Partial(prefix, Control::Error(e))
+        }
         // The body produced some outputs before erroring (#400): emit them
         // (`try (1,2,error("x")) catch "c"` is `1`, `2`, `"c"`), then run the
         // catch handler and splice its own result — which may itself be
@@ -9429,19 +9447,14 @@ fn builtin_tonumber<W: Clone + AsRef<[u64]>>(
             // that literal is valid RFC 8259 syntax (#966).
             QueryResult::Owned(OwnedValue::from_number_bytes(n.raw_bytes()))
         }
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                match tonumber_from_str(cow.as_ref()) {
-                    Ok(n) => QueryResult::Owned(n),
-                    Err(_) if optional => QueryResult::None,
-                    Err(e) => e.into(),
-                }
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
-            }
-        }
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => match tonumber_from_str(cow.as_ref()) {
+                Ok(n) => QueryResult::Owned(n),
+                Err(_) if optional => QueryResult::None,
+                Err(e) => e.into(),
+            },
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_parse_as_number(&to_owned(&value))),
     }
@@ -9541,22 +9554,17 @@ fn builtin_toboolean<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Bool(b) => QueryResult::Owned(OwnedValue::Bool(*b)),
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                match cow.as_ref() {
-                    "true" => QueryResult::Owned(OwnedValue::Bool(true)),
-                    "false" => QueryResult::Owned(OwnedValue::Bool(false)),
-                    _ if optional => QueryResult::None,
-                    other => QueryResult::Error(EvalError::new(format!(
-                        "string ({other:?}) cannot be parsed as a boolean"
-                    ))),
-                }
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
-            }
-        }
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => match cow.as_ref() {
+                "true" => QueryResult::Owned(OwnedValue::Bool(true)),
+                "false" => QueryResult::Owned(OwnedValue::Bool(false)),
+                _ if optional => QueryResult::None,
+                other => QueryResult::Error(EvalError::new(format!(
+                    "string ({other:?}) cannot be parsed as a boolean"
+                ))),
+            },
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new(format!(
             "{} cannot be parsed as a boolean",
@@ -9670,8 +9678,8 @@ fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => {
                 let json_str = cow.as_ref();
                 // The whole string must be one JSON value: jq rejects `"0x10"`
                 // and `"1 2"` rather than reading the first value and dropping
@@ -9681,12 +9689,9 @@ fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
                     Err(_) if optional => QueryResult::None,
                     Err(_) => QueryResult::Error(EvalError::invalid_numeric_literal(json_str)),
                 }
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
             }
-        }
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::only_strings_can_be_parsed(&to_owned(&value))),
     }
@@ -10076,19 +10081,16 @@ fn builtin_explode<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => {
                 let codepoints: Vec<OwnedValue> = cow
                     .chars()
                     .map(|c| OwnedValue::Int(c as u32 as i64))
                     .collect();
                 QueryResult::Owned(OwnedValue::Array(codepoints))
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
             }
-        }
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new("explode input must be a string")),
     }
@@ -10248,15 +10250,10 @@ fn builtin_test<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             // Check if the input string contains the pattern (simple substring match)
             match &value {
-                StandardJson::String(s) => {
-                    if let Ok(cow) = s.as_str() {
-                        QueryResult::Owned(OwnedValue::Bool(cow.contains(&pattern)))
-                    } else if optional {
-                        QueryResult::None
-                    } else {
-                        QueryResult::Error(EvalError::new("invalid string"))
-                    }
-                }
+                StandardJson::String(s) => match s.as_str() {
+                    Ok(cow) => QueryResult::Owned(OwnedValue::Bool(cow.contains(&pattern))),
+                    Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+                },
                 _ if optional => QueryResult::None,
                 _ => QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
             }
@@ -10297,8 +10294,9 @@ fn string_slice_pattern<W>(
     let (StandardJson::String(s), OwnedValue::Object(desc)) = (value, pattern) else {
         return None;
     };
-    let Ok(text) = s.as_str() else {
-        return Some(Err(EvalError::new("invalid string")));
+    let text = match s.as_str() {
+        Ok(text) => text,
+        Err(e) => return Some(Err(EvalError::decode_failure(e.message()))),
     };
     Some(SliceBounds::from_descriptor(desc).map(|bounds| {
         OwnedValue::String(slice::slice_str(
@@ -10381,21 +10379,20 @@ fn indices_with_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(non_string_pattern(value, pattern)),
             };
-            if let Ok(cow) = s.as_str() {
-                let mut indices = Vec::new();
-                let mut start = 0;
-                while let Some(pos) = cow[start..].find(pattern_str.as_str()) {
-                    indices.push(OwnedValue::Int((start + pos) as i64));
-                    start += pos + 1;
-                    if start >= cow.len() {
-                        break;
+            match s.as_str() {
+                Ok(cow) => {
+                    let mut indices = Vec::new();
+                    let mut start = 0;
+                    while let Some(pos) = cow[start..].find(pattern_str.as_str()) {
+                        indices.push(OwnedValue::Int((start + pos) as i64));
+                        start += pos + 1;
+                        if start >= cow.len() {
+                            break;
+                        }
                     }
+                    QueryResult::Owned(OwnedValue::Array(indices))
                 }
-                QueryResult::Owned(OwnedValue::Array(indices))
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
+                Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
             }
         }
         StandardJson::Array(elements) => {
@@ -10466,16 +10463,15 @@ fn index_with_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(non_string_pattern(value, pattern)),
             };
-            if let Ok(cow) = s.as_str() {
-                if let Some(pos) = cow.find(pattern_str.as_str()) {
-                    QueryResult::Owned(OwnedValue::Int(pos as i64))
-                } else {
-                    QueryResult::Owned(OwnedValue::Null)
+            match s.as_str() {
+                Ok(cow) => {
+                    if let Some(pos) = cow.find(pattern_str.as_str()) {
+                        QueryResult::Owned(OwnedValue::Int(pos as i64))
+                    } else {
+                        QueryResult::Owned(OwnedValue::Null)
+                    }
                 }
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
+                Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
             }
         }
         StandardJson::Array(elements) => {
@@ -10596,16 +10592,15 @@ fn rindex_with_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(non_string_pattern(value, pattern)),
             };
-            if let Ok(cow) = s.as_str() {
-                if let Some(pos) = cow.rfind(pattern_str.as_str()) {
-                    QueryResult::Owned(OwnedValue::Int(pos as i64))
-                } else {
-                    QueryResult::Owned(OwnedValue::Null)
+            match s.as_str() {
+                Ok(cow) => {
+                    if let Some(pos) = cow.rfind(pattern_str.as_str()) {
+                        QueryResult::Owned(OwnedValue::Int(pos as i64))
+                    } else {
+                        QueryResult::Owned(OwnedValue::Null)
+                    }
                 }
-            } else if optional {
-                QueryResult::None
-            } else {
-                QueryResult::Error(EvalError::new("invalid string"))
+                Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
             }
         }
         StandardJson::Array(elements) => {
@@ -11377,8 +11372,7 @@ fn builtin_match<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let input = match &value {
                 StandardJson::String(s) => match s.as_str() {
                     Ok(cow) => cow.into_owned(),
-                    Err(_) if optional => return QueryResult::None,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 },
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12112,8 +12106,7 @@ fn builtin_test_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let input = match &value {
                 StandardJson::String(s) => match s.as_str() {
                     Ok(cow) => cow.into_owned(),
-                    Err(_) if optional => return QueryResult::None,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 },
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12180,8 +12173,7 @@ fn builtin_capture_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let input = match &value {
                 StandardJson::String(s) => match s.as_str() {
                     Ok(cow) => cow.into_owned(),
-                    Err(_) if optional => return QueryResult::None,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 },
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12356,8 +12348,7 @@ fn yq_sub_arity3_empty_replace<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let input = match &value {
                 StandardJson::String(s) => match s.as_str() {
                     Ok(cow) => cow.into_owned(),
-                    Err(_) if optional => return QueryResult::None,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 },
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12409,8 +12400,7 @@ fn sub_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
         },
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12809,8 +12799,7 @@ fn scan_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>>(
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
         },
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -12891,8 +12880,7 @@ fn split_regex_resolved<'a, W: Clone + AsRef<[u64]>>(
     let input = match value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
         },
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(value))),
@@ -13002,8 +12990,7 @@ fn splits_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>>(
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
         },
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(&value))),
@@ -17498,8 +17485,11 @@ fn resolve_node<'a, S: EvalSemantics>(
             // path expressions any more than in value position (#791) —
             // only a genuine error or a break (below) reaches `catch`;
             // everything else propagates unchanged, as does an
-            // invalid-path-expression complaint (#530).
-            Err((prefix, EvalEscape::Error(e))) if !e.is_invalid_path_expression() => {
+            // invalid-path-expression complaint (#530) and, per the same
+            // reasoning, a decode failure (#1247, #1620).
+            Err((prefix, EvalEscape::Error(e)))
+                if !e.is_invalid_path_expression() && !e.is_decode_failure() =>
+            {
                 resolve_catch::<S>(catch.as_deref(), prefix, e.payload())
             }
             // `catch` catches a `break` the same way it catches a raised
@@ -28821,8 +28811,7 @@ fn builtin_strptime<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let input = match &value {
                 StandardJson::String(s) => match s.as_str() {
                     Ok(cow) => cow.into_owned(),
-                    Err(_) if optional => return QueryResult::None,
-                    Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
                 },
                 _ if optional => return QueryResult::None,
                 // #929: confirmed live: `5 | strptime("%Y")` raises "strptime/1
@@ -29243,8 +29232,7 @@ fn builtin_fromdate<W: Clone + AsRef<[u64]>>(
     let input = match &value {
         StandardJson::String(s) => match s.as_str() {
             Ok(cow) => cow.into_owned(),
-            Err(_) if optional => return QueryResult::None,
-            Err(_) => return QueryResult::Error(EvalError::new("invalid string")),
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
         },
         _ if optional => return QueryResult::None,
         // #929: `fromdate` is defined in terms of `strptime` in real jq, so
@@ -34453,6 +34441,56 @@ mod tests {
                 other => panic!("unexpected result: {:?}", other),
             }
         }};
+    }
+
+    /// #1620: a decode failure reached through this module's own dispatch
+    /// (the public `succinctly::jq::eval` library API, not the CLI's
+    /// `eval_generic.rs` bridge) must not be suppressed by `?` -- same rule,
+    /// same reasoning, as `eval_generic.rs`'s `Expr::Optional` arm. Exercises
+    /// the 18-site `builtin_tonumber`-shaped fix directly: before it, this
+    /// site checked `optional` before the decode check and silently
+    /// swallowed the failure as `QueryResult::None`.
+    #[test]
+    fn test_optional_does_not_suppress_decode_failure_1620() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a | tonumber?",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1620: `try`/`catch` -- `eval_try`, this module's own native
+    /// dispatch for both `Expr::Try` and `Expr::Optional` -- must not catch
+    /// a decode failure either. Uses `tonumber`, not `length`: `eval.rs`'s
+    /// own `builtin_length` silently substitutes `0` on a decode failure
+    /// instead of raising at all -- a separate, `to_owned`-family-shaped gap
+    /// (also not reachable via the CLI), out of #1620's scope.
+    #[test]
+    fn test_try_catch_does_not_catch_decode_failure_1620() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "try (.a | tonumber) catch \"caught\"",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1620 negative control: an *ordinary* type error must still be
+    /// suppressed by `?` and caught by `try`/`catch` here, proving the new
+    /// exclusion is scoped to decode failures only.
+    #[test]
+    fn test_ordinary_type_error_still_suppressed_and_caught_1620() {
+        query!(b"{\"a\": 1}", ".a | keys?", QueryResult::None => {});
+        query!(
+            b"{\"a\": 1}",
+            "try (.a | keys) catch \"caught\"",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "caught");
+            }
+        );
     }
 
     /// #1067: pins `collapse_vec`'s own 0/1/2+ shape, independent of any

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -167,7 +167,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             // invisible. Wording matches the sibling `owned_from_standard_json`
             // conversion #1192 fixed first.
             if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::new(format!("{reason} in object key")));
+                return Err(EvalError::decode_failure(format!("{reason} in object key")));
             }
             // A key that will not stringify at all is not a decode failure --
             // it is a key JSON's grammar never allowed (`{123: 1}`), which
@@ -219,7 +219,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // decode. Raising here is #1247's core fix; the deferral comment that
         // used to sit in the `else` below (naming #1098 and PR #1190's
         // reverted `panic!`) described exactly this and is now resolved.
-        Err(EvalError::new(reason.to_string()))
+        Err(EvalError::decode_failure(reason))
     } else if value.is_error() {
         // A *structurally* malformed value -- `[xyz123]`, `[tru]` -- which
         // the semi-index accepted as a span but could not classify as any
@@ -271,7 +271,7 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         while let Some((field, rest)) = f.uncons() {
             // Same key ordering as `to_owned_at_depth` above, same reason.
             if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::new(format!("{reason} in object key")));
+                return Err(EvalError::decode_failure(format!("{reason} in object key")));
             }
             // Same two #1194 checks as `to_owned_at_depth` above, same
             // reasons -- these two conversions are copies of each other and a
@@ -368,26 +368,6 @@ fn to_owned_with_cursor<V: DocumentValue>(
 /// caller takes the fallible one above.
 fn to_owned_for_diagnostic<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> OwnedValue {
     to_owned_with_cursor(value, cursor).unwrap_or(OwnedValue::Null)
-}
-
-/// The error a builtin should raise when its type dispatch fell through.
-///
-/// Those dispatches are chains of `as_str()`/`as_array()`/`as_i64()`/...
-/// tests, so a string scalar whose bytes don't decode fails *every* one and
-/// lands in the same `else` as a genuine type mismatch. Reporting the type
-/// error there is actively misleading -- `{"a":"\ud800"} | .a | length` said
-/// `null (null) has no length` about a value that is a perfectly good string
-/// token, naming a symptom two steps removed from the cause. Check for the
-/// decode failure first and report that instead (#1247); everything else
-/// keeps the caller's own wording, which the jq oracle tests pin.
-fn type_error_or_decode_failure<V: DocumentValue>(
-    value: &V,
-    type_error: impl FnOnce() -> EvalError,
-) -> EvalError {
-    match value.string_decode_error() {
-        Some(reason) => EvalError::new(reason.to_string()),
-        None => type_error(),
-    }
 }
 
 /// The jq `type` name for `value` at `cursor`, resolving an explicit YAML
@@ -706,7 +686,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         while let Some((field, rest)) = f.uncons() {
             // Same key ordering as `to_owned_at_depth`, same reason (#1247).
             if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::new(format!("{reason} in object key")));
+                return Err(EvalError::decode_failure(format!("{reason} in object key")));
             }
             if let Some(key) = field.key_str() {
                 let key = key.into_owned();
@@ -1647,7 +1627,12 @@ fn finish_fork_generic<V: DocumentValue>(
 ) -> GenericResult<V> {
     match control {
         None => owned_vec_to_generic_result(outputs),
-        Some(Control::Error(_)) if optional => owned_vec_to_generic_result(outputs),
+        // A decode failure (#1620) is never silenced by an ambient
+        // `optional`, unlike an ordinary trailing error -- see
+        // `Expr::Optional`'s own arm above for the full rationale.
+        Some(Control::Error(ref e)) if optional && !e.is_decode_failure() => {
+            owned_vec_to_generic_result(outputs)
+        }
         Some(control) => partial_generic(outputs, control),
     }
 }
@@ -3779,12 +3764,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 } else {
                     GenericResult::ManyCursor(cursors)
                 }
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::cannot_iterate_with(S::TAG, &to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::cannot_iterate_with(
+                    S::TAG,
+                    &to_owned_for_diagnostic(&value, cursor),
+                ))
             }
         }
 
@@ -3814,6 +3802,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // ordinary `empty`, so the fan-out wrongly kept going instead of
         // stopping (#693).
         Expr::Optional(inner) => match eval_single::<S, _>(inner, value, optional, cursor) {
+            // A decode failure (#1247) must never be suppressed by `?`, any
+            // more than it's caught by `try`/`catch` -- jq's own equivalent
+            // is a parse-time rejection no program could ever catch either
+            // (#1620). Checked before the ordinary `Error`/`Break` catch
+            // below so it falls through to `other => other` instead.
+            GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
             GenericResult::Error(_) | GenericResult::Break(_) => GenericResult::None,
             // `prefix` is never empty here: `partial_generic` (and
             // `eval::partial`, its mirror) already collapse an empty prefix
@@ -3828,6 +3822,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // `eval::eval_try`'s identical jq-mode arm calls into and which
             // already routes its own prefix-collapse through
             // `owned_vec_to_result`/`collapse_vec`.
+            //
+            // Same #1620 decode-failure exclusion as the bare `Error` arm
+            // above -- a `Partial` ending in a decode failure must still
+            // propagate uncaught, not collapse its prefix into `None`.
+            GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+                GenericResult::Partial(prefix, Control::Error(e))
+            }
             GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => collapse_vec(
                 prefix,
                 || GenericResult::None,
@@ -3848,6 +3849,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // errored/exit-5 here before this arm existed).
             GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
                 Ok(owned) => GenericResult::Owned(owned),
+                // Same #1620 exclusion as above: a decode failure surfacing
+                // only once the `LazySeq` is forced must still propagate
+                // uncaught, checked before the ordinary `Error`/`Break`
+                // catch right below.
+                Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
                 Err(Control::Error(_) | Control::Break(_)) => GenericResult::None,
                 // Unlike `Error`/`Break` just above, `?` must NOT catch a
                 // `halt` (verified against real jq: `("x"|halt_error)? //
@@ -5616,12 +5622,15 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     None => LazySource::Values(fields),
                 };
                 GenericResult::LazySeq(LazySeq::new(source).push_map(f, S::TAG))
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::cannot_iterate_with(S::TAG, &to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::cannot_iterate_with(
+                    S::TAG,
+                    &to_owned_for_diagnostic(&value, cursor),
+                ))
             }
         }
 
@@ -5790,12 +5799,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 })
             } else if let Some(f) = value.as_f64() {
                 GenericResult::Owned(OwnedValue::Float(f.abs()))
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::has_no_length(&to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::has_no_length(&to_owned_for_diagnostic(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -5819,12 +5830,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // yet; `length`, `.[]`, `.[n]`, `first`, and `last` can all
                 // answer directly from `len` (see the `Pipe` dispatch below).
                 GenericResult::LazyIndexRange(elements.len())
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -5843,12 +5856,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(elements) = value.as_array() {
                 // Same laziness as the array branch of `Keys` above (#684).
                 GenericResult::LazyIndexRange(elements.len())
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -5908,7 +5923,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     // Key decode checked before `key_str`, as everywhere else
                     // (#1247) -- YAML stringifies an undecodable key to `""`.
                     if let Some(reason) = field.key.string_decode_error() {
-                        return GenericResult::Error(EvalError::new(format!(
+                        return GenericResult::Error(EvalError::decode_failure(format!(
                             "{reason} in object key"
                         )));
                     }
@@ -5934,6 +5949,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     entries.push(OwnedValue::Object(entry));
                 }
                 GenericResult::Owned(OwnedValue::Array(entries))
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else {
                 // No `optional`-guarded arm here: `Builtin::ToEntries` isn't
                 // `IndexExpr`/`SliceExpr`, so #693's dispatch never forces
@@ -5941,9 +5958,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // evaluates it at the ambient `optional` (normally `false`)
                 // and lets the outer `Expr::Optional`/`eval_try`-style catch
                 // convert the resulting `Error` to `None` once instead.
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::has_no_keys(&to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -6117,12 +6134,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     Err(_) if optional => GenericResult::None,
                     Err(e) => GenericResult::Error(e),
                 }
+            } else if let Some(reason) = value.string_decode_error() {
+                GenericResult::Error(EvalError::decode_failure(reason))
             } else if optional {
                 GenericResult::None
             } else {
-                GenericResult::Error(type_error_or_decode_failure(&value, || {
-                    EvalError::cannot_parse_as_number(&to_owned_for_diagnostic(&value, cursor))
-                }))
+                GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned_for_diagnostic(
+                    &value, cursor,
+                )))
             }
         }
 
@@ -6307,6 +6326,67 @@ mod tests {
             "message: {}",
             err.message
         );
+    }
+
+    /// #1620: `?` must not suppress a decode failure -- `Expr::Optional`'s
+    /// own arm now excludes it explicitly (see its doc comment), instead of
+    /// folding it into the ordinary `Error`/`Break` -> `None` catch every
+    /// other error takes.
+    #[test]
+    fn test_generic_optional_does_not_suppress_decode_failure_1620() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(
+            &Expr::Optional(Box::new(Expr::Builtin(Builtin::Length))),
+            value,
+        );
+
+        match result {
+            GenericResult::Error(e) => assert!(
+                e.is_decode_failure() && e.message.contains("invalid UTF-8"),
+                "message: {}",
+                e.message
+            ),
+            other => panic!("expected an uncaught decode-failure error, got {other:?}"),
+        }
+    }
+
+    /// #1620: `try`/`catch` -- routed through the reindex-bridge wildcard
+    /// since this module has no native `Expr::Try` arm (see that arm's own
+    /// doc comment) -- must not catch a decode failure either.
+    #[test]
+    fn test_generic_try_catch_does_not_catch_decode_failure_1620() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(
+            &Expr::Try {
+                expr: Box::new(Expr::Pipe(vec![
+                    Expr::Field("a".to_string()),
+                    Expr::Builtin(Builtin::Length),
+                ])),
+                catch: Some(Box::new(Expr::Literal(Literal::String(
+                    "caught".to_string(),
+                )))),
+            },
+            value,
+        );
+
+        match result {
+            GenericResult::Error(e) => assert!(
+                e.is_decode_failure() && e.message.contains("invalid UTF-8"),
+                "message: {}",
+                e.message
+            ),
+            other => panic!("expected an uncaught decode-failure error, got {other:?}"),
+        }
     }
 
     /// #1247: a valid document still materializes unchanged -- the guard

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21808,6 +21808,85 @@ fn test_sort_keys_and_color_force_materialize_and_surface_decode_failure_1247() 
     }
 }
 
+/// #1620: a decode failure must never be suppressed by `?`, matching how
+/// `try`/`catch` already never catches one -- real jq's equivalent is a
+/// parse-time rejection no program could ever catch either. Before this fix,
+/// `?` swallowed the same failure `test_decode_failure_surfaces_as_error_1247`
+/// pins as uncaught: `.a | length?` on `{"a":"\ud800"}` silently produced no
+/// output at exit 0 instead of erroring. Every filter here now errors, same
+/// as its bare (non-`?`) counterpart.
+///
+/// `.a?` (no downstream builtin) is deliberately not included: bare field
+/// access never decodes the string at all -- it only echoes the raw token --
+/// so there is no decode failure for `?` to have swallowed in the first
+/// place.
+#[test]
+fn test_decode_failure_not_suppressed_by_optional_1620() {
+    let doc = r#"{"a": "\ud800"}"#;
+    for filter in [
+        ".a | length?",
+        ".a | tonumber?",
+        "to_entries?",
+        "[.a] | sort?",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_ne!(
+            code, 0,
+            "`{filter}` should fail, not be suppressed by `?`\nstdout: {stdout}"
+        );
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "`{filter}` should name the decode failure\nstderr: {stderr}"
+        );
+    }
+}
+
+/// #1620 regression pin: `try`/`catch` must keep NOT catching a decode
+/// failure -- already true before this fix (by accident, per #1620's own
+/// analysis), now true by design. Paired with the `?` case above so neither
+/// mechanism can silently start suppressing this again.
+#[test]
+fn test_decode_failure_not_caught_by_try_catch_1620() {
+    let doc = r#"{"a": "\ud800"}"#;
+    for filter in [
+        r#"try (.a | length) catch "caught""#,
+        r#"try (.a | ascii_downcase) catch "caught""#,
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_ne!(code, 0, "`{filter}` should still fail\nstdout: {stdout}");
+        assert!(
+            !stdout.contains("caught"),
+            "`{filter}` should not have run the catch handler\nstdout: {stdout}"
+        );
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "`{filter}` should name the decode failure\nstderr: {stderr}"
+        );
+    }
+}
+
+/// #1620 negative control: an *ordinary* type error (not a decode failure)
+/// must still be suppressed by `?` and caught by `try`/`catch` exactly as
+/// before -- proves the new decode-failure exclusion is scoped to decode
+/// failures only, not a general regression of `?`/`try` suppression.
+#[test]
+fn test_ordinary_type_error_still_suppressed_and_caught_1620() {
+    let doc = r#"{"a": 1}"#;
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | keys?"], Some(doc))
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "", "stdout: {stdout}");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"try (.a | keys) catch "caught""#], Some(doc))
+            .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), r#""caught""#);
+}
+
 /// #1194 (the half in #1247's scope): a *structurally* malformed value --
 /// one the semi-index accepted as a span but could not classify as any JSON
 /// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21948,6 +21948,72 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
     Ok(())
 }
 
+/// #1620: a decode failure must never be suppressed by `?`, matching how
+/// `try`/`catch` already never catches one -- real yq's equivalent is a
+/// parse-time rejection no program could ever catch either. `\q` is not a
+/// YAML escape, so the scalar is structurally valid but undecodable, same
+/// repro as `test_decode_failure_does_not_corrupt_json_output_1247` above.
+///
+/// `.a?` (no downstream builtin) is deliberately not included: bare field
+/// access never decodes the string at all, so there is no decode failure for
+/// `?` to have swallowed in the first place -- same reasoning as the jq-side
+/// pin in `jq_cli_tests.rs`.
+#[test]
+fn test_decode_failure_not_suppressed_by_optional_1620() -> Result<()> {
+    let input = "a: \"x\\qy\"\nb: 2\n";
+    for filter in [".a | length?", "to_entries?"] {
+        let (output, stderr, exit_code) = run_yq_stdin_with_stderr(filter, input, &[])?;
+        assert_ne!(
+            exit_code, 0,
+            "`{filter}` should fail, not be suppressed by `?`\noutput: {output:?}"
+        );
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` should name the decode failure\nstderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #1620 regression pin: `try`/`catch` must keep NOT catching a decode
+/// failure -- already true before this fix, now true by design. Paired with
+/// the `?` case above so neither mechanism can silently start suppressing
+/// this again.
+#[test]
+fn test_decode_failure_not_caught_by_try_catch_1620() -> Result<()> {
+    let input = "a: \"x\\qy\"\n";
+    let filter = "try (.a | length) catch \"caught\"";
+    let (output, stderr, exit_code) = run_yq_stdin_with_stderr(filter, input, &[])?;
+    assert_ne!(exit_code, 0, "should still fail\noutput: {output:?}");
+    assert!(
+        !output.contains("caught"),
+        "should not have run the catch handler\noutput: {output:?}"
+    );
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "should name the decode failure\nstderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #1620 negative control: an *ordinary* type error (not a decode failure)
+/// must still be suppressed by `?` and caught by `try`/`catch` exactly as
+/// before -- proves the new decode-failure exclusion is scoped to decode
+/// failures only, not a general regression of `?`/`try` suppression.
+#[test]
+fn test_ordinary_type_error_still_suppressed_and_caught_1620() -> Result<()> {
+    let input = "a: 1\n";
+
+    let (output, exit_code) = run_yq_stdin(".a | keys?", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "");
+
+    let (output, exit_code) = run_yq_stdin("try (.a | keys) catch \"caught\"", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "caught");
+    Ok(())
+}
+
 /// #1242: `succinctly yq` accepted a document with a dangling
 /// non-continuable UTF-8 byte, indexed it, and handed back `null` for the
 /// scalar that byte was in -- at exit 0, with `--validate` no help because


### PR DESCRIPTION
## Summary

- Resolves #1620 (Open Risk 1 from #1247's design doc): a decode failure was catchable by `.a?`/`try .a catch` but not by real jq's equivalent (a parse-time rejection). Before this PR the two suppression mechanisms even disagreed with each other — `?` silently swallowed a decode failure, `try`/`catch` did not — for accidental reasons neither had actually decided.
- Adds `EvalError::decode_failure()`/`is_decode_failure()`, mirroring the existing `is_invalid_path_expression` precedent, and consults it at every `?`/`try`/`catch` boundary in both evaluators (`eval_generic.rs` and `eval.rs`) so a decode failure now passes through unmatched instead of being suppressed or caught — while staying on the ordinary per-record `Control::Error` channel (not `Control::Halt`, which is whole-process-fatal and would trade this divergence for a worse one against a multi-document stream).
- Also fixes 20 sites in `eval.rs` (unreachable via the CLI today, only via the public library API) that either gated a decode failure behind `optional` or used a placeholder `"invalid string"` message instead of the real decode reason.
- Records the resolution in `docs/plan/decode-failure-routing.md`'s Open Risk 1 / follow-up list.

## Test plan

- [x] 11 new `_1620` tests: 5 unit tests (`eval_generic.rs`, `eval.rs`) + 3 `jq_cli_tests.rs` + 3 `yq_cli_tests.rs` — covering the positive case (`?` no longer swallows it), a regression pin (`try`/`catch` still doesn't catch it), and negative controls (an ordinary type error is still suppressed/caught as before).
- [x] `cargo build --features cli,simd,regex,serde` and `cargo build --no-default-features` (no_std gate)
- [x] Both CI clippy legs (`--all-features` and the `std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests` leg) clean, `cargo fmt --check` clean
- [x] Full `cargo test --features cli,simd,regex,serde` green (958+ tests across 55 binaries, including `json_test_suite.rs`/`jq_golden_tests.rs`/`yq_golden_tests.rs`/`cli_golden_tests.rs`, which the design doc flagged as places this kind of change could show up as unrelated-looking churn)
- [x] Manually verified against the release binary in both jq and yq mode, and both the stdin and `-n` (dual-evaluator) invocation paths