### PR TITLE
fix(yq): only error contains/inside kind mismatch when a container is involved

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -438,6 +438,19 @@ which was true only before #1534.
   but routes through the same eager, escape-clearing `fanout_arg` machinery `FirstOnly`/
   `RejectMany` already use. Confirmed by
   `test_yq_contains_gate_emits_nothing_when_the_argument_escapes_1553` and its siblings.
+- **`contains`/`inside` on a top-level kind mismatch** ([#1649](https://github.com/rust-works/succinctly/issues/1649),
+  now closed). `f_contains`'s `jq_kind(a) != jq_kind(b)` screen raises
+  `EvalError::containment_check` unconditionally in jq mode — correct there — but real yq
+  (v4.53.3, live-verified across every kind pairing, not just the string-vs-number case the
+  issue was filed for) only errors when **at least one** operand is container-shaped
+  (array/object); a mismatch between two scalars (including a `true`/`false` pairing, which
+  `jq_kind` itself still treats as a "mismatch" per #358) answers `false` instead. This is the
+  *opposite* of "both operands must be containers to error" — a single container operand
+  (array-vs-string, object-vs-string, null-vs-array) is already enough. `contains`/`inside`
+  are now gated per `S::TAG` via the shared `containment_kind_mismatch_is_error` (`inside`
+  follows the same rule for internal consistency with `contains`, even though real yq has no
+  `inside` at all to verify it against — see the fan-out table above). Confirmed by
+  `test_yq_contains_scalar_vs_scalar_kind_mismatch_answers_false_1649` and its siblings.
 
 ### Regex flag grammar — `test`/`match`/`capture` fixed, `split` still open
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7292,7 +7292,8 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `ArgFanout::contains_gate`'s doc comment.
         ArgFanout::contains_gate::<S>(),
         |b| {
-            if jq_kind(&input) != jq_kind(&b) {
+            if jq_kind(&input) != jq_kind(&b) && containment_kind_mismatch_is_error::<S>(&input, &b)
+            {
                 return if optional {
                     QueryResult::None
                 } else {
@@ -7302,6 +7303,28 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Bool(owned_contains::<S>(&input, &b)))
         },
     )
+}
+
+/// Whether a top-level kind mismatch between `contains`/`inside`'s two
+/// operands should raise [`EvalError::containment_check`], or -- in yq
+/// mode only -- fall through to a plain `false` (#1649).
+///
+/// jq has no carve-out here: `f_contains` errors on any kind mismatch,
+/// unconditionally, which is what `S::TAG != EvalTag::Yq` preserves.
+///
+/// Real yq (v4.53.3, live-verified across every kind pairing below, not
+/// just the issue's own string-vs-number repro) only errors when *at
+/// least one* operand is container-shaped (`Array`/`Object`) --
+/// array-vs-object, array-vs-string, object-vs-string, and null-vs-array
+/// all error there. A kind mismatch between two *scalars* (covering every
+/// non-container `OwnedValue`, including a `Bool(true)`/`Bool(false)`
+/// pairing, which `jq_kind` itself still treats as a "mismatch" per #358)
+/// answers `false` instead: string-vs-number, number-vs-bool, and
+/// null-vs-string were all confirmed live to return `false`, not error.
+/// This is the *opposite* of a "both must be containers to error" guess --
+/// a single container operand is already enough to error.
+fn containment_kind_mismatch_is_error<S: EvalSemantics>(a: &OwnedValue, b: &OwnedValue) -> bool {
+    S::TAG != EvalTag::Yq || is_owned_container(a) || is_owned_container(b)
 }
 
 /// Check if `a` contains `b` (recursive containment check)
@@ -7361,7 +7384,8 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         ArgFanout::All,
         |b| {
             // inside is the inverse of contains: b contains input
-            if jq_kind(&b) != jq_kind(&input) {
+            if jq_kind(&b) != jq_kind(&input) && containment_kind_mismatch_is_error::<S>(&b, &input)
+            {
                 return if optional {
                     QueryResult::None
                 } else {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7292,8 +7292,7 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `ArgFanout::contains_gate`'s doc comment.
         ArgFanout::contains_gate::<S>(),
         |b| {
-            if jq_kind(&input) != jq_kind(&b) && containment_kind_mismatch_is_error::<S>(&input, &b)
-            {
+            if containment_kind_mismatch_should_error::<S>(&input, &b) {
                 return if optional {
                     QueryResult::None
                 } else {
@@ -7305,9 +7304,12 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     )
 }
 
-/// Whether a top-level kind mismatch between `contains`/`inside`'s two
-/// operands should raise [`EvalError::containment_check`], or -- in yq
-/// mode only -- fall through to a plain `false` (#1649).
+/// Whether `contains`/`inside`'s two top-level operands `a`/`b` should
+/// raise [`EvalError::containment_check`] instead of proceeding to the
+/// real containment check (#1649). Self-contained: absorbs the kind
+/// comparison itself, not just the yq-only carve-out, so a caller has one
+/// predicate to call rather than an inline `jq_kind(..) != jq_kind(..)`
+/// duplicated (mirror-image argument order) at each of the two call sites.
 ///
 /// jq has no carve-out here: `f_contains` errors on any kind mismatch,
 /// unconditionally, which is what `S::TAG != EvalTag::Yq` preserves.
@@ -7323,8 +7325,12 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// null-vs-string were all confirmed live to return `false`, not error.
 /// This is the *opposite* of a "both must be containers to error" guess --
 /// a single container operand is already enough to error.
-fn containment_kind_mismatch_is_error<S: EvalSemantics>(a: &OwnedValue, b: &OwnedValue) -> bool {
-    S::TAG != EvalTag::Yq || is_owned_container(a) || is_owned_container(b)
+fn containment_kind_mismatch_should_error<S: EvalSemantics>(
+    a: &OwnedValue,
+    b: &OwnedValue,
+) -> bool {
+    jq_kind(a) != jq_kind(b)
+        && (S::TAG != EvalTag::Yq || is_owned_container(a) || is_owned_container(b))
 }
 
 /// Check if `a` contains `b` (recursive containment check)
@@ -7380,12 +7386,15 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         b_expr,
         value.clone(),
         optional,
-        // Real yq has no `inside` (lexer-rejected); see `builtin_ltrimstr`.
+        // `inside` is a jq-only builtin real yq's lexer would reject if it
+        // were properly gated -- it currently isn't (#1650: ~13 jq-only
+        // builtins, `inside` named explicitly, are silently reachable in
+        // yq mode without `--jq-extensions`), so this stays reachable
+        // ungated today; see `builtin_ltrimstr` for the sibling case.
         ArgFanout::All,
         |b| {
             // inside is the inverse of contains: b contains input
-            if jq_kind(&b) != jq_kind(&input) && containment_kind_mismatch_is_error::<S>(&b, &input)
-            {
+            if containment_kind_mismatch_should_error::<S>(&b, &input) {
                 return if optional {
                     QueryResult::None
                 } else {
@@ -13831,9 +13840,11 @@ pub(crate) fn owned_bound_to_i64(
 }
 
 /// Whether `target` is a genuine container -- `Array` or `Object`. The one
-/// exclusion both `is_yq_slice_empty_container_scalar` and
-/// `is_yq_field_index_noop_scalar` below share; factored out so a future
-/// `OwnedValue` variant only needs a decision made in one place, not two
+/// exclusion `is_yq_slice_empty_container_scalar` and
+/// `is_yq_field_index_noop_scalar` below share, and also the container test
+/// `containment_kind_mismatch_should_error` (#1649) uses for `contains`/
+/// `inside`'s yq-mode kind-mismatch rule; factored out so a future
+/// `OwnedValue` variant only needs a decision made in one place, not three
 /// near-identical `matches!` lists left to drift (the "duplicated
 /// predicates diverge silently" lesson from #106).
 fn is_owned_container(target: &OwnedValue) -> bool {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21627,14 +21627,19 @@ fn test_jq_contains_still_emits_the_prefix_before_an_escape_1553() -> Result<()>
 }
 
 /// #1553: the new eager path pulls the whole argument before ever calling
-/// `body`, so a later value's escape now outranks an earlier value's
-/// `body`-level type error -- rather than `body` failing on the first
-/// mismatched value the way jq mode still does (below), the escape wins.
-/// Live-verified against yq v4.53.3: `.x | contains((1, error("boom")))`
-/// on `abc` is `Error: boom`, not `body`'s own containment-check error.
-/// A "smarter" reimplementation that checked `body` incrementally before
-/// consulting the argument's trailing control would silently flip this back
-/// to the wrong (jq-mode) answer with nothing else here to catch it.
+/// `body`, so a later value's escape wins over whatever an earlier value's
+/// own `body` call would have answered -- unconditionally, not just when
+/// that earlier answer happens to be an error. (At the time this test was
+/// written, `1` vs `"abc"` was itself a `body`-level containment-check
+/// error in yq mode too; #1649 later made a scalar-vs-scalar kind mismatch
+/// answer `false` there instead, so the premise below is now `body` never
+/// running at all rather than `body` erroring -- the escape wins either
+/// way, which is what this test actually asserts.) Live-verified against
+/// yq v4.53.3: `.x | contains((1, error("boom")))` on `abc` is
+/// `Error: boom`, not `body`'s own answer for `1`. A "smarter"
+/// reimplementation that checked `body` incrementally before consulting the
+/// argument's trailing control would silently flip this back to running
+/// `body` on `1` first, with nothing else here to catch it.
 #[test]
 fn test_yq_contains_gate_a_later_escape_outranks_an_earlier_body_error_1553() -> Result<()> {
     let (out, err, code) = run_yq_stdin_with_stderr(
@@ -21696,42 +21701,58 @@ fn test_yq_contains_scalar_vs_scalar_kind_mismatch_answers_false_1649() -> Resul
 /// #1649: the exact opposite boundary from the test above -- any mismatch
 /// where at least one side is a container (array/object) still errors in
 /// yq mode, live-verified against v4.53.3 for every combination below
-/// (array-vs-object, array-vs-scalar, object-vs-scalar, scalar-vs-array).
-/// A naive "both operands must be containers to error" reading of the
-/// issue's suggested fix direction would get this wrong -- a single
-/// container operand is already enough.
+/// (array-vs-object, its reverse object-vs-array, array-vs-scalar,
+/// object-vs-scalar, scalar-vs-array). A naive "both operands must be
+/// containers to error" reading of the issue's suggested fix direction
+/// would get this wrong -- a single container operand is already enough.
+///
+/// Asserts the full error text (not just a `.contains(..)` substring) so
+/// a future change to `builtin_contains`'s/`builtin_inside`'s
+/// `EvalError::containment_check(a, b)` argument order -- easy to get
+/// backwards given the two functions are near-mirror-images of each
+/// other -- would be caught here rather than passing silently.
 #[test]
 fn test_yq_contains_any_container_operand_kind_mismatch_still_errors_1649() -> Result<()> {
     let (_, err, code) =
         run_yq_stdin_with_stderr(".x | contains({})", "x: [1, 2]\n", &["-o", "json"])?;
     assert_eq!(code, 1, "err: {err:?}");
-    assert!(
-        err.contains("cannot have their containment checked"),
-        "err: {err:?}"
+    assert_eq!(
+        err.trim(),
+        "Error: array ([1,2]) and object ({}) cannot have their containment checked"
+    );
+
+    // Reverse of the case above -- confirms the gate is symmetric in `a`/`b`
+    // and not just tested in one operand order.
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | contains([1])", "x:\n  a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert_eq!(
+        err.trim(),
+        r#"Error: object ({"a":1}) and array ([1]) cannot have their containment checked"#
     );
 
     let (_, err, code) =
         run_yq_stdin_with_stderr(".x | contains(\"a\")", "x: [1, 2]\n", &["-o", "json"])?;
     assert_eq!(code, 1, "err: {err:?}");
-    assert!(
-        err.contains("cannot have their containment checked"),
-        "err: {err:?}"
+    assert_eq!(
+        err.trim(),
+        r#"Error: array ([1,2]) and string ("a") cannot have their containment checked"#
     );
 
     let (_, err, code) =
         run_yq_stdin_with_stderr(".x | contains(\"a\")", "x:\n  a: 1\n", &["-o", "json"])?;
     assert_eq!(code, 1, "err: {err:?}");
-    assert!(
-        err.contains("cannot have their containment checked"),
-        "err: {err:?}"
+    assert_eq!(
+        err.trim(),
+        r#"Error: object ({"a":1}) and string ("a") cannot have their containment checked"#
     );
 
     let (_, err, code) =
         run_yq_stdin_with_stderr(".x | contains([1])", "x: null\n", &["-o", "json"])?;
     assert_eq!(code, 1, "err: {err:?}");
-    assert!(
-        err.contains("cannot have their containment checked"),
-        "err: {err:?}"
+    assert_eq!(
+        err.trim(),
+        "Error: null (null) and array ([1]) cannot have their containment checked"
     );
     Ok(())
 }
@@ -21740,6 +21761,10 @@ fn test_yq_contains_any_container_operand_kind_mismatch_still_errors_1649() -> R
 /// and shares the same kind-mismatch rule, gated the same way even though
 /// real yq has no `inside` at all (lexer-rejected) to verify it against --
 /// this is an internal-consistency check with `contains`, not yq parity.
+/// (`inside` itself is currently reachable in yq mode without
+/// `--jq-extensions`, a separate, pre-existing gap tracked by #1650 -- not
+/// this test's concern, which is only whether the kind-mismatch rule
+/// matches `contains`'s own once `inside` is reached at all.)
 #[test]
 fn test_yq_inside_shares_contains_kind_mismatch_rule_1649() -> Result<()> {
     let (out, code) = run_yq_stdin(".x | inside(\"abc\")", "x: 5\n", &["-o", "json"])?;
@@ -21749,9 +21774,9 @@ fn test_yq_inside_shares_contains_kind_mismatch_rule_1649() -> Result<()> {
     let (_, err, code) =
         run_yq_stdin_with_stderr(".x | inside(\"abc\")", "x: [1]\n", &["-o", "json"])?;
     assert_eq!(code, 1, "err: {err:?}");
-    assert!(
-        err.contains("cannot have their containment checked"),
-        "err: {err:?}"
+    assert_eq!(
+        err.trim(),
+        r#"Error: string ("abc") and array ([1]) cannot have their containment checked"#
     );
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21666,6 +21666,124 @@ fn test_jq_contains_body_error_still_wins_over_a_later_escape_1553() -> Result<(
     Ok(())
 }
 
+/// #1649: real yq (v4.53.3, live-verified) only raises a containment-check
+/// error on a top-level kind mismatch when *at least one* operand is
+/// container-shaped (array/object) -- a mismatch between two scalars
+/// answers `false` instead. `succinctly yq` used to raise unconditionally
+/// on any mismatch, matching jq's own (correct-for-jq) rule instead.
+#[test]
+fn test_yq_contains_scalar_vs_scalar_kind_mismatch_answers_false_1649() -> Result<()> {
+    let (out, code) = run_yq_stdin(".x | contains(5)", "x: \"abc\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(".x | contains(true)", "x: 5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin(".x | contains(\"a\")", "x: null\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    // `true`/`false` are distinct `jq_kind`s (#358) but both scalar --
+    // still `false`, not the containment-check error.
+    let (out, code) = run_yq_stdin(".x | contains(false)", "x: true\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "false");
+    Ok(())
+}
+
+/// #1649: the exact opposite boundary from the test above -- any mismatch
+/// where at least one side is a container (array/object) still errors in
+/// yq mode, live-verified against v4.53.3 for every combination below
+/// (array-vs-object, array-vs-scalar, object-vs-scalar, scalar-vs-array).
+/// A naive "both operands must be containers to error" reading of the
+/// issue's suggested fix direction would get this wrong -- a single
+/// container operand is already enough.
+#[test]
+fn test_yq_contains_any_container_operand_kind_mismatch_still_errors_1649() -> Result<()> {
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | contains({})", "x: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | contains(\"a\")", "x: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | contains(\"a\")", "x:\n  a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | contains([1])", "x: null\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+    Ok(())
+}
+
+/// #1649: `inside` is documented in this codebase as `contains`'s inverse
+/// and shares the same kind-mismatch rule, gated the same way even though
+/// real yq has no `inside` at all (lexer-rejected) to verify it against --
+/// this is an internal-consistency check with `contains`, not yq parity.
+#[test]
+fn test_yq_inside_shares_contains_kind_mismatch_rule_1649() -> Result<()> {
+    let (out, code) = run_yq_stdin(".x | inside(\"abc\")", "x: 5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "false");
+
+    let (_, err, code) =
+        run_yq_stdin_with_stderr(".x | inside(\"abc\")", "x: [1]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+    Ok(())
+}
+
+/// #1649: `?` still swallows the containment-check error exactly as
+/// before for the cases that still raise it (container operand involved) --
+/// confirms the new false-vs-error boundary didn't disturb `optional`
+/// handling.
+#[test]
+fn test_yq_contains_optional_still_suppresses_the_remaining_error_cases_1649() -> Result<()> {
+    let (out, code) = run_yq_stdin(".x | contains(\"a\")?", "x: [1]\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {out:?}");
+    assert_eq!(out.trim(), "");
+    Ok(())
+}
+
+/// #1649: jq mode must stay exactly as it was -- any top-level kind
+/// mismatch errors unconditionally, container or not, matching jq 1.7.1's
+/// own `f_contains`. Confirms the new yq-only carve-out is properly
+/// `EvalSemantics`-gated rather than leaking into jq mode.
+#[test]
+fn test_jq_contains_scalar_vs_scalar_kind_mismatch_still_errors_1649() -> Result<()> {
+    let (out, err, code) = run_jq_stdin_with_stderr("contains(5)", r#""abc""#, &["-c"])?;
+    assert_eq!(out, "", "err: {err:?}");
+    assert_eq!(code, 5, "err: {err:?}");
+    assert!(
+        err.contains("cannot have their containment checked"),
+        "err: {err:?}"
+    );
+    Ok(())
+}
+
 /// #1533 (single-argument half): `ArgFanout::RejectMany` used to test
 /// `args.len() > 1` before ever looking at the argument's own trailing
 /// control, so a real `error(...)` inside the generator was masked by


### PR DESCRIPTION
## Summary

`builtin_contains`/`builtin_inside`'s shared `jq_kind(a) != jq_kind(b)` screen raised `EvalError::containment_check` unconditionally on any top-level kind mismatch — correct for jq mode (matches jq 1.7.1's own `f_contains`), but not what real yq does.

```console
$ printf 'x: "abc"\n' | yq            -o json '.x | contains(5)'
false
$ printf 'x: "abc"\n' | succinctly yq -o json '.x | contains(5)'
Error: string ("abc") and number (5) cannot have their containment checked
```

## The exact boundary (live-verified against yq v4.53.3)

Real yq only errors when **at least one** operand is container-shaped (array/object). I verified this across every kind pairing, not just the issue's own string-vs-number repro — and it's the **opposite** of the issue's own suggested "both operands must be containers to error" boundary:

| a | b | real yq |
|---|---|---|
| array | object | **error** |
| array | string | **error** (one container is already enough) |
| object | string | **error** |
| null | array | **error** |
| string | number | `false` |
| number | bool | `false` |
| null | string | `false` |
| `true` | `false` | `false` (distinct `jq_kind`s per #358, but both scalar) |

## Fix

Adds `containment_kind_mismatch_is_error<S: EvalSemantics>`, gated on `S::TAG`, reusing the existing `is_owned_container` helper (CLAUDE.md's #106 lesson: one definition, not a third hand-rolled container check — `is_owned_container` was already factored out for exactly this kind of reuse). `inside` gets the same treatment as `contains` for internal consistency (this codebase documents `inside` as `contains`'s inverse), even though real yq has no `inside` at all to verify it against (lexer-rejected — a pre-existing, separately-tracked gap, #1650).

Documented in `docs/compliance/yq/limitations.md`'s Residues section, alongside the sibling `contains` entries from #1553/#1533.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo test --features cli,simd,regex,serde` — 55/55 test binaries pass, 0 failures
- [x] New tests: scalar-vs-scalar (false) and container-involved (error) for both `contains`/`inside`, `?` suppression, jq-mode-unaffected regression check
- [x] Live-verified every repro in this PR description and the issue against the pinned `yq` v4.53.3 binary

Fixes #1649