### PR TITLE
fix(jq): flush stdout explicitly before --validate's lazy-path early return

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -25,8 +25,8 @@ use succinctly::json::JsonIndex;
 
 use super::JqCommand;
 use crate::output::{
-    self, escape_json_string, escape_json_string_ascii, exit_codes, ColorScheme, ControlEscape,
-    DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts,
+    self, escape_json_string, escape_json_string_ascii, exit_codes, flush_then_err, ColorScheme,
+    ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts,
 };
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -1254,11 +1254,11 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                             // in this same run, and a genuine (non-malformed-
                             // document) error here shouldn't leave that
                             // relying on `Drop`'s own best-effort,
-                            // error-swallowing flush.
-                            None => {
-                                out.flush()?;
-                                return Err(e);
-                            }
+                            // error-swallowing flush. `flush_then_err`
+                            // (review of #1673) keeps `e` as the reported
+                            // error even if the flush also fails, instead of
+                            // the flush error silently displacing it.
+                            None => return flush_then_err(&mut out, e),
                         }
                     }
                     // result is dropped here, freeing its memory immediately

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1161,6 +1161,14 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
             // Validate JSON if --validate flag is set
             if args.validate {
                 if let Err(exit_code) = validate_json_input(raw, filename.as_deref()) {
+                    // Every other early return in this function flushes
+                    // explicitly before returning (#1563) -- this one used
+                    // to rely on `out`'s own `Drop` impl to flush any
+                    // already-buffered output from files processed before
+                    // this one, which works today but silently swallows a
+                    // flush error (e.g. a closed stdout) instead of
+                    // propagating it, unlike every sibling return path.
+                    out.flush()?;
                     return Ok(exit_code);
                 }
             }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1161,13 +1161,18 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
             // Validate JSON if --validate flag is set
             if args.validate {
                 if let Err(exit_code) = validate_json_input(raw, filename.as_deref()) {
-                    // Every other early return in this function flushes
-                    // explicitly before returning (#1563) -- this one used
-                    // to rely on `out`'s own `Drop` impl to flush any
-                    // already-buffered output from files processed before
-                    // this one, which works today but silently swallows a
-                    // flush error (e.g. a closed stdout) instead of
-                    // propagating it, unlike every sibling return path.
+                    // Every other return from this loop that can run after
+                    // `out` has already buffered real output flushes
+                    // explicitly first (#1563; review: not a blanket claim
+                    // about the whole function -- the separate materializing
+                    // branch below has its own early returns that provably
+                    // run before anything is ever written to `out`, so
+                    // nothing to flush there). This one used to rely on
+                    // `out`'s own `Drop` impl to flush any already-buffered
+                    // output from files processed before this one, which
+                    // works today but silently swallows a flush error (e.g.
+                    // a closed stdout) instead of propagating it, unlike
+                    // every sibling return path in this loop.
                     out.flush()?;
                     return Ok(exit_code);
                 }
@@ -1243,7 +1248,17 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                                 sink.report(DiagStyle::Jq, err, &at);
                                 break;
                             }
-                            None => return Err(e),
+                            // Same reasoning as the `--validate` early
+                            // return above (#1563): `out` can already hold
+                            // buffered output from earlier documents/files
+                            // in this same run, and a genuine (non-malformed-
+                            // document) error here shouldn't leave that
+                            // relying on `Drop`'s own best-effort,
+                            // error-swallowing flush.
+                            None => {
+                                out.flush()?;
+                                return Err(e);
+                            }
                         }
                     }
                     // result is dropped here, freeing its memory immediately

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -227,6 +227,25 @@ impl ErrorSink {
     }
 }
 
+/// Flush `writer`'s already-buffered output, then return `err` (#1673).
+///
+/// A multi-file/multi-document run can hit a real error after `writer`
+/// already holds output from earlier documents/files; relying on
+/// `Drop`'s own best-effort flush would silently swallow a write failure
+/// instead of propagating it. If the flush itself also fails, `err` is
+/// not discarded in favor of the flush error -- it's kept as the
+/// returned error's primary message, with the flush failure layered on
+/// as additional context.
+pub fn flush_then_err<W: std::io::Write, T>(
+    writer: &mut W,
+    err: anyhow::Error,
+) -> anyhow::Result<T> {
+    if let Err(flush_err) = writer.flush() {
+        return Err(err.context(format!("(also failed to flush output: {flush_err})")));
+    }
+    Err(err)
+}
+
 /// Print build configuration information (similar to jq --build-configuration)
 pub fn print_build_configuration(tool: &str) {
     println!("succinctly {tool} build configuration:");

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -241,7 +241,15 @@ pub fn flush_then_err<W: std::io::Write, T>(
     err: anyhow::Error,
 ) -> anyhow::Result<T> {
     if let Err(flush_err) = writer.flush() {
-        return Err(err.context(format!("(also failed to flush output: {flush_err})")));
+        // Deliberately not `err.context(...)`: anyhow's `.context(C)` makes
+        // `C` the new top-level `Display` message and demotes the receiver
+        // to the cause chain (visible only via `{:?}`) -- the opposite of
+        // what's documented above. Folding the flush error into a single
+        // message keeps `err`'s own text as the primary, readable-under-
+        // `{}` content (review of #1673).
+        return Err(anyhow::anyhow!(
+            "{err} (also failed to flush output: {flush_err})"
+        ));
     }
     Err(err)
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3477,6 +3477,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 if let Some(code) =
                     yaml_validate_guard(&yaml_bytes, fmt, args.validate, Some(file_path))
                 {
+                    // Sibling of jq_runner.rs's identical fix (#1563): a
+                    // later file's validation failure can fire after
+                    // `writer` already buffered real output from earlier
+                    // files in this same `'m2_files` loop. The halt case
+                    // just above (`break 'm2_files`) reaches this
+                    // function's own tail `writer.flush()?` by falling
+                    // through; this early `return` doesn't, and used to
+                    // rely on `writer`'s `Drop` impl instead -- which
+                    // silently swallows a flush error rather than
+                    // propagating it.
+                    writer.flush()?;
                     return Ok(code);
                 }
                 let mut index = YamlIndex::build(&yaml_bytes)

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -29,8 +29,8 @@ use succinctly::yaml::{
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
-    self, exit_codes, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation,
-    JsonFormatOpts,
+    self, exit_codes, flush_then_err, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle,
+    InputLocation, JsonFormatOpts,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -3472,7 +3472,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         } else {
             'm2_files: for file_path in &input_files {
                 let path = Path::new(file_path);
-                let yaml_bytes = read_file(path)?;
+                // A later file's read failure can fire after `writer`
+                // already buffered real output from earlier files in this
+                // same loop (review of #1673, same class as the
+                // `yaml_validate_guard`/`YamlIndex::build` returns just
+                // below) -- `flush_then_err` keeps this error as the
+                // reported one even if the flush also fails.
+                let yaml_bytes = match read_file(path) {
+                    Ok(bytes) => bytes,
+                    Err(e) => return flush_then_err(&mut writer, e),
+                };
                 let fmt = resolve_input_format(args.input_format, Some(path));
                 if let Some(code) =
                     yaml_validate_guard(&yaml_bytes, fmt, args.validate, Some(file_path))
@@ -3490,8 +3499,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     writer.flush()?;
                     return Ok(code);
                 }
-                let mut index = YamlIndex::build(&yaml_bytes)
-                    .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
+                let mut index = match YamlIndex::build(&yaml_bytes) {
+                    Ok(index) => index,
+                    Err(e) => {
+                        let e = anyhow::anyhow!("YAML parse error in {file_path}: {e}");
+                        return flush_then_err(&mut writer, e);
+                    }
+                };
                 if fmt == InputFormat::Json {
                     index.mark_json_sourced();
                 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12918,6 +12918,33 @@ fn test_dom_path_validate_multi_file_second_invalid_keeps_first_files_output_156
     Ok(())
 }
 
+/// #1563 sibling: the plain (non-`--eval-all`) multi-file `--validate` path
+/// streams each file's output as it's processed, so a later file's
+/// validation failure can fire after an earlier file's output is already
+/// buffered -- jq's own identical case (`test_validate_multi_file_second_
+/// invalid_keeps_first_files_output_1558`). Confirms the first file's
+/// output still reaches stdout (an explicit flush now guarantees this
+/// rather than relying on `Drop`'s own best-effort, error-swallowing one).
+#[test]
+fn test_validate_multi_file_second_invalid_keeps_first_files_output_1563() -> Result<()> {
+    let mut good_file = NamedTempFile::new()?;
+    writeln!(good_file, "ok: 1")?;
+    let mut bad_file = NamedTempFile::new()?;
+    writeln!(bad_file, "a: [1, 2")?;
+    let (stdout, stderr, code) = run_yq_files(
+        ".",
+        &[good_file.path(), bad_file.path()],
+        &["-o", "json", "--validate"],
+    )?;
+    assert_ne!(code, 0);
+    assert_eq!(
+        stdout, "{\n  \"ok\": 1\n}\n",
+        "the first file's valid output survives"
+    );
+    assert!(stderr.contains("validation error"), "stderr: {stderr}");
+    Ok(())
+}
+
 /// #1564 sibling: `--split-exp` also processes/emits each file
 /// independently (one split file per file), so it gets the same fix --
 /// the first file's split output must be written before the second


### PR DESCRIPTION
## Summary

`run_jq`'s lazy path (`src/bin/succinctly/jq_runner.rs`) had an early return
that skipped the function's own explicit-flush convention every other early
return follows:

```rust
if args.validate {
    if let Err(exit_code) = validate_json_input(raw, filename.as_deref()) {
        return Ok(exit_code);   // <-- no out.flush() here
    }
}
```

`out`/`writer` in both `run_jq` and `run_yq` are `BufWriter::new(stdout.lock())`.
`BufWriter::drop` performs a best-effort flush when they go out of scope, so
already-buffered output from files processed before a failing one still
reaches stdout in practice today — but that correctness rested on `Drop`,
which silently **swallows** any flush error (e.g. a broken pipe) instead of
propagating it, unlike an explicit `.flush()?`.

## What grew during review

Code review on the initial one-line fix found the identical bug in
`yq_runner.rs`'s own multi-file `'m2_files` streaming loop (three sites:
`read_file`, `yaml_validate_guard`, `YamlIndex::build`), plus a real bug in
the shared `flush_then_err` helper this PR introduced: `err.context(flush_msg)`
made the *flush* failure the primary displayed message instead of the
original error, the opposite of the helper's own documented intent —
verified against `anyhow`'s actual `Context`/`Display` source. All three
fixed in follow-up commits, each re-verified with a full local test run.

A deeper multi-angle review pass then confirmed the fix is correct as far as
it goes, but incomplete relative to the *general* pattern: several more
structurally identical unguarded-write sites exist in both files (e.g.
`yq_runner.rs`'s `stream_cursor!` macro and DOM "collect" path,
`jq_runner.rs`'s DSV loop and materializing-branch loops). Chasing all of
those here would have turned a narrow bug fix into a much larger refactor of
two ~5,000-line functions with no clear stopping point, so the remaining
sites and the review's suggested architectural direction (a flush-on-Drop
safety net at writer construction, instead of per-site annotation) are
tracked in #1680 instead of folded into this PR.

## Fix

- `out.flush()?`/`writer.flush()?` before the early returns named above.
- `output.rs::flush_then_err`, shared by both runners: flushes before
  propagating a real error, and — if the flush itself also fails — keeps the
  original error as the primary message rather than losing it.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo test --features cli,simd,regex,serde` — 55/55 test binaries pass, 0 failures (re-run after every round of changes, including post-rebase)
- [x] New test: `test_validate_multi_file_second_invalid_keeps_first_files_output_1563` (`tests/yq_cli_tests.rs`), mirroring the existing jq-side sibling test for the same bug class
- [x] All existing `--validate`-related tests pass unchanged
- [x] Live-verified both the `--validate` and plain-YAML-parse-error multi-file cases via the built CLI

Fixes #1563

