### PR TITLE
fix(bench): pin codegen-units for A/B comparisons, re-check #595/#649

### DIFF
--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -905,6 +905,49 @@ because `.` had barely moved at that commit; a second bisect on `.` was needed t
 signal proves one thing. Before believing a bisect result, ask which paths the suspected change
 touches and whether the signal is sensitive to each of them.
 
+### 9. Pin the build profile before comparing two binaries
+
+`Cargo.toml` has no `[profile.release]`, so `cargo build --release` uses Rust's default
+`codegen-units = 16`, no LTO — the crate is split into 16 independently-optimized chunks, and
+changing code in one module can shift how LLVM lays out *unrelated* modules in the binary. That
+has nothing to do with the diff under test: `succinctly jq type`, a query that touches no keys,
+measured **+12% on an M4 Pro and +27% on a 7950X** between two binaries whose diff cannot reach
+that code path (#1587). It doesn't bisect to the same commit on both machines either — the
+signature of a placement artifact, not a real regression, which always gives the same answer on
+both.
+
+`--control` does not catch this. It times `--before` against a copy of itself, so the two
+binaries always share one codegen placement by construction; it bounds machine noise, not
+placement drift between two genuinely *different* builds.
+
+Rebuilding both sides with `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` removes it —
+`docs/plan/jq-duplicate-key-collapse.md` collapsed that same +12%/+27% pair to +0.2% this way,
+mid-investigation, before the practice was written down here. Set the env var for both
+`--before` and `--after` builds, then tell `scripts/ab-cli.py`/`scripts/perf-ab.py` what you did
+via `--before-profile`/`--after-profile` (free text, e.g. `codegen-units=1`) — the scripts
+cannot read a binary's codegen-units back out, so they only warn when the two builds' profiles
+are unrecorded or don't match:
+
+```bash
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 cargo build --release --features cli   # both checkouts
+
+scripts/ab-cli.py --before ./succ-base --after ./succ-head \
+    --before-profile codegen-units=1 --after-profile codegen-units=1 \
+    --corpus ~/wrk/bench-scratch/mycorpus
+```
+
+The crate's actual `[profile.release]` is deliberately left at Rust's default: pinning
+`codegen-units = 1` there measured **1.98x-3.0x slower clean release builds** with no benefit to
+the interactive edit-compile-test loop, which uses debug builds, not release — so this is a
+benchmarking-time convention, not a shipped build setting.
+
+Also worth knowing: #595's x86-only 12-28% `block_scalars` anomaly was closed as "expected, no
+action — binary code-layout artifact from the recompile," using cachegrind to show flat
+instruction counts (`Ir`) but rising L1-icache misses (`I1mr`). That diagnosis predates this
+rule and never pinned codegen-units — see #1587 for the re-check. It does not, however, put
+`scripts/perf-guard.py`'s CI gate in question: that gate reads cachegrind `Ir`, which stayed
+flat in the same investigation — only `I1mr`, which perf-guard doesn't gate on, moved.
+
 ### Building both halves on a remote box
 
 A source-only tarball plus a reverse patch of the commit under test is enough, with no pushing:
@@ -1080,14 +1123,17 @@ test bench_name ... bench:  1,234 ns/iter (+/- 56)
 - **Date**: When benchmark was run (e.g., "2026-01-17")
 - **Platform**: CPU model and OS version
 - **Tool versions**: For comparison benchmarks (jq-1.6, yq v4.48.1)
-- **Build flags**: Any special RUSTFLAGS or features
+- **Build flags**: Any special RUSTFLAGS or features, and — for an A/B comparing two binaries —
+  whether `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` was pinned on both sides (see [A/B
+  Benchmarking Method § 9](#a-b-benchmarking-method), #1587). Unstated means default
+  `codegen-units=16`, which can add its own ±10-27% independent of the change being measured.
 
 **Example**:
 ```markdown
 **Date**: 2026-01-17
 **Platform**: AMD Ryzen 9 7950X (Zen 4, x86_64)
 **OS**: Linux 6.6.87.2-microsoft-standard-WSL2
-**Build**: `RUSTFLAGS="-C target-cpu=native" cargo build --release`
+**Build**: `RUSTFLAGS="-C target-cpu=native" cargo build --release` (codegen-units=1, both sides)
 ```
 
 ### Formatting Tables

--- a/docs/plan/cspoppy.md
+++ b/docs/plan/cspoppy.md
@@ -448,6 +448,111 @@ favourably (as #595's theory would predict) or something else stays an open
 question. Revisit if ARM instruction-counting tooling becomes available on
 the sanctioned bench hosts, or if the effect ever flips to a regression.
 
+### 5d. Issue #1587 follow-up (2026-08-26): the anomaly is a codegen-units artifact, not an unavoidable recompile cost
+
+Re-checked #595's "expected, no action" call using #1587's finding: this crate
+has no `[profile.release]`, so it builds at Rust's default `codegen-units =
+16`, and an unrelated code change can reshuffle binary layout on every
+rebuild. §5b's cachegrind numbers were captured under that default profile;
+this re-runs the identical `becd1b8d`/`09158571` comparison on `terminus`
+using the same `scripts/perf-ab.py --tool cachegrind` harness (now carrying
+#1587's `--before-profile`/`--after-profile` recording), same box, same
+session, same 5 reps × 50 iterations — with only the codegen-units setting
+changed between the two runs below.
+
+**`terminus`, default profile (`codegen-units=16`, rebuilt today):**
+
+| shape              | Ir Δ  | I1mr Δ  | ILmr Δ |
+|--------------------|-------|---------|--------|
+| 10x10lines         | -0.1% | +27.2%  | -0.4%  |
+| 50x50lines         | -0.0% | +22.4%  | -0.4%  |
+| 100x100lines       | -0.0% | +17.4%  | -0.4%  |
+| 10x1000lines       | -0.0% | +23.3%  | -0.4%  |
+| long_10x100lines   | -0.0% | +27.6%  | -0.4%  |
+| long_50x100lines   | -0.0% | +14.1%  | -0.5%  |
+| long_100x100lines  | -0.0% | +11.8%  | -0.5%  |
+
+Median I1mr Δ **+22.45%**, essentially reproducing §5b's original
++11.8%..+27.7% almost exactly — same box, same commits, five months later,
+so the artifact is not a one-off.
+
+**Same box, same commits, same session — `codegen-units=1` on both sides:**
+
+| shape              | Ir Δ  | I1mr Δ  | ILmr Δ |
+|--------------------|-------|---------|--------|
+| 10x10lines         | -0.1% | -14.9%  | -0.0%  |
+| 50x50lines         | -0.0% | -19.1%  | -0.1%  |
+| 100x100lines       | -0.0% | -10.7%  | -0.2%  |
+| 10x1000lines       | -0.0% | -7.8%   | -0.1%  |
+| long_10x100lines   | -0.0% | -8.7%   | -0.1%  |
+| long_50x100lines   | -0.0% | -10.0%  | -0.1%  |
+| long_100x100lines  | -0.0% | +1.3%   | -0.2%  |
+
+Median I1mr Δ **-10.02%** — not just reduced but reversed in sign, on the
+same seven shapes that read +11.8%..+27.6% one env var earlier. `Ir` stayed
+flat in both runs, and the checksum identity gate passed 7/7 both times —
+nothing about the underlying `YamlIndex::build` work changed between binaries
+either time; only the compiler's layout choice did.
+
+**`johns-mac-mini` (M4 Pro, ARM), `--tool wallclock`, 9 interleaved reps ×
+200 iterations** — checked too, to complete the cross-arch record rather
+than assume "already neutral" needed no re-run:
+
+**Default profile (`codegen-units=16`, rebuilt today):**
+
+| shape              | min ms Δ | median ms Δ |
+|--------------------|----------|-------------|
+| 10x10lines         | -0.9%    | -1.2%       |
+| 50x50lines         | -0.5%    | +0.3%       |
+| 100x100lines       | +0.6%    | +0.5%       |
+| 10x1000lines       | +0.2%    | +0.2%       |
+| long_10x100lines   | -9.3%    | -7.5%       |
+| long_50x100lines   | -9.7%    | -8.6%       |
+| long_100x100lines  | -9.7%    | -9.4%       |
+
+Matches §5b/§5c's established pattern exactly: short shapes neutral, `long_*`
+shapes read as a ~7-10% "improvement" — the one #649 investigated and left
+with "mechanism unconfirmed, no ARM instruction-counting tool available."
+
+**Same box, same commits, same session — `codegen-units=1` on both sides:**
+
+| shape              | min ms Δ | median ms Δ |
+|--------------------|----------|-------------|
+| 10x10lines         | +1.4%    | -1.3%       |
+| 50x50lines         | +0.5%    | -0.0%       |
+| 100x100lines       | +0.1%    | +0.1%       |
+| 10x1000lines       | -0.2%    | -0.0%       |
+| long_10x100lines   | -2.6%    | -0.8%       |
+| long_50x100lines   | -2.6%    | -1.8%       |
+| long_100x100lines  | -0.4%    | -2.1%       |
+
+Short shapes stay inside §5b's own established control band (-1.0%..+0.4%)
+either way — consistent with the original "neutral" call, which was correct
+on those four shapes and is why they weren't the ones under suspicion. The
+`long_*` "improvement" #649 could not explain shrinks from ~7-10% to
+~0-2.6% under the identical pin that erased #595's x86 regression. A small
+residual remains at 9 reps and isn't chased further here — an order of
+magnitude smaller than the original effect, and #649's own framing
+("improvement, not a regression, no user-facing harm, revisit if it ever
+flips to a regression") already covers a residual this size.
+
+**Conclusion: #595's diagnosis stands ("layout, not logic") but its framing
+needs correcting, and the same fix substantially explains #649 too.** §5b's
+cachegrind evidence that this was a code-layout/cache artifact rather than
+real extra work was right — but "binary code-layout artifact from the
+recompile," closed as expected and unavoidable, was not quite right either.
+The layout shift is not an intrinsic property of recompiling; it is a direct
+consequence of this crate's unpinned `codegen-units=16` default (#1587).
+Pinning `codegen-units=1` on both sides — now documented as [A/B
+Benchmarking Method § 9](../guides/benchmarking.md#a-b-benchmarking-method)
+— removes #595's x86 regression entirely in a same-session, same-box,
+same-commit re-run (even reversing its sign), and collapses most of #649's
+unexplained ARM `long_*` "improvement" down to noise-adjacent levels in the
+same re-run. Filed under #1587 rather than reopening either #595 or #649,
+since no action is needed against CS-Poppy's logic in any case; recorded
+here so a future reader doesn't take either issue's original framing as the
+final word on *why* the numbers moved.
+
 ---
 
 ## 6. Future developments

--- a/scripts/ab-cli.py
+++ b/scripts/ab-cli.py
@@ -41,6 +41,12 @@ def parse_args(argv=None):
     )
     p.add_argument("--before", required=True, help="baseline binary")
     p.add_argument("--after", help="binary under test (omit with --control)")
+    p.add_argument("--before-profile",
+                   help="build profile --before was built with, e.g. 'codegen-units=1' "
+                        "(recorded only, not verified — rule 9)")
+    p.add_argument("--after-profile",
+                   help="build profile --after was built with; a mismatch against "
+                        "--before-profile is warned about (rule 9)")
     p.add_argument("--corpus", help="directory searched recursively for inputs")
     p.add_argument("--files", nargs="*", default=[], help="explicit input files or globs")
     p.add_argument("--tool", default="yq", help="succinctly subcommand (default: yq)")
@@ -70,6 +76,30 @@ def collect_inputs(args):
             seen.add(p)
             unique.append(p)
     return unique
+
+
+def profile_status(args):
+    """Rule 9: codegen-units/LTO placement differences between two binaries can add
+    noise unrelated to any code change (issue #1587), and a binary can't be
+    introspected after the fact to check — this only reports what the caller asserts."""
+    if args.control:
+        return None  # a copy of --before always shares its own layout
+    before, after = args.before_profile, args.after_profile
+    if before and after:
+        if before == after:
+            return f"profile: {before} (matched)"
+        return (f"WARNING: binaries were built with different profiles "
+                f"(before={before!r}, after={after!r}) — a measured delta may include a "
+                f"codegen-placement artifact, not just the code change. See "
+                f"docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
+    if before or after:
+        return (f"WARNING: build profile given for only one binary "
+                f"(before={before!r}, after={after!r}) — pass both or neither. See "
+                f"docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
+    return ("WARNING: build profile not specified for either binary — codegen-units/LTO "
+            "differences between --before and --after can add noise unrelated to any code "
+            "change (issue #1587). Pass --before-profile/--after-profile once confirmed. See "
+            "docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
 
 
 def machine_warnings():
@@ -187,6 +217,9 @@ def main(argv=None):
 
     print(f"before={args.before}")
     print(f"after ={args.after}" + ("  (copy of --before: noise floor)" if args.control else ""))
+    status = profile_status(args)
+    if status:
+        print(status)
     print(f"inputs={len(inputs)} queries={args.queries} reps={args.reps}")
     print()
 

--- a/scripts/perf-ab.py
+++ b/scripts/perf-ab.py
@@ -65,6 +65,12 @@ def parse_args(argv=None):
     )
     p.add_argument("--before", required=True, help="baseline harness binary")
     p.add_argument("--after", help="binary under test (omit with --control)")
+    p.add_argument("--before-profile",
+                   help="build profile --before was built with, e.g. 'codegen-units=1' "
+                        "(recorded only, not verified — rule 9)")
+    p.add_argument("--after-profile",
+                   help="build profile --after was built with; a mismatch against "
+                        "--before-profile is warned about (rule 9)")
     p.add_argument("--tool", choices=["cachegrind", "perf", "wallclock"], default="cachegrind")
     p.add_argument("--valgrind-bin", default="valgrind",
                    help="path to valgrind (e.g. a rootless ~/local/bin/valgrind build)")
@@ -82,6 +88,30 @@ def parse_args(argv=None):
     p.add_argument("--force", action="store_true",
                    help="run even if the machine looks busy")
     return p.parse_args(argv)
+
+
+def profile_status(args):
+    """Rule 9: codegen-units/LTO placement differences between two binaries can add
+    noise unrelated to any code change (issue #1587), and a binary can't be
+    introspected after the fact to check — this only reports what the caller asserts."""
+    if args.control:
+        return None  # a copy of --before always shares its own layout
+    before, after = args.before_profile, args.after_profile
+    if before and after:
+        if before == after:
+            return f"profile: {before} (matched)"
+        return (f"WARNING: binaries were built with different profiles "
+                f"(before={before!r}, after={after!r}) — a measured delta may include a "
+                f"codegen-placement artifact, not just the code change. See "
+                f"docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
+    if before or after:
+        return (f"WARNING: build profile given for only one binary "
+                f"(before={before!r}, after={after!r}) — pass both or neither. See "
+                f"docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
+    return ("WARNING: build profile not specified for either binary — codegen-units/LTO "
+            "differences between --before and --after can add noise unrelated to any code "
+            "change (issue #1587). Pass --before-profile/--after-profile once confirmed. See "
+            "docs/guides/benchmarking.md § A/B Benchmarking Method, rule 9.")
 
 
 def machine_warnings():
@@ -252,6 +282,9 @@ def main(argv=None):
 
     print(f"before={args.before}")
     print(f"after ={args.after}" + ("  (copy of --before: noise floor)" if args.control else ""))
+    status = profile_status(args)
+    if status:
+        print(status)
     print(f"tool={args.tool} shapes={args.shapes} iterations={args.iterations} reps={args.reps}")
     print()
 


### PR DESCRIPTION
## Summary

- `Cargo.toml` has no `[profile.release]`, so `cargo build --release` uses Rust's default `codegen-units = 16`, no LTO — unrelated code changes can shift binary layout enough to add ±10-27% noise into every CLI A/B this project records (#1587).
- Measured pinning `codegen-units=1` crate-wide: 1.98x-3.0x slower clean release builds with no benefit to the (debug-build) edit-compile-test loop, so `Cargo.toml`'s default is left untouched — this is a benchmarking-time convention instead.
- `scripts/ab-cli.py`/`scripts/perf-ab.py` gain `--before-profile`/`--after-profile`: record what the caller asserts, warn on mismatch or when unrecorded. Neither script can introspect a binary's codegen-units after the fact, so this is operator-asserted by design.
- Documents the convention as rule 9 in `docs/guides/benchmarking.md`'s A/B Benchmarking Method.
- Re-checked #595 (x86-only 12-28% `block_scalars` anomaly, closed as "expected, unavoidable recompile artifact") and #649 (ARM `long_*` "improvement", "mechanism unconfirmed") under the same pin, same commits (`becd1b8d`/`09158571`), same boxes, same session:
  - **x86 (terminus)**: I1mr swings from +11.8%..+27.6% (default) to -19.1%..+1.3% (`codegen-units=1`) — the regression reverses sign entirely.
  - **ARM (johns-mac-mini)**: the `long_*` "improvement" shrinks from ~7-10% (default) to ~0-2.6% (`codegen-units=1`); short shapes stay in the noise band either way.
  - Confirms both were the same unpinned-build-profile artifact, not properties of CS-Poppy's logic. No action needed against that logic either way — recorded in `docs/plan/cspoppy.md` §5d rather than reopening either issue.

## Test plan

- [x] Syntax-checked both scripts (`ast.parse`) and exercised `--help` output
- [x] Unit-verified all four `profile_status` branches (matched / mismatched / one-only / neither given / `--control` skip)
- [x] Live `--control` smoke run of `ab-cli.py` confirmed the warning is suppressed as designed
- [x] Re-ran the exact `#595`/`#649` comparison end-to-end on both pinned bench boxes (terminus via cachegrind, johns-mac-mini via wallclock), checksum identity gate passing 7/7 in every run

Fixes #1587