### PR TITLE
fix(yaml): report the real escape kind for a bad \u/\U hex digit

### DIFF
--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1263,7 +1263,16 @@ impl<'a> Validator<'a> {
         self.skip_spaces_and_tabs();
         match self.peek() {
             None | Some(b'\n' | b'\r' | b'#' | b':') => Ok(()),
-            Some(_) => Err(self.error(YamlValidationErrorKind::UnbalancedFlow { found: ']' })),
+            // The real offending byte, not a hardcoded `']'` -- same bug
+            // class #1636 fixed for `InvalidEscape`, found a second time in
+            // this file during that fix's own review. `decode_char_at`, not
+            // a bare `byte as char` cast, for the same multi-byte-safety
+            // reason `InvalidEscape`'s own `_other` arm above already uses
+            // it (#1422): trailing content after a flow collection can be
+            // any UTF-8 character, not just ASCII.
+            Some(_) => Err(self.error(YamlValidationErrorKind::UnbalancedFlow {
+                found: crate::text::utf8::decode_char_at(self.input, self.offset),
+            })),
         }
     }
 
@@ -1444,30 +1453,38 @@ impl<'a> Validator<'a> {
                 self.skip_spaces();
                 Ok(())
             }
-            b'x' => self.scan_hex_escape('x', 2),
-            b'u' => self.scan_hex_escape('u', 4),
-            b'U' => self.scan_hex_escape('U', 8),
+            b'x' => self.scan_hex_escape(2),
+            b'u' => self.scan_hex_escape(4),
+            b'U' => self.scan_hex_escape(8),
             _other => Err(self.error(YamlValidationErrorKind::InvalidEscape {
                 sequence: crate::text::utf8::decode_char_at(self.input, self.offset),
             })),
         }
     }
 
-    /// Validate `n` hex digits following `\x`/`\u`/`\U`. Positioned on `x`/`u`/`U`,
-    /// which the caller also passes as `kind` -- reported back on a bad digit
-    /// (#1636) rather than a hardcoded `'x'`, since a bad `\u`/`\U` escape must
-    /// name itself, not whichever kind happened to be checked first.
-    fn scan_hex_escape(&mut self, kind: char, n: usize) -> Result<(), YamlValidationError> {
-        self.advance(); // consume x/u/U
+    /// Validate `n` hex digits following `\x`/`\u`/`\U`. Positioned on `x`/`u`/`U`
+    /// (all ASCII, so the `as char` cast below is exact) -- read locally off
+    /// `advance()`'s own return value (the byte it just consumed) rather than
+    /// threaded through as a parameter the three call sites above would just
+    /// be echoing back (they're already positioned there too, and a caller
+    /// literal drifting out of sync with its own match arm is exactly how
+    /// this bug happened the first time). Reported back on a bad digit
+    /// (#1636) instead of the hardcoded `'x'` this used to have, since a bad
+    /// `\u`/`\U` escape must name itself, not whichever kind happened to be
+    /// checked first.
+    fn scan_hex_escape(&mut self, n: usize) -> Result<(), YamlValidationError> {
+        // `escape_kind`, not `kind`: `Self::error` takes its own `kind:
+        // YamlValidationErrorKind` parameter, and this is an unrelated `char`.
+        let escape_kind = self.advance().expect("caller matched on this byte") as char; // consume x/u/U
         for _ in 0..n {
             match self.peek() {
                 Some(c) if c.is_ascii_hexdigit() => {
                     self.advance();
                 }
                 _ => {
-                    return Err(
-                        self.error(YamlValidationErrorKind::InvalidEscape { sequence: kind })
-                    )
+                    return Err(self.error(YamlValidationErrorKind::InvalidEscape {
+                        sequence: escape_kind,
+                    }))
                 }
             }
         }
@@ -1906,7 +1923,7 @@ mod tests {
         )); // CTN5
         assert!(matches!(
             kind(b"---\n[ a, b, c ] ]\n"),
-            UnbalancedFlow { .. }
+            UnbalancedFlow { found: ']' }
         )); // 4H7K
         assert!(matches!(
             kind(b"---\n[ a, b, c,#invalid\n]\n"),
@@ -1917,6 +1934,22 @@ mod tests {
             UnexpectedCharacter { found: '-', .. }
         )); // YJV2
         assert!(matches!(kind(b"[ a, b"), UnclosedFlow { bracket: '[' }));
+    }
+
+    /// #1636 review: `check_after_top_level_flow` hardcoded `found: ']'`
+    /// for *any* disallowed trailing content after *any* top-level flow
+    /// collection closes -- the same "hardcoded literal instead of the
+    /// actual character" bug #1636 fixed for `InvalidEscape`, found a
+    /// second time in this file during that fix's own review. The
+    /// pre-existing `rejects_flow_wellformedness` case (4H7K) never
+    /// caught this because its trailing content coincidentally *was* `]`.
+    #[test]
+    fn rejects_unbalanced_flow_reports_the_real_trailing_byte_1636() {
+        assert!(matches!(kind(b"[a, b] x\n"), UnbalancedFlow { found: 'x' }));
+        // The shared call site fires for `{...}` too, not just `[...]` --
+        // confirmed live to previously report `found: ']'` even though no
+        // `]` appears anywhere in this input.
+        assert!(matches!(kind(b"{a: 1} x\n"), UnbalancedFlow { found: 'x' }));
     }
 
     #[test]

--- a/src/yaml/validate.rs
+++ b/src/yaml/validate.rs
@@ -1444,17 +1444,20 @@ impl<'a> Validator<'a> {
                 self.skip_spaces();
                 Ok(())
             }
-            b'x' => self.scan_hex_escape(2),
-            b'u' => self.scan_hex_escape(4),
-            b'U' => self.scan_hex_escape(8),
+            b'x' => self.scan_hex_escape('x', 2),
+            b'u' => self.scan_hex_escape('u', 4),
+            b'U' => self.scan_hex_escape('U', 8),
             _other => Err(self.error(YamlValidationErrorKind::InvalidEscape {
                 sequence: crate::text::utf8::decode_char_at(self.input, self.offset),
             })),
         }
     }
 
-    /// Validate `n` hex digits following `\x`/`\u`/`\U`. Positioned on `x`/`u`/`U`.
-    fn scan_hex_escape(&mut self, n: usize) -> Result<(), YamlValidationError> {
+    /// Validate `n` hex digits following `\x`/`\u`/`\U`. Positioned on `x`/`u`/`U`,
+    /// which the caller also passes as `kind` -- reported back on a bad digit
+    /// (#1636) rather than a hardcoded `'x'`, since a bad `\u`/`\U` escape must
+    /// name itself, not whichever kind happened to be checked first.
+    fn scan_hex_escape(&mut self, kind: char, n: usize) -> Result<(), YamlValidationError> {
         self.advance(); // consume x/u/U
         for _ in 0..n {
             match self.peek() {
@@ -1462,7 +1465,9 @@ impl<'a> Validator<'a> {
                     self.advance();
                 }
                 _ => {
-                    return Err(self.error(YamlValidationErrorKind::InvalidEscape { sequence: 'x' }))
+                    return Err(
+                        self.error(YamlValidationErrorKind::InvalidEscape { sequence: kind })
+                    )
                 }
             }
         }
@@ -1834,6 +1839,27 @@ mod tests {
     fn accepts_valid_escapes() {
         assert!(validate(b"a: \"tab\\tnl\\n hex \\x41 \\u0041 \\U00000041\"\n").is_ok());
         assert!(validate(b"a: \"q \\\" s \\/ b \\\\ nbsp \\_ next \\N\"\n").is_ok());
+    }
+
+    /// #1636: `scan_hex_escape` used to hardcode `sequence: 'x'` regardless
+    /// of which escape kind (`\x`/`\u`/`\U`) called it, so a bad `\u`/`\U`
+    /// escape was misreported as `\x`. Only `\x` itself happened to report
+    /// correctly, by coincidence -- covering all three kinds here so a
+    /// regression in any one of them fails a named assertion.
+    #[test]
+    fn rejects_bad_hex_digit_reports_the_real_escape_kind_1636() {
+        assert!(matches!(
+            kind(b"---\na: \"\\xZZ\"\n"),
+            InvalidEscape { sequence: 'x' }
+        ));
+        assert!(matches!(
+            kind(b"---\na: \"\\uZZZZ\"\n"),
+            InvalidEscape { sequence: 'u' }
+        ));
+        assert!(matches!(
+            kind(b"---\na: \"\\UZZZZZZZZ\"\n"),
+            InvalidEscape { sequence: 'U' }
+        ));
     }
 
     #[test]

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -126,6 +126,30 @@ fn bad_hex_escape_reports_the_real_escape_kind_1636() -> Result<()> {
     Ok(())
 }
 
+/// #1636 review: `check_after_top_level_flow` hardcoded `found: ']'` for
+/// *any* disallowed trailing content after *any* top-level flow collection
+/// closes -- the same bug class fixed above for `InvalidEscape`, found a
+/// second time in the same file during that fix's own review. Covers both
+/// `[...]` and `{...}` through the real CLI, since both share the one call
+/// site that had the hardcoded literal.
+#[test]
+fn unbalanced_flow_reports_the_real_trailing_byte_1636() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("[a, b] x\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("unbalanced flow collection near 'x'"),
+        "stderr: {stderr}"
+    );
+
+    let (_, stderr, code) = run_validate_stdin("{a: 1} x\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("unbalanced flow collection near 'x'"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn file_input_reports_filename_and_missing_file() -> Result<()> {
     let mut file = NamedTempFile::new()?;

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -97,6 +97,35 @@ fn error_output_has_rustc_style_caret() -> Result<()> {
     Ok(())
 }
 
+/// #1636: a bad hex digit after `\u`/`\U` used to be misreported as `\x`
+/// (a hardcoded literal, not derived from which escape kind actually
+/// failed) -- only `\x` itself happened to report correctly, by
+/// coincidence. Covers all three kinds through the real CLI.
+#[test]
+fn bad_hex_escape_reports_the_real_escape_kind_1636() -> Result<()> {
+    let (_, stderr, code) = run_validate_stdin("a: \"\\xZZ\"\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("invalid escape sequence '\\x'"),
+        "stderr: {stderr}"
+    );
+
+    let (_, stderr, code) = run_validate_stdin("a: \"\\uZZZZ\"\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("invalid escape sequence '\\u'"),
+        "stderr: {stderr}"
+    );
+
+    let (_, stderr, code) = run_validate_stdin("a: \"\\UZZZZZZZZ\"\n", &["--no-color"])?;
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("invalid escape sequence '\\U'"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn file_input_reports_filename_and_missing_file() -> Result<()> {
     let mut file = NamedTempFile::new()?;


### PR DESCRIPTION
## Summary

`src/yaml/validate.rs`'s `scan_hex_escape` hardcoded `sequence: 'x'` in its `InvalidEscape` error regardless of which escape kind (`\x`/`\u`/`\U`) called it, so a bad `\u` or `\U` escape was misreported as `\x`. Only `\x` itself happened to report correctly, by coincidence.

```
$ printf 'a: "\uZZZZ"\n' | succinctly yaml validate
error: invalid escape sequence '\x'          # should say '\u'
$ printf 'a: "\UZZZZZZZZ"\n' | succinctly yaml validate
error: invalid escape sequence '\x'          # should say '\U'
```

## Fix

Derives the escape kind from `advance()`'s own return value (the byte it just consumed) rather than threading it through as a parameter — no new state, and no risk of a caller literal drifting out of sync with its own match arm (exactly how this bug happened the first time).

## Review found a second, live instance of the same bug class in the same file

`check_after_top_level_flow` hardcoded `UnbalancedFlow { found: ']' }` for *any* disallowed trailing content after *any* top-level flow collection closes:

```
$ printf '{a: 1} x\n' | succinctly yaml validate   # before: found: ']', no ']' anywhere in the input
$ printf '[a, b] x\n' | succinctly yaml validate   # before: found: ']' instead of the real byte 'x'
```

The existing test for this path only exercised trailing-`]`-after-`]`, which happened to make `']'` the correct answer and masked the bug. Fixed with the same `decode_char_at` call `InvalidEscape`'s own multi-byte-safe fallback arm already uses (#1422), and tightened the existing test to assert the exact `found` value instead of only the variant.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo test --features cli,simd,regex,serde` — 55/55 test binaries pass, 0 failures
- [x] New unit and CLI-level tests for both fixes (all three escape kinds; both `[...]` and `{...}` trailing content)
- [x] Live-verified against every repro above, plus valid escapes and well-formed flow collections unaffected

Fixes #1636
