### PR TITLE
fix(jq): guard 5 unchecked capacity-product multiplications against overflow

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -689,10 +689,18 @@ Confirmed live against the pinned jq 1.7.1 binary for this exact shape (not just
 from the string-repeat case above): a genuinely large-but-indexable cross product
 (`[range(50000) | [1,2]] | .[][(range(50000))]`) neither errors nor crashes — jq streams
 results one at a time instead of pre-allocating a single buffer, so it just keeps producing
-output rather than answering promptly or refusing. Unlike `s * n` above, a live check did
-not turn up an analogous yq-side cap for this shape either — this guard is symmetric across
-both modes, converting a host-process crash into a catchable error in each, with no
-cap-specific divergence to record in
+output rather than answering promptly or refusing.
+
+Unlike `s * n` above, this is symmetric across both modes rather than a yq-specific
+divergence to record — but not because a live check for a yq-side cap came back empty.
+Real yq v4.53.3's lexer rejects `range` outright (confirmed live, `range(5)` →
+`lexer: invalid input text` — matching the `--jq-extensions`-gated builtin table above), so
+there is no *generator*-driven way to construct a comparably large cross product in real
+yq's own grammar at all: the query shape needed to test this doesn't exist there, as
+opposed to existing and having been tested clean. A large *document-sourced* array of
+literal keys could in principle still reach comparable scale in yq; that variant wasn't
+pursued within this issue's scope. Either way, the guard converts a host-process crash into
+a catchable error uniformly in both modes, with no cap-specific divergence to record in
 [yq Limitations](../yq/limitations.md).
 
 ## Regex flags `l` and `n`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -669,20 +669,30 @@ This guard is jq-mode-only. See [yq Limitations](../yq/limitations.md) for `succ
 mode, which refuses much earlier via its own, separate cap.
 
 Computed-index/-slice expansion (`.[$keys]`, `.[$s:$e]`, both in value position and under
-`path()`) has the identical shape again, at five call sites (#1634): each pre-sizes its
-output with a product of two or three independent, generator-controlled `Vec::len()`s
-(e.g. `keys.len() * targets.len()`), previously handed straight to an infallible
-`Vec::with_capacity`. A large enough cross product — e.g. two independent 100,000-element
-generators feeding the same `.[$keys]` — asks for more elements than the allocator can
-satisfy even though neither input list is individually unreasonable to materialize.
-succinctly now refuses with `Cannot allocate <n> elements for a computed-index expansion`
-(or, for the astronomically rarer case where the product itself overflows even a `u128`
-before a length can be checked, `Cannot allocate elements for a computed-index expansion:
-size overflows u128`) via the same `Vec::try_reserve_exact` technique as the `setpath`/
-string-repeat cases above, applied through a shared `try_reserve_product` helper. Unlike
-`s * n` above, a live check did not turn up an analogous yq-side cap for this shape — this
-guard is symmetric across both modes, converting a host-process crash into a catchable
-error in each, with no cap-specific divergence to record in
+`path()`) has the identical shape again, at seven call sites (#1634): five in
+[src/jq/eval.rs](../../../src/jq/eval.rs) (`eval_index_expr` ×2 arms, `eval_slice_expr`,
+`resolve_index_expr`, `resolve_slice_expr`) plus two more in
+[src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)'s own independent
+`eval_index_expr`/`eval_slice_expr` — the latter two are what a real `succinctly jq`/
+`succinctly yq` CLI invocation actually dispatches an ordinary `.[$keys]`/`.[$s:$e]` read
+through (the `eval.rs` siblings are reached only via the direct library API, or via
+`eval_generic.rs`'s own fallback for expressions it doesn't handle natively). Each site
+pre-sizes its output with a product of two or three independent, generator-controlled
+`Vec::len()`s (e.g. `keys.len() * targets.len()`), previously handed straight to an
+infallible `Vec::with_capacity`. A large enough cross product — e.g. two independent
+100,000-element generators feeding the same `.[$keys]` — asks for more elements than the
+allocator can satisfy even though neither input list is individually unreasonable to
+materialize. succinctly now refuses with `Cannot allocate <factors joined by " * "> elements
+for a computed-index expansion` via the same `Vec::try_reserve_exact` technique as the
+`setpath`/string-repeat cases above, applied through a shared `try_reserve_product` helper.
+Confirmed live against the pinned jq 1.7.1 binary for this exact shape (not just analogized
+from the string-repeat case above): a genuinely large-but-indexable cross product
+(`[range(50000) | [1,2]] | .[][(range(50000))]`) neither errors nor crashes — jq streams
+results one at a time instead of pre-allocating a single buffer, so it just keeps producing
+output rather than answering promptly or refusing. Unlike `s * n` above, a live check did
+not turn up an analogous yq-side cap for this shape either — this guard is symmetric across
+both modes, converting a host-process crash into a catchable error in each, with no
+cap-specific divergence to record in
 [yq Limitations](../yq/limitations.md).
 
 ## Regex flags `l` and `n`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -668,6 +668,23 @@ still repeats, so `"ab" * 3` and #1230's float-count cases are unaffected.
 This guard is jq-mode-only. See [yq Limitations](../yq/limitations.md) for `succinctly yq`
 mode, which refuses much earlier via its own, separate cap.
 
+Computed-index/-slice expansion (`.[$keys]`, `.[$s:$e]`, both in value position and under
+`path()`) has the identical shape again, at five call sites (#1634): each pre-sizes its
+output with a product of two or three independent, generator-controlled `Vec::len()`s
+(e.g. `keys.len() * targets.len()`), previously handed straight to an infallible
+`Vec::with_capacity`. A large enough cross product — e.g. two independent 100,000-element
+generators feeding the same `.[$keys]` — asks for more elements than the allocator can
+satisfy even though neither input list is individually unreasonable to materialize.
+succinctly now refuses with `Cannot allocate <n> elements for a computed-index expansion`
+(or, for the astronomically rarer case where the product itself overflows even a `u128`
+before a length can be checked, `Cannot allocate elements for a computed-index expansion:
+size overflows u128`) via the same `Vec::try_reserve_exact` technique as the `setpath`/
+string-repeat cases above, applied through a shared `try_reserve_product` helper. Unlike
+`s * n` above, a live check did not turn up an analogous yq-side cap for this shape — this
+guard is symmetric across both modes, converting a host-process crash into a catchable
+error in each, with no cap-specific divergence to record in
+[yq Limitations](../yq/limitations.md).
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13521,6 +13521,58 @@ pub(crate) fn index_one_owned(
     }
 }
 
+/// Reserve capacity for a `Vec<T>` sized as the product of `factors`,
+/// without risking the unconditional panic/abort `Vec::with_capacity`
+/// gives an unrepresentable or unallocatable length (#1634, same
+/// technique #1612/#1017 already established for this bug class:
+/// `arith_mul`'s string-repeat guard, `pad_with_nulls`'s array-grow
+/// guard). Every computed-index cross-product site in this file
+/// (`.[$keys]`/`.[$s:$e]`, both value- and `path()`-position) reduces to
+/// "how many output slots could this generator combination produce, at
+/// most" — a `keys.len() * ts.len()`-style product of generator- or
+/// document-controlled lengths that used to be handed straight to an
+/// infallible `Vec::with_capacity`. `keys`/`ts`/`starts`/`ends`/
+/// `target_branches` are each already-materialized `Vec`s by the time any
+/// of these call sites runs, so unlike #1612's `s.len() * n` (a single
+/// scalar read straight from the document), there is no cheap, portable
+/// way to force `try_reserve_exact`'s own failure path in an end-to-end
+/// test here without exhausting real memory first — this function's own
+/// unit tests instead call it directly with synthetic large factors,
+/// bypassing the (expensive or outright infeasible) generator
+/// materialization a live repro of comparable scale would need.
+///
+/// `factors`' own product is computed in `u128` first so overflow can't
+/// happen a second time in the check meant to catch it (mirrors #1612's
+/// own `s.len() as u128 * n as u128`).
+///
+/// No mode-specific cap: unlike #1612's `MAX_STRING_REPEAT_BYTES` (a
+/// confirmed, deliberate real-yq limit reproduced verbatim), a live check
+/// for an analogous yq-side cap on this cross-product shape didn't turn up
+/// one within this issue's scope. This is purely an internal safety net
+/// converting an uncatchable panic/abort into a catchable `EvalError` in
+/// both modes, per ADR-0018's "would take the host process down"
+/// divergence exception — jq has no cap of its own for this class either
+/// (matching #1612's own precedent: the reference tool has no oracle
+/// wording to reproduce here, since it just keeps running or gets
+/// OOM-killed by the OS rather than answering promptly).
+fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
+    let total: u128 = factors.iter().map(|&f| f as u128).product();
+    let Ok(len) = usize::try_from(total) else {
+        return Err(cannot_reserve_cross_product(total));
+    };
+    let mut out = Vec::new();
+    if out.try_reserve_exact(len).is_err() {
+        return Err(cannot_reserve_cross_product(total));
+    }
+    Ok(out)
+}
+
+fn cannot_reserve_cross_product(total: u128) -> EvalError {
+    EvalError::new(format!(
+        "Cannot allocate {total} elements for a computed-index expansion"
+    ))
+}
+
 /// Evaluate `E[K]` — indexing by a computed key.
 ///
 /// jq compiles this as `K as $k | E | .[$k]`, and three consequences of that
@@ -13627,7 +13679,11 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (2) Key outer, target inner.
     match targets {
         Targets::Borrowed(ts) => {
-            let mut out: Vec<StandardJson<'a, W>> = Vec::with_capacity(keys.len() * ts.len());
+            let mut out: Vec<StandardJson<'a, W>> =
+                match try_reserve_product(&[keys.len(), ts.len()]) {
+                    Ok(out) => out,
+                    Err(e) => return QueryResult::Error(e),
+                };
             for k in &keys {
                 for t in &ts {
                     match index_one::<W>(t.clone(), k, optional) {
@@ -13655,7 +13711,10 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         Targets::Owned(ts) => {
-            let mut out: Vec<OwnedValue> = Vec::with_capacity(keys.len() * ts.len());
+            let mut out: Vec<OwnedValue> = match try_reserve_product(&[keys.len(), ts.len()]) {
+                Ok(out) => out,
+                Err(e) => return QueryResult::Error(e),
+            };
             for k in &keys {
                 for t in &ts {
                     match index_one_owned(t, k, optional) {
@@ -13751,7 +13810,10 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // owned: slicing constructs a new array/string (see `eval_single`'s
     // `Expr::Slice` arm), so there is nothing to borrow except its rare
     // whole-value fast paths, which `to_owned` below just copies out of.
-    let mut out: Vec<OwnedValue> = Vec::with_capacity(starts.len() * ends.len());
+    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
+        Ok(out) => out,
+        Err(e) => return QueryResult::Error(e),
+    };
     match &targets {
         Targets::Borrowed(ts) => {
             for s in &starts {
@@ -19817,7 +19879,10 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     } else {
         &keys[..]
     };
-    let mut out = Vec::with_capacity(keys.len() * target_branches.len());
+    let mut out = match try_reserve_product(&[keys.len(), target_branches.len()]) {
+        Ok(out) => out,
+        Err(e) => return Err((Vec::new(), e.into())),
+    };
     for k in keys {
         for PathBranch {
             path: components,
@@ -20080,7 +20145,10 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // the `ends.is_empty()` early return: `target` > `end` > `start` --
     // `bounds_escape` already carries the `end` > `start` half.
     let escape = target_escape.or(bounds_escape);
-    let mut out = Vec::with_capacity(starts.len() * ends.len() * target_branches.len());
+    let mut out = match try_reserve_product(&[starts.len(), ends.len(), target_branches.len()]) {
+        Ok(out) => out,
+        Err(e) => return Err((Vec::new(), e.into())),
+    };
     for (s, s_key) in starts {
         for (e, e_key) in ends {
             // #1326: a genuinely dynamic bound (unlike a literal one, which
@@ -35875,6 +35943,72 @@ mod tests {
         // jq mode's own cases are unaffected by the yq-only cap.
         query!(br#"{"s": "ab", "n": 5242881}"#, ".s * .n",
             QueryResult::Owned(OwnedValue::String(s)) if s.len() == 10_485_762 => {}
+        );
+    }
+
+    /// #1634: unlike #1612's `s.len() * n` (a single scalar read straight
+    /// from the document, cheap to make astronomically large via a huge
+    /// `NumberLiteral`), each of `try_reserve_product`'s factors here is a
+    /// real `Vec::len()` -- there is no way to make one huge without
+    /// actually materializing that many elements first, which for a
+    /// factor large enough to overflow `usize`/`isize` on its own is
+    /// infeasible to do in a test. Calls the guard directly with synthetic
+    /// large factors instead, bypassing the generator materialization a
+    /// live repro of comparable scale would need (see the doc comment on
+    /// `try_reserve_product` itself for why).
+    #[test]
+    fn test_try_reserve_product_refuses_usize_overflow_1634() {
+        // `usize::MAX * 2` (widened to `u128` first) doesn't fit back into
+        // `usize` at all.
+        let result: Result<Vec<OwnedValue>, EvalError> = try_reserve_product(&[usize::MAX, 2]);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    /// #1634: a product that *does* fit `usize` (as raw element count) but
+    /// whose byte size -- once multiplied by `size_of::<OwnedValue>()`
+    /// inside `Vec::try_reserve_exact` -- exceeds `isize::MAX` must also
+    /// refuse cleanly. This is the boundary `Vec::with_capacity` itself
+    /// panics past even when the raw `usize` conversion above would have
+    /// succeeded, so it needs its own case distinct from the outright
+    /// `usize`-overflow one above.
+    #[test]
+    fn test_try_reserve_product_refuses_isize_byte_overflow_1634() {
+        // 4e18 raw elements comfortably fits `usize` (~1.8e19), but
+        // `OwnedValue` is well over 2 bytes wide, so the byte size
+        // (`4e18 * size_of::<OwnedValue>()`) is nowhere close to fitting
+        // `isize::MAX` (~9.2e18 bytes).
+        let result: Result<Vec<OwnedValue>, EvalError> =
+            try_reserve_product(&[2_000_000_000_000_000_000usize, 2]);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    /// #1634: the guard must not become a de facto cap on legitimate,
+    /// modest cross products -- an ordinary small product still succeeds
+    /// and reserves the exact requested capacity, matching what
+    /// `Vec::with_capacity` itself would have done before this fix.
+    #[test]
+    fn test_try_reserve_product_succeeds_for_ordinary_sizes_1634() {
+        let out: Vec<OwnedValue> =
+            try_reserve_product(&[10, 20]).expect("a 10*20 product must not refuse");
+        assert!(out.capacity() >= 200, "capacity: {}", out.capacity());
+        assert!(out.is_empty());
+    }
+
+    /// #1634: end-to-end sanity that the guard is actually reachable from a
+    /// real `.[$keys]` query and doesn't change output for a size that
+    /// previously worked (the value-position, `Targets::Borrowed` arm of
+    /// `eval_index_expr` -- the other three wired call sites share the same
+    /// `try_reserve_product` helper and are covered by the direct unit
+    /// tests above and the CLI-level path/slice tests elsewhere in this
+    /// file, e.g. `test_path_...`/`test_slice_...` cases exercising
+    /// `.[$s:$e]` and `path(...)`).
+    #[test]
+    fn test_computed_index_ordinary_cross_product_unaffected_1634() {
+        query!(br#"{"a":1,"b":2}"#, r#".[("a","b")]"#,
+            QueryResult::Many(vs) => {
+                let values: Vec<OwnedValue> = vs.iter().map(to_owned).collect();
+                assert_eq!(values, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13555,8 +13555,25 @@ pub(crate) fn index_one_owned(
 /// (matching #1612's own precedent: the reference tool has no oracle
 /// wording to reproduce here, since it just keeps running or gets
 /// OOM-killed by the OS rather than answering promptly).
-fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
-    let total: u128 = factors.iter().map(|&f| f as u128).product();
+pub(crate) fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
+    // `checked_mul`, not a bare `.product()`: with 3+ factors (the
+    // `path()`-position slice sites pass `starts`/`ends`/`target_branches`
+    // together), the running product can itself overflow `u128` before
+    // ever reaching the `usize::try_from` check below meant to catch an
+    // overflow -- `.product()` would silently wrap instead of erroring.
+    // Not reachable with today's callers (each factor is a real
+    // `Vec::len()`; three factors near 2^43 apiece to trigger this would
+    // already have exhausted real memory materializing the inputs), but
+    // the function's own contract shouldn't depend on that.
+    let mut total: u128 = 1;
+    for &f in factors {
+        let Some(next) = total.checked_mul(f as u128) else {
+            return Err(EvalError::new(
+                "Cannot allocate elements for a computed-index expansion: size overflows u128",
+            ));
+        };
+        total = next;
+    }
     let Ok(len) = usize::try_from(total) else {
         return Err(cannot_reserve_cross_product(total));
     };
@@ -13677,6 +13694,15 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
 
     // (2) Key outer, target inner.
+    //
+    // A capacity failure here bypasses `pending_halt` -- deliberately: it
+    // is a fresh error arising before any element has even been indexed,
+    // so it takes the exact same priority as an ordinary `index_one`/
+    // `index_one_owned` failure partway through the loop below, which the
+    // comment on that arm documents as already outranking a still-pending
+    // halt (jq's own interleaved key/index evaluation model). `out` is
+    // always empty at this point regardless, so there is no already-
+    // produced prefix a `Partial` could preserve either way.
     match targets {
         Targets::Borrowed(ts) => {
             let mut out: Vec<StandardJson<'a, W>> =
@@ -13810,10 +13836,22 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // owned: slicing constructs a new array/string (see `eval_single`'s
     // `Expr::Slice` arm), so there is nothing to borrow except its rare
     // whole-value fast paths, which `to_owned` below just copies out of.
-    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
-        Ok(out) => out,
-        Err(e) => return QueryResult::Error(e),
+    //
+    // All three factors, not just `starts.len() * ends.len()`: the loop
+    // below is genuinely S outer / T middle / E inner, so the true upper
+    // bound includes the target count too (#1634 review) -- an
+    // under-reservation here wouldn't overflow on its own, but it would
+    // leave the eventual `Vec::push` growth past this capacity unguarded
+    // for exactly the same crash class this function exists to close.
+    let targets_len = match &targets {
+        Targets::Borrowed(ts) => ts.len(),
+        Targets::Owned(ts) => ts.len(),
     };
+    let mut out: Vec<OwnedValue> =
+        match try_reserve_product(&[starts.len(), ends.len(), targets_len]) {
+            Ok(out) => out,
+            Err(e) => return QueryResult::Error(e),
+        };
     match &targets {
         Targets::Borrowed(ts) => {
             for s in &starts {
@@ -19879,6 +19917,13 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     } else {
         &keys[..]
     };
+    // A capacity failure here bypasses `target_escape`/`key_escape` --
+    // deliberately, and for the same reason as `eval_index_expr`'s
+    // identical arm: this fires before the loop below produces anything,
+    // so `out` (the `Err` tuple's own prefix) is always empty regardless,
+    // and a fresh error at this point takes the same priority a mid-loop
+    // `index_one_owned` failure already does (`return Err((out, e.into()))`
+    // below, which likewise doesn't fold in either escape).
     let mut out = match try_reserve_product(&[keys.len(), target_branches.len()]) {
         Ok(out) => out,
         Err(e) => return Err((Vec::new(), e.into())),
@@ -20145,6 +20190,11 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // the `ends.is_empty()` early return: `target` > `end` > `start` --
     // `bounds_escape` already carries the `end` > `start` half.
     let escape = target_escape.or(bounds_escape);
+    // A capacity failure here bypasses `escape` -- same reasoning as
+    // `resolve_index_expr`'s identical arm: `out` is always empty at this
+    // point, and a fresh error at this point takes the same priority a
+    // mid-loop failure already does further down in this function (its own
+    // `return Err((out, ...))` arms likewise don't fold `escape` in).
     let mut out = match try_reserve_product(&[starts.len(), ends.len(), target_branches.len()]) {
         Ok(out) => out,
         Err(e) => return Err((Vec::new(), e.into())),
@@ -35973,12 +36023,33 @@ mod tests {
     /// `usize`-overflow one above.
     #[test]
     fn test_try_reserve_product_refuses_isize_byte_overflow_1634() {
-        // 4e18 raw elements comfortably fits `usize` (~1.8e19), but
-        // `OwnedValue` is well over 2 bytes wide, so the byte size
-        // (`4e18 * size_of::<OwnedValue>()`) is nowhere close to fitting
-        // `isize::MAX` (~9.2e18 bytes).
+        // `usize::MAX / 4`, not a hardcoded 64-bit-only literal (this
+        // crate has existing `target_pointer_width = "64"` gates
+        // elsewhere, e.g. `trees/bp.rs`/`bits/select.rs`, so 32-bit
+        // portability is a live concern) -- times 2 comfortably fits
+        // `usize` as a raw element count on any pointer width, but
+        // `OwnedValue` is well over 2 bytes wide, so the byte size (once
+        // multiplied by `size_of::<OwnedValue>()`) overflows `isize::MAX`
+        // on both 32- and 64-bit targets.
+        let factor = usize::MAX / 4;
+        let result: Result<Vec<OwnedValue>, EvalError> = try_reserve_product(&[factor, 2]);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    /// #1634 review: the product computation itself must not silently
+    /// wrap when 3+ factors overflow `u128`, before the `usize::try_from`
+    /// check below even runs -- the `path()`-position slice site
+    /// (`resolve_slice_expr`) passes three factors together
+    /// (`starts`/`ends`/`target_branches`), so a naive running
+    /// multiplication with no overflow check of its own could wrap past
+    /// `u128::MAX` back down to a small, wrong value instead of erring.
+    #[test]
+    fn test_try_reserve_product_refuses_u128_overflow_with_three_factors_1634() {
+        // Each factor is ~2^43; three of them multiply to ~2^129, past
+        // `u128::MAX` (2^128).
+        let factor: usize = 1 << 43;
         let result: Result<Vec<OwnedValue>, EvalError> =
-            try_reserve_product(&[2_000_000_000_000_000_000usize, 2]);
+            try_reserve_product(&[factor, factor, factor]);
         assert!(result.is_err(), "expected Err, got {result:?}");
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13557,20 +13557,41 @@ pub(crate) fn index_one_owned(
 /// zero that brings the real product back down.
 ///
 /// No mode-specific cap: unlike #1612's `MAX_STRING_REPEAT_BYTES` (a
-/// confirmed, deliberate real-yq limit reproduced verbatim), a live check
-/// for an analogous yq-side cap on this cross-product shape didn't turn up
-/// one within this issue's scope. This is purely an internal safety net
-/// converting an uncatchable panic/abort into a catchable `EvalError` in
-/// both modes, per ADR-0018's "would take the host process down"
-/// divergence exception — confirmed live against the pinned jq 1.7.1
-/// binary for this exact cross-product shape (not just analogized from
-/// #1612's own string-repeat case): a genuinely large-but-indexable
-/// `.[$keys]` cross product (`[range(50000) | [1,2]] | .[][(range(50000))]`)
-/// neither errors nor crashes -- jq streams results one at a time rather
-/// than pre-allocating a single buffer the way `Vec::with_capacity` does,
-/// so it just keeps producing output (139M+ lines observed before the
-/// probe was killed at a 15s wall-clock cap, well short of the eventual
-/// 2.5 billion) rather than answering promptly or refusing.
+/// confirmed, deliberate real-yq limit reproduced verbatim). This is purely
+/// an internal safety net converting an uncatchable panic/abort into a
+/// catchable `EvalError` in both modes, per ADR-0018's "would take the host
+/// process down" divergence exception -- for the *reservation* itself, not
+/// necessarily for the write that follows it. `try_reserve_exact` only
+/// catches a Layout that's unrepresentable or an allocation the allocator
+/// refuses outright; under Linux's default memory overcommit, a large but
+/// `isize`-representable reservation can still succeed and only fail later,
+/// page fault by page fault, as the subsequent element-by-element writes
+/// actually touch that memory -- at which point it's the OS's OOM killer
+/// terminating the process, not this guard, the same residual risk #1612's
+/// own `try_reserve_exact` adoption already carries for its real-OOM half
+/// (documented there as accepted under the identical ADR-0018 exception,
+/// not something this guard newly introduces).
+///
+/// jq side, confirmed live against the pinned jq 1.7.1 binary for this
+/// exact cross-product shape (not just analogized from #1612's own
+/// string-repeat case): a genuinely large-but-indexable `.[$keys]` cross
+/// product (`[range(50000) | [1,2]] | .[][(range(50000))]`) neither errors
+/// nor crashes -- jq streams results one at a time rather than
+/// pre-allocating a single buffer the way `Vec::with_capacity` does, so it
+/// just keeps producing output (139M+ lines observed before the probe was
+/// killed at a 15s wall-clock cap, well short of the eventual 2.5 billion)
+/// rather than answering promptly or refusing.
+///
+/// yq side: real yq v4.53.3's lexer rejects `range` outright (confirmed
+/// live, `range(5)` -> `lexer: invalid input text` -- matching the
+/// existing `--jq-extensions`-gated builtin table elsewhere in this file),
+/// so there is no equivalent *generator*-driven way to construct a
+/// comparably large cross product in real yq's own grammar to test this
+/// shape against at all -- not "a cap wasn't found", but "the query shape
+/// needed to trigger this can't be expressed there". A large *document-
+/// sourced* array of literal keys (rather than a generator) could still
+/// reach comparable scale in principle; that variant wasn't pursued
+/// further within this issue's scope.
 pub(crate) fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
     if factors.contains(&0) {
         return Ok(Vec::new());

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13526,24 +13526,35 @@ pub(crate) fn index_one_owned(
 /// gives an unrepresentable or unallocatable length (#1634, same
 /// technique #1612/#1017 already established for this bug class:
 /// `arith_mul`'s string-repeat guard, `pad_with_nulls`'s array-grow
-/// guard). Every computed-index cross-product site in this file
-/// (`.[$keys]`/`.[$s:$e]`, both value- and `path()`-position) reduces to
-/// "how many output slots could this generator combination produce, at
-/// most" — a `keys.len() * ts.len()`-style product of generator- or
-/// document-controlled lengths that used to be handed straight to an
-/// infallible `Vec::with_capacity`. `keys`/`ts`/`starts`/`ends`/
-/// `target_branches` are each already-materialized `Vec`s by the time any
-/// of these call sites runs, so unlike #1612's `s.len() * n` (a single
-/// scalar read straight from the document), there is no cheap, portable
-/// way to force `try_reserve_exact`'s own failure path in an end-to-end
-/// test here without exhausting real memory first — this function's own
-/// unit tests instead call it directly with synthetic large factors,
-/// bypassing the (expensive or outright infeasible) generator
-/// materialization a live repro of comparable scale would need.
+/// guard). Every computed-index cross-product site in this file and in
+/// `eval_generic.rs` (`.[$keys]`/`.[$s:$e]`, value- and `path()`-position,
+/// native and generic-cursor evaluators alike — 7 call sites total)
+/// reduces to "how many output slots could this generator combination
+/// produce, at most" — a `keys.len() * ts.len()`-style product of
+/// generator- or document-controlled lengths that used to be handed
+/// straight to an infallible `Vec::with_capacity`. `keys`/`ts`/`starts`/
+/// `ends`/`target_branches` are each already-materialized `Vec`s by the
+/// time any of these call sites runs, so unlike #1612's `s.len() * n` (a
+/// single scalar read straight from the document), there is no cheap,
+/// portable way to force `try_reserve_exact`'s own failure path in an
+/// end-to-end test here without exhausting real memory first — this
+/// function's own unit tests instead call it directly with synthetic
+/// large factors, bypassing the (expensive or outright infeasible)
+/// generator materialization a live repro of comparable scale would need.
 ///
-/// `factors`' own product is computed in `u128` first so overflow can't
-/// happen a second time in the check meant to catch it (mirrors #1612's
-/// own `s.len() as u128 * n as u128`).
+/// Every factor is checked in plain `usize` via a `checked_mul` chain,
+/// with an upfront short-circuit for a zero factor. Widening to `u128`
+/// first (an earlier version of this function did) is unnecessary: given
+/// the zero short-circuit, every remaining factor is `>= 1`, so a
+/// left-to-right running product can only grow, meaning the *first* point
+/// (if any) where `checked_mul` overflows `usize` is exactly the point
+/// where the true mathematical product has already exceeded `usize::MAX`
+/// — there is no case a `u128` detour catches that direct `usize`
+/// arithmetic misses, and `usize` is what `try_reserve_exact` needs
+/// anyway. The zero short-circuit isn't just an optimization: without it,
+/// factors like `[usize::MAX, 2, 0]` (true product `0`, must succeed)
+/// would spuriously refuse at the second factor before ever reaching the
+/// zero that brings the real product back down.
 ///
 /// No mode-specific cap: unlike #1612's `MAX_STRING_REPEAT_BYTES` (a
 /// confirmed, deliberate real-yq limit reproduced verbatim), a live check
@@ -13551,42 +13562,41 @@ pub(crate) fn index_one_owned(
 /// one within this issue's scope. This is purely an internal safety net
 /// converting an uncatchable panic/abort into a catchable `EvalError` in
 /// both modes, per ADR-0018's "would take the host process down"
-/// divergence exception — jq has no cap of its own for this class either
-/// (matching #1612's own precedent: the reference tool has no oracle
-/// wording to reproduce here, since it just keeps running or gets
-/// OOM-killed by the OS rather than answering promptly).
+/// divergence exception — confirmed live against the pinned jq 1.7.1
+/// binary for this exact cross-product shape (not just analogized from
+/// #1612's own string-repeat case): a genuinely large-but-indexable
+/// `.[$keys]` cross product (`[range(50000) | [1,2]] | .[][(range(50000))]`)
+/// neither errors nor crashes -- jq streams results one at a time rather
+/// than pre-allocating a single buffer the way `Vec::with_capacity` does,
+/// so it just keeps producing output (139M+ lines observed before the
+/// probe was killed at a 15s wall-clock cap, well short of the eventual
+/// 2.5 billion) rather than answering promptly or refusing.
 pub(crate) fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
-    // `checked_mul`, not a bare `.product()`: with 3+ factors (the
-    // `path()`-position slice sites pass `starts`/`ends`/`target_branches`
-    // together), the running product can itself overflow `u128` before
-    // ever reaching the `usize::try_from` check below meant to catch an
-    // overflow -- `.product()` would silently wrap instead of erroring.
-    // Not reachable with today's callers (each factor is a real
-    // `Vec::len()`; three factors near 2^43 apiece to trigger this would
-    // already have exhausted real memory materializing the inputs), but
-    // the function's own contract shouldn't depend on that.
-    let mut total: u128 = 1;
-    for &f in factors {
-        let Some(next) = total.checked_mul(f as u128) else {
-            return Err(EvalError::new(
-                "Cannot allocate elements for a computed-index expansion: size overflows u128",
-            ));
-        };
-        total = next;
+    if factors.contains(&0) {
+        return Ok(Vec::new());
     }
-    let Ok(len) = usize::try_from(total) else {
-        return Err(cannot_reserve_cross_product(total));
-    };
+    let mut len: usize = 1;
+    for &f in factors {
+        let Some(next) = len.checked_mul(f) else {
+            return Err(cannot_reserve_cross_product(factors));
+        };
+        len = next;
+    }
     let mut out = Vec::new();
     if out.try_reserve_exact(len).is_err() {
-        return Err(cannot_reserve_cross_product(total));
+        return Err(cannot_reserve_cross_product(factors));
     }
     Ok(out)
 }
 
-fn cannot_reserve_cross_product(total: u128) -> EvalError {
+fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
+    let product = factors
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(" * ");
     EvalError::new(format!(
-        "Cannot allocate {total} elements for a computed-index expansion"
+        "Cannot allocate {product} elements for a computed-index expansion"
     ))
 }
 
@@ -13695,14 +13705,21 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // (2) Key outer, target inner.
     //
-    // A capacity failure here bypasses `pending_halt` -- deliberately: it
-    // is a fresh error arising before any element has even been indexed,
-    // so it takes the exact same priority as an ordinary `index_one`/
-    // `index_one_owned` failure partway through the loop below, which the
-    // comment on that arm documents as already outranking a still-pending
-    // halt (jq's own interleaved key/index evaluation model). `out` is
-    // always empty at this point regardless, so there is no already-
-    // produced prefix a `Partial` could preserve either way.
+    // A capacity failure here bypasses both `pending_halt` and `optional` --
+    // deliberately, on both counts. It is a fresh error arising before any
+    // element has even been indexed, so it takes the exact same priority as
+    // an ordinary `index_one`/`index_one_owned` failure partway through the
+    // loop below, which the comment on that arm documents as already
+    // outranking a still-pending halt (jq's own interleaved key/index
+    // evaluation model); `out` is always empty at this point regardless, so
+    // there is no already-produced prefix a `Partial` could preserve either
+    // way. And this function's own doc comment is explicit that `optional`
+    // "reaches `index_one` and nothing else" -- concretely, not even key or
+    // target evaluation are covered (`.[error("boom")]?` still raises,
+    // `"str" | .a[length]?` still fails) -- so a capacity check that runs
+    // before `index_one`/`index_one_owned` is ever called is, by that same
+    // explicit contract, outside `?`'s reach too, exactly like key/target
+    // evaluation already is.
     match targets {
         Targets::Borrowed(ts) => {
             let mut out: Vec<StandardJson<'a, W>> =
@@ -13817,6 +13834,14 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Borrowed(Vec<StandardJson<'a, W>>),
         Owned(Vec<OwnedValue>),
     }
+    impl<W> Targets<'_, W> {
+        fn len(&self) -> usize {
+            match self {
+                Self::Borrowed(ts) => ts.len(),
+                Self::Owned(ts) => ts.len(),
+            }
+        }
+    }
     let targets = match targets {
         QueryResult::One(v) => Targets::Borrowed(vec![v]),
         QueryResult::Many(vs) => Targets::Borrowed(vs),
@@ -13843,12 +13868,8 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // under-reservation here wouldn't overflow on its own, but it would
     // leave the eventual `Vec::push` growth past this capacity unguarded
     // for exactly the same crash class this function exists to close.
-    let targets_len = match &targets {
-        Targets::Borrowed(ts) => ts.len(),
-        Targets::Owned(ts) => ts.len(),
-    };
     let mut out: Vec<OwnedValue> =
-        match try_reserve_product(&[starts.len(), ends.len(), targets_len]) {
+        match try_reserve_product(&[starts.len(), ends.len(), targets.len()]) {
             Ok(out) => out,
             Err(e) => return QueryResult::Error(e),
         };
@@ -19924,6 +19945,18 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
     // and a fresh error at this point takes the same priority a mid-loop
     // `index_one_owned` failure already does (`return Err((out, e.into()))`
     // below, which likewise doesn't fold in either escape).
+    //
+    // `optional` is *not* extended to a capacity failure either: this
+    // function's own doc comment scopes the `?`/non-`?` difference to
+    // exactly one thing -- "what happens when the resolved key cannot be
+    // applied to the container it reached" (i.e. `key_to_path_component`/
+    // `index_one_owned`'s own per-pair failure below) -- and says
+    // "everything else is shared" between the two spellings. A capacity
+    // failure is not that one named exception, so it stays shared: the
+    // same hard error either way, matching key/target evaluation failures
+    // (also outside the named exception) and `eval_index_expr`'s identical
+    // arm, whose own doc comment is even more explicit that `optional`
+    // "reaches `index_one` and nothing else".
     let mut out = match try_reserve_product(&[keys.len(), target_branches.len()]) {
         Ok(out) => out,
         Err(e) => return Err((Vec::new(), e.into())),
@@ -20195,6 +20228,17 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // point, and a fresh error at this point takes the same priority a
     // mid-loop failure already does further down in this function (its own
     // `return Err((out, ...))` arms likewise don't fold `escape` in).
+    //
+    // Unlike `resolve_index_expr`, `optional` is *not* extended to a
+    // capacity failure here: this function's own doc comment deliberately
+    // narrows `?` to "only the final application of the resolved bounds to
+    // the target", explicitly excluding bound resolution and any check
+    // that isn't that final per-element application -- the same narrower
+    // convention `eval_slice_expr` (value position) already follows, unlike
+    // `eval_index_expr`'s broader "covers the indexing" scope. A capacity
+    // check is neither S/T's evaluation nor the final application; treating
+    // it as covered here would be extending `?` past what this function's
+    // own documented contract already draws the line at.
     let mut out = match try_reserve_product(&[starts.len(), ends.len(), target_branches.len()]) {
         Ok(out) => out,
         Err(e) => return Err((Vec::new(), e.into())),
@@ -36036,21 +36080,19 @@ mod tests {
         assert!(result.is_err(), "expected Err, got {result:?}");
     }
 
-    /// #1634 review: the product computation itself must not silently
-    /// wrap when 3+ factors overflow `u128`, before the `usize::try_from`
-    /// check below even runs -- the `path()`-position slice site
-    /// (`resolve_slice_expr`) passes three factors together
-    /// (`starts`/`ends`/`target_branches`), so a naive running
-    /// multiplication with no overflow check of its own could wrap past
-    /// `u128::MAX` back down to a small, wrong value instead of erring.
+    /// #1634 review: a zero factor must short-circuit to success *before*
+    /// the `checked_mul` chain runs, not just fall out of it naturally --
+    /// `[usize::MAX, 2, 0]`'s true mathematical product is `0` (trivially
+    /// satisfiable), but without an upfront zero check, the chain would
+    /// overflow at the second factor (`usize::MAX * 2`) and spuriously
+    /// refuse before ever reaching the zero that brings the real product
+    /// back down. Also exercises 3 factors, the `path()`-position slice
+    /// sites' own arity.
     #[test]
-    fn test_try_reserve_product_refuses_u128_overflow_with_three_factors_1634() {
-        // Each factor is ~2^43; three of them multiply to ~2^129, past
-        // `u128::MAX` (2^128).
-        let factor: usize = 1 << 43;
-        let result: Result<Vec<OwnedValue>, EvalError> =
-            try_reserve_product(&[factor, factor, factor]);
-        assert!(result.is_err(), "expected Err, got {result:?}");
+    fn test_try_reserve_product_zero_factor_short_circuits_even_after_an_overflowing_pair_1634() {
+        let out: Vec<OwnedValue> = try_reserve_product(&[usize::MAX, 2, 0])
+            .expect("a true product of 0 must succeed regardless of factor order");
+        assert!(out.is_empty());
     }
 
     /// #1634: the guard must not become a de facto cap on legitimate,
@@ -36068,10 +36110,14 @@ mod tests {
     /// #1634: end-to-end sanity that the guard is actually reachable from a
     /// real `.[$keys]` query and doesn't change output for a size that
     /// previously worked (the value-position, `Targets::Borrowed` arm of
-    /// `eval_index_expr` -- the other three wired call sites share the same
-    /// `try_reserve_product` helper and are covered by the direct unit
-    /// tests above and the CLI-level path/slice tests elsewhere in this
-    /// file, e.g. `test_path_...`/`test_slice_...` cases exercising
+    /// `eval.rs`'s own `eval_index_expr` -- the other 4 call sites in this
+    /// file (`eval_index_expr`'s `Targets::Owned` arm, `eval_slice_expr`,
+    /// `resolve_index_expr`, `resolve_slice_expr`) plus the 2 in
+    /// `eval_generic.rs` (the actual CLI dispatch path -- see
+    /// `test_generic_computed_index_ordinary_cross_product_unaffected_1634`)
+    /// share the same `try_reserve_product` helper and are covered by the
+    /// direct unit tests above and the CLI-level path/slice tests elsewhere
+    /// in this file, e.g. `test_path_...`/`test_slice_...` cases exercising
     /// `.[$s:$e]` and `path(...)`).
     #[test]
     fn test_computed_index_ordinary_cross_product_unaffected_1634() {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5269,6 +5269,14 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         Borrowed(Vec<V>),
         Owned(Vec<OwnedValue>),
     }
+    impl<V> Targets<V> {
+        fn len(&self) -> usize {
+            match self {
+                Self::Borrowed(ts) => ts.len(),
+                Self::Owned(ts) => ts.len(),
+            }
+        }
+    }
     let targets = match eval_single::<S, V>(target, value, false, cursor) {
         GenericResult::Error(e) => return GenericResult::Error(e),
         GenericResult::Break(label) => return GenericResult::Break(label),
@@ -5311,14 +5319,10 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     // on `Expr::SliceExpr`'s own match arm above), so this site -- not
     // `eval::eval_slice_expr`'s sibling -- is what a real `succinctly
     // jq`/`succinctly yq` invocation hits.
-    let targets_len = match &targets {
-        Targets::Borrowed(ts) => ts.len(),
-        Targets::Owned(ts) => ts.len(),
-    };
     let mut out: Vec<OwnedValue> = owned_or_err!(try_reserve_product(&[
         starts.len(),
         ends.len(),
-        targets_len
+        targets.len()
     ]));
     match &targets {
         Targets::Borrowed(ts) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -30,8 +30,8 @@ use super::eval::{
     apply_compare_op, arith_combine, collapse_vec, eval as full_eval, eval_each_owned,
     format_owned, index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
-    slice_owned_value_read, tonumber_from_str, Control, Demand, EvalError, EvalSemantics, EvalTag,
-    Flow, JqSemantics, QueryResult, YqSemantics,
+    slice_owned_value_read, tonumber_from_str, try_reserve_product, Control, Demand, EvalError,
+    EvalSemantics, EvalTag, Flow, JqSemantics, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -5110,7 +5110,15 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         | GenericResult::LazyIndexRange(_)
         | GenericResult::LazySeq(_)) => {
             let targets = owned_or_err!(owned.collect_owned());
-            let mut out = Vec::with_capacity(keys.len() * targets.len());
+            // #1634: `keys.len() * targets.len()` is a product of two
+            // independent, generator-controlled lengths -- an unguarded
+            // `Vec::with_capacity` here can panic/abort the process on
+            // overflow or a genuine allocation failure. This is the actual
+            // dispatch path for an ordinary `.[$keys]` CLI read (see the
+            // comment on `Expr::IndexExpr`'s own match arm above), so this
+            // site -- not `eval::eval_index_expr`'s sibling -- is what a
+            // real `succinctly jq`/`succinctly yq` invocation hits.
+            let mut out = owned_or_err!(try_reserve_product(&[keys.len(), targets.len()]));
             for k in &keys {
                 for t in &targets {
                     match index_owned_by_key(t, k, optional) {
@@ -5292,7 +5300,26 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     // Start outer, end middle, target inner. The result is always owned:
     // slicing constructs a fresh array/string, same invariant as
     // `eval::eval_slice_expr`.
-    let mut out: Vec<OwnedValue> = Vec::with_capacity(starts.len() * ends.len());
+    //
+    // All three factors (#1634 review): the loop below is genuinely S
+    // outer / E middle / T inner, so `starts.len() * ends.len()` alone
+    // under-reserves whenever the target itself has more than one output
+    // -- an unguarded `Vec::with_capacity` product of two or three such
+    // generator-controlled lengths can also panic/abort the process on
+    // overflow or a genuine allocation failure. This is the actual
+    // dispatch path for an ordinary `.[$s:$e]` CLI read (see the comment
+    // on `Expr::SliceExpr`'s own match arm above), so this site -- not
+    // `eval::eval_slice_expr`'s sibling -- is what a real `succinctly
+    // jq`/`succinctly yq` invocation hits.
+    let targets_len = match &targets {
+        Targets::Borrowed(ts) => ts.len(),
+        Targets::Owned(ts) => ts.len(),
+    };
+    let mut out: Vec<OwnedValue> = owned_or_err!(try_reserve_product(&[
+        starts.len(),
+        ends.len(),
+        targets_len
+    ]));
     match &targets {
         Targets::Borrowed(ts) => {
             for s in &starts {
@@ -6496,6 +6523,36 @@ mod tests {
             matches!(result, GenericResult::None),
             "expected None, got {result:?}"
         );
+    }
+
+    /// #1634 review: `eval.rs`'s own end-to-end regression test for the
+    /// computed-index capacity guard
+    /// (`test_computed_index_ordinary_cross_product_unaffected_1634`) goes
+    /// through `eval::eval()`, a *different* entry point from the one
+    /// `src/bin/succinctly/{jq,yq}_runner.rs` actually call for an
+    /// ordinary `.[$keys]` read -- `Expr::IndexExpr` is handled natively
+    /// here, in this module's own `eval_index_expr` (see the comment on
+    /// its match arm above), so that other test never touched this
+    /// module's independently-guarded `try_reserve_product` call site at
+    /// all. This test exercises this module's real dispatch path
+    /// directly, targeting the specific arm the guard was added to (an
+    /// *owned* target -- `({"x":1,"y":2})`, a constructed value rather than
+    /// a document navigation, takes `eval_index_expr`'s `owned @ (...)`
+    /// arm rather than the unguarded cursor-based loop below it).
+    #[test]
+    fn test_generic_computed_index_ordinary_cross_product_unaffected_1634() {
+        let json = br"null";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(&parse(r#"({"x":1,"y":2})[("x","y")]"#).unwrap(), value);
+        match result {
+            GenericResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`eval_index_expr`/`eval_slice_expr` (value position) and `resolve_index_expr`/`resolve_slice_expr` (`path()` position) each pre-size their output `Vec` with an unguarded product of two or three independent, generator-controlled lengths, handed straight to an infallible `Vec::with_capacity` — at **7 call sites**: 5 in `eval.rs`, and 2 independent copies in `eval_generic.rs` (the actual dispatch path either `succinctly jq` or `succinctly yq` uses for an ordinary `.[$keys]`/`.[$s:$e]` read).

#1612 already closed the same bug class for `arith_mul`'s string-repeat arm; this closes it here.

## Fix

Adds a shared `try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError>` helper. Every factor is checked via a plain `usize` `checked_mul` chain, with an upfront short-circuit for a zero factor (needed for correctness — without it, e.g. `[usize::MAX, 2, 0]`, whose true product is `0`, would spuriously refuse at the second factor). `Vec::try_reserve_exact` reports both an unrepresentable length and a genuine allocation failure as one catchable `EvalError` instead of an uncatchable panic/abort.

**No mode-specific cap**: confirmed live against the pinned jq 1.7.1 binary (not just analogized from #1612's string-repeat case) that a genuinely large-but-indexable cross product neither errors nor crashes in real jq — it streams results one at a time instead of pre-allocating a single buffer.

## Review history (three rounds)

1. **First commit**: patched only `eval.rs`'s 5 sites. First review round caught that `eval_generic.rs` independently reimplements `eval_index_expr`/`eval_slice_expr` with the identical unguarded pattern — that's the actual CLI dispatch path, so only the two `path()`-position resolvers were genuinely protected. Also caught a missing third factor in `eval_slice_expr`'s guard, a `u128`-`.product()` overflow risk with 3 factors, and a 32-bit-incompatible test literal.
2. **Second commit**: fixed all of the above — wired both `eval_generic.rs` sites, added the missing factor, switched to `checked_mul`, made the test literal portable, documented the `pending_halt`/escape-bypass reasoning, and added a `docs/compliance/jq/limitations.md` entry.
3. **Second review round** found: the `u128` widening was unnecessary complexity (a plain `usize` chain + zero short-circuit is simpler *and* fixes a real correctness gap the `u128` version shared); the "jq has no cap" claim was stated by analogy rather than live-verified (a real CLAUDE.md violation — now live-verified); stale "five call sites" / "other three" counts after the second commit; and (after closer investigation, not a code change) confirmed that *not* extending `?`/`optional` to a capacity failure is actually correct and consistent with each function's own documented, narrower `?` scope — documented that reasoning rather than changing behavior. This commit addresses all of it, plus a small `Targets::len()` dedup.

Filed **#1669** (`combinations(n)`/`cartesian_product` have the identical crash, confirmed live via a SIGABRT repro) and **#1670** (consider a `clippy` lint against this recurring pattern — this is its fourth independent instance) as follow-ups, out of scope for this PR.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo test --features cli,simd,regex,serde` — 55/55 test binaries pass, 0 failures
- [x] Unit tests: `usize`-overflow refusal, `isize`-byte-overflow refusal (portable across pointer widths), zero-factor-short-circuits-after-an-overflowing-pair correctness, ordinary-size success, and end-to-end sanity through **both** evaluator dispatch paths
- [x] Live-verified all four evaluator arms with ordinary-sized cross products through the real CLI binary — unchanged output
- [x] Live-verified jq 1.7.1's own behavior for this cross-product shape directly (not analogized)

Fixes #1634
