### PR TITLE
docs(yq): fix yaml_validate_guard's stale doc comment and wrong exit-code constant

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -375,9 +375,16 @@ fn read_file(path: &Path) -> Result<Vec<u8>> {
 /// when `--validate` is set, additionally runs the opt-in strict validator
 /// (`succinctly::yaml::validate`) before indexing and, on the first
 /// violation, prints a rustc-style diagnostic. Either failure returns the
-/// exit code to bail with. Mirrors `sjq --validate`
-/// (`jq_runner::validate_json_input`) for the `--validate` half; JSON input
-/// (`-p json`) is left to jq-side validation for both halves (#1616).
+/// exit code to bail with. The `--validate` half mirrors `sjq --validate`
+/// (`jq_runner::validate_json_input`), an opt-in strict check for its own
+/// primary format the same way this one is for YAML.
+///
+/// This function returns `None` unconditionally for `InputFormat::Json`
+/// (`-p json`) -- **neither half runs for JSON input**, not "runs
+/// elsewhere": `validate_json_input` above is `sjq`'s own flag, reached only
+/// from the `jq` subcommand, and is never called from this file. `-p json`
+/// therefore gets no encoding or grammar check of any kind today, a known
+/// silent-data-loss gap tracked as #1616.
 fn yaml_validate_guard(
     input: &[u8],
     format: InputFormat,

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -369,11 +369,15 @@ fn read_file(path: &Path) -> Result<Vec<u8>> {
     std::fs::read(path).with_context(|| format!("failed to read file: {}", path.display()))
 }
 
-/// When `--validate` is set and the resolved input format is YAML, run the
-/// opt-in strict validator (`succinctly::yaml::validate`) before indexing and,
-/// on the first violation, print a rustc-style diagnostic and return the exit
-/// code to bail with. Mirrors `sjq --validate` (`jq_runner::validate_json_input`);
-/// JSON input is left to jq-side validation.
+/// For a YAML/Auto-format input, always rejects a non-UTF-8 byte stream
+/// outright (#1242) -- this half is unconditional, not gated on
+/// `--validate`, matching real yq's own refusal of a stray byte. Then, only
+/// when `--validate` is set, additionally runs the opt-in strict validator
+/// (`succinctly::yaml::validate`) before indexing and, on the first
+/// violation, prints a rustc-style diagnostic. Either failure returns the
+/// exit code to bail with. Mirrors `sjq --validate`
+/// (`jq_runner::validate_json_input`) for the `--validate` half; JSON input
+/// (`-p json`) is left to jq-side validation for both halves (#1616).
 fn yaml_validate_guard(
     input: &[u8],
     format: InputFormat,
@@ -399,7 +403,7 @@ fn yaml_validate_guard(
     // error.
     if let Err(err) = succinctly::text::utf8::validate_utf8(input) {
         eprintln!("Error: YAML parse error: {err}");
-        return Some(exit_codes::FALSE_OR_NULL);
+        return Some(exit_codes::YQ_FAILURE);
     }
     if !validate {
         return None;


### PR DESCRIPTION
## Summary

Two small accuracy defects in \`yaml_validate_guard\` (\`src/bin/succinctly/yq_runner.rs\`),
both introduced when #1242's unconditional UTF-8 check was added to a function that until
then only ran under \`--validate\`.

1. **The doc comment describes a function that no longer exists.** The summary line still
   says the whole function is gated on \`--validate\`, when the UTF-8 check it now performs
   first runs unconditionally on every \`yq\` invocation — a caller reading the summary alone
   (the part a reader skims) to answer "does \`-p json\` get this check?" gets the wrong
   answer (it doesn't — #1616). Rewrote the summary to describe both halves and their
   different gating.
2. **Wrong exit-code constant for the intent.** The UTF-8 failure branch returned
   \`exit_codes::FALSE_OR_NULL\`, numerically identical to \`exit_codes::YQ_FAILURE\` (both
   \`1\`) but naming the wrong reason — a YAML parse error is a yq failure, not a
   falsy-result signal. The two constants exist specifically to keep that distinction
   meaningful in code that reads them (per their own doc comments in \`output.rs\`).

No behavior change either way — same exit code, doc-comment-only rewording for the other
half.

Fixes #1621.

## Test plan

- [x] \`cargo build --features cli\`
- [x] \`cargo test --features cli,simd,regex,serde\` (full suite, 968 tests, all green)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\`
- [x] Confirmed exit code is unchanged (still \`1\`) for a non-UTF-8 input before/after
- [x] No test changes needed — neither edit is externally observable