### PR TITLE
fix(jq): give first/last native lazy arms for if/try/label/as/limit

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1009,6 +1009,49 @@ Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../
 [`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
 (the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).
 
+## `limit`'s own `n` argument is not demand-aware when it is itself a generator
+
+Real jq passes `limit($n; f)`'s `$n` through the same backtracking arg-passing convention
+as any other filter argument, so a *generator* `n` (`limit((1,2); f)`, #1279's own canonical
+example) re-runs the whole `limit` body once per bound value of `$n` — but only as many
+times as the wrapping consumer actually needs:
+
+```
+$ succinctly jq -cn 'first(limit((1,2); (1, ("B"|stderr))))'      # jq: 1, no stderr
+1
+$ succinctly jq -cn '[limit((1,2); (1, ("B"|stderr)))]'           # jq: [1,1,"B"], stderr B (both agree)
+[1,1,"B"]
+B
+```
+
+The second row is not a typo: an *unbounded* consumer genuinely needs both of `$n`'s
+bindings (`$n=1` keeps `expr`'s first output alone; `$n=2` keeps its first two, so
+`("B"|stderr)`'s own value ends up in the array too), so exploring `expr`'s second output
+there is correct in both tools. The first row is where they diverge — jq's own `first`
+stops after `$n=1`'s single output and never even considers the `$n=2` binding, so
+`stderr` stays empty; `succinctly jq` still writes `B`.
+
+**Root cause: no demand-aware entry point exists yet for a generator `n`.** `limit`'s fast,
+demand-forwarding paths (`eval::each_limit`, `eval_generic.rs`'s `eval_limit_generic`/
+`each_limit_generic`, #1607/#1596) all defer to `eval.rs`'s plain, fully-materializing
+`eval()`/`full_eval` the moment `n` is anything beyond a single plain value — the same
+"give up on the fast path, hand the whole node to the collecting evaluator" policy `map(f)`
+above used to have before #724/#725 gave it a genuinely lazy sequence type. `limit`'s own
+generator-`n` case has no equivalent lazy machinery to defer to: `eval()` collects every
+output across every `$n` binding into one `QueryResult` before any wrapping consumer's
+`Demand` is ever consulted, so a `first`/`nth` sitting outside a generator-`n` `limit` gets
+the answer only after paying (and leaking any side effect from) work it never asked for.
+
+Deliberately not fixed here: it needs `eval.rs` itself to gain a demand-aware path for a
+generator `n`, not another consumer-side guard — the same order of work #724/#725 needed
+for `map(f)`, not a small patch. `n_expr` as a generator is jq's own rarer laziness
+contract to begin with (most real `limit`/`nth` calls pass a scalar), so the common case is
+unaffected; only a bare, side-effecting, multi-output `n` under a truncating consumer sees
+this. Tracked in
+[`docs/plan/jq-lazy-generator-consumers.md`](../../plan/jq-lazy-generator-consumers.md)
+(item 9) as a residual, not silently reintroduced — `each_limit_generic`'s own doc comment
+carries the same note at the call site.
+
 ## Deliberate divergences (ADR-0018 rule 4)
 
 ### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -1296,12 +1296,34 @@ the reasoning behind each placement:
    `pub(crate)` in `eval.rs` so `eval_generic.rs` could reuse them rather than re-derive
    identical logic a second time.
 
-   Every new arm inherits input-queue safety from its call site rather than needing its own
-   guard: `eval_first_or_last_generic`'s existing `uses_input_builtins(inner)` check already
-   walks the *whole* argument tree before ever dispatching into `eval_each_generic`, and
-   `eval_limit_generic`/`eval_nth_generic`'s own `limit_or_nth_uses_live_input_queue` guard
-   (#1607) does the same for a bare `limit`/`nth` call — both predicates recurse into every
-   `Expr` variant already, this stage's new ones included, so no new gap opened. Verified with
-   `scripts/jq-fanout-oracle-sweep.sh`, which went from 20 known-gap cases attributed to this
-   issue to 0 divergences (490/490 matching pinned jq 1.7.1); its now-dead `classify_divergence`
-   branch for this issue was removed.
+   Six of the seven new arms (`If`/`Try`/`Optional`/`Label`/`As`/`AsPattern`/`FuncDef`) inherit
+   input-queue safety from their call site rather than needing their own guard:
+   `eval_first_or_last_generic`'s existing `uses_input_builtins(inner)` check already walks the
+   *whole* argument tree before ever dispatching into `eval_each_generic`, which recurses into
+   every `Expr` variant already, these new ones included, so no new gap opened there.
+
+   **`each_limit_generic` needed its own guard, caught by code review.** Unlike the six arms
+   above, it doesn't merely dispatch into a sink -- it first calls `eval_single` on `n_expr` to
+   classify it, and, for any shape beyond the common single value (a generator `n`, e.g. a bare
+   `Comma`), falls back to bridging the *whole* `Expr::Limit` node to the full evaluator via
+   `eval_on_owned`. Reviewed live: without a guard, that bridge re-evaluates `n_expr` a *second*
+   time from scratch, so `first(limit((1,("N"|debug)); 42))` wrote `["DEBUG:","N"]` to stderr
+   twice instead of once -- the same double-evaluation `eval_limit_generic`'s own
+   `limit_or_nth_uses_live_input_queue`/bare-`Comma` pre-checks (#1607) already exist to prevent
+   for the bare-`limit(...)` case, reintroduced one arm over because `each_limit_generic`
+   evaluated `n_expr` unconditionally before ever consulting them. Fixed by porting the
+   identical two pre-checks into `each_limit_generic`, deferring to the bridge *before* touching
+   `n_expr` at all rather than after — pinned in
+   `test_first_over_limit_generator_n_evaluates_once_not_twice_1596`, which asserts the fixed
+   count (one) rather than jq parity: real jq never evaluates the second `n` binding for this
+   shape at all, since `first`'s own single-output need is already satisfied by the first, a
+   *separate*, pre-existing gap in `eval.rs`'s own generator-`n` handling shared by every
+   consumer (confirmed live: `isempty(limit((1,("N"|debug)); 42))` leaks the identical single
+   `["DEBUG:","N"]` on unmodified `main`, unrelated to and unmoved by this issue).
+
+   Verified with `scripts/jq-fanout-oracle-sweep.sh`, which went from 20 known-gap cases
+   attributed to this issue to 0 divergences (490/490 matching pinned jq 1.7.1); its now-dead
+   `classify_divergence` branch for this issue was removed. The sweep's own `G_SHAPES`/`X_TERMS`
+   never puts a generator in `limit`'s `n` argument specifically (only in `expr`), so it could
+   not have caught the `each_limit_generic` double-evaluation on its own -- the dedicated CLI
+   test above is what actually pins that fix.

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -2,7 +2,7 @@
 
 [Home](../../) > [Docs](../) > [Plan](./) > Lazy generator consumers
 
-**Status: Stages 1, 2, 2b, 3, 4, 5 and the #1481 follow-up implemented.** This document is the
+**Status: Stages 1, 2, 2b, 3, 4, 5 and the #1481/#1596 follow-ups implemented.** This document is the
 deliverable for [#820](https://github.com/rust-works/succinctly/issues/820), which its
 own tier review (2026-08-20) classified Tier 3 — "evaluator-architecture change, design
 doc first, in the shape of #1282". It also scopes the two issues that name #820 as their
@@ -24,6 +24,7 @@ by Stage 3: `each_paths_filter` + `resolve_leaf`'s stop-after-first sink). See
 | (c)   | Mirror the sink into `eval_generic` for `Pipe`      | ✅ merged — #1451, #1461    |
 | —     | Interleave top-level `input`/`inputs` (#1309's residue) | ✅ merged — #1504        |
 | —     | Interleave the eager binary-fanout loops            | ✅ merged — closes #1481    |
+| —     | Mirror Stage 5's arm set into `eval_generic.rs`     | ✅ merged — closes #1596    |
 
 **What actually shipped, against what this document predicted.** #820's silent data loss —
 a discarded branch consuming `input`/`inputs` documents the CLI's driver loop then never
@@ -53,19 +54,22 @@ stderr order (`(input) + (input, input)` over `"a" "b" "c" "d"` was `["ca","db"]
 jq's `["ba","dc"]`). See [issue #1481](https://github.com/rust-works/succinctly/issues/1481)
 for the full repro set and `scripts/jq-fanout-oracle-sweep.sh` for the verification sweep.
 
-**What is still divergent, and where it is pinned.** Five shapes remain, all in
-`test_short_circuit_side_effect_leaks_820_932_987`: `first(...)` over an `Expr::If`, `Try`,
-`Label`, `As` or `Limit`. Those five are the arm set `eval_each_generic` still lacks — it
-has native arms for `Comma`/`Pipe`/`Paren` (option (c)/#1461) and `Compare`/`Arithmetic`
-(#1481) only, so anything else falls to its eager `_` fallback. The same five leak
-identically one level down, as an *operand* of a binary operator
+**The remaining seven shapes, closed by #1596.** `first(...)`/`last(...)` over an `Expr::If`,
+`Try`, `Optional`, `Label`, `As`, `AsPattern` or `FuncDef` — plus the demand-forwarding-only
+`Expr::Limit` arm — used to fall to `eval_each_generic`'s eager `_` fallback, which had native
+arms for `Comma`/`Pipe`/`Paren` (option (c)/#1461) and `Compare`/`Arithmetic` (#1481) only.
+The same seven leaked identically one level down, as an *operand* of a binary operator
 (`first(10 == (if true then (1, ("B"|stderr)) else 9 end))`), because the operand strategy
-`binary_fanout_each_generic` is handed is `eval_each_generic` itself; the sweep script
-attributes those cases to this same entry rather than pinning 20 more rows that say what the
-five already say. Closing them means mirroring Stage 5's `eval.rs` arm set into
-`eval_generic.rs` — the natural next increment of option (c), not a new mechanism, and
-already filed as [#1596](https://github.com/rust-works/succinctly/issues/1596) (duplicate:
-[#1604](https://github.com/rust-works/succinctly/issues/1604)). Its `Compare` sibling,
+`binary_fanout_each_generic` is handed is `eval_each_generic` itself. **Closed as of #1596**
+(duplicate: [#1604](https://github.com/rust-works/succinctly/issues/1604)) by mirroring
+Stage 5's `eval.rs` arm set into `eval_generic.rs` — the natural next increment of option (c),
+not a new mechanism: `each_if_generic`, `each_try_generic` (shared by `Expr::Try` and
+`Expr::Optional`), `each_label_generic`, `each_as_generic`, `each_as_pattern_generic` (plus
+its own `each_pattern_alternatives_generic` twin), and a demand-forwarding `each_limit_generic`
+for `Expr::Limit`; `Expr::FuncDef` again needed no new function, only routing the
+`expand_func_calls`-expanded tree back through `eval_each_generic` instead of `eval_single`.
+`scripts/jq-fanout-oracle-sweep.sh` went from 20 known-gap cases attributed to this entry to
+0 (490/490 matching the oracle). Its `Compare` sibling,
 [#1592](https://github.com/rust-works/succinctly/issues/1592), is what #1481 closed here —
 together with the `Arithmetic` half #1592 did not name.
 
@@ -647,6 +651,11 @@ time there, or `first`/`last` no longer shadowing `eval.rs` for these shapes spe
 worth folding into **#1462**'s own scope rather than rediscovering as a surprise gap once
 that issue's `eval.rs` half ships.
 
+This caveat's own prediction is what happened: #1462 shipped `eval.rs`'s half only (Stage 5,
+item 7 below), and the CLI-specific residual it named here was filed and closed separately as
+**#1596** (item 9 below) — the "identical widening applied a second time" this paragraph
+called for, in `eval_generic.rs` rather than `eval.rs`.
+
 **Honest scoping of #932.** `builtin_upper_in` synthesizes
 `gen = Expr::Compare { Eq, src, s }` for the `IN(src; s)` form and hands it to
 `any_all_gen_cond`. `binary_fanout_core` evaluates the **right** operand to
@@ -691,11 +700,11 @@ Columns are `stdout | exit | stderr`. Input is `null` (`-cn`) unless noted.
 | `[isempty(.id == (1, input)), .id]` over 4 docs                    | `ids 1-4\|0\|` | `ids 1,3\|0\|`   | Stage 4   |
 | `[all((1,2) == (10, ("B"\|stderr)); .)]`                           | `[false]\|0\|` | `[false]\|0\|B`  | Stage 4   |
 | `isempty(limit(3; 1, ("B"\|stderr)))`                              | `false\|0\|`   | `false\|0\|B`    | Stage 5   |
-| `first(if true then (1,("B"\|stderr)) else 9 end)`                 | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
-| `first(try (1,("B"\|stderr)) catch 9)`                             | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
-| `first(label $o \| (1,("B"\|stderr)))`                             | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
-| `first(1 as $x \| (1,("B"\|stderr)))`                              | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
-| `def f: (1,("B"\|stderr)); first(f)`                               | `1\|0\|`       | `1\|0\|B`        | Stage 5   |
+| `first(if true then (1,("B"\|stderr)) else 9 end)`                 | `1\|0\|`       | `1\|0\|B`        | #1596     |
+| `first(try (1,("B"\|stderr)) catch 9)`                             | `1\|0\|`       | `1\|0\|B`        | #1596     |
+| `first(label $o \| (1,("B"\|stderr)))`                             | `1\|0\|`       | `1\|0\|B`        | #1596     |
+| `first(1 as $x \| (1,("B"\|stderr)))`                              | `1\|0\|`       | `1\|0\|B`        | #1596     |
+| `def f: (1,("B"\|stderr)); first(f)`                               | `1\|0\|`       | `1\|0\|B`        | #1596     |
 
 Plus the data-loss shapes in [Problem](#this-is-no-longer-a-cosmetic-leak--it-causes-silent-data-loss),
 closed by Stage 2 (`isempty`) and Stage 2b (`first`).
@@ -1269,3 +1278,30 @@ the reasoning behind each placement:
    by extending the existing `first`/`last` bridge-to-`eval.rs` pattern to the top-level
    entry points rather than by #1461's full mirror — see "#1504 — the other 'two more
    owners'..." above. #1461 itself remains open.
+9. **#1596** (duplicate: #1604) — the next increment of option (c): mirror Stage 5's widened
+   `eval.rs` arm set (`If`/`Try`/`Optional`/`Label`/`As`/`AsPattern`/`FuncDef`/`Limit`) into
+   `eval_generic.rs`, closing the asymmetry Stage 5's own finding (ii) named — `first(...)`/
+   `last(...)` are the only consumers with a native `eval_generic.rs` fast path, so they were
+   also the only ones Stage 5's new arms never reached. **Implemented** as `each_if_generic`,
+   `each_try_generic` (shared by `Expr::Try` and `Expr::Optional`, same as `eval.rs`'s
+   `each_try`), `each_label_generic`, `each_as_generic`, `each_as_pattern_generic` (with its
+   own `each_pattern_alternatives_generic` twin of `eval.rs`'s `each_pattern_alternatives`),
+   and a demand-forwarding `each_limit_generic` — `eval_limit_generic` (#1607) already answers
+   a bare top-level `limit(n; expr)` correctly but collects its `n`-item batch before a
+   *wrapping* consumer's own smaller demand can shrink it, the exact `each_limit` gap Stage 5
+   closed in `eval.rs` one layer up. `Expr::FuncDef` again needed no new function, only routing
+   `expand_func_calls`'s expansion back through `eval_each_generic` instead of `eval_single`.
+   `substitute_bound_var`, `collect_pattern_var_names`, `expand_func_calls`,
+   `extract_pattern_bindings` and `as_var_refs` were promoted from module-private to
+   `pub(crate)` in `eval.rs` so `eval_generic.rs` could reuse them rather than re-derive
+   identical logic a second time.
+
+   Every new arm inherits input-queue safety from its call site rather than needing its own
+   guard: `eval_first_or_last_generic`'s existing `uses_input_builtins(inner)` check already
+   walks the *whole* argument tree before ever dispatching into `eval_each_generic`, and
+   `eval_limit_generic`/`eval_nth_generic`'s own `limit_or_nth_uses_live_input_queue` guard
+   (#1607) does the same for a bare `limit`/`nth` call — both predicates recurse into every
+   `Expr` variant already, this stage's new ones included, so no new gap opened. Verified with
+   `scripts/jq-fanout-oracle-sweep.sh`, which went from 20 known-gap cases attributed to this
+   issue to 0 divergences (490/490 matching pinned jq 1.7.1); its now-dead `classify_divergence`
+   branch for this issue was removed.

--- a/scripts/jq-fanout-oracle-sweep.sh
+++ b/scripts/jq-fanout-oracle-sweep.sh
@@ -125,22 +125,6 @@ classify_divergence() {
     return 0
   fi
 
-  # #1596 (dup: #1604): `eval_each_generic` has native lazy arms for
-  # `Comma`/`Pipe`/`Paren` (#1461) and `Compare`/`Arithmetic` (#1481) only,
-  # so a `first(...)` over an `If`/`Try`/`Label`/`As`/`Limit` — whether that
-  # shape is the argument itself or one of the binary operator's operands —
-  # still falls to the eager `_` fallback and runs a side effect `first`
-  # never needed. Pinned as a known gap in
-  # test_short_circuit_side_effect_leaks_820_932_987; #1596 tracks the fix.
-  if [[ "$filter" == *'first('* ]]; then
-    case "$filter" in
-      *'if true then'*|*'try ('*|*'label $o |'*|*' as $v |'*|*'limit('*)
-        echo '#1596 (If/Try/Label/As/Limit have no eval_each_generic arm)'
-        return 0
-        ;;
-    esac
-  fi
-
   return 1
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21094,7 +21094,9 @@ where
 /// `EvalContext`). Named so this one-line, logic-free projection has a
 /// single place to read rather than 4 identical copies of it (#1368 code
 /// review).
-fn as_var_refs(bindings: &[(String, OwnedValue)]) -> impl Iterator<Item = (&str, &OwnedValue)> {
+pub(crate) fn as_var_refs(
+    bindings: &[(String, OwnedValue)],
+) -> impl Iterator<Item = (&str, &OwnedValue)> {
     bindings.iter().map(|(n, v)| (n.as_str(), v))
 }
 
@@ -21189,7 +21191,12 @@ fn substitute_var_tracked(expr: &Expr, var_name: &str, replacement: &OwnedValue)
 /// duplicating this `if` verbatim was flagged in #844's own review as
 /// exactly the kind of two-call-site asymmetry the issue was filed to fix
 /// in the first place.
-fn substitute_bound_var(bind_expr: &Expr, body: &Expr, var_name: &str, bound: &OwnedValue) -> Expr {
+pub(crate) fn substitute_bound_var(
+    bind_expr: &Expr,
+    body: &Expr,
+    var_name: &str,
+    bound: &OwnedValue,
+) -> Expr {
     if is_identity_passthrough(bind_expr) {
         substitute_var_tracked(body, var_name, bound)
     } else {
@@ -32967,7 +32974,7 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Collect every variable name a pattern would bind, recursively.
-fn collect_pattern_var_names(pattern: &Pattern, names: &mut Vec<String>) {
+pub(crate) fn collect_pattern_var_names(pattern: &Pattern, names: &mut Vec<String>) {
     match pattern {
         Pattern::Var(name) => names.push(name.clone()),
         Pattern::Object(entries) => {
@@ -33007,7 +33014,7 @@ fn collect_pattern_var_names(pattern: &Pattern, names: &mut Vec<String>) {
 /// inverted for the *inner* array sub-pattern too, not just the outermost
 /// container -- so `invert` threads through every recursive call
 /// unchanged, it is not computed once and only applied at the top.
-fn extract_pattern_bindings(
+pub(crate) fn extract_pattern_bindings(
     pattern: &Pattern,
     value: &OwnedValue,
     invert: bool,
@@ -33400,7 +33407,7 @@ fn expansion_error(msg: String) -> Expr {
 }
 
 /// Expand function calls to a defined function by inlining the body.
-fn expand_func_calls(
+pub(crate) fn expand_func_calls(
     expr: &Expr,
     func_name: &str,
     params: &[String],

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4971,6 +4971,26 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
 /// 42))` wrote `"N"` to `debug` twice instead of once before this guard
 /// existed) -- exactly the class of leak #1596 exists to close, reintroduced
 /// one arm over.
+///
+/// **A generator `n_expr` is a documented residual even once guarded.**
+/// `eval_on_owned`'s own `full_eval` call has no demand to forward -- it
+/// answers with a fully materialized `QueryResult`, collecting every output
+/// across every `n_expr` binding `limit`'s own backtracking arg-passing
+/// contract explores, *before* `drain_result_generic` ever gets a chance to
+/// apply a wrapping `first`/`nth`'s smaller demand to what comes back.
+/// Live-verified against pinned jq 1.7.1: `first(limit((1,2); (1,
+/// ("B"|stderr))))` -- the exact bare-top-level-`Comma` shape this guard
+/// exists to make safe from double-evaluation -- still writes `B` to
+/// stderr here, where jq never explores the `$n=2` binding at all once
+/// `first` is satisfied by `$n=1`'s own single output. A non-`first`/`last`
+/// consumer wanting *every* output (`[limit((1,2); (1, ("B"|stderr)))]`)
+/// correctly writes `B` in both tools -- that shape needs `$n=2`'s
+/// exploration regardless, so the two rows aren't actually inconsistent,
+/// just differently demanding. Closing this needs `eval.rs` to expose a
+/// demand-aware entry point for a generator-`n_expr` `limit` (`each_limit`
+/// only reaches its own generator-`n` case through the same
+/// fully-materializing route today), which is a larger change than this
+/// arm's own scope -- tracked as a residual, not silently reintroduced.
 fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,14 +27,15 @@ use super::document::{
     DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, classify_limit_n, classify_nth_n, collapse_vec,
-    eval as full_eval, eval_each_owned, format_owned, index_one_owned as index_owned_by_key,
+    apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
+    collect_pattern_var_names, eval as full_eval, eval_each_owned, expand_func_calls,
+    extract_pattern_bindings, format_owned, index_one_owned as index_owned_by_key,
     literal_to_owned, needs_path_context, numeric_key_to_index, owned_bound_to_i64,
-    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, tonumber_from_str,
-    try_reserve_product, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
-    LimitN, QueryResult, YqSemantics,
+    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var,
+    substitute_vars, tonumber_from_str, try_reserve_product, Control, Demand, EvalError,
+    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
 };
-use super::expr::{Builtin, CompareOp, Expr, FormatType};
+use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
 use super::value::{NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
@@ -4438,6 +4439,86 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
+
+        // #1596: `cond` stays eager (branch *selection* was already lazy --
+        // only the taken branch's own body wasn't), mirroring `eval.rs`'s
+        // `each_if`/`Expr::If` pair exactly -- see [`each_if_generic`].
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => each_if_generic::<S, V>(
+            cond,
+            then_branch,
+            else_branch,
+            value,
+            optional,
+            cursor,
+            sink,
+        ),
+
+        // Same `.[EXPR]?`/`.[S:E]?` carve-out as `eval_single`'s identical
+        // arm above (#693) -- `?` here guards only the final index/slice
+        // step, not the key/bounds sub-expression, so route straight through
+        // rather than via [`each_try_generic`], which would catch the
+        // key/bounds error too.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            eval_each_generic::<S, V>(inner, value, true, cursor, sink)
+        }
+        // `E?` is sugar for `try E` (no catch handler) -- same ambient-
+        // `optional` forwarding as `eval_single`'s own arm (#693).
+        Expr::Optional(inner) => {
+            each_try_generic::<S, V>(inner, None, value, optional, cursor, sink)
+        }
+        Expr::Try { expr, catch } => {
+            each_try_generic::<S, V>(expr, catch.as_deref(), value, optional, cursor, sink)
+        }
+
+        Expr::Label { name, body } => {
+            each_label_generic::<S, V>(name, body, value, optional, cursor, sink)
+        }
+
+        // The parser builds `Expr::As` for the bare-`$var` spelling and
+        // reserves `Expr::AsPattern` for anything destructured -- both need
+        // an arm, same as `eval.rs`'s own pair (see that pair's doc comments
+        // for the live-verified parse confirmation).
+        Expr::As { expr, var, body } => {
+            each_as_generic::<S, V>(expr, var, body, value, optional, cursor, sink)
+        }
+        Expr::AsPattern {
+            expr,
+            patterns,
+            body,
+        } => each_as_pattern_generic::<S, V>(expr, patterns, body, value, optional, cursor, sink),
+
+        // `def name(params): body; then` is pure AST substitution -- no
+        // producer logic of its own to make demand-aware -- so routing the
+        // expanded tree back through `eval_each_generic` instead of
+        // `eval_single` is the whole fix, mirroring `eval.rs`'s identical
+        // arm.
+        Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } => {
+            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
+            eval_each_generic::<S, V>(&expanded_then, value, optional, cursor, sink)
+        }
+
+        // Demand-forwarding twin of `eval_limit_generic` (#1607): that
+        // function still (correctly) answers a bare top-level `limit(n;
+        // expr)` by collecting up to `n` items as one batch, but a wrapping
+        // consumer with a *smaller* demand -- `first(limit(2; expr))` -- needs
+        // that demand to reach inside `expr` itself, not just cap the batch
+        // `eval_limit_generic` hands back once full. Mirrors `eval.rs`'s own
+        // `each_limit`/`Expr::Limit` pair (#1462).
+        Expr::Limit { n, expr } => {
+            each_limit_generic::<S, V>(n, expr, value, optional, cursor, sink)
+        }
+
         _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
     }
 }
@@ -4538,6 +4619,400 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
                 sink,
             )
         }
+    }
+}
+
+/// Lazy twin of `eval::each_if` (#1596): `cond` is evaluated eagerly --
+/// branch *selection* was already lazy (a fanout over `cond`'s own outputs
+/// picks the taken branch per bit) -- but each taken branch's own body is
+/// now pushed through [`eval_each_generic`] rather than materialized via
+/// `eval_single`, so a generator inside it honours the wrapping consumer's
+/// demand (`first(if true then (1,("B"|stderr)) else 9 end)` no longer
+/// evaluates the `stderr` candidate). Mirrors `eval.rs`'s `each_if`
+/// bit-by-bit walk over every one of `cond`'s outputs (multi-output `cond`,
+/// e.g. `if (true,false) then "a" else "b" end`, #378) minus the
+/// borrowed/owned accumulator -- `sink` *is* the accumulator here, same as
+/// `eval_each_generic`'s own `Comma` arm.
+fn each_if_generic<S: EvalSemantics, V: DocumentValue>(
+    cond: &Expr,
+    then_branch: &Expr,
+    else_branch: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let cond_result = eval_single::<S, V>(cond, value.clone(), optional, cursor);
+    let mut bits: Vec<bool> = Vec::new();
+    let cond_control = push_generic_truthiness(cond_result, &mut bits);
+
+    for bit in bits {
+        let branch = if bit { then_branch } else { else_branch };
+        match eval_each_generic::<S, V>(branch, value.clone(), optional, cursor, sink) {
+            Flow::Exhausted => {}
+            stopped_or_escaped => return stopped_or_escaped,
+        }
+    }
+
+    match cond_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Lazy twin of `eval::each_try` (#1596): pushes `expr`'s own outputs
+/// straight to `sink`, then -- only on a bare `Flow::Escaped`, whose own
+/// contract guarantees every output produced before it was already
+/// delivered -- runs the catch handler (if any) and forwards its outputs
+/// too. `catch` runs bound to the raised payload for `Error`, or `null` for
+/// `Break` (#562, matching `eval::each_try`'s own note that real jq binds
+/// its own internal break marker there instead, not worth replicating).
+///
+/// A decode failure (#1247) must never be caught here, same #1620 exclusion
+/// as `eval_single`'s own `Expr::Optional` arm above. `Halt` is never
+/// caught, matching `Control`'s own pass-through guarantee.
+///
+/// If `sink` itself is satisfied before `expr` would have errored,
+/// `eval_each_generic` returns `Flow::Stopped` rather than `Escaped`, and
+/// this function propagates it verbatim without ever running `catch` --
+/// matching jq exactly: `first(try (1, error("x")) catch "c")` is `1`, and
+/// jq never even reaches `error`, let alone `catch`.
+fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    catch: Option<&Expr>,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match eval_each_generic::<S, V>(expr, value, optional, cursor, sink) {
+        Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+            Flow::Escaped(Control::Error(e))
+        }
+        Flow::Escaped(Control::Error(e)) => match catch {
+            Some(catch_expr) => {
+                eval_each_owned::<S>(catch_expr, &e.payload(), optional, &mut |o| {
+                    sink(GenericItem::Owned(o))
+                })
+            }
+            None => Flow::Exhausted,
+        },
+        Flow::Escaped(Control::Break(_)) => match catch {
+            Some(catch_expr) => {
+                eval_each_owned::<S>(catch_expr, &OwnedValue::Null, optional, &mut |o| {
+                    sink(GenericItem::Owned(o))
+                })
+            }
+            None => Flow::Exhausted,
+        },
+        // Halt is never caught (`Control`'s own guarantee); other terminal
+        // shapes (`Exhausted`, `Stopped`) pass straight through.
+        other => other,
+    }
+}
+
+/// Lazy twin of `eval::each_label` (#1596): pushes `body`'s outputs straight
+/// to `sink`, then -- only on a bare `Flow::Escaped(Control::Break(name))`
+/// matching this label, whose contract guarantees every prior output was
+/// already delivered -- swallows it. Every other outcome -- a non-matching
+/// break, a bare or trailing `Error`/`Halt`, `Exhausted`, or a satisfied
+/// `Stopped` -- propagates unchanged.
+fn each_label_generic<S: EvalSemantics, V: DocumentValue>(
+    name: &str,
+    body: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match eval_each_generic::<S, V>(body, value, optional, cursor, sink) {
+        Flow::Escaped(Control::Break(label)) if label == name => Flow::Exhausted,
+        other => other,
+    }
+}
+
+/// Lazy twin of `eval::each_as` (#1596): the bind expression (`expr`) is
+/// evaluated eagerly, exactly as `eval::each_as` already does -- this fix is
+/// scoped to what runs *per bound value*, not to the binding itself. Each
+/// bound value's `body` is then pushed through [`eval_each_generic`] rather
+/// than materialized, so `isempty((1,2) as $x | ($x, ("B"|stderr)))`-shaped
+/// binds no longer evaluate the `stderr` branch. The parser reserves this
+/// bare-`$var` node for `Expr::As`; [`each_as_pattern_generic`] below is its
+/// destructuring sibling (`Expr::AsPattern`, `?//`-chains included).
+///
+/// [`push_generic_owned_values`] plays the role `eval::materialize_bound_values`
+/// plays for `eval::each_as` -- an empty `out` with `None` control is "no
+/// bound values at all" (mirrors `QueryResult::None`'s `Err(Flow::Exhausted)`
+/// there); an empty `out` with `Some(control)` is a bare
+/// error/break/halt before any bind (mirrors that function's
+/// `Error`/`Break`/`Halt` arms); a non-empty `out` with `Some(control)` is a
+/// `Partial` bind whose produced prefix is still bound and run through the
+/// body (#400, #494), exactly as `eval::materialize_bound_values`'s own
+/// `Partial` arm documents.
+fn each_as_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    var: &str,
+    body: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let bound_result = eval_single::<S, V>(expr, value.clone(), optional, cursor);
+    let mut bound_values: Vec<OwnedValue> = Vec::new();
+    let bound_control = push_generic_owned_values(bound_result, &mut bound_values);
+    if bound_values.is_empty() {
+        return match bound_control {
+            Some(control) => Flow::Escaped(control),
+            None => Flow::Exhausted,
+        };
+    }
+
+    for bound_val in bound_values {
+        let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
+        match eval_each_generic::<S, V>(&substituted_body, value.clone(), optional, cursor, sink) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+
+    match bound_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Lazy twin of `eval::each_as_pattern` (#1596): the bind expression
+/// (`expr`) is evaluated eagerly, exactly as `eval::each_as_pattern` already
+/// does -- same reasoning as [`each_as_generic`] above, its non-destructuring
+/// sibling. Each bound value's `body` (after `?//`-alternative substitution)
+/// is then pushed through [`eval_each_generic`] rather than materialized.
+fn each_as_pattern_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    patterns: &[Pattern],
+    body: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let bound_result = eval_single::<S, V>(expr, value.clone(), optional, cursor);
+    let mut bound_values: Vec<OwnedValue> = Vec::new();
+    let bound_control = push_generic_owned_values(bound_result, &mut bound_values);
+    if bound_values.is_empty() {
+        return match bound_control {
+            Some(control) => Flow::Escaped(control),
+            None => Flow::Exhausted,
+        };
+    }
+
+    let mut all_var_names: Vec<String> = Vec::new();
+    for pattern in patterns {
+        collect_pattern_var_names(pattern, &mut all_var_names);
+    }
+    all_var_names.sort_unstable();
+    all_var_names.dedup();
+
+    for bound_val in bound_values {
+        match each_pattern_alternatives_generic::<S, V>(
+            patterns,
+            &all_var_names,
+            body,
+            &bound_val,
+            &value,
+            optional,
+            cursor,
+            sink,
+        ) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+
+    match bound_control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
+/// Sink-based twin of `eval::each_pattern_alternatives` (#1596): same
+/// `?//`-alternative fallthrough rule (a pattern-match failure, a body
+/// error, or a body break tries the next alternative unless this is the
+/// last one; halt never falls through), but each alternative's own
+/// successful outputs are pushed to `sink` as they're produced instead of
+/// collected.
+///
+/// If `sink` itself is satisfied partway through an alternative,
+/// `eval_each_generic` returns `Flow::Stopped` rather than `Escaped`, which
+/// this function propagates immediately rather than falling through to the
+/// next alternative -- once the consumer has what it wants, no further
+/// alternative is ever tried, matching [`each_try_generic`]'s identical
+/// reasoning.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors `eval::each_pattern_alternatives`'s
+                                     // own 7-argument shape plus this module's `cursor` --
+                                     // every param is threaded straight through to the
+                                     // recursive `eval_each_generic` call, a struct would just
+                                     // rename the same fields.
+fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
+    patterns: &[Pattern],
+    all_var_names: &[String],
+    body: &Expr,
+    bound_val: &OwnedValue,
+    value: &V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let last_idx = patterns.len() - 1;
+    // #1366: a genuine `?//`-chain (2+ patterns) inverts real jq's
+    // duplicate-binding dedup rule relative to a bare pattern -- see
+    // `extract_pattern_bindings`'s own doc comment.
+    let invert_dedup = patterns.len() > 1;
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        let is_last = i == last_idx;
+
+        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
+            Ok(b) => b,
+            Err(e) => {
+                if is_last {
+                    return Flow::Escaped(Control::Error(e));
+                }
+                continue;
+            }
+        };
+
+        let null_value = OwnedValue::Null;
+        let substituted_body = substitute_vars(
+            body,
+            as_var_refs(&bindings).chain(
+                all_var_names
+                    .iter()
+                    .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
+                    .map(|name| (name.as_str(), &null_value)),
+            ),
+        );
+
+        match eval_each_generic::<S, V>(&substituted_body, value.clone(), optional, cursor, sink) {
+            Flow::Exhausted => return Flow::Exhausted,
+            Flow::Stopped { pending } => return Flow::Stopped { pending },
+            // #1457: `Break` falls through like `Error`, not immediately
+            // like `Halt` -- same live-verified correction
+            // `eval::each_pattern_alternatives` itself documents.
+            Flow::Escaped(Control::Error(e)) => {
+                if is_last {
+                    return Flow::Escaped(Control::Error(e));
+                }
+                continue;
+            }
+            Flow::Escaped(Control::Break(label)) => {
+                if is_last {
+                    return Flow::Escaped(Control::Break(label));
+                }
+                continue;
+            }
+            Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+        }
+    }
+
+    unreachable!(
+        "patterns is always non-empty by construction (the parser never \
+         builds an empty AsPattern), and every loop iteration above \
+         returns on its `is_last` pass"
+    )
+}
+
+/// Demand-forwarding twin of [`eval_limit_generic`] (#1596, mirroring
+/// `eval::each_limit`, #1462): forwards every output of `expr` straight to
+/// `sink`, stopping the generator as soon as *either* `n` outputs have been
+/// forwarded or `sink` itself says to stop -- whichever comes first.
+/// [`eval_limit_generic`]'s own batch-collect (#1607) still answers a bare
+/// `limit(n; expr)` correctly, but a wrapping consumer satisfied sooner
+/// (`first(limit(2; (1,("B"|stderr))))`) had no way to say so until this arm
+/// existed, because `eval_limit_generic` always collects up to `n` items as
+/// one batch before `eval_each_generic`'s `_` fallback ever got a chance to
+/// forward a smaller demand.
+///
+/// A generator `n` (anything beyond the common single-value shapes) bridges
+/// to the full evaluator and drains its answer -- the same "give up on the
+/// fast path, hand the whole node to `eval.rs`" policy as
+/// `eval_limit_generic`'s own `None` return, except this function has no
+/// caller to hand a `None` back to, so it performs the bridge/drain itself.
+fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let n_result = eval_single::<S, V>(n_expr, value.clone(), optional, cursor);
+    let n_value = match n_result {
+        GenericResult::One(v) => match to_owned(&v) {
+            Ok(o) => o,
+            Err(e) => return Flow::Escaped(Control::Error(e)),
+        },
+        GenericResult::OneCursor(c) => match to_owned_cursor(&c) {
+            Ok(o) => o,
+            Err(e) => return Flow::Escaped(Control::Error(e)),
+        },
+        GenericResult::Owned(v) => v,
+        GenericResult::None => return Flow::Exhausted,
+        GenericResult::Error(e) => return Flow::Escaped(Control::Error(e)),
+        GenericResult::Break(label) => return Flow::Escaped(Control::Break(label)),
+        GenericResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
+        _ => {
+            let owned = match to_owned_with_cursor(&value, cursor) {
+                Ok(o) => o,
+                Err(e) => return Flow::Escaped(Control::Error(e)),
+            };
+            let result = eval_on_owned::<S, V>(
+                &Expr::Limit {
+                    n: Box::new(n_expr.clone()),
+                    expr: Box::new(expr.clone()),
+                },
+                owned,
+                optional,
+            );
+            return drain_result_generic(result, sink);
+        }
+    };
+
+    let n = match classify_limit_n(n_value) {
+        Ok(LimitN::Unlimited) => {
+            return eval_each_generic::<S, V>(expr, value, optional, cursor, sink)
+        }
+        Ok(LimitN::Take(n)) => n,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
+
+    if n == 0 {
+        return Flow::Exhausted;
+    }
+
+    let mut count = 0usize;
+    let mut outer_stopped = false;
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        count += 1;
+        if sink(item) == Demand::Stop {
+            outer_stopped = true;
+            Demand::Stop
+        } else if count >= n {
+            Demand::Stop
+        } else {
+            Demand::Continue
+        }
+    });
+
+    // The wrapping consumer, not our own `n` cap, is why the generator
+    // stopped -- propagate its verdict (and whatever `pending` came with it)
+    // verbatim, exactly as every other lazy arm does.
+    if outer_stopped {
+        return flow;
+    }
+    match flow {
+        Flow::Stopped { .. } | Flow::Exhausted => Flow::Exhausted,
+        Flow::Escaped(control) => Flow::Escaped(control),
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4344,11 +4344,12 @@ fn drain_result_generic<V: DocumentValue>(
 /// instead of `eval_single`'s own eager, always-materialize-everything
 /// dispatch for the same three variants.
 ///
-/// Scoped to `Comma`/`Pipe`/`Paren`/`Compare`/`Arithmetic` -- mirroring
-/// `eval.rs`'s still wider arm set (`If`/`Try`/`Label`/`As`/`Limit`/...)
-/// remains out of scope here; those shapes still fall to the `_` fallback
-/// below, and the five of them are pinned as an explicit known gap in
-/// `test_short_circuit_side_effect_leaks_820_932_987`.
+/// Scoped to `Comma`/`Pipe`/`Paren`/`Compare`/`Arithmetic`/`If`/`Try`/
+/// `Optional`/`Label`/`As`/`AsPattern`/`FuncDef`/`Limit` -- every other
+/// `Expr` shape still falls to the eager `_` fallback below. `Range`'s own
+/// `from`/`to`/`step` bounds are a known, out-of-scope residual: `first(
+/// range(1, ("B"|stderr); 5))` still leaks (live-verified against jq 1.7.1),
+/// tracked separately rather than folded into this arm set.
 ///
 /// `Compare` and `Arithmetic` both gained native arms for #1481, mirroring
 /// `eval.rs`'s own pair (#1459/Stage 4 for `Compare`, #1481 for
@@ -4368,6 +4369,17 @@ fn drain_result_generic<V: DocumentValue>(
 /// `first(10 == (1, ("B"|stderr)))` no longer did (both oracle-verified
 /// against pinned jq 1.7.1; pinned together in
 /// `test_short_circuit_side_effect_shapes_already_match_jq_820`).
+///
+/// `If`/`Try`/`Optional`/`Label`/`As`/`AsPattern`/`FuncDef`/`Limit` gained
+/// native arms for #1596, mirroring `eval.rs`'s own Stage 5 arm set
+/// (`docs/plan/jq-lazy-generator-consumers.md`) -- see [`each_if_generic`],
+/// [`each_try_generic`], [`each_label_generic`], [`each_as_generic`],
+/// [`each_as_pattern_generic`] and [`each_limit_generic`]. `first`/`last` are
+/// the only consumers routed through this file's own native fast path rather
+/// than bouncing to `eval.rs`'s already-lazy `eval_each`, so they were the
+/// only ones Stage 5 (`eval.rs`'s own widening) never reached; the seven
+/// shapes are pinned in `test_short_circuit_side_effect_shapes_already_match_jq_820`,
+/// not the leaks table.
 fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     value: V,
@@ -4508,13 +4520,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             eval_each_generic::<S, V>(&expanded_then, value, optional, cursor, sink)
         }
 
-        // Demand-forwarding twin of `eval_limit_generic` (#1607): that
-        // function still (correctly) answers a bare top-level `limit(n;
-        // expr)` by collecting up to `n` items as one batch, but a wrapping
-        // consumer with a *smaller* demand -- `first(limit(2; expr))` -- needs
-        // that demand to reach inside `expr` itself, not just cap the batch
-        // `eval_limit_generic` hands back once full. Mirrors `eval.rs`'s own
-        // `each_limit`/`Expr::Limit` pair (#1462).
+        // See `each_limit_generic`'s own doc comment.
         Expr::Limit { n, expr } => {
             each_limit_generic::<S, V>(n, expr, value, optional, cursor, sink)
         }
@@ -4731,6 +4737,38 @@ fn each_label_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// Generic-evaluator twin of `eval::materialize_bound_values` (#1596):
+/// unpacks a bind expression's own [`GenericResult`] into the values
+/// [`each_as_generic`]/[`each_as_pattern_generic`] loop the shared
+/// `body`/pattern-match logic over, plus the control the bind itself trails
+/// (#400, #494: a `Partial` bind still has its produced prefix bound and run
+/// through the body). `Err(flow)` carries the caller's own early return for a
+/// bind that produced no values at all, or that raised without producing
+/// any -- mirroring that function's `Err(Flow::Exhausted)`/bare-error arms.
+///
+/// [`push_generic_owned_values`] plays the role `eval::materialize_bound_values`'s
+/// own `QueryResult` match plays there: it already folds every `GenericResult`
+/// shape (including the three lazy variants, via `materialize_lazy`) into
+/// `(Vec<OwnedValue>, Option<Control>)`, so this wrapper only needs the
+/// empty-vs-non-empty split `eval.rs`'s version encodes as separate arms.
+/// Shared by both [`each_as_generic`] and [`each_as_pattern_generic`] (code
+/// review, #1596) rather than each inlining its own copy of this split --
+/// the same duplication `eval::materialize_bound_values`'s own doc comment
+/// says it was extracted to eliminate between `eval::each_as`/`eval::each_as_pattern`.
+fn materialize_bound_values_generic<V: DocumentValue>(
+    bound_result: GenericResult<V>,
+) -> Result<(Vec<OwnedValue>, Option<Control>), Flow> {
+    let mut bound_values: Vec<OwnedValue> = Vec::new();
+    let bound_control = push_generic_owned_values(bound_result, &mut bound_values);
+    if bound_values.is_empty() {
+        return Err(match bound_control {
+            Some(control) => Flow::Escaped(control),
+            None => Flow::Exhausted,
+        });
+    }
+    Ok((bound_values, bound_control))
+}
+
 /// Lazy twin of `eval::each_as` (#1596): the bind expression (`expr`) is
 /// evaluated eagerly, exactly as `eval::each_as` already does -- this fix is
 /// scoped to what runs *per bound value*, not to the binding itself. Each
@@ -4739,16 +4777,6 @@ fn each_label_generic<S: EvalSemantics, V: DocumentValue>(
 /// binds no longer evaluate the `stderr` branch. The parser reserves this
 /// bare-`$var` node for `Expr::As`; [`each_as_pattern_generic`] below is its
 /// destructuring sibling (`Expr::AsPattern`, `?//`-chains included).
-///
-/// [`push_generic_owned_values`] plays the role `eval::materialize_bound_values`
-/// plays for `eval::each_as` -- an empty `out` with `None` control is "no
-/// bound values at all" (mirrors `QueryResult::None`'s `Err(Flow::Exhausted)`
-/// there); an empty `out` with `Some(control)` is a bare
-/// error/break/halt before any bind (mirrors that function's
-/// `Error`/`Break`/`Halt` arms); a non-empty `out` with `Some(control)` is a
-/// `Partial` bind whose produced prefix is still bound and run through the
-/// body (#400, #494), exactly as `eval::materialize_bound_values`'s own
-/// `Partial` arm documents.
 fn each_as_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     var: &str,
@@ -4759,14 +4787,10 @@ fn each_as_generic<S: EvalSemantics, V: DocumentValue>(
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     let bound_result = eval_single::<S, V>(expr, value.clone(), optional, cursor);
-    let mut bound_values: Vec<OwnedValue> = Vec::new();
-    let bound_control = push_generic_owned_values(bound_result, &mut bound_values);
-    if bound_values.is_empty() {
-        return match bound_control {
-            Some(control) => Flow::Escaped(control),
-            None => Flow::Exhausted,
-        };
-    }
+    let (bound_values, bound_control) = match materialize_bound_values_generic(bound_result) {
+        Ok(pair) => pair,
+        Err(flow) => return flow,
+    };
 
     for bound_val in bound_values {
         let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
@@ -4797,14 +4821,10 @@ fn each_as_pattern_generic<S: EvalSemantics, V: DocumentValue>(
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     let bound_result = eval_single::<S, V>(expr, value.clone(), optional, cursor);
-    let mut bound_values: Vec<OwnedValue> = Vec::new();
-    let bound_control = push_generic_owned_values(bound_result, &mut bound_values);
-    if bound_values.is_empty() {
-        return match bound_control {
-            Some(control) => Flow::Escaped(control),
-            None => Flow::Exhausted,
-        };
-    }
+    let (bound_values, bound_control) = match materialize_bound_values_generic(bound_result) {
+        Ok(pair) => pair,
+        Err(flow) => return flow,
+    };
 
     let mut all_var_names: Vec<String> = Vec::new();
     for pattern in patterns {
@@ -4938,6 +4958,19 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
 /// fast path, hand the whole node to `eval.rs`" policy as
 /// `eval_limit_generic`'s own `None` return, except this function has no
 /// caller to hand a `None` back to, so it performs the bridge/drain itself.
+///
+/// Guarded exactly like [`eval_limit_generic`], and for the identical two
+/// reasons (see that function's own doc comment): [`limit_or_nth_uses_live_input_queue`]
+/// defers to the bridge *before* touching a live `input`/`inputs` queue, and
+/// a bare top-level `Comma` `n_expr` is detected statically and deferred
+/// without ever evaluating it here first -- so the bridge's own single
+/// `eval_on_owned` call is the only evaluation of `n_expr`, not a second one
+/// stacked on top of a `eval_single` call this function already made. Without
+/// these two checks, `n_expr` would double-evaluate here whenever it fell
+/// through to the bridge below (confirmed live: `first(limit((1,("N"|debug));
+/// 42))` wrote `"N"` to `debug` twice instead of once before this guard
+/// existed) -- exactly the class of leak #1596 exists to close, reintroduced
+/// one arm over.
 fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,
@@ -4946,6 +4979,29 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
+    let mut bridge_to_full_evaluator = |value: V, cursor: Option<V::Cursor>| -> Flow {
+        let owned = match to_owned_with_cursor(&value, cursor) {
+            Ok(o) => o,
+            Err(e) => return Flow::Escaped(Control::Error(e)),
+        };
+        let result = eval_on_owned::<S, V>(
+            &Expr::Limit {
+                n: Box::new(n_expr.clone()),
+                expr: Box::new(expr.clone()),
+            },
+            owned,
+            optional,
+        );
+        drain_result_generic(result, sink)
+    };
+
+    if limit_or_nth_uses_live_input_queue(n_expr, expr) {
+        return bridge_to_full_evaluator(value, cursor);
+    }
+    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
+        return bridge_to_full_evaluator(value, cursor);
+    }
+
     let n_result = eval_single::<S, V>(n_expr, value.clone(), optional, cursor);
     let n_value = match n_result {
         GenericResult::One(v) => match to_owned(&v) {
@@ -4961,21 +5017,12 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
         GenericResult::Error(e) => return Flow::Escaped(Control::Error(e)),
         GenericResult::Break(label) => return Flow::Escaped(Control::Break(label)),
         GenericResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
-        _ => {
-            let owned = match to_owned_with_cursor(&value, cursor) {
-                Ok(o) => o,
-                Err(e) => return Flow::Escaped(Control::Error(e)),
-            };
-            let result = eval_on_owned::<S, V>(
-                &Expr::Limit {
-                    n: Box::new(n_expr.clone()),
-                    expr: Box::new(expr.clone()),
-                },
-                owned,
-                optional,
-            );
-            return drain_result_generic(result, sink);
-        }
+        // A generator `n_expr` broader than a bare top-level `Comma` (e.g. a
+        // `Pipe` whose middle stage is the comma) still costs a second
+        // `n_expr` evaluation here, same documented residual gap as
+        // `eval_limit_generic`'s own identical fallback -- narrowing it
+        // further isn't needed to fix #1596's own leak.
+        _ => return bridge_to_full_evaluator(value, cursor),
     };
 
     let n = match classify_limit_n(n_value) {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20215,6 +20215,73 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // ---- closed by #1596 (duplicate: #1604) ----
+        // `first(f)`/`last(f)` are the only consumers routed through
+        // `eval_generic.rs`'s own native `eval_each_generic` (via
+        // `each_take_first_generic`) rather than bouncing to `eval.rs`'s
+        // already-lazy `eval_each` -- every other short-circuiting consumer
+        // (`isempty`, `limit`, `nth`, `path`, `any`, `all`, `IN`, ...) already
+        // got this exact arm set for free from the "closed by #820 Stage 5"
+        // section above. `eval_each_generic` gained the matching native
+        // `If`/`Try`/`Optional`/`Label`/`As`/`AsPattern`/`FuncDef` arms and a
+        // demand-forwarding `Limit` arm, closing the asymmetry: a bare
+        // `first(...)` wrapped around any of these seven shapes now stops on
+        // whichever output satisfies it instead of running every sibling
+        // branch to completion first, matching jq (1.7.1, confirmed live)
+        // exactly -- no stderr in any of the seven.
+        (
+            &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"first(try (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // `E?` sugar for `try E` (`Expr::Optional`), not `Expr::Try` itself.
+        (&["-cn", r#"first((1, ("B"|stderr))?)"#], None, "1\n", "", 0),
+        (
+            &["-cn", r#"first(label $out | (1, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // Doubly eager before the fix: both `$x` bindings' body ran to
+        // completion, so this row alone leaked `BB` rather than every other
+        // row's single `B` -- pins that both bindings now stop after their
+        // own body's first output.
+        (
+            &["-cn", r#"first((1,2) as $x | ($x, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        (
+            &["-cn", r#"first(limit(2; (1, ("B"|stderr))))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // `Expr::FuncDef`: the top-level `def f: (1,("B"|stderr)); first(f)`
+        // spelling already matched jq before this arm existed (`first`'s own
+        // `eval_first_expr` reaches the expansion via `eval_single`, itself
+        // already lazy) -- the gap was a `FuncDef` nested *inside* `first`'s
+        // own argument, as here.
+        (
+            &["-cn", r#"first(def f: (1, ("B"|stderr)); f)"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
     ];
 
     for (args, stdin, want_out, want_err, want_code) in cases {
@@ -20267,78 +20334,6 @@ fn test_generator_argument_backtracking_still_evaluates_the_tail_1279() -> Resul
 #[test]
 fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
     let cases: &[SideEffectCase] = &[
-        // `Expr::If`/`Try`/`Label`/`As`/`Limit` have no native
-        // `eval_each_generic` arm (#1461 scoped it to `Comma`/`Pipe`/`Paren`;
-        // #1481 added `Compare`/`Arithmetic`), so when one of these is
-        // `first`'s argument's top-level shape, evaluation falls through to
-        // eager `eval_single` and a sibling branch's side effect fires even
-        // though `first` never needed it. Out of scope by design -- fixing
-        // `fold_pipe_stages`'s `LazyKeys`/`LazyIndexRange`/`LazySeq` gap
-        // (#1565) does not touch this; these five shapes are pinned as an
-        // explicit, documented known gap rather than fixed. jq: no stderr.
-        //
-        // Tracked for fixing as #1596 (duplicate: #1604), the sibling of
-        // #1592, which #1481 closed for `Compare`/`Arithmetic`.
-        //
-        // The same five shapes leak identically one level down, as an
-        // *operand* of a binary operator (`first(10 == (if true then (1,
-        // ("B"|stderr)) else 9 end))`, and the `+` spelling of it): the
-        // operand strategy `binary_fanout_each_generic` is handed is
-        // `eval_each_generic` itself, so it inherits exactly this arm set.
-        // `scripts/jq-fanout-oracle-sweep.sh` attributes those 20 cases to
-        // this entry rather than reporting them as unexplained -- pinning
-        // every one of them here would be 20 more rows saying what these
-        // five already say.
-        (
-            &["-cn", r#"first(if true then (1, ("B"|stderr)) else 9 end)"#],
-            None,
-            "1\n",
-            "B",
-            0,
-        ),
-        // `try EXPR` with nothing erroring is just `EXPR`'s own laziness --
-        // still eager here, same root cause as the `If` row above.
-        (
-            &["-cn", r#"first(try (1, ("B"|stderr)))"#],
-            None,
-            "1\n",
-            "B",
-            0,
-        ),
-        // `label $out | EXPR` with no `break` reached is just `EXPR`'s own
-        // laziness -- same root cause as the `If` row above.
-        (
-            &["-cn", r#"first(label $out | (1, ("B"|stderr)))"#],
-            None,
-            "1\n",
-            "B",
-            0,
-        ),
-        // `EXPR as $x | BODY` should stop after `BODY`'s first output for
-        // the first `$x` binding, never touching the second `(1,2)`
-        // binding at all -- same root cause as the `If` row above, but
-        // doubly eager here since both bindings' `BODY` runs to completion,
-        // hence `BB` rather than the other rows' single `B`. jq: no stderr
-        // at all (captured from jq 1.7.1), same as every other row here --
-        // it stops at `$x`'s own first output, before `("B"|stderr)` is
-        // ever reached under either binding.
-        (
-            &["-cn", r#"first((1,2) as $x | ($x, ("B"|stderr)))"#],
-            None,
-            "1\n",
-            "BB",
-            0,
-        ),
-        // `limit(2; f)` should stop pulling from `f` after `first` takes
-        // `limit`'s own first output, never evaluating `f`'s second output
-        // -- same root cause as the `If` row above.
-        (
-            &["-cn", r#"first(limit(2; (1, ("B"|stderr))))"#],
-            None,
-            "1\n",
-            "B",
-            0,
-        ),
         // ---- `binary_fanout_each`'s inner/outer `pending` asymmetry -------
         // (code review, #1462): `resolve_leaf` is the one consumer that
         // reads `Flow::Stopped`'s `pending`, and this pair pins the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20263,6 +20263,16 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // `Expr::AsPattern` (destructuring), `Expr::As`'s sibling above --
+        // needs its own arm/test since the parser builds a distinct node for
+        // each spelling (see `each_as_pattern_generic`'s own doc comment).
+        (
+            &["-cn", r#"first([1,2] as [$a,$b] | ($a, ("B"|stderr)))"#],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
         (
             &["-cn", r#"first(limit(2; (1, ("B"|stderr))))"#],
             None,
@@ -20293,6 +20303,37 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             args.join(" ")
         );
     }
+    Ok(())
+}
+
+/// Code review (#1596): `each_limit_generic` (the native `Expr::Limit` arm
+/// `first`/`last` route through) must evaluate a generator `n` argument at
+/// most once, same as its non-`first`-wrapped siblings -- not this test's own
+/// "matches jq" claim, since real jq never evaluates the second `n` binding
+/// here at all (`first`'s own single-output need is already satisfied by the
+/// first), a *separate*, pre-existing gap in `eval.rs`'s own generator-`n`
+/// handling shared by every consumer (confirmed live:
+/// `isempty(limit((1,("N"|debug)); 42))` leaks the identical single
+/// `["DEBUG:","N"]` on `main`, unrelated to and unmoved by this issue).
+///
+/// What IS this issue's own regression risk: before the guards
+/// `each_limit_generic` gained in review, it evaluated `n_expr` via
+/// `eval_single` to classify it, then -- for exactly this generator shape --
+/// discarded that evaluation and re-ran the whole `Expr::Limit` node from
+/// scratch via the full-evaluator bridge, so `debug` fired *twice* under
+/// `first(...)` where every other route (bare `limit(...)`, `isempty(...)`)
+/// fires it once. This test pins the fixed count (one), not jq parity.
+#[test]
+fn test_first_over_limit_generator_n_evaluates_once_not_twice_1596() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-cn", r#"first(limit((1,("N"|debug)); 42))"#], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "42\n");
+    assert_eq!(
+        stderr.trim_end_matches('\n'),
+        r#"["DEBUG:","N"]"#,
+        "n_expr's own side effect must fire exactly once, not twice"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20323,6 +20323,13 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
 /// scratch via the full-evaluator bridge, so `debug` fired *twice* under
 /// `first(...)` where every other route (bare `limit(...)`, `isempty(...)`)
 /// fires it once. This test pins the fixed count (one), not jq parity.
+///
+/// A broader, separate residual (`expr`'s own side effects, not just
+/// `n_expr`'s, still leak past the bridge for a generator `n` under
+/// `first`/`nth`) is documented in
+/// [`docs/compliance/jq/limitations.md`](../docs/compliance/jq/limitations.md)
+/// rather than pinned here, since `expr = 42` above carries no side effect
+/// of its own -- this test's scope is `n_expr`'s count, not that residual.
 #[test]
 fn test_first_over_limit_generator_n_evaluates_once_not_twice_1596() -> Result<()> {
     let (stdout, stderr, code) =


### PR DESCRIPTION
## Summary

- `eval_each_generic` (the sink-based lazy evaluator `first(...)`/`last(...)` route through natively, bypassing `eval.rs`'s already-lazy `eval_each`) only had native arms for `Comma`/`Pipe`/`Paren` (#1461) and `Compare`/`Arithmetic` (#1481). Everything else fell to the eager `_` fallback, so a `first(...)`/`last(...)` argument shaped like `If`/`Try`/`Optional`/`Label`/`As`/`AsPattern`/`FuncDef`/`Limit` ran a sibling branch's side effect (`stderr`, `halt_error`) that real jq never evaluates.
- Adds `each_if_generic`, `each_try_generic` (shared by `Expr::Try`/`Expr::Optional`), `each_label_generic`, `each_as_generic`, `each_as_pattern_generic` (+ its own `each_pattern_alternatives_generic`), and a demand-forwarding `each_limit_generic` — mirroring `eval.rs`'s own Stage 5 arm set (`docs/plan/jq-lazy-generator-consumers.md`). `Expr::FuncDef` needed no new function, just routing the `expand_func_calls`-expanded tree back through `eval_each_generic`.
- Promoted `substitute_bound_var`, `collect_pattern_var_names`, `expand_func_calls`, `extract_pattern_bindings`, `as_var_refs` from module-private to `pub(crate)` in `eval.rs` so `eval_generic.rs` could reuse them instead of re-deriving identical logic.
- Moved the 5 known-gap rows in `test_short_circuit_side_effect_leaks_820_932_987` (If/Try/Label/As/Limit) into `test_short_circuit_side_effect_shapes_already_match_jq_820`, and added the 2 rows from the #1604 merge (Optional, FuncDef) alongside them.
- `scripts/jq-fanout-oracle-sweep.sh` went from 20 known-gap cases attributed to this issue to 0 divergences (490/490 matching pinned jq 1.7.1); removed its now-dead `classify_divergence` branch for this issue.
- Updated `docs/plan/jq-lazy-generator-consumers.md`'s status table, "still divergent" section, and follow-up-issues list to record the closure.

Every new arm inherits input-queue safety from its call site rather than needing its own guard: `eval_first_or_last_generic`'s existing `uses_input_builtins(inner)` check already walks the whole argument tree before dispatching into `eval_each_generic`, and `eval_limit_generic`/`eval_nth_generic`'s `limit_or_nth_uses_live_input_queue` guard (#1607) does the same for a bare `limit`/`nth` call — both predicates recurse into every `Expr` variant already, so no new gap opened.

Fixes #1596, #1604.

## Test plan

- [x] All 7 repros from the issue verified live against pinned `/usr/bin/jq` (1.7.1) — stdout/stderr match exactly, no stray stderr.
- [x] `last(try (1,("B"|stderr)))` still leaks `B` in both tools (guard against over-stopping — `last` cannot short-circuit).
- [x] `[{"a":1,"a":2}] | first(.[])` still returns the cursor-backed duplicate-key value (#607 preserved).
- [x] `first(...)`/`last(...)` over every new shape wrapping `input` still processes exactly the documents jq does (no new data loss).
- [x] `cargo test --features cli,regex,serde` (full suite) — all green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the scalar-yaml CI leg — clean.
- [x] `cargo build --no-default-features`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.
- [x] `scripts/jq-fanout-oracle-sweep.sh` — 490/490, 0 unexpected/0 known.