### PR TITLE
perf(jq): short-circuit del()'s root-branch resolve, fix #1651

### DIFF
--- a/benches/jq_recurse_clone_bench.rs
+++ b/benches/jq_recurse_clone_bench.rs
@@ -51,6 +51,29 @@
 //! value that was sitting there), so that clone cost is pure waste — exactly
 //! the waste #668 describes.
 //!
+//! **#1651 update.** #701 made `push_recursive_branches`'s *path* half O(1)
+//! per node (an `Rc<PathPrefix>` cons-list replacing a `Vec<Expr>` clone),
+//! but this benchmark's growth exponent stayed k≈1.94 regardless — because
+//! `del(..)`'s own consumer, not `push_recursive_branches`, still flattened
+//! that O(1)-to-construct chain back down to an owned `Vec<Expr>`
+//! (`resolve_dynamic_indexes`'s `assemble`) and then *again* to
+//! `Vec<DeleteStep>` (`builtin_del`'s `flatten_delete_path`) — once per
+//! resolved branch, unconditionally, even though this fixture's own guard
+//! above proves the result is always `null` and neither flattened form is
+//! ever inspected. `resolve_dynamic_indexes` now takes a
+//! `short_circuit_del_root` flag, set only by `del()`'s own call: when any
+//! resolved branch is the document root (true for `..`/bare
+//! `recurse`/`recurse(f)`/`recurse(f;cond)` unconditionally, since each
+//! emits self before recursing into children), it returns
+//! `[Expr::Identity]` immediately, skipping both flattens. This benchmark
+//! now exercises only `push_recursive_branches`'s own O(d) branch
+//! construction (still real work — every node's path is still resolved) —
+//! its growth exponent should read ~k≈1 post-fix. A **filtered** recurse
+//! whose match set excludes the root (`del(.. | select(cond))` where `cond`
+//! rejects `.`) is *not* covered by this flag and still pays both O(d²)
+//! flattens in full — deliberately out of scope here; see the #1651
+//! follow-up issue for that shape.
+//!
 //! This file makes **no timing assertion** — it is a Criterion benchmark for
 //! manual before/after comparison, not a CI gate. Run it interleaved
 //! before/after #668's fix lands, per the A/B method in

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -23,6 +23,7 @@ This directory documents optimization techniques used in the succinctly library,
 | **String search**    | [jq-string-search.md](jq-string-search.md)               | memmem vs std Two-Way for jq substring builtins                       |
 | **jq allocation**    | [jq-format-allocation.md](jq-format-allocation.md)       | `@csv`/`@tsv`/`@dsv`/`@sh` byte-scan rewrite — investigated, rejected |
 | **Select scan**      | [select-scan.md](select-scan.md)                         | #40 scan-length measurement, IB cursor O(n²) fix                      |
+| **`del()` root short-circuit** | [del-root-shortcircuit.md](del-root-shortcircuit.md) | #1651 double-flatten O(d²) fix, k≈1.96→1.14                    |
 | **Targets**          | [targets.md](targets.md)                                 | CPU target configurations, architecture flags                         |
 | **SIMD Strategy**    | [simd-strategy.md](simd-strategy.md)                     | Per-module SIMD usage, platform support, lessons                      |
 
@@ -53,6 +54,7 @@ This directory documents optimization techniques used in the succinctly library,
 | O1 Sequential Cursor           | **3-13%** (query)  | Compact encoding | [end-positions.md](end-positions.md)                     |
 | O2 Gap-Skip rank1              | **2-6%** (query)   | Compact encoding | [end-positions.md](end-positions.md)                     |
 | jq Lazy String Slicing         | **8.5%** (vs regression), **2%** (vs baseline) | Control flow | src/jq/eval.rs |
+| `del()` Root Short-Circuit     | **20-49x** (grows with depth) | Control flow | [del-root-shortcircuit.md](del-root-shortcircuit.md) |
 
 ### Notable Failures (Instructive)
 

--- a/docs/optimizations/del-root-shortcircuit.md
+++ b/docs/optimizations/del-root-shortcircuit.md
@@ -1,0 +1,129 @@
+# `del()` Root-Branch Short-Circuit (#1651)
+
+[Home](../../) > [Docs](../) > [Optimizations](./) > `del()` root short-circuit
+
+Investigation of [#1651](https://github.com/rust-works/succinctly/issues/1651): #701/PR #1631
+made `push_recursive_branches`'s path-construction O(1) per node (an `Rc<PathPrefix>`
+persistent cons-list replacing a per-node `Vec<Expr>` clone), but `del(..)` on a depth-`d`
+document measured unchanged growth — k≈1.94 before *and* after that fix.
+
+**Outcome: the O(d²) was never in `delete_at_path`'s apply walk, as the issue's own title
+hypothesized — it was in two redundant flattening passes upstream that ran unconditionally
+before delete's own short-circuit ever got a chance to fire.**
+
+## The corrected root cause
+
+For `del(..)` on a linear-nesting document, `delete_expr_paths_at` (`src/jq/eval.rs`) already
+short-circuits to `Ok(Null)` on its very first call — `paths.iter().any(|path| path.len() ==
+start)` is true immediately, because the root branch's path has length 0. `delete_at_path`'s
+own `Expr::Identity` arm does the same thing for the single-path case. Neither function ever
+actually walks the tree for this query shape.
+
+The real O(d²) sat in two passes that ran *before* either of those checks:
+
+1. `resolve_dynamic_indexes`'s `assemble()` closure — shared infrastructure for
+   `path()`/`del()`/`=`/`|=` — calls `PathPrefix::to_vec()`, the persistent chain's one
+   documented O(depth) operation, **once per resolved branch**. `del(..)` resolves `d+1`
+   branches (one per visited node) with path lengths `0..=d`, summing to O(d²).
+2. `builtin_del`'s multi-path branch then calls `flatten_delete_path` **again**, per branch,
+   on the `Vec<Expr>` `assemble()` just built — a second, independent O(d²) pass.
+
+Both ran to completion, and both outputs were discarded, before `delete_expr_paths_at` was ever
+invoked.
+
+## Why `..`/`recurse` always hit this
+
+`push_recursive_branches` emits the branch for the current node *before* recursing into its
+children — the root branch is always `out[0]`. `recurse`'s own definition emits `.` regardless
+of what the recursion function does. So every unconditional recursive-descent construct
+(`..`, bare `recurse`, `recurse(f)`, `recurse(f;cond)`) resolves the document root as one of
+its branches, unconditionally — and `delete_expr_paths_at`'s existing rule (an exhausted path
+subsumes every sibling, collapsing the whole subtree to `null`) already covers that case. The
+fix is checking for it *before* paying either flatten, not a new semantic.
+
+## The fix
+
+`resolve_dynamic_indexes` gained a `short_circuit_del_root: bool` parameter, set to `true` only
+by `del()`'s own call site (`path()`, `=`, `|=` pass `false` — they need every resolved branch
+regardless of whether one is the root). When true, and any resolved branch's
+`PathPrefix::depth() == 0` — an O(1) check, since `depth` is a cached field on the persistent
+chain — it returns `[Expr::Identity]` immediately, skipping both flattens entirely:
+
+```rust
+Ok(branches) => {
+    if short_circuit_del_root && branches.iter().any(|b| b.path.depth() == 0) {
+        return Ok(vec![Expr::Identity]);
+    }
+    Ok(assemble(branches))
+}
+```
+
+Collapsing to `[Expr::Identity]` reuses a path `del(.)` already exercised before this change
+(plain `del(.)` hits `resolve_dynamic_indexes`'s `!needs_path_prepass` early return and produces
+exactly that), so no new code path was created.
+
+## Measured result
+
+A/B benchmark (`benches/jq_recurse_clone_bench.rs`'s `del(..)` on a linear-nesting document,
+Apple M4 Pro, dedicated idle bench box, interleaved per
+[the project's A/B method](../guides/benchmarking.md#ab-benchmarking-method), 3 rounds,
+`before` = `2467ca6c8` — the pre-#701 merge-base the issue's own original measurement used —
+`after` = this fix):
+
+| depth | before (avg of 3) | after (avg of 3) | speedup |
+|------:|-------------------:|-------------------:|--------:|
+| 100   | 318.9 µs            | 15.9 µs             | **20.0x**  |
+| 200   | 1225.4 µs           | 34.3 µs             | **35.7x**  |
+| 300   | 2751.8 µs           | 55.8 µs             | **49.3x**  |
+
+Fitting time ∝ depth^k across the three points: **k ≈ 1.96 before, k ≈ 1.14 after** — quadratic
+to near-linear. The speedup itself grows with depth (20x → 36x → 49x) rather than staying flat,
+which is the signature of an algorithmic term being removed rather than a constant-factor win.
+`before` here predates both #701 and this fix, but the issue's own prior measurement already
+established #701 alone left k≈1.94 unchanged — so this exponent drop is attributable to this
+fix specifically, not to #701's earlier, separate change.
+
+Output correctness: `del(..)` still collapses to `null` at every depth for both binaries (the
+benchmark's own built-in assertion), and the full test suite — including the golden fixtures —
+passes unchanged.
+
+## Deliberate scope boundary
+
+This fix covers exactly the shape where a resolved branch *is* the document root. It does
+**not** cover a filtered recursive descent whose match set excludes the root —
+`del(.. | select(cond))` where `cond` rejects `.` but matches scattered descendants (a "broom"
+shape: a shared deep prefix ending in a wide fan-out of matching leaf siblings). That shape
+never finds a `depth() == 0` branch, so both flattens still run in full. It's arguably the more
+common real-world case — most practical uses of `del(.. | select(...))` want to delete a
+*subset* of nodes, not the whole document — and is tracked as a separate, larger follow-up (a
+hash-consed deletion trie built from `Rc<PathPrefix>` pointer identity, giving true amortized
+O(d) for that shape too), matching this file's own established pattern of landing one verified
+O(d²) fix at a time (`push_recursive_branches`'s value clone → #668, its path clone → #701,
+`del()`'s flatten-before-apply cost → this fix).
+
+## Lessons
+
+- **A benchmark's own short-circuit can hide where the cost actually lives.** `del(..)`'s result
+  was always `null`, computed via a pre-existing O(1) collapse — but the code paths *leading up
+  to* that collapse still paid full freight. Profiling (or, here, reading the call graph against
+  what the benchmark's own correctness assertion guaranteed about its output) is what separated
+  "this function looks like it should be the bottleneck" from where the cost actually was.
+- **A prior fix's own unchanged exponent is a strong signal to keep looking, not to distrust the
+  fix.** #701's O(1)-per-node path construction was real and correct; the benchmark's exponent
+  staying flat meant a *second*, independent O(d²) term was hiding behind it, not that #701
+  didn't work.
+- **Growth-exponent, not one ratio.** A single before/after ratio at one depth would have shown
+  "faster" either way; only the scaling curve across three depths (and the speedup's own growth
+  with depth) distinguishes an algorithmic fix from a constant-factor one.
+
+## See also
+
+- [select-scan.md](select-scan.md) — the precedent this write-up is modeled on: a proposed
+  optimization that turned out to be measuring a different, quadratic defect entirely
+- [`src/jq/eval.rs`](../../src/jq/eval.rs) — `resolve_dynamic_indexes`, `builtin_del`,
+  `PathPrefix`, `delete_expr_paths_at`
+- [`benches/jq_recurse_clone_bench.rs`](../../benches/jq_recurse_clone_bench.rs) — the
+  benchmark this fix targets, and its own doc comment for the full `path(..)`-is-a-poor-isolator
+  reasoning
+- [docs/guides/benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method) — the A/B
+  method used for the measurement above

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -55121,6 +55121,44 @@ mod tests {
     }
 
     #[test]
+    fn flatten_delete_path_identity_arm_called_directly() {
+        // Before #1651, a comma branch that flattened to the document root
+        // (a bare `.` sibling, `del(., .a)`) reached this `Expr::Identity`
+        // arm through `builtin_del`'s own multi-path walk. `resolve_dynamic_indexes`'s
+        // `short_circuit_del_root` flag now catches every such branch first
+        // and returns `[Expr::Identity]` before `flatten_delete_path` is ever
+        // called on it, so that route is gone -- the arm's only remaining
+        // caller through the CLI is `yq_del_slice_outcome`'s bare,
+        // non-comma `del(.)`-shaped yq path. Exercised directly here rather
+        // than depending on that indirect route to keep it covered.
+        let mut steps = Vec::new();
+        flatten_delete_path(&Expr::Identity, false, &mut steps);
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn delete_expr_paths_at_exhausted_sibling_guard_called_directly() {
+        // #1651's `short_circuit_del_root` flag intercepts every comma
+        // branch that resolves to the document root before `builtin_del`
+        // ever calls `delete_expr_paths_at`, and `delete_expr_object_paths`/
+        // `delete_expr_array_paths` both filter an exhausted sibling into
+        // their own `terminal` set before recursing back in -- so this
+        // guard's `paths.iter().any(|path| path.len() == start)` arm can no
+        // longer be reached from any parseable query. Kept anyway: it is
+        // the panic-preventing check standing in front of
+        // `delete_expr_object_paths`/`delete_expr_array_paths`'s own
+        // `path[start]` indexing, which would panic on an empty path
+        // instead of returning cleanly if a future caller ever violated the
+        // invariant. Exercised directly, the same way the parser-unreachable
+        // `builtin_*` functions above are.
+        let empty: &[DeleteStep] = &[];
+        match delete_expr_paths_at(OwnedValue::Null, &[empty], 0) {
+            Ok(OwnedValue::Null) => {}
+            other => panic!("expected Ok(Null), got {other:?}"),
+        }
+    }
+
+    #[test]
     fn builtin_limit_propagates_halt_from_expr_argument() {
         // `Builtin::Limit` is never constructed by the parser: a CLI
         // `limit(n; expr)` always parses through `parse_limit_expr` (matched

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14951,7 +14951,7 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // fail in practice; falling back to `NotChecked` on the (unreachable)
     // `Err` arm just means the caller re-derives from scratch, same as
     // before this function existed.
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
         Ok(paths) => paths,
         Err(_) => return YqAssignNoopCheck::NotChecked,
     };
@@ -15040,7 +15040,7 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
         YqAssignNoopCheck::NotChecked => {
             let pristine = to_owned(&input);
-            let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+            let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
                 Ok(paths) => paths,
                 // `?` swallows only a genuine error; a halt always escapes,
                 // so `(.[(halt_error(3))] = 1)?` still halts instead of
@@ -15160,7 +15160,7 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // an outer `(.[-5] |= 9)?` needs exactly that swallowed. `update_path` is
     // always entered with `false` below; any `?` it still sees came from an
     // `Expr::Optional` node inside `path_expr` itself.
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the
         // matching comment in `eval_assign` (#791).
@@ -20847,11 +20847,42 @@ fn resolve_seq<'a, S: EvalSemantics>(
 /// repro is 22.0s -> 0.38s at 400,000. The four items above remain the
 /// reason this flag is `false`; they are not a prerequisite for `del`'s
 /// scaling.
+///
+/// `short_circuit_del_root` (#1651): when `true`, and any resolved branch's
+/// path is empty (`PathBranch::path.depth() == 0` — the document root
+/// itself was one of the resolved paths), returns `[Expr::Identity]`
+/// immediately, without calling `assemble()`. This is `del()`'s own
+/// exhausted-path rule (`delete_expr_paths_at`'s `paths.iter().any(|path|
+/// path.len() == start)` check, and `delete_at_path`'s `Expr::Identity`
+/// arm both already collapse the whole value to `null` once any branch is
+/// the root) applied *before* paying `assemble`'s `PathPrefix::to_vec()` —
+/// O(depth) per branch — for every other, now-irrelevant branch. `..`/bare
+/// `recurse`/`recurse(f)`/`recurse(f;cond)` all emit the root branch
+/// unconditionally (`push_recursive_branches` pushes the current node
+/// before recursing into children, and `recurse`'s own definition emits
+/// `.` regardless of what `f` does), so this turns `del(..)` from O(d²)
+/// (one O(depth) flatten per one of `d+1` branches) into O(d) (one O(1)
+/// `.depth()` check per branch) on a depth-`d` document — the residual
+/// term #701/#1631 left unfixed. Left `false` for `path()`/`=`/`|=`: they
+/// need every resolved branch regardless of whether one is the root
+/// (`path(.., .)` still reports every path; `(.., .) = 9` still writes
+/// every one), so a root branch carries no shortcut meaning for them.
+///
+/// Deliberately narrow: a filtered descent whose match set does *not*
+/// include the root (`del(.. | select(cond))` where `cond` rejects `.`)
+/// never finds a `depth() == 0` branch here and pays the full flatten
+/// regardless — that shape is tracked separately, not fixed by this flag.
 fn resolve_dynamic_indexes<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     defer_trailing_iterate: bool,
+    short_circuit_del_root: bool,
 ) -> Result<Vec<Expr>, (Vec<Expr>, EvalEscape)> {
+    debug_assert!(
+        !(short_circuit_del_root && defer_trailing_iterate),
+        "short_circuit_del_root is only meaningful for del()'s own call \
+         shape, which always passes defer_trailing_iterate=false"
+    );
     if !needs_path_prepass(expr) {
         return Ok(vec![expr.clone()]);
     }
@@ -20998,7 +21029,12 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         return match resolve_node::<S>(expr, input, true, false)
             .and_then(|branches| reject_untracked_at_terminal(branches, false))
         {
-            Ok(branches) => Ok(assemble(branches)),
+            Ok(branches) => {
+                if short_circuit_del_root && branches.iter().any(|b| b.path.depth() == 0) {
+                    return Ok(vec![Expr::Identity]);
+                }
+                Ok(assemble(branches))
+            }
             Err((prefix, e)) => Err((assemble(prefix), e)),
         };
     }
@@ -25777,7 +25813,7 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // a later one errors (confirmed live) — so that prefix is walked below
     // exactly like a successful resolution, and only the *error* is deferred
     // to the end.
-    let (exprs, resolve_error) = match resolve_dynamic_indexes::<S>(expr, &owned, true) {
+    let (exprs, resolve_error) = match resolve_dynamic_indexes::<S>(expr, &owned, true, false) {
         Ok(exprs) => (exprs, None),
         Err((exprs, e)) => (exprs, Some(e)),
     };
@@ -27579,7 +27615,14 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // but is always the sole entry, so it takes the `paths.len() <= 1`
     // branch below rather than `delete_expr_paths_at`'s comma-grouped one
     // (#1382).
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
+    //
+    // `short_circuit_del_root=true` (#1651): if any resolved branch is the
+    // document root, this returns `[Expr::Identity]` here without paying
+    // `assemble`'s O(depth)-per-branch flatten for every other branch —
+    // `delete_expr_paths_at`/`delete_at_path` would collapse the whole
+    // document to `null` once they got there anyway, on exactly this
+    // condition (see `resolve_dynamic_indexes`'s doc comment).
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false, true) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the
         // matching comment in `eval_assign` (#791).

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -1814,6 +1814,72 @@ fn test_del_with_comma_mixing_identity_and_other_paths() {
     check(r#"{"a":1,"b":2}"#, "del(., .)", Outcome::values(&["null"]));
 }
 
+/// #1651: `..`/bare `recurse`/`recurse(f)`/`recurse(f;cond)` all emit the
+/// document root as one of their resolved branches unconditionally — `del`
+/// of any of them collapses the whole document to `null`, the same rule
+/// [`test_del_with_comma_mixing_identity_and_other_paths`] pins for a
+/// hand-written comma. Before this fix, reaching that same `null` still
+/// cost an O(depth) flatten (`resolve_dynamic_indexes`'s `assemble`, then
+/// `builtin_del`'s own `flatten_delete_path`) *per resolved branch* — `d+1`
+/// of them on a depth-`d` document — even though the result was always
+/// `null` and neither flatten's output was ever inspected. Every value here
+/// was captured from real jq 1.7.1.
+#[test]
+fn test_del_recurse_family_root_branch_short_circuits_1651() {
+    check(r#"{"a":{"b":1}}"#, "del(..)", Outcome::values(&["null"]));
+    check(
+        r#"{"a":{"b":1}}"#,
+        "del(recurse)",
+        Outcome::values(&["null"]),
+    );
+    check(
+        r#"{"a":{"b":1}}"#,
+        "del(recurse(.[]?))",
+        Outcome::values(&["null"]),
+    );
+    check(
+        r#"{"a":{"b":1}}"#,
+        "del(recurse(.[]?; true))",
+        Outcome::values(&["null"]),
+    );
+    // A filtered recurse whose match set *does* include the root still
+    // collapses, exactly like the unconditional forms above — the
+    // short-circuit only depends on whether a `depth() == 0` branch is
+    // present, not on how it got there.
+    check(
+        r#"{"a":{"b":1}}"#,
+        r"del(.. | select(true))",
+        Outcome::values(&["null"]),
+    );
+}
+
+/// #1651: the root-branch short-circuit is `del()`-only. `path()`, `=` and
+/// `|=` must keep resolving *every* branch even when one of them is the
+/// document root — collapsing early for them would silently drop every
+/// other resolved path. Values captured from real jq 1.7.1.
+#[test]
+fn test_del_root_short_circuit_does_not_leak_into_path_or_writers_1651() {
+    check(
+        r#"{"a":1}"#,
+        r"[path(., .a)]",
+        Outcome::values(&[r#"[[],["a"]]"#]),
+    );
+    check(
+        r#"{"a":1}"#,
+        r"[path(recurse)]",
+        Outcome::values(&[r#"[[],["a"]]"#]),
+    );
+    // Root's own update is a no-op (it's an object, not a number), but `.a`
+    // and `.b` still get updated — if the short-circuit wrongly fired here,
+    // `.a`/`.b` would be silently skipped and the result would equal the
+    // unmodified input.
+    check(
+        r#"{"a":1,"b":2}"#,
+        r#"(., .a, .b) |= (if type == "number" then . + 10 else . end)"#,
+        Outcome::values(&[r#"{"a":11,"b":12}"#]),
+    );
+}
+
 /// #527: two comma siblings continuing through the same *missing* field
 /// (`.a.b.c` and `.a.b.d`, both through `.a.b`) put `delete_expr_object_paths`
 /// in front of a field name the object doesn't have, and it raised


### PR DESCRIPTION
## Summary

`del(..)`/`del(recurse(...))` resolve `d+1` static paths on a depth-`d` document, and each
was flattened from the shared, O(1)-to-construct `Rc<PathPrefix>` chain (#701/PR #1631) back
down to an owned `Vec<Expr>`/`Vec<DeleteStep>` — twice, once in `resolve_dynamic_indexes`'s
`assemble()` and again in `builtin_del`'s own `flatten_delete_path` — before
`delete_expr_paths_at` ever got the chance to short-circuit on the root branch it was always
going to find. That's why #701 fixed path *construction* but the growth exponent stayed
k≈1.94 in #1651's own measurement.

`resolve_dynamic_indexes` now takes a `short_circuit_del_root` flag, set only by `del()`'s
own call site. When any resolved branch is the document root (true unconditionally for `..`
and every `recurse(...)` variant, since each emits self before recursing into children), it
returns `[Expr::Identity]` immediately, skipping both flattens. `path()`/`=`/`|=` are
unaffected — they still resolve every branch regardless.

- A/B on the dedicated ARM bench box (interleaved, 3 rounds, `benches/jq_recurse_clone_bench.rs`'s
  `del(..)`): growth exponent drops from **k≈1.96 to k≈1.14**, with the speedup itself growing
  with depth (20x → 36x → 49x at depth 100/200/300) — the signature of an algorithmic fix, not
  a constant-factor one. Full numbers and analysis in
  [docs/optimizations/del-root-shortcircuit.md](docs/optimizations/del-root-shortcircuit.md).
- Deliberately scoped: a filtered recursive descent whose match set excludes the root
  (`del(.. | select(cond))` where `cond` rejects `.`) still pays both flattens — tracked as
  follow-up #1690, with a trie-based design already sketched there.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo build --no-default-features` (no_std path)
- [x] `cargo fmt --check`
- [x] `cargo test --features cli,regex` — full suite, 0 failures (2 new tests added:
      `test_del_recurse_family_root_branch_short_circuits_1651`,
      `test_del_root_short_circuit_does_not_leak_into_path_or_writers_1651`)
- [x] Manual probes cross-checked against real `jq` (`/usr/bin/jq` 1.7.1) for `del(..)`,
      `del(recurse)`, `del(recurse(.[]?))`, `del(., .[.x])`
- [x] A/B benchmark on the dedicated idle ARM box, interleaved per
      `docs/guides/benchmarking.md#ab-benchmarking-method`