### PR TITLE
fix(jq, json): raise on a missing or doubled JSON delimiter

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -580,6 +580,16 @@ struct PreparedField<'a> {
     key_bp: usize,
     /// BP position of the value cursor.
     value_bp: usize,
+    /// The value cursor's own `text_position()`, if the #1643 delimiter
+    /// check already resolved one -- `usize::MAX` otherwise (a sentinel
+    /// rather than `Option<usize>` for the same reason this struct hoists
+    /// `text`/`index` into `Frame` above: an `Option<usize>` doubles this
+    /// field's size to 16 bytes on a type with no spare bit pattern to
+    /// exploit, which the same 1M-field-object memory math this struct's
+    /// own doc comment cites would double again. The write loop passes it
+    /// to `print_json` as `known_text_pos` so that recursive call doesn't
+    /// redo the same rank/select lookup the check already paid for.
+    value_start: usize,
     /// The key's raw source span, quotes included.
     raw: &'a [u8],
     /// Whether that span contains a backslash escape.
@@ -3405,9 +3415,25 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
     // For preserve mode (!jq_compat), use the preserve formatter (keeps original number format)
     if !config.sort_keys && !config.color_output {
         if config.jq_compat {
-            print_json(out, value, &JqCompatFormatter, config, 0, &mut Vec::new())?;
+            print_json(
+                out,
+                value,
+                &JqCompatFormatter,
+                config,
+                0,
+                &mut Vec::new(),
+                None,
+            )?;
         } else {
-            print_json(out, value, &PreserveFormatter, config, 0, &mut Vec::new())?;
+            print_json(
+                out,
+                value,
+                &PreserveFormatter,
+                config,
+                0,
+                &mut Vec::new(),
+                None,
+            )?;
         }
     } else {
         // For complex output (pretty-print, sort_keys, colors), materialize
@@ -3587,6 +3613,94 @@ impl LiteralFormatter for PreserveFormatter {
 // Generic JSON Printer
 // =============================================================================
 
+/// Whether the byte span immediately before `child_start` is exactly the
+/// delimiter JSON's grammar requires there -- neither missing nor doubled
+/// (#1643).
+///
+/// The semi-index has no signal for this at all: `json::standard::is_delim`
+/// maps `,` and `:` to the same invisible bit as whitespace, so `{"a" 1}`,
+/// `{"a":1 "b":2}`, `{"a":1,,"b":2}` and `[1 2]` all index exactly as if
+/// they were well-formed -- `#1194`'s `ends_unpaired`/`key_is_malformed`
+/// checks can't see any of them either, since every one leaves an even,
+/// well-typed BP child count, the only anomaly those checks test for.
+///
+/// Scans *backward* from `child_start` (a cheap, O(1)-via-rank/select
+/// position every direct child already has) rather than forward from the
+/// previous sibling's own end: finding a sibling's end is O(that
+/// sibling's own subtree) whenever it's a container -- `JsonCursor::
+/// text_range`'s own comment explains why: IB only marks *opening*
+/// positions, so there is no cheap text-position lookup for a closing
+/// bracket. Scanning forward from there at every recursion level would
+/// make a deeply nested document's check cost quadratic in nesting depth.
+/// Walking backward instead touches only the whitespace/delimiter run in
+/// the gap itself, stopping the instant it reaches non-whitespace content
+/// it doesn't need to identify -- bounded by the gap, not by anything
+/// before it.
+///
+/// Deliberately narrower than re-running the strict validator over the
+/// same bytes would be: this only inspects gap bytes between already-
+/// recognized children, never a child's own content, so it can't regress
+/// this crate's own established leniencies beyond strict RFC 8259 --
+/// leading zeros (#1149), a leading-dot number (#1171), a malformed
+/// nested number like `1.2.3` (#1194/#966) -- none of which live in a gap.
+///
+/// Only catches a missing or doubled delimiter between two real children.
+/// A trailing delimiter (`{"a":1,}`) or a delimiter in an apparently-empty
+/// container (`{,}`) needs the *closing* bracket's text position, which is
+/// exactly the expensive lookup this function exists to avoid -- tracked
+/// as a follow-up rather than folded in here.
+fn preceding_gap_ok(text: &[u8], child_start: usize, expected: Option<u8>) -> bool {
+    let mut i = child_start;
+    let mut found = None;
+    while i > 0 {
+        match text[i - 1] {
+            b @ (b',' | b':') => {
+                if found.is_some() {
+                    return false; // doubled delimiter
+                }
+                found = Some(b);
+                i -= 1;
+            }
+            b if b.is_ascii_whitespace() => i -= 1,
+            _ => break, // reached the previous sibling's own content
+        }
+    }
+    found == expected
+}
+
+/// Array-element wrapper around [`preceding_gap_ok`]: element `index` (0-
+/// based) must be preceded by `,`, except the first, which must be
+/// preceded by nothing (#1643).
+///
+/// Called from the array arm's own validation pass, before any of `[`'s
+/// contents are written -- same discipline as the object arm just below,
+/// and for the same reason (its own comment there explains it): a
+/// malformed array must not leave a partial `[` on `out` when the error
+/// surfaces.
+///
+/// Returns the element's own `text_position()` on success, so the caller
+/// can cache it and hand it to `print_json` as `known_text_pos` once the
+/// write loop reaches that same element, instead of that recursive call
+/// re-deriving the same rank/select lookup a second time -- a version
+/// that didn't cache this measured 19-30% slower on `sjq -c .` (#1643,
+/// see the PR): a document with many short elements pays for this lookup
+/// once per element regardless, so paying for it *twice* per element,
+/// once here and again moments later, was the entire regression, not the
+/// gap check itself.
+fn check_preceding_delimiter<W: AsRef<[u64]>>(
+    child_cursor: &JsonCursor<'_, W>,
+    index: usize,
+) -> Result<Option<usize>> {
+    let Some(start) = child_cursor.text_position() else {
+        return Ok(None);
+    };
+    let expected = if index == 0 { None } else { Some(b',') };
+    if !preceding_gap_ok(child_cursor.text(), start, expected) {
+        return Err(MalformedJsonError(EvalError::malformed_json_text(child_cursor.text())).into());
+    }
+    Ok(Some(start))
+}
+
 /// Print a JqValue as JSON using the provided literal formatter.
 ///
 /// This is the unified printer that handles JSON structure (arrays, objects,
@@ -3615,6 +3729,15 @@ fn print_json<'a, F, Out, Wrd>(
     config: &OutputConfig,
     level: usize,
     scratch: &mut Vec<PreparedField<'a>>,
+    // #1643: when `value` is a `JqValue::Cursor` and the caller has
+    // *already* called `text_position()` on it (to check the delimiter
+    // preceding it against a sibling), it's passed through here so the
+    // `Cursor` arm below can call `value_at` instead of `value` --
+    // `text_position()` is a rank/select lookup, not free, and every
+    // array/object element already pays for it once at the call site.
+    // `None` for a value with no such caller-side lookup (the top-level
+    // call, or any non-`Cursor` variant, which ignores this either way).
+    known_text_pos: Option<usize>,
 ) -> Result<()>
 where
     F: LiteralFormatter,
@@ -3654,7 +3777,14 @@ where
         }
         JqValue::Cursor(c) => {
             use succinctly::json::light::StandardJson;
-            match c.value() {
+            // #1643: reuse the caller's `text_position()` lookup when it
+            // handed one in, instead of `value()` redoing it -- see
+            // `known_text_pos`'s own doc comment above.
+            let resolved = match known_text_pos.or_else(|| c.text_position()) {
+                Some(text_pos) => c.value_at(text_pos),
+                None => StandardJson::Error("invalid cursor position"),
+            };
+            match resolved {
                 StandardJson::Null => out.write_all(b"null")?,
                 StandardJson::Bool(true) => out.write_all(b"true")?,
                 StandardJson::Bool(false) => out.write_all(b"false")?,
@@ -3688,31 +3818,66 @@ where
                 StandardJson::Array(elements) => {
                     if elements.is_empty() {
                         out.write_all(b"[]")?;
-                    } else if compact {
-                        out.write_all(b"[")?;
-                        for (i, child_cursor) in elements.cursor_iter().enumerate() {
-                            if i > 0 {
-                                out.write_all(b",")?;
-                            }
-                            let child_value = JqValue::Cursor(child_cursor);
-                            print_json(out, &child_value, formatter, config, level + 1, scratch)?;
-                        }
-                        out.write_all(b"]")?;
                     } else {
-                        out.write_all(b"[")?;
-                        out.write_all(separator.as_bytes())?;
+                        // #1643: validate every element's preceding
+                        // delimiter *before* writing anything, same
+                        // discipline as the object arm below and for the
+                        // same reason (its own comment explains why: a
+                        // malformed document must not leave a partial `{`
+                        // -- or here, `[` -- already on `out` when the
+                        // error surfaces). Caches each element's own
+                        // `text_position()` along the way, since it's
+                        // needed for the check anyway, so the write loop
+                        // below doesn't make `print_json`'s recursion
+                        // re-derive the same rank/select lookup a second
+                        // time -- a version that didn't cache measured
+                        // 19-30% slower on `sjq -c .` (#1643, see the PR).
+                        let mut positions = Vec::new();
                         for (i, child_cursor) in elements.cursor_iter().enumerate() {
-                            if i > 0 {
-                                out.write_all(b",")?;
-                                out.write_all(separator.as_bytes())?;
-                            }
-                            out.write_all(next_indent.as_bytes())?;
-                            let child_value = JqValue::Cursor(child_cursor);
-                            print_json(out, &child_value, formatter, config, level + 1, scratch)?;
+                            positions.push(check_preceding_delimiter(&child_cursor, i)?);
                         }
-                        out.write_all(separator.as_bytes())?;
-                        out.write_all(current_indent.as_bytes())?;
-                        out.write_all(b"]")?;
+                        if compact {
+                            out.write_all(b"[")?;
+                            for (i, child_cursor) in elements.cursor_iter().enumerate() {
+                                if i > 0 {
+                                    out.write_all(b",")?;
+                                }
+                                let child_value = JqValue::Cursor(child_cursor);
+                                print_json(
+                                    out,
+                                    &child_value,
+                                    formatter,
+                                    config,
+                                    level + 1,
+                                    scratch,
+                                    positions[i],
+                                )?;
+                            }
+                            out.write_all(b"]")?;
+                        } else {
+                            out.write_all(b"[")?;
+                            out.write_all(separator.as_bytes())?;
+                            for (i, child_cursor) in elements.cursor_iter().enumerate() {
+                                if i > 0 {
+                                    out.write_all(b",")?;
+                                    out.write_all(separator.as_bytes())?;
+                                }
+                                out.write_all(next_indent.as_bytes())?;
+                                let child_value = JqValue::Cursor(child_cursor);
+                                print_json(
+                                    out,
+                                    &child_value,
+                                    formatter,
+                                    config,
+                                    level + 1,
+                                    scratch,
+                                    positions[i],
+                                )?;
+                            }
+                            out.write_all(separator.as_bytes())?;
+                            out.write_all(current_indent.as_bytes())?;
+                            out.write_all(b"]")?;
+                        }
                     }
                 }
                 StandardJson::Object(fields) => {
@@ -3764,6 +3929,7 @@ where
                         // of `sjq '.'` over 10 MB. This is the same single
                         // walk, just keeping its own tail.
                         let mut remaining = fields;
+                        let mut field_index = 0usize;
                         while let Some((field, rest)) = remaining.uncons() {
                             // The `_` arm is *not* unreachable, whatever this
                             // comment used to claim: nothing enforces the JSON
@@ -3785,14 +3951,40 @@ where
                                 ))
                                 .into());
                             };
+                            // #1643: this key must be preceded by a `,` (or
+                            // nothing, if it's the object's first field), and
+                            // its value must be preceded by a `:` -- neither
+                            // is enforced anywhere else on this path. See
+                            // `preceding_gap_ok` for why a missing/doubled
+                            // trailing comma is what this catches, not a
+                            // trailing one. `k.start()` reuses the position
+                            // `field.key()` just resolved above rather than
+                            // asking `field.key_cursor()` to re-derive it.
+                            let key_start = k.start();
+                            let value_start = field.value_cursor().text_position();
+                            if let Some(value_start) = value_start {
+                                let comma_expected =
+                                    if field_index == 0 { None } else { Some(b',') };
+                                if !preceding_gap_ok(frame.text, key_start, comma_expected)
+                                    || !preceding_gap_ok(frame.text, value_start, Some(b':'))
+                                {
+                                    scratch.truncate(base);
+                                    return Err(MalformedJsonError(
+                                        EvalError::malformed_json_text(frame.text),
+                                    )
+                                    .into());
+                                }
+                            }
                             let (raw, escaped) = k.raw_and_escaped();
                             scratch.push(PreparedField {
                                 key_bp: field.key_cursor().bp_position(),
                                 value_bp: field.value_cursor().bp_position(),
+                                value_start: value_start.unwrap_or(usize::MAX),
                                 raw,
                                 escaped,
                             });
                             remaining = rest;
+                            field_index += 1;
                         }
                         // An odd number of BP children means the text was
                         // never `key: value` -- `{invalid}`, `{"a"}`, or the
@@ -3833,7 +4025,21 @@ where
                             out.write_all(next_indent.as_bytes())?;
                             write_object_key(out, &frame, &field, config, space_after_colon)?;
                             let child_value = JqValue::Cursor(frame.cursor(field.value_bp));
-                            print_json(out, &child_value, formatter, config, level + 1, scratch)?;
+                            // #1643: `value_start` was already resolved by
+                            // the check above (or is the sentinel, if that
+                            // check's own lookup came back `None`) -- see
+                            // `PreparedField::value_start`'s doc comment.
+                            let known_text_pos =
+                                (field.value_start != usize::MAX).then_some(field.value_start);
+                            print_json(
+                                out,
+                                &child_value,
+                                formatter,
+                                config,
+                                level + 1,
+                                scratch,
+                                known_text_pos,
+                            )?;
                         }
                         out.write_all(separator.as_bytes())?;
                         out.write_all(current_indent.as_bytes())?;
@@ -3881,7 +4087,7 @@ where
                     if i > 0 {
                         out.write_all(b",")?;
                     }
-                    print_json(out, v, formatter, config, level + 1, scratch)?;
+                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
                 }
                 out.write_all(b"]")?;
             } else {
@@ -3893,7 +4099,7 @@ where
                         out.write_all(separator.as_bytes())?;
                     }
                     out.write_all(next_indent.as_bytes())?;
-                    print_json(out, v, formatter, config, level + 1, scratch)?;
+                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
                 }
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;
@@ -3917,7 +4123,7 @@ where
                     };
                     out.write_all(escaped.as_bytes())?;
                     out.write_all(b"\":")?;
-                    print_json(out, v, formatter, config, level + 1, scratch)?;
+                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
                 }
                 out.write_all(b"}")?;
             } else {
@@ -3938,7 +4144,7 @@ where
                     out.write_all(escaped.as_bytes())?;
                     out.write_all(b"\":")?;
                     out.write_all(space_after_colon.as_bytes())?;
-                    print_json(out, v, formatter, config, level + 1, scratch)?;
+                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
                 }
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3908,24 +3908,42 @@ where
                         // same reason (its own comment explains why: a
                         // malformed document must not leave a partial `{`
                         // -- or here, `[` -- already on `out` when the
-                        // error surfaces). Caches each element's own
-                        // `text_position()` along the way, since it's
-                        // needed for the check anyway, so the write loop
-                        // below doesn't make `print_json`'s recursion
-                        // re-derive the same rank/select lookup a second
-                        // time -- a version that didn't cache measured
-                        // 19-30% slower on `sjq -c .` (#1643, see the PR).
-                        let mut positions = Vec::new();
+                        // error surfaces).
+                        //
+                        // Walked exactly once: a first cut called
+                        // `elements.cursor_iter()` a second time for the
+                        // write loop, re-navigating the same BP siblings
+                        // it had just walked for the check -- the same
+                        // shape of re-walk the object arm's own comment
+                        // below measured at 8-9% of `sjq '.'` over a 10 MB
+                        // document, and here it cost 12-15% of instruction
+                        // count on a large flat array (#1643 perf-guard
+                        // failure, arrays_identity). Recording each
+                        // element's BP position -- not a whole
+                        // `JsonCursor`, for the same reason `PreparedField`
+                        // hoists `text`/`index` into `Frame` rather than
+                        // storing them per element -- plus its
+                        // already-resolved `text_position()` lets the
+                        // write loop reconstruct the cursor via
+                        // `Frame::cursor` instead of re-deriving it.
+                        let frame = Frame {
+                            text: c.text(),
+                            index: c.index(),
+                        };
+                        let mut prepared: Vec<(usize, usize)> = Vec::new();
                         for (i, child_cursor) in elements.cursor_iter().enumerate() {
-                            positions.push(check_preceding_delimiter(&child_cursor, i)?);
+                            let pos = check_preceding_delimiter(&child_cursor, i)?;
+                            prepared.push((child_cursor.bp_position(), pos.unwrap_or(usize::MAX)));
                         }
                         if compact {
                             out.write_all(b"[")?;
-                            for (i, child_cursor) in elements.cursor_iter().enumerate() {
+                            for (i, &(bp, value_start)) in prepared.iter().enumerate() {
                                 if i > 0 {
                                     out.write_all(b",")?;
                                 }
-                                let child_value = JqValue::Cursor(child_cursor);
+                                let child_value = JqValue::Cursor(frame.cursor(bp));
+                                let known_text_pos =
+                                    (value_start != usize::MAX).then_some(value_start);
                                 print_json(
                                     out,
                                     &child_value,
@@ -3933,20 +3951,22 @@ where
                                     config,
                                     level + 1,
                                     scratch,
-                                    positions[i],
+                                    known_text_pos,
                                 )?;
                             }
                             out.write_all(b"]")?;
                         } else {
                             out.write_all(b"[")?;
                             out.write_all(separator.as_bytes())?;
-                            for (i, child_cursor) in elements.cursor_iter().enumerate() {
+                            for (i, &(bp, value_start)) in prepared.iter().enumerate() {
                                 if i > 0 {
                                     out.write_all(b",")?;
                                     out.write_all(separator.as_bytes())?;
                                 }
                                 out.write_all(next_indent.as_bytes())?;
-                                let child_value = JqValue::Cursor(child_cursor);
+                                let child_value = JqValue::Cursor(frame.cursor(bp));
+                                let known_text_pos =
+                                    (value_start != usize::MAX).then_some(value_start);
                                 print_json(
                                     out,
                                     &child_value,
@@ -3954,7 +3974,7 @@ where
                                     config,
                                     level + 1,
                                     scratch,
-                                    positions[i],
+                                    known_text_pos,
                                 )?;
                             }
                             out.write_all(separator.as_bytes())?;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -12,7 +12,8 @@ use std::path::{Path, PathBuf};
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors};
 use succinctly::jq::eval_generic::{
-    eval_with_cursor, to_owned as generic_to_owned, GenericResult, MAX_NESTING_DEPTH,
+    assert_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult,
+    MAX_NESTING_DEPTH,
 };
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
@@ -2713,9 +2714,7 @@ fn parse_json_stream(s: &str) -> Result<Vec<OwnedValue>> {
             match find_json_values(bytes) {
                 Ok(spans) => spans
                     .into_iter()
-                    .map(|(start, end)| {
-                        crate::output::json_bytes_to_owned_value(&bytes[start..end])
-                    })
+                    .map(|(start, end)| json_bytes_to_owned_value_checked(&bytes[start..end]))
                     // Wrapped rather than flattened, for the same reason as
                     // the sibling site in `parse_json_stream_strict`: the
                     // caller reports a document error in jq's channel at
@@ -3699,6 +3698,90 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
         return Err(MalformedJsonError(EvalError::malformed_json_text(child_cursor.text())).into());
     }
     Ok(Some(start))
+}
+
+/// Recursively validate every object/array in `cursor`'s subtree for a
+/// missing or doubled `,`/`:` (#1643), via [`preceding_gap_ok`] -- the same
+/// check `print_json`'s object/array arms perform, needed again here for a
+/// caller that doesn't go through `print_json` at all.
+///
+/// [`crate::output::json_bytes_to_owned_value`]'s own doc comment says
+/// plainly that it "performs no validation of its own" and expects the
+/// caller to have done so first; [`parse_json_stream`]'s fallback below
+/// (which backs `-S`, `-C`, and `--slurp` -- none of which route through
+/// `print_json`) was calling it directly on unvalidated bytes, so `{"a"
+/// 1}` would silently materialize as `{"a":1}` under those flags even
+/// though the default `sjq -c .` path already rejects it since #1643.
+///
+/// `depth` guards against a stack overflow on adversarially deep input the
+/// same way [`generic_to_owned`]'s own recursion does (`assert_nesting_depth`,
+/// #998) -- this walk runs *before* that one on the same document, so it
+/// needs the identical ceiling rather than risking a raw stack overflow at
+/// some other depth first.
+///
+/// Not a hot path: `parse_json_stream_strict`'s `serde_json` validation
+/// already runs first and only fails (routing here) for a real jq leniency
+/// like a leading-zero number (#1094) or a genuinely malformed document, so
+/// this walk is cold by construction and doesn't need `print_json`'s
+/// `known_text_pos` reuse trick.
+fn validate_json_delimiters<W: AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+    depth: usize,
+) -> core::result::Result<(), EvalError> {
+    assert_nesting_depth(depth);
+    match cursor.value() {
+        StandardJson::Array(elements) => {
+            for (i, child) in elements.cursor_iter().enumerate() {
+                if let Some(start) = child.text_position() {
+                    let expected = if i == 0 { None } else { Some(b',') };
+                    if !preceding_gap_ok(child.text(), start, expected) {
+                        return Err(EvalError::malformed_json_text(child.text()));
+                    }
+                }
+                validate_json_delimiters(&child, depth + 1)?;
+            }
+        }
+        StandardJson::Object(fields) => {
+            let mut remaining = fields;
+            let mut field_index = 0usize;
+            while let Some((field, rest)) = remaining.uncons() {
+                let StandardJson::String(k) = field.key() else {
+                    return Err(EvalError::malformed_json_text(cursor.text()));
+                };
+                let value_cursor = field.value_cursor();
+                if let Some(value_start) = value_cursor.text_position() {
+                    let comma_expected = if field_index == 0 { None } else { Some(b',') };
+                    if !preceding_gap_ok(cursor.text(), k.start(), comma_expected)
+                        || !preceding_gap_ok(cursor.text(), value_start, Some(b':'))
+                    {
+                        return Err(EvalError::malformed_json_text(cursor.text()));
+                    }
+                }
+                validate_json_delimiters(&value_cursor, depth + 1)?;
+                remaining = rest;
+                field_index += 1;
+            }
+            if remaining.ends_unpaired() {
+                return Err(EvalError::malformed_json_text(cursor.text()));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// [`crate::output::json_bytes_to_owned_value`], preceded by the #1643
+/// delimiter check that function's own doc comment says its caller must
+/// supply. Used only by [`parse_json_stream`]'s fallback -- every other
+/// caller of the unchecked version re-serializes an already-validated span
+/// (`--argjson`'s retry re-validates its normalized copy against
+/// `serde_json` before ever reaching it; the primary lazy input path
+/// validates via `print_json` instead).
+fn json_bytes_to_owned_value_checked(bytes: &[u8]) -> core::result::Result<OwnedValue, EvalError> {
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    validate_json_delimiters(&cursor, 0)?;
+    generic_to_owned(&cursor.value())
 }
 
 /// Print a JqValue as JSON using the provided literal formatter.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3421,6 +3421,7 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
                 config,
                 0,
                 &mut Vec::new(),
+                &mut Vec::new(),
                 None,
             )?;
         } else {
@@ -3430,6 +3431,7 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
                 &PreserveFormatter,
                 config,
                 0,
+                &mut Vec::new(),
                 &mut Vec::new(),
                 None,
             )?;
@@ -3805,6 +3807,11 @@ fn json_bytes_to_owned_value_checked(bytes: &[u8]) -> core::result::Result<Owned
 /// `Result` and already threads a `level` parameter (previously used only
 /// for indentation, reused here as the depth counter), so there's no reason
 /// to give up the clean failure mode the way `to_owned` had to.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: `array_scratch` (#1643) joins `scratch`
+                                     // (#1385) as a second recursion-threaded buffer with its own distinct element type -- each
+                                     // exists solely to give one specific container arm (object, array) a shared allocation instead
+                                     // of a fresh `Vec` per container, so bundling them into one struct would hide that they're
+                                     // independent, not a related group the way `DirectEvalOptions`'s bools are.
 fn print_json<'a, F, Out, Wrd>(
     out: &mut Out,
     value: &JqValue<'a, Wrd>,
@@ -3812,6 +3819,17 @@ fn print_json<'a, F, Out, Wrd>(
     config: &OutputConfig,
     level: usize,
     scratch: &mut Vec<PreparedField<'a>>,
+    // #1643: shared stack for the array arm's own single-walk validation,
+    // same `base`/`truncate` discipline as `scratch` above and for the same
+    // reason -- a fresh `Vec` per array measured as a real cost here, not
+    // just for objects: the `arrays` perf-guard shape (#1523) is a top-level
+    // array of ~100K 5-element arrays, so a fresh heap allocation per *inner*
+    // array (100K of them) was still enough on its own to push
+    // `arrays_identity` over the 5% threshold even after the double-walk fix
+    // removed the dominant cost. Holds `(bp_pos, value_start)` pairs -- see
+    // `PreparedField::value_start`'s doc comment for why `usize::MAX` is the
+    // sentinel rather than `Option<usize>`.
+    array_scratch: &mut Vec<(usize, usize)>,
     // #1643: when `value` is a `JqValue::Cursor` and the caller has
     // *already* called `text_position()` on it (to check the delimiter
     // preceding it against a sibling), it's passed through here so the
@@ -3926,19 +3944,29 @@ where
                         // already-resolved `text_position()` lets the
                         // write loop reconstruct the cursor via
                         // `Frame::cursor` instead of re-deriving it.
+                        //
+                        // `array_scratch` is the shared buffer threaded
+                        // through the whole recursion (see its own doc
+                        // comment on `print_json`'s signature): this
+                        // array's elements occupy `base..`, a nested array
+                        // appends past that and truncates back on the way
+                        // out, same stack discipline `scratch` already uses
+                        // for object fields.
                         let frame = Frame {
                             text: c.text(),
                             index: c.index(),
                         };
-                        let mut prepared: Vec<(usize, usize)> = Vec::new();
+                        let base = array_scratch.len();
                         for (i, child_cursor) in elements.cursor_iter().enumerate() {
                             let pos = check_preceding_delimiter(&child_cursor, i)?;
-                            prepared.push((child_cursor.bp_position(), pos.unwrap_or(usize::MAX)));
+                            array_scratch
+                                .push((child_cursor.bp_position(), pos.unwrap_or(usize::MAX)));
                         }
                         if compact {
                             out.write_all(b"[")?;
-                            for (i, &(bp, value_start)) in prepared.iter().enumerate() {
-                                if i > 0 {
+                            for i in base..array_scratch.len() {
+                                let (bp, value_start) = array_scratch[i];
+                                if i > base {
                                     out.write_all(b",")?;
                                 }
                                 let child_value = JqValue::Cursor(frame.cursor(bp));
@@ -3951,6 +3979,7 @@ where
                                     config,
                                     level + 1,
                                     scratch,
+                                    array_scratch,
                                     known_text_pos,
                                 )?;
                             }
@@ -3958,8 +3987,9 @@ where
                         } else {
                             out.write_all(b"[")?;
                             out.write_all(separator.as_bytes())?;
-                            for (i, &(bp, value_start)) in prepared.iter().enumerate() {
-                                if i > 0 {
+                            for i in base..array_scratch.len() {
+                                let (bp, value_start) = array_scratch[i];
+                                if i > base {
                                     out.write_all(b",")?;
                                     out.write_all(separator.as_bytes())?;
                                 }
@@ -3974,6 +4004,7 @@ where
                                     config,
                                     level + 1,
                                     scratch,
+                                    array_scratch,
                                     known_text_pos,
                                 )?;
                             }
@@ -3981,6 +4012,7 @@ where
                             out.write_all(current_indent.as_bytes())?;
                             out.write_all(b"]")?;
                         }
+                        array_scratch.truncate(base);
                     }
                 }
                 StandardJson::Object(fields) => {
@@ -4141,6 +4173,7 @@ where
                                 config,
                                 level + 1,
                                 scratch,
+                                array_scratch,
                                 known_text_pos,
                             )?;
                         }
@@ -4190,7 +4223,16 @@ where
                     if i > 0 {
                         out.write_all(b",")?;
                     }
-                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
+                    print_json(
+                        out,
+                        v,
+                        formatter,
+                        config,
+                        level + 1,
+                        scratch,
+                        array_scratch,
+                        None,
+                    )?;
                 }
                 out.write_all(b"]")?;
             } else {
@@ -4202,7 +4244,16 @@ where
                         out.write_all(separator.as_bytes())?;
                     }
                     out.write_all(next_indent.as_bytes())?;
-                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
+                    print_json(
+                        out,
+                        v,
+                        formatter,
+                        config,
+                        level + 1,
+                        scratch,
+                        array_scratch,
+                        None,
+                    )?;
                 }
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;
@@ -4226,7 +4277,16 @@ where
                     };
                     out.write_all(escaped.as_bytes())?;
                     out.write_all(b"\":")?;
-                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
+                    print_json(
+                        out,
+                        v,
+                        formatter,
+                        config,
+                        level + 1,
+                        scratch,
+                        array_scratch,
+                        None,
+                    )?;
                 }
                 out.write_all(b"}")?;
             } else {
@@ -4247,7 +4307,16 @@ where
                     out.write_all(escaped.as_bytes())?;
                     out.write_all(b"\":")?;
                     out.write_all(space_after_colon.as_bytes())?;
-                    print_json(out, v, formatter, config, level + 1, scratch, None)?;
+                    print_json(
+                        out,
+                        v,
+                        formatter,
+                        config,
+                        level + 1,
+                        scratch,
+                        array_scratch,
+                        None,
+                    )?;
                 }
                 out.write_all(separator.as_bytes())?;
                 out.write_all(current_indent.as_bytes())?;

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -643,7 +643,18 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
         let Some(text_pos) = self.text_position() else {
             return StandardJson::Error("invalid cursor position");
         };
+        self.value_at(text_pos)
+    }
 
+    /// Same as [`value`](Self::value), for a caller that has already
+    /// resolved this cursor's `text_position()` for some other reason (a
+    /// delimiter gap check against a sibling, #1643) and doesn't want to
+    /// pay for the same rank/select lookup a second time.
+    ///
+    /// `text_pos` must be this cursor's own `text_position()` -- passing
+    /// any other offset produces nonsense, silently, since there is
+    /// nothing here to check it against.
+    pub fn value_at(&self, text_pos: usize) -> StandardJson<'a, W> {
         if text_pos >= self.text.len() {
             return StandardJson::Error("text position out of bounds");
         }
@@ -1359,6 +1370,17 @@ pub struct JsonString<'a> {
 }
 
 impl<'a> JsonString<'a> {
+    /// The byte offset of the opening quote in the document text.
+    ///
+    /// Lets a caller that already resolved this string via
+    /// [`JsonCursor::value`] reuse that position (e.g. for a delimiter gap
+    /// check, #1643) instead of paying for another `text_position()` --
+    /// itself a rank/select lookup, not free -- to re-derive it.
+    #[inline]
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
     /// Get the raw bytes including quotes.
     pub fn raw_bytes(&self) -> &'a [u8] {
         let end = self.find_end();

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16684,6 +16684,63 @@ fn test_jq_trailing_leading_comma_still_a_known_gap_1643() -> Result<()> {
     Ok(())
 }
 
+/// #1643 follow-up: `-S`/`-C`/`--slurp` bypass `print_json` entirely --
+/// they materialize via `parse_json_stream`'s fallback (which backs the
+/// "original" input path `-S`/`-C`/`--slurp` force), reaching
+/// `json_bytes_to_owned_value_checked` instead. Before this was fixed, a
+/// missing delimiter silently survived on this path even though the
+/// default `sjq -c .` path already rejected it since #1643 -- confirmed
+/// live: real jq errors (exit 5) on every one of these regardless of flag.
+#[test]
+fn test_jq_missing_delimiter_raises_under_sort_keys_color_and_slurp_1643() -> Result<()> {
+    for args in [
+        vec!["-S", "."],
+        vec!["-C", "-c", "."],
+        vec!["-c", "--slurp", "."],
+    ] {
+        let (out, stderr, code) = run_jq_full(&args, Some(r#"{"a" 1}"#))?;
+        assert_eq!(code, 5, "{args:?}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{args:?}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{args:?}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1643 follow-up: a malformed value elsewhere in a multi-value stream
+/// (not just the first) is still caught under `-S`, since
+/// `parse_json_stream`'s fallback validates every span it materializes,
+/// not just the one `serde_json` first stumbled on.
+#[test]
+fn test_jq_missing_delimiter_raises_under_sort_keys_mid_stream_1643() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-S", "."], Some("{\"x\":1}\n{\"a\" 1}"))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #1643 follow-up: `parse_json_stream`'s fallback exists specifically to
+/// preserve jq's own leading-zero leniency (#1094) once `serde_json`
+/// rejects it -- the new delimiter check added for the previous two tests
+/// must not regress that leniency for `-S`/`--slurp`.
+#[test]
+fn test_jq_leading_zero_leniency_unaffected_under_sort_keys_and_slurp_1643() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-S", "-c", "."], Some(r#"{"a":007}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), r#"{"a":7}"#);
+
+    let (out, stderr, code) = run_jq_full(&["-c", "--slurp", "."], Some(r#"{"a":007}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), r#"[{"a":7}]"#);
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16598,6 +16598,92 @@ fn test_jq_wellformed_objects_unaffected_by_1194() -> Result<()> {
     Ok(())
 }
 
+/// #1643: a missing or doubled `,`/`:` between two real object members or
+/// array elements now raises, matching real jq's parse error, instead of
+/// the semi-index silently inventing the missing delimiter (or dropping
+/// the extra one) on the way back out. `#1194`'s own checks can't see any
+/// of these -- every one leaves an even, well-typed BP child count.
+#[test]
+fn test_jq_missing_or_doubled_delimiter_raises_1643() -> Result<()> {
+    for input in [
+        r#"{"a" 1}"#,        // missing `:` between key and value
+        r#"{"a":1 "b":2}"#,  // missing `,` between members
+        r#"{"a":1,,"b":2}"#, // doubled `,` between members
+        "[1 2]",             // missing `,` between elements
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1643: the same class of check applies through a field lookup, not just
+/// the bare identity filter -- whatever value ends up printed is checked,
+/// wherever it's found in the tree.
+#[test]
+fn test_jq_missing_delimiter_raises_through_field_lookup_1643() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", ".a"], Some(r#"{"a":{"b" 1}}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #1643: well-formed documents -- including ones whose *string content*
+/// contains a literal `,`/`:`, and nested containers -- are unaffected.
+/// The check inspects only the whitespace/delimiter gap between children,
+/// never a child's own bytes.
+#[test]
+fn test_jq_wellformed_documents_unaffected_by_1643() -> Result<()> {
+    for (input, expected) in [
+        (r#"{"a":1}"#, r#"{"a":1}"#),
+        (r#"{"a":1,"b":2}"#, r#"{"a":1,"b":2}"#),
+        ("[1,2,3]", "[1,2,3]"),
+        ("{}", "{}"),
+        ("[]", "[]"),
+        (r#"{"a":{"b":1}}"#, r#"{"a":{"b":1}}"#),
+        ("[1,[2,3],{\"x\":4}]", "[1,[2,3],{\"x\":4}]"),
+        (r#"{"a":"1,2:3"}"#, r#"{"a":"1,2:3"}"#),
+        (r#"{ "a" : 1 , "b" : 2 }"#, r#"{"a":1,"b":2}"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
+/// #1643: known, documented gap -- a trailing/leading comma next to a
+/// bracket (rather than between two real children) is not yet caught.
+/// Catching it needs the *closing* bracket's text position, which has no
+/// cheap lookup today (IB only marks opening positions); see
+/// `preceding_gap_ok`'s doc comment in `jq_runner.rs` for why. Pinned here
+/// so a future fix for this class updates this test rather than being
+/// silently covered by a coincidence.
+#[test]
+fn test_jq_trailing_leading_comma_still_a_known_gap_1643() -> Result<()> {
+    for (input, expected) in [
+        (r#"{"a":1,}"#, r#"{"a":1}"#),
+        ("[1,2,]", "[1,2]"),
+        ("{,}", "{}"),
+        ("[,]", "[]"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching


### PR DESCRIPTION
## Summary

`succinctly jq`'s semi-index never validates `,`/`:` placement at all —
`json::standard::is_delim` maps both to the same invisible bit as whitespace,
so `{"a" 1}`, `{"a":1 "b":2}`, `[1 2]` and `{"a":1,,"b":2}` all index exactly
as if they were well-formed. `sjq -c .` on `{"a" 1}` silently invented the
missing `:`, producing `{"a":1}` at exit 0 — a different, well-formed
document that no consumer downstream could tell was ever wrong. #1194's own
`ends_unpaired`/`key_is_malformed` checks can't see any of this: every one of
these shapes leaves an even, well-typed BP child count, the only anomaly
those checks test for.

- `print_json`'s object/array arms now validate the gap immediately before
  each direct child against the source text, scanning *backward* from the
  child's own cheap `text_position()` rather than forward from the previous
  sibling's end (which has no cheap lookup when it's a container — IB only
  marks opening positions). No change to the PFSM/SIMD scanning code, and it
  can't regress this crate's own established leniencies beyond strict RFC
  8259 (leading zeros #1149, a leading-dot number #1171, a malformed nested
  number like `1.2.3` #1194/#966), since it only inspects gap bytes between
  already-recognized children, never a child's own content.
- Both arms validate before writing anything, so a malformed document is
  rejected before its opening `{`/`[` reaches output, matching the existing
  #1194 discipline.
- Reuses the same `EvalError::malformed_json_text`/`MalformedJsonError`/
  `ErrorSink` channel #1194 established, so the message re-runs the real
  strict validator and matches jq's own wording and exit code exactly for
  the 4 repros covered.

## Performance

A first cut recomputed `text_position()` (a rank/select lookup, not free)
once for the check and again moments later when `print_json`'s own
recursion resolved the same child — measured **19-30% slower** on
`sjq -c .` on both array- and object-heavy documents (interleaved A/B, 9
reps, min-of-N per CLAUDE.md's benchmarking discipline). Fixed by threading
the already-resolved position through as a new `known_text_pos` parameter
so the recursive call reuses it via a new `JsonCursor::value_at`/
`JsonString::start`, instead of re-deriving it. Re-measured within noise of
the pre-change binary on a flat 1M-element array, a 200K-object array, and a
realistic ~7MB generated document — and confirmed byte-identical output
throughout.

## Scope (both deliberate)

- Catches a missing delimiter between two real children (`{"a" 1}`,
  `[1 2]`) and a doubled one (`{"a":1,,"b":2}`). A **trailing** delimiter
  next to a closing bracket (`{"a":1,}`) or one in an apparently-empty
  container (`{,}`) is **not yet caught** — that needs the closing
  bracket's own text position, which has no cheap lookup today (same IB
  limitation above), so it's left as a follow-up rather than paying for a
  bracket-matching scan on every container. Pinned by
  `test_jq_trailing_leading_comma_still_a_known_gap_1643` so a future fix
  updates that test rather than silently landing uncovered.
- Only the CLI's own print path is covered (`sjq`'s `print_json`), not
  `succinctly::jq::eval`/`eval_generic` as a library API, and not a filter
  that reaches into a malformed container without ever re-serializing it
  whole (`.[]`, `length`, `add`, ...) — the same class of "which path
  validates" gap #1611 already tracks for a different flag-driven
  divergence.

## Test plan

- [x] `cargo test --features cli --test jq_cli_tests` — 982 passed
- [x] `cargo test --features cli --lib` — 2868 passed (debug mode, to avoid
      the release-mode `debug_assert` false-negative on an unrelated test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (CI's 2nd leg)
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features` — clean (no_std)
- [x] Exit codes verified against `/usr/bin/jq` 1.7.1 for all 8 repro shapes
      from the issue
- [x] Interleaved A/B benchmark (flat array, object array, realistic doc) —
      within noise of the pre-change binary, byte-identical output
- [x] New `_1643` regression tests: caught cases (identity + field lookup),
      the known trailing/leading-comma gap, and a well-formed sweep
      including strings containing literal `,`/`:` and whitespace around
      delimiters

Fixes #1643