### PR TITLE
fix(jq): validate parent(n)'s argument as a non-negative integer

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23927,6 +23927,42 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
+/// Classify `parent(n)`'s count argument into a validated ancestor-hop
+/// count (#1487). The previous inline casts (`i as usize` for `Int`, `f as
+/// usize` for `Float`) disagreed with each other on the same logical
+/// argument: a negative `Int` bit-wraps to a huge `usize` (treated as
+/// overshooting past root), while a negative or NaN `Float` saturates to
+/// `0` (treated as a no-op self-reference) -- `parent(-1)` and
+/// `parent(-1.0)` produced different results for what a caller would
+/// reasonably expect to be the same argument. There is no "unlimited"
+/// counterpart here the way `classify_limit_n` has for `limit(n; f)` --
+/// `n` must name a concrete, non-negative hop count, so every negative,
+/// non-finite, or non-numeric input is a hard error instead. Reuses
+/// `numeric_key_to_index`'s existing truncate-and-reject-NaN convention
+/// (already relied on for real `.[key]` indexing elsewhere in this file)
+/// rather than a third hand-rolled numeric conversion.
+fn classify_parent_n(n_value: &OwnedValue) -> Result<usize, EvalError> {
+    match numeric_key_to_index(n_value) {
+        Some(i) if i >= 0 => Ok(i as usize),
+        Some(_) => Err(EvalError::new(
+            "parent(n) requires a non-negative integer argument",
+        )),
+        // A `Float`/`NumberLiteral(Float)` returns `None` from
+        // `numeric_key_to_index` only when it's NaN; any other type
+        // (string, bool, array, object, null) also lands here.
+        None if matches!(
+            n_value,
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
+        ) =>
+        {
+            Err(EvalError::new(
+                "parent(n) requires a non-negative integer argument",
+            ))
+        }
+        None => Err(EvalError::type_error("number", n_value.type_name())),
+    }
+}
+
 /// Resolve the value `n` levels up from `current_path` -- `parent` is this
 /// with `n = 1`, `parent(n)` with whatever `n` evaluates to. Returns both
 /// the ancestor's own path (for `rest`'s continuation, via
@@ -24284,16 +24320,13 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // `key`'s own value).
         let n = match eval_owned_expr_opt::<S>(n_expr, value, optional) {
             Ok(None) => return QueryResult::None,
-            Ok(Some(OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _))) => {
-                i as usize
-            }
-            Ok(Some(OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _))) => {
-                f as usize
-            }
-            Ok(Some(_)) if optional => return QueryResult::None,
-            Ok(Some(_)) => return QueryResult::Error(EvalError::type_error("number", "other")),
-            // `?` swallows only a genuine error; a halt always escapes
-            // (#791).
+            Ok(Some(ref v)) => match classify_parent_n(v) {
+                Ok(n) => n,
+                // `?` swallows only a genuine error; a halt always escapes
+                // (#791).
+                Err(_) if optional => return QueryResult::None,
+                Err(e) => return QueryResult::Error(e),
+            },
             Err(EvalEscape::Error(_)) if optional => return QueryResult::None,
             Err(escape) => return escape.into(),
         };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23970,27 +23970,34 @@ fn classify_parent_n<S: EvalSemantics>(
     let Some(raw) = n_value.as_f64() else {
         return Err(EvalError::type_error("number", n_value.type_name()));
     };
-    if raw.is_nan() {
-        return Err(EvalError::new(NOT_NON_NEGATIVE_INT));
-    }
     if raw >= 0.0 {
-        // Sign already checked on the *untruncated* value above -- unlike
-        // checking `numeric_key_to_index`'s truncated result for
-        // negativity, this doesn't miss a fractional value in `(-1, 0)`
-        // (e.g. `-0.5`, which truncates toward zero to `0` and would
-        // otherwise slip through as a silent, valid self-reference -- the
-        // exact "negative Float saturates to a no-op" bug this function
-        // exists to eliminate).
-        let i = numeric_key_to_index(n_value).expect("checked non-NaN above");
+        // Sign checked on the *untruncated* value above -- unlike checking
+        // `numeric_key_to_index`'s truncated result for negativity, this
+        // doesn't miss a fractional value in `(-1, 0)` (e.g. `-0.5`, which
+        // truncates toward zero to `0` and would otherwise slip through as
+        // a silent, valid self-reference -- the exact "negative Float
+        // saturates to a no-op" bug this function exists to eliminate).
+        // NaN satisfies neither this comparison nor the branch below, so it
+        // falls through to the final hard error without a separate check.
+        let i = numeric_key_to_index(n_value).expect("checked non-NaN above (raw >= 0.0)");
         return Ok(i as usize);
     }
     // `raw < 0.0`. Yq mode's wraparound rule (see doc comment above) only
     // has meaning for a genuine negative *integer* -- a fractional negative
     // (e.g. `-0.5`) has no whole hop count to wrap to, and no oracle at all
     // (real yq's grammar can't express it either way), so it falls through
-    // to the same hard error as jq mode.
-    if S::TAG == EvalTag::Yq && raw.fract() == 0.0 {
-        let i = raw as i64;
+    // to the same hard error as jq mode. `raw.is_infinite()` is checked
+    // alongside `raw.fract() == 0.0` because `f64::fract` itself returns
+    // NaN for an infinite input (`inf - inf`), which would otherwise
+    // inconsistently hard-error on `-infinite` while every other
+    // sufficiently-negative finite value (e.g. `-1e300`) clamps to self.
+    if S::TAG == EvalTag::Yq && (raw.fract() == 0.0 || raw.is_infinite()) {
+        // Reuses `numeric_key_to_index`'s exact `i64` conversion rather
+        // than `raw as i64` -- `raw` is only an `f64` approximation of the
+        // original value (lossy for an `Int`/`NumberLiteral(Int)` beyond
+        // 2^53), and the branch above already gets this right by deferring
+        // to the same helper.
+        let i = numeric_key_to_index(n_value).expect("checked non-NaN above (raw < 0.0)");
         return Ok((depth as i64 + 1 + i).max(0) as usize);
     }
     Err(EvalError::new(NOT_NON_NEGATIVE_INT))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23928,39 +23928,72 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Classify `parent(n)`'s count argument into a validated ancestor-hop
-/// count (#1487). The previous inline casts (`i as usize` for `Int`, `f as
-/// usize` for `Float`) disagreed with each other on the same logical
-/// argument: a negative `Int` bit-wraps to a huge `usize` (treated as
-/// overshooting past root), while a negative or NaN `Float` saturates to
-/// `0` (treated as a no-op self-reference) -- `parent(-1)` and
-/// `parent(-1.0)` produced different results for what a caller would
-/// reasonably expect to be the same argument. There is no "unlimited"
-/// counterpart here the way `classify_limit_n` has for `limit(n; f)` --
-/// `n` must name a concrete, non-negative hop count, so every negative,
-/// non-finite, or non-numeric input is a hard error instead. Reuses
+/// count (#1487), at the given `depth` (`current_path.len()` at the call
+/// site -- needed for yq mode's wraparound rule below). The previous inline
+/// casts (`i as usize` for `Int`, `f as usize` for `Float`) disagreed with
+/// each other on the same logical argument: a negative `Int` bit-wraps to a
+/// huge `usize` (treated as overshooting past root), while a negative or
+/// NaN `Float` saturates to `0` (treated as a no-op self-reference) --
+/// `parent(-1)` and `parent(-1.0)` produced different results for what a
+/// caller would reasonably expect to be the same argument. Reuses
 /// `numeric_key_to_index`'s existing truncate-and-reject-NaN convention
 /// (already relied on for real `.[key]` indexing elsewhere in this file)
 /// rather than a third hand-rolled numeric conversion.
-fn classify_parent_n(n_value: &OwnedValue) -> Result<usize, EvalError> {
-    match numeric_key_to_index(n_value) {
-        Some(i) if i >= 0 => Ok(i as usize),
-        Some(_) => Err(EvalError::new(
-            "parent(n) requires a non-negative integer argument",
-        )),
-        // A `Float`/`NumberLiteral(Float)` returns `None` from
-        // `numeric_key_to_index` only when it's NaN; any other type
-        // (string, bool, array, object, null) also lands here.
-        None if matches!(
-            n_value,
-            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
-        ) =>
-        {
-            Err(EvalError::new(
-                "parent(n) requires a non-negative integer argument",
-            ))
-        }
-        None => Err(EvalError::type_error("number", n_value.type_name())),
+///
+/// **Yq mode, negative integer `n`**: real yq (mikefarah/yq v4.53.3,
+/// live-verified) accepts this and treats it as Python-style reverse
+/// indexing into the list `[self, parent(1), .., parent(depth)=root]` (a
+/// real, working feature -- not something to error on): `parent(-k)` for
+/// `1 <= k <= depth + 1` equals `parent(depth + 1 - k)`, and any `k` beyond
+/// that clamps to `parent(0)` (self) rather than erroring further or
+/// wrapping past it again. Real yq's own grammar only accepts a bare
+/// integer literal for `n` (a float, or any computed expression, is a
+/// parse-time error there, confirmed live) -- succinctly's `parent(n_expr)`
+/// already accepts a full expression as an extension beyond that grammar,
+/// so this rule is naturally generalized here to any *integer*-valued `n`
+/// (literal or computed), matching the meaning real yq assigns whenever it
+/// can parse the argument at all. There is no oracle at all for a
+/// non-integer (`Float`/NaN) `n` in yq mode -- real yq can't even parse
+/// that shape -- so it falls through to the same hard error as jq mode.
+///
+/// **Jq mode**: jq has no `parent`/`parent(n)` builtin, so there is no
+/// oracle to match for any of this. `n` is validated as a plain
+/// non-negative integer; every negative, non-finite, or non-numeric input
+/// is a hard error instead of picking one of the two disagreeing legacy
+/// behaviors.
+fn classify_parent_n<S: EvalSemantics>(
+    n_value: &OwnedValue,
+    depth: usize,
+) -> Result<usize, EvalError> {
+    const NOT_NON_NEGATIVE_INT: &str = "parent(n) requires a non-negative integer argument";
+
+    let Some(raw) = n_value.as_f64() else {
+        return Err(EvalError::type_error("number", n_value.type_name()));
+    };
+    if raw.is_nan() {
+        return Err(EvalError::new(NOT_NON_NEGATIVE_INT));
     }
+    if raw >= 0.0 {
+        // Sign already checked on the *untruncated* value above -- unlike
+        // checking `numeric_key_to_index`'s truncated result for
+        // negativity, this doesn't miss a fractional value in `(-1, 0)`
+        // (e.g. `-0.5`, which truncates toward zero to `0` and would
+        // otherwise slip through as a silent, valid self-reference -- the
+        // exact "negative Float saturates to a no-op" bug this function
+        // exists to eliminate).
+        let i = numeric_key_to_index(n_value).expect("checked non-NaN above");
+        return Ok(i as usize);
+    }
+    // `raw < 0.0`. Yq mode's wraparound rule (see doc comment above) only
+    // has meaning for a genuine negative *integer* -- a fractional negative
+    // (e.g. `-0.5`) has no whole hop count to wrap to, and no oracle at all
+    // (real yq's grammar can't express it either way), so it falls through
+    // to the same hard error as jq mode.
+    if S::TAG == EvalTag::Yq && raw.fract() == 0.0 {
+        let i = raw as i64;
+        return Ok((depth as i64 + 1 + i).max(0) as usize);
+    }
+    Err(EvalError::new(NOT_NON_NEGATIVE_INT))
 }
 
 /// Resolve the value `n` levels up from `current_path` -- `parent` is this
@@ -24320,7 +24353,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // `key`'s own value).
         let n = match eval_owned_expr_opt::<S>(n_expr, value, optional) {
             Ok(None) => return QueryResult::None,
-            Ok(Some(ref v)) => match classify_parent_n(v) {
+            Ok(Some(ref v)) => match classify_parent_n::<S>(v, current_path.len()) {
                 Ok(n) => n,
                 // `?` swallows only a genuine error; a halt always escapes
                 // (#791).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22335,3 +22335,43 @@ fn test_parent_n_non_negative_unaffected_1487() -> Result<()> {
     assert_eq!(stdout, "{\"b\":1}\n");
     Ok(())
 }
+
+/// #1487: `n` in the open interval `(-1, 0)` (e.g. `-0.5`) truncates toward
+/// zero to `0` -- checking negativity on the *truncated* value instead of
+/// the raw one would silently accept this as a valid `n=0` self-reference,
+/// reproducing the exact "negative Float saturates to a no-op" bug this fix
+/// exists to eliminate.
+#[test]
+fn test_parent_n_fractional_negative_in_open_unit_interval_errors_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(-0.5)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("parent(n) requires a non-negative integer argument"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1487: the non-numeric-argument error now reports the real type name
+/// (`n_value.type_name()`) instead of the old hardcoded placeholder
+/// `"other"`.
+#[test]
+fn test_parent_n_non_numeric_argument_reports_real_type_name_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(\"x\")"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("expected number, got string"),
+        "stderr: {stderr:?}"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(null)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("expected number, got null"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22254,3 +22254,84 @@ fn test_jq_string_repeat_huge_count_compound_assign_does_not_panic_1612() -> Res
     assert_eq!(code, 5, "stderr: {stderr:?}");
     Ok(())
 }
+
+/// #1487: `parent(n)`'s `n` argument used to cast via bit-reinterpreting
+/// `as usize` for an `Int` (a negative value wraps to a huge count, treated
+/// as overshooting past root -- `{}`) but a saturating `as usize` for a
+/// `Float` (negative/NaN saturates to `0`, a silent self-reference no-op).
+/// `-1` and `-1.0` are the same logical argument and must now agree: both
+/// error instead of picking one of the two old, disagreeing behaviors.
+#[test]
+fn test_parent_n_negative_int_errors_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(-1)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("parent(n) requires a non-negative integer argument"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parent_n_negative_float_errors_same_as_negative_int_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(-1.0)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("parent(n) requires a non-negative integer argument"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parent_n_nan_errors_instead_of_silent_self_reference_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(nan)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("parent(n) requires a non-negative integer argument"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// A positive-infinity `n` still overshoots past root (`{}`) rather than
+/// erroring -- unlike negative/NaN, "more hops than the document has
+/// depth" is a legitimate, well-defined overshoot per
+/// `resolve_ancestor_path`, not a malformed argument.
+#[test]
+fn test_parent_n_positive_infinite_still_overshoots_to_empty_object_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(infinite)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "{}\n");
+    Ok(())
+}
+
+/// `?` still swallows the new error exactly like any other `parent(n)`
+/// error path -- confirms the validation didn't bypass the existing
+/// `optional` handling.
+#[test]
+fn test_parent_n_negative_with_optional_suppresses_error_1487() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | parent(-1)?"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// Sanity check that ordinary non-negative `n` (both `Int` and a whole
+/// `Float`) is unaffected by the new validation.
+#[test]
+fn test_parent_n_non_negative_unaffected_1487() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a.b | parent(1)"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"b\":1}\n");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a.b | parent(1.0)"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"b\":1}\n");
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20788,10 +20788,13 @@ fn test_yq_halt_error_empty_code_argument_produces_no_output_1408() -> Result<()
 /// #1476: `parent(n)` must agree with bare `parent` exactly at the root
 /// boundary (`n == current_path.len()`) in yq mode too, since both route
 /// through the same `eval_pipe_with_path_context_internal` shared by jq
-/// and yq mode. `parent`/`parent(n)` are succinctly-only extensions with
-/// no real yq equivalent, so this is an internal-consistency check, not a
-/// yq-parity one: `.a | parent` and `.a | parent(1)` must still agree with
-/// each other, and both give the root.
+/// and yq mode. Both `parent` and `parent(n)` *are* real yq builtins
+/// (confirmed live against yq v4.53.3 -- `parent` is one level up, exactly
+/// as here; #1487's own investigation corrected an earlier assumption in
+/// this comment that there was no real yq equivalent at all), so this is
+/// also implicitly a yq-parity check for the boundary case: `.a | parent`
+/// and `.a | parent(1)` must still agree with each other, and both give
+/// the root.
 #[test]
 fn test_yq_parent_n_agrees_with_chained_parent_at_root_boundary_1476() -> Result<()> {
     let (chained, code) = run_yq_stdin(".a | parent", "a: 1\n", &["-o", "json"])?;
@@ -20800,6 +20803,53 @@ fn test_yq_parent_n_agrees_with_chained_parent_at_root_boundary_1476() -> Result
     assert_eq!(code, 0, "output: {n_form:?}");
     assert_eq!(n_form, chained, "parent(1) must agree with parent");
     assert!(n_form.contains(r#""a": 1"#), "output: {n_form:?}");
+    Ok(())
+}
+
+/// #1487: real yq (v4.53.3, live-verified) accepts a negative integer
+/// literal for `parent(n)` and treats it as Python-style reverse indexing
+/// into `[self, parent(1), .., parent(depth)=root]` -- NOT an error, unlike
+/// jq mode (which has no `parent(n)` oracle at all and hard-errors on any
+/// negative `n`). On the 3-level document below (`.a.b.c`, depth 3):
+/// `parent(-1)` == `parent(3)` (root), `parent(-2)` == `parent(2)`,
+/// `parent(-3)` == `parent(1)`, and `parent(-4)`/beyond clamp to
+/// `parent(0)` (self) instead of erroring or wrapping further. Every one of
+/// these exact input/output pairs was captured directly from the pinned
+/// `yq` binary, not derived from a description of its behavior.
+#[test]
+fn test_yq_parent_n_negative_wraps_like_real_yq_1487() -> Result<()> {
+    let doc = "a:\n  b:\n    c: 1\n";
+    let cases: &[(&str, &str)] = &[
+        ("-1", "a:\n  b:\n    c: 1\n"),
+        ("-2", "b:\n  c: 1\n"),
+        ("-3", "c: 1\n"),
+        ("-4", "1\n"),
+        ("-5", "1\n"),
+    ];
+    for (n, expected) in cases {
+        let filter = format!(".a.b.c | parent({n})");
+        let (out, stderr, code) = run_yq_stdin_with_stderr(&filter, doc, &[])?;
+        assert_eq!(code, 0, "n={n}: stderr={stderr}");
+        assert_eq!(out, *expected, "n={n}: stderr={stderr}");
+    }
+    Ok(())
+}
+
+/// #1487: a negative *fractional* `n` (e.g. `-0.5`) has no real yq oracle
+/// at all -- real yq's own `parent(n)` grammar only accepts a bare integer
+/// literal (a float argument is a parse-time error there, live-verified),
+/// so it falls through to the same hard error as jq mode rather than
+/// attempting to wrap a non-whole hop count.
+#[test]
+fn test_yq_parent_n_negative_fractional_has_no_oracle_and_errors_1487() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a.b.c | parent(-0.5)", "a:\n  b:\n    c: 1\n", &[])?;
+    assert_eq!(out, "", "stderr={stderr}");
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("parent(n) requires a non-negative integer argument"),
+        "stderr={stderr}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
@/private/tmp/claude-501/-Users-jky-wrk-rust-works-succinctly/14c5cd15-1972-4ab1-a56b-eb65748d3f33/scratchpad/pr_1659_body.md