### PR TITLE
fix(jq, json): preserve an undecodable object key instead of raising on it

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -642,6 +642,39 @@ $ echo '{"a\q":1,"b":2,"b":3}' | sjq -c .        # {"a\q":1,"b":3}
 has two members. Dropping it instead — which is what the first cut of #1385 did — deleted
 the field from output while `length` went on counting it.
 
+`to_entries` and `has` agree too (#1642). PR #1391 (the #1247 fix) made `keys`/`to_entries`
+*raise* on exactly this key instead of preserving it, without noticing that now contradicted
+#1385's own rule above — so the same document gave four different answers depending on
+which builtin was asked. `has` raised for an unrelated reason: it had no native handling and
+fell back to fully materializing the object first, which failed on the unrelated bad key
+before `has` ever got to check the one it was actually asked about. All five now agree,
+pinned together in one test (`test_undecodable_key_builtins_agree_1642`) rather than
+trusting each builtin's own prose to stay in sync:
+
+```
+$ echo '{"a\q":1,"b":2}' | sjq -c 'length, keys, keys_unsorted, to_entries, has("b")'
+2
+["a\\q","b"]
+["a\\q","b"]
+[{"key":"a\\q","value":1},{"key":"b","value":2}]
+true
+```
+
+A comma is enough to cost `keys_unsorted` its genuinely-lazy raw-byte path (#140's
+`materialize_lazy_keys`/`effective_keys` escape hatch), so every result above is a real
+materialized string — `a\q`'s one source backslash doubles to `\\`, which is why `keys`
+and this `keys_unsorted` agree byte-for-byte. **Bare** `keys_unsorted` (the sole top-level
+filter) stays lazy and echoes the exact source bytes verbatim instead:
+
+```
+$ echo '{"a\q":1,"b":2}' | sjq -c 'keys_unsorted'
+["a\q","b"]
+```
+
+Both spellings agree the key is present and the count is 2 — the literal escaping
+differing between a raw-byte echo and a materialized value is an inherent property of the
+two representations, not a new inconsistency #1642 introduces.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -675,6 +675,24 @@ Both spellings agree the key is present and the count is 2 — the literal escap
 differing between a raw-byte echo and a materialized value is an inherent property of the
 two representations, not a new inconsistency #1642 introduces.
 
+**One exception, on the materializing routes only** (`to_owned`/`materialize` — `-S`,
+`-s`, a multi-result filter like `.,.`). Two *different* decode-failure keys can share the
+same display fallback (byte-identical raw escapes, or two distinct bad `\u` escapes that
+both lossy-decode to the same replacement text) — never the same key under #1385's rule
+above, but a plain `IndexMap<String, _>` cannot hold two entries under one string. Silently
+keeping only the last value would be *quieter* data loss than #1247's original raise, not a
+fix, so `DisplayKeyGuard` ([src/jq/document.rs](../../../src/jq/document.rs)) makes this
+specific collision raise instead:
+
+```
+$ echo '{"\ud800":1,"\ud800":2}' | sjq -Sc .
+jq: error (at <stdin>:0): object key "\ud800" is ambiguous: an undecodable key's display
+form collides with another key of the same name and cannot be represented
+```
+
+An *ordinary* repeated key (no decode failure on either side) is unaffected and still
+collapses to its last value, matching jq's normal duplicate-key handling.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -675,6 +675,12 @@ Both spellings agree the key is present and the count is 2 — the literal escap
 differing between a raw-byte echo and a materialized value is an inherent property of the
 two representations, not a new inconsistency #1642 introduces.
 
+`paths` and `leaf_paths` agree with the same five now too: both were left on the
+pre-#1642 `field.key_str()` (`None` for a decode-failure key, indistinguishable from
+#1194's genuinely absent one) when the rest of this file's builtins were rewired onto the
+shared `key_display_string` fallback, so a bad key's path silently vanished from `paths`'s
+output while `keys` went on reporting it.
+
 **One exception, on the materializing routes only** (`to_owned`/`materialize` — `-S`,
 `-s`, a multi-result filter like `.,.`). Two *different* decode-failure keys can share the
 same display fallback (byte-identical raw escapes, or two distinct bad `\u` escapes that

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -729,6 +729,24 @@ on a bad key while the default streamed identity output already preserved it as 
 same one-document-many-answers problem #1642's JSON-side fix closes, on the mapping-key
 axis instead of the object-key one.
 
+**One exception, on the materializing routes only.** Every decode-failure key's display
+fallback is the fixed constant `""`, so a mapping with *two* decode-failure keys collides
+the instant a materializing route (`--arg`, `-P`, `.,.`) builds an `IndexMap<String, _>`
+keyed by that string -- the two are never actually the same key (#1385's "never a
+duplicate" rule again), but a plain string-keyed map cannot hold both entries under `""`.
+Rather than resurrect the silent-overwrite bug this whole effort exists to close,
+`DisplayKeyGuard` ([src/jq/document.rs](../../../src/jq/document.rs)) makes that specific
+collision raise instead:
+
+```console
+$ printf '"a\qb": 1\n"c\qd": 2\n' | succinctly yq --arg z y '.'
+Error: object key "" is ambiguous: an undecodable key's display form collides with
+another key of the same name and cannot be represented
+```
+
+An *ordinary* repeated key (no decode failure on either side) is unaffected and still
+collapses to its last value, matching yq's normal duplicate-key handling.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -709,10 +709,25 @@ design doc names. The second and third (default YAML→YAML output, no `-o` flag
 `stream_yaml_string_value`/`write_yaml_field_key`, the single most common `yq`
 invocation) are the same gap on its YAML-target sibling, not previously recorded anywhere.
 Every *materializing* route (a `--arg`-forced DOM, a multi-result filter, `to_entries`,
-`length`) already raises correctly; only these two purely-streamed writers do not. Fixing
-either needs `stream_json_value`/`stream_yaml_value` and their callers to carry a richer
-error than `fmt::Error` — the design doc's own stated reason Stage 6 was split out and
-deferred rather than attempted alongside the rest of #1247's landed stages.
+`length`) already raises correctly for a bad *value* like the one above; only these two
+purely-streamed writers do not. Fixing either needs `stream_json_value`/`stream_yaml_value`
+and their callers to carry a richer error than `fmt::Error` — the design doc's own stated
+reason Stage 6 was split out and deferred rather than attempted alongside the rest of
+#1247's landed stages.
+
+A bad *key* is a different story, on both routes, since [#1642](https://github.com/rust-works/succinctly/issues/1642):
+`to_entries`/`keys`/`length` all preserve it (as `""`, `YamlValue::key_string`'s existing
+convention for a mapping key with no scalar form -- issue #222) rather than raising, on
+*every* route, streamed or materialized alike -- matching the third example above
+(`"a\qb": 1` → `"": 1`) and jq mode's own analogous fix for a JSON key (see the "A key
+that will not decode is never a duplicate" note under [jq Limitations § Duplicate object
+keys collapse, except under `--preserve-input`](../jq/limitations.md#duplicate-object-keys-collapse-except-under---preserve-input)).
+`has`/`in` agree too, for the same reason as jq mode: neither has native handling and both
+fall back to materializing the whole mapping first, which no longer fails on an unrelated
+bad key. This was a live inconsistency prior to #1642 -- `to_entries`/`keys` used to raise
+on a bad key while the default streamed identity output already preserved it as `""`, the
+same one-document-many-answers problem #1642's JSON-side fix closes, on the mapping-key
+axis instead of the object-key one.
 
 ### Other categories
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -436,7 +436,15 @@ Implementation notes, all discovered while doing it:
 - **Not everything that looks like a degrade is one.** `length` on an object answers from
   `fields.len()` without decoding, and `keys_unsorted` streams each key's raw byte span
   verbatim. Neither loses data — both are the same raw-passthrough class as `jq '.'` —
-  so both were left alone, and the tests say why.
+  so both were left alone, and the tests say why. **This stage's own key guards did not
+  yet draw that line consistently**: `keys`/`to_entries` (and `has`, indirectly, via this
+  stage's `to_owned`/`cursor_to_owned` family) raised on a decode-failure key instead of
+  joining `length`/`keys_unsorted`/`.` in the raw-passthrough class — contradicting #1385's
+  own "never a duplicate" rule one section up, on the same document. Closed by
+  [#1642](https://github.com/rust-works/succinctly/issues/1642), which moved the
+  substitution point into `DocumentValue::key_raw_source_span`/`document::key_display_string`
+  so every key guard in this stage (and `effective_keys`'s own dedup step) shares one
+  definition instead of each re-deriving the #1194-vs-decode-failure distinction.
 
 **Stage 4 — the `StandardJson::Error` arms (sites 17–18). ✅ landed.** Fixes
 `[xyz123] → [null]`, i.e. #1194's in-scope half. Small once Stage 3 exists: the arms
@@ -678,6 +686,9 @@ what Stage 6 is left with is bad escapes only.
   is the deliverable for.
 - [#1620](https://github.com/rust-works/succinctly/issues/1620) (resolved) — Open Risk 1,
   decode-failure catchability, filed and settled per this document's own follow-up list.
+- [#1642](https://github.com/rust-works/succinctly/issues/1642) (resolved) — Stage 3's key
+  guards raised inconsistently with `length`/`keys_unsorted`/`.`, contradicting #1385;
+  fixed by moving every key guard onto one shared substitution point.
 - [#1192](https://github.com/rust-works/succinctly/issues/1192) (closed) — fixed two
   sibling copies and established the `EvalError` wording convention reused here.
 - [#1098](https://github.com/rust-works/succinctly/issues/1098) (closed) — the original

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,7 +9,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    effective_keys, key_display_string, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec,
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
@@ -615,7 +616,16 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            if let Some(key) = field.key_str() {
+            // `key_display_string`, not `field.key_str()`: a key that will
+            // not *decode* (#1247/#1385) is preserved via its raw source
+            // span rather than dropped (#1642) -- this loop used to
+            // silently drop such a field under `--slurp`/`--eval-all`/
+            // `--inplace` (the only callers of `parse_input`, hence of this
+            // function), one short of `length`'s real field count. A key
+            // the format's grammar never allowed at all (#1194) is still
+            // dropped, same as before this fix (this function has no error
+            // channel to raise through).
+            if let Some(key) = key_display_string(&field.key) {
                 map.insert(
                     key.into_owned(),
                     to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1),

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1869,7 +1869,9 @@ mod checked_len_tests {
 
 #[cfg(test)]
 mod key_display_string_tests {
-    use super::{effective_keys, key_display_string, key_is_malformed, DocumentValue};
+    use super::{
+        effective_keys, key_display_string, key_is_malformed, DocumentFields, DocumentValue,
+    };
     use crate::json::JsonIndex;
 
     /// A normal key stringifies exactly as `key_string()` already would --
@@ -1945,5 +1947,38 @@ mod key_display_string_tests {
             effective_keys(&fields, false).expect("well formed"),
             vec!["a".to_string(), "a".to_string(), "b".to_string()]
         );
+    }
+
+    /// `DocumentFields::keys()`'s per-field raise for a key the format's
+    /// grammar never allowed at all (#1194) -- distinct from a
+    /// decode-failure key, which `key_display_string` now folds into a
+    /// fallback spelling instead (#1642) and which this method no longer
+    /// raises on either. This trait method itself has had no production
+    /// caller since `effective_keys`'s own #1385 rewrite moved off it (see
+    /// that function's doc comment above), but it stays `pub` API surface
+    /// and must keep raising correctly for a caller outside this crate.
+    #[test]
+    fn document_fields_keys_raises_on_malformed_key_1194() {
+        let json: &[u8] = br"{123: 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let err = fields.keys().expect_err("a bare numeric key is not JSON");
+        assert!(err.message.contains("Invalid JSON text"), "{err:?}");
+    }
+
+    /// The post-walk sibling of the test above: `{invalid}`'s lone child
+    /// never pairs into a field at all, so nothing reaches the per-field
+    /// check -- only `ends_unpaired()` after the loop catches it, same
+    /// two-fault split as `test_jq_malformed_object_keys_raises_on_both_faults_1194`
+    /// in `tests/jq_cli_tests.rs` exercises through the CLI.
+    #[test]
+    fn document_fields_keys_raises_on_unpaired_trailing_field_1194() {
+        let json: &[u8] = br"{invalid}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let err = fields.keys().expect_err("an unpaired member is not JSON");
+        assert!(err.message.contains("Invalid JSON text"), "{err:?}");
     }
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -761,26 +761,101 @@ pub(crate) fn key_is_malformed<V: DocumentValue>(key: &V) -> bool {
 }
 
 /// The string to show for a key, substituting a best-effort fallback when
-/// the key is malformed only because its bytes won't *decode* (#1642) --
-/// never for a key the format's grammar rejects outright (#1194), which
-/// `key_is_malformed` still catches and which still must raise.
+/// the key is malformed only because its bytes won't *decode* (#1642).
 ///
-/// `None` here means the caller should raise -- exactly the #1194 case.
+/// Never for a key the format's grammar rejects outright (#1194), which
+/// `key_is_malformed` still catches and which still must raise. `None`
+/// here means the caller should raise -- exactly the #1194 case.
 /// The substituted fallback is a **display-only** value: it must never
 /// feed back into an identity or hashing decision (`key_hash_of`,
 /// `key_string()` itself, `collapse_repeated`/`DistinctKeyCursors`'s
 /// dedup), because two different decode-failure keys can produce the same
 /// fallback spelling and must still never be treated as duplicates of one
-/// another (#1385).
-pub(crate) fn key_display_string<V: DocumentValue>(key: &V) -> Option<Cow<'_, str>> {
+/// another (#1385). A caller that keys a *map* by this string (rather than
+/// just displaying it) needs to know when that risk applies -- see
+/// `key_display_string_kind` and `DisplayKeyGuard`.
+///
+/// `pub`, not `pub(crate)`: `succinctly-cli`'s `yq_runner.rs` (a separate
+/// binary crate) needs the same key-display logic for its own
+/// `--input-format json` materializer, and must not re-derive it.
+pub fn key_display_string<V: DocumentValue>(key: &V) -> Option<Cow<'_, str>> {
+    key_display_string_kind(key).map(|(key, _is_fallback)| key)
+}
+
+/// [`key_display_string`], plus whether the string is the decode-failure
+/// **fallback** spelling (`true`) rather than a genuine decode (`false`).
+///
+/// Must check `string_decode_error()` *first*, not `key_string()`: YAML's
+/// `key_string()` override never returns `None` at all (#222 -- a complex
+/// or undecodable key stringifies to `""` rather than being dropped), so
+/// checking it first would make every YAML decode-failure key silently
+/// report `is_fallback = false`, indistinguishable from a genuine key
+/// spelled `""`. JSON's two checks happen to be redundant with each other
+/// (`string_decode_error()` and `key_string()` both resolve via the same
+/// `as_str()`), but the order has to serve both formats' actual contracts,
+/// not just the cheaper one.
+pub(crate) fn key_display_string_kind<V: DocumentValue>(key: &V) -> Option<(Cow<'_, str>, bool)> {
     if key.string_decode_error().is_some() {
-        Some(match key.key_raw_source_span() {
-            Some(raw) => String::from_utf8_lossy(raw).into_owned().into(),
-            None => Cow::Borrowed(""),
-        })
-    } else {
-        key.key_string()
+        let fallback = key
+            .key_raw_source_span()
+            .map_or(Cow::Borrowed(""), String::from_utf8_lossy);
+        return Some((fallback, true));
     }
+    key.key_string().map(|key| (key, false))
+}
+
+/// Guards a display-keyed `IndexMap` (`to_owned`/`materialize`, #1642)
+/// against silently merging two keys that [`key_display_string_kind`]'s own
+/// contract forbids treating as the same key: a decode-failure key's
+/// fallback spelling colliding with another decode-failure key's, or with
+/// an unrelated key that happens to decode to the identical text. An
+/// `IndexMap<String, _>` has no way to hold two entries under one string,
+/// so letting that insert happen the ordinary way silently drops the
+/// earlier value -- quieter data loss than #1247's original raise, which
+/// this fix relaxed but must not replace with a worse failure mode.
+///
+/// An *ordinary* repeated key -- neither side a decode-failure fallback --
+/// still overwrites without complaint here, matching jq's normal
+/// last-key-wins duplicate handling; only a fallback spelling on either
+/// side of the collision is refused.
+#[derive(Default)]
+pub(crate) struct DisplayKeyGuard {
+    fallback_keys: Vec<String>,
+}
+
+impl DisplayKeyGuard {
+    /// Checks `key` (with the `is_fallback` flag from
+    /// [`key_display_string_kind`]) against every key already present in
+    /// `map` and every fallback key this guard has already approved.
+    /// Returns `true` when it is safe to insert (a fresh key, or an
+    /// ordinary repeat); `false` when inserting would silently collapse two
+    /// keys that must stay distinct, in which case the caller should raise
+    /// instead.
+    pub(crate) fn check<T>(
+        &mut self,
+        map: &IndexMap<String, T>,
+        key: &str,
+        is_fallback: bool,
+    ) -> bool {
+        let collides = map.contains_key(key)
+            && (is_fallback || self.fallback_keys.iter().any(|seen| seen.as_str() == key));
+        if !collides && is_fallback {
+            self.fallback_keys.push(String::from(key));
+        }
+        !collides
+    }
+}
+
+/// The error for two keys that collide only because a decode-failure key's
+/// display fallback (#1642) matches another key's spelling. #1385 forbids
+/// treating them as the same key, but a display-keyed map has no way to
+/// hold both, so this is what `to_owned`/`materialize` raise instead of
+/// silently dropping one of them -- see [`DisplayKeyGuard`].
+pub(crate) fn colliding_display_key_error(key: &str) -> EvalError {
+    EvalError::decode_failure(alloc::format!(
+        "object key \"{key}\" is ambiguous: an undecodable key's display form \
+         collides with another key of the same name and cannot be represented"
+    ))
 }
 
 /// An open-addressed set of key hashes: "have I seen this one?" answered

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -5,13 +5,11 @@
 //! intermediate conversion.
 
 #[cfg(not(test))]
-use alloc::format;
-#[cfg(not(test))]
 use alloc::vec;
 #[cfg(not(test))]
 use alloc::{borrow::Cow, string::String, vec::Vec};
 
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 #[cfg(test)]
 use std::borrow::Cow;
 
@@ -436,6 +434,21 @@ pub trait DocumentValue: Sized + Clone {
         None
     }
 
+    /// This key's raw source-text span (quotes stripped), regardless of
+    /// whether the bytes inside it actually decode.
+    ///
+    /// Unlike [`key_raw_unescaped`](Self::key_raw_unescaped), which bails
+    /// out to `None` on any escape at all, this answers for an escaped-but-
+    /// undecodable span too -- it exists solely as a display fallback for
+    /// `key_display_string` (#1642), never for identity or hashing.
+    /// Defaults to `None`; JSON overrides it, YAML does not (a decode
+    /// failure there falls back to `""`, matching its existing
+    /// [`key_string`](Self::key_string) convention for any key with no
+    /// scalar form).
+    fn key_raw_source_span(&self) -> Option<&[u8]> {
+        None
+    }
+
     /// Try to get as object fields.
     fn as_object(&self) -> Option<Self::Fields>;
 
@@ -617,17 +630,13 @@ pub trait DocumentFields: Sized + Clone {
         let mut keys = Vec::new();
         let mut fields = self.clone();
         while let Some((field, rest)) = fields.uncons() {
-            // Before `key_str`, not after -- same ordering rule as every
-            // other key-materializing site (#1247): an undecodable key must
-            // raise here, not silently vanish once `key_str` stringifies it.
-            if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::decode_failure(format!("{reason} in object key")));
-            }
-            // A key that will not stringify at all never allowed by the
-            // format's grammar in the first place -- structurally malformed,
-            // not a decode failure (#1194). It used to be skipped, so `keys`
-            // reported one name fewer than `length` counted members.
-            let Some(key) = field.key_str() else {
+            // A key that will not *decode* (#1247/#1385) is preserved via
+            // its raw source span rather than raised on (#1642) -- `keys`
+            // must agree with `length`/`keys_unsorted`/`.` on whether such
+            // a key is present. A key that will not stringify at *all* is a
+            // different, structural fault the format's grammar never
+            // allowed (#1194) and still raises.
+            let Some(key) = key_display_string(&field.key) else {
                 return Err(fields.malformed_member_error());
             };
             keys.push(key.into_owned());
@@ -749,6 +758,29 @@ fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, 
 /// predicate on a branch it never takes.
 pub(crate) fn key_is_malformed<V: DocumentValue>(key: &V) -> bool {
     key.string_decode_error().is_none() && key.key_string().is_none()
+}
+
+/// The string to show for a key, substituting a best-effort fallback when
+/// the key is malformed only because its bytes won't *decode* (#1642) --
+/// never for a key the format's grammar rejects outright (#1194), which
+/// `key_is_malformed` still catches and which still must raise.
+///
+/// `None` here means the caller should raise -- exactly the #1194 case.
+/// The substituted fallback is a **display-only** value: it must never
+/// feed back into an identity or hashing decision (`key_hash_of`,
+/// `key_string()` itself, `collapse_repeated`/`DistinctKeyCursors`'s
+/// dedup), because two different decode-failure keys can produce the same
+/// fallback spelling and must still never be treated as duplicates of one
+/// another (#1385).
+pub(crate) fn key_display_string<V: DocumentValue>(key: &V) -> Option<Cow<'_, str>> {
+    if key.string_decode_error().is_some() {
+        Some(match key.key_raw_source_span() {
+            Some(raw) => String::from_utf8_lossy(raw).into_owned().into(),
+            None => Cow::Borrowed(""),
+        })
+    } else {
+        key.key_string()
+    }
 }
 
 /// An open-addressed set of key hashes: "have I seen this one?" answered
@@ -1448,30 +1480,31 @@ fn checked_len<F: DocumentFields>(fields: &F) -> Result<usize, EvalError> {
 /// An object's field names under the mode's duplicate-key rule, in
 /// document order (first position of each key).
 ///
-/// Probes with [`KeyHashes`] first and returns the walked keys untouched
-/// when nothing repeats, which is the overwhelmingly common case (#1514).
-/// Only a document that actually carries a repeat pays for the
-/// `IndexSet`, whose `insert` keeps the first occurrence's position and
-/// discards later equal ones -- the whole rule, since a key array carries
-/// no values for "last value wins" to choose between.
+/// Walks [`DistinctKeyCursors`] rather than hashing `fields.keys()`'s own
+/// output: collapsing on the *materialized strings* would be unsafe once a
+/// decode-failure key can produce a non-`None` `key_display_string`
+/// fallback (#1642) -- two different such keys can share a fallback
+/// spelling and must still never collapse into one (#1385).
+/// `DistinctKeyCursors` already gets this right, by deciding collapse from
+/// `key_hash_of`/[`key_string`](DocumentValue::key_string) -- both `None`,
+/// hence "never a duplicate", for exactly a decode-failure key -- *before*
+/// any display fallback is ever applied.
 pub fn effective_keys<F: DocumentFields>(
     fields: &F,
     collapse: bool,
 ) -> Result<Vec<String>, EvalError> {
-    let keys = fields.keys()?;
-    if !collapse {
-        return Ok(keys);
+    let mut keys = Vec::new();
+    let mut cursors = DistinctKeyCursors::new(fields, collapse);
+    for (key, _cursor) in cursors.by_ref() {
+        let Some(key) = key_display_string(&key) else {
+            return Err(fields.malformed_member_error());
+        };
+        keys.push(key.into_owned());
     }
-    let mut hashes: Vec<u64> = keys.iter().map(|key| key_hash(key.as_bytes())).collect();
-    hashes.sort_unstable();
-    if !hashes_repeat(&hashes) {
-        return Ok(keys);
+    if cursors.ended_unpaired() {
+        return Err(fields.malformed_member_error());
     }
-    let mut seen: IndexSet<String> = IndexSet::with_capacity(keys.len());
-    for key in keys {
-        seen.insert(key);
-    }
-    Ok(seen.into_iter().collect())
+    Ok(keys)
 }
 
 /// A single field from an object.
@@ -1756,5 +1789,86 @@ mod checked_len_tests {
         let fields = cursor.value().as_object().expect("an object");
 
         assert_eq!(effective_len_checked(&fields, false).ok(), Some(2));
+    }
+}
+
+#[cfg(test)]
+mod key_display_string_tests {
+    use super::{effective_keys, key_display_string, key_is_malformed, DocumentValue};
+    use crate::json::JsonIndex;
+
+    /// A normal key stringifies exactly as `key_string()` already would --
+    /// the fallback must never engage when there is nothing to fall back
+    /// from.
+    #[test]
+    fn normal_key_is_unaffected_1642() {
+        let json: &[u8] = br#"{"a":1}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let (field, _) = fields.uncons().expect("one field");
+        assert_eq!(key_display_string(&field.key()).as_deref(), Some("a"));
+    }
+
+    /// A key whose bytes won't *decode* (#1247) gets its raw source span
+    /// instead of raising -- the whole point of #1642.
+    #[test]
+    fn decode_failure_key_falls_back_to_raw_span_1642() {
+        let json: &[u8] = br#"{"a\q":1}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let (field, _) = fields.uncons().expect("one field");
+        assert_eq!(key_display_string(&field.key()).as_deref(), Some("a\\q"));
+    }
+
+    /// A key the format's grammar never allowed at all (#1194) is a
+    /// different, structural fault -- still `None`, still the caller's cue
+    /// to raise.
+    #[test]
+    fn structurally_malformed_key_still_reports_none_1642() {
+        let json: &[u8] = br"{123: 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let (field, _) = fields.uncons().expect("one field");
+        assert!(key_display_string(&field.key()).is_none());
+        assert!(key_is_malformed(&field.key()));
+    }
+
+    /// Two different decode-failure keys with byte-identical source spans
+    /// must never collapse into one under jq mode's collapse rule (#1385) --
+    /// `effective_keys` has to decide collapse from `key_hash_of`/
+    /// `key_string`, which stay `None`-safe for a decode failure, *before*
+    /// `key_display_string`'s fallback is ever applied for display.
+    #[test]
+    fn effective_keys_never_collapses_colliding_decode_failures_1642() {
+        let json: &[u8] = br#"{"\ud800":1,"\ud800":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+
+        let keys = effective_keys(&fields, true).expect("no genuine #1194 fault");
+        assert_eq!(keys, vec!["\\ud800".to_string(), "\\ud800".to_string()]);
+    }
+
+    /// A real duplicate still collapses under jq mode exactly as before --
+    /// `effective_keys`'s rewrite around `DistinctKeyCursors` must not
+    /// regress the ordinary case it replaces.
+    #[test]
+    fn effective_keys_still_collapses_a_real_duplicate_1642() {
+        let json: &[u8] = br#"{"a":1,"a":2,"b":3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+
+        assert_eq!(
+            effective_keys(&fields, true).expect("well formed"),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(
+            effective_keys(&fields, false).expect("well formed"),
+            vec!["a".to_string(), "a".to_string(), "b".to_string()]
+        );
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13884,6 +13884,57 @@ mod tests {
         assert_eq!(out, "- \u{FFFD}\u{FFFD}");
     }
 
+    /// The sibling of the test above with a genuinely #1194-malformed key:
+    /// `stream_json`/`stream_yaml`'s `LazyKeys { sorted: true, .. }` arm
+    /// still raises through `materialize_lazy_keys`'s `Err` side (#1642 only
+    /// relaxed the decode-failure case above, not this structural one) --
+    /// nothing reaches `out` on either output format, matching every other
+    /// `keys`/`length`/`.` route's agreement on a malformed member (#1194).
+    #[test]
+    fn test_stream_sorted_lazy_keys_arm_raises_on_malformed_key_1194() {
+        let json: &[u8] = b"{123: 1}";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys").unwrap(), cursor);
+        assert!(matches!(
+            result,
+            GenericResult::LazyKeys { sorted: true, .. }
+        ));
+
+        let mut out = String::new();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert!(stats.error.is_some());
+        assert_eq!(out, "");
+
+        let mut out = String::new();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert!(stats.error.is_some());
+        assert_eq!(out, "");
+    }
+
+    /// `GenericResult::materialize_lazy`'s `LazyKeys` arm `Err` side:
+    /// reached whenever a `LazyKeys` result is materialized by a consumer
+    /// other than `stream_json`/`stream_yaml`/`fold_lazy_keys_stage` (which
+    /// each have their own dedicated tests) -- here, `push_generic_owned_values`
+    /// inside `Expr::Comma`'s evaluation. `keys, 1` puts a bare `keys` as
+    /// the comma's first operand over a document with a #1194-malformed
+    /// key; `push_generic_owned_values` calls `materialize_lazy` on it
+    /// before `to_owned`/`to_owned_cursor` ever run, converting the
+    /// `LazyKeys` into `GenericResult::Error` directly.
+    #[test]
+    fn test_materialize_lazy_keys_arm_raises_on_malformed_key_1194() {
+        let json: &[u8] = b"{123: 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys, 1").unwrap(), cursor);
+        assert!(result.is_error(), "{result:?}");
+    }
+
     /// `stream_json`'s `LazySeq` arm falls back to materializing each
     /// `LazyElem` via `lazy_elem_to_owned` whenever
     /// `sequence_streamable_cursors` answers `None` -- unconditional for
@@ -14035,6 +14086,22 @@ mod tests {
             GenericResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "\u{FFFD}\u{FFFD}"),
             other => panic!("expected Owned(String(..)): {other:?}"),
         }
+    }
+
+    /// The sibling of the test above with a genuinely #1194-malformed key
+    /// rather than a mere decode failure: `materialize_lazy_keys`'s `Err`
+    /// arm inside `fold_lazy_keys_stage`'s catch-all still raises, since
+    /// #1642 only relaxed the decode-failure case, not this one. Same
+    /// `keys | .[0]` shape reaching the same catch-all arm (see that
+    /// test's own doc comment for why `.[0]` falls here rather than one of
+    /// the dedicated fast-path arms).
+    #[test]
+    fn test_fold_lazy_keys_stage_catchall_raises_on_malformed_key_1194() {
+        let json: &[u8] = b"{123: 1}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys | .[0]").unwrap(), cursor);
+        assert!(result.is_error(), "{result:?}");
     }
 
     /// `each_lazy_keys_iterate_sink`'s sorted branch (#1599) decodes and

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -23,8 +23,9 @@ use indexmap::IndexMap;
 
 use super::document::{
     collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
-    effective_keys, effective_len_checked, key_is_malformed, DistinctKeyCursors, DocumentCursor,
-    DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    effective_keys, effective_len_checked, key_display_string, key_is_malformed,
+    DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields, DocumentValue,
+    IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
@@ -163,21 +164,16 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            // Before `key_str`, not after: YAML's `key_string` stringifies an
-            // undecodable key to `""` (#222's never-drop-a-key rule), so by
-            // the time `key_str` answers `Some`, the failure is already
-            // invisible. Wording matches the sibling `owned_from_standard_json`
-            // conversion #1192 fixed first.
-            if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::decode_failure(format!("{reason} in object key")));
-            }
-            // A key that will not stringify at all is not a decode failure --
-            // it is a key JSON's grammar never allowed (`{123: 1}`), which
-            // the semi-index accepted because `:` and `,` mean the same
-            // nothing to it. Dropping the field silently is #1194: it
-            // vanished from output while `length` went on counting it, the
-            // disagreement #1385's postmortem names as the thing to avoid.
-            let Some(key) = field.key_str() else {
+            // A key that will not *decode* (#1247/#1385) is preserved via
+            // its raw source span rather than raised on (#1642), matching
+            // `length`/`keys_unsorted`/`.`. A key that will not stringify
+            // at all is a different, structural fault -- a key JSON's
+            // grammar never allowed (`{123: 1}`), which the semi-index
+            // accepted because `:` and `,` mean the same nothing to it --
+            // and that still raises: dropping the field silently is #1194,
+            // the disagreement #1385's postmortem names as the thing to
+            // avoid.
+            let Some(key) = key_display_string(&field.key) else {
                 return Err(f.malformed_member_error());
             };
             map.insert(
@@ -271,15 +267,11 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         let mut map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            // Same key ordering as `to_owned_at_depth` above, same reason.
-            if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::decode_failure(format!("{reason} in object key")));
-            }
-            // Same two #1194 checks as `to_owned_at_depth` above, same
-            // reasons -- these two conversions are copies of each other and a
-            // fix that moved only one would leave the cursor and value
-            // domains disagreeing about whether a document is valid.
-            let Some(key) = field.key_str() else {
+            // Same key handling as `to_owned_at_depth` above, same reasons --
+            // these two conversions are copies of each other and a fix that
+            // moved only one would leave the cursor and value domains
+            // disagreeing about whether a document is valid.
+            let Some(key) = key_display_string(&field.key) else {
                 return Err(f.malformed_member_error());
             };
             map.insert(
@@ -686,38 +678,43 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         let mut key_comment_map = IndexMap::new();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            // Same key ordering as `to_owned_at_depth`, same reason (#1247).
-            if let Some(reason) = field.key.string_decode_error() {
-                return Err(EvalError::decode_failure(format!("{reason} in object key")));
-            }
-            if let Some(key) = field.key_str() {
-                let key = key.into_owned();
-                let (v, c) = to_owned_with_comments_at_depth(
-                    &field.value,
-                    Some(&field.value_cursor),
-                    depth + 1,
-                )?;
-                map.insert(key.clone(), v);
-                comment_map.insert(key.clone(), c);
-                // A comment trailing the key's own line, when the value is
-                // deferred to a following line (issue #765) - distinct from
-                // `c`'s own comment above, which belongs to the value.
-                // Recorded alongside whether the deferred value
-                // materialized as nothing at all (a sibling key follows, or
-                // EOF): a folded scalar continuation that merely *reads* as
-                // null (`a: # c\n  null`) is a different, unhandled case
-                // where real yq places the comment after the folded value
-                // instead of right after the key, which `v`/`is_null()`
-                // alone can't tell apart from true absence - both collapse
-                // through the same semantic check `to_owned` uses - so this
-                // also checks the raw text is empty, not just null-ish.
-                if let Some(kc) = field.key_cursor.line_comment_raw() {
-                    let value_absent = field.value.is_null()
-                        && field.value.as_str().map_or(true, |s| s.is_empty());
-                    key_comment_map.insert(key, (kc, value_absent));
-                }
+            // Same key handling as `to_owned_at_depth`, same reasons
+            // (#1247/#1642): preserve a decode-failure key via its raw
+            // source span; still raise on a key the format's grammar never
+            // allowed at all (#1194) -- this arm used to silently drop such
+            // a field instead of raising, the same swallow #1194 names.
+            let Some(key) = key_display_string(&field.key) else {
+                return Err(f.malformed_member_error());
+            };
+            let key = key.into_owned();
+            let (v, c) = to_owned_with_comments_at_depth(
+                &field.value,
+                Some(&field.value_cursor),
+                depth + 1,
+            )?;
+            map.insert(key.clone(), v);
+            comment_map.insert(key.clone(), c);
+            // A comment trailing the key's own line, when the value is
+            // deferred to a following line (issue #765) - distinct from
+            // `c`'s own comment above, which belongs to the value.
+            // Recorded alongside whether the deferred value
+            // materialized as nothing at all (a sibling key follows, or
+            // EOF): a folded scalar continuation that merely *reads* as
+            // null (`a: # c\n  null`) is a different, unhandled case
+            // where real yq places the comment after the folded value
+            // instead of right after the key, which `v`/`is_null()`
+            // alone can't tell apart from true absence - both collapse
+            // through the same semantic check `to_owned` uses - so this
+            // also checks the raw text is empty, not just null-ish.
+            if let Some(kc) = field.key_cursor.line_comment_raw() {
+                let value_absent =
+                    field.value.is_null() && field.value.as_str().map_or(true, |s| s.is_empty());
+                key_comment_map.insert(key, (kc, value_absent));
             }
             f = rest;
+        }
+        if f.ends_unpaired() {
+            return Err(f.malformed_member_error());
         }
         Ok((
             OwnedValue::Object(map),
@@ -6909,24 +6906,21 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // A loop for the same reason as the array arm above.
                 let mut entries: Vec<OwnedValue> = Vec::new();
                 for field in effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
-                    // Key decode checked before `key_str`, as everywhere else
-                    // (#1247) -- YAML stringifies an undecodable key to `""`.
-                    if let Some(reason) = field.key.string_decode_error() {
-                        return GenericResult::Error(EvalError::decode_failure(format!(
-                            "{reason} in object key"
-                        )));
-                    }
-                    // `continue` here was #1194's third drop site: an entry
-                    // vanished from the array while `length` still counted
-                    // the member it came from.
+                    // A key that will not *decode* is preserved via its raw
+                    // source span rather than raised on (#1247/#1642),
+                    // matching `length`/`keys_unsorted`/`.`. `continue` here
+                    // was #1194's third drop site: an entry vanished from
+                    // the array while `length` still counted the member it
+                    // came from.
                     //
-                    // Unreachable as it stands -- `malformed_object_member`
-                    // above has already proved every key stringifies -- but
-                    // `key_str` is an `Option` and something has to be
-                    // written here. Report the same cause rather than invent
-                    // a second one, so that if the pre-check is ever moved
-                    // this arm is still right rather than merely quiet.
-                    let Some(key) = field.key_str() else {
+                    // The `else` is unreachable as it stands --
+                    // `malformed_object_member` above has already proved
+                    // every key stringifies -- but `key_display_string` is
+                    // an `Option` and something has to be written here.
+                    // Report the same cause rather than invent a second one,
+                    // so that if the pre-check is ever moved this arm is
+                    // still right rather than merely quiet.
+                    let Some(key) = key_display_string(&field.key) else {
                         return GenericResult::Error(fields.malformed_member_error());
                     };
                     let mut entry = IndexMap::new();
@@ -7323,20 +7317,25 @@ mod tests {
         );
     }
 
-    /// #1247: the same for an undecodable *key*, which used to drop the
-    /// whole field instead of degrading its value.
+    /// #1247 used to raise on an undecodable *key* here (closing the
+    /// original fault: it used to drop the whole field instead of
+    /// degrading its value). #1642 preserves it instead, via its raw
+    /// source span (lossily decoded), matching `length`/`keys_unsorted`/
+    /// `.`.
     #[test]
-    fn test_to_owned_errors_on_object_key_decode_failure_1247() {
+    fn test_to_owned_preserves_object_key_decode_failure_1642() {
         use crate::json::JsonIndex;
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let err = to_owned(&value).expect_err("an undecodable key must not materialize");
-        assert!(
-            err.message.contains("in object key"),
-            "message: {}",
-            err.message
+        let owned = to_owned(&value).expect("an undecodable key is preserved, not raised on");
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([(
+                "\u{FFFD}\u{FFFD}".to_string(),
+                OwnedValue::from_number_literal("1")
+            )]))
         );
     }
 
@@ -13559,18 +13558,33 @@ mod tests {
     // cursor-carrying variant instead, so `One`/`Many` only ever arise when
     // the ambient cursor is `None` to begin with.
 
-    /// `to_owned_with_comments` mirrors `to_owned`'s decode-failure checks
-    /// (#1247) -- this covers the object-key check specifically, since #1247
-    /// added it to this function too, not just `to_owned_at_depth`.
+    /// `to_owned_with_comments` mirrors `to_owned`'s key handling -- this
+    /// covers the object-key case specifically, since #1247 added its check
+    /// to this function too, not just `to_owned_at_depth`, and #1642
+    /// changed both from raising to preserving in the same way.
     #[test]
-    fn test_to_owned_with_comments_errors_on_object_key_decode_failure_1247() {
+    fn test_to_owned_with_comments_preserves_object_key_decode_failure_1642() {
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let err = to_owned_with_comments(&value, Some(&cursor))
-            .expect_err("an undecodable key must not materialize");
-        assert!(err.message.contains("in object key"), "{err:?}");
+        let (owned, comments) = to_owned_with_comments(&value, Some(&cursor))
+            .expect("an undecodable key is preserved, not raised on");
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([(
+                "\u{FFFD}\u{FFFD}".to_string(),
+                OwnedValue::from_number_literal("1")
+            )]))
+        );
+        let CommentTree::Object(_, comment_map, key_comment_map) = comments else {
+            panic!("expected CommentTree::Object: {comments:?}");
+        };
+        assert!(
+            comment_map.contains_key("\u{FFFD}\u{FFFD}"),
+            "{comment_map:?}"
+        );
+        assert!(key_comment_map.is_empty(), "{key_comment_map:?}");
     }
 
     /// The value-side sibling of the test above: a field whose *value* (not
@@ -13772,9 +13786,11 @@ mod tests {
     /// falls back to `materialize_lazy_keys`, which decodes every key --
     /// `keys` (not `keys_unsorted`, which stays lazy) over a document with an
     /// undecodable key reaches this on both output formats. CLI-reachable:
-    /// `sjq keys`/`syq keys` over such a document.
+    /// `sjq keys`/`syq keys` over such a document. #1247 raised here;
+    /// #1642 preserves the key via its raw source span instead, matching
+    /// every other `keys`/`length`/`.` route.
     #[test]
-    fn test_stream_sorted_lazy_keys_arm_reports_decode_failure_1247() {
+    fn test_stream_sorted_lazy_keys_arm_preserves_decode_failure_1642() {
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
 
         let index = JsonIndex::build(json);
@@ -13789,15 +13805,15 @@ mod tests {
         let stats = result
             .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
             .unwrap();
-        assert_eq!(out, "");
-        assert!(stats.error.is_some());
+        assert!(stats.error.is_none(), "{:?}", stats.error);
+        assert_eq!(out, "[\"\u{FFFD}\u{FFFD}\"]");
 
         let mut out = String::new();
         let stats = result
             .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
             .unwrap();
-        assert_eq!(out, "");
-        assert!(stats.error.is_some());
+        assert!(stats.error.is_none(), "{:?}", stats.error);
+        assert_eq!(out, "- \u{FFFD}\u{FFFD}");
     }
 
     /// `stream_json`'s `LazySeq` arm falls back to materializing each
@@ -13942,26 +13958,35 @@ mod tests {
     /// too, so with `keys` (sorted) it falls through the same as any other
     /// non-`length` stage. CLI-reachable: `sjq 'keys | .[0]'`.
     #[test]
-    fn test_fold_lazy_keys_stage_catchall_decode_failure_1247() {
+    fn test_fold_lazy_keys_stage_catchall_preserves_decode_failure_1642() {
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let result = eval_with_cursor(&crate::jq::parse("keys | .[0]").unwrap(), cursor);
-        assert!(result.is_error(), "{result:?}");
+        match result {
+            GenericResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "\u{FFFD}\u{FFFD}"),
+            other => panic!("expected Owned(String(..)): {other:?}"),
+        }
     }
 
     /// `each_lazy_keys_iterate_sink`'s sorted branch (#1599) decodes and
     /// sorts every key via `effective_keys` before iterating -- reached by
     /// `keys | .[]` (the demand-driven `Expr::Iterate` fan-out over a lazy
-    /// keys result) over a document with an undecodable key.
+    /// keys result) over a document with an undecodable key. #1247 raised
+    /// here; #1642 preserves the key instead.
     /// CLI-reachable: `sjq 'keys | .[]'`.
     #[test]
-    fn test_each_lazy_keys_iterate_sink_sorted_decode_failure_1247() {
+    fn test_each_lazy_keys_iterate_sink_sorted_preserves_decode_failure_1642() {
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let result = eval_with_cursor(&crate::jq::parse("keys | .[]").unwrap(), cursor);
-        assert!(result.is_error(), "{result:?}");
+        match result {
+            GenericResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::String("\u{FFFD}\u{FFFD}".to_string())]);
+            }
+            other => panic!("expected ManyOwned([..]): {other:?}"),
+        }
     }
 
     /// `eval_index_expr`'s "key outer, target inner" loop takes its

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,10 +22,10 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
-    effective_keys, effective_len_checked, key_display_string, key_is_malformed,
-    DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields, DocumentValue,
-    IndentSpec,
+    collapsed_fields, collapsed_fields_if, colliding_display_key_error, effective_fields,
+    effective_fields_checked, effective_keys, effective_len_checked, key_display_string,
+    key_display_string_kind, key_is_malformed, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor,
+    DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
@@ -162,6 +162,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
+        let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             // A key that will not *decode* (#1247/#1385) is preserved via
@@ -173,13 +174,19 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             // and that still raises: dropping the field silently is #1194,
             // the disagreement #1385's postmortem names as the thing to
             // avoid.
-            let Some(key) = key_display_string(&field.key) else {
+            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
                 return Err(f.malformed_member_error());
             };
-            map.insert(
-                key.into_owned(),
-                to_owned_at_depth(&field.value, depth + 1)?,
-            );
+            let key = key.into_owned();
+            // Two decode-failure keys (or a decode-failure key and an
+            // unrelated one) can share a display spelling -- #1385 forbids
+            // treating them as the same key, but this `IndexMap` cannot
+            // hold two entries under one string. Raise rather than let the
+            // insert below silently overwrite the earlier value (#1642).
+            if !guard.check(&map, &key, is_fallback) {
+                return Err(colliding_display_key_error(&key));
+            }
+            map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
             f = rest;
         }
         // The walk ran out -- but on an unpaired child, or genuinely? Only
@@ -265,17 +272,24 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
     let value = cursor.value();
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
+        let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             // Same key handling as `to_owned_at_depth` above, same reasons --
             // these two conversions are copies of each other and a fix that
             // moved only one would leave the cursor and value domains
             // disagreeing about whether a document is valid.
-            let Some(key) = key_display_string(&field.key) else {
+            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
                 return Err(f.malformed_member_error());
             };
+            let key = key.into_owned();
+            // See `to_owned_at_depth`'s identical guard: two colliding
+            // display-fallback keys must raise, not silently overwrite.
+            if !guard.check(&map, &key, is_fallback) {
+                return Err(colliding_display_key_error(&key));
+            }
             map.insert(
-                key.into_owned(),
+                key,
                 to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
             );
             f = rest;
@@ -676,6 +690,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
         let mut key_comment_map = IndexMap::new();
+        let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
             // Same key handling as `to_owned_at_depth`, same reasons
@@ -683,10 +698,18 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             // source span; still raise on a key the format's grammar never
             // allowed at all (#1194) -- this arm used to silently drop such
             // a field instead of raising, the same swallow #1194 names.
-            let Some(key) = key_display_string(&field.key) else {
+            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
                 return Err(f.malformed_member_error());
             };
             let key = key.into_owned();
+            // See `to_owned_at_depth`'s identical guard. `map`,
+            // `comment_map` and `key_comment_map` are always populated
+            // together for the same key, so checking `map` alone catches a
+            // collision that would otherwise silently drop the earlier
+            // key's value *and* comment.
+            if !guard.check(&map, &key, is_fallback) {
+                return Err(colliding_display_key_error(&key));
+            }
             let (v, c) = to_owned_with_comments_at_depth(
                 &field.value,
                 Some(&field.value_cursor),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6454,7 +6454,15 @@ fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
             return;
         }
         for field in fields {
-            let Some(key) = field.key_str() else {
+            // `key_display_string`, not `field.key_str()`: a key that will
+            // not *decode* (#1247/#1385) is preserved via its raw source
+            // span rather than skipped (#1642), matching
+            // `length`/`keys`/`keys_unsorted`/`.` -- this loop used to
+            // silently drop such a field's path, disagreeing with `keys`
+            // over the same document. A key the format's grammar never
+            // allowed at all (#1194) is still skipped, same as before this
+            // fix (this function has no error channel to raise through).
+            let Some(key) = key_display_string(&field.key) else {
                 continue;
             };
             current_path.push(OwnedValue::String(key.into_owned()));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13602,6 +13602,43 @@ mod tests {
         assert!(err.message.contains("invalid UTF-8"), "{err:?}");
     }
 
+    /// #1194: `to_owned_with_comments` mirrors `to_owned`/`to_owned_cursor`'s
+    /// non-string-key check (`test_both_owned_conversions_raise_on_non_string_key_1194`)
+    /// -- this is the third conversion reaching the same `key_display_string`
+    /// `else` arm, for a key the format's grammar never allowed at all, as
+    /// opposed to #1642's decode-failure preservation covered above.
+    #[test]
+    fn test_to_owned_with_comments_raises_on_non_string_key_1194() {
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = to_owned_with_comments(&value, Some(&cursor))
+            .expect_err("a bare numeric key is not JSON");
+        assert!(
+            err.message.contains("expected string key"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #1194: an object whose children don't pair (`{invalid}`) raises from
+    /// `to_owned_with_comments` too -- this function's own `ends_unpaired`
+    /// check, added alongside the #1642 preserve-not-raise change and until
+    /// now untested. `to_owned`/`to_owned_cursor` already had this guard; see
+    /// `test_owned_from_standard_json_raises_on_unpaired_field_1194` for the
+    /// value-domain sibling using the same repro.
+    #[test]
+    fn test_to_owned_with_comments_raises_on_unpaired_field_1194() {
+        let json: &[u8] = b"{invalid}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = to_owned_with_comments(&value, Some(&cursor))
+            .expect_err("an unpaired member is not JSON");
+        assert!(err.message.contains("Invalid JSON text"), "{err:?}");
+    }
+
     /// `to_owned_key_shape`'s array/object branches (#626/#670/#903) are a
     /// shape-only fast path for a computed index/slice-bound candidate --
     /// reached from `eval_index_expr`'s `keys` match when the key expression

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -27,7 +27,10 @@ use std::borrow::Cow;
 
 use crate::json::light::{JsonCursor, StandardJson};
 
-use super::document::{effective_len, key_display_string, DistinctKeyCursors};
+use super::document::{
+    colliding_display_key_error, effective_len, key_display_string, key_display_string_kind,
+    DisplayKeyGuard, DistinctKeyCursors,
+};
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
@@ -748,6 +751,7 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
+            let mut guard = DisplayKeyGuard::default();
             for field in fields {
                 // A key that isn't a `String` token at all is *structurally*
                 // malformed and still drops the field silently -- #1194's
@@ -755,12 +759,19 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 // won't decode is preserved via its raw source span rather
                 // than raised on (#1247/#1642), matching
                 // `length`/`keys_unsorted`/`.`.
-                if let Some(cow) = key_display_string(&field.key()) {
+                if let Some((cow, is_fallback)) = key_display_string_kind(&field.key()) {
+                    let key = cow.into_owned();
+                    // Two decode-failure keys (or a decode-failure key and
+                    // an unrelated one) can share a display spelling --
+                    // #1385 forbids treating them as the same key, but this
+                    // `IndexMap` cannot hold two entries under one string.
+                    // Raise rather than silently overwrite the earlier
+                    // value (#1642).
+                    if !guard.check(&map, &key, is_fallback) {
+                        return Err(colliding_display_key_error(&key));
+                    }
                     let value_cursor = field.value_cursor();
-                    map.insert(
-                        cow.into_owned(),
-                        cursor_to_owned_at_depth(&value_cursor, depth + 1)?,
-                    );
+                    map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
                 }
             }
             OwnedValue::Object(map)

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -27,7 +27,7 @@ use std::borrow::Cow;
 
 use crate::json::light::{JsonCursor, StandardJson};
 
-use super::document::{effective_len, DistinctKeyCursors};
+use super::document::{effective_len, key_display_string, DistinctKeyCursors};
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
 use super::expr::Literal;
@@ -684,12 +684,11 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
 ) -> Result<OwnedValue, EvalError> {
     let mut keys = Vec::new();
     for (key, _) in DistinctKeyCursors::new(fields, collapse) {
-        if let StandardJson::String(k) = key {
-            // An undecodable key used to vanish from `keys` entirely, so the
-            // array silently came back short (#1247).
-            let s = k
-                .as_str()
-                .map_err(|e| EvalError::new(format!("{e} in object key")))?;
+        // A key that will not *decode* is preserved via its raw source span
+        // rather than raised on (#1247/#1642), matching
+        // `length`/`keys_unsorted`/`.`. A non-string key (#1194) still has
+        // no name to report and is skipped here, same as before this fix.
+        if let Some(s) = key_display_string(&key) {
             keys.push(OwnedValue::String(s.into_owned()));
         }
     }
@@ -753,12 +752,10 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 // A key that isn't a `String` token at all is *structurally*
                 // malformed and still drops the field silently -- #1194's
                 // territory, unchanged here. A key that is a string but
-                // won't decode used to drop the field just as quietly; that
-                // half raises now (#1247).
-                if let StandardJson::String(key_str) = field.key() {
-                    let cow = key_str
-                        .as_str()
-                        .map_err(|e| EvalError::new(format!("{e} in object key")))?;
+                // won't decode is preserved via its raw source span rather
+                // than raised on (#1247/#1642), matching
+                // `length`/`keys_unsorted`/`.`.
+                if let Some(cow) = key_display_string(&field.key()) {
                     let value_cursor = field.value_cursor();
                     map.insert(
                         cow.into_owned(),
@@ -975,23 +972,28 @@ mod tests {
         assert!(val.into_owned().is_err());
     }
 
-    /// #1247: an undecodable *key* used to drop its whole field silently,
-    /// so the object simply came back smaller.
+    /// #1247 used to raise here; #1642 preserves instead, matching
+    /// `length`/`keys_unsorted`/`.` -- an undecodable *key* must never drop
+    /// its whole field silently (#1247's original fix), but nor should it
+    /// make the object unusable when every other route already tolerates
+    /// it.
     #[test]
-    fn test_materialize_errors_on_object_key_decode_failure_1247() {
+    fn test_materialize_preserves_object_key_decode_failure_1642() {
         use crate::json::JsonIndex;
 
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let val = JqValue::from_cursor(cursor);
-        let err = val
+        let owned = val
             .materialize()
-            .expect_err("an undecodable key must not materialize");
-        assert!(
-            err.message.contains("in object key"),
-            "message: {}",
-            err.message
+            .expect("an undecodable key is preserved, not raised on (#1642)");
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([(
+                "\u{FFFD}\u{FFFD}".to_string(),
+                OwnedValue::from_number_literal("1")
+            )]))
         );
     }
 
@@ -1421,14 +1423,17 @@ mod tests {
         );
     }
 
-    /// #684/#1247: `lazy_keys_array_to_owned` is `LazyKeysArray`'s own
+    /// #684/#1247/#1642: `lazy_keys_array_to_owned` is `LazyKeysArray`'s own
     /// materializer -- the escape hatch `materialize`/`into_owned` reach for
     /// `sort_keys`/color output/etc. Exercise it directly, both outcomes: a
     /// clean object hits the `Ok(OwnedValue::Array(keys))` return, and an
-    /// object with an undecodable key hits the `Err` raised out of the
-    /// `DistinctKeyCursors` walk instead of the field silently vanishing.
+    /// object with an undecodable key hits the *same* `Ok` return -- the
+    /// key preserved via its raw source span (lossily decoded, since this
+    /// key is raw invalid UTF-8 rather than a bad escape) instead of either
+    /// raising (#1247's answer) or the field silently vanishing (the fault
+    /// #1247 fixed).
     #[test]
-    fn test_lazy_keys_array_to_owned_ok_and_err_1247() {
+    fn test_lazy_keys_array_to_owned_ok_and_preserves_decode_failure_1642() {
         use crate::json::JsonIndex;
 
         let json: &[u8] = br#"{"b":1,"a":2}"#;
@@ -1453,20 +1458,21 @@ mod tests {
             StandardJson::Object(fields) => fields,
             other => panic!("expected object, got {other:?}"),
         };
-        let err = lazy_keys_array_to_owned(&fields, true)
-            .expect_err("an undecodable key must not materialize");
-        assert!(err.message.contains("in object key"), "{}", err.message);
+        assert_eq!(
+            lazy_keys_array_to_owned(&fields, true).expect("preserved, not raised (#1642)"),
+            OwnedValue::Array(vec![OwnedValue::String("\u{FFFD}\u{FFFD}".to_string())])
+        );
     }
 
-    /// #1247: the same `LazyKeysArray` arms as above, reached this time
-    /// through `materialize`/`into_owned`'s recursive `Array`/`Object` cases
-    /// at depth > 0 -- e.g. `[keys_unsorted]`/`{x: keys_unsorted}` forced to
-    /// materialize by `--sort-keys`/`-C` at the CLI boundary
+    /// #1247/#1642: the same `LazyKeysArray` arms as above, reached this
+    /// time through `materialize`/`into_owned`'s recursive `Array`/`Object`
+    /// cases at depth > 0 -- e.g. `[keys_unsorted]`/`{x: keys_unsorted}`
+    /// forced to materialize by `--sort-keys`/`-C` at the CLI boundary
     /// (`write_output_jq_value`'s "complex output" branch in
     /// `jq_runner.rs`), rather than `lazy_keys_array_to_owned` being called
     /// on a bare top-level `keys_unsorted` result.
     #[test]
-    fn test_lazy_keys_array_nested_materialize_and_into_owned_1247() {
+    fn test_lazy_keys_array_nested_materialize_and_into_owned_1642() {
         use crate::json::JsonIndex;
 
         let json: &[u8] = b"{\"\xff\xfe\": 1}";
@@ -1482,17 +1488,27 @@ mod tests {
         };
 
         let nested_in_array = JqValue::Array(vec![lazy_keys.clone()]);
-        let err = nested_in_array
-            .materialize()
-            .expect_err("a nested undecodable key must not materialize");
-        assert!(err.message.contains("in object key"), "{}", err.message);
+        assert_eq!(
+            nested_in_array
+                .materialize()
+                .expect("a nested undecodable key is preserved, not raised on (#1642)"),
+            OwnedValue::Array(vec![OwnedValue::Array(vec![OwnedValue::String(
+                "\u{FFFD}\u{FFFD}".to_string()
+            )])])
+        );
 
         let nested_in_object: JqValue<'_, Vec<u64>> =
             JqValue::Object(IndexMap::from([("x".to_string(), lazy_keys)]));
-        let err = nested_in_object
+        let owned = nested_in_object
             .into_owned()
-            .expect_err("a nested undecodable key must not materialize");
-        assert!(err.message.contains("in object key"), "{}", err.message);
+            .expect("a nested undecodable key is preserved, not raised on (#1642)");
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([(
+                "x".to_string(),
+                OwnedValue::Array(vec![OwnedValue::String("\u{FFFD}\u{FFFD}".to_string())])
+            )]))
+        );
     }
 
     /// #1194: sibling of `jq_runner.rs`'s `standard_json_to_jq_value` and its

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -23,7 +23,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use super::document::{DistinctKeyCursors, DocumentFields, DocumentValue, IndentSpec};
+use super::document::{key_display_string, DistinctKeyCursors, DocumentFields, IndentSpec};
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
@@ -549,11 +549,11 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     out.write_char('[')?;
     let mut i = 0usize;
     for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
-        // `key_string()` is expected to always return `Some` (see
-        // `DocumentField::key_str`'s doc comment); a key with no
-        // stringifiable spelling is silently skipped, matching
-        // `DocumentFields::keys()`'s default walk.
-        if let Some(key) = key.key_string() {
+        // A key that will not *decode* is preserved via its raw source
+        // span rather than silently skipped (#1642), matching
+        // `DocumentFields::keys()`. A key with no stringifiable spelling at
+        // all (#1194) has no name to report and is still skipped here.
+        if let Some(key) = key_display_string(&key) {
             if i > 0 {
                 out.write_char(',')?;
             }
@@ -877,7 +877,9 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
         // Flow style
         out.write_char('[')?;
         for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
-            if let Some(key) = key.key_string() {
+            // Preserved via its raw source span rather than skipped on a
+            // decode failure (#1642), matching `stream_lazy_keys_json`.
+            if let Some(key) = key_display_string(&key) {
                 if i > 0 {
                     out.write_str(", ")?;
                 }
@@ -889,7 +891,7 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
     } else {
         // Block style
         for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
-            if let Some(key) = key.key_string() {
+            if let Some(key) = key_display_string(&key) {
                 if i > 0 {
                     out.write_char('\n')?;
                 }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2021,6 +2021,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
         }
     }
 
+    /// Unlike [`key_raw_unescaped`](Self::key_raw_unescaped), this answers
+    /// for an escaped span too -- including one whose escape is invalid --
+    /// since it exists only as a display fallback for a key that fails to
+    /// *decode* (#1642), not for hashing.
+    fn key_raw_source_span(&self) -> Option<&[u8]> {
+        match self {
+            StandardJson::String(s) => {
+                let raw = s.raw_bytes();
+                (raw.len() >= 2).then(|| &raw[1..raw.len() - 1])
+            }
+            _ => None,
+        }
+    }
+
     fn as_object(&self) -> Option<Self::Fields> {
         match self {
             StandardJson::Object(fields) => Some(*fields),

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2031,6 +2031,12 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
                 let raw = s.raw_bytes();
                 (raw.len() >= 2).then(|| &raw[1..raw.len() - 1])
             }
+            // Unreachable as it stands -- `key_display_string`'s only
+            // caller (`document.rs`) reaches this method solely behind
+            // `string_decode_error().is_some()`, which for this type is
+            // itself only `Some` on the `String` arm above -- but the
+            // trait's return type is an `Option` and something has to be
+            // written here. `None` matches the trait default.
             _ => None,
         }
     }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2511,6 +2511,22 @@ mod tests {
         assert_eq!(DocumentCursor::line_comment(&root), None);
     }
 
+    /// `key_raw_source_span`'s non-`String` arm is unreachable via any real
+    /// evaluation path -- `key_display_string_kind` only calls it once
+    /// `string_decode_error()` is `Some`, which for this type is itself
+    /// only `Some` on the `String` arm (#1642) -- but the trait method
+    /// still needs an answer for every variant. Calls it directly on a
+    /// non-string value to pin that contract: no span to show for
+    /// something that was never a string in the first place.
+    #[test]
+    fn test_key_raw_source_span_is_none_for_non_string_value_1642() {
+        let json = br"1";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        assert!(matches!(value, StandardJson::Number(_)));
+        assert_eq!(value.key_raw_source_span(), None);
+    }
+
     /// `stream_json_as_yaml`'s scalar-string arm previously read
     /// `raw_bytes()` (the source JSON bytes, quotes and escapes included)
     /// instead of the decoded `as_str()` content, so a plain string value

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2752,6 +2752,32 @@ fn test_undecodable_key_builtins_agree_1642() -> Result<()> {
     Ok(())
 }
 
+/// #1642 follow-up: `paths`/`leaf_paths` were left on the old
+/// `field.key_str()` (`None` for a decode-failure key, same as for a
+/// #1194 key the grammar never allowed), so they silently dropped a
+/// decode-failure key's path while `keys`/`length`/`to_entries` -- routed
+/// through the shared `key_display_string` -- correctly reported it. Same
+/// "one document, many answers" failure `test_undecodable_key_builtins_agree_1642`
+/// pins for the other five builtins, just on this pair.
+#[test]
+fn test_paths_and_leaf_paths_agree_with_keys_on_decode_failure_1642() -> Result<()> {
+    let doc = r#"{"a\q":1,"b":2}"#;
+
+    let (out, _, code) = run_jq_full(&["-c", "keys"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[\"a\\\\q\",\"b\"]");
+
+    let (out, _, code) = run_jq_full(&["-c", "paths"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[\"a\\\\q\"]\n[\"b\"]");
+
+    let (out, _, code) = run_jq_full(&["-c", "leaf_paths"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[\"a\\\\q\"]\n[\"b\"]");
+
+    Ok(())
+}
+
 /// #1642 follow-up: `to_owned`/`materialize` (`-S`, `-s`, a multi-result
 /// filter like `.,.`) build an `IndexMap<String, _>` keyed by
 /// `key_display_string`'s fallback. Two *different* decode-failure keys can

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2752,6 +2752,57 @@ fn test_undecodable_key_builtins_agree_1642() -> Result<()> {
     Ok(())
 }
 
+/// #1642 follow-up: `to_owned`/`materialize` (`-S`, `-s`, a multi-result
+/// filter like `.,.`) build an `IndexMap<String, _>` keyed by
+/// `key_display_string`'s fallback. Two *different* decode-failure keys can
+/// share that fallback spelling (byte-identical raw escapes, or two
+/// separate bad `\u` escapes that both lossy-decode to U+FFFD), and #1385
+/// forbids treating them as the same key -- but the map cannot hold two
+/// entries under one string. Before this fix that silently kept only the
+/// last value (worse than #1247's original raise, which turned into
+/// quieter data loss instead of louder consistency); now it raises. See
+/// `DisplayKeyGuard` in `src/jq/document.rs`.
+#[test]
+fn test_materializing_route_raises_on_colliding_decode_failure_keys_1642() -> Result<()> {
+    let dup_doc = r#"{"\ud800":1,"\ud800":2}"#;
+
+    for args in [
+        &["-Sc", "."][..],
+        &["-c", "-s", "."][..],
+        &["-c", ".,."][..],
+    ] {
+        let (out, err, code) = run_jq_full(args, Some(dup_doc))?;
+        assert_ne!(
+            code, 0,
+            "args {args:?} should raise rather than silently drop a value, out: {out:?}"
+        );
+        assert!(err.contains("ambiguous"), "args {args:?}, stderr: {err}");
+    }
+
+    // A single decode-failure key still preserves fine under the same
+    // routes -- no false positive from the new guard.
+    let single_doc = r#"{"\ud800":1,"b":2}"#;
+    let (out, err, code) = run_jq_full(&["-Sc", "."], Some(single_doc))?;
+    assert_eq!(
+        code, 0,
+        "single bad key should still succeed, stderr: {err}"
+    );
+    assert_eq!(out.trim(), "{\"\\\\ud800\":1,\"b\":2}");
+
+    // An ordinary repeated key -- no decode failure on either side -- still
+    // collapses to the last value (jq's normal duplicate-key handling); the
+    // guard must not turn a genuine duplicate into a raise.
+    let ordinary_dup = r#"{"a":1,"a":2}"#;
+    let (out, err, code) = run_jq_full(&["-Sc", "."], Some(ordinary_dup))?;
+    assert_eq!(
+        code, 0,
+        "ordinary duplicate key should not raise, stderr: {err}"
+    );
+    assert_eq!(out.trim(), "{\"a\":2}");
+
+    Ok(())
+}
+
 /// #1514: `keys_unsorted | map(f)` and `keys_unsorted | .[]` no longer probe
 /// the whole object before the first key comes out — they dedup as they walk
 /// and switch to the exact collapsed list only once a hash repeats. That

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2682,6 +2682,76 @@ fn test_undecodable_keys_are_not_duplicates_1385() -> Result<()> {
     Ok(())
 }
 
+/// #1642: `length`, `keys`, `keys_unsorted`, `to_entries` and `has` must all
+/// agree on whether a document with an undecodable object key is usable --
+/// before this fix, `keys`/`to_entries`/`has` raised (exit 5) on exactly the
+/// same document `.`/`length`/bare `keys_unsorted` accepted (exit 0), so a
+/// script's behaviour depended on which builtin it happened to call. This
+/// extends `test_undecodable_keys_are_not_duplicates_1385`'s guarantee (a
+/// key that will not decode is never a duplicate) to the two builtins that
+/// used to raise before ever reaching it.
+///
+/// `keys`/`to_entries` report the bad key re-escaped from a real
+/// materialized `String` (`a\q`'s single source backslash doubles to
+/// `\\`), where bare `keys_unsorted` echoes the exact source bytes verbatim
+/// -- an inherent, harmless difference between a genuinely-lazy raw-byte
+/// echo and a value that has actually been materialized, not a new
+/// inconsistency.
+#[test]
+fn test_undecodable_key_builtins_agree_1642() -> Result<()> {
+    let doc = r#"{"a\q":1,"b":2}"#;
+
+    let (out, _, code) = run_jq_full(&["-c", "length"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    let (out, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["a\q","b"]"#);
+
+    let (out, _, code) = run_jq_full(&["-c", "keys"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[\"a\\\\q\",\"b\"]");
+
+    let (out, _, code) = run_jq_full(&["-c", "to_entries"], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        "[{\"key\":\"a\\\\q\",\"value\":1},{\"key\":\"b\",\"value\":2}]"
+    );
+
+    let (out, _, code) = run_jq_full(&["-c", r#"has("b")"#], Some(doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "true");
+
+    // Two decode-failure keys, byte-identical source: #1385 already pins
+    // that they never collapse under `.`/`length`/`[.[]]`; extend that to
+    // `keys`/`to_entries`, which used to raise before ever getting the
+    // chance to (dis)agree.
+    let dup_doc = r#"{"\ud800":1,"\ud800":2}"#;
+
+    let (out, _, code) = run_jq_full(&["-c", "length"], Some(dup_doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    let (out, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(dup_doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["\ud800","\ud800"]"#);
+
+    let (out, _, code) = run_jq_full(&["-c", "keys"], Some(dup_doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[\"\\\\ud800\",\"\\\\ud800\"]");
+
+    let (out, _, code) = run_jq_full(&["-c", "to_entries"], Some(dup_doc))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        "[{\"key\":\"\\\\ud800\",\"value\":1},{\"key\":\"\\\\ud800\",\"value\":2}]"
+    );
+
+    Ok(())
+}
+
 /// #1514: `keys_unsorted | map(f)` and `keys_unsorted | .[]` no longer probe
 /// the whole object before the first key comes out — they dedup as they walk
 /// and switch to the exact collapsed list only once a hash repeats. That
@@ -22268,40 +22338,41 @@ fn test_undecodable_object_key_does_not_hide_later_fields_1247() {
     assert_eq!(stdout.trim(), r#"["\ud800","b"]"#, "stderr: {stderr}");
 }
 
-/// #1247 follow-up: `keys_unsorted` piped into anything else -- even just a
-/// second comma-generator result, as here -- can no longer stay on the
+/// #1642: `keys_unsorted` piped into anything else -- even just a second
+/// comma-generator result, as here -- can no longer stay on the
 /// genuinely-lazy raw-byte path `test_undecodable_object_key_does_not_hide_later_fields_1247`
 /// pins above; it has to materialize through the same escape-hatch fallback
 /// (`materialize_lazy_keys`/`effective_keys`, #140) that `keys` (sorted) and
-/// `{x: keys_unsorted}` (object construction) already went through. That
-/// fallback decodes every key via `key_str()`, so it inherits #1247's core
-/// rule: an undecodable key raises instead of silently vanishing. Before
-/// this test's fix, the fallback silently dropped the bad key instead
-/// (`keys_unsorted, length` printed `["b"]` then `2`, exit 0) -- the same
-/// swallow this whole issue exists to close, just reachable from a third
-/// angle the original #1247 sweep missed.
+/// `{x: keys_unsorted}` (object construction) already go through.
+///
+/// Before this fix, that fallback raised on an undecodable key
+/// (`keys_unsorted, length` exited 5) where the bare, genuinely-lazy fast
+/// path answered fine -- the same document giving a different answer
+/// depending on which pipeline shape reached it, exactly the inconsistency
+/// #1642 exists to close. It now agrees with the bare path: the key
+/// survives via its raw source span rather than being dropped *or* raised
+/// on. `keys` (sorted) always needed a full decode to sort by, so it goes
+/// through the identical fallback and now agrees too -- properly
+/// re-escaped this time, since it is a real materialized `String`, not a
+/// byte-verbatim echo (a literal `\` in the source doubles to `\\`, unlike
+/// bare `keys_unsorted`'s raw echo).
 #[test]
-fn test_undecodable_key_in_materialized_keys_unsorted_surfaces_as_error_1247() {
+fn test_undecodable_key_in_materialized_keys_unsorted_agrees_with_bare_1642() {
     let input = r#"{"\ud800": 1, "b": 2}"#;
 
     let (stdout, stderr, code) = run_jq_full(&["-c", "keys_unsorted, length"], Some(input))
         .unwrap_or_else(|e| panic!("`keys_unsorted, length` failed to run: {e}"));
-    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
-    assert!(
-        stderr.contains("invalid unicode escape sequence in object key"),
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        stdout.trim(),
+        "[\"\\\\ud800\",\"b\"]\n2",
         "stderr: {stderr}"
     );
 
-    // Same fallback, reached via sorting instead of a second comma result:
-    // `keys` (sorted) always needed a full decode to sort by, even before
-    // this fix, and already raised.
     let (stdout, stderr, code) = run_jq_full(&["-c", "keys"], Some(input))
         .unwrap_or_else(|e| panic!("`keys` failed to run: {e}"));
-    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
-    assert!(
-        stderr.contains("invalid unicode escape sequence in object key"),
-        "stderr: {stderr}"
-    );
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), "[\"\\\\ud800\",\"b\"]", "stderr: {stderr}");
 }
 
 /// #1247 core: a string scalar the semi-index accepted but that cannot be
@@ -22341,19 +22412,24 @@ fn test_decode_failure_surfaces_as_error_1247() {
     }
 }
 
-/// #1247: an undecodable *key* raises too, and does not silently shrink the
-/// object. `to_entries` used to return one entry fewer than the document had
-/// -- `effective_fields`' dedup walk dropped any field whose key wouldn't
-/// decode, before anything could notice.
+/// #1642 (was #1247): an undecodable *key* does not silently shrink the
+/// object -- `to_entries` used to return one entry fewer than the document
+/// had, because `effective_fields`' dedup walk dropped any field whose key
+/// wouldn't decode, before anything could notice. #1247 closed that by
+/// raising instead; #1642 closes it the other way, by preserving the key
+/// via its raw source span, matching `length`/`keys_unsorted`/`.`/`keys`
+/// (which #1247 had left disagreeing with each other -- see
+/// `test_undecodable_key_in_materialized_keys_unsorted_agrees_with_bare_1642`).
+/// Either way, no entry goes missing.
 #[test]
-fn test_decode_failure_in_key_surfaces_as_error_1247() {
+fn test_decode_failure_in_key_preserved_in_to_entries_1642() {
     let doc = r#"{"\ud800": 1, "b": 2}"#;
     let (stdout, stderr, code) = run_jq_full(&["-c", "to_entries"], Some(doc))
         .unwrap_or_else(|e| panic!("failed to run: {e}"));
-    assert_ne!(code, 0, "stdout: {stdout}");
-    assert!(
-        stderr.contains("in object key"),
-        "stderr should name the key as the site: {stderr}"
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stdout.trim(),
+        "[{\"key\":\"\\\\ud800\",\"value\":1},{\"key\":\"b\",\"value\":2}]"
     );
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2829,6 +2829,33 @@ fn test_materializing_route_raises_on_colliding_decode_failure_keys_1642() -> Re
     Ok(())
 }
 
+/// #1642 follow-up: `-e`/`--exit-status` forces `JqValue::materialize()` on
+/// every result before `jq_runner.rs`'s own guarded `print_json` path ever
+/// runs (see `cursor_to_owned`'s doc comment in `src/jq/lazy.rs`) -- a
+/// second, independent materializer from the `-S`/`-s`/`.,.`  routes the
+/// test above covers, with its own `DisplayKeyGuard` call site that a fix
+/// touching only the other three left unexercised. Without `-e`, the same
+/// document streams both colliding keys through untouched (#1385: a
+/// decode-failure key is never a duplicate, so nothing raises); `-e` alone
+/// is what forces the raise.
+#[test]
+fn test_exit_status_materialize_route_raises_on_colliding_decode_failure_keys_1642() -> Result<()> {
+    let dup_doc = r#"{"\ud800":1,"\ud800":2}"#;
+
+    let (out, code) = run_jq_stdin(".", dup_doc, &["-c"])?;
+    assert_eq!(code, 0, "no -e: both keys should stream through untouched");
+    assert_eq!(out.trim(), r#"{"\ud800":1,"\ud800":2}"#);
+
+    let (out, err, code) = run_jq_full(&["-e", "-c", "."], Some(dup_doc))?;
+    assert_ne!(
+        code, 0,
+        "-e should raise rather than silently drop a value, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    Ok(())
+}
+
 /// #1514: `keys_unsorted | map(f)` and `keys_unsorted | .[]` no longer probe
 /// the whole object before the first key comes out — they dedup as they walk
 /// and switch to the exact collapsed list only once a hash repeats. That

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -23489,6 +23489,54 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
     Ok(())
 }
 
+/// #1642 follow-up: two *different* decode-failure keys share the same
+/// display fallback (YAML's is always `""` -- #222) once a materializing
+/// route (`--arg`, `-P`) inserts that fallback into a plain
+/// `IndexMap<String, _>`. #1385 forbids treating two decode-failure keys as
+/// the same key, and the map cannot hold two entries under one string, so
+/// this must raise rather than silently keep only the last value -- the
+/// silent-data-loss regression `DisplayKeyGuard`
+/// (`src/jq/document.rs`) closes.
+#[test]
+fn test_materializing_route_raises_on_colliding_decode_failure_keys_1642() -> Result<()> {
+    let input = "\"a\\qb\": 1\n\"c\\qd\": 2\n";
+    for extra in [&["--arg", "z", "y"][..], &["-P"][..]] {
+        let (output, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, extra)?;
+        assert_eq!(
+            exit_code, 1,
+            "args {extra:?} should raise rather than silently drop a value, output: {output:?}"
+        );
+        assert!(
+            stderr.contains("ambiguous"),
+            "args {extra:?}, stderr: {stderr}"
+        );
+    }
+
+    // A single decode-failure key still preserves fine -- no false positive
+    // from the new guard.
+    let single = "\"a\\qb\": 1\n\"c\": 2\n";
+    let (output, stderr, exit_code) = run_yq_stdin_with_stderr(".", single, &["--arg", "z", "y"])?;
+    assert_eq!(
+        exit_code, 0,
+        "single bad key should still succeed, stderr: {stderr}"
+    );
+    assert_eq!(output.trim(), "'': 1\nc: 2");
+
+    // An ordinary repeated key -- no decode failure on either side -- still
+    // collapses to the last value, matching yq's normal duplicate handling;
+    // the guard must not turn a genuine duplicate into a raise.
+    let ordinary_dup = "a: 1\na: 2\n";
+    let (output, stderr, exit_code) =
+        run_yq_stdin_with_stderr(".", ordinary_dup, &["--arg", "z", "y"])?;
+    assert_eq!(
+        exit_code, 0,
+        "ordinary duplicate key should not raise, stderr: {stderr}"
+    );
+    assert_eq!(output.trim(), "a: 2");
+
+    Ok(())
+}
+
 /// #1620: a decode failure must never be suppressed by `?`, matching how
 /// `try`/`catch` already never catches one -- real yq's equivalent is a
 /// parse-time rejection no program could ever catch either. `\q` is not a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1416,6 +1416,46 @@ fn test_duplicate_json_key_field_access_last_wins_1251() -> Result<()> {
     Ok(())
 }
 
+/// #1642 follow-up: `--slurp`/`--eval-all`/`--inplace`'s own JSON reindex
+/// bridge (`parse_input` -> `to_owned_canonicalizing_numbers_at_depth` in
+/// `yq_runner.rs` -- the one path that genuinely parses `--input-format
+/// json` input as JSON rather than as YAML flow syntax, per #1398) was left
+/// on the old `field.key_str()`, silently dropping a decode-failure key
+/// instead of preserving it via `key_display_string` like every other
+/// materializer this fix touched. Before this fix, `.[0] | length` here
+/// reported `1`, one short of the document's real field count, while
+/// `.[0] | keys` silently omitted the bad key's entry entirely.
+#[test]
+fn test_input_format_json_bridge_preserves_decode_failure_key_1642() -> Result<()> {
+    let json = r#"{"a\q":1,"b":2}"#;
+
+    let (output, code) = run_yq_stdin(
+        ".[0] | length",
+        json,
+        &["--input-format", "json", "--slurp"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2", "--slurp length");
+
+    let (output, code) = run_yq_stdin(
+        ".[0] | keys",
+        json,
+        &["--input-format", "json", "--slurp", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a\\q","b"]"#, "--slurp keys");
+
+    let (output, code) = run_yq_stdin(
+        ".[0] | length",
+        json,
+        &["--input-format", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "2", "--eval-all length");
+
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -23429,16 +23429,23 @@ fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> 
 /// Two routes, deliberately different at this stage of #1247's design (see
 /// `docs/plan/decode-failure-routing.md`):
 ///
-/// * the **materializing** routes raise a real error and exit non-zero;
+/// * the **materializing** routes raise a real error and exit non-zero --
+///   except for a bad *key* (`"a\qb": 1`), which #1642 changed to preserve
+///   instead (via its raw source span, matching YAML's existing
+///   never-drop-a-key convention for a key with no scalar form), so it
+///   stays in this list only for the bad *value* case;
 /// * the **streaming** routes still degrade to `null`/`""` -- but the
 ///   document they emit is now parseable, which is what this test's first
 ///   half pins. Making streaming loud too needs an error channel through
 ///   `stream_json_value`'s `core::fmt::Result`, which is its own stage.
 #[test]
 fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
-    for (input, expected) in [
-        ("b: \"x\\qy\"\n", r#"{"b":null}"#),
-        ("\"a\\qb\": 1\n", r#"{"":1}"#),
+    // `materialized`: `None` if materializing must still raise (a bad
+    // *value*); `Some(json)` if it must now succeed with `json` per result
+    // (a bad *key*, #1642).
+    for (input, streamed, materialized) in [
+        ("b: \"x\\qy\"\n", r#"{"b":null}"#, None),
+        ("\"a\\qb\": 1\n", r#"{"":1}"#, Some(r#"{"":1}"#)),
     ] {
         // Streaming: still degrades, but the emitted JSON is valid. `-P`
         // takes this route too -- it forces pretty-printing, not the DOM.
@@ -23448,22 +23455,35 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
         ] {
             let (output, exit_code) = run_yq_stdin(".", input, extra)?;
             assert_eq!(exit_code, 0, "args {extra:?}, output: {output:?}");
-            assert_eq!(output.trim(), expected, "args {extra:?}");
+            assert_eq!(output.trim(), streamed, "args {extra:?}");
         }
 
         // Materializing: `--arg` forces the DOM path, and a multi-result
-        // filter loses its cursor to `GenericResult::Many`. Both raise.
+        // filter loses its cursor to `GenericResult::Many`.
         for extra in [
             &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
             &["-o", "json", "-I", "0"][..],
         ] {
             let filter = if extra.len() > 4 { "." } else { ".,." };
             let (output, stderr, exit_code) = run_yq_split(filter, input, extra)?;
-            assert_eq!(exit_code, 1, "args {extra:?}, output: {output:?}");
-            assert!(
-                stderr.contains("invalid escape sequence"),
-                "args {extra:?}, stderr: {stderr}"
-            );
+            match materialized {
+                None => {
+                    assert_eq!(exit_code, 1, "args {extra:?}, output: {output:?}");
+                    assert!(
+                        stderr.contains("invalid escape sequence"),
+                        "args {extra:?}, stderr: {stderr}"
+                    );
+                }
+                Some(expected) => {
+                    assert_eq!(exit_code, 0, "args {extra:?}, stderr: {stderr}");
+                    let expected = if filter == ".,." {
+                        format!("{expected}\n{expected}")
+                    } else {
+                        expected.to_string()
+                    };
+                    assert_eq!(output.trim(), expected, "args {extra:?}");
+                }
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Description

For an object with a key whose bytes don't decode (invalid escape, lone surrogate — e.g.
`{"a\q":1,"b":2}`), `succinctly jq` gave contradictory answers depending on which builtin
was asked: `.`/`length`/bare `keys_unsorted`/`.b` already treated the bad key as present
(a deliberate, documented divergence — #1385's "a key that will not decode is never a
duplicate"), but `keys`/`to_entries` raised, and `has()` raised for a third, unrelated
reason. This PR converges all of them on the "preserve" side, since that's the direction
already established by `.`/`length`/bare `keys_unsorted` and the pinned #1385 test.

Root causes:
- `keys`/`to_entries` raised because PR #1391 (the #1247 fix) added an explicit
  `string_decode_error()` check before using the key, to close a *different* swallow (a
  bad key silently vanishing) — without noticing it now contradicted #1385's own rule for
  the same key.
- `has("b")` raised for an unrelated reason: `Builtin::Has` has no native implementation
  in the live evaluator, so it falls through to a catch-all that fully materializes the
  whole object before ever checking for `"b"` — and that materialization raised on the
  first bad key it found anywhere, whether or not it was the key being asked about.

Fix: a new `DocumentValue::key_raw_source_span`/`document::key_display_string` pair
substitutes a key's raw source span (lossily decoded) instead of raising, threaded
through every key guard that used to raise (`DocumentFields::keys`, `to_owned_at_depth`,
`to_owned_cursor_at_depth`, `to_owned_with_comments_at_depth`, `Builtin::ToEntries`,
`lazy_keys_array_to_owned`, `cursor_to_owned_at_depth`). A key the grammar rejects
outright (#1194) still raises, unchanged. `effective_keys` needed a real rewrite (not
just a substitution) to stay collision-safe — see the fix commit's message for why.
`has`/`in` needed no dedicated code: they're fixed for free once `to_owned_at_depth`
stops raising.

Also found and fixed two smaller, previously-undocumented inconsistencies for the same
builtins along the way (see commit messages): `to_owned_with_comments_at_depth` silently
dropped a #1194-malformed field instead of raising, and the library-level
`stream_lazy_keys_json`/`stream_lazy_keys_yaml` writers silently *skipped* a
decode-failure key instead of raising or preserving it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement
- [ ] CI/CD changes

## Related Issue
Fixes #1642

## Changes Made
- `src/jq/document.rs`, `src/json/light.rs`: new `key_raw_source_span`/`key_display_string`
  substitution mechanism; `DocumentFields::keys()` and `effective_keys` rewritten to use it
  without reopening #1385's never-a-duplicate guarantee.
- `src/jq/eval_generic.rs`, `src/jq/lazy.rs`: every `to_owned*`/`to_entries`/
  `lazy_keys_array_to_owned` key guard switched from raise to preserve.
- `src/jq/stream.rs`: `stream_lazy_keys_json`/`stream_lazy_keys_yaml` preserve instead of
  silently skipping a decode-failure key.
- `tests/jq_cli_tests.rs`: inverts two tests that pinned the old raise behavior, adds the
  consolidated `test_undecodable_key_builtins_agree_1642`.
- `tests/yq_cli_tests.rs`: splits a test that conflated a still-raising bad-value case
  with a now-preserving bad-key case (same shared code path, yq mode too).
- `docs/compliance/jq/limitations.md`, `docs/compliance/yq/limitations.md`,
  `docs/plan/decode-failure-routing.md`: updated to describe the new, consistent behavior.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [x] Tested on aarch64/ARM (Apple Silicon dev machine)
- [ ] Tested on x86_64

### Test Commands
```bash
cargo test --features cli,regex   # 2879+ lib tests, 1187 jq CLI tests, yq/doc tests — all green
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
cargo build --no-default-features  # no_std
cargo fmt --check
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
```

Manually re-verified the issue's own repro table against a `--release --features cli`
build — all five builtins now agree:

```console
$ echo '{"a\q":1,"b":2}' | sjq -c 'length, keys, keys_unsorted, to_entries, has("b")'
2
["a\\q","b"]
["a\q","b"]
[{"key":"a\\q","value":1},{"key":"b","value":2}]
true
```

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (include benchmarks below)
- [ ] Potential performance regression (justify below)

No hot-path change: the substitution only fires on the already-cold decode-failure path
(`string_decode_error().is_some()`), which every touched call site already checked before
this PR — the well-formed path is untouched.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

The commit history is split into four logical commits: the core `fix(jq, json)`, then
`test(jq)`/`test(yq)` updating the two integration test suites, then `docs(jq, yq)`
recording the new behavior — each commit message has the full reasoning for its part.
