### PR TITLE
test(cli): dedup classify_cargo_run_exit, fix false-pass in ?// yq test

### DIFF
--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -26,12 +26,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::classify_cargo_run_exit;
-
-/// Maximum retries for `cargo run` commands that fail with exit code 101.
-/// Handles flaky failures from cargo lock contention when tests run in parallel
-/// (same rationale as the other CLI integration tests).
-const MAX_CARGO_RETRIES: u32 = 3;
+use cargo_run_exit::{classify_cargo_run_exit, MAX_CARGO_RETRIES};
 
 /// Run `succinctly <args>` with `stdin` piped in, returning captured stdout.
 ///

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -24,6 +24,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::classify_cargo_run_exit;
+
 /// Maximum retries for `cargo run` commands that fail with exit code 101.
 /// Handles flaky failures from cargo lock contention when tests run in parallel
 /// (same rationale as the other CLI integration tests).
@@ -49,16 +53,15 @@ fn run(args: &[&str], stdin: &str) -> Result<String> {
         }
 
         let output = cmd.wait_with_output()?;
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry.
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if exit_code != 0 {
             anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
         }
 

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -9,11 +9,7 @@ use std::time::Duration;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, signal_death_error};
-
-/// Maximum retries for cargo run commands that fail with exit code 101.
-/// This handles flaky failures from cargo lock contention when tests run in parallel.
-const MAX_CARGO_RETRIES: u32 = 3;
+use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
 
 /// Helper to run a CLI command and capture its output
 fn run_cli(args: &[&str]) -> Result<String> {

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -7,6 +7,10 @@ use anyhow::Result;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::{classify_cargo_run_exit, signal_death_error};
+
 /// Maximum retries for cargo run commands that fail with exit code 101.
 /// This handles flaky failures from cargo lock contention when tests run in parallel.
 const MAX_CARGO_RETRIES: u32 = 3;
@@ -19,16 +23,15 @@ fn run_cli(args: &[&str]) -> Result<String> {
             .args(args)
             .output()?;
 
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if exit_code != 0 {
             anyhow::bail!("Command failed: {stderr}");
         }
 
@@ -360,9 +363,13 @@ fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
         .stderr(Stdio::piped())
         .output()?;
 
-    let exit_code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    // #1546: `.code().unwrap_or(-1)` would coerce a signal-killed child to a
+    // fake exit code -1 rather than reporting the death.
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -13,6 +13,18 @@
 
 use anyhow::Result;
 
+/// Maximum retries for a `cargo run` command that fails with exit code 101,
+/// or whose child is killed by a signal (`ExitStatus::code()` returns `None`
+/// only in that case, on Unix). Both are treated as transient: `101` often
+/// means cargo lock contention between concurrently running tests, and a
+/// signal death under the same heavy concurrent load (an OOM kill, another
+/// session's `pkill`, or fallout from that same lock contention) is just as
+/// likely to be environmental as a real bug in the code under test (#1516).
+/// Shared here, not redeclared per file (#1546 code review): a retry budget
+/// tuned in one file and not the others would recreate the exact drift this
+/// module exists to prevent, just for a constant instead of a function.
+pub const MAX_CARGO_RETRIES: u32 = 3;
+
 /// Builds the "child was killed by signal N" error for a signal-terminated
 /// process (`ExitStatus::code()` returns `None` only in that case, on Unix),
 /// naming the signal and the captured stderr. Historically every call site

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -1,0 +1,66 @@
+//! Shared exit-code classification for `cargo run`-spawned CLI test helpers.
+//!
+//! Included by `tests/jq_cli_tests.rs`, `tests/cli_golden_tests.rs`,
+//! `tests/cli_characterization_tests.rs` and `tests/deep_nesting_valid_tests.rs`
+//! via `#[path = ...] mod`, per the `tests/common/` convention `json_oracle.rs`
+//! established. #1516 fixed the signal-death misdiagnosis
+//! (`.code().unwrap_or(-1)` silently coercing a killed child to a fake exit
+//! code) in `jq_cli_tests.rs` alone; its own `/code-review` found the
+//! identical pattern hand-rolled in three more files (#1546). Sharing one
+//! copy here, rather than four independently drifting ones, is the fix.
+
+#![allow(dead_code)] // Each consumer uses a different subset.
+
+use anyhow::Result;
+
+/// Builds the "child was killed by signal N" error for a signal-terminated
+/// process (`ExitStatus::code()` returns `None` only in that case, on Unix),
+/// naming the signal and the captured stderr. Historically every call site
+/// below silently coerced this to `-1` via `.code().unwrap_or(-1)`, which
+/// renders as an inscrutable `left: -1, right: 0` with no indication a child
+/// was ever killed -- exactly what cost a wrong root-cause call in the #1459
+/// review (#1516).
+pub fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
+    // `ExitStatus::code()` returns `None` only when the child was
+    // terminated by a signal (Unix) -- there is no other cause.
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    anyhow::anyhow!(
+        "child was killed by signal {}; stderr:\n{stderr}",
+        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
+    )
+}
+
+/// Classifies a `cargo run` child's exit for a retry loop, so each call site
+/// doesn't hand-roll its own "retry on 101" check.
+///
+/// Returns `Ok(Some(code))` once a real exit code is available to the
+/// caller, or `Ok(None)` when the caller should sleep (per `attempt`) and
+/// retry -- covering both the `101` lock-contention case and a signal death
+/// within `max_retries` attempts (a signal death under the same heavy
+/// concurrent load -- an OOM kill, another session's `pkill`, or fallout
+/// from that same lock contention -- is just as plausible as `101` is).
+/// Once retries are exhausted on a signal death, returns
+/// [`signal_death_error`] instead of `Ok(Some(-1))`.
+pub fn classify_cargo_run_exit(
+    status: std::process::ExitStatus,
+    stderr: &str,
+    attempt: u32,
+    max_retries: u32,
+) -> Result<Option<i32>> {
+    if let Some(code) = status.code() {
+        if code == 101 && attempt + 1 < max_retries {
+            return Ok(None);
+        }
+        return Ok(Some(code));
+    }
+    if attempt + 1 < max_retries {
+        return Ok(None);
+    }
+    Err(signal_death_error(status, stderr))
+}

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -22,9 +22,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::classify_cargo_run_exit;
-
-const MAX_CARGO_RETRIES: u32 = 3;
+use cargo_run_exit::{classify_cargo_run_exit, MAX_CARGO_RETRIES};
 
 /// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
 /// yet comfortably under the ~128-level DoS cap proposed in #151/#152.

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -20,6 +20,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::classify_cargo_run_exit;
+
 const MAX_CARGO_RETRIES: u32 = 3;
 
 /// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
@@ -42,13 +46,13 @@ fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
         }
 
         let output = cmd.wait_with_output()?;
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        // Exit code 101 often indicates cargo lock contention; retry.
-        if exit_code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
-        }
+        };
 
         let stdout = String::from_utf8(output.stdout)?;
         return Ok((stdout, exit_code));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10,6 +10,10 @@ use std::time::Duration;
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::{classify_cargo_run_exit, signal_death_error};
+
 /// Maximum retries for cargo run commands that fail with exit code 101, or
 /// whose child is killed by a signal (`ExitStatus::code()` returns `None`
 /// only in that case, on Unix). Both are treated as transient: `101` often
@@ -26,61 +30,6 @@ const MAX_CARGO_RETRIES: u32 = 3;
 /// `run_jq_stdin_streams`). `spawn()` can transiently observe that path
 /// mid-replacement and fail with `ENOENT` (#550).
 const MAX_SPAWN_RETRIES: u32 = 3;
-
-/// Builds the "child was killed by signal N" error for a signal-terminated
-/// process (`ExitStatus::code()` returns `None` only in that case, on
-/// Unix), naming the signal and the captured stderr -- shared by
-/// `classify_cargo_run_exit` below and by `run_jq_full`, which spawns the
-/// pre-built binary directly rather than through `cargo run` and so has no
-/// retry loop to hook a classifier into, but is just as exposed to a
-/// signal-killed child under heavy concurrent load. Historically both
-/// silently coerced this to `-1` via `.code().unwrap_or(-1)`, which renders
-/// as an inscrutable `left: -1, right: 0` with no indication a child was
-/// ever killed -- exactly what cost a wrong root-cause call in the #1459
-/// review (#1516).
-fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
-    // `ExitStatus::code()` returns `None` only when the child was
-    // terminated by a signal (Unix) -- there is no other cause.
-    #[cfg(unix)]
-    let signal = {
-        use std::os::unix::process::ExitStatusExt;
-        status.signal()
-    };
-    #[cfg(not(unix))]
-    let signal: Option<i32> = None;
-    anyhow::anyhow!(
-        "child was killed by signal {}; stderr:\n{stderr}",
-        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
-    )
-}
-
-/// Classifies a `cargo run` child's exit for the retry loops below, so each
-/// of the four call sites doesn't hand-roll the same "retry on 101" check.
-///
-/// Returns `Ok(Some(code))` once a real exit code is available to the
-/// caller, or `Ok(None)` when the caller should sleep (per `attempt`) and
-/// retry -- covering both the existing `101` lock-contention case and a
-/// signal death within `MAX_CARGO_RETRIES` attempts (a signal death under
-/// the same heavy concurrent load -- an OOM kill, another session's
-/// `pkill`, or fallout from that same lock contention -- is just as
-/// plausible as `101` is). Once retries are exhausted on a signal death,
-/// returns the `signal_death_error` above instead of `Ok(Some(-1))`.
-fn classify_cargo_run_exit(
-    status: std::process::ExitStatus,
-    stderr: &str,
-    attempt: u32,
-) -> Result<Option<i32>> {
-    if let Some(code) = status.code() {
-        if code == 101 && attempt + 1 < MAX_CARGO_RETRIES {
-            return Ok(None);
-        }
-        return Ok(Some(code));
-    }
-    if attempt + 1 < MAX_CARGO_RETRIES {
-        return Ok(None);
-    }
-    Err(signal_death_error(status, stderr))
-}
 
 /// #1516: a signal-killed child used to render as an inscrutable
 /// `left: -1, right: 0` panic -- exercises `classify_cargo_run_exit`
@@ -105,8 +54,13 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
 
     // On the last allowed attempt, a signal death must be a real error --
     // naming the signal and the captured stderr -- not `Ok(Some(-1))`.
-    let err = classify_cargo_run_exit(killed, "some stderr output", MAX_CARGO_RETRIES - 1)
-        .expect_err("a signal death on the last attempt must error, not return a fake exit code");
+    let err = classify_cargo_run_exit(
+        killed,
+        "some stderr output",
+        MAX_CARGO_RETRIES - 1,
+        MAX_CARGO_RETRIES,
+    )
+    .expect_err("a signal death on the last attempt must error, not return a fake exit code");
     let msg = err.to_string();
     assert!(
         msg.contains("signal 9"),
@@ -122,12 +76,12 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
     // and an interior one (`MAX_CARGO_RETRIES` is 3, so attempt 1 is the
     // only non-boundary value).
     assert_eq!(
-        classify_cargo_run_exit(killed, "", 0).unwrap(),
+        classify_cargo_run_exit(killed, "", 0, MAX_CARGO_RETRIES).unwrap(),
         None,
         "a signal death within retry budget should ask for a retry"
     );
     assert_eq!(
-        classify_cargo_run_exit(killed, "", 1).unwrap(),
+        classify_cargo_run_exit(killed, "", 1, MAX_CARGO_RETRIES).unwrap(),
         None,
         "a signal death on an interior attempt should still ask for a retry"
     );
@@ -141,17 +95,17 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
         "sanity: from_raw encodes exit code 101"
     );
     assert_eq!(
-        classify_cargo_run_exit(contention, "", 0).unwrap(),
+        classify_cargo_run_exit(contention, "", 0, MAX_CARGO_RETRIES).unwrap(),
         None,
         "101 within retry budget should still retry"
     );
     assert_eq!(
-        classify_cargo_run_exit(contention, "", 1).unwrap(),
+        classify_cargo_run_exit(contention, "", 1, MAX_CARGO_RETRIES).unwrap(),
         None,
         "101 on an interior attempt should still retry"
     );
     assert_eq!(
-        classify_cargo_run_exit(contention, "", MAX_CARGO_RETRIES - 1).unwrap(),
+        classify_cargo_run_exit(contention, "", MAX_CARGO_RETRIES - 1, MAX_CARGO_RETRIES).unwrap(),
         Some(101),
         "101 with no retries left surfaces as-is, same as before this change"
     );
@@ -159,11 +113,11 @@ fn test_classify_cargo_run_exit_reports_signal_death_1516() {
     // A genuine, non-101 exit code passes through unchanged regardless of
     // attempt number.
     assert_eq!(
-        classify_cargo_run_exit(ExitStatus::from_raw(0), "", 0).unwrap(),
+        classify_cargo_run_exit(ExitStatus::from_raw(0), "", 0, MAX_CARGO_RETRIES).unwrap(),
         Some(0)
     );
     assert_eq!(
-        classify_cargo_run_exit(ExitStatus::from_raw(1 << 8), "", 0).unwrap(),
+        classify_cargo_run_exit(ExitStatus::from_raw(1 << 8), "", 0, MAX_CARGO_RETRIES).unwrap(),
         Some(1)
     );
 }
@@ -210,7 +164,8 @@ fn run_jq_stdin_streams(
 
         let output = cmd.wait_with_output()?;
         let lossy_stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) = classify_cargo_run_exit(output.status, &lossy_stderr, attempt)?
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &lossy_stderr, attempt, MAX_CARGO_RETRIES)?
         else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
@@ -299,7 +254,9 @@ fn run_jq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
             .output()?;
 
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
         };
@@ -330,7 +287,9 @@ fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
             .output()?;
 
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
         };
@@ -3952,7 +3911,9 @@ fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Resul
 
         let output = cmd.wait_with_output()?;
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) = classify_cargo_run_exit(output.status, &stderr, attempt)? else {
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
             std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
             continue;
         };
@@ -13166,9 +13127,15 @@ fn test_as_pattern_alt_rejected_in_yq_mode_720() -> Result<()> {
     let mut child = cmd.spawn()?;
     child.stdin.take().unwrap().write_all(b"a: 5\n")?;
     let output = child.wait_with_output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // #1546: `.code().unwrap_or(-1)` would coerce a signal-killed child to
+    // `-1`, which still satisfies `assert_ne!(_, 0)` -- a false pass masking
+    // a signal death as a successful correctness check.
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     assert_ne!(
-        output.status.code().unwrap_or(-1),
-        0,
+        code, 0,
         "yq mode must reject ?// as a parse error, matching real yq"
     );
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12,16 +12,7 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, signal_death_error};
-
-/// Maximum retries for cargo run commands that fail with exit code 101, or
-/// whose child is killed by a signal (`ExitStatus::code()` returns `None`
-/// only in that case, on Unix). Both are treated as transient: `101` often
-/// means cargo lock contention between concurrently running tests, and a
-/// signal death under the same heavy concurrent load (an OOM kill, another
-/// session's `pkill`, or fallout from that same lock contention) is just as
-/// likely to be environmental as a real bug in the code under test (#1516).
-const MAX_CARGO_RETRIES: u32 = 3;
+use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
 
 /// Maximum retries for spawning the pre-built binary directly.
 ///


### PR DESCRIPTION
## Summary

- #1516 fixed the signal-death misdiagnosis (`.code().unwrap_or(-1)` silently coercing a killed child to a fake exit code, rendering as an inscrutable `left: -1, right: 0` panic) in `tests/jq_cli_tests.rs`'s four `cargo run`-based helpers. Its own `/code-review` found the identical hand-rolled pattern in three more files, deliberately left out of that PR's scope (#1546).
- Factors `classify_cargo_run_exit`/`signal_death_error` out into a shared `tests/common/cargo_run_exit.rs` module (following the `tests/common/json_oracle.rs` precedent already established for cross-file test sharing) and routes all four files' helpers through it: `jq_cli_tests.rs` (its own former copy, now the shared one), `cli_golden_tests.rs` (`run_cli` + `run_cli_bin`'s direct-spawn variant), `cli_characterization_tests.rs` (`run`), `deep_nesting_valid_tests.rs` (`run`).
- Fixes the pre-existing false-pass `test_as_pattern_alt_rejected_in_yq_mode_720`: `assert_ne!(output.status.code().unwrap_or(-1), 0)` still holds when the child is killed by a signal (`None` → `-1` → still `!= 0`), silently masking a signal death as a successful "yq rejects `?//`" check.
- Filed #1691 for the broader scope this surfaced but is out of this issue's own stated bounds: 3 more false-pass sites with the identical shape in `tests/yq_cli_tests.rs`, plus the wider `.code().unwrap_or(-1)` coercion pattern spread across 7 other test files.

Fixes #1546.

## Test plan

- [x] All 4 touched test files pass: `cli_characterization_tests` (13), `cli_golden_tests` (23), `deep_nesting_valid_tests` (3), `jq_cli_tests` (989).
- [x] `test_classify_cargo_run_exit_reports_signal_death_1516` (the shared classifier's own unit test, now exercising the shared module) still passes.
- [x] `test_as_pattern_alt_rejected_in_yq_mode_720` still passes, now correctly distinguishing a real rejection from a signal death.
- [x] Full `cargo test --features cli,regex,serde` — all green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the scalar-yaml CI leg — clean.
- [x] `cargo build --no-default-features`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.