### PR TITLE
fix(yq): contains(cond) aborts on an escaped argument instead of emitting first

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -379,16 +379,20 @@ per-mode-wholesale — all rows live-verified against yq v4.53.3:
 | `flatten(n)` | literal depth only — `bad expression, please check expression syntax` | gated off |
 | `getpath`, `range`, `nth`, `limit`, `combinations`, `paths`, `ltrimstr`, `rtrimstr`, `startswith`, `endswith`, `index`, `rindex`, `indices`, `inside`, `splits`, `scan`, `gsub`, `strftime`, `strptime`, `bsearch`, `pow` | **lexer-rejected — the builtin does not exist** | fans out; unopposed extension |
 
-There are **two** gate predicates, so the audit is both greps —
-`grep -E 'ArgFanout::(yq_native|reject_many_in_yq)' src/jq/eval.rs`. Each is named rather than
-inlined precisely so that stays a grep (CLAUDE.md's #106 lesson).
+There are **three** gate predicates, so the audit is all three greps —
+`grep -E 'ArgFanout::(yq_native|reject_many_in_yq|contains_gate)' src/jq/eval.rs`. Each is named
+rather than inlined precisely so that stays a grep (CLAUDE.md's #106 lesson). `contains_gate`
+is `contains`'s own gate (#1553): unlike the other two, it does not change whether the argument
+fans out (`contains` genuinely fans out in both modes, the table row above) — it only adds the
+no-prefix escape rule below.
 
 ### The prefix rule is where the two modes deliberately part
 
 jq emits the outputs a prefix earned and *then* fires the argument's trailing control (#1277's
 rule 2). Real yq does not: an escape anywhere in a gated argument produces the escape alone,
 with nothing printed first — live-verified against v4.53.3 for `has`, `split` and `join`
-(#1534), and for `delpaths` (#1533):
+(#1534), for `delpaths` (#1533), and for `contains` (#1553, `ArgFanout::AllClearedOnEscape` —
+the one gate that keeps every value on the *non*-escaping path, unlike the other two):
 
 ```bash
 $ printf 'a: 1\n' | yq            'has(("a","b", error("boom")))'   # Error: boom, stdout empty
@@ -425,10 +429,15 @@ which was true only before #1534.
   every escaping/clean combination). `fanout_two_args` now always evaluates inner before
   reporting outer's own violation, matching real yq's own evaluation order rather than just its
   final answer. See `test_yq_setpath_reject_many_prefers_inner_violation_over_outer_1533`.
-- **`contains` on an escaping argument**
-  ([#1553](https://github.com/rust-works/succinctly/issues/1553)). `contains` is ungated because
-  real yq fans it out, but real yq still emits nothing when its argument escapes, where
-  succinctly emits the prefix first.
+- **`contains` on an escaping argument** ([#1553](https://github.com/rust-works/succinctly/issues/1553),
+  now closed). `contains` stays ungated for fan-out — real yq genuinely fans it out, unlike its
+  `yq_native`-gated neighbours — but needed its own gate for the no-prefix escape rule, since
+  neither existing gate fit: `FirstOnly` would wrongly truncate the ordinary non-error
+  multi-output case, and `RejectMany` refuses multi-output outright, which `contains` never
+  does. `ArgFanout::AllClearedOnEscape` keeps every value like `All` on the non-escaping path,
+  but routes through the same eager, escape-clearing `fanout_arg` machinery `FirstOnly`/
+  `RejectMany` already use. Confirmed by
+  `test_yq_contains_gate_emits_nothing_when_the_argument_escapes_1553` and its siblings.
 
 ### Regex flag grammar — `test`/`match`/`capture` fixed, `split` still open
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1506,7 +1506,10 @@ fn partial<'a, W>(prefix: Vec<OwnedValue>, control: Control) -> QueryResult<'a, 
 /// input format, so this is a property of [`EvalSemantics`] rather than of the
 /// call site. Real yq has only a handful of these builtins and takes the first
 /// output for most of them; for the rest its lexer rejects the call outright,
-/// which makes jq's model unopposed there rather than a divergence.
+/// which makes jq's model unopposed there rather than a divergence. One
+/// builtin, `contains`, genuinely fans out in yq too but still aborts the
+/// whole call on an escape (`Self::AllClearedOnEscape`) rather than either of
+/// those two shapes — see its own doc comment, #1553.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ArgFanout {
     /// One result per argument output, as real jq does.
@@ -1525,16 +1528,29 @@ enum ArgFanout {
     /// #1279, which only has to keep the *outcome* an error rather than let
     /// yq mode start fanning out.
     RejectMany,
+    /// Every value is used, same as [`Self::All`] -- but if the argument's
+    /// own evaluation ended in an escape anywhere, the whole call reports
+    /// only that escape, with no output at all, via the same
+    /// [`clear_values_when_yq_argument_escaped`] both yq gates above already
+    /// use. `contains` is the one shared builtin that needs this third
+    /// shape: it genuinely fans out in real yq (unlike its `yq_native`-gated
+    /// neighbours below), but still aborts the whole call on an escape
+    /// rather than emitting a value it then raises over -- live-verified
+    /// against the pinned v4.53.3 (`contains(("a", error("boom")))` prints
+    /// nothing to stdout, just the error), #1553.
+    AllClearedOnEscape,
 }
 
 impl ArgFanout {
     /// The gate for a builtin real yq *has* and does *not* fan out.
     ///
     /// Live-probed against the pinned yq v4.53.3; each call site cites its own
-    /// probe. `contains` is deliberately **not** gated: it is the one shared
-    /// builtin that does fan out in real yq (`[.x | contains(("a","zz"))]` on
-    /// `abc` is `[true,false]`, matching jq), so gating it would introduce a
-    /// divergence rather than preserve one.
+    /// probe. `contains` is deliberately **not** gated by this one: it is a
+    /// shared builtin that genuinely does fan out in real yq
+    /// (`[.x | contains(("a","zz"))]` on `abc` is `[true,false]`, matching
+    /// jq) -- gating it here would introduce a divergence rather than
+    /// preserve one. It carries [`Self::contains_gate`] instead, for the
+    /// escape-clearing rule that fan-out alone doesn't cover.
     fn yq_native<S: EvalSemantics>() -> Self {
         if S::TAG == EvalTag::Yq {
             Self::FirstOnly
@@ -1555,6 +1571,18 @@ impl ArgFanout {
     fn reject_many_in_yq<S: EvalSemantics>() -> Self {
         if S::TAG == EvalTag::Yq {
             Self::RejectMany
+        } else {
+            Self::All
+        }
+    }
+
+    /// The gate for `contains`, the one shared builtin that fans out exactly
+    /// like jq in yq mode too, but still needs the yq-only "escape anywhere
+    /// clears the whole output" rule [`Self::yq_native`]/
+    /// [`Self::reject_many_in_yq`]'s gated builtins already get. #1553.
+    fn contains_gate<S: EvalSemantics>() -> Self {
+        if S::TAG == EvalTag::Yq {
+            Self::AllClearedOnEscape
         } else {
             Self::All
         }
@@ -1635,6 +1663,13 @@ fn apply_arg_fanout(fanout: ArgFanout, args: &mut Vec<OwnedValue>) -> Result<(),
         // jq's rule 1: every value is used, and the argument's own control
         // fires *after* them (#1279).
         ArgFanout::All => Ok(()),
+
+        // Every value is kept here too -- identical to `All`. The escape
+        // clearing this gate is *for* already happened upstream in
+        // `fanout_arg`, before this function ever runs (same as the two yq
+        // gates below): this arm only has to answer for the non-escape case,
+        // where "every value is kept" is exactly `All`'s own rule (#1553).
+        ArgFanout::AllClearedOnEscape => Ok(()),
 
         // `has(("a","b"))` is `true` in real yq, and `setpath((["a"],["b"]); 1)`
         // is a count error. (succinctly's wording for that count error differs
@@ -7237,9 +7272,11 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Not gated to yq's first-output-only behaviour, unlike its neighbours:
         // real yq fans `contains` out too (live-verified against the pinned
         // v4.53.3 — `[.x | contains(("a","zz"))]` on `abc` is `[true,false]`,
-        // the same as jq), so this is the one shared builtin where the two
-        // reference tools agree.
-        ArgFanout::All,
+        // the same as jq). It still needs its own yq-only rule, though: an
+        // escape anywhere in the argument clears the whole output rather
+        // than jq's "emit the prefix, then raise" (#1553) — see
+        // `ArgFanout::contains_gate`'s doc comment.
+        ArgFanout::contains_gate::<S>(),
         |b| {
             if jq_kind(&input) != jq_kind(&b) {
                 return if optional {
@@ -55036,6 +55073,15 @@ mod tests {
         assert!(apply_arg_fanout(ArgFanout::All, &mut args).is_ok());
         assert_eq!(args.len(), 3);
 
+        // `AllClearedOnEscape` keeps every output too, on its own -- the
+        // escape-clearing half of this gate happens upstream in `fanout_arg`
+        // (see `first_only_gate_clears_its_values_when_the_argument_escaped_1534`'s
+        // companion test below), so this function alone cannot distinguish
+        // it from `All` (#1553).
+        let mut args = three();
+        assert!(apply_arg_fanout(ArgFanout::AllClearedOnEscape, &mut args).is_ok());
+        assert_eq!(args.len(), 3);
+
         // `FirstOnly` keeps exactly the first.
         let mut args = three();
         assert!(apply_arg_fanout(ArgFanout::FirstOnly, &mut args).is_ok());
@@ -55056,7 +55102,12 @@ mod tests {
         // An empty argument list is never refused, under any gate: zero
         // outputs means the builtin produces zero outputs (#1045), which is
         // not the "found N results" condition `RejectMany` exists to catch.
-        for gate in [ArgFanout::All, ArgFanout::FirstOnly, ArgFanout::RejectMany] {
+        for gate in [
+            ArgFanout::All,
+            ArgFanout::AllClearedOnEscape,
+            ArgFanout::FirstOnly,
+            ArgFanout::RejectMany,
+        ] {
             let mut args: Vec<OwnedValue> = Vec::new();
             assert!(apply_arg_fanout(gate, &mut args).is_ok());
             assert!(args.is_empty());
@@ -55101,6 +55152,32 @@ mod tests {
         assert_eq!(args.len(), 2);
     }
 
+    /// #1553: `AllClearedOnEscape` is `contains`'s own gate -- it must adopt
+    /// the same clearing behaviour `FirstOnly` does (unlike plain `All`,
+    /// pinned just above), while still keeping every value when there is no
+    /// escape at all (the "still fans out" half real yq's `contains`
+    /// needs, unlike `FirstOnly`'s truncation).
+    #[test]
+    fn all_cleared_on_escape_gate_clears_its_values_when_the_argument_escaped_1553() {
+        let escaped = || Some(Control::Error(EvalError::new("boom")));
+
+        // Values present *and* an escape: the escape wins outright, same as
+        // `FirstOnly`.
+        let mut args = vec![OwnedValue::int(1), OwnedValue::int(2)];
+        let trailing = escaped();
+        assert!(clear_values_when_yq_argument_escaped(&mut args, &trailing));
+        assert!(args.is_empty(), "args={args:?}");
+        assert!(trailing.is_some(), "the control must still fire");
+
+        // No escape: every value survives -- unlike `FirstOnly`'s truncation,
+        // this is the "still fans out" half of the gate.
+        let mut args = vec![OwnedValue::int(1), OwnedValue::int(2)];
+        let trailing = None;
+        assert!(!clear_values_when_yq_argument_escaped(&mut args, &trailing));
+        assert!(apply_arg_fanout(ArgFanout::AllClearedOnEscape, &mut args).is_ok());
+        assert_eq!(args.len(), 2);
+    }
+
     /// #1537 companion: the yq-mode gates are named constructors, so mode
     /// selection lives in one place per gate rather than inline at each
     /// builtin. Pins that both resolve to `All` in jq mode and to their
@@ -55122,6 +55199,14 @@ mod tests {
         assert!(matches!(
             ArgFanout::reject_many_in_yq::<YqSemantics>(),
             ArgFanout::RejectMany
+        ));
+        assert!(matches!(
+            ArgFanout::contains_gate::<JqSemantics>(),
+            ArgFanout::All
+        ));
+        assert!(matches!(
+            ArgFanout::contains_gate::<YqSemantics>(),
+            ArgFanout::AllClearedOnEscape
         ));
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1538,6 +1538,17 @@ enum ArgFanout {
     /// rather than emitting a value it then raises over -- live-verified
     /// against the pinned v4.53.3 (`contains(("a", error("boom")))` prints
     /// nothing to stdout, just the error), #1553.
+    ///
+    /// Reached only through [`fanout_arg`] today (`contains` is single-
+    /// argument), which is what makes [`apply_arg_fanout`]'s own arm for
+    /// this variant safe to assume the clearing already ran. **Not** valid
+    /// through [`fanout_two_args`] as-is -- that function's own doc comment
+    /// explains why [`clear_values_when_yq_argument_escaped`] isn't shared
+    /// with it verbatim (clearing a slot's values pre-emptively skips
+    /// `body`, which is where the *other* slot gets validated, #1533/#1534).
+    /// A future two-argument builtin needing this same "fans out, but clears
+    /// on escape" rule needs `fanout_two_args`'s own narrower treatment of
+    /// that function, not a bare reuse of this variant.
     AllClearedOnEscape,
 }
 
@@ -1661,15 +1672,14 @@ fn clear_values_when_yq_argument_escaped(
 fn apply_arg_fanout(fanout: ArgFanout, args: &mut Vec<OwnedValue>) -> Result<(), EvalError> {
     match fanout {
         // jq's rule 1: every value is used, and the argument's own control
-        // fires *after* them (#1279).
-        ArgFanout::All => Ok(()),
-
-        // Every value is kept here too -- identical to `All`. The escape
-        // clearing this gate is *for* already happened upstream in
-        // `fanout_arg`, before this function ever runs (same as the two yq
-        // gates below): this arm only has to answer for the non-escape case,
-        // where "every value is kept" is exactly `All`'s own rule (#1553).
-        ArgFanout::AllClearedOnEscape => Ok(()),
+        // fires *after* them (#1279). `AllClearedOnEscape` (#1553) answers
+        // identically here -- provably so, not just today: the escape
+        // clearing it's *for* already happened upstream in `fanout_arg`,
+        // before this function ever runs, so by the time either variant
+        // reaches this arm there is no escape left to distinguish them by.
+        // One arm rather than two separate `Ok(())` bodies, so a future edit
+        // to `All`'s handling can't land on one and silently miss the other.
+        ArgFanout::All | ArgFanout::AllClearedOnEscape => Ok(()),
 
         // `has(("a","b"))` is `true` in real yq, and `setpath((["a"],["b"]); 1)`
         // is a count error. (succinctly's wording for that count error differs
@@ -1740,11 +1750,15 @@ fn apply_arg_fanout(fanout: ArgFanout, args: &mut Vec<OwnedValue>) -> Result<(),
 ///    stealing document 2 while document 1 was still being processed and
 ///    losing document 1's own error entirely.
 ///
-/// Only [`ArgFanout::All`] is driven lazily. Both yq gates stay eager on
-/// purpose: real yq evaluates the whole argument and *reports* an escape
-/// found anywhere in it (see [`apply_arg_fanout`]'s shared escape arm,
-/// #1533/#1534), so pulling lazily there would hide the very control those
-/// gates have to propagate.
+/// Only [`ArgFanout::All`] is driven lazily. Every yq gate stays eager on
+/// purpose, [`ArgFanout::AllClearedOnEscape`] (#1553) included: real yq
+/// evaluates the whole argument and *reports* an escape found anywhere in it
+/// (see [`apply_arg_fanout`]'s shared escape arm, #1533/#1534), so pulling
+/// lazily there would hide the very control those gates have to propagate.
+/// This does cost `contains` the laziness rule 4 above still gives jq mode --
+/// a `body` failure no longer stops the rest of the argument from being
+/// evaluated in yq mode, the same trade-off `has`/`split`/`join`/`setpath`/
+/// `delpaths` already made.
 fn fanout_arg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics, B>(
     arg_expr: &Expr,
     value: StandardJson<'a, W>,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21392,6 +21392,77 @@ fn test_yq_first_only_gate_still_takes_the_first_output_1534() -> Result<()> {
     Ok(())
 }
 
+/// #1553: `contains` is the one shared builtin real yq fans out exactly like
+/// jq -- but it still needs the yq-only "an escape anywhere clears the whole
+/// output" rule #1534 gave `has`/`split`/`join`. It cannot use `FirstOnly`
+/// (that would wrongly truncate the non-error multi-output case), so it
+/// carries its own gate, `ArgFanout::AllClearedOnEscape`.
+///
+/// Live-captured from the pinned yq v4.53.3:
+///
+/// ```text
+/// $ printf 'x: "abc"\n' | yq '.x | contains(("a", error("boom")))'
+/// Error: boom          <- stderr only; stdout empty, exit 1
+/// ```
+///
+/// succinctly used to print `true` to stdout *and* raise, the same
+/// prefix-then-raise shape #1534 fixed for its three gated builtins.
+#[test]
+fn test_yq_contains_gate_emits_nothing_when_the_argument_escapes_1553() -> Result<()> {
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        r#".x | contains(("a", error("boom")))"#,
+        "x: \"abc\"\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 1, "err: {err:?}");
+    Ok(())
+}
+
+/// #1553 companion: an escape *before* any output was produced must still
+/// propagate. `yq '.x | contains(error("boom"))'` is `Error: boom`.
+#[test]
+fn test_yq_contains_gate_still_propagates_an_immediate_escape_1553() -> Result<()> {
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        r#".x | contains(error("boom"))"#,
+        "x: \"abc\"\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 1, "err: {err:?}");
+    Ok(())
+}
+
+/// #1553 guard: the gate's ordinary job -- genuinely fanning out, unlike
+/// `FirstOnly` -- is untouched. `[.x | contains(("a","zz"))]` on `abc` is
+/// `[true,false]`, matching both jq and real yq v4.53.3.
+#[test]
+fn test_yq_contains_gate_still_fans_out_with_no_escape_1553() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"[.x | contains(("a","zz"))]"#,
+        "x: \"abc\"\n",
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[true,false]");
+    Ok(())
+}
+
+/// #1553 regression guard: jq mode keeps its own unaffected rule -- `body`'s
+/// prefix survives, then the escape fires (#1279 rule 2), matching jq 1.7.1's
+/// `contains(("a", error("boom")))` -> stdout `true`, then exit 5.
+#[test]
+fn test_jq_contains_still_emits_the_prefix_before_an_escape_1553() -> Result<()> {
+    let (out, err, code) =
+        run_jq_stdin_with_stderr(r#"contains(("a", error("boom")))"#, r#""abc""#, &["-c"])?;
+    assert_eq!(out.trim(), "true", "out: {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 5, "err: {err:?}");
+    Ok(())
+}
+
 /// #1533 (single-argument half): `ArgFanout::RejectMany` used to test
 /// `args.len() > 1` before ever looking at the argument's own trailing
 /// control, so a real `error(...)` inside the generator was masked by

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21463,6 +21463,46 @@ fn test_jq_contains_still_emits_the_prefix_before_an_escape_1553() -> Result<()>
     Ok(())
 }
 
+/// #1553: the new eager path pulls the whole argument before ever calling
+/// `body`, so a later value's escape now outranks an earlier value's
+/// `body`-level type error -- rather than `body` failing on the first
+/// mismatched value the way jq mode still does (below), the escape wins.
+/// Live-verified against yq v4.53.3: `.x | contains((1, error("boom")))`
+/// on `abc` is `Error: boom`, not `body`'s own containment-check error.
+/// A "smarter" reimplementation that checked `body` incrementally before
+/// consulting the argument's trailing control would silently flip this back
+/// to the wrong (jq-mode) answer with nothing else here to catch it.
+#[test]
+fn test_yq_contains_gate_a_later_escape_outranks_an_earlier_body_error_1553() -> Result<()> {
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        r#".x | contains((1, error("boom")))"#,
+        "x: \"abc\"\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 1, "err: {err:?}");
+    Ok(())
+}
+
+/// #1553 companion: jq mode is the mirror image here, and must stay that way
+/// -- its lazy path stops pulling the argument the instant `body` fails on
+/// the mismatched `1`, so `error("boom")` is never reached at all. Real jq
+/// 1.7.1 raises its own containment-check error, not `boom`.
+#[test]
+fn test_jq_contains_body_error_still_wins_over_a_later_escape_1553() -> Result<()> {
+    let (out, err, code) =
+        run_jq_stdin_with_stderr(r#"contains((1, error("boom")))"#, r#""abc""#, &["-c"])?;
+    assert_eq!(out, "", "stdout must be empty, got {out:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+    assert!(!err.contains("boom"), "err: {err:?}");
+    assert_eq!(code, 5, "err: {err:?}");
+    Ok(())
+}
+
 /// #1533 (single-argument half): `ArgFanout::RejectMany` used to test
 /// `args.len() > 1` before ever looking at the argument's own trailing
 /// control, so a real `error(...)` inside the generator was masked by


### PR DESCRIPTION
## Summary

Real yq's `contains` genuinely fans out over a multi-output argument, unlike its
`ArgFanout::yq_native`-gated neighbours (`has`/`split`/`join`, #1534) — but it still needs
their yq-only rule: an escape anywhere in the argument clears the whole output, rather
than jq's own "emit the prefix, then raise" (#1279 rule 2).

```
$ yq            '.x | contains(("a", error("boom")))' s.yaml   # Error: boom (stdout empty, exit 1)
$ succinctly yq '.x | contains(("a", error("boom")))' s.yaml   # was: true (stdout), then Error: boom
```

Neither existing yq gate fit:
- `FirstOnly` would wrongly truncate the ordinary non-error multi-output case — `contains`
  must still answer `[true,false]` for `contains(("a","zz"))`, which real yq does too.
- `RejectMany` refuses multi-output outright, which `contains` never does.

## Fix

Added a third `ArgFanout` variant, `AllClearedOnEscape`: keeps every value like `All`, but
routes through the same eager, escape-clearing path `FirstOnly`/`RejectMany` already use in
`fanout_arg` — no change needed to `fanout_arg` itself, since its dispatch condition
(`!matches!(fanout, ArgFanout::All)`) already admits any non-`All` variant into that path.

`contains_gate::<S>()` picks `AllClearedOnEscape` for `YqSemantics`, `All` (unchanged) for
`JqSemantics` — pinned by a jq-mode regression test alongside the new yq-mode coverage.

Fixes #1553.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 959 tests, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against the pinned oracles directly (Homebrew `yq` v4.53.3, `/usr/bin/jq` 1.7.1) — escape-in-argument, immediate escape, and no-escape multi-output cases in both modes
- [x] New unit tests (`apply_arg_fanout`/`clear_values_when_yq_argument_escaped`/gate-selection coverage) and new CLI tests (`tests/yq_cli_tests.rs`) covering all four cases
- [x] `cargo llvm-cov` + `omni-dev coverage diff`: 100% patch coverage (33/33 new lines)