### PR TITLE
fix(yq): stop -I0's DOM path from collapsing nested containers

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -252,9 +252,15 @@ what a construct loses, the question to ask is which output route it takes, not 
 implements** — a construct on the DOM route loses everything the DOM cannot carry, all at
 once.
 
-The `-I0` nesting bug that surfaced along the way is *wider* than `map` and is not fixed:
-`to_entries -I=0` still emits a nested container at its parent's indent, while `-P -I=0` is
-correct for both. #757 only closed the route `map` took into it.
+The `-I0` nesting bug that surfaced along the way was *wider* than `map`: any filter
+`can_use_m2_streaming` rejects (`to_entries`, `with_entries`, `walk`, `--arg`-bearing
+queries, ...) reached the DOM emitter with an empty per-level indent string at `-I0`,
+corrupting nested containers on read-back regardless of which construct routed it there.
+#757 only closed the route `map` took into it; the underlying DOM-emitter bug itself was
+fixed generally, for every construct that reaches the DOM path, by
+[#1575](https://github.com/rust-works/succinctly/issues/1575) — `OutputConfig::compute_indent_str`
+now clamps `-I0`'s YAML indent width to 2 (the same convention the M2 streaming path already
+used for its own `-I0`) instead of collapsing to an empty string.
 
 ### `input`, `inputs`, `input_line_number` are rejected, but at runtime rather than parse time
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -255,12 +255,27 @@ once.
 The `-I0` nesting bug that surfaced along the way was *wider* than `map`: any filter
 `can_use_m2_streaming` rejects (`to_entries`, `with_entries`, `walk`, `--arg`-bearing
 queries, ...) reached the DOM emitter with an empty per-level indent string at `-I0`,
-corrupting nested containers on read-back regardless of which construct routed it there.
-#757 only closed the route `map` took into it; the underlying DOM-emitter bug itself was
-fixed generally, for every construct that reaches the DOM path, by
+corrupting nested containers on read-back regardless of which construct routed it there —
+the earlier claim that `-P -I=0` was already correct for this case was itself false
+(verified live against the pre-#1575 binary: `-P` doesn't force the DOM path for an
+M2-streamable filter, since `can_yaml_fast_path`'s gate is already satisfied by `-I0`'s own
+`compact` flag regardless of `-P`), not merely superseded by the fix below. #757 only
+closed the route `map` took into it; the underlying DOM-emitter bug itself was fixed
+generally, for every construct that reaches the DOM path, by
 [#1575](https://github.com/rust-works/succinctly/issues/1575) — `OutputConfig::compute_indent_str`
 now clamps `-I0`'s YAML indent width to 2 (the same convention the M2 streaming path already
 used for its own `-I0`) instead of collapsing to an empty string.
+
+**Residual divergence, deliberately not chased by #1575**: real yq's own `-I0` is not width
+2 — it's empirically identical to its own `-I4` output (verified live against v4.53.3),
+plus an irregular per-level quirk beyond even that (a compact block-sequence item's inlined
+mapping doesn't increment its own indent depth for the purpose of computing its fields'
+children, so the jump from the mapping's own line to its first nested level is narrower
+than every jump after it). Neither succinctly output route models this — both settle for a
+uniform width-2 step, matching each other but not the oracle. Widening to width 4 alone
+would still not close the gap (the irregular per-level part is unmodeled by both routes at
+every non-default `-I` width, not just `-I0`), so this remains open rather than folded into
+#1575's fix.
 
 ### `input`, `inputs`, `input_line_number` are rejected, but at runtime rather than parse time
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1114,7 +1114,9 @@ pub struct YqCommand {
     #[arg(long)]
     pub tab: bool,
 
-    /// Sets indent level for output (default 2). Use 0 for compact output.
+    /// Sets indent level for output (default 2). 0 means compact/flow for
+    /// JSON output, but for YAML (whose block style can't go flow-compact
+    /// the same way) means "use a small default width" instead (#1575).
     #[arg(short = 'I', long, value_name = "N", default_value = "2", value_parser = clap::value_parser!(u8).range(0..=7))]
     pub indent: u8,
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -199,16 +199,20 @@ impl OutputConfig {
         }
     }
 
-    /// `-I1` clamps to 2 for YAML output (#1486): real yq's YAML output at
-    /// `-I1` is byte-identical to its own `-I2` output at every level,
-    /// mirroring the fast-path streamer's identical clamp on
-    /// `yaml_indent_spaces` below. JSON has no such quirk (verified live:
-    /// `-I1 -o=json` genuinely indents 1 space per level in real yq) --
-    /// `indent_str` is shared by both formats' DOM emitters (see its use in
-    /// the JSON branch of `output_value`), so the clamp only applies when
-    /// `output_value` will actually take the YAML branch, i.e.
-    /// `effective_output_format == Yaml` exactly -- matching that
-    /// dispatch's own condition, not its complement.
+    /// `-I0`/`-I1` both clamp to width 2 for YAML output (#1486, #1575):
+    /// real yq's YAML output at `-I1` is byte-identical to its own `-I2`
+    /// output at every level, mirroring the fast-path streamer's identical
+    /// clamp on `yaml_indent_spaces` below; `-I0` reuses the same clamp
+    /// rather than modeling real yq's own irregular `-I0`-behaves-like-`-I4`
+    /// quirk (see `compute_indent_str`'s own comment on the clamp). JSON has
+    /// no such quirk (verified live: `-I1 -o=json` genuinely indents 1
+    /// space per level in real yq, and `-I0 -o=json` means compact/flow,
+    /// handled separately by `OutputConfig::compact`) -- `indent_str` is
+    /// shared by both formats' DOM emitters (see its use in the JSON branch
+    /// of `output_value`), so the clamp only applies when `output_value`
+    /// will actually take the YAML branch, i.e. `effective_output_format ==
+    /// Yaml` exactly -- matching that dispatch's own condition, not its
+    /// complement.
     ///
     /// Takes the caller's *effective* format rather than reading
     /// `args.output_format` directly: `Self::from_args` passes
@@ -220,30 +224,23 @@ impl OutputConfig {
     /// unconditionally, since `-o=auto` always rendered JSON regardless of
     /// input format anyway.
     fn compute_indent_str(args: &YqCommand, effective_output_format: OutputFormat) -> String {
-        if args.indent == 0 {
-            // YAML's significant whitespace means an empty indent string
-            // collapses every nesting level onto the same column, corrupting
-            // the document on read-back (#1575: a nested nested container
-            // under `-I=0` silently disappears). Real yq's own `-I0` behaves
-            // like a nonzero width with its own irregular per-level quirk
-            // this DOM emitter doesn't otherwise model; mirror the M2
-            // streaming fast path's own pre-existing, documented `-I0`
-            // choice of width 2 (`yaml_indent_spaces` below) instead of
-            // chasing that exact quirk. JSON is unaffected: `-I0` there
-            // means compact/flow, and `OutputConfig::compact` already
-            // forces JSON's own indent to `""` independently of this
-            // string.
-            return match (effective_output_format, args.tab) {
-                (OutputFormat::Yaml, true) => "\t".to_string(),
-                (OutputFormat::Yaml, false) => "  ".to_string(),
-                (_, _) => String::new(),
-            };
-        }
         if args.tab {
             return "\t".to_string();
         }
         let width = args.indent as usize;
         let width = if effective_output_format == OutputFormat::Yaml {
+            // This clamp used to run only for a nonzero `args.indent`; an
+            // early return above it short-circuited `-I0` straight to an
+            // empty string instead. YAML's significant whitespace then read
+            // a nested container's fields back as siblings of their parent
+            // key, silently losing the whole value on read-back (#1575).
+            // `0.max(2)` already lands on the same width-2 convention the M2
+            // streaming fast path uses for its own `-I0`
+            // (`yaml_indent_spaces` below), so letting `-I0` reach this
+            // clamp like every other width is the whole fix. JSON is
+            // unaffected either way: `-I0` there means compact/flow, and
+            // `OutputConfig::compact` already forces JSON's own indent to
+            // `""` independently of this string.
             width.max(2)
         } else {
             width

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -221,7 +221,23 @@ impl OutputConfig {
     /// input format anyway.
     fn compute_indent_str(args: &YqCommand, effective_output_format: OutputFormat) -> String {
         if args.indent == 0 {
-            return String::new();
+            // YAML's significant whitespace means an empty indent string
+            // collapses every nesting level onto the same column, corrupting
+            // the document on read-back (#1575: a nested nested container
+            // under `-I=0` silently disappears). Real yq's own `-I0` behaves
+            // like a nonzero width with its own irregular per-level quirk
+            // this DOM emitter doesn't otherwise model; mirror the M2
+            // streaming fast path's own pre-existing, documented `-I0`
+            // choice of width 2 (`yaml_indent_spaces` below) instead of
+            // chasing that exact quirk. JSON is unaffected: `-I0` there
+            // means compact/flow, and `OutputConfig::compact` already
+            // forces JSON's own indent to `""` independently of this
+            // string.
+            return match (effective_output_format, args.tab) {
+                (OutputFormat::Yaml, true) => "\t".to_string(),
+                (OutputFormat::Yaml, false) => "  ".to_string(),
+                (_, _) => String::new(),
+            };
         }
         if args.tab {
             return "\t".to_string();

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8801,6 +8801,40 @@ fn test_navigation_queries_keep_whole_float_decimal_point_yaml() -> Result<()> {
     Ok(())
 }
 
+/// `-I=0` on the DOM output path (any filter `can_use_m2_streaming` rejects,
+/// e.g. `to_entries`) used to thread an empty indent string into the nested
+/// emitter, collapsing every nesting level onto the same column and losing
+/// the nested value entirely on read-back (#1575). `-P` (which forces the
+/// DOM path too) already rendered this correctly, so its width-2 indent is
+/// the reference here — matching the M2 streaming fast path's own
+/// pre-existing, documented `-I0` choice of width 2.
+#[test]
+fn test_dom_path_indent_zero_preserves_nested_container_1575() -> Result<()> {
+    let yaml = "a:\n  b:\n    c: 1\n";
+    let (out, code) = run_yq_stdin("to_entries", yaml, &["-o=yaml", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- key: a\n  value:\n    b:\n      c: 1\n");
+
+    // Read back the nested value — must not be empty.
+    let (readback, code) = run_yq_stdin(".[0].value", &out, &["-o=yaml", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(readback, "b:\n  c: 1\n");
+    Ok(())
+}
+
+/// `-o=json -I=0` must stay compact — this fix only widens YAML's `-I0`
+/// indent string; JSON's own compact/flow meaning for `-I0` is unaffected
+/// (`OutputConfig::compact` already forces JSON's indent to `""`
+/// independently of `indent_str`).
+#[test]
+fn test_dom_path_indent_zero_json_output_still_compact_1575() -> Result<()> {
+    let yaml = "a:\n  b:\n    c: 1\n";
+    let (out, code) = run_yq_stdin("to_entries", yaml, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"[{"key":"a","value":{"b":{"c":1}}}]"#);
+    Ok(())
+}
+
 // =============================================================================
 // Computed-float scientific notation — #997
 // =============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8804,10 +8804,9 @@ fn test_navigation_queries_keep_whole_float_decimal_point_yaml() -> Result<()> {
 /// `-I=0` on the DOM output path (any filter `can_use_m2_streaming` rejects,
 /// e.g. `to_entries`) used to thread an empty indent string into the nested
 /// emitter, collapsing every nesting level onto the same column and losing
-/// the nested value entirely on read-back (#1575). `-P` (which forces the
-/// DOM path too) already rendered this correctly, so its width-2 indent is
-/// the reference here — matching the M2 streaming fast path's own
-/// pre-existing, documented `-I0` choice of width 2.
+/// the nested value entirely on read-back (#1575). Expected output matches
+/// the M2 streaming fast path's own pre-existing, documented `-I0` choice of
+/// width 2 (`yaml_indent_spaces` in `yq_runner.rs`), which this fix mirrors.
 #[test]
 fn test_dom_path_indent_zero_preserves_nested_container_1575() -> Result<()> {
     let yaml = "a:\n  b:\n    c: 1\n";
@@ -8832,6 +8831,34 @@ fn test_dom_path_indent_zero_json_output_still_compact_1575() -> Result<()> {
     let (out, code) = run_yq_stdin("to_entries", yaml, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"[{"key":"a","value":{"b":{"c":1}}}]"#);
+    Ok(())
+}
+
+/// `--tab` output cannot be read back by succinctly's own YAML parser at
+/// *any* indent width or nesting shape — pure, unmixed tab indentation
+/// alone already fails with "tab character used for indentation" on
+/// unmodified `main`, unrelated to `-I0` or this fix (tracked separately as
+/// #1684). This fix's `compute_indent_str` change makes `--tab -I=0`
+/// combined with a compact block-sequence item newly mix 2 literal spaces
+/// (the sequence item's own fixed `- `-width offset, #785/#1362) with
+/// tab-based per-level indent on the same line — pinning that exact,
+/// still-broken output here so a future change to either side doesn't
+/// silently shift it without updating #1684's own investigation.
+#[test]
+fn test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575() -> Result<()> {
+    let yaml = "a:\n  b:\n    c: 1\n";
+    let (out, code) = run_yq_stdin("to_entries", yaml, &["-o=yaml", "-I=0", "--tab"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- key: a\n  value:\n  \tb:\n  \t\tc: 1\n");
+
+    // Read-back still fails — see #1684, not attempted here.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".[0].value", &out, &["-o=yaml", "-I=0", "--tab"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("tab character used for indentation"),
+        "stderr: {stderr}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `-I0`'s DOM output path (any filter `can_use_m2_streaming` rejects, e.g. `to_entries`) threaded an empty indent string into the nested YAML emitter, so every nesting level added a zero-width step and a nested container's fields were read back as siblings of their parent key — silently losing the value entirely.
- Fix: `OutputConfig::compute_indent_str` no longer short-circuits `-I0` to an empty string before its own `width.max(2)` clamp runs; `0.max(2)` already lands on the same width-2 convention the M2 streaming fast path uses for its own `-I0`. JSON's `-I0` (compact/flow) is unaffected — `OutputConfig::compact` already forces JSON's own indent to `""` independently of this string.

## Details

Confirmed live against pinned `yq` v4.53.3: real yq's own `-I0` is empirically identical to its `-I4` output, with an irregular per-level quirk (a compact block-sequence item's inlined mapping doesn't increment its own indent depth for the purposes of computing its fields' children) that this DOM emitter doesn't otherwise model even at explicit non-zero widths (verified `-I3`/`-I4`/`-I6` against the DOM path pre-fix — none match real yq's exact byte layout beyond `-I2`, where the quirk happens to be invisible since the irregular first jump coincides with the regular step). Chasing that exact quirk is out of scope here; this fix targets the actual reported defect (silent data loss), using the same non-byte-matching-but-safe convention the M2 path already established and documented for `-I0`.

## Review follow-ups (second commit)

The mandatory multi-agent `/code-review` (8 finder angles) confirmed the fix but surfaced:
- **Simplification**: the first commit added a 3-arm `match` that reimplemented logic the function's own existing `width.max(2)` clamp already generalized correctly to `width == 0`. Simplified to deleting the old `-I0` early return.
- **Docs**: `docs/compliance/yq/limitations.md` still described this exact bug as open ("not fixed") — updated.
- **Inaccurate claim**: a comment/test doc claimed `-P` already forced the DOM path at `-I0` and rendered correctly. False — `can_yaml_fast_path`'s OR-gate is satisfied by `output_config.compact` alone (`== args.indent == 0`) regardless of `-P`, so an M2-streamable filter with `-P -I0` still takes the fast path, not the DOM path. Removed the claim.
- **New (pre-existing) bug found**: `--tab -I0` on a compact block-sequence item now mixes literal spaces with tab-based indent on the same line and fails to read back. Traced to a much larger pre-existing bug, unrelated to `-I0`: succinctly's own YAML reader rejects *any* tab indentation — pure or mixed — at *any* `-I` width, reproducing identically on unmodified `main`. Filed #1684 to track it; added a test pinning the current (still-broken, not attempted here) `--tab -I0` output so it can't silently drift further.

## Test plan

- [x] `test_dom_path_indent_zero_preserves_nested_container_1575` — exact DOM-path output plus a successful, non-empty read-back of the nested value.
- [x] `test_dom_path_indent_zero_json_output_still_compact_1575` — JSON's `-I0` compact behavior unaffected.
- [x] `test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575` — pins the current (pre-existing, tracked by #1684) `--tab -I0` read-back failure so it's visible rather than silently untested.
- [x] Full `yq_cli_tests`/`yq_golden_tests`/`yq_path_consistency_tests` suites pass.
- [x] Full `cargo test --features cli,simd,regex,serde` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second clippy leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`) both clean.
- [x] `cargo build --no-default-features` still builds (no_std).
- [x] `cargo fmt --check` clean.

Fixes #1575
