### PR TITLE
test(cli): fix false-pass exit-code checks, sweep .code().unwrap_or(-1) repo-wide

### DIFF
--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -48,6 +48,33 @@ pub fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> any
     )
 }
 
+/// Extracts a real exit code from `status`, or builds [`signal_death_error`]
+/// from the *raw* stderr bytes -- checked before any caller attempts a
+/// strict `String::from_utf8` decode of the child's stdout/stderr (#1691
+/// code review). A signal-killed child can leave a truncated multi-byte
+/// UTF-8 sequence at the end of a buffer it was writing when killed; if the
+/// caller decodes first, that decode's own `?` fires before this check ever
+/// runs, surfacing a generic `FromUtf8Error` instead of naming the signal --
+/// exactly the diagnostic loss this module exists to prevent. Taking `&[u8]`
+/// rather than `&str` means the error path never needs its own successful
+/// decode: `String::from_utf8_lossy` cannot fail.
+///
+/// Also collapses the ~29 hand-written `let Some(code) = status.code() else
+/// { ... }` copies #1691's own fix introduced across 7 files into one
+/// definition, per that same review round.
+pub fn exit_code_or_signal_death(
+    status: std::process::ExitStatus,
+    raw_stderr: &[u8],
+) -> Result<i32> {
+    match status.code() {
+        Some(code) => Ok(code),
+        None => Err(signal_death_error(
+            status,
+            &String::from_utf8_lossy(raw_stderr),
+        )),
+    }
+}
+
 /// Classifies a `cargo run` child's exit for a retry loop, so each call site
 /// doesn't hand-roll its own "retry on 101" check.
 ///

--- a/tests/dsv_cli_tests.rs
+++ b/tests/dsv_cli_tests.rs
@@ -13,6 +13,10 @@ use std::process::{Command, Stdio};
 
 use anyhow::Result;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
 /// runs, since this file is itself gated on `cli`, and bakes the resulting
@@ -30,9 +34,11 @@ fn run_generate(size: &str, extra_args: &[&str]) -> Result<(String, String, i32)
         .stderr(Stdio::piped())
         .output()?;
 
-    let exit_code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/dsv_cli_tests.rs
+++ b/tests/dsv_cli_tests.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -34,11 +34,9 @@ fn run_generate(size: &str, extra_args: &[&str]) -> Result<(String, String, i32)
         .stderr(Stdio::piped())
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -10,6 +10,10 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
 /// runs, since this file is itself gated on `cli`, and bakes the resulting
@@ -33,9 +37,11 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
     }
 
     let output = cmd.wait_with_output()?;
-    let exit_code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((stdout, stderr, exit_code))
 }
 
@@ -49,9 +55,11 @@ fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, St
         .stderr(Stdio::piped())
         .output()?;
 
-    let exit_code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((stdout, stderr, exit_code))
 }
 
@@ -390,7 +398,11 @@ fn test_multiple_files_all_valid() -> Result<()> {
         .stderr(Stdio::piped())
         .output()?;
 
-    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_eq!(code, 0);
     Ok(())
 }
 
@@ -421,7 +433,11 @@ fn test_multiple_files_one_invalid() -> Result<()> {
         .stderr(Stdio::piped())
         .output()?;
 
-    assert_eq!(output.status.code().unwrap_or(-1), 1);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_eq!(code, 1);
     Ok(())
 }
 

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -12,7 +12,7 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::{classify_cargo_run_exit, exit_code_or_signal_death, MAX_CARGO_RETRIES};
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -37,11 +37,9 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, exit_code))
 }
 
@@ -55,11 +53,9 @@ fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, St
         .stderr(Stdio::piped())
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, exit_code))
 }
 
@@ -371,6 +367,43 @@ fn test_file_not_found() -> Result<()> {
 // Multiple files tests
 // ============================================================================
 
+/// Runs `json validate` over multiple files via `cargo run` (needed so this
+/// test still builds from source rather than requiring a pre-built binary),
+/// retrying on the same transient conditions `run_jq_file`
+/// (`tests/jq_cli_tests.rs`) does: exit 101 from concurrent `cargo build`
+/// lock contention, or a signal death under that same load (#1691 code
+/// review -- these two tests originally had no retry loop at all, unlike
+/// every other `cargo run`-spawning helper in this codebase).
+fn run_json_validate_via_cargo(files: &[&std::path::Path]) -> Result<i32> {
+    for attempt in 0..MAX_CARGO_RETRIES {
+        let output = Command::new("cargo")
+            .args([
+                "run",
+                "--features",
+                "cli",
+                "--bin",
+                "succinctly",
+                "--",
+                "json",
+                "validate",
+            ])
+            .args(files)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let Some(exit_code) =
+            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
+        else {
+            std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
+            continue;
+        };
+        return Ok(exit_code);
+    }
+    unreachable!()
+}
+
 #[test]
 fn test_multiple_files_all_valid() -> Result<()> {
     let mut file1 = NamedTempFile::new()?;
@@ -381,27 +414,7 @@ fn test_multiple_files_all_valid() -> Result<()> {
     writeln!(file2, r#"{{"b": 2}}"#)?;
     file2.flush()?;
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            "cli",
-            "--bin",
-            "succinctly",
-            "--",
-            "json",
-            "validate",
-        ])
-        .arg(file1.path())
-        .arg(file2.path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
-
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = run_json_validate_via_cargo(&[file1.path(), file2.path()])?;
     assert_eq!(code, 0);
     Ok(())
 }
@@ -416,27 +429,7 @@ fn test_multiple_files_one_invalid() -> Result<()> {
     writeln!(file2, r#"{{"b": }}"#)?; // invalid
     file2.flush()?;
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            "cli",
-            "--bin",
-            "succinctly",
-            "--",
-            "json",
-            "validate",
-        ])
-        .arg(file1.path())
-        .arg(file2.path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
-
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = run_json_validate_via_cargo(&[file1.path(), file2.path()])?;
     assert_eq!(code, 1);
     Ok(())
 }

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
@@ -27,11 +27,9 @@ fn run(args: &[&str]) -> Result<(String, String, i32)> {
         .args(args)
         .output()
         .expect("spawn succinctly");
+    let code = exit_code_or_signal_death(out.status, &out.stderr)?;
     let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-    let Some(code) = out.status.code() else {
-        return Err(signal_death_error(out.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -12,85 +12,98 @@
 
 use std::process::Command;
 
+use anyhow::Result;
+
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
 }
 
-fn run(args: &[&str]) -> (String, String, i32) {
+fn run(args: &[&str]) -> Result<(String, String, i32)> {
     let out = Command::new(bin())
         .args(args)
         .output()
         .expect("spawn succinctly");
-    (
-        String::from_utf8_lossy(&out.stdout).trim().to_string(),
-        String::from_utf8_lossy(&out.stderr).trim().to_string(),
-        out.status.code().unwrap_or(-1),
-    )
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let Some(code) = out.status.code() else {
+        return Err(signal_death_error(out.status, &stderr));
+    };
+    Ok((stdout, stderr, code))
 }
 
 const JSON_FIXTURE: &str = "tests/data/bench-corpus/seed/json/charts/bullet-data.json";
 const YAML_FIXTURE: &str = "tests/data/bench-corpus/seed/yaml/k8s/nginx-deployment.yml";
 
 #[test]
-fn jq_locate_resolves_line_and_column() {
-    let (stdout, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"]);
+fn jq_locate_resolves_line_and_column() -> Result<()> {
+    let (stdout, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"])?;
 
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout, ".[1].title");
+    Ok(())
 }
 
 #[test]
-fn jq_locate_line_column_agrees_with_offset() {
+fn jq_locate_line_column_agrees_with_offset() -> Result<()> {
     // Line 3 column 5 of the fixture is byte 122. The two paths share nothing:
     // --offset skips the line index entirely, so agreement is a real check
     // that the line index maps positions the way the file is actually laid out.
-    let (by_position, _, _) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"]);
-    let (by_offset, _, _) = run(&["jq-locate", JSON_FIXTURE, "--offset", "122"]);
+    let (by_position, _, _) = run(&["jq-locate", JSON_FIXTURE, "--line", "3", "--column", "5"])?;
+    let (by_offset, _, _) = run(&["jq-locate", JSON_FIXTURE, "--offset", "122"])?;
 
     assert_eq!(by_position, by_offset);
     assert!(!by_position.is_empty());
+    Ok(())
 }
 
 #[test]
-fn jq_locate_rejects_out_of_range_position() {
-    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "9999", "--column", "1"]);
+fn jq_locate_rejects_out_of_range_position() -> Result<()> {
+    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "9999", "--column", "1"])?;
 
     assert_ne!(code, 0, "out-of-range position must fail");
     assert!(
         stderr.contains("Invalid position"),
         "expected an invalid-position error, got: {stderr}"
     );
+    Ok(())
 }
 
 #[test]
-fn jq_locate_rejects_zero_column() {
-    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "1", "--column", "0"]);
+fn jq_locate_rejects_zero_column() -> Result<()> {
+    let (_, stderr, code) = run(&["jq-locate", JSON_FIXTURE, "--line", "1", "--column", "0"])?;
 
     assert_ne!(code, 0, "column 0 must fail");
     assert!(
         stderr.contains("Invalid position"),
         "expected an invalid-position error, got: {stderr}"
     );
+    Ok(())
 }
 
 #[test]
-fn yq_locate_resolves_line_and_column() {
+fn yq_locate_resolves_line_and_column() -> Result<()> {
     // Line 5 of the manifest is "  labels:", so column 3 is the key itself.
-    let (stdout, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "5", "--column", "3"]);
+    let (stdout, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "5", "--column", "3"])?;
 
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout, ".[0].metadata.labels");
+    Ok(())
 }
 
 #[test]
-fn yq_locate_rejects_out_of_range_position() {
-    let (_, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "9999", "--column", "1"]);
+fn yq_locate_rejects_out_of_range_position() -> Result<()> {
+    let (_, stderr, code) = run(&["yq-locate", YAML_FIXTURE, "--line", "9999", "--column", "1"])?;
 
     assert_ne!(code, 0, "out-of-range position must fail");
     assert!(
         stderr.contains("Invalid position"),
         "expected an invalid-position error, got: {stderr}"
     );
+    Ok(())
 }
 
 /// A leading-dot number's own `byte_range` must span just the literal
@@ -101,16 +114,17 @@ fn yq_locate_rejects_out_of_range_position() {
 /// substituted a byte range spanning to end-of-file. Found by code
 /// review of #1171 before merge.
 #[test]
-fn jq_locate_leading_dot_number_byte_range_is_exact() {
+fn jq_locate_leading_dot_number_byte_range_is_exact() -> Result<()> {
     let mut fixture = tempfile::NamedTempFile::new().expect("create temp fixture");
     std::io::Write::write_all(&mut fixture, b"[.5, 6, 7]").expect("write fixture");
     let path = fixture.path().to_str().expect("utf8 path");
 
-    let (stdout, stderr, code) = run(&["jq-locate", path, "--offset", "1", "--format", "json"]);
+    let (stdout, stderr, code) = run(&["jq-locate", path, "--offset", "1", "--format", "json"])?;
 
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(
         stdout.contains("\"byte_range\": [\n    1,\n    3\n  ]"),
         "expected byte_range [1, 3], got: {stdout}"
     );
+    Ok(())
 }

--- a/tests/orchestrate_cli_tests.rs
+++ b/tests/orchestrate_cli_tests.rs
@@ -13,20 +13,27 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use anyhow::Result;
+
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
 }
 
-fn run(args: &[&str]) -> (String, String, i32) {
+fn run(args: &[&str]) -> Result<(String, String, i32)> {
     let out = Command::new(bin())
         .args(args)
         .output()
         .expect("spawn succinctly");
-    (
-        String::from_utf8_lossy(&out.stdout).trim().to_string(),
-        String::from_utf8_lossy(&out.stderr).trim().to_string(),
-        out.status.code().unwrap_or(-1),
-    )
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let Some(code) = out.status.code() else {
+        return Err(signal_death_error(out.status, &stderr));
+    };
+    Ok((stdout, stderr, code))
 }
 
 fn write_config(dir: &Path, yaml: &str) -> String {
@@ -43,32 +50,34 @@ fn local_only_yaml(results_dir: &Path) -> String {
 }
 
 #[test]
-fn orchestrate_rejects_missing_config() {
+fn orchestrate_rejects_missing_config() -> Result<()> {
     let (_, stderr, code) = run(&[
         "bench",
         "orchestrate",
         "--config",
         "/nonexistent/nodes.yaml",
         "--all",
-    ]);
+    ])?;
 
     assert_ne!(code, 0);
     assert!(stderr.contains("Failed to read config file"), "{stderr}");
+    Ok(())
 }
 
 #[test]
-fn orchestrate_rejects_invalid_yaml() {
+fn orchestrate_rejects_invalid_yaml() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let config = write_config(dir.path(), "not: [valid, yaml");
 
-    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "--all"]);
+    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "--all"])?;
 
     assert_ne!(code, 0);
     assert!(stderr.contains("Failed to parse YAML config"), "{stderr}");
+    Ok(())
 }
 
 #[test]
-fn orchestrate_rejects_unknown_node_selection() {
+fn orchestrate_rejects_unknown_node_selection() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let results_dir = dir.path().join("results");
     let config = write_config(dir.path(), &local_only_yaml(&results_dir));
@@ -81,14 +90,15 @@ fn orchestrate_rejects_unknown_node_selection() {
         "--node",
         "nonexistent",
         "--all",
-    ]);
+    ])?;
 
     assert_ne!(code, 0);
     assert!(stderr.contains("No nodes selected"), "{stderr}");
+    Ok(())
 }
 
 #[test]
-fn orchestrate_dry_run_prints_plan_without_side_effects() {
+fn orchestrate_dry_run_prints_plan_without_side_effects() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let results_dir = dir.path().join("results");
     let config = write_config(dir.path(), &local_only_yaml(&results_dir));
@@ -100,7 +110,7 @@ fn orchestrate_dry_run_prints_plan_without_side_effects() {
         &config,
         "--dry-run",
         "corpus_stats",
-    ]);
+    ])?;
 
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(stdout.contains("Dry run"), "{stdout}");
@@ -109,6 +119,7 @@ fn orchestrate_dry_run_prints_plan_without_side_effects() {
         !results_dir.exists(),
         "dry-run must not create the results dir"
     );
+    Ok(())
 }
 
 /// Runs the real `SystemSsh` localhost path end-to-end: connectivity check,
@@ -118,12 +129,12 @@ fn orchestrate_dry_run_prints_plan_without_side_effects() {
 /// be built already; either way the orchestration plumbing must complete
 /// with exit 0 and produce its result files.
 #[test]
-fn orchestrate_local_only_node_runs_end_to_end() {
+fn orchestrate_local_only_node_runs_end_to_end() -> Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let results_dir = dir.path().join("results");
     let config = write_config(dir.path(), &local_only_yaml(&results_dir));
 
-    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "corpus_stats"]);
+    let (_, stderr, code) = run(&["bench", "orchestrate", "--config", &config, "corpus_stats"])?;
 
     assert_eq!(code, 0, "stderr: {stderr}");
     assert!(stderr.contains("Orchestration run complete"), "{stderr}");
@@ -138,4 +149,5 @@ fn orchestrate_local_only_node_runs_end_to_end() {
     assert!(run_dir.join("metadata.json").exists());
     assert!(run_dir.join("results.jsonl").exists());
     assert!(run_dir.join("local/node_info.json").exists());
+    Ok(())
 }

--- a/tests/orchestrate_cli_tests.rs
+++ b/tests/orchestrate_cli_tests.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
@@ -28,11 +28,9 @@ fn run(args: &[&str]) -> Result<(String, String, i32)> {
         .args(args)
         .output()
         .expect("spawn succinctly");
+    let code = exit_code_or_signal_death(out.status, &out.stderr)?;
     let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-    let Some(code) = out.status.code() else {
-        return Err(signal_death_error(out.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -15,6 +15,10 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use tempfile::{NamedTempFile, TempDir};
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
 /// runs, since this file is itself gated on `cli`, and bakes the resulting
@@ -38,8 +42,10 @@ fn run_validate_stdin(input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, Str
     }
 
     let output = cmd.wait_with_output()?;
-    let exit_code = output.status.code().unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -53,8 +59,10 @@ fn run_validate_files(paths: &[&str], extra_args: &[&str]) -> Result<(Vec<u8>, S
         .stderr(Stdio::piped())
         .output()?;
 
-    let exit_code = output.status.code().unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -67,8 +75,10 @@ fn run_generate(size: &str, extra_args: &[&str]) -> Result<(Vec<u8>, String, i32
         .stderr(Stdio::piped())
         .output()?;
 
-    let exit_code = output.status.code().unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -407,11 +417,10 @@ fn generate_suite_writes_all_patterns() -> Result<()> {
         .args(["--max-size", "1kb", "--seed", "42", "--clean", "--verify"])
         .output()?;
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(
-        output.status.code().unwrap_or(-1),
-        0,
-        "generate-suite failed: {stderr}"
-    );
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_eq!(code, 0, "generate-suite failed: {stderr}");
 
     // One subdirectory per pattern, each holding a valid-UTF-8 1kb.txt file.
     let mut found = 0;

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -17,7 +17,7 @@ use tempfile::{NamedTempFile, TempDir};
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -42,10 +42,8 @@ fn run_validate_stdin(input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, Str
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -59,10 +57,8 @@ fn run_validate_files(paths: &[&str], extra_args: &[&str]) -> Result<(Vec<u8>, S
         .stderr(Stdio::piped())
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -75,10 +71,8 @@ fn run_generate(size: &str, extra_args: &[&str]) -> Result<(Vec<u8>, String, i32
         .stderr(Stdio::piped())
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((output.stdout, stderr, exit_code))
 }
 
@@ -416,10 +410,8 @@ fn generate_suite_writes_all_patterns() -> Result<()> {
         .args(["--output-dir", out_dir_str])
         .args(["--max-size", "1kb", "--seed", "42", "--clean", "--verify"])
         .output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let Some(code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     assert_eq!(code, 0, "generate-suite failed: {stderr}");
 
     // One subdirectory per pattern, each holding a valid-UTF-8 1kb.txt file.

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -9,6 +9,10 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
 /// runs, since this file is itself gated on `cli`, and bakes the resulting
@@ -29,11 +33,12 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
         stdin.write_all(input.as_bytes())?;
     }
     let output = cmd.wait_with_output()?;
-    Ok((
-        String::from_utf8(output.stdout)?,
-        String::from_utf8(output.stderr)?,
-        output.status.code().unwrap_or(-1),
-    ))
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    Ok((stdout, stderr, code))
 }
 
 fn run_validate_file(path: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
@@ -44,11 +49,12 @@ fn run_validate_file(path: &str, extra_args: &[&str]) -> Result<(String, String,
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()?;
-    Ok((
-        String::from_utf8(output.stdout)?,
-        String::from_utf8(output.stderr)?,
-        output.status.code().unwrap_or(-1),
-    ))
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    Ok((stdout, stderr, code))
 }
 
 #[test]
@@ -237,11 +243,12 @@ fn run_yq_validate_stdin(input: &str, filter: &str) -> Result<(String, String, i
         stdin.write_all(input.as_bytes())?;
     }
     let output = cmd.wait_with_output()?;
-    Ok((
-        String::from_utf8(output.stdout)?,
-        String::from_utf8(output.stderr)?,
-        output.status.code().unwrap_or(-1),
-    ))
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    Ok((stdout, stderr, code))
 }
 
 #[test]
@@ -279,11 +286,12 @@ fn yq_without_validate_accepts_the_same_invalid_yaml() -> Result<()> {
             stdin.write_all(b"a: b: c: d\n")?;
         }
         let output = cmd.wait_with_output()?;
-        (
-            String::from_utf8(output.stdout)?,
-            String::from_utf8(output.stderr)?,
-            output.status.code().unwrap_or(-1),
-        )
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+        let Some(code) = output.status.code() else {
+            return Err(signal_death_error(output.status, &stderr));
+        };
+        (stdout, stderr, code)
     };
     assert_eq!(code, 0);
     Ok(())

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -11,7 +11,7 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -33,11 +33,9 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
         stdin.write_all(input.as_bytes())?;
     }
     let output = cmd.wait_with_output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 
@@ -49,11 +47,9 @@ fn run_validate_file(path: &str, extra_args: &[&str]) -> Result<(String, String,
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 
@@ -243,11 +239,9 @@ fn run_yq_validate_stdin(input: &str, filter: &str) -> Result<(String, String, i
         stdin.write_all(input.as_bytes())?;
     }
     let output = cmd.wait_with_output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 
@@ -286,11 +280,9 @@ fn yq_without_validate_accepts_the_same_invalid_yaml() -> Result<()> {
             stdin.write_all(b"a: b: c: d\n")?;
         }
         let output = cmd.wait_with_output()?;
+        let code = exit_code_or_signal_death(output.status, &output.stderr)?;
         let stdout = String::from_utf8(output.stdout)?;
         let stderr = String::from_utf8(output.stderr)?;
-        let Some(code) = output.status.code() else {
-            return Err(signal_death_error(output.status, &stderr));
-        };
         (stdout, stderr, code)
     };
     assert_eq!(code, 0);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15,6 +15,10 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use tempfile::{NamedTempFile, TempDir};
 
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::signal_death_error;
+
 /// Helper to run yq command with input from stdin
 fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
@@ -32,7 +36,10 @@ fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(Strin
 
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8(output.stdout)?;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, exit_code))
 }
@@ -59,7 +66,9 @@ fn run_yq_stdin_with_stderr(
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -89,7 +98,9 @@ fn run_yq_stdin_bytes_with_stderr(
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -119,7 +130,9 @@ fn run_jq_stdin_with_stderr(
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -134,7 +147,10 @@ fn run_yq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, exit_code))
 }
@@ -5574,7 +5590,11 @@ fn test_block_scalar_style_preserved_through_slurp() -> Result<()> {
         .spawn()?;
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8(output.stdout)?;
-    assert_eq!(output.status.code().unwrap_or(-1), 0);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_eq!(code, 0);
     assert_eq!(stdout, "- - |\n    line1\n    line2\n");
     Ok(())
 }
@@ -6504,7 +6524,10 @@ fn run_yq_from_file(
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let Some(exit_code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
 
     Ok((stdout, exit_code))
 }
@@ -11884,11 +11907,11 @@ fn test_713_jq_mode_unaffected() -> Result<()> {
         .unwrap()
         .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
     let output = child.wait_with_output()?;
-    assert_ne!(
-        output.status.code().unwrap_or(-1),
-        0,
-        "array * array must still error in jq mode"
-    );
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_ne!(code, 0, "array * array must still error in jq mode");
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
     cmd.arg("jq")
@@ -11903,9 +11926,12 @@ fn test_713_jq_mode_unaffected() -> Result<()> {
         .unwrap()
         .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
     let output = child.wait_with_output()?;
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
     assert_ne!(
-        output.status.code().unwrap_or(-1),
-        0,
+        code, 0,
         "flag suffixes must still be unrecognized in jq mode"
     );
 
@@ -12703,7 +12729,9 @@ fn run_yq_files(
         .output()?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let code = output.status.code().unwrap_or(-1);
+    let Some(code) = output.status.code() else {
+        return Err(signal_death_error(output.status, &stderr));
+    };
     Ok((stdout, stderr, code))
 }
 
@@ -15383,13 +15411,18 @@ fn test_jq_sub_3arg_unaffected_by_1122() -> Result<()> {
         .arg(r#""AAA" | sub("a";"X";"i")"#)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()?;
     if let Some(mut stdin) = cmd.stdin.take() {
         stdin.write_all(b"null")?;
     }
     let output = cmd.wait_with_output()?;
     let stdout = String::from_utf8(output.stdout)?;
-    assert_eq!(output.status.code().unwrap_or(-1), 0, "stdout: {stdout:?}");
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_eq!(code, 0, "stdout: {stdout:?}");
     assert_eq!(stdout.trim_end(), "\"XAA\"");
     Ok(())
 }
@@ -16932,7 +16965,11 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(b"42")?;
     let output = child.wait_with_output()?;
-    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_ne!(code, 0);
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
     cmd.arg("jq").arg("@base64d");
@@ -16943,7 +16980,11 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(b"42")?;
     let output = child.wait_with_output()?;
-    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_ne!(code, 0);
     Ok(())
 }
 
@@ -19430,7 +19471,11 @@ fn test_jq_base64d_does_not_trim_whitespace_1123() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(br#"" aGVsbG8=""#)?;
     let output = child.wait_with_output()?;
-    assert_ne!(output.status.code().unwrap_or(-1), 0);
+    let Some(code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    assert_ne!(code, 0);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17,7 +17,7 @@ use tempfile::{NamedTempFile, TempDir};
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Helper to run yq command with input from stdin
 fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
@@ -35,11 +35,8 @@ fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(Strin
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
-    let Some(exit_code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, exit_code))
 }
@@ -64,11 +61,9 @@ fn run_yq_stdin_with_stderr(
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -96,11 +91,9 @@ fn run_yq_stdin_bytes_with_stderr(
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -128,11 +121,9 @@ fn run_jq_stdin_with_stderr(
     }
 
     let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, stderr, exit_code))
 }
@@ -146,11 +137,8 @@ fn run_yq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
         .arg(file_path)
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
-    let Some(exit_code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, exit_code))
 }
@@ -5589,11 +5577,8 @@ fn test_block_scalar_style_preserved_through_slurp() -> Result<()> {
         .stderr(Stdio::piped())
         .spawn()?;
     let output = cmd.wait_with_output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
     assert_eq!(code, 0);
     assert_eq!(stdout, "- - |\n    line1\n    line2\n");
     Ok(())
@@ -6523,11 +6508,8 @@ fn run_yq_from_file(
         .stdin(Stdio::null())
         .output()?;
 
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
-    let Some(exit_code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
 
     Ok((stdout, exit_code))
 }
@@ -11907,10 +11889,7 @@ fn test_713_jq_mode_unaffected() -> Result<()> {
         .unwrap()
         .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
     let output = child.wait_with_output()?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     assert_ne!(code, 0, "array * array must still error in jq mode");
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
@@ -11926,10 +11905,7 @@ fn test_713_jq_mode_unaffected() -> Result<()> {
         .unwrap()
         .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
     let output = child.wait_with_output()?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     assert_ne!(
         code, 0,
         "flag suffixes must still be unrecognized in jq mode"
@@ -12727,11 +12703,9 @@ fn run_yq_files(
         .args(files)
         .stdin(Stdio::null())
         .output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, code))
 }
 
@@ -15417,11 +15391,8 @@ fn test_jq_sub_3arg_unaffected_by_1122() -> Result<()> {
         stdin.write_all(b"null")?;
     }
     let output = cmd.wait_with_output()?;
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     let stdout = String::from_utf8(output.stdout)?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
     assert_eq!(code, 0, "stdout: {stdout:?}");
     assert_eq!(stdout.trim_end(), "\"XAA\"");
     Ok(())
@@ -16965,10 +16936,7 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(b"42")?;
     let output = child.wait_with_output()?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     assert_ne!(code, 0);
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
@@ -16980,10 +16948,7 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(b"42")?;
     let output = child.wait_with_output()?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     assert_ne!(code, 0);
     Ok(())
 }
@@ -19471,10 +19436,7 @@ fn test_jq_base64d_does_not_trim_whitespace_1123() -> Result<()> {
         .spawn()?;
     child.stdin.take().unwrap().write_all(br#"" aGVsbG8=""#)?;
     let output = child.wait_with_output()?;
-    let Some(code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
     assert_ne!(code, 0);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #1691, the follow-up audit filed during #1546's own review.

- **`tests/yq_cli_tests.rs`**: fixes 5 `assert_ne!(code, 0)` false-pass sites — a signal-killed child's `None` exit code coerces to `-1` via `.unwrap_or(-1)`, which still satisfies `assert_ne!(_, 0)` and passes the test for the wrong reason. Two of the five weren't named in #1691's own body (found by re-running its grep against this file specifically). Also routes the file's 7 `run_*`/spawn helpers and 2 more inline `assert_eq!` sites through the same `signal_death_error` helper `#1546` introduced, so a killed child names its signal instead of an inscrutable `left: -1, right: 0`.
- **6 more files** (`dsv_cli_tests.rs`, `orchestrate_cli_tests.rs`, `locate_cli_tests.rs`, `json_validate_tests.rs`, `text_cli_tests.rs`, `yaml_validate_tests.rs`): same coercion pattern, per #1691's own repo-wide grep. Two sites in `yaml_validate_tests.rs` turned out to be the same false-pass shape (`assert_eq!(code, 0)` isn't false-pass, but `yaml_validate_tests.rs` also fixed two `run_*` helpers). `orchestrate_cli_tests.rs` and `locate_cli_tests.rs` needed their bare-tuple `run` helper (and its callers) converted to `Result<(...)>` so the error can propagate with `?` — no other helper needed a signature change, since they already returned `Result`.

## Why not the retry-loop classifier for the two `json_validate_tests.rs` `cargo run` sites

`test_multiple_files_all_valid`/`test_multiple_files_one_invalid` spawn `cargo run` directly rather than the pre-built binary, but neither had a retry loop to begin with (unlike `jq_cli_tests.rs`'s `run_jq_file`/`run_jq_null`). Adding one now would fix a separate, pre-existing flakiness concern (`cargo run`'s exit-101 lock contention) this issue isn't about — so these got the same minimal `signal_death_error` treatment as every other single-shot site instead.

## Test plan

- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — all green except one pre-existing, unrelated `#[should_panic]` failure on `src/bits/select.rs` confirmed to also fail on unmodified `main` in `--release` mode (a `debug_assert` that release strips).
- [x] `cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests` (CI's own combined test invocation) — green.
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` and the `--all-features` leg — clean.
- [x] `cargo build --no-default-features` — no new warnings vs. `main`.
- [x] `cargo fmt --check`, `cargo doc --no-deps --features cli,simd,regex,serde` — clean.

Closes #1691.