### PR TITLE
docs(docs): drop the duplicate jq-range-lazy-bounds.md index row

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -28,7 +28,6 @@ These plans are kept for:
 | [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output  |
 | [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound-argument resolution          |
 | [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                      |
-| [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound resolution                   |
 
 ## Archived Plans
 


### PR DESCRIPTION
## Summary

- #1639 and an independent, separately-authored fix landed in parallel, each adding its own row for `jq-range-lazy-bounds.md` to `docs/plan/README.md`'s Active Plans table. The two diffs touched different lines so the merge queue let both through, leaving `main` with a duplicate entry.
- Drops the later (my) duplicate, keeping the earlier row: better placement (grouped with its sibling `jq-generator-argument-fanout.md` rather than trailing the table after the unrelated `decode-failure-routing.md`) and slightly more precise "bound-argument" wording.
- No other duplication found — checked the whole table for repeats, and confirmed my separate `jq-generator-argument-fanout.md` cross-reference edits from #1639 don't overlap with the other fix (it touched `jq-lazy-generator-consumers.md` instead).

No code changes.