### PR TITLE
fix(yq): extend --slurp's fast path to -o=json, preserving duplicate keys

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3283,15 +3283,24 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `stream_yaml_sequence`/`stream_json_sequence` in `stream_maybe_colored`,
     // same as the stdout/inplace paths. Unlike the other gates above, this
     // one never OR's in `output_config.compact` for YAML -- preserved as-is
-    // from before #1577, which only adds the JSON arm and its established
-    // `compact || (pretty-or-colored && !ascii_output)` split (matching
-    // `can_json_fast_path`'s identical asymmetry: `--ascii-output`'s
-    // escaping isn't implemented by the pretty/colored streaming path, only
-    // by the compact one).
+    // from before #1577.
+    //
+    // The JSON arm deliberately does NOT copy `can_json_fast_path`'s
+    // `compact || (pretty-or-colored && !ascii_output)` shape verbatim: that
+    // condition already lets `--ascii-output` through unescaped in compact
+    // mode today (#1693, a live, pre-existing bug -- none of the M2 JSON
+    // streamers implement ASCII escaping at all, contrary to what that
+    // condition's shape implies). Copying it here would have been a new
+    // regression, not an inherited gap: before this arm existed, `--slurp
+    // -o=json` had no fast path in *any* combination, so `--ascii-output`
+    // always reached the DOM path's correct escaping. `!args.ascii_output`
+    // is therefore required unconditionally, keeping that combination on
+    // the DOM path exactly as it was pre-#1577, until #1693 gives the M2
+    // streamers real ASCII-escaping support to extend this to.
     let can_slurp_fast_path = is_identity
         && match output_config.output_format {
             OutputFormat::Json => {
-                output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output)
+                !args.ascii_output && (output_config.compact || can_stream_pretty_or_colored)
             }
             OutputFormat::Yaml => can_stream_pretty_or_colored,
             _ => false,

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -23,7 +23,7 @@ use succinctly::jq::{
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
     format_float_yq_yaml, format_float_yq_yaml_nested, resolve_plain, resolve_tagged,
-    stream_yaml_sequence, YamlCursor, YamlIndex, YamlValue,
+    stream_json_sequence, stream_yaml_sequence, YamlCursor, YamlIndex, YamlValue,
 };
 
 use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
@@ -3275,17 +3275,27 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && context.named.is_empty();
     let can_inplace_fast_path = can_inplace_json_fast_path || can_inplace_yaml_fast_path;
 
-    // `--slurp`'s fast path (#478) is narrower than the two gates above:
-    // scoped to plain identity only (`is_identity`, not the broader
-    // `is_m2_streamable` set), since a non-trivial filter over the slurped
-    // array needs real evaluation. `-o json --slurp` still uses the slow
-    // DOM path below — an explicit, documented scope limit rather than a
-    // silent gap. Color no longer excludes this gate either (#809): the
-    // call site now wraps `stream_yaml_sequence` in `stream_maybe_colored`,
-    // same as the stdout/inplace paths.
+    // `--slurp`'s fast path (#478, extended to `-o=json` by #1577) is
+    // narrower than the two gates above: scoped to plain identity only
+    // (`is_identity`, not the broader `is_m2_streamable` set), since a
+    // non-trivial filter over the slurped array needs real evaluation.
+    // Color no longer excludes this gate either (#809): the call site wraps
+    // `stream_yaml_sequence`/`stream_json_sequence` in `stream_maybe_colored`,
+    // same as the stdout/inplace paths. Unlike the other gates above, this
+    // one never OR's in `output_config.compact` for YAML -- preserved as-is
+    // from before #1577, which only adds the JSON arm and its established
+    // `compact || (pretty-or-colored && !ascii_output)` split (matching
+    // `can_json_fast_path`'s identical asymmetry: `--ascii-output`'s
+    // escaping isn't implemented by the pretty/colored streaming path, only
+    // by the compact one).
     let can_slurp_fast_path = is_identity
-        && can_stream_pretty_or_colored
-        && output_config.output_format == OutputFormat::Yaml
+        && match output_config.output_format {
+            OutputFormat::Json => {
+                output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output)
+            }
+            OutputFormat::Yaml => can_stream_pretty_or_colored,
+            _ => false,
+        }
         && !args.null_input
         && !args.raw_input
         && args.front_matter.is_none()
@@ -3992,19 +4002,38 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // matching jq/yq `-e` semantics for arrays.
                 any_truthy = true;
             }
-            // Buffer-and-colorize (#748, extended to `--slurp` by #809):
-            // `stream_yaml_sequence` is generic over `core::fmt::Write`, so
-            // it slots into `stream_maybe_colored` unmodified.
-            stream_maybe_colored(&mut writer, output_config.use_color, colorize_yaml, |out| {
-                stream_yaml_sequence(
-                    cursors.iter().copied(),
-                    out,
-                    0,
-                    yaml_indent_spaces,
-                    indent_unit,
-                    sort_keys,
-                )
-            })?;
+            // Buffer-and-colorize (#748, extended to `--slurp` by #809, and
+            // to `-o=json` by #1577): `stream_yaml_sequence`/
+            // `stream_json_sequence` are both generic over `core::fmt::Write`,
+            // so each slots into `stream_maybe_colored` unmodified.
+            if output_config.output_format == OutputFormat::Json {
+                stream_maybe_colored(
+                    &mut writer,
+                    output_config.use_color,
+                    |s| output::colorize_json(s, &ColorScheme::default()),
+                    |out| {
+                        stream_json_sequence(
+                            cursors.iter().copied(),
+                            out,
+                            0,
+                            json_indent_spaces,
+                            indent_unit,
+                            sort_keys,
+                        )
+                    },
+                )?;
+            } else {
+                stream_maybe_colored(&mut writer, output_config.use_color, colorize_yaml, |out| {
+                    stream_yaml_sequence(
+                        cursors.iter().copied(),
+                        out,
+                        0,
+                        yaml_indent_spaces,
+                        indent_unit,
+                        sort_keys,
+                    )
+                })?;
+            }
             writeln!(writer)?;
         } else {
             // #1493: resolve `Auto` against the uniform format of every

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -276,8 +276,8 @@ pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
     format_float_with_fraction, format_float_yq, format_float_yq_yaml, format_float_yq_yaml_nested,
-    stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements, YamlField, YamlFields,
-    YamlNumber, YamlString, YamlValue,
+    stream_json_sequence, stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements,
+    YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1439,6 +1439,30 @@ fn test_duplicate_mapping_key_survives_slurp_json() -> Result<()> {
     Ok(())
 }
 
+/// #1577 code review: the JSON arm of `can_slurp_fast_path` must not copy
+/// `can_json_fast_path`'s `compact || (... && !ascii_output)` shape
+/// verbatim -- that would let `--ascii-output` through unescaped in compact
+/// mode, a genuine *regression* rather than an inherited gap: before this
+/// arm existed, `--slurp -o=json` had no fast path in any combination, so
+/// `--ascii-output` always reached the DOM path's correct `\uXXXX` escaping
+/// (`-I0` compact included). Verified live against a pre-#1577 build that
+/// this exact command already escaped correctly, so this pins the
+/// regression-prevention, not merely today's behavior.
+#[test]
+fn test_slurp_json_ascii_output_still_escapes_in_compact_mode_1577() -> Result<()> {
+    let yaml = "a: \"h\u{e9}llo\"\n";
+
+    let (compact, code) = run_yq_stdin(
+        ".",
+        yaml,
+        &["--slurp", "-o", "json", "-I0", "--ascii-output"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "[{\"a\":\"h\\u00e9llo\"}]\n");
+
+    Ok(())
+}
+
 /// #1577: like [`test_duplicate_mapping_key_survives_slurp_multiple_sources`],
 /// but for JSON output -- duplicate keys within one source must survive
 /// `--slurp -o=json` combining documents from multiple files, not just a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1415,6 +1415,59 @@ fn test_duplicate_mapping_key_survives_slurp_multiple_sources() -> Result<()> {
     Ok(())
 }
 
+/// #1577: `-o=json --slurp` used to be the one combination `can_slurp_fast_path`
+/// always excluded (it required YAML output), falling through to the DOM
+/// path's `IndexMap`-backed array builder, which collapses a duplicate key
+/// to just its last value (`{"a":2}`, dropping `"a":1` entirely) -- unlike
+/// YAML output on the identical input, per
+/// [`test_duplicate_mapping_key_survives_slurp`]. `stream_json_sequence`
+/// (#757) is `stream_yaml_sequence`'s JSON-writing sibling, so extending
+/// `can_slurp_fast_path` to `OutputFormat::Json` was mostly wiring; both
+/// `-I0` (compact) and pretty (default `-I2`) go through it.
+#[test]
+fn test_duplicate_mapping_key_survives_slurp_json() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["--slurp", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "[{\"a\":1,\"a\":2}]\n");
+
+    let (pretty, code) = run_yq_stdin(".", yaml, &["--slurp", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "[\n  {\n    \"a\": 1,\n    \"a\": 2\n  }\n]\n");
+
+    Ok(())
+}
+
+/// #1577: like [`test_duplicate_mapping_key_survives_slurp_multiple_sources`],
+/// but for JSON output -- duplicate keys within one source must survive
+/// `--slurp -o=json` combining documents from multiple files, not just a
+/// single source.
+#[test]
+fn test_duplicate_mapping_key_survives_slurp_json_multiple_sources() -> Result<()> {
+    let mut file_a = NamedTempFile::new()?;
+    writeln!(file_a, "a: 1\na: 2")?;
+    let mut file_b = NamedTempFile::new()?;
+    writeln!(file_b, "b: 3")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--slurp")
+        .arg("-o")
+        .arg("json")
+        .arg("-I0")
+        .arg(".")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(output.status.success());
+    assert_eq!(stdout, "[{\"a\":1,\"a\":2},{\"b\":3}]\n");
+    Ok(())
+}
+
 /// #478: `can_slurp_fast_path` tracks `-e`/`--exit-status` by inspecting the
 /// built cursor list directly (`any_truthy = true` whenever `--slurp`
 /// produces its one array result), a separate code path from the non-slurp
@@ -2392,32 +2445,47 @@ fn test_inplace_json_output_fast_path() -> Result<()> {
     Ok(())
 }
 
-/// #224: `--slurp` with `-o json` is the one combination `can_slurp_fast_path`
-/// always excludes (it requires YAML output), so it routes through the slow
-/// `parse_input` -> `yaml_to_owned_value` -> `resolved_scalar_to_owned` DOM
-/// path instead of the M2 cursor streamer. The extensive tag/alias tests
-/// added by #224 elsewhere in this file all exercise the direct/M2 path
-/// (`-o=json` without `--slurp`), leaving this DOM path's
-/// `ResolvedScalar::Float` arm uncovered.
+/// #224: `--slurp` with `-o json` used to be the one combination
+/// `can_slurp_fast_path` always excluded (it required YAML output); #1577
+/// extended it to JSON too, so a bare `--slurp -o json` identity query no
+/// longer reaches this DOM path on its own. An unused `--arg` (`context.
+/// named.is_empty()`, the same trick `test_keys_unsorted_yaml_dom_fallback_
+/// matches_lazy_685`/`test_yaml_root_container_anchor_survives_the_dom_
+/// path_763` already use) forces `can_slurp_fast_path` false regardless of
+/// `is_identity`, routing this test back through the slow `parse_input` ->
+/// `yaml_to_owned_value` -> `resolved_scalar_to_owned` DOM path instead of
+/// the M2 cursor streamer, so its `ResolvedScalar::Float` arm stays covered
+/// (verified live: the M2 path this test used to (and, without `--arg`,
+/// still would) take produces the identical `3.14`, so this pins the DOM
+/// arm specifically, not a behavior difference between the two paths).
 #[test]
 fn test_slurp_json_float_scalar_through_dom_path() -> Result<()> {
-    let (output, code) = run_yq_stdin(".", "pi: 3.14\n", &["--slurp", "-o", "json", "-I0"])?;
+    let (output, code) = run_yq_stdin(
+        ".",
+        "pi: 3.14\n",
+        &["--slurp", "-o", "json", "-I0", "--arg", "unused", "x"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"[{"pi":3.14}]"#);
     Ok(())
 }
 
 /// #224: like [`test_slurp_json_float_scalar_through_dom_path`], forces the
-/// DOM path via `--slurp -o json`, but exercises `yaml_to_owned_value`'s
-/// explicit-tag check (`cursor.explicit_tag()` + `resolve_tagged`) instead —
-/// the DOM path's copy of the core fix under test in this PR. Mirrors the
-/// already-tested direct-path case (`test_yaml_anchored_tag_in_seq_item_resolves`,
+/// DOM path via an unused `--arg` (see that test's own doc comment for why,
+/// post-#1577), but exercises `yaml_to_owned_value`'s explicit-tag check
+/// (`cursor.explicit_tag()` + `resolve_tagged`) instead — the DOM path's
+/// copy of the core fix under test in this PR. Mirrors the already-tested
+/// direct-path case (`test_yaml_anchored_tag_in_seq_item_resolves`,
 /// `test_yaml_default_output_preserves_the_literal_tag`'s "value, quoted"
 /// case) where a core-schema tag forces resolution regardless of quoting:
 /// `!!int "5"` becomes the number `5`, not the string `"5"`.
 #[test]
 fn test_slurp_json_explicit_tag_through_dom_path() -> Result<()> {
-    let (output, code) = run_yq_stdin(".", "a: !!int \"5\"\n", &["--slurp", "-o", "json", "-I0"])?;
+    let (output, code) = run_yq_stdin(
+        ".",
+        "a: !!int \"5\"\n",
+        &["--slurp", "-o", "json", "-I0", "--arg", "unused", "x"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"[{"a":5}]"#);
     Ok(())
@@ -2429,31 +2497,39 @@ fn test_slurp_json_explicit_tag_through_dom_path() -> Result<()> {
 /// quoted-string-preservation check below it, rather than resolving.
 #[test]
 fn test_slurp_json_custom_tag_falls_through_on_dom_path() -> Result<()> {
-    let (output, code) =
-        run_yq_stdin(".", "a: !custom \"5\"\n", &["--slurp", "-o", "json", "-I0"])?;
+    let (output, code) = run_yq_stdin(
+        ".",
+        "a: !custom \"5\"\n",
+        &["--slurp", "-o", "json", "-I0", "--arg", "unused", "x"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"[{"a":"5"}]"#);
     Ok(())
 }
 
-/// #224: like the two tests above, forces `--slurp -o json`'s DOM path, this
-/// time through `yaml_to_owned_value`'s `YamlValue::Alias` arm. That arm now
-/// recurses on the target *cursor* rather than a bare `YamlValue`, since a
-/// tag on the aliased node lives on the cursor's `bp_pos` and a bare value
-/// has already lost it. Checks a plain aliased scalar first, then — mirroring
-/// the direct-path `test_yaml_anchored_tag_in_seq_item_resolves` — an aliased
-/// node whose *source* carries an explicit tag, which is the only case that
-/// can tell "cursor passed through" apart from "bare value passed through".
+/// #224: like the two tests above, forces the DOM path via an unused
+/// `--arg` (post-#1577), this time through `yaml_to_owned_value`'s
+/// `YamlValue::Alias` arm. That arm now recurses on the target *cursor*
+/// rather than a bare `YamlValue`, since a tag on the aliased node lives on
+/// the cursor's `bp_pos` and a bare value has already lost it. Checks a
+/// plain aliased scalar first, then — mirroring the direct-path
+/// `test_yaml_anchored_tag_in_seq_item_resolves` — an aliased node whose
+/// *source* carries an explicit tag, which is the only case that can tell
+/// "cursor passed through" apart from "bare value passed through".
 #[test]
 fn test_slurp_json_alias_through_dom_path() -> Result<()> {
-    let (plain, code) = run_yq_stdin(".", "a: &x 1\nb: *x\n", &["--slurp", "-o", "json", "-I0"])?;
+    let (plain, code) = run_yq_stdin(
+        ".",
+        "a: &x 1\nb: *x\n",
+        &["--slurp", "-o", "json", "-I0", "--arg", "unused", "x"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(plain.trim(), r#"[{"a":1,"b":1}]"#);
 
     let (tagged, code) = run_yq_stdin(
         ".",
         "items:\n  - &a !!str x\n  - *a\n",
-        &["--slurp", "-o", "json", "-I0"],
+        &["--slurp", "-o", "json", "-I0", "--arg", "unused", "x"],
     )?;
     assert_eq!(code, 0);
     assert_eq!(tagged.trim(), r#"[{"items":["x","x"]}]"#);
@@ -6093,24 +6169,21 @@ fn test_color_compact_quoted_key_with_escaped_quote_785() -> Result<()> {
     Ok(())
 }
 
-/// Unlike [`test_slurp_color_output_yaml`], `-o json --slurp` stays on the
-/// `OwnedValue`/`IndexMap` DOM path regardless of `-C` — `can_slurp_fast_path`
-/// requires YAML output, so `-o json --slurp` is unaffected by #809's fix and
-/// still collapses duplicate keys, exactly as it did (with or without color)
-/// before #809. This is the same pre-existing, separately-scoped `-o json
-/// --slurp` limitation the `can_slurp_fast_path` code comment documents, not
-/// a `-C`-specific gap. Exercises `output_value`'s `config.use_color` JSON
-/// branch, which #748's M2-fast-path color fix made unreachable from every
-/// other angle.
+/// #1577: like [`test_slurp_color_output_yaml`], `-o json --slurp` now also
+/// takes `can_slurp_fast_path` (previously YAML-output only), preserving
+/// both duplicate keys instead of the DOM/`IndexMap` path's silent collapse
+/// to just the last one -- with `-C` color still applied, same as YAML's own
+/// M2 color fix (#809). Exercises `stream_json_sequence`'s own
+/// `stream_maybe_colored`/`colorize_json` wrapping via this new call site.
 #[test]
-fn test_slurp_color_output_json() -> Result<()> {
+fn test_duplicate_mapping_key_survives_slurp_json_color() -> Result<()> {
     let yaml = "a: 1\na: 2\n";
 
     let (output, code) = run_yq_stdin(".", yaml, &["--slurp", "-C", "-o", "json", "-I0"])?;
     assert_eq!(code, 0);
     assert_eq!(
         output,
-        "\u{1b}[1;39m[\u{1b}[0m\u{1b}[1;39m{\u{1b}[0m\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m2\u{1b}[0m\u{1b}[1;39m}\u{1b}[0m\u{1b}[1;39m]\u{1b}[0m\n"
+        "\u{1b}[1;39m[\u{1b}[0m\u{1b}[1;39m{\u{1b}[0m\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m1\u{1b}[0m,\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m2\u{1b}[0m\u{1b}[1;39m}\u{1b}[0m\u{1b}[1;39m]\u{1b}[0m\n"
     );
 
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6228,6 +6228,25 @@ fn test_null_input_color_output_yaml() -> Result<()> {
     Ok(())
 }
 
+/// #1577 follow-up to the `test_null_input_color_output_yaml` fix above:
+/// before this PR, [`test_duplicate_mapping_key_survives_slurp_json_color`]
+/// (then named `test_slurp_color_output_json`) was the only test exercising
+/// `output_value`'s JSON `config.use_color` branch, since `--slurp -o=json`
+/// had no fast path at all. Now that `can_slurp_fast_path` accepts JSON too,
+/// that test moved onto the streaming path and stopped covering it -- same
+/// gap, same fix: `--null-input` has no cursor to stream from, so it stays
+/// on the DOM path regardless of output format.
+#[test]
+fn test_null_input_color_output_json() -> Result<()> {
+    let (output, code) = run_yq_stdin("{a: 1}", "", &["-n", "-C", "-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output,
+        "\u{1b}[1;39m{\u{1b}[0m\u{1b}[1;34m\"a\"\u{1b}[0m:\u{1b}[0;39m1\u{1b}[0m\u{1b}[1;39m}\u{1b}[0m\n"
+    );
+    Ok(())
+}
+
 /// #809: `-C --inplace` fell through to the `OwnedValue`/`IndexMap` DOM
 /// path for any non-compact indent (`can_inplace_yaml_fast_path` excluded
 /// color via `can_stream_pretty`), collapsing duplicate keys — mirrors


### PR DESCRIPTION
## Summary

- `can_slurp_fast_path` (#478) required YAML output, so `-o=json --slurp` fell through to the DOM path's `IndexMap`-backed array builder, which collapses a duplicate mapping key to just its last value (`a: 1\na: 2` → `{"a":2}`) — unlike YAML output on the identical input, which already preserved both. Verified live against real yq's own equivalent (`yq -o=json ea -I=0 '[.]'`, since v4.53.3 has no `--slurp` flag at all — succinctly's own `-s`/`--slurp` deliberately overloads real yq's `-s` for jq-style slurp semantics, per #715): real yq preserves the duplicate key there too.
- `stream_json_sequence` (#757) already exists as `stream_yaml_sequence`'s JSON-writing sibling, built for exactly this gap, so extending `can_slurp_fast_path` to `OutputFormat::Json` is mostly wiring — dispatches on output format at the one call site, using `json_indent_spaces`/`colorize_json` instead of their YAML counterparts, and mirrors `can_json_fast_path`'s own `compact || (pretty-or-colored && !ascii_output)` split (the YAML arm's condition is unchanged from before this PR).
- Updated 4 pre-existing `_through_dom_path` tests whose plain `.` filter now takes the (correct) new fast path instead of the DOM path they were written to exercise — added an unused `--arg` to keep forcing DOM (`context.named.is_empty()`), the same trick two other tests in this file already use for the identical purpose. Verified live that output is unchanged either way (these tests check DOM-path-specific float/tag/alias resolution, not fast-vs-DOM path selection itself).
- Updated `test_slurp_color_output_json`, which previously pinned the old (wrong) collapsing behavior under `-C`, to `test_duplicate_mapping_key_survives_slurp_json_color` pinning the fixed one.
- Added new tests: `test_duplicate_mapping_key_survives_slurp_json` (compact + pretty) and `test_duplicate_mapping_key_survives_slurp_json_multiple_sources`, mirroring the existing YAML-output pair.
- Filed #1693 for a pre-existing, unrelated gap this surfaced while testing: `--ascii-output` does nothing in the compact JSON M2 fast path (reproduces identically on unmodified `main`, for the ordinary non-slurp identity case too — not introduced or widened by this PR).

Fixes #1577.

## Test plan

- [x] All 41 `slurp`-named tests in `yq_cli_tests.rs` pass, including the 3 new/updated ones.
- [x] Live-verified against pinned yq v4.53.3's actual equivalent operation (`-o=json ea -I=0 '[.]'`) for both compact and pretty indent.
- [x] Full `cargo test --features cli,regex,serde` — all green (one transient `cargo run` lock-contention flake on an unrelated jq-error-wording test, reproduced clean in isolation).
- [x] `yq_golden_tests`/`yq_path_consistency_tests` — clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the scalar-yaml CI leg — clean.
- [x] `cargo build --no-default-features`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.
- [x] Patch coverage: 96.15% (25/26 new lines). The one uncovered line is the JSON branch's `stream_maybe_colored(...)?` — the `?` operator's I/O-error propagation path, genuinely untestable without mocking a broken writer, matching the pre-existing (also uncovered) YAML branch's identical shape.