### PR TITLE
docs(bench): correct two review findings in the codegen-units writeup

### DIFF
--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -937,9 +937,15 @@ scripts/ab-cli.py --before ./succ-base --after ./succ-head \
 ```
 
 The crate's actual `[profile.release]` is deliberately left at Rust's default: pinning
-`codegen-units = 1` there measured **1.98x-3.0x slower clean release builds** with no benefit to
-the interactive edit-compile-test loop, which uses debug builds, not release — so this is a
-benchmarking-time convention, not a shipped build setting.
+`codegen-units = 1` there costs real compile time, with no benefit to the interactive
+edit-compile-test loop, which uses debug builds, not release — so this is a benchmarking-time
+convention, not a shipped build setting. Three interleaved clean `cargo build --release --features
+cli` reps (18-core Apple M5 Max, `Johns-M5-Pro-Max` — a development machine running concurrent
+work, not one of the idle bench boxes named elsewhere in this guide, so treat this as directional)
+measured **1.4x-1.9x slower** (median 1.8x; 28.9s/24.1s/31.2s at `codegen-units=16` vs
+51.4s/46.9s/42.3s paired at `codegen-units=1`). The multiplier scales with available parallelism —
+losing per-crate codegen concurrency costs more on a wider machine — so don't expect a fixed ratio
+across hardware.
 
 Also worth knowing: #595's x86-only 12-28% `block_scalars` anomaly was closed as "expected, no
 action — binary code-layout artifact from the recompile," using cachegrind to show flat

--- a/docs/plan/cspoppy.md
+++ b/docs/plan/cspoppy.md
@@ -526,12 +526,13 @@ with "mechanism unconfirmed, no ARM instruction-counting tool available."
 | long_50x100lines   | -2.6%    | -1.8%       |
 | long_100x100lines  | -0.4%    | -2.1%       |
 
-Short shapes stay inside §5b's own established control band (-1.0%..+0.4%)
-either way — consistent with the original "neutral" call, which was correct
-on those four shapes and is why they weren't the ones under suspicion. The
-`long_*` "improvement" #649 could not explain shrinks from ~7-10% to
-~0-2.6% under the identical pin that erased #595's x86 regression. A small
-residual remains at 9 reps and isn't chased further here — an order of
+Short shapes stay noise-level small either way (-1.3%..+1.4% across both
+runs, close to but slightly wider than §5b's own established -1.0%..+0.4%
+control band) — consistent with the original "neutral" call, which was
+correct on those four shapes and is why they weren't the ones under
+suspicion. The `long_*` "improvement" #649 could not explain shrinks from
+~7-10% to ~0-2.6% under the identical pin that erased #595's x86 regression.
+A small residual remains at 9 reps and isn't chased further here — an order of
 magnitude smaller than the original effect, and #649's own framing
 ("improvement, not a regression, no user-facing harm, revisit if it ever
 flips to a regression") already covers a residual this size.


### PR DESCRIPTION
## Summary
- Follow-up to #1587 / #1667, which merged before this review pass landed.
- Rule 9's "1.98x-3.0x slower clean release builds" claim cited no host, rep count, or build command, unlike every other figure in that guide. Replaced with an interleaved 3-rep measurement (18-core Apple M5 Max, explicitly noted as a non-idle dev machine) and a note that the multiplier scales with available parallelism.
- `docs/plan/cspoppy.md` §5d claimed the ARM short shapes "stay inside §5b's own established control band (-1.0%..+0.4%) either way", which the two tables directly above it contradict (e.g. `10x10lines` reads +1.4%/-1.3%). Restated as the actual observed range.

## Test plan
- Docs-only change; no code or behavior affected.
- Verified the corrected build-time figures against 3 interleaved `cargo build --release --features cli` reps on this machine.
- Verified the corrected short-shape range against the existing tables in the same section.