### PR TITLE
fix(yq): apply json_sourced_floats to a reconstructed NumberLiteral too

### DIFF
--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -363,6 +363,19 @@ fn escape_json_body(s: &str, opts: &JsonFormatOpts) -> String {
     }
 }
 
+/// A JSON-sourced float's yq-mode display: a plain, bare `f64::to_string()`
+/// with no forced decimal point and no scientific-notation threshold --
+/// real yq's own JSON-input convention (#978/#1398), distinct from
+/// `format_float_yq`'s own (non-JSON-sourced) threshold/fraction rules.
+/// Named and shared rather than a hand-copied `f.to_string()` at each call
+/// site, matching `jq_bare_float_display`'s own precedent for the
+/// identical class of problem (CLAUDE.md's #106 lesson) -- `format_json_impl`'s
+/// `Float` arm and its `NumberLiteral` arm (#1498, the same rule reached
+/// through a reconstructed literal) both need this exact formatter.
+fn json_sourced_float_display(f: f64) -> String {
+    f.to_string()
+}
+
 /// Format a value as JSON text (compact or pretty, per `opts`).
 pub fn format_json(value: &OwnedValue, opts: &JsonFormatOpts) -> String {
     format_json_impl(value, opts, 0)
@@ -419,13 +432,8 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 }
             } else if opts.control_escape == ControlEscape::Yq && opts.json_sourced {
                 // A JSON-sourced float never keeps a decimal point, in any
-                // output mode (#978, #1398) -- real yq's JSON-input
-                // convention is a plain re-serialize through bare `f64`
-                // `Display`, with no scientific-notation threshold at all
-                // (matching `format_float_yq`'s own doc comment on this
-                // exact exclusion, and the M2 streaming writers' identical
-                // `json_sourced_canonical_float` rule in `src/yaml/light.rs`).
-                f.to_string()
+                // output mode (#978, #1398) -- see `json_sourced_float_display`.
+                json_sourced_float_display(*f)
             } else if opts.control_escape == ControlEscape::Yq {
                 // yq mode: scientific notation past yq's magnitude threshold
                 // (#997), decimal-with-fraction otherwise, regardless of
@@ -446,30 +454,48 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
         OwnedValue::NumberLiteral(repr, literal) => {
             if value.as_f64().is_some_and(f64::is_nan) {
                 "null".to_string() // JSON doesn't support NaN
-            } else if opts.control_escape == ControlEscape::Yq && opts.json_sourced {
-                // #1498: a `NumberLiteral` can still reach here for
-                // JSON-sourced input despite `to_owned_canonicalizing_numbers`
-                // stripping it at parse time -- `--eval-all`'s
-                // `eval_owned_input` reindex round-trip (serialize the
-                // already-stripped `OwnedValue` back to JSON text, then
-                // re-parse it through the library's own literal-preserving
-                // `to_owned`, #918) reconstructs one. Whichever route
-                // produced it, the same #978/#1398 rule applies: a
-                // JSON-sourced *float* never keeps a decimal point. Matches
-                // the `Float` arm's own `json_sourced` branch above exactly
-                // -- int-shaped literals have no such spelling ambiguity, so
-                // they fall through to the verbatim-echo branch below
-                // unchanged.
-                match repr {
-                    NumberRepr::Float(f) => f.to_string(),
-                    NumberRepr::Int(_) => literal.to_string(),
-                }
             } else if opts.control_escape == ControlEscape::Yq {
-                // yq mode: echo the source spelling verbatim (#1008) --
-                // matches the Float arm's own yq/jq split above, and real
-                // yq's documented byte-for-byte literal preservation,
-                // regardless of finiteness (confirmed live: a genuine
-                // document `1e999` literal echoes verbatim in real yq too).
+                match repr {
+                    // #1498 review: `json_sourced_float_display` (plain
+                    // `f64::to_string()`) renders an infinite `f` as
+                    // `inf`/`-inf`, not valid JSON -- the `Float` arm above
+                    // avoids this by special-casing `is_infinite()` before
+                    // its own `json_sourced` branch ever runs. No live path
+                    // reconstructs an *infinite* `NumberLiteral` for
+                    // JSON-sourced document input today (`to_json_for_reindex`'s
+                    // unparseable sentinel gets intercepted back to a plain
+                    // `Float` on reparse, never boxed into a `NumberLiteral`
+                    // -- see that function's own doc comment) -- but a
+                    // query-*text* literal like `1e400` reaches this same
+                    // arm via the parser directly, independent of the
+                    // reindex bridge, and `json_sourced` is a document-level
+                    // flag that doesn't distinguish the two origins. Guarded
+                    // here defensively, matching the `Float` arm's own
+                    // `"null"` answer, rather than relying on that
+                    // cross-file invariant to keep holding.
+                    NumberRepr::Float(f) if opts.json_sourced && f.is_infinite() => {
+                        "null".to_string()
+                    }
+                    // #1498: a `NumberLiteral` can still reach here for
+                    // JSON-sourced input despite `to_owned_canonicalizing_numbers`
+                    // stripping it at parse time -- `--eval-all`'s
+                    // `eval_owned_input` reindex round-trip (serialize the
+                    // already-stripped `OwnedValue` back to JSON text, then
+                    // re-parse it through the library's own literal-preserving
+                    // `to_owned`, #918) reconstructs one. Same rule as the
+                    // `Float` arm above either way: a JSON-sourced *finite*
+                    // float never keeps a decimal point.
+                    NumberRepr::Float(f) if opts.json_sourced => json_sourced_float_display(*f),
+                    // Int literals have no such spelling ambiguity, and a
+                    // non-`json_sourced` float has no rule to apply here at
+                    // all -- both echo the source spelling verbatim (#1008),
+                    // matching real yq's documented byte-for-byte literal
+                    // preservation regardless of finiteness (confirmed live:
+                    // a genuine document `1e999` literal echoes verbatim in
+                    // real yq too).
+                    _ => literal.to_string(),
+                }
+            } else {
                 // jq mode keeps `format_number_jq_compat`'s reformatting
                 // unchanged, which itself already reformats a non-finite
                 // literal's mantissa correctly (#1083/#1087) rather than
@@ -479,8 +505,6 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 // YAML), but it has other pre-existing divergences from
                 // real jq, unrelated and left alone here, e.g. `0.1e1` ->
                 // `1E+0` here vs real jq's `1`.
-                literal.to_string()
-            } else {
                 format_number_jq_compat(literal.as_bytes())
             }
         }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -12,7 +12,7 @@ use succinctly::jq::escape::{
 use succinctly::jq::eval_generic::to_owned as generic_to_owned;
 use succinctly::jq::{
     assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, EvalError,
-    JqSemantics, OwnedValue, StreamError,
+    JqSemantics, NumberRepr, OwnedValue, StreamError,
 };
 use succinctly::json::JsonIndex;
 use succinctly::yaml::format_float_with_fraction;
@@ -443,9 +443,27 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 }
             }
         }
-        OwnedValue::NumberLiteral(_, literal) => {
+        OwnedValue::NumberLiteral(repr, literal) => {
             if value.as_f64().is_some_and(f64::is_nan) {
                 "null".to_string() // JSON doesn't support NaN
+            } else if opts.control_escape == ControlEscape::Yq && opts.json_sourced {
+                // #1498: a `NumberLiteral` can still reach here for
+                // JSON-sourced input despite `to_owned_canonicalizing_numbers`
+                // stripping it at parse time -- `--eval-all`'s
+                // `eval_owned_input` reindex round-trip (serialize the
+                // already-stripped `OwnedValue` back to JSON text, then
+                // re-parse it through the library's own literal-preserving
+                // `to_owned`, #918) reconstructs one. Whichever route
+                // produced it, the same #978/#1398 rule applies: a
+                // JSON-sourced *float* never keeps a decimal point. Matches
+                // the `Float` arm's own `json_sourced` branch above exactly
+                // -- int-shaped literals have no such spelling ambiguity, so
+                // they fall through to the verbatim-echo branch below
+                // unchanged.
+                match repr {
+                    NumberRepr::Float(f) => f.to_string(),
+                    NumberRepr::Int(_) => literal.to_string(),
+                }
             } else if opts.control_escape == ControlEscape::Yq {
                 // yq mode: echo the source spelling verbatim (#1008) --
                 // matches the Float arm's own yq/jq split above, and real

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8993,6 +8993,73 @@ fn test_computed_whole_float_json_sourced_input_unaffected_by_949() -> Result<()
     Ok(())
 }
 
+/// #1498: `--eval-all` never applied `json_sourced_floats`, unlike every
+/// other JSON-input path -- `.a`'s value came back `1.0` instead of `1`.
+/// Root cause was one level deeper than `OutputConfig` itself: `for_source`
+/// already computed `json_sourced_floats` correctly for `--eval-all`, but
+/// `eval_owned_input`'s reindex round-trip (needed because `.[0].a` isn't
+/// covered by the owned-value fast path) reconstructed an
+/// `OwnedValue::NumberLiteral` from the re-serialized JSON text via the
+/// library's own literal-preserving `to_owned` (#918) -- and the
+/// `NumberLiteral` formatting arm echoed that spelling verbatim, never
+/// consulting `json_sourced` the way the `Float` arm already did. Not
+/// oracle-verified (`--eval-all` is a succinctly-only extension, #715); the
+/// standard (non-`--eval-all`) path on the same input is the reference this
+/// pins internal consistency against.
+#[test]
+fn test_eval_all_applies_json_sourced_floats_1498() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".[0].a",
+        r#"{"a":1.0}"#,
+        &["--input-format", "json", "--eval-all", "-o=json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1");
+    Ok(())
+}
+
+/// #1498 companion: a genuine trailing fraction (not just `.0`) is stripped
+/// too, matching the `Float` arm's own rule exactly -- `2.50` becomes `2.5`,
+/// not `2.50` (literal-preserving) or `2` (over-truncated).
+#[test]
+fn test_eval_all_json_sourced_float_strips_trailing_zero_not_the_fraction_1498() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".[0].a",
+        r#"{"a":2.50}"#,
+        &["--input-format", "json", "--eval-all", "-o=json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "2.5");
+    Ok(())
+}
+
+/// #1498 companion: an int-shaped JSON literal reaching the same code path
+/// is unaffected (no decimal-point ambiguity to strip).
+#[test]
+fn test_eval_all_json_sourced_int_unaffected_1498() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        ".[0].a",
+        r#"{"a":5}"#,
+        &["--input-format", "json", "--eval-all", "-o=json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+    Ok(())
+}
+
+/// #1498 companion: YAML-sourced input reaching the same `--eval-all`
+/// reindex path must keep its literal spelling exactly as before --
+/// `json_sourced_floats` is specifically a JSON-input override
+/// (`InputFormat::Json` only, `OutputConfig::for_source`), so a YAML
+/// `1.50` must not be affected by this fix at all.
+#[test]
+fn test_eval_all_yaml_sourced_float_keeps_literal_spelling_1498() -> Result<()> {
+    let (out, code) = run_yq_stdin(".[0].a", "a: 1.50\n", &["--eval-all", "-o=json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "1.50");
+    Ok(())
+}
+
 /// An untouched literal is unaffected by this fix in any output mode.
 /// Bare `.` (identity) here takes the cursor-based P9/M2 streaming path,
 /// echoing the source text straight from `YamlCursor` without ever

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9060,6 +9060,33 @@ fn test_eval_all_yaml_sourced_float_keeps_literal_spelling_1498() -> Result<()> 
     Ok(())
 }
 
+/// #1498 review follow-up: the fix's own `json_sourced_float_display`
+/// (plain `f64::to_string()`) would render an infinite value as `inf`/
+/// `-inf` -- not valid JSON -- unless guarded the same way the sibling
+/// `Float` arm already guards it (`is_infinite()` before ever consulting
+/// `json_sourced`). No live path reconstructs an infinite `NumberLiteral`
+/// from JSON *document* input (the reindex bridge's own unparseable
+/// sentinel gets intercepted back to a plain `Float` on reparse), but a
+/// query-*text* literal like `1e400` reaches the exact same code path via
+/// the parser directly -- `json_sourced` is a document-level flag that
+/// doesn't distinguish where the number came from. Guarded defensively,
+/// matching the `Float` arm's own `"null"` answer for yq-mode Infinity
+/// (#1087's own scope note: real yq's Go `encoding/json` refuses to
+/// marshal Infinity at all, so `"null"` is this codebase's own established,
+/// deliberate choice here, not a fresh one this fix invents).
+#[test]
+fn test_eval_all_json_sourced_infinite_literal_does_not_emit_invalid_json_1498() -> Result<()> {
+    // `--` before the filter: `-1e400` on its own would otherwise be parsed
+    // as an (unrecognised) flag, not the filter argument.
+    for expr in ["1e400", "-1e400"] {
+        let (out, code) =
+            run_yq_stdin(expr, "null\n", &["--input-format", "json", "-o=json", "--"])?;
+        assert_eq!(code, 0, "expr {expr}: out: {out:?}");
+        assert_eq!(out.trim(), "null", "expr {expr}: out: {out:?}");
+    }
+    Ok(())
+}
+
 /// An untouched literal is unaffected by this fix in any output mode.
 /// Bare `.` (identity) here takes the cursor-based P9/M2 streaming path,
 /// echoing the source text straight from `YamlCursor` without ever


### PR DESCRIPTION
## Summary

\`--eval-all\`'s \`.a\` on JSON-sourced \`1.0\` printed \`1.0\` instead of \`1\` — the one output
path \`json_sourced_floats\` (#978/#1398) doesn't reach; every other JSON-input path is
unaffected.

\`\`\`
$ succinctly yq --eval-all -o=json -p=json '.[0].a' <<< '{"a":1.0}'   # was 1.0, now 1
$ succinctly yq            -o=json -p=json '.a'      <<< '{"a":1.0}'  # 1 (already correct)
\`\`\`

## Root cause

\`OutputConfig::for_source\` already computed \`json_sourced_floats\` correctly for
\`--eval-all\`. The gap was one level deeper: \`.[0].a\` isn't covered by
\`eval_owned_input\`'s owned-value fast path, so it takes the "serialize back to JSON text,
reparse, evaluate" reindex round-trip. Reparsing routes through the library's own
\`to_owned\`, which preserves a document's literal spelling by design (#918, correct for
YAML) — reconstructing an \`OwnedValue::NumberLiteral(\"1.0\")\` from text that
\`to_owned_canonicalizing_numbers\` had already stripped to a plain \`Float\` at
\`parse_input\` time. \`format_json\`'s \`NumberLiteral\` arm then echoed that spelling
verbatim in yq mode unconditionally — the one arm that never consulted \`json_sourced\`;
the sibling \`Float\` arm already did.

## Fix

Fixed at the formatting layer: the \`NumberLiteral\` arm now checks \`opts.json_sourced\` the
same way the \`Float\` arm does, and for a \`Float\`-repr'd literal (an \`Int\`-repr'd one has
no spelling ambiguity to strip), formats via plain \`f64::to_string()\` instead of echoing
the source text.

Confirmed \`--slurp\` (a sibling of \`--eval-all\` through the same \`JsonIndex\`-based
\`parse_input\` path) was already unaffected — unclear whether it never hits this exact
reindex shape or coincidentally, not investigated further since it wasn't reported broken.

Fixes #1498.

## Test plan

- [x] \`cargo build --features cli\`
- [x] \`cargo test --features cli,simd,regex,serde\` (full suite, 968 tests, all green)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\`
- [x] Live-verified the fix against the issue's own repro and confirmed no regression on: YAML-sourced literal spelling (unaffected, still preserved), JSON-sourced ints (unaffected), JSON-sourced floats with a genuine trailing fraction (\`2.50\` → \`2.5\`, matching the \`Float\` arm's own rule), and \`--slurp\`
- [x] New CLI tests covering all four cases above
- [x] \`cargo llvm-cov\` + \`omni-dev coverage diff\`: 100% patch coverage (5/5 new lines)