### PR TITLE
fix(jq): give limit/nth native, duplicate-key-preserving arms

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2887,6 +2887,25 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => {
             can_use_m2_streaming(inner)
         }
+
+        // Same reasoning as `FirstExpr`/`LastExpr` above, now that #1607
+        // gave `Expr::Limit`/`Builtin::NthStream` (the arm real
+        // `nth(n; expr)` calls reach) their own native, cursor-threading
+        // arms in `eval_generic.rs`: `limit(3; .[])`/`nth(0; .[])` stream a
+        // `GenericResult` cursor exactly like plain navigation when `expr`
+        // itself does, so route them through `eval_with_cursor_using`
+        // here too rather than `evaluate_yaml_cursor`'s unconditional
+        // `to_owned()` DOM path -- otherwise #1607's own fix is discarded
+        // one layer up: a correctly cursor-preserving `GenericResult`
+        // still gets flattened into an `IndexMap`-backed `OwnedValue` the
+        // moment `evaluate_yaml_cursor` materializes it for output,
+        // silently re-losing a duplicate key *inside* the captured item
+        // (not the `limit`/`nth` walk itself, which #1607 already fixed
+        // regardless of this gate). `n` is never recursed into: it's
+        // always evaluated as a single control value, never streamed.
+        Expr::Limit { n: _, expr } => can_use_m2_streaming(expr),
+        Expr::NthExpr { n: _, expr } => can_use_m2_streaming(expr),
+        Expr::Builtin(Builtin::NthStream(_, expr)) => can_use_m2_streaming(expr),
         Expr::IndexExpr { .. } => true,
 
         // `select(...)` never changes position - a truthy output is always

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2903,9 +2903,9 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         // (not the `limit`/`nth` walk itself, which #1607 already fixed
         // regardless of this gate). `n` is never recursed into: it's
         // always evaluated as a single control value, never streamed.
-        Expr::Limit { n: _, expr } => can_use_m2_streaming(expr),
-        Expr::NthExpr { n: _, expr } => can_use_m2_streaming(expr),
-        Expr::Builtin(Builtin::NthStream(_, expr)) => can_use_m2_streaming(expr),
+        Expr::Limit { n: _, expr }
+        | Expr::NthExpr { n: _, expr }
+        | Expr::Builtin(Builtin::NthStream(_, expr)) => can_use_m2_streaming(expr),
         Expr::IndexExpr { .. } => true,
 
         // `select(...)` never changes position - a truthy output is always

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3143,6 +3143,29 @@ pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError>
     }
 }
 
+/// `nth(n; expr)`'s own `n` classification, shared by [`builtin_nth_stream`]
+/// and `eval_generic.rs`'s `eval_nth_generic` (#1607) so the two spellings
+/// (`Builtin::NthStream`, the arm real `nth(n; expr)` calls reach, and the
+/// generic evaluator's native fast path over the same shape) can't drift
+/// apart the way a hand-copied classification already has once before
+/// (#1313, the reason [`classify_limit_n`] above exists at all).
+///
+/// A document-sourced number arrives here as an `OwnedValue`; preferring
+/// `as_i64()` over `as_f64()` matters because an integer past `f64`'s
+/// 53-bit mantissa would otherwise be rounded on its way to `usize`.
+pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
+    match n_owned {
+        ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
+            let f = owned.as_f64().unwrap_or(0.0);
+            if f < 0.0 {
+                return Err(EvalError::new("nth doesn't support negative indices"));
+            }
+            Ok(owned.as_i64().map_or(f as usize, |i| i as usize))
+        }
+        ref other => Err(EvalError::type_error("number", other.type_name())),
+    }
+}
+
 /// Demand-forwarding twin of [`eval_limit`] (#1462, Stage 5): forwards every
 /// output of `expr` straight to `sink`, stopping the generator as soon as
 /// *either* `n` outputs have been forwarded or `sink` itself says to stop --
@@ -30911,28 +30934,9 @@ fn builtin_nth_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Real yq has no `nth` (lexer-rejected); see `builtin_ltrimstr`.
         ArgFanout::All,
         |n_owned| {
-            // A document-sourced number arrives here as an `OwnedValue`; it used
-            // to arrive as a borrowed `QueryResult::One` and take an arm of its
-            // own, which preferred `as_i64()` and only fell back to `as_f64()`.
-            // That preference is kept: an integer past f64's 53-bit mantissa
-            // would otherwise be rounded on its way to `usize`. The sibling
-            // owned arm this replaces used `as_f64()` alone, so consolidating on
-            // the *borrowed* arm's rule is the lossless direction.
-            let n = match n_owned {
-                ref owned @ (OwnedValue::Int(_)
-                | OwnedValue::Float(_)
-                | OwnedValue::NumberLiteral(..)) => {
-                    let f = owned.as_f64().unwrap_or(0.0);
-                    if f < 0.0 {
-                        return QueryResult::Error(EvalError::new(
-                            "nth doesn't support negative indices",
-                        ));
-                    }
-                    owned.as_i64().map_or(f as usize, |i| i as usize)
-                }
-                ref other => {
-                    return QueryResult::Error(EvalError::type_error("number", other.type_name()))
-                }
+            let n = match classify_nth_n(n_owned) {
+                Ok(n) => n,
+                Err(e) => return QueryResult::Error(e),
             };
 
             // Same sink as `eval_nth_expr`, differing only in always materializing

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3114,7 +3114,7 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// categorically instead of relying on a differential test to catch the
 /// next divergence.
 #[derive(Debug)]
-enum LimitN {
+pub(crate) enum LimitN {
     /// Unlimited passthrough: run the caller's own `expr`/`resolve_node`
     /// unbounded.
     Unlimited,
@@ -3122,7 +3122,7 @@ enum LimitN {
     Take(usize),
 }
 
-fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError> {
+pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError> {
     match n_value {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
             Ok(LimitN::Take(i as usize))

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5099,17 +5099,21 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
             Demand::Continue
         }
     });
-    let satisfied = out.len() >= n;
     Some(match flow {
-        // Short of `n`: there is no lazy `GenericResult` shape that carries
-        // both a prefix and a pending control, so decode the captured
-        // prefix eagerly and surface the trailing control alongside it --
-        // matches `limit_with_n`'s identical rule
-        // (`[limit(3; 1,2,error("x"),4)]` raises).  A decode failure while
+        // The sink returns `Demand::Stop` the instant `out.len() >= n`, and
+        // every `eval_each_generic` arm stops pulling as soon as `Demand`
+        // says to -- so an escape can only fire *before* that point, never
+        // after: `flow` alone already tells us whether `n` was reached,
+        // with no need to separately track/re-check `out.len()` against
+        // `n`. Short of `n`, there is no lazy `GenericResult` shape that
+        // carries both a prefix and a pending control, so decode the
+        // captured prefix eagerly and surface the trailing control
+        // alongside it -- matches `limit_with_n`'s identical rule
+        // (`[limit(3; 1,2,error("x"),4)]` raises). A decode failure while
         // draining that prefix is itself reported in place of the
         // generator's own control, the same priority a mid-pull `stray`
         // took before this batch conversion existed.
-        Flow::Escaped(control) if !satisfied => {
+        Flow::Escaped(control) => {
             let mut owned = Vec::with_capacity(out.len());
             let mut decode_err = None;
             for item in out {
@@ -5129,7 +5133,7 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
         // any trailing control, so both resolve the same way.
         _ => match items_to_generic_result(out) {
             Ok(result) => result,
-            Err(control) => partial_generic(Vec::new(), control),
+            Err((prefix, control)) => partial_generic(prefix, control),
         },
     })
 }
@@ -5175,25 +5179,47 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
 
     let mut seen = 0usize;
     let mut wanted: Option<GenericItem<V>> = None;
+    let mut skipped_err: Option<Control> = None;
     let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
         if seen == n {
             wanted = Some(item);
             seen += 1;
-            Demand::Stop
-        } else {
-            seen += 1;
-            Demand::Continue
+            return Demand::Stop;
         }
+        seen += 1;
+        // jq defines `nth($n; f)` as `last(limit($n + 1; f))`: every output
+        // of `f` up to index `n` is genuinely produced, not just the one
+        // ultimately kept -- a *skipped* item's own lazy computation (a
+        // buffered `map`/`select` chain, `GenericItem::LazySeq`, #724/#725)
+        // must still run for its side effects/errors even though its value
+        // is discarded here. `each_take_nth` in `eval.rs` gets this for
+        // free (its `Item`s are never themselves lazy, only ever borrowed
+        // or already-owned); this sink has to force it explicitly, or
+        // `nth(2; .[] | map(10/.))` over `[[1],[0],[2]]` would silently
+        // skip the division-by-zero `map` never ran on `[0]` and answer
+        // from `[2]` instead of erroring. The item *at* index `n` is
+        // deliberately exempted from this force -- see below.
+        if let Err(control) = generic_item_into_owned(item) {
+            skipped_err = Some(control);
+            return Demand::Stop;
+        }
+        Demand::Continue
     });
     // Mirrors `each_take_nth` + its caller's own priority exactly: a
     // captured item at index `n` always wins, even over a trailing escape
-    // from beyond that point; short of reaching index `n` at all, whatever
-    // ended the pull (exhaustion, or an escape before index `n`) decides.
-    // Kept cursor-backed ([`generic_item_to_result`], #607's own conversion)
-    // rather than forced through `OwnedValue`, so a duplicate key *inside*
-    // the captured item survives too, not just across the walk to reach it.
+    // from beyond that point (and, by construction, over `skipped_err` too
+    // -- once `wanted` is set the sink returns `Demand::Stop` immediately,
+    // so no later item, and no `skipped_err`, can still be pending);
+    // short of reaching index `n` at all, whatever ended the pull
+    // (exhaustion, a skipped item's own forced failure, or the generator's
+    // own escape before index `n`) decides. The *wanted* item alone is
+    // kept cursor-backed ([`generic_item_to_result`], #607's own
+    // conversion) rather than forced through `OwnedValue`, so a duplicate
+    // key *inside* it survives too, not just across the walk to reach it.
     Some(if let Some(item) = wanted {
         generic_item_to_result(item)
+    } else if let Some(control) = skipped_err {
+        partial_generic(Vec::new(), control)
     } else {
         match flow {
             Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
@@ -5209,19 +5235,54 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
 /// over eagerly decoding into `ManyOwned`. Used by
 /// [`eval_limit_generic`]'s own success path so `limit` extends #607's
 /// duplicate-key fidelity to what it *captures*, not only to how it walks.
+///
+/// `OneCursorValue` gets its own arm rather than folding into the
+/// cursor-only one below: its value is always an already-decoded key
+/// string, the exact thing `each_lazy_keys_iterate_sink`'s `!sorted` arm
+/// (its one construction site, #1514/#1609) exists to avoid re-decoding.
+/// Collapsing straight to `ManyCursor` would throw that decode away, only
+/// for `cursor_vec_to_generic_result`'s eventual `to_owned_cursor` to redo
+/// it later -- fine once for `first`/`last` (`generic_item_to_result`'s own
+/// doc comment already accepts that single cost), but `limit(n; keys|.[])`
+/// pays it once *per captured key*, silently reintroducing O5's own
+/// double-decode on the exact shape it was measured against. Since a key
+/// string has no nested containers of its own, converting it directly with
+/// `to_owned` carries no duplicate-key risk to reintroduce.
+///
+/// On a mid-batch decode failure, the error comes back paired with
+/// whatever prefix already decoded cleanly, not bare -- `limit(5; f)` must
+/// still stream the outputs `f` produced before a later one failed
+/// (`[400/0.4]`, err) rather than losing them, matching real jq's
+/// streaming-before-error contract (#400/#494) and `limit_with_n`'s own
+/// identical rule. A plain `Result<_, Control>` here would have silently
+/// discarded that prefix at the `?` the moment any item failed.
 fn items_to_generic_result<V: DocumentValue>(
     items: Vec<GenericItem<V>>,
-) -> Result<GenericResult<V>, Control> {
-    if items.iter().all(|item| {
-        matches!(
-            item,
-            GenericItem::OneCursor(_) | GenericItem::OneCursorValue(_, _)
-        )
-    }) {
+) -> Result<GenericResult<V>, (Vec<OwnedValue>, Control)> {
+    if items
+        .iter()
+        .all(|item| matches!(item, GenericItem::OneCursorValue(_, _)))
+    {
+        let mut owned = Vec::with_capacity(items.len());
+        for item in items {
+            let GenericItem::OneCursorValue(_, v) = item else {
+                unreachable!("checked by the all() above")
+            };
+            match to_owned(&v) {
+                Ok(o) => owned.push(o),
+                Err(e) => return Err((owned, Control::Error(e))),
+            }
+        }
+        return Ok(owned_vec_to_generic_result(owned));
+    }
+    if items
+        .iter()
+        .all(|item| matches!(item, GenericItem::OneCursor(_)))
+    {
         let cursors: Vec<V::Cursor> = items
             .into_iter()
             .map(|item| match item {
-                GenericItem::OneCursor(c) | GenericItem::OneCursorValue(c, _) => c,
+                GenericItem::OneCursor(c) => c,
                 _ => unreachable!("checked by the all() above"),
             })
             .collect();
@@ -5229,7 +5290,10 @@ fn items_to_generic_result<V: DocumentValue>(
     }
     let mut owned = Vec::with_capacity(items.len());
     for item in items {
-        owned.push(generic_item_into_owned(item)?);
+        match generic_item_into_owned(item) {
+            Ok(v) => owned.push(v),
+            Err(control) => return Err((owned, control)),
+        }
     }
     Ok(owned_vec_to_generic_result(owned))
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,11 +27,12 @@ use super::document::{
     DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, collapse_vec, eval as full_eval, eval_each_owned,
-    format_owned, index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
-    numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
-    slice_owned_value_read, tonumber_from_str, try_reserve_product, Control, Demand, EvalError,
-    EvalSemantics, EvalTag, Flow, JqSemantics, QueryResult, YqSemantics,
+    apply_compare_op, arith_combine, classify_limit_n, collapse_vec, eval as full_eval,
+    eval_each_owned, format_owned, index_one_owned as index_owned_by_key, literal_to_owned,
+    needs_path_context, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
+    slice_object_as_yq_children, slice_owned_value_read, tonumber_from_str, try_reserve_product,
+    Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult,
+    YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -3931,6 +3932,60 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             eval_first_or_last_generic::<S, _>(inner, value, optional, cursor, true)
         }
 
+        // Same reasoning as `FirstExpr`/`LastExpr` above (#607), a second
+        // instance of it (#1607): the `_` fallback below materializes the
+        // whole input via `to_owned()` before `expr` ever runs, so
+        // `limit(n; keys|.[])` on a document with a duplicate mapping key
+        // lost every duplicate — `OwnedValue::Object` is `IndexMap`-backed
+        // and cannot represent them, even though `keys|.[]` alone (via
+        // `LazyKeys`/`DistinctKeyCursors`) already preserves them correctly.
+        // `eval_limit_generic` only takes over the common case (`n_expr`
+        // evaluates to one plain value); see its own doc comment for why a
+        // generator `n` is left on the pre-existing path below.
+        Expr::Limit { n, expr } => {
+            match eval_limit_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
+                Some(result) => result,
+                None => {
+                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+                    eval_on_owned::<S, _>(
+                        &Expr::Limit {
+                            n: n.clone(),
+                            expr: expr.clone(),
+                        },
+                        owned,
+                        optional,
+                    )
+                }
+            }
+        }
+
+        // A CLI `nth(n; expr)` always parses to `Builtin::NthStream` (see
+        // that arm in `eval_builtin`, where the real fix lives) --
+        // `Expr::NthExpr` itself is never freshly constructed by the parser,
+        // only passed through unchanged by AST rewrites like
+        // `substitute_var` (see `eval.rs`'s `eval_nth_expr_n_argument_
+        // propagates_halt` for the same note on its `eval.rs` counterpart).
+        // Handled here anyway, at the same cost as the arm above, so a
+        // rewrite-preserved `NthExpr` gets the identical duplicate-key fix
+        // rather than silently falling back to the lossy path depending on
+        // which of the two spellings it happens to carry.
+        Expr::NthExpr { n, expr } => {
+            match eval_nth_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
+                Some(result) => result,
+                None => {
+                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+                    eval_on_owned::<S, _>(
+                        &Expr::NthExpr {
+                            n: n.clone(),
+                            expr: expr.clone(),
+                        },
+                        owned,
+                        optional,
+                    )
+                }
+            }
+        }
+
         // #1062: was a hand-rolled arm-for-arm copy of the same six
         // `Literal` variants (one of three targeting `OwnedValue` -- see
         // `literal_to_owned`'s own doc comment for the other two); delegates
@@ -4933,6 +4988,182 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         GenericResult::Partial(_, Control::Error(e)) => GenericResult::Error(e),
         GenericResult::Partial(_, Control::Break(label)) => GenericResult::Break(label),
         GenericResult::Partial(_, Control::Halt(code)) => GenericResult::Halt(code),
+    }
+}
+
+/// Native `Expr::Limit` arm for the generic evaluator (#1607) — the same
+/// fix `eval_first_or_last_generic` already applies to `first`/`last`
+/// (#607), a second instance of the same root cause: `eval_single`'s `_`
+/// fallback materializes the whole input into an `OwnedValue` before `expr`
+/// ever runs, and `OwnedValue::Object` is `IndexMap`-backed and cannot
+/// represent a duplicate mapping key. `limit(n; keys|.[])` on a document
+/// with one silently dropped every duplicate that `keys|.[]` alone (via
+/// `GenericResult::LazyKeys`/`DistinctKeyCursors`) already preserves
+/// correctly, regardless of `S::COLLAPSE_DUPLICATE_KEYS`.
+///
+/// Returns `None` to defer to the caller's own fallback rather than
+/// handling every shape `eval.rs`'s `eval_limit`/`fanout_arg` do: only the
+/// common case — `n_expr` evaluates to exactly one plain value — is taken
+/// natively here, via [`eval_each_generic`]'s own demand-driven `Pipe`/
+/// `Iterate`/`LazyKeys` machinery (what keeps `expr`'s duplicate keys
+/// alive). `n_expr` as a *generator* (`limit((1,2); f)`, re-running `expr`
+/// once per `n` value, #1279) is jq's own rarer laziness contract, which
+/// `eval.rs`'s `fanout_arg` already implements correctly for every
+/// document `eval.rs` can represent losslessly — reproducing that richness
+/// here isn't needed to fix this issue's actual bug. The cost of deferring
+/// is `n_expr` being evaluated a second time by the caller's fallback, in
+/// the rare case it isn't a plain single value; a side-effecting `n_expr`
+/// (`limit(debug; f)`) would observe that, but this shape is not known to
+/// occur in practice and is out of this fix's scope.
+fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> Option<GenericResult<V>> {
+    let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
+        GenericResult::One(v) => to_owned(&v).ok()?,
+        GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
+        GenericResult::Owned(v) => v,
+        _ => return None,
+    };
+    let n = match classify_limit_n(n_value) {
+        Ok(LimitN::Unlimited) => {
+            return Some(eval_single::<S, V>(expr, value, optional, cursor));
+        }
+        Ok(LimitN::Take(n)) => n,
+        Err(e) => return Some(GenericResult::Error(e)),
+    };
+    if n == 0 {
+        return Some(GenericResult::None);
+    }
+
+    // Pull at most `n`, then stop the generator -- mirrors `eval.rs`'s own
+    // `each_take_n`, adapted to `eval_each_generic`'s `GenericItem` sink so
+    // a `LazyKeys` item stays cursor-backed (and duplicate-preserving)
+    // until `generic_item_into_owned` decodes it here.
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let mut stray: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        match generic_item_into_owned(item) {
+            Ok(v) => {
+                out.push(v);
+                if out.len() >= n {
+                    Demand::Stop
+                } else {
+                    Demand::Continue
+                }
+            }
+            Err(control) => {
+                stray = Some(control);
+                Demand::Stop
+            }
+        }
+    });
+    let satisfied = out.len() >= n;
+    // Mirrors `limit_with_n`'s own reconciliation: once `n` outputs arrived,
+    // jq's own `foreach ... break $out` fires, so a trailing control --
+    // `eval_each_generic` escaping natively, or a lazy item that failed to
+    // materialize here (`stray`, which has no `eval.rs` counterpart since
+    // `Item` there is never itself lazy) -- is dropped; short of `n`, it
+    // surfaces instead (`[limit(3; 1,2,error("x"),4)]` raises).
+    let control = match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => stray,
+        Flow::Escaped(control) => Some(control),
+    };
+    Some(match control {
+        Some(control) if !satisfied => partial_generic(out, control),
+        _ => owned_vec_to_generic_result(out),
+    })
+}
+
+/// Native `Builtin::NthStream`/`Expr::NthExpr` arm for the generic evaluator
+/// (#1607) — [`eval_limit_generic`]'s twin, same root cause, same deferral
+/// contract (see its doc comment). jq defines `nth($n; f)` as `last(limit($n
+/// + 1; f))`, so this pulls only as far as index `n` then stops, mirroring
+/// `eval.rs`'s own `each_take_nth`.
+///
+/// `n`'s classification (accept `Int`/`Float`/`NumberLiteral`, negative ->
+/// "nth doesn't support negative indices", anything else -> a type error)
+/// matches `builtin_nth_stream` exactly, not `eval_nth_expr`'s narrower
+/// integer-only rule — `Builtin::NthStream` is the arm real `nth(n; expr)`
+/// calls actually reach (see this function's call sites), so its
+/// classification is the one this native path must reproduce bug-for-bug.
+fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> Option<GenericResult<V>> {
+    let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
+        GenericResult::One(v) => to_owned(&v).ok()?,
+        GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
+        GenericResult::Owned(v) => v,
+        _ => return None,
+    };
+    let n = match n_value {
+        ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
+            let f = owned.as_f64().unwrap_or(0.0);
+            if f < 0.0 {
+                return Some(GenericResult::Error(EvalError::new(
+                    "nth doesn't support negative indices",
+                )));
+            }
+            owned.as_i64().map_or(f as usize, |i| i as usize)
+        }
+        ref other => {
+            return Some(GenericResult::Error(EvalError::type_error(
+                "number",
+                other.type_name(),
+            )));
+        }
+    };
+
+    let mut seen = 0usize;
+    let mut wanted: Option<OwnedValue> = None;
+    let mut decode_err: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        if seen == n {
+            match generic_item_into_owned(item) {
+                Ok(v) => wanted = Some(v),
+                Err(control) => decode_err = Some(control),
+            }
+            seen += 1;
+            Demand::Stop
+        } else {
+            seen += 1;
+            Demand::Continue
+        }
+    });
+    // Mirrors `each_take_nth` + its caller's own priority exactly: a
+    // captured item at index `n` always wins, even over a trailing escape
+    // from beyond that point; a decode failure *at* index `n` surfaces as
+    // that error (no `eval.rs` counterpart, since `Item` there is never
+    // itself lazy); short of reaching index `n` at all, whatever ended the
+    // pull (exhaustion, or an escape before index `n`) decides.
+    Some(if let Some(v) = wanted {
+        GenericResult::Owned(v)
+    } else if let Some(control) = decode_err {
+        control_to_generic_result(control)
+    } else {
+        match flow {
+            Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
+            Flow::Escaped(control) => control_to_generic_result(control),
+        }
+    })
+}
+
+/// Convert a bare [`Control`] into the [`GenericResult`] shape that
+/// terminates a stream with no successful output at all -- the
+/// zero-outputs-collected counterpart to [`partial_generic`], which handles
+/// the same three variants alongside a non-empty prefix.
+fn control_to_generic_result<V: DocumentValue>(control: Control) -> GenericResult<V> {
+    match control {
+        Control::Error(e) => GenericResult::Error(e),
+        Control::Break(label) => GenericResult::Break(label),
+        Control::Halt(code) => GenericResult::Halt(code),
     }
 }
 
@@ -6176,6 +6407,29 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
         Builtin::LastStream(inner) => {
             eval_first_or_last_generic::<S, _>(inner, value, optional, cursor, true)
+        }
+
+        // `nth(n; expr)` (arity 2) parses straight to this `Builtin`
+        // spelling, not `Expr::NthExpr` -- unlike `first`/`last`/`limit`,
+        // whose parser rules build the dedicated `Expr` variant directly
+        // (confirmed in `parser.rs`: `nth`'s two-arg form returns
+        // `Builtin::NthStream`, no `Expr::NthExpr` construction site exists
+        // there at all). So this is the arm real `nth(n; expr)` calls
+        // actually reach, not `eval_single`'s `Expr::NthExpr` arm -- same
+        // #607/#1607 duplicate-key reasoning applies here, reusing
+        // `eval_nth_generic` rather than duplicating its logic.
+        Builtin::NthStream(n, expr) => {
+            match eval_nth_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
+                Some(result) => result,
+                None => {
+                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+                    eval_on_owned::<S, _>(
+                        &Expr::Builtin(Builtin::NthStream(n.clone(), expr.clone())),
+                        owned,
+                        optional,
+                    )
+                }
+            }
         }
 
         Builtin::Reverse => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,12 +27,12 @@ use super::document::{
     DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, classify_limit_n, collapse_vec, eval as full_eval,
-    eval_each_owned, format_owned, index_one_owned as index_owned_by_key, literal_to_owned,
-    needs_path_context, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
-    slice_object_as_yq_children, slice_owned_value_read, tonumber_from_str, try_reserve_product,
-    Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult,
-    YqSemantics,
+    apply_compare_op, arith_combine, classify_limit_n, classify_nth_n, collapse_vec,
+    eval as full_eval, eval_each_owned, format_owned, index_one_owned as index_owned_by_key,
+    literal_to_owned, needs_path_context, numeric_key_to_index, owned_bound_to_i64,
+    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, tonumber_from_str,
+    try_reserve_product, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType};
 use super::slice::{slice_str, SliceBounds};
@@ -4991,6 +4991,22 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// Whether `expr` reaches [`crate::jq::walk::uses_input_builtins`] while the
+/// shared `input`/`inputs` queue is live -- shared by [`eval_limit_generic`]/
+/// [`eval_nth_generic`] for the same reason [`eval_first_or_last_generic`]
+/// checks it locally (#1309): neither `limit`/`nth` run their body to
+/// completion either, so an `inputs`-consuming `n_expr` or `expr` reaching
+/// this function's own-pull path (below) would drain the queue eagerly via
+/// `eval.rs`'s `builtin_inputs` instead of stopping at `n`/index `n`, same
+/// failure class as the un-guarded `first` once had. The one-load
+/// `input_queue_is_active` check comes first so yq mode, library embedders
+/// and the common `limit(3; .[])` never pay for the AST walk.
+fn limit_or_nth_uses_live_input_queue(n_expr: &Expr, expr: &Expr) -> bool {
+    crate::jq::input_queue_is_active()
+        && (crate::jq::walk::uses_input_builtins(n_expr)
+            || crate::jq::walk::uses_input_builtins(expr))
+}
+
 /// Native `Expr::Limit` arm for the generic evaluator (#1607) — the same
 /// fix `eval_first_or_last_generic` already applies to `first`/`last`
 /// (#607), a second instance of the same root cause: `eval_single`'s `_`
@@ -5001,6 +5017,13 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
 /// `GenericResult::LazyKeys`/`DistinctKeyCursors`) already preserves
 /// correctly, regardless of `S::COLLAPSE_DUPLICATE_KEYS`.
 ///
+/// Also guards `n_expr`/`expr` against a live `input`/`inputs` queue
+/// (`limit_or_nth_uses_live_input_queue`, mirroring
+/// `eval_first_or_last_generic`'s own #1309 guard): `limit`/`nth` stop
+/// early just like `first` does, so an `inputs`-consuming operand reaching
+/// the eager `_` fallback below would drain the whole remaining queue
+/// instead of stopping at `n`/index `n`.
+///
 /// Returns `None` to defer to the caller's own fallback rather than
 /// handling every shape `eval.rs`'s `eval_limit`/`fanout_arg` do: only the
 /// common case — `n_expr` evaluates to exactly one plain value — is taken
@@ -5010,11 +5033,26 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
 /// once per `n` value, #1279) is jq's own rarer laziness contract, which
 /// `eval.rs`'s `fanout_arg` already implements correctly for every
 /// document `eval.rs` can represent losslessly — reproducing that richness
-/// here isn't needed to fix this issue's actual bug. The cost of deferring
-/// is `n_expr` being evaluated a second time by the caller's fallback, in
-/// the rare case it isn't a plain single value; a side-effecting `n_expr`
-/// (`limit(debug; f)`) would observe that, but this shape is not known to
-/// occur in practice and is out of this fix's scope.
+/// here isn't needed to fix this issue's actual bug (a generator `n_expr`
+/// still loses `expr`'s duplicate keys on the deferred fallback path,
+/// exactly as before this fix; tracked as a residual gap, not silently
+/// reintroduced).
+///
+/// A **bare top-level `Comma`** (`limit((1,2); f)`, matching #1279's own
+/// canonical example) is detected statically and deferred *without* ever
+/// evaluating `n_expr` here, so the caller's single fallback evaluation is
+/// the only one — closing the double-evaluation this fix would otherwise
+/// cause for exactly that shape. This check is deliberately shallow: it
+/// only recognizes `n_expr` itself being (optionally parenthesized) a
+/// `Comma`, not a `Comma` buried inside some other construct (e.g.
+/// `(1|debug,2|debug)` parses as a `Pipe` whose middle stage is the
+/// `Comma`, not a bare one) — that broader shape, and any other
+/// side-effecting `n_expr` that isn't a plain literal or a bare comma,
+/// still costs a second `n_expr` evaluation on the fallback path.
+/// Live-verified: `debug` inside such an `n_expr` fires twice here where
+/// real jq fires it once. `input`/`inputs` inside `n_expr` is unaffected
+/// by this residual gap — that shape is caught unconditionally by the
+/// input-queue guard above, before any evaluation is attempted.
 fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,
@@ -5022,6 +5060,13 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> Option<GenericResult<V>> {
+    if limit_or_nth_uses_live_input_queue(n_expr, expr) {
+        return None;
+    }
+    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
+        return None;
+    }
+
     let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
         GenericResult::One(v) => to_owned(&v).ok()?,
         GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
@@ -5040,56 +5085,69 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
     }
 
     // Pull at most `n`, then stop the generator -- mirrors `eval.rs`'s own
-    // `each_take_n`, adapted to `eval_each_generic`'s `GenericItem` sink so
-    // a `LazyKeys` item stays cursor-backed (and duplicate-preserving)
-    // until `generic_item_into_owned` decodes it here.
-    let mut out: Vec<OwnedValue> = Vec::new();
-    let mut stray: Option<Control> = None;
+    // `each_take_n`. Items stay as `GenericItem`s, not decoded yet, so
+    // `items_to_generic_result` below can keep a cursor-backed batch as
+    // `ManyCursor` -- preserving a duplicate key *inside* a captured item
+    // too (`limit(2; .[])` on a sequence of duplicate-keyed mappings), not
+    // only across the `limit`/`nth` walk itself.
+    let mut out: Vec<GenericItem<V>> = Vec::new();
     let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
-        match generic_item_into_owned(item) {
-            Ok(v) => {
-                out.push(v);
-                if out.len() >= n {
-                    Demand::Stop
-                } else {
-                    Demand::Continue
-                }
-            }
-            Err(control) => {
-                stray = Some(control);
-                Demand::Stop
-            }
+        out.push(item);
+        if out.len() >= n {
+            Demand::Stop
+        } else {
+            Demand::Continue
         }
     });
     let satisfied = out.len() >= n;
-    // Mirrors `limit_with_n`'s own reconciliation: once `n` outputs arrived,
-    // jq's own `foreach ... break $out` fires, so a trailing control --
-    // `eval_each_generic` escaping natively, or a lazy item that failed to
-    // materialize here (`stray`, which has no `eval.rs` counterpart since
-    // `Item` there is never itself lazy) -- is dropped; short of `n`, it
-    // surfaces instead (`[limit(3; 1,2,error("x"),4)]` raises).
-    let control = match flow {
-        Flow::Exhausted | Flow::Stopped { .. } => stray,
-        Flow::Escaped(control) => Some(control),
-    };
-    Some(match control {
-        Some(control) if !satisfied => partial_generic(out, control),
-        _ => owned_vec_to_generic_result(out),
+    Some(match flow {
+        // Short of `n`: there is no lazy `GenericResult` shape that carries
+        // both a prefix and a pending control, so decode the captured
+        // prefix eagerly and surface the trailing control alongside it --
+        // matches `limit_with_n`'s identical rule
+        // (`[limit(3; 1,2,error("x"),4)]` raises).  A decode failure while
+        // draining that prefix is itself reported in place of the
+        // generator's own control, the same priority a mid-pull `stray`
+        // took before this batch conversion existed.
+        Flow::Escaped(control) if !satisfied => {
+            let mut owned = Vec::with_capacity(out.len());
+            let mut decode_err = None;
+            for item in out {
+                match generic_item_into_owned(item) {
+                    Ok(v) => owned.push(v),
+                    Err(c) => {
+                        decode_err = Some(c);
+                        break;
+                    }
+                }
+            }
+            partial_generic(owned, decode_err.unwrap_or(control))
+        }
+        // Either a clean stop (`n` outputs arrived, or the generator ran
+        // dry on its own) or an escape *past* `n` -- jq's own
+        // `foreach ... break $out` fires once `n` outputs exist, dropping
+        // any trailing control, so both resolve the same way.
+        _ => match items_to_generic_result(out) {
+            Ok(result) => result,
+            Err(control) => partial_generic(Vec::new(), control),
+        },
     })
 }
 
 /// Native `Builtin::NthStream`/`Expr::NthExpr` arm for the generic evaluator
 /// (#1607) — [`eval_limit_generic`]'s twin, same root cause, same deferral
-/// contract (see its doc comment). jq defines `nth($n; f)` as `last(limit($n
-/// + 1; f))`, so this pulls only as far as index `n` then stops, mirroring
-/// `eval.rs`'s own `each_take_nth`.
+/// contract (see its doc comment, including the input-queue guard and the
+/// static-`Comma` detection). jq defines `nth($n; f)` as
+/// `last(limit($n + 1; f))`, so this pulls only as far as index `n` then
+/// stops, mirroring `eval.rs`'s own `each_take_nth`.
 ///
-/// `n`'s classification (accept `Int`/`Float`/`NumberLiteral`, negative ->
-/// "nth doesn't support negative indices", anything else -> a type error)
-/// matches `builtin_nth_stream` exactly, not `eval_nth_expr`'s narrower
-/// integer-only rule — `Builtin::NthStream` is the arm real `nth(n; expr)`
-/// calls actually reach (see this function's call sites), so its
-/// classification is the one this native path must reproduce bug-for-bug.
+/// `n`'s classification ([`classify_nth_n`], shared with `builtin_nth_stream`
+/// so the two can't silently drift apart the way `classify_limit_n` was
+/// extracted to prevent, #1313) matches `Builtin::NthStream` exactly, not
+/// `eval_nth_expr`'s narrower integer-only rule — `Builtin::NthStream` is
+/// the arm real `nth(n; expr)` calls actually reach (see this function's
+/// call sites), so its classification is the one this native path must
+/// reproduce bug-for-bug.
 fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,
@@ -5097,39 +5155,29 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> Option<GenericResult<V>> {
+    if limit_or_nth_uses_live_input_queue(n_expr, expr) {
+        return None;
+    }
+    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
+        return None;
+    }
+
     let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
         GenericResult::One(v) => to_owned(&v).ok()?,
         GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
         GenericResult::Owned(v) => v,
         _ => return None,
     };
-    let n = match n_value {
-        ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
-            let f = owned.as_f64().unwrap_or(0.0);
-            if f < 0.0 {
-                return Some(GenericResult::Error(EvalError::new(
-                    "nth doesn't support negative indices",
-                )));
-            }
-            owned.as_i64().map_or(f as usize, |i| i as usize)
-        }
-        ref other => {
-            return Some(GenericResult::Error(EvalError::type_error(
-                "number",
-                other.type_name(),
-            )));
-        }
+    let n = match classify_nth_n(n_value) {
+        Ok(n) => n,
+        Err(e) => return Some(GenericResult::Error(e)),
     };
 
     let mut seen = 0usize;
-    let mut wanted: Option<OwnedValue> = None;
-    let mut decode_err: Option<Control> = None;
+    let mut wanted: Option<GenericItem<V>> = None;
     let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
         if seen == n {
-            match generic_item_into_owned(item) {
-                Ok(v) => wanted = Some(v),
-                Err(control) => decode_err = Some(control),
-            }
+            wanted = Some(item);
             seen += 1;
             Demand::Stop
         } else {
@@ -5139,32 +5187,51 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     });
     // Mirrors `each_take_nth` + its caller's own priority exactly: a
     // captured item at index `n` always wins, even over a trailing escape
-    // from beyond that point; a decode failure *at* index `n` surfaces as
-    // that error (no `eval.rs` counterpart, since `Item` there is never
-    // itself lazy); short of reaching index `n` at all, whatever ended the
-    // pull (exhaustion, or an escape before index `n`) decides.
-    Some(if let Some(v) = wanted {
-        GenericResult::Owned(v)
-    } else if let Some(control) = decode_err {
-        control_to_generic_result(control)
+    // from beyond that point; short of reaching index `n` at all, whatever
+    // ended the pull (exhaustion, or an escape before index `n`) decides.
+    // Kept cursor-backed ([`generic_item_to_result`], #607's own conversion)
+    // rather than forced through `OwnedValue`, so a duplicate key *inside*
+    // the captured item survives too, not just across the walk to reach it.
+    Some(if let Some(item) = wanted {
+        generic_item_to_result(item)
     } else {
         match flow {
             Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
-            Flow::Escaped(control) => control_to_generic_result(control),
+            Flow::Escaped(control) => partial_generic(Vec::new(), control),
         }
     })
 }
 
-/// Convert a bare [`Control`] into the [`GenericResult`] shape that
-/// terminates a stream with no successful output at all -- the
-/// zero-outputs-collected counterpart to [`partial_generic`], which handles
-/// the same three variants alongside a non-empty prefix.
-fn control_to_generic_result<V: DocumentValue>(control: Control) -> GenericResult<V> {
-    match control {
-        Control::Error(e) => GenericResult::Error(e),
-        Control::Break(label) => GenericResult::Break(label),
-        Control::Halt(code) => GenericResult::Halt(code),
+/// Convert a batch of pulled [`GenericItem`]s into the smallest
+/// [`GenericResult`] shape that represents it, preferring `ManyCursor` --
+/// which keeps every item cursor-backed, so a duplicate key *inside* a
+/// captured item (not only across the pull that captured it) survives --
+/// over eagerly decoding into `ManyOwned`. Used by
+/// [`eval_limit_generic`]'s own success path so `limit` extends #607's
+/// duplicate-key fidelity to what it *captures*, not only to how it walks.
+fn items_to_generic_result<V: DocumentValue>(
+    items: Vec<GenericItem<V>>,
+) -> Result<GenericResult<V>, Control> {
+    if items.iter().all(|item| {
+        matches!(
+            item,
+            GenericItem::OneCursor(_) | GenericItem::OneCursorValue(_, _)
+        )
+    }) {
+        let cursors: Vec<V::Cursor> = items
+            .into_iter()
+            .map(|item| match item {
+                GenericItem::OneCursor(c) | GenericItem::OneCursorValue(c, _) => c,
+                _ => unreachable!("checked by the all() above"),
+            })
+            .collect();
+        return Ok(cursor_vec_to_generic_result(cursors));
     }
+    let mut owned = Vec::with_capacity(items.len());
+    for item in items {
+        owned.push(generic_item_into_owned(item)?);
+    }
+    Ok(owned_vec_to_generic_result(owned))
 }
 
 /// Apply one resolved key to one target value.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18629,6 +18629,43 @@ fn test_jq_cursor_metadata_carve_out_keeps_limit_and_nth_inputs_lazy_1607() -> R
     Ok(())
 }
 
+/// #1607 review follow-up: `limit`'s native fast path must still stream
+/// every output it already produced before a *later* one fails, matching
+/// real jq's streaming-before-error contract (#400/#494) and `eval.rs`'s
+/// own `limit_with_n` (`[limit(3; 1,2,error("x"),4)]` raises, but only
+/// after printing `1` and `2`). The native path's batch-to-`GenericResult`
+/// conversion used to discard the whole prefix on a mid-batch decode
+/// failure instead of surfacing it alongside the error.
+#[test]
+fn test_jq_limit_streams_prefix_before_a_later_output_fails_1607() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "limit(5; .[] | map(10/.))"], Some("[[1],[0]]\n"))
+            .expect("limit streaming-before-error repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "[10]\n");
+    assert!(stderr.contains("divided"), "stderr: {stderr}");
+    Ok(())
+}
+
+/// #1607 review follow-up: jq defines `nth($n; f)` as `last(limit($n + 1;
+/// f))` -- every output of `f` up to index `n` must genuinely run, not
+/// just the one `nth` ultimately keeps, so an error while producing a
+/// *skipped* output still surfaces. The native fast path's sink used to
+/// discard a skipped item without forcing its own lazy computation (a
+/// buffered `map`/`select` chain) to run at all, silently skipping past
+/// what should have been a division-by-zero error and answering from a
+/// later index instead.
+#[test]
+fn test_jq_nth_still_evaluates_a_skipped_output_that_would_error_1607() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "nth(2; .[] | map(10/.))"], Some("[[1],[0],[2]]\n"))
+            .expect("nth skipped-output repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("divided"), "stderr: {stderr}");
+    Ok(())
+}
+
 /// The carve-out keys off the `line`/`at_offset`/... *builtins*, so a field
 /// or key that merely spells one of their names must not trip it -- that
 /// would quietly switch a filter back to the eager path and undo #1504's own

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18605,6 +18605,30 @@ fn test_jq_cursor_metadata_carve_out_keeps_first_inputs_lazy_1504() -> Result<()
     Ok(())
 }
 
+/// #1607's own native `Expr::Limit`/`Builtin::NthStream` arms in
+/// `eval_generic.rs` are reachable from the same carved-out path as
+/// `first(inputs), line` above, and needed the identical #1309 guard --
+/// without it, `limit`/`nth` over `inputs` mixed with a cursor-metadata
+/// builtin silently drained the whole remaining queue via `eval.rs`'s
+/// eager `builtin_inputs` instead of stopping at `n`/index `n` (a
+/// regression this PR's own new native arms would otherwise have
+/// introduced, not a pre-existing gap: pre-#1607, `Expr::Limit`/
+/// `Builtin::NthStream` always fell straight to `eval.rs`'s fully-lazy
+/// `each_take_n`/`each_take_nth`, which never had this problem).
+#[test]
+fn test_jq_cursor_metadata_carve_out_keeps_limit_and_nth_inputs_lazy_1607() -> Result<()> {
+    for (filter, expected) in [
+        ("[nth(1; inputs), line, [inputs]]", "[2,1,[3,4]]\n"),
+        ("[limit(2; inputs), line, [inputs]]", "[1,2,1,[3,4]]\n"),
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-cn", filter], Some("1\n2\n3\n4\n")).expect("limit/nth carve-out runs");
+        assert_eq!(code, 0, "{filter}: stdout: {stdout}\nstderr: {stderr}");
+        assert_eq!(stdout, expected, "{filter}");
+    }
+    Ok(())
+}
+
 /// The carve-out keys off the `line`/`at_offset`/... *builtins*, so a field
 /// or key that merely spells one of their names must not trip it -- that
 /// would quietly switch a filter back to the eager path and undo #1504's own

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22532,6 +22532,111 @@ fn test_lazy_keys_streaming_preserves_yaml_duplicates_1599() -> Result<()> {
     Ok(())
 }
 
+/// #1607: `limit`/`nth` over `keys | .[]` used to disagree with the
+/// collecting path (`[keys | .[]]`) on the same duplicate-key document —
+/// `[limit(3; keys|.[])]` capped at 2 keys regardless of how large `n` was
+/// (`limit(9; ...)` gave the identical, wrong answer), and `nth(2; ...)`
+/// produced nothing at all. Root cause: `Expr::Limit`/`Builtin::NthStream`
+/// had no native arm in the generic evaluator, so both fell to the `_`
+/// fallback that materializes the whole input into an `OwnedValue` before
+/// `expr` ever runs — and `OwnedValue::Object` is `IndexMap`-backed and
+/// cannot represent a duplicate mapping key, unlike `keys|.[]` alone (via
+/// `GenericResult::LazyKeys`/`DistinctKeyCursors`), which already preserved
+/// them correctly. Mirrors #607's identical fix for `first`/`last`.
+#[test]
+fn test_limit_and_nth_over_lazy_keys_preserve_yaml_duplicates_1607() -> Result<()> {
+    let dup = "b: 1\na: 2\nb: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+
+    // The reference: the collecting path already preserves every duplicate.
+    let (out, code) = run_yq_stdin("[keys | .[]]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","a","b"]"#);
+
+    // `limit` must agree with it at every `n`, including past the document's
+    // own key count (`n` capping the *output*, not silently capping at the
+    // first duplicate regardless of `n`).
+    for (n, want) in [
+        (1, r#"["b"]"#),
+        (2, r#"["b","a"]"#),
+        (3, r#"["b","a","b"]"#),
+        (9, r#"["b","a","b"]"#),
+    ] {
+        let (out, code) = run_yq_stdin(&format!("[limit({n}; keys|.[])]"), dup, &args)?;
+        assert_eq!(code, 0, "limit({n}; ...)");
+        assert_eq!(out.trim(), want, "limit({n}; ...)");
+    }
+
+    // `nth` must reach the second occurrence of the duplicated key too, not
+    // just the first.
+    for (n, want) in [(0, r#""b""#), (1, r#""a""#), (2, r#""b""#)] {
+        let (out, code) = run_yq_stdin(&format!("nth({n}; keys|.[])"), dup, &args)?;
+        assert_eq!(code, 0, "nth({n}; ...)");
+        assert_eq!(out.trim(), want, "nth({n}; ...)");
+    }
+    // Past the last key: no output, not an error.
+    let (out, code) = run_yq_stdin("nth(3; keys|.[])", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "");
+
+    Ok(())
+}
+
+/// #1607 follow-up: control-flow edge cases the native `limit`/`nth` arms
+/// must still get right once duplicate keys stopped being the reason to
+/// take the `_` fallback -- these don't depend on any duplicate key at all,
+/// just on the sink/`Flow` reconciliation `eval_limit_generic`/
+/// `eval_nth_generic` reimplement from `eval.rs`'s `each_take_n`/
+/// `each_take_nth`.
+#[test]
+fn test_limit_and_nth_control_flow_1607() -> Result<()> {
+    // `n == 0` is the empty result, not an error.
+    let (out, code) = run_yq_stdin(
+        "[limit(0; keys|.[])]",
+        "a: 1\nb: 2\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[]");
+
+    // A negative `n` is unlimited for `limit` (#983) -- every output passes
+    // through unchanged, including both occurrences of a duplicate key.
+    let (out, code) = run_yq_stdin(
+        "[limit(-1; keys|.[])]",
+        "b: 1\na: 2\nb: 3\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","a","b"]"#);
+
+    // A negative `n` is instead an error for `nth`, not unlimited --
+    // `eval_nth_generic` must reproduce `builtin_nth_stream`'s classification
+    // (and its exact message), not `eval_nth_expr`'s different one.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(
+        "nth(-1; keys|.[])",
+        "a: 1\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("nth doesn't support negative indices"),
+        "stderr: {stderr}"
+    );
+
+    // A generator `n` (`limit((1,2); f)`, re-running `f` once per `n` value,
+    // #1279) is deliberately left on the deferred fallback -- confirm it
+    // still gets the right, jq-parity answer through that path.
+    let (out, code) = run_yq_stdin(
+        "[limit((1,2); (10,20,30))]",
+        "null\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[10,10,20]");
+
+    Ok(())
+}
+
 /// #1247: a mapping key that fails to decode must not hide the *valid*
 /// fields after it. `YamlFields::find`/`find_cursor` used to `?` out of the
 /// whole search on the first undecodable key, so `.b` answered `null` here

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22637,6 +22637,39 @@ fn test_limit_and_nth_control_flow_1607() -> Result<()> {
     Ok(())
 }
 
+/// #1607 review follow-up: `limit`/`nth` must preserve a duplicate key
+/// *inside the captured value itself*, not only across their own iteration
+/// walk (the original repro's scope, `keys|.[]`, only ever captures plain
+/// strings, which have nothing internal to lose). `limit(1; .[])`/
+/// `nth(0; .[])` on a sequence whose picked element is itself a
+/// duplicate-keyed mapping used to collapse that duplicate, unlike
+/// `first(.[])` on the identical input (#607) -- both routes need
+/// `can_use_m2_streaming` to recurse into `expr` the same way
+/// `FirstExpr`/`LastExpr`/`Map` already do, or a correctly cursor-preserving
+/// `GenericResult` from `eval_generic.rs` still gets flattened into an
+/// `IndexMap`-backed `OwnedValue` one layer up, in `evaluate_yaml_cursor`'s
+/// DOM path.
+#[test]
+fn test_limit_and_nth_preserve_duplicate_keys_inside_captured_item_1607() -> Result<()> {
+    let dup = "- b: 1\n  a: 2\n  b: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+    let want = r#"{"b":1,"a":2,"b":3}"#;
+
+    let (out, code) = run_yq_stdin("first(.[])", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), want, "first(.[]) (reference, #607)");
+
+    let (out, code) = run_yq_stdin("limit(1; .[])", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), want, "limit(1; .[])");
+
+    let (out, code) = run_yq_stdin("nth(0; .[])", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), want, "nth(0; .[])");
+
+    Ok(())
+}
+
 /// #1247: a mapping key that fails to decode must not hide the *valid*
 /// fields after it. `YamlFields::find`/`find_cursor` used to `?` out of the
 /// whole search on the first undecodable key, so `.b` answered `null` here


### PR DESCRIPTION
## Summary

- `limit(n; keys|.[])`/`nth(n; keys|.[])` disagreed with the collecting path (`[keys|.[]]`) on a document with a duplicate mapping key — `limit` capped at 2 keys regardless of `n`, and `nth(2; ...)` produced nothing at all.
- Root cause: `eval_generic.rs`'s `eval_single`/`eval_builtin` had no native arm for `Expr::Limit`/`Builtin::NthStream` — the parsed forms `limit(n;f)`/`nth(n;f)` actually reach — so both fell to the `_` fallback that materializes the whole input into an `OwnedValue` *before* `expr` ever runs. `OwnedValue::Object` is `IndexMap`-backed and structurally cannot represent a duplicate key. This is exactly the same shape as #607's fix for `first`/`last`.
- `eval_limit_generic`/`eval_nth_generic` add the missing native handling, built on `eval_each_generic`'s existing demand-driven `Pipe`/`Iterate`/`LazyKeys` machinery so duplicate keys survive.

## Three review rounds, in order

This PR went through three full multi-agent `/code-review` rounds (10 finder angles each, several with live binary reproduction against the parent commit and against real jq). Each round found genuine issues in the *new* code from the round before:

**Round 2** fixed:
- **Input-queue drain regression**: `limit`/`nth` over `inputs` combined with a cursor-metadata builtin silently drained the whole remaining queue instead of stopping at `n`/index `n`. Fixed with the same guard `eval_first_or_last_generic` uses for `first`/`last` (#1309).
- **`n_expr` double-evaluation**: a generator `n` was probed once, discovered multi-valued, and re-evaluated by the fallback — doubling any side effect. A bare top-level `Comma` is now detected and deferred *without* evaluating `n_expr` at all, closing the common case (a residual gap for a `Comma` hidden deeper, e.g. inside a `Pipe`, is documented and filed as #1687).
- **Captured-item duplicate keys**: `limit(1; .[])` on a duplicate-keyed mapping element still collapsed it, since every captured item was eagerly decoded instead of staying cursor-backed like `first`/`last`. Fixed with `items_to_generic_result` plus a `can_use_m2_streaming` fix in `yq_runner.rs` (a correctly cursor-preserving `GenericResult` was still getting flattened one layer up in `evaluate_yaml_cursor`'s DOM path).
- `classify_nth_n` extracted to `eval.rs` (shared with `builtin_nth_stream`, matching `classify_limit_n`'s own #1313 precedent).

**Round 3** fixed two more serious correctness bugs, both live-verified against `/usr/bin/jq` and the parent commit:
- **Lost streaming-before-error**: `limit`'s success path discarded the *entire* already-decoded prefix when a later item's decode failed, instead of surfacing it alongside the error the way real jq streams before erroring (#400/#494). `items_to_generic_result` now returns the partial prefix on failure. `limit(5; .[] | map(10/.))` on `[[1],[0]]` now prints `[10]` before erroring, matching real jq exactly (previously printed nothing).
- **`nth` skipped a side-effecting output it should have evaluated**: jq defines `nth($n;f)` as `last(limit($n+1;f))` — every output up to index `n` must genuinely run, not just the one kept. The sink discarded skipped items without forcing their lazy computation (a buffered `map`/`select` chain), so `nth(2; .[] | map(10/.))` on `[[1],[0],[2]]` silently skipped a division-by-zero and answered `[5]`/exit 0 instead of erroring/exit 5. Skipped items are now forced (but not decode-and-kept); the actually-captured item at index `n` stays cursor-backed as before.
- Also: a real (non-correctness) performance regression against O5/#1609 — `limit(n; keys|.[])` was re-decoding each captured key a second time; fixed with a dedicated `OneCursorValue` fast path. Simplified `eval_limit_generic`'s now-always-true `satisfied` guard away. Merged the three `can_use_m2_streaming` arms into one or-pattern, matching the existing `FirstExpr`/`LastExpr` precedent.

Filed **#1687** for what's still knowingly out of scope: `reduce`/`foreach`/`sort_by`/`group_by`/`unique_by`/`while`/`until`/`repeat` still reach the lossy `_` fallback (not a regression — always broken this way), and `limit`/`nth`'s own generator-`n` path still loses duplicate keys via that fallback.

## Test plan

- [x] `test_limit_and_nth_over_lazy_keys_preserve_yaml_duplicates_1607` — `limit`/`nth` agree with the collecting path at every position.
- [x] `test_limit_and_nth_control_flow_1607` — `limit(0;...)`, negative-n semantics (unlimited for `limit`, error for `nth`), deferred generator-`n` path.
- [x] `test_limit_and_nth_preserve_duplicate_keys_inside_captured_item_1607` — captured-item duplicate keys match `first(.[])`.
- [x] `test_jq_cursor_metadata_carve_out_keeps_limit_and_nth_inputs_lazy_1607` — `limit`/`nth` over `inputs` stay lazy, mirroring the existing `first(inputs)` carve-out test.
- [x] `test_jq_limit_streams_prefix_before_a_later_output_fails_1607` — streaming-before-error, pinned against real jq's own error text/exit code.
- [x] `test_jq_nth_still_evaluates_a_skipped_output_that_would_error_1607` — skipped-output evaluation, pinned against real jq's own error text/exit code.
- [x] Full `jq_cli_tests`/`jq_golden_tests`/`yq_cli_tests`/`yq_golden_tests` suites pass — zero regressions.
- [x] Full `cargo test --features cli,simd,regex,serde` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second clippy leg both clean.
- [x] `cargo build --no-default-features` still builds (no_std).
- [x] `cargo fmt --check` clean.

Fixes #1607
