### PR TITLE
jq: raise on the two remaining streaming malformed-member/value swallows (#1641)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -551,29 +551,20 @@ is the opt-in form for callers who want it (exit 3, its own separately-pinned co
 `to_entries`, `keys`, `length` (in all three of its spellings, including `keys | length`),
 `--slurp`, `--sort-keys`, `--ascii-output`, and any filter shape that costs the value its cursor
 (a comma, an `if`) — because #1247 made the `to_owned`/`cursor_to_owned` family fallible and
-this check rides along with it. Three routes remain, for two different reasons: two of them
-stream, so they have no error channel to raise into; the third never walks the whole object, so
-it is not in a position to find the malformed member at all.
+this check rides along with it. Bare `.[]` and the identity printer raise now too (#1641, below).
+One route remains, and it never walks the whole object, so it is not in a position to find the
+malformed member at all:
 
 ```
-$ echo '{invalid}'        | sjq -c '.[]'                 # no output, exit 0
-$ echo '[xyz123]'         | sjq -c .                     # [null],    exit 0
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'     # 123 then "b", exit 0
 ```
 
-`.[]` walks the field list through `LazySource::Values`, whose `uncons` reports an unpaired
-child as plain exhaustion and returns `Option`, not `Result`. `[xyz123]`'s identity path reaches
-`print_json`'s `StandardJson::Error` arm, which #1247's own design doc deferred for the same
-reason: by the time a nested error is discovered the opening bracket has been written, so bailing
-there yields a truncated document where every materializing route gives a clean diagnostic.
-Both are that document's Stage 6.
-
-The third is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `[n]`, `first`, `last`.
+This is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `[n]`, `first`, `last`.
 `#1514` and `#1599` deliberately took the whole-object probe *off* these arms: `first` and `[0]`
 answer from one `uncons_key` because collapsing keeps every key at its first position, so the
 answer holds whatever the rest of the object turns out to be. Restoring a #1194 check means
 restoring exactly the walk those two issues removed, which is why it is tracked separately
-(#1629) rather than folded in here. `keys_unsorted | length` is *not* in this set — it reaches
+(#1629) rather than fixed here. `keys_unsorted | length` is *not* in this set — it reaches
 `effective_len`, which walks, and so carries the check for free.
 
 Bare `keys_unsorted` — no stage after it — does raise, but only part-way through: it streams,
@@ -581,15 +572,56 @@ and finds a non-string key once its `[` is already out, so a **truncated** array
 stdout beside the exit 5. Pre-checking would mean a second walk over every key on a path
 `scripts/perf-guard.py` measures.
 
-The identity printer has no such limit for an object malformed at the *top* level — its check
-rides inside a walk it was already making, so nothing is emitted at all. A malformed object
-*nested* inside a well-formed one is found only once its parent's opening bytes are written, so
-that case truncates like `keys_unsorted` does:
+A malformed object *nested* inside a well-formed one is found only once its parent's opening
+bytes are written, so that case truncates the same way:
 
 ```
 $ echo '{invalid}'        | sjq -c .   # (nothing),  exit 5
 $ echo '{"a": {invalid}}' | sjq -c .   # `{"a":`,    exit 5
 ```
+
+**Bare `.[]` and the identity printer now raise too (#1641).** Both were previously misdiagnosed
+(here and in the issue that fixed them) as blocked on "no error channel to raise into" — tracing
+the actual code disproved that for both.
+
+Bare `.[]`'s object arm is `Expr::Iterate` in `eval_generic.rs`, not `LazySource::Values` (that
+machinery is reached only by `obj | map(f)`, a distinct construct — see below). `Expr::Iterate`
+already walks every field eagerly via `effective_fields`, so there was no laziness to preserve;
+`effective_fields`'s underlying `all_fields()` walk just never exposed whether it ended on an
+unpaired child. `effective_fields_checked` folds the check into that same walk, the way
+`effective_len_checked` already does for `length`:
+
+```
+$ echo '{invalid: 1}' | sjq -c '.[]'   # exit 5 now (was: 1,          exit 0)
+$ echo '{invalid}'    | sjq -c '.[]'   # exit 5 now (was: no output, exit 0)
+```
+
+The walk is atomic — it builds the whole field list before `.[]` starts emitting — so a malformed
+member anywhere in the object, including *after* a valid field, raises before any output at all:
+`{"a":1, invalid} | .[]` prints nothing, not `1`.
+
+`print_json`'s `StandardJson::Error` arm (`jq_runner.rs`) — reached by the identity path on a
+structurally malformed *value* (`[xyz123]`, `[tru]`) rather than a malformed *member* — now raises
+through the same `MalformedJsonError` convention the object-member check above uses. This one
+**does** truncate, the same accepted trade `keys_unsorted` and a nested `{invalid}` already make
+above: the writer streams child cursors as it walks, so an earlier sibling and the opening bracket
+are already out by the time a later error is found:
+
+```
+$ echo '[xyz123]'  | sjq -c .   # `[`,   exit 5 now (was: [null],       exit 0)
+$ echo '[1,zzz,3]' | sjq -c .   # `[1,`, exit 5 now (was: [1,null,3], exit 0)
+```
+
+This exact fix was tried once before and reverted: the earlier attempt predated
+`MalformedJsonError`, so bailing surfaced as a generic exit 1 instead of jq's own exit 5 — worse
+than the silent `null` it replaced. Reusing the now-established convention keeps the exit code and
+diagnostic clean; the truncation itself was already the accepted trade, not a new one.
+
+**Not fixed: `obj | map(f)` has the identical latent gap.** `{invalid: 1} | map(.)` goes through
+`LazySource::Values` in `eval_generic.rs`, whose `uncons` still cannot tell "no more fields" from
+"the last field never got a value" apart — the same ambiguity `effective_fields_checked` closes for
+bare `.[]`. Left open by #1641, mirroring the `#1629` precedent above rather than silently
+expanding that PR's scope.
 
 `--preserve-input` is not an exception to any of this: it changes how values are *rendered*
 (number literals and escape sequences kept as written), not whether the document is accepted,

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -463,12 +463,31 @@ all of 17–20 under this stage's "✅ landed."** Re-reading both directly:
   for the two siblings that are recorded; this third one belongs in the same bucket once
   Stage 6 is scoped.
 
-One site was reverted after being written. `print_json`'s `StandardJson::Error` arm
-(`jq_runner.rs`) walks child cursors lazily and streams as it goes, so by the time a
-nested error is reached it has already written the opening `[`. Bailing there produced a
-truncated document plus a generic exit 1, where every materializing route gives a clean
-diagnostic and exit 5 — worse on every axis than the silent `null` it replaced. Left as
-`null` with the reasoning in place, and folded into Stage 6, which is the same problem.
+One site was reverted after being written, and later fixed for real by
+[#1641](https://github.com/rust-works/succinctly/issues/1641). `print_json`'s
+`StandardJson::Error` arm (`jq_runner.rs`) walks child cursors lazily and streams as it
+goes, so by the time a nested error is reached it has already written the opening `[`.
+The first attempt to raise there produced a truncated document plus a *generic* exit 1 —
+worse on every axis than the silent `null` it replaced — and was reverted, with the
+reasoning folded into Stage 6 below on the theory that this site needed the same new
+error channel the YAML streaming siblings do.
+
+**That theory was wrong.** `print_json` already returns `anyhow::Result<()>`, and by the
+time #1641 revisited this site, the sibling object-member check a few lines above it
+(Stage 3/#1194) had already established `MalformedJsonError` — a thin `anyhow`-downcastable
+wrapper around `EvalError` that lets `run_jq` tell a diagnosable data error from a real I/O
+failure and choose exit 5 over exit 1. The channel this arm was "missing" already existed
+in the same function; the original revert predated that convention, not a genuine
+architectural gap. Reusing it needed no new error type, only the one-line change from
+`out.write_all(b"null")?` to raising through it. The truncation trade itself was never in
+question — it is the same one `keys_unsorted` and a nested `{invalid}` already accepted;
+see
+[jq Limitations](../compliance/jq/limitations.md#duplicate-object-keys-collapse-except-under---preserve-input).
+
+Site 20 (`json/light.rs:2098`, the JSON→YAML streaming output path) is a genuinely
+different case from this one, not covered by #1641: it is built on `core::fmt::Write`,
+which really does carry no richer error type, so it remains folded into Stage 6 below
+alongside its YAML→JSON and YAML→YAML siblings.
 
 Evaluation still continues past the bad value, so the good documents either side of it in
 a multi-value stream are still processed (`ErrorSink`, #355). Real jq aborts the whole run
@@ -646,6 +665,11 @@ what Stage 6 is left with is bad escapes only.
   `to_owned_at_depth`'s doc comment exists.
 - [#1194](https://github.com/rust-works/succinctly/issues/1194) — half in scope (see
   Correction 3).
+- [#1641](https://github.com/rust-works/succinctly/issues/1641) — bare `.[]` and
+  `print_json`'s `StandardJson::Error` arm, the two routes left after #1194/#1608/#1628
+  closed the materializing side. Corrected this document's own claim that the `print_json`
+  site needed Stage 6's new error channel — see the "One site was reverted" discussion
+  above.
 - [#1242](https://github.com/rust-works/succinctly/issues/1242) — the YAML invalid-UTF-8
   repro; Stage 5.
 - [#1191](https://github.com/rust-works/succinctly/issues/1191) (closed) — the stated
@@ -664,8 +688,15 @@ what Stage 6 is left with is bad escapes only.
 Not yet filed. Once this document is reviewed:
 
 1. One implementation issue per stage above, linking back here.
-2. **`JsonFields::uncons` cannot represent a malformed field** — #1194's headline repro
-   (`{invalid} → {}`), see Correction 3.
+2. ~~**`JsonFields::uncons` cannot represent a malformed field** — #1194's headline repro
+   (`{invalid} → {}`), see Correction 3.~~ Filed and fixed for the two routes that
+   materialize nothing today as
+   [#1641](https://github.com/rust-works/succinctly/issues/1641), by working around the
+   ambiguity at each caller (`effective_fields_checked`, `MalformedJsonError`) rather than
+   changing `uncons`'s own contract. One instance remains open: `obj | map(f)`
+   (`LazySource::Values` in `eval_generic.rs`) has the identical gap and was deliberately
+   left unfixed there — see
+   [jq Limitations](../compliance/jq/limitations.md#duplicate-object-keys-collapse-except-under---preserve-input).
 3. ~~**Decide catchability of decode errors** — Open Risk 1, if it is not settled during
    Stage 3's review.~~ Filed as [#1620](https://github.com/rust-works/succinctly/issues/1620),
    resolved there -- see Open Risk 1 above.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3822,21 +3822,21 @@ where
                         scratch.truncate(base);
                     }
                 }
-                // A structurally malformed value the semi-index accepted as
-                // a span but could not classify (`[xyz123]`, `[tru]`), still
-                // printed as `null` -- so this lazy output path disagrees
-                // with every materializing one, which now raises (#1194).
-                //
-                // Deliberately NOT raised here, and this was tried: `print_json`
-                // walks child cursors lazily and streams as it goes, so by the
-                // time a nested error is reached it has already written the
-                // opening `[`. Bailing produced a truncated document plus a
-                // generic exit 1, where the materializing routes give a clean
-                // diagnostic and exit 5 -- worse on every axis than the silent
-                // `null`. Needs the same error channel as the YAML streaming
-                // path; tracked together as Stage 6 in
-                // `docs/plan/decode-failure-routing.md`.
-                StandardJson::Error(_) => out.write_all(b"null")?,
+                // A structurally malformed value the semi-index accepted as a
+                // span but could not classify (`[xyz123]`, `[tru]`). An
+                // earlier attempt to raise here predated `MalformedJsonError`
+                // (added for the object-member check just above): without
+                // it, bailing produced a truncated document at a *generic*
+                // exit 1 -- worse on every axis than the silent `null` it
+                // replaced, so it was reverted back to `null` (#1194). That
+                // convention exists now, so reuse it: same truncated-prefix
+                // trade the object arm above and the `keys_unsorted` writer
+                // already make (`docs/compliance/jq/limitations.md`), but a
+                // clean diagnostic and jq's own exit 5 instead of a silent
+                // wrong answer (#1641).
+                StandardJson::Error(_) => {
+                    return Err(MalformedJsonError(EvalError::malformed_json_text(c.text())).into());
+                }
             }
         }
         JqValue::String(s) => {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1094,6 +1094,41 @@ pub fn effective_fields<F: DocumentFields>(
     }
 }
 
+/// [`effective_fields`], refusing an object whose members the format's
+/// grammar never allowed (#1194).
+///
+/// The value-cursor-carrying counterpart of [`effective_len_checked`], for a
+/// caller that needs the fields themselves (`.[]`'s bare object arm) rather
+/// than just a count. The check and the field list come out of the same
+/// walk this function was already making, for the reason
+/// `effective_len_checked`'s own doc comment gives: a caller-side pre-check
+/// (`malformed_object_member`) would double the cost of a walk this function
+/// already runs. `to_entries` is the one caller for which that redundant
+/// walk is negligible (it materializes every value regardless), which is
+/// why it keeps using the pre-check instead.
+#[allow(clippy::type_complexity)] // STYLE-0004: mirrors effective_fields's own Vec<DocumentField<..>>, plus a Result for the #1194 check; a named alias would add indirection for one extra wrapper.
+pub fn effective_fields_checked<F: DocumentFields>(
+    fields: &F,
+    collapse: bool,
+) -> Result<Vec<DocumentField<F::Value, F::Cursor>>, EvalError> {
+    let mut out = Vec::new();
+    let mut walk = fields.clone();
+    while let Some((field, rest)) = walk.uncons() {
+        if key_is_malformed(&field.key) {
+            return Err(walk.malformed_member_error());
+        }
+        out.push(field);
+        walk = rest;
+    }
+    if walk.ends_unpaired() {
+        return Err(walk.malformed_member_error());
+    }
+    if collapse && keys_repeat(&out) {
+        out = collapse_repeated(out);
+    }
+    Ok(out)
+}
+
 /// The collapsed field list, or `None` when no key repeats.
 ///
 /// Lets a caller keep whatever zero-allocation fast path it already has for

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,9 +22,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, effective_fields, effective_keys, effective_len_checked,
-    key_is_malformed, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
-    DocumentValue, IndentSpec,
+    collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
+    effective_keys, effective_len_checked, key_is_malformed, DistinctKeyCursors, DocumentCursor,
+    DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, collapse_vec, eval as full_eval, eval_each_owned,
@@ -3764,14 +3764,28 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // yq is inconsistent here and does collapse under `.[]`
                 // traversal alone (confirmed live against yq v4.53.3), so
                 // this always passes `true` rather than the mode flag.
-                let cursors: Vec<_> = effective_fields(&fields, true)
-                    .into_iter()
-                    .map(|field| field.value_cursor)
-                    .collect();
-                if cursors.is_empty() {
-                    GenericResult::None
-                } else {
-                    GenericResult::ManyCursor(cursors)
+                //
+                // `_checked`: an object member the semi-index accepted but
+                // JSON does not (a bareword key, an unpaired trailing child,
+                // #1194) used to reach here silently, because
+                // `effective_fields`'s walk discards the exhausted tail that
+                // is the only place `ends_unpaired` can still answer (#1641).
+                // The check is free here -- it rides the same walk this arm
+                // already ran unconditionally, same as `effective_len_checked`
+                // does for `length`.
+                match effective_fields_checked(&fields, true) {
+                    Ok(effective) => {
+                        let cursors: Vec<_> = effective
+                            .into_iter()
+                            .map(|field| field.value_cursor)
+                            .collect();
+                        if cursors.is_empty() {
+                            GenericResult::None
+                        } else {
+                            GenericResult::ManyCursor(cursors)
+                        }
+                    }
+                    Err(err) => GenericResult::Error(err),
                 }
             } else if let Some(reason) = value.string_decode_error() {
                 GenericResult::Error(EvalError::decode_failure(reason))

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16496,12 +16496,83 @@ fn test_jq_malformed_object_length_agrees_across_spellings_1194() -> Result<()> 
 /// already-recognized container still degrades to `null` at exit 0. This
 /// fix is about object member *structure*, not number grammar, and the two
 /// have deliberately opposite conventions.
+///
+/// `[xyz123]` used to sit in this same table (a structurally malformed
+/// *value*, not a malformed number, degrading to `[null]`) -- it moved out
+/// once #1641 made the identity printer raise on it instead. See
+/// `test_jq_identity_on_malformed_array_element_errors_1641` below.
 #[test]
 fn test_jq_malformed_nested_number_unaffected_by_1194() -> Result<()> {
-    for (input, expected) in [(r#"{"a": 1.2.3}"#, r#"{"a":null}"#), ("[xyz123]", "[null]")] {
-        let (out, _stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
-        assert_eq!(code, 0, "{input}: out: {out:?}");
-        assert_eq!(out.trim(), expected, "{input}");
+    let (input, expected) = (r#"{"a": 1.2.3}"#, r#"{"a":null}"#);
+    let (out, _stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+    assert_eq!(code, 0, "{input}: out: {out:?}");
+    assert_eq!(out.trim(), expected, "{input}");
+
+    Ok(())
+}
+
+/// #1641: `.[]` over an object walks it via `Expr::Iterate`'s own arm in
+/// `eval_generic.rs`, not `LazySource::Values` as the issue text (and this
+/// codebase's own `docs/compliance/jq/limitations.md`, corrected alongside
+/// this test) both assumed -- that machinery is reached only by `obj |
+/// map(f)`, a distinct construct #1641 deliberately leaves unfixed (see the
+/// doc). `Expr::Iterate`'s object arm already walks every field eagerly via
+/// `effective_fields`, so `effective_fields_checked` folds the #1194 check
+/// into that same walk for free, exactly as `effective_len_checked` already
+/// does for `length`.
+///
+/// The walk is atomic: it builds the whole field list before `.[]` ever
+/// starts emitting, so a malformed member anywhere -- including *after* a
+/// valid field -- raises before any output at all.
+#[test]
+fn test_jq_bare_iterate_over_malformed_object_errors_1641() -> Result<()> {
+    for input in ["{invalid: 1}", "{invalid}", r#"{"a":1, invalid}"#] {
+        let (out, stderr, code) = run_jq_full(&["-c", ".[]"], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            out.trim().is_empty(),
+            "{input} should print nothing at all, got: {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input} should name the cause on stderr, got: {stderr:?}"
+        );
+    }
+
+    // Unaffected: a well-formed object still iterates its values normally.
+    let (out, stderr, code) = run_jq_full(&["-c", ".[]"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.lines().collect::<Vec<_>>(), ["1", "2"]);
+
+    Ok(())
+}
+
+/// #1641: `print_json`'s `StandardJson::Error` arm (`jq_runner.rs`) now
+/// raises through the same `MalformedJsonError` convention the sibling
+/// object-member check above it already uses, instead of silently printing
+/// `null`. Unlike the bare-`.[]` fix above, this writer streams byte-by-byte
+/// with no rewind, so the accepted trade is a **truncated** prefix on
+/// stdout -- the same trade already shipped for `keys_unsorted`'s
+/// non-string-key case and a nested `{invalid}` -- plus a clean diagnostic
+/// and jq's own exit 5, rather than a silently wrong `null`.
+#[test]
+fn test_jq_identity_on_malformed_array_element_errors_1641() -> Result<()> {
+    for (input, prefix) in [
+        ("[xyz123]", "["),
+        ("[tru]", "["),
+        ("[1,zzz,3]", "[1,"),
+        (r#"{"a": xyz123}"#, r#"{"a":"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert_eq!(
+            out, prefix,
+            "{input} should truncate to exactly its well-formed prefix"
+        );
+        assert!(
+            !stderr.is_empty(),
+            "{input} should carry a diagnostic: {stderr:?}"
+        );
     }
 
     Ok(())
@@ -21999,16 +22070,16 @@ fn test_ordinary_type_error_still_suppressed_and_caught_1620() {
 /// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`
 /// at exit 0 where real jq raises `Invalid numeric literal` and exits 5.
 ///
-/// Every materializing route raises now. The lazy output path (`.`, `.[0]`)
-/// still prints `null`: it streams as it walks, so by the time a nested
-/// error is reached the opening bracket is already written, and bailing
-/// there truncates the document. That is tracked as Stage 6 of #1247's
-/// design, not fixed here -- see `docs/plan/decode-failure-routing.md`.
+/// Every materializing route raises now (this test's own `to_entries`).
+/// The lazy output path (`.`, `.[0]`) also raises now, via #1641 --
+/// see `test_jq_identity_on_malformed_array_element_errors_1641` --
+/// though it still streams as it walks, so the accepted trade there is a
+/// truncated prefix on stdout rather than nothing at all.
 ///
-/// `{invalid}` is NOT covered: `JsonFields::uncons` collapses a lone
-/// bareword leaf into "no more fields" at the semi-index layer, so no field
-/// is ever constructed to raise on, and the object simply reads as `{}`.
-/// That is #1194's remaining half and needs its own change.
+/// `{invalid}` (a lone bareword leaf, no sibling to pair as a value) is
+/// covered too, both for `to_entries` here (`malformed_object_member`,
+/// #1194) and for bare `.[]` (`effective_fields_checked`, #1641) -- see
+/// `test_jq_bare_iterate_over_malformed_object_errors_1641`.
 #[test]
 fn test_malformed_value_surfaces_as_error_1194() {
     for doc in ["[xyz123]", "[tru]", "[1,zzz,3]"] {


### PR DESCRIPTION
## Summary

Closes #1641. Two streaming jq routes still silently swallowed a malformed
document member/value instead of raising jq's own exit 5:

```console
$ echo '{invalid: 1}' | sjq -c '.[]'   # 1,          exit 0   (jq: parse error, exit 5)
$ echo '{invalid}'    | sjq -c '.[]'   # (nothing),  exit 0
$ echo '[xyz123]'     | sjq -c .       # [null],     exit 0   (jq: parse error, exit 5)
```

Both were misdiagnosed in the issue and in this crate's own docs as blocked on
"the writer has no error channel to raise into." Tracing the actual code
disproved that for both:

- **Bare `.[]`** does not go through `LazySource::Values` as claimed — that
  machinery is reached only by `obj | map(f)`, a distinct construct. Bare
  `.[]` hits `Expr::Iterate`'s own arm in `eval_single`, which already walks
  every field eagerly via `effective_fields` — there was no laziness to
  preserve, `all_fields()`'s walk just never exposed whether it ended on an
  unpaired child.
- **`print_json`'s `StandardJson::Error` arm** already sits inside a function
  returning `anyhow::Result<()>`, and the sibling object-member check a few
  lines above it already raises through `MalformedJsonError` + `anyhow`
  downcast. The doc's claim that this arm needed a new error channel was
  stale — the only reason an earlier attempt regressed to a generic exit 1
  is that it predated that convention.

## Changes

- `fix(jq)`: add `effective_fields_checked` (`document.rs`), folding the
  #1194 unpaired-member/non-string-key check into the walk `Expr::Iterate`'s
  object arm already runs, the way `effective_len_checked` already does for
  `length`. Bare `.[]` over `{invalid: 1}`/`{invalid}` now raises, exit 5,
  atomically (no partial output, even when the malformed member follows a
  valid one).
- `fix(jq)`: `print_json`'s `StandardJson::Error` arm now raises through the
  same `MalformedJsonError` convention the object-member check uses, instead
  of printing `null`. `[xyz123]`/`[tru]`/a nested malformed value now raise,
  exit 5, truncating stdout to whatever prefix was already streamed (the
  same accepted trade `keys_unsorted` and a nested `{invalid}` already make).
- `test(jq)`: new CLI-level coverage for both fixes; corrects two existing
  tests that asserted the now-fixed buggy behavior.
- `docs(jq)`: corrects `docs/compliance/jq/limitations.md`'s description of
  which code path bare `.[]` actually takes, and
  `docs/plan/decode-failure-routing.md`'s Stage 6 framing for the
  `print_json` site. Documents `obj | map(f)` (`LazySource::Values`) as a
  known, deliberately-unfixed instance of the same gap, mirroring the
  existing `#1629` precedent — out of scope for this PR by design.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (55
      test binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the two
      other CI clippy invocations (`std,simd,serde,cli,regex,bench-runner,
      large-tests,mmap-tests` with and without `broadword-yaml`) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features` (no_std) — clean
- [x] `cargo doc --no-deps` — clean, no broken intra-doc links
- [x] Manually verified all new repros' exit codes against `/usr/bin/jq`
      1.7.1 (the pinned oracle) — matches on every case