### PR TITLE
fix(jq): debug/debug(msg) write ["DEBUG:",value] to stderr

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31414,10 +31414,19 @@ fn builtin_isfinite<W: Clone + AsRef<[u64]>>(
 /// formatter `builtin_stderr` uses, so non-finite floats etc. render
 /// identically across both rather than re-deriving the jq/yq JSON-shape fork
 /// a second time.
+///
+/// Builds the whole line before writing it, in one `write_stderr` call --
+/// matching `builtin_halt_error`'s own single-write convention just below,
+/// rather than the three separate writes an earlier revision used. Also
+/// makes this atomic against a mid-formatting panic (e.g.
+/// `assert_value_tree_depth`'s nesting-depth guard): a panic during
+/// `owned_value_to_json` now leaves stderr untouched rather than a
+/// truncated `["DEBUG:",` fragment with no closing bracket.
 fn write_debug_line<S: EvalSemantics>(value: &OwnedValue) {
-    write_stderr("[\"DEBUG:\",");
-    write_stderr(&owned_value_to_json::<S>(value));
-    write_stderr("]\n");
+    write_stderr(&format!(
+        "[\"DEBUG:\",{}]\n",
+        owned_value_to_json::<S>(value)
+    ));
 }
 
 /// Builtin: debug - print `["DEBUG:", .]` to stderr, pass `.` through
@@ -31432,41 +31441,69 @@ fn builtin_debug<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: debug(msg) - print `["DEBUG:", <msg output>]` to stderr once per
-/// output of `msg` (real jq's own definition is `(msg|debug|empty), .`, so a
-/// multi-output `msg` writes one line per output -- confirmed live:
-/// `debug(("a","b"))` writes two lines), then pass `.` (not `msg`'s value)
-/// through unchanged.
+/// output of `msg`, *as each output is produced* -- real jq's own definition
+/// is `(msg|debug|empty), .`, a per-item pipe, not "collect every output,
+/// then print". This matters in two live-verified ways an eager collect
+/// (`eval_owned_multi`, an earlier revision's approach) gets wrong:
+///
+/// 1. **Ordering.** A side effect nested inside a later output of `msg` must
+///    not fire before an earlier output's own debug line prints:
+///    `debug((1, (2|stderr|empty)))` writes `["DEBUG:",1]` then raw `2` in
+///    real jq, in that order, because jq only asks `msg` for its second
+///    output after the first has already been consumed (here, printed).
+///    Collecting `msg`'s outputs into a `Vec` first evaluates the whole
+///    expression -- side effects included -- before any debug line is
+///    written, reversing the order.
+/// 2. **Partial output on a later escape.** `debug(("a", error("boom")))`
+///    still writes `["DEBUG:","a"]` to stderr in real jq before the error
+///    propagates -- the first output was already consumed (printed) by the
+///    time the second one escapes. An eager collector that gathers every
+///    output into `Ok(Vec<_>)` and only prints on success discards that
+///    already-produced value the moment `msg` later errors/breaks/halts,
+///    silently losing it. Same loss for `break`/`halt_error` reached after
+///    at least one output.
+///
+/// [`eval_each_owned`] is the codebase's existing demand-driven sink (#820,
+/// `docs/plan/jq-lazy-generator-consumers.md`) built for exactly this
+/// "consumer must see each output as it happens, not after the fact" shape
+/// (its own module doc cites `stderr`, two functions below, as the
+/// canonical example) -- calling `write_debug_line` directly from the sink,
+/// always answering `Demand::Continue`, prints each line in true generator
+/// order and naturally preserves whatever already printed before a later
+/// escape, with no separate "keep the prefix" bookkeeping needed.
 fn builtin_debug_msg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     msg: &Expr,
     value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    // `msg` still has to be evaluated for its control effects even before
-    // considering what to print: a halt reached while producing it
-    // (`debug(halt_error(3))`) must halt the process exactly as it would
-    // anywhere else `msg` could sit (#791), and a plain error must propagate
-    // too — real jq defines `debug(msg)` as `(msg|debug|empty), .` with no
-    // `try`/`?`, so an error raised while producing `msg` aborts the whole
-    // expression (verified live: `debug(error("boom"))` errors out in real
-    // jq rather than passing `.` through).
     let owned = to_owned(&value);
-    let msg_outputs = match eval_owned_multi::<S>(msg, &owned) {
-        Ok(outputs) => outputs,
-        Err(escape) => return QueryResult::from(escape),
-    };
-    for msg_value in &msg_outputs {
-        write_debug_line::<S>(msg_value);
+    let flow = eval_each_owned::<S>(msg, &owned, false, &mut |msg_value| {
+        write_debug_line::<S>(&msg_value);
+        Demand::Continue
+    });
+    // This sink never answers `Stop`, so `Flow::Stopped` cannot actually
+    // occur -- folded into "no trailing control" anyway rather than
+    // `unreachable!()`, the same "a defensible answer beats a panic"
+    // precedent `resolve_leaf`'s own always-`Continue` `eval_each_owned` use
+    // takes for the identical shape (citing `any_all_gen_cond` as its
+    // precedent in turn). A `Halt` is never downgraded: `QueryResult::from`
+    // (via `EvalEscape::from(Control)`) carries it straight through,
+    // matching #791's "halt is an unconditional process-termination signal"
+    // rule -- unchanged from the pre-existing halt-propagation behavior
+    // this replaces.
+    if let Flow::Escaped(control) = flow {
+        return QueryResult::from(EvalEscape::from(control));
     }
     QueryResult::Owned(owned)
 }
 
 // Process control functions (#791)
 //
-// Unlike `debug`/`debug(msg)` above, these genuinely write to stderr rather
-// than staying a library-context no-op: `stderr`'s write has to fire *during*
-// generator iteration (e.g. `(1,2,3) | stderr` needs three separate
-// interleaved writes as each value streams through), which can't be deferred
-// to a CLI-layer batch print the way `ErrorSink`'s diagnostics are. Gated the
+// `stderr`'s write has to fire *during* generator iteration (e.g.
+// `(1,2,3) | stderr` needs three separate interleaved writes as each value
+// streams through), which can't be deferred to a CLI-layer batch print the
+// way `ErrorSink`'s diagnostics are -- the same requirement `debug`/
+// `debug(msg)` above now meet too, via `eval_each_owned`. Gated the
 // same way `$ENV`/`env` gate their (read-only) OS interaction below.
 
 /// Write raw bytes to stderr. No-op under `no_std` (mirrors `eval_env`'s

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5532,7 +5532,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::IsFinite => builtin_isfinite::<W>(value, optional),
 
         // Phase 10: Debug
-        Builtin::Debug => builtin_debug::<W>(value, optional),
+        Builtin::Debug => builtin_debug::<W, S>(value, optional),
         Builtin::DebugMsg(msg) => builtin_debug_msg::<W, S>(msg, value, optional),
 
         // Process control (#791)
@@ -31407,37 +31407,55 @@ fn builtin_isfinite<W: Clone + AsRef<[u64]>>(
 
 // Debug functions
 
-/// Builtin: debug - output value to stderr, pass through unchanged
-fn builtin_debug<W: Clone + AsRef<[u64]>>(
+/// Writes one `["DEBUG:", value]` line to stderr, matching jq 1.7.1
+/// byte-for-byte: compact JSON, a trailing newline -- unlike `stderr`'s own
+/// builtin just below, which has none (`jq -cn '1 | debug'` writes
+/// `["DEBUG:",1]\n` to stderr). Reuses `owned_value_to_json`, the same
+/// formatter `builtin_stderr` uses, so non-finite floats etc. render
+/// identically across both rather than re-deriving the jq/yq JSON-shape fork
+/// a second time.
+fn write_debug_line<S: EvalSemantics>(value: &OwnedValue) {
+    write_stderr("[\"DEBUG:\",");
+    write_stderr(&owned_value_to_json::<S>(value));
+    write_stderr("]\n");
+}
+
+/// Builtin: debug - print `["DEBUG:", .]` to stderr, pass `.` through
+/// unchanged.
+fn builtin_debug<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
-    // In a library context we don't actually print to stderr
-    // We just pass through the value unchanged
-    QueryResult::Owned(to_owned(&value))
+    let owned = to_owned(&value);
+    write_debug_line::<S>(&owned);
+    QueryResult::Owned(owned)
 }
 
-/// Builtin: debug(msg) - output message and value to stderr
+/// Builtin: debug(msg) - print `["DEBUG:", <msg output>]` to stderr once per
+/// output of `msg` (real jq's own definition is `(msg|debug|empty), .`, so a
+/// multi-output `msg` writes one line per output -- confirmed live:
+/// `debug(("a","b"))` writes two lines), then pass `.` (not `msg`'s value)
+/// through unchanged.
 fn builtin_debug_msg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     msg: &Expr,
     value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    // In a library context we don't actually print to stderr, matching
-    // `builtin_debug`'s own no-op policy — but `msg` still has to be
-    // evaluated for its control effects, even though its value is discarded:
-    // a halt reached while producing it (`debug(halt_error(3))`) must halt
-    // the process exactly as it would anywhere else `msg` could sit (#791),
-    // and a plain error must propagate too — real jq defines `debug(msg)` as
-    // `(msg|debug|empty), .` with no `try`/`?`, so an error raised while
-    // producing `msg` aborts the whole expression (verified live:
-    // `debug(error("boom"))` errors out in real jq rather than passing `.`
-    // through). This does not change the pre-existing no-print policy, only
-    // stops a halt/error from vanishing because the argument was never
-    // evaluated at all.
+    // `msg` still has to be evaluated for its control effects even before
+    // considering what to print: a halt reached while producing it
+    // (`debug(halt_error(3))`) must halt the process exactly as it would
+    // anywhere else `msg` could sit (#791), and a plain error must propagate
+    // too — real jq defines `debug(msg)` as `(msg|debug|empty), .` with no
+    // `try`/`?`, so an error raised while producing `msg` aborts the whole
+    // expression (verified live: `debug(error("boom"))` errors out in real
+    // jq rather than passing `.` through).
     let owned = to_owned(&value);
-    if let Err(escape) = eval_owned_multi::<S>(msg, &owned) {
-        return QueryResult::from(escape);
+    let msg_outputs = match eval_owned_multi::<S>(msg, &owned) {
+        Ok(outputs) => outputs,
+        Err(escape) => return QueryResult::from(escape),
+    };
+    for msg_value in &msg_outputs {
+        write_debug_line::<S>(msg_value);
     }
     QueryResult::Owned(owned)
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4863,8 +4863,13 @@ fn test_debug_msg_argument_halt_propagates() -> Result<()> {
     // halt_error's introduction made `debug(msg)` the one builtin argument
     // position where a halt had zero effect -- no stderr write, no exit
     // code. Verified against jq 1.7.1: `jq -n 'debug(halt_error(3))'` exits
-    // 3 (the pre-existing no-print policy for `msg`'s *text* is unchanged;
-    // only its control effects must reach the process).
+    // 3 -- and, since #1594, `msg`'s own text no longer stays silent either
+    // (the library-context no-print policy this comment used to describe is
+    // gone entirely): a `halt_error` fires before `msg`'s value is ever
+    // produced, so no `["DEBUG:", ...]` line reaches stderr for *this*
+    // repro specifically, but that's `halt_error`'s own short-circuit, not a
+    // debug-line suppression -- see `test_debug_writes_the_debug_line_1594`
+    // for the case that does print.
     let (stdout, stderr, code) = run_jq_full(&["-n", "debug(halt_error(3)), \"after\""], None)?;
     assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
@@ -4887,6 +4892,48 @@ fn test_debug_msg_argument_error_propagates() -> Result<()> {
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
     assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1594: `debug`/`debug(msg)` were explicit, commented no-ops -- `.` passed
+/// through unchanged, nothing ever reached stderr. Real jq writes
+/// `["DEBUG:", value]` as compact JSON with a trailing newline. Verified
+/// byte-for-byte (via separate stdout/stderr file redirection, not this
+/// helper's own combined capture) against jq 1.7.1: `jq -cn '1 | debug'`
+/// writes `["DEBUG:",1]\n` to stderr and `1\n` to stdout.
+#[test]
+fn test_debug_writes_the_debug_line_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "1 | debug"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stderr, "[\"DEBUG:\",1]\n");
+    assert_eq!(stdout, "1\n");
+    Ok(())
+}
+
+/// #1594 companion: `debug(msg)` prints `msg`'s own evaluated value into the
+/// `["DEBUG:", ...]` line, not `.` -- but still passes `.` (not `msg`) through
+/// to stdout unchanged. Verified against jq 1.7.1: `jq -cn '1 | debug("hi")'`
+/// writes `["DEBUG:","hi"]\n` to stderr, `1\n` to stdout.
+#[test]
+fn test_debug_msg_writes_msgs_own_value_not_input_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", r#"1 | debug("hi")"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stderr, "[\"DEBUG:\",\"hi\"]\n");
+    assert_eq!(stdout, "1\n");
+    Ok(())
+}
+
+/// #1594 companion: real jq's own definition is `(msg|debug|empty), .`, so a
+/// multi-output `msg` writes one `["DEBUG:", ...]` line per output, in order
+/// -- not one line for the whole stream. Verified against jq 1.7.1:
+/// `jq -cn '1 | debug(("a","b"))'` writes two separate newline-terminated
+/// lines.
+#[test]
+fn test_debug_msg_multi_output_writes_one_line_per_output_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", r#"1 | debug(("a","b"))"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stderr, "[\"DEBUG:\",\"a\"]\n[\"DEBUG:\",\"b\"]\n");
+    assert_eq!(stdout, "1\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4937,6 +4937,62 @@ fn test_debug_msg_multi_output_writes_one_line_per_output_1594() -> Result<()> {
     Ok(())
 }
 
+/// #1594 review follow-up: real jq's per-item pipe semantics mean an escape
+/// on a *later* output of `msg` does not retroactively un-print an earlier
+/// output's debug line -- the first output was already consumed by the time
+/// the second one escapes. An eager "collect every output into one Vec, then
+/// print" implementation (this fix's own first revision) gets this wrong:
+/// it discards the whole Vec the moment `msg` later errors, silently losing
+/// the already-produced line. Live-verified against jq 1.7.1:
+/// `jq -cn '1 | debug(("a", error("boom")))'` writes `["DEBUG:","a"]` to
+/// stderr *before* the error, not instead of it.
+#[test]
+fn test_debug_msg_keeps_the_prefix_when_a_later_output_errors_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", r#"1 | debug(("a", error("boom")))"#], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.starts_with("[\"DEBUG:\",\"a\"]\n"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1594 review follow-up, `break` sibling of the test above: a `break`
+/// reached after `msg` has already produced output(s) must not un-print
+/// them either. Live-verified against jq 1.7.1:
+/// `jq -cn 'label $out | debug(("a","b", break $out))'` writes both DEBUG
+/// lines, then breaks (no error, no further stdout).
+#[test]
+fn test_debug_msg_keeps_the_prefix_when_a_later_output_breaks_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", r#"label $out | debug(("a","b", break $out))"#],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "[\"DEBUG:\",\"a\"]\n[\"DEBUG:\",\"b\"]\n");
+    Ok(())
+}
+
+/// #1594 review follow-up: `msg`'s outputs must be produced and printed in
+/// true generator order, interleaved with any side effect nested inside a
+/// later output -- not "evaluate the whole of `msg` first (side effects
+/// included), print afterward". Live-verified against jq 1.7.1 (bytes
+/// confirmed via separate stdout/stderr file redirection, `od -c`):
+/// `jq -cn 'debug((1, (2|stderr|empty)))'` writes `["DEBUG:",1]` then raw
+/// `2` to stderr, in that order -- debug's own line for the first output
+/// prints before the second output's nested `stderr` call ever runs.
+#[test]
+fn test_debug_msg_interleaves_with_a_nested_side_effect_in_generator_order_1594() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "debug((1, (2|stderr|empty)))"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stderr, "[\"DEBUG:\",1]\n2");
+    assert_eq!(stdout, "null\n");
+    Ok(())
+}
+
 #[test]
 fn test_paths_filter_halt_on_scalar_root() -> Result<()> {
     // `builtin_paths_filter` only evaluated `filter` against nodes reached
@@ -19318,13 +19374,17 @@ fn test_tonumber_rejects_internal_overflow_sentinels_1090() {
 // interleaves the two misleadingly, since stdout is buffered when piped but
 // stderr is not (same convention as the `halt`/`stderr` block above).
 //
-// `stderr` and `halt_error` are the only two builtins whose Rust
-// implementation performs I/O *at evaluation time* (`write_stderr`, via
-// `builtin_stderr`/`builtin_halt_error` in `src/jq/eval.rs`); `debug` and
-// `debug(msg)` are deliberate library-context no-ops, and `error(...)` carries
-// its payload in the result. So `stderr` is the only usable probe for "was
-// this sub-expression evaluated at all?" -- which is why #820's own original
-// `first(1, debug)` repro was a false negative.
+// `stderr`, `halt_error`, and (since #1594) `debug`/`debug(msg)` are the
+// builtins whose Rust implementation performs I/O *at evaluation time*
+// (`write_stderr`, via `builtin_stderr`/`builtin_halt_error`/`builtin_debug`/
+// `builtin_debug_msg` in `src/jq/eval.rs`); `error(...)` carries its payload
+// in the result instead. `stderr` remains this file's probe of choice below
+// -- unlike `debug`, its output is unwrapped raw text (`"B"` rather than
+// `["DEBUG:","B"]`), which keeps the tables' expected-stderr strings
+// shorter -- but `debug`/`debug(msg)` are equally usable "was this
+// sub-expression evaluated at all?" probes now. Before #1594 they were
+// deliberate library-context no-ops, which is why #820's own original
+// `first(1, debug)` repro was a false negative at the time.
 //
 // `input`/`inputs` are a second, *destructive* probe: they pop from the same
 // process-global queue the CLI's own per-document driver loop drains, so an

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1177,6 +1177,25 @@ fn test_yq_range_multi_output_bound_fanout_and_laziness_1556() -> Result<()> {
     Ok(())
 }
 
+/// #1594: `debug` reaches this same shared `<S: EvalSemantics>` builtin in
+/// yq mode too (gated behind `--jq-extensions`, real yq has no `debug` at
+/// all). Not oracle-verified -- no real-yq equivalent -- but pins that the
+/// fix (writing a `["DEBUG:", value]` line via the mode-aware
+/// `owned_value_to_json`) reaches yq mode identically to jq mode rather than
+/// only being wired up on the jq-mode call site.
+#[test]
+fn test_yq_debug_writes_the_debug_line_1594() -> Result<()> {
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | debug",
+        "a: 1\n",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
+    assert_eq!(code, 0, "out: {output:?} stderr: {stderr:?}");
+    assert_eq!(output, "1\n");
+    assert_eq!(stderr, "[\"DEBUG:\",1]\n");
+    Ok(())
+}
+
 /// Updated for #1398: `paths` on `--input-format json` input must now agree
 /// with YAML input (both preserve every duplicate-key occurrence, matching
 /// `to_entries`'s own format-independent behavior) rather than applying


### PR DESCRIPTION
## Summary

\`builtin_debug\`/\`builtin_debug_msg\` were explicit, commented no-ops — \`.\` passed through
unchanged, nothing ever reached stderr, so \`debug\`'s whole diagnostic purpose was silently
missing:

\`\`\`
$ jq            -cn '1 | debug'   # writes ["DEBUG:",1] to stderr, 1 to stdout
$ succinctly jq -cn '1 | debug'   # was: 1 to stdout, nothing to stderr
\`\`\`

## Fix

Real jq writes a compact-JSON \`["DEBUG:", value]\` line with a trailing newline;
\`debug(msg)\` writes one such line **per output of \`msg\`** (its own definition is
\`(msg|debug|empty), .\` — confirmed live: \`debug(("a","b"))\` writes two lines), and the
line contains \`msg\`'s own evaluated value, not \`.\`.

Reuses \`write_stderr\` and \`owned_value_to_json::<S>\` — the same primitives
\`stderr\`/\`halt_error\` already use — so non-finite floats etc. render identically across
all three rather than a fourth hand-rolled formatter.

\`debug(msg)\`'s pre-existing halt/error propagation (#791: control effects reach the
process even though \`msg\`'s text used to stay silent) is unchanged by this fix — only the
no-print policy itself is gone. Two existing tests referencing that old policy in their
comments (\`test_debug_msg_argument_halt_propagates\`, still passing unmodified) had their
comments updated to stay accurate.

Reaches yq mode identically (\`debug\` is gated behind \`--jq-extensions\` there — real yq has
no \`debug\` at all), pinned alongside the jq-mode coverage.

Fixes #1594.

## Test plan

- [x] \`cargo build --features cli\`
- [x] \`cargo test --features cli,simd,regex,serde\` (full suite, 965 tests, all green; one
      isolated SIGKILL flake from machine contention, reproduced green in isolation)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\`
- [x] \`cargo build --no-default-features\` (no_std) — same 6 pre-existing dead-code warnings as unmodified \`main\`, none new
- [x] Diffed output byte-for-byte against the pinned jq 1.7.1 oracle (via separate stdout/stderr file redirection, not a combined capture) — bare \`debug\`, \`debug(msg)\` with a scalar/string msg, multi-output \`msg\`, and \`debug(error(...))\`/\`debug(halt_error(n))\` control-flow propagation
- [x] New unit + CLI tests (jq mode and yq mode) pinning the exact stderr byte content
- [x] \`cargo llvm-cov\` + \`omni-dev coverage diff\`: 100% patch coverage (15/15 new lines)