### PR TITLE
fix(yq): stop discarding earlier valid files on a later --validate failure

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -498,14 +498,9 @@ fn apply_front_matter(
     Ok((fm.yaml.to_vec(), InputFormat::Yaml, body))
 }
 
-/// The result of [`gather_input_sources`]: either the gathered sources, or
-/// an exit code from a failed `--validate` check that the caller must
-/// return immediately, mirroring [`yaml_validate_guard`]'s "bail with this
-/// code" contract at each of this function's now-single call site.
-enum GatheredSources {
-    Sources(Vec<(Vec<u8>, InputFormat, Option<Vec<u8>>)>),
-    ExitCode(i32),
-}
+/// One gathered input source: its bytes, resolved format, and (only under
+/// `--front-matter=process`) the untouched body carried alongside it.
+type GatheredSource = (Vec<u8>, InputFormat, Option<Vec<u8>>);
 
 /// Reads each input source -- stdin if `input_files` is empty, else each
 /// file in listed order -- applying `--front-matter` (a no-op unless the
@@ -515,12 +510,22 @@ enum GatheredSources {
 /// this identical stdin-or-per-file gather step; each `--front-matter`
 /// body is `None` unless `front_matter` is `Some(Process)`, same contract
 /// as `apply_front_matter`.
+///
+/// Stops at the first source that fails `--validate` (matching jq's own
+/// stop-at-first-failure semantics, #1558) and returns the exit code for
+/// it alongside every earlier source that DID pass. The caller decides
+/// what to do with that valid prefix: `--slurp`/`--eval-all` discard it
+/// (both combine every source into one value, so a partial set can't
+/// stand in for "every file combined"), while the per-file-independent
+/// paths (the default path, `--split-exp`) process and emit it before
+/// reporting the failure -- matching the M2-streaming path's own
+/// already-established "earlier valid output survives" behavior (#1564).
 fn gather_input_sources(
     input_files: &[String],
     input_format: InputFormat,
     front_matter: Option<FrontMatterMode>,
     validate: bool,
-) -> Result<GatheredSources> {
+) -> Result<(Vec<GatheredSource>, Option<i32>)> {
     let mut sources = Vec::new();
     if input_files.is_empty() {
         let raw_bytes = read_stdin()?;
@@ -528,7 +533,7 @@ fn gather_input_sources(
         let (input_bytes, format, body) =
             apply_front_matter(raw_bytes, resolved_format, front_matter, "<stdin>")?;
         if let Some(code) = yaml_validate_guard(&input_bytes, format, validate, None) {
-            return Ok(GatheredSources::ExitCode(code));
+            return Ok((sources, Some(code)));
         }
         sources.push((input_bytes, format, body));
     } else {
@@ -540,12 +545,12 @@ fn gather_input_sources(
                 apply_front_matter(raw_bytes, resolved_format, front_matter, file_path)?;
             if let Some(code) = yaml_validate_guard(&input_bytes, format, validate, Some(file_path))
             {
-                return Ok(GatheredSources::ExitCode(code));
+                return Ok((sources, Some(code)));
             }
             sources.push((input_bytes, format, body));
         }
     }
-    Ok(GatheredSources::Sources(sources))
+    Ok((sources, None))
 }
 
 /// Materializes a `DocumentValue` into an `OwnedValue` the same way
@@ -3108,6 +3113,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // output and all-falsy output alike as "no matches found".
     let mut any_truthy = false;
 
+    // #1564: set by the default path / --split-exp when
+    // `gather_input_sources` finds a later file that fails `--validate` --
+    // rather than bailing immediately (losing the earlier files' already-
+    // valid output, the bug this exists to fix), those two branches still
+    // process/emit whatever passed and defer reporting the failure's exit
+    // code until the shared tail below, after that output is written.
+    let mut deferred_validate_exit_code: Option<i32> = None;
+
     // Uncaught evaluation errors. Evaluation continues past one, so the failure
     // is remembered here and turned into yq's exit 1 below (#355).
     let mut sink = ErrorSink::default();
@@ -3572,15 +3585,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // `evaluate_input`, so `file_index` resolves against that side table.
         // `--front-matter` is rejected in combination above, so every
         // gathered body is `None` here.
-        let input_sources = match gather_input_sources(
+        let (input_sources, validate_exit_code) = gather_input_sources(
             &input_files,
             args.input_format,
             args.front_matter,
             args.validate,
-        )? {
-            GatheredSources::Sources(s) => s,
-            GatheredSources::ExitCode(code) => return Ok(code),
-        };
+        )?;
+        if let Some(code) = validate_exit_code {
+            // #1564: --eval-all combines every source into one evaluation
+            // (see below), so a partial set missing the file that failed
+            // (and everything after it) can't stand in for "every file
+            // combined" -- bail before evaluating anything, unlike the
+            // per-file-independent paths this issue actually fixes.
+            return Ok(code);
+        }
 
         // #1493 review: this branch was missed by the original fix --
         // every other output-producing branch resolves `Auto` per-source,
@@ -3690,15 +3708,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         } else {
             // `--front-matter` is rejected in combination above, so every
             // gathered body is `None` here.
-            let input_sources = match gather_input_sources(
+            let (input_sources, validate_exit_code) = gather_input_sources(
                 &input_files,
                 args.input_format,
                 args.front_matter,
                 args.validate,
-            )? {
-                GatheredSources::Sources(s) => s,
-                GatheredSources::ExitCode(code) => return Ok(code),
-            };
+            )?;
+            // #1564: unlike --eval-all/--slurp, each file's split output is
+            // already written independently of the others (the loop below)
+            // -- process whatever passed and report the failure once done,
+            // instead of losing every earlier file's already-valid output.
+            deferred_validate_exit_code = validate_exit_code;
 
             let mut global_doc_index: usize = 0;
             'files: for (bytes, format, _) in &input_sources {
@@ -3836,15 +3856,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // mode is rejected above since a slurped array can't reattach a body
         // per input file) is applied before validation, since the raw
         // file bytes (e.g. Markdown) aren't valid standalone YAML.
-        let input_sources = match gather_input_sources(
+        let (input_sources, validate_exit_code) = gather_input_sources(
             &input_files,
             args.input_format,
             args.front_matter,
             args.validate,
-        )? {
-            GatheredSources::Sources(s) => s,
-            GatheredSources::ExitCode(code) => return Ok(code),
-        };
+        )?;
+        if let Some(code) = validate_exit_code {
+            // #1564: --slurp combines every source into one array (see
+            // below), so a partial set can't stand in for "the slurped
+            // array of every file" -- bail before evaluating anything,
+            // unlike the per-file-independent paths this issue fixes.
+            return Ok(code);
+        }
 
         if can_slurp_fast_path {
             // M2 streaming fast path (#478): stream each source's document
@@ -4281,15 +4305,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // Markdown) aren't valid standalone YAML; `process` mode's body is
         // carried alongside each source for reattachment in the output loop
         // below.
-        let input_sources = match gather_input_sources(
+        let (input_sources, validate_exit_code) = gather_input_sources(
             &input_files,
             args.input_format,
             args.front_matter,
             args.validate,
-        )? {
-            GatheredSources::Sources(s) => s,
-            GatheredSources::ExitCode(code) => return Ok(code),
-        };
+        )?;
+        // #1564: each file's results are collected/emitted independently
+        // of the others (the two loops below) -- process whatever passed
+        // and report the failure once done, instead of losing every
+        // earlier file's already-valid output the way this path used to.
+        deferred_validate_exit_code = validate_exit_code;
 
         // Process all inputs first to collect results, then determine multi-doc status
         // This avoids double-parsing YAML for document counting
@@ -4427,6 +4453,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // stops evaluating further input as soon as it's requested, but still
     // finishes writing whatever output it already had buffered/collected.
     if let Some(code) = sink.halted() {
+        return Ok(code);
+    }
+
+    // #1564: a `--validate` failure on a later file, discovered up front
+    // during gathering, outranks the normal success/hit/falsy
+    // determination below -- but every earlier file that DID pass
+    // validation was still processed/emitted above (see
+    // `deferred_validate_exit_code`'s own comment). A halt during that
+    // processing still wins, same precedence the M2-streaming path
+    // already gives it (checked immediately above).
+    if let Some(code) = deferred_validate_exit_code {
         return Ok(code);
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12893,6 +12893,110 @@ fn test_eval_all_validate_rejects_invalid_yaml_from_file() -> Result<()> {
     Ok(())
 }
 
+/// #1564: the default (DOM) path used to discard *every* file's output on
+/// a later file's `--validate` failure -- unlike the M2-streaming path
+/// (jq's own sibling: `test_validate_multi_file_second_invalid_keeps_
+/// first_files_output_1558`), which already preserved an earlier valid
+/// file's output. `[.]` forces the DOM path (never M2-streaming-eligible).
+#[test]
+fn test_dom_path_validate_multi_file_second_invalid_keeps_first_files_output_1564() -> Result<()> {
+    let mut good_file = NamedTempFile::new()?;
+    writeln!(good_file, "ok: 1")?;
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: [1, 2")?;
+    let (stdout, stderr, code) = run_yq_files(
+        "[.]",
+        &[good_file.path(), bad_file.path()],
+        &["-o", "json", "--validate"],
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(
+        stdout, "[\n  {\n    \"ok\": 1\n  }\n]\n",
+        "the first file's valid output survives"
+    );
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// #1564 sibling: `--split-exp` also processes/emits each file
+/// independently (one split file per file), so it gets the same fix --
+/// the first file's split output must be written before the second
+/// file's validation failure is reported.
+#[test]
+fn test_split_exp_validate_multi_file_second_invalid_keeps_first_files_output_1564() -> Result<()> {
+    let dir = TempDir::new()?;
+    let mut good_file = NamedTempFile::new()?;
+    writeln!(good_file, "ok: 1")?;
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: [1, 2")?;
+    let pattern = format!(
+        "\"{}/out_\" + ($index|tostring) + \".yml\"",
+        dir.path().display()
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--split-exp", &pattern, "--validate"])
+        .arg(".")
+        .arg(good_file.path())
+        .arg(bad_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    let content = std::fs::read_to_string(dir.path().join("out_0.yml"))?;
+    assert_eq!(content, "ok: 1\n", "the first file's split output survives");
+    assert!(
+        !dir.path().join("out_1.yml").exists(),
+        "the second (invalid) file must not produce a split output"
+    );
+    Ok(())
+}
+
+/// #1564: `--slurp` combines every file into one array, so -- unlike the
+/// default path and `--split-exp` above -- it must keep discarding
+/// everything on any file's `--validate` failure; a partial array can't
+/// stand in for "every file slurped together".
+#[test]
+fn test_slurp_validate_multi_file_second_invalid_still_discards_everything_1564() -> Result<()> {
+    let mut good_file = NamedTempFile::new()?;
+    writeln!(good_file, "ok: 1")?;
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: [1, 2")?;
+    let (stdout, stderr, code) = run_yq_files(
+        ".",
+        &[good_file.path(), bad_file.path()],
+        &["--slurp", "--validate"],
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(stdout, "", "a partial slurped array must never be emitted");
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// #1564 sibling to the `--slurp` case above: `--eval-all` also combines
+/// every file into one evaluation, so it keeps the same all-or-nothing
+/// behavior on a later file's `--validate` failure.
+#[test]
+fn test_eval_all_validate_multi_file_second_invalid_still_discards_everything_1564() -> Result<()> {
+    let mut good_file = NamedTempFile::new()?;
+    writeln!(good_file, "ok: 1")?;
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: [1, 2")?;
+    let (stdout, stderr, code) = run_yq_files(
+        ".",
+        &[good_file.path(), bad_file.path()],
+        &["--eval-all", "--validate"],
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "a partial combined evaluation must never be emitted"
+    );
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
 /// Regression test for the `needs_path_context`/`Compare` runtime-arm fix
 /// (#715): `key` used inside `select(...)`'s condition previously produced
 /// no output at all, independent of `--eval-all`.


### PR DESCRIPTION
## Summary

`succinctly yq --validate` gave two different answers for the identical two files
depending only on whether the filter happened to be M2-streaming-eligible:

```console
$ succinctly yq --validate '[.]' good1.yaml bad2.yaml     # non-M2 filter (DOM path)
yq: validation error: unclosed flow collection '{'
  --> bad2.yaml:2:1
                                                            # <-- good1.yaml's output: NONE
exit 3

$ succinctly yq --validate '.' good1.yaml bad2.yaml        # M2-streaming-eligible filter
yq: validation error: unclosed flow collection '{'
  --> bad2.yaml:2:1

{"a": 1}                                                   # <-- good1.yaml's output: present
exit 3
```

Root cause: `gather_input_sources` validated every input file in a loop and, on the
first failure, discarded the `sources` Vec built so far -- including any
already-validated-good entries -- returning an early exit code with nothing gathered.
Every DOM-path call site then had nothing to process, so no output was ever written.

`--validate` is a succinctly-only extension (confirmed: neither `/usr/bin/jq` 1.7.1 nor
Homebrew `yq` v4.53.3 has this flag), so this is purely an internal-consistency question,
not a jq/yq fidelity one.

## Investigation: 4 call sites, not 1 "DOM path"

The issue's own suggested-fix section flagged this as needing investigation. Reading
each of `gather_input_sources`'s 4 call sites found they have genuinely different
semantics:

- **`--slurp` / `--eval-all`**: combine every source into *one* array/evaluation.
  Bailing entirely on any file's validation failure (no partial output) is correct here
  -- a partial set can't sensibly stand in for "every file combined". **Unchanged.**
- **the default path / `--split-exp`**: process and emit each file's results
  independently of the others. These now use whatever prefix of sources passed
  validation and defer reporting the failure until after that valid prefix's output is
  written -- matching the M2-streaming path's already-established behavior.

## Fix

`gather_input_sources` now returns `(Vec<sources>, Option<i32>)` instead of an
all-or-nothing enum: whatever prefix of sources passed validation, plus the failing
exit code if one occurred (still stopping at the first failure, matching jq's own
`--validate` semantics). Each call site decides what to do with a partial result per its
own semantics (see above). A new `deferred_validate_exit_code` variable lets the
default path / `--split-exp` process/emit their valid prefix before returning the
recorded failure code from the function's shared tail, right after the existing
halt-precedence check (a halt during that processing still wins, same precedence the
M2 path already gives it).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo test --features cli,simd,regex,serde` -- 55/55 test binaries pass, 0 failures
- [x] 4 new tests: default-path and `--split-exp` now preserve an earlier valid file's
      output (mirroring jq's own `--validate` guarantee); `--slurp` and `--eval-all`
      confirmed to still discard everything on any failure (unchanged, deliberate)
- [x] Live-verified all 4 call sites via the built CLI (including inspecting the actual
      split file written by `--split-exp`)

Fixes #1564
