### PR TITLE
perf(jq): eliminate collect_paths/leaf_paths/tostream_events/stream's O(d²) prefix rebuild

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,10 @@ name = "jq_recurse_clone_bench"
 harness = false
 
 [[bench]]
+name = "jq_leaf_paths_clone_bench"
+harness = false
+
+[[bench]]
 name = "jq_generic_index_bench"
 harness = false
 

--- a/benches/jq_leaf_paths_clone_bench.rs
+++ b/benches/jq_leaf_paths_clone_bench.rs
@@ -1,0 +1,108 @@
+//! Depth-scaling benchmark for `collect_leaf_paths`'s per-node prefix-rebuild
+//! cost (#1657), isolating one of the four sibling functions #1657 covers
+//! (`collect_paths`/`collect_leaf_paths`/`collect_tostream_events`/
+//! `collect_stream`, `src/jq/eval.rs`) from the others.
+//!
+//! Reuses `jq_recurse_clone_bench.rs`'s `linear_nest` fixture verbatim:
+//! `{"k": {"k": ... {} ...}}`, `depth` levels of `"k"` nesting, terminating
+//! in an empty object. `[leaf_paths]` (not `[paths]`) is the isolator here,
+//! deliberately, not just an arbitrary pick between the two options #1657
+//! names:
+//!
+//! - `[leaf_paths]` on this fixture visits `depth` nodes along the chain but
+//!   records exactly **one** output — the single leaf (the innermost `{}`,
+//!   a leaf under this crate's tree-structural definition, see
+//!   `collect_leaf_paths`'s doc comment and #771) at path length `depth`.
+//!   Total *necessary* output size is `O(depth)`. Before #1657, each of the
+//!   `depth` descents still rebuilt the whole current-depth prefix via
+//!   `current_path.to_vec()` before extending it by one component — an
+//!   `O(depth)` rebuild repeated at every level, `O(depth^2)` summed, even
+//!   though only one path is ever recorded. Push/recurse/pop reduces that
+//!   traversal to `O(1)` per level (`O(depth)` total), leaving only the
+//!   single unavoidable `O(depth)` clone at the leaf — `O(depth)` overall,
+//!   i.e. linear.
+//! - `[paths]` on the same fixture is a poor isolator by contrast: `paths`
+//!   records **every** node's path, not just leaves, so a `depth`-level
+//!   chain with one child per level yields `depth` outputs of lengths
+//!   `1..=depth` — `O(depth^2)` of *necessary* output regardless of the
+//!   traversal fix (writing that many result elements can't be done in less
+//!   than the time it takes to write them). A `[paths]` benchmark on a plain
+//!   chain would still show quadratic growth after the fix, just with a
+//!   smaller constant, and would not demonstrate the asymptotic improvement
+//!   #1657's acceptance criteria call for.
+//!
+//! This file makes **no timing assertion** — it is a Criterion benchmark for
+//! manual before/after comparison, not a CI gate. Run it interleaved
+//! before/after #1657's fix lands, per the A/B method in
+//! `docs/guides/benchmarking.md#ab-benchmarking-method`, and record the
+//! resulting table in that issue/PR rather than here.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench --bench jq_leaf_paths_clone_bench
+//! ```
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+use succinctly::jq::{eval, parse, JqSemantics, OwnedValue, QueryResult, MAX_VALUE_TREE_DEPTH};
+use succinctly::json::JsonIndex;
+
+/// `{"k": {"k": ... {} ... }}`, `depth` levels of `"k"` nesting, no other
+/// fields — identical to `jq_recurse_clone_bench.rs`'s fixture of the same
+/// name, duplicated here rather than shared so this file stays a
+/// self-contained, independently runnable benchmark like its siblings.
+fn linear_nest(depth: usize) -> Vec<u8> {
+    let open = "{\"k\":".repeat(depth);
+    let close = "}".repeat(depth);
+    format!("{open}{{}}{close}").into_bytes()
+}
+
+fn bench_leaf_paths_clone_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_leaf_paths_clone_depth");
+    // Same depth points as `jq_recurse_clone_bench.rs` for cross-benchmark
+    // comparability; the top depth is derived from `MAX_VALUE_TREE_DEPTH`
+    // (384) rather than hardcoded, since `collect_leaf_paths` panics past it
+    // (#1025).
+    for &depth in &[100usize, 200, 300, MAX_VALUE_TREE_DEPTH - 9] {
+        let json = linear_nest(depth);
+        let index = JsonIndex::build(&json);
+        let expr = parse("[leaf_paths]").expect("filter parses");
+        // Guard the premise: exactly one leaf path, of length `depth`,
+        // pointing at the innermost `{}` -- a different shape would mean
+        // this fixture stopped isolating the single-output case the module
+        // doc above depends on.
+        let cursor = index.root(&json);
+        let probe: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
+        match probe {
+            QueryResult::Owned(OwnedValue::Array(paths)) => {
+                assert_eq!(
+                    paths.len(),
+                    1,
+                    "depth {depth} fixture must yield exactly one leaf path"
+                );
+                match &paths[0] {
+                    OwnedValue::Array(components) => assert_eq!(
+                        components.len(),
+                        depth,
+                        "depth {depth} fixture's leaf path must have length {depth}"
+                    ),
+                    other => panic!("depth {depth} fixture: expected an array path, got {other:?}"),
+                }
+            }
+            other => panic!("depth {depth} fixture: expected a single-array result, got {other:?}"),
+        }
+
+        group.throughput(Throughput::Elements(depth as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(depth), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
+                black_box(result.collect_owned().len())
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_leaf_paths_clone_depth);
+criterion_main!(benches);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10733,32 +10733,35 @@ fn builtin_tojsonstream<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     // Simplified: just return the value as JSON lines format
     let owned = to_owned(&value);
-    fn collect_stream(value: &OwnedValue, path: &[OwnedValue], results: &mut Vec<OwnedValue>) {
+    fn collect_stream(
+        value: &OwnedValue,
+        path: &mut Vec<OwnedValue>,
+        results: &mut Vec<OwnedValue>,
+    ) {
         match value {
             OwnedValue::Array(arr) => {
                 for (i, v) in arr.iter().enumerate() {
-                    let mut new_path = path.to_vec();
-                    new_path.push(OwnedValue::Int(i as i64));
-                    collect_stream(v, &new_path, results);
+                    path.push(OwnedValue::Int(i as i64));
+                    collect_stream(v, path, results);
+                    path.pop();
                 }
             }
             OwnedValue::Object(obj) => {
                 for (k, v) in obj {
-                    let mut new_path = path.to_vec();
-                    new_path.push(OwnedValue::String(k.clone()));
-                    collect_stream(v, &new_path, results);
+                    path.push(OwnedValue::String(k.clone()));
+                    collect_stream(v, path, results);
+                    path.pop();
                 }
             }
             _ => {
-                let entry =
-                    OwnedValue::Array(vec![OwnedValue::Array(path.to_vec()), value.clone()]);
+                let entry = OwnedValue::Array(vec![OwnedValue::Array(path.clone()), value.clone()]);
                 results.push(entry);
             }
         }
     }
 
     let mut results = Vec::new();
-    collect_stream(&owned, &[], &mut results);
+    collect_stream(&owned, &mut Vec::new(), &mut results);
     QueryResult::Owned(OwnedValue::Array(results))
 }
 
@@ -25996,25 +25999,36 @@ fn extend(current_path: &[OwnedValue], component: OwnedValue) -> Vec<OwnedValue>
 /// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
 /// levels of nesting (#1021, following #1005's precedent) — `current_path`
 /// already grows by exactly one component per descent from both call sites
-/// (`builtin_paths`/`builtin_paths_filter`, both starting at `&[]`), so its
-/// length doubles as the recursion depth with no extra parameter needed.
-fn collect_paths(value: &OwnedValue, current_path: &[OwnedValue], paths: &mut Vec<OwnedValue>) {
+/// (`builtin_paths`/`builtin_paths_filter`, both starting at an empty
+/// `Vec`), so its length doubles as the recursion depth with no extra
+/// parameter needed.
+///
+/// `current_path` is threaded through with push/recurse/pop rather than
+/// clone-and-extend (#1657, mirroring `eval_generic::collect_paths_generic`'s
+/// #701 fix) — every `push` is matched by exactly one `pop` on every exit
+/// path out of that iteration, so a fresh `O(depth)` prefix no longer has to
+/// be rebuilt at every node just to extend it by one component.
+fn collect_paths(
+    value: &OwnedValue,
+    current_path: &mut Vec<OwnedValue>,
+    paths: &mut Vec<OwnedValue>,
+) {
     assert_value_tree_depth(current_path.len());
     match value {
         OwnedValue::Object(entries) => {
             for (key, val) in entries {
-                let mut new_path = current_path.to_vec();
-                new_path.push(OwnedValue::String(key.clone()));
-                paths.push(OwnedValue::Array(new_path.clone()));
-                collect_paths(val, &new_path, paths);
+                current_path.push(OwnedValue::String(key.clone()));
+                paths.push(OwnedValue::Array(current_path.clone()));
+                collect_paths(val, current_path, paths);
+                current_path.pop();
             }
         }
         OwnedValue::Array(arr) => {
             for (i, val) in arr.iter().enumerate() {
-                let mut new_path = current_path.to_vec();
-                new_path.push(OwnedValue::Int(i as i64));
-                paths.push(OwnedValue::Array(new_path.clone()));
-                collect_paths(val, &new_path, paths);
+                current_path.push(OwnedValue::Int(i as i64));
+                paths.push(OwnedValue::Array(current_path.clone()));
+                collect_paths(val, current_path, paths);
+                current_path.pop();
             }
         }
         _ => {}
@@ -26030,34 +26044,49 @@ fn collect_paths(value: &OwnedValue, current_path: &[OwnedValue], paths: &mut Ve
 /// Panics past [`MAX_VALUE_TREE_DEPTH`](crate::jq::value::MAX_VALUE_TREE_DEPTH)
 /// levels of nesting (#1021, following #1005's precedent) — `path` already
 /// grows by exactly one component per descent from its sole call site
-/// (`builtin_tostream`, starting at `&[]`), so its length doubles as the
-/// recursion depth with no extra parameter needed.
-fn collect_tostream_events(value: &OwnedValue, path: &[OwnedValue], events: &mut Vec<OwnedValue>) {
+/// (`builtin_tostream`, starting at an empty `Vec`), so its length doubles as
+/// the recursion depth with no extra parameter needed.
+///
+/// `path` is threaded through with push/recurse/pop rather than
+/// clone-and-extend (#1657, mirroring `eval_generic::collect_paths_generic`'s
+/// #701 fix): every `push` is matched by exactly one `pop` on every exit path
+/// out of that iteration. The closing `[path]` marker re-pushes the last
+/// child's own key/index after the loop — for an array that's an O(1) index
+/// recompute (`arr.len() - 1`); for an object, `IndexMap::last()` reads the
+/// final entry's key in O(1) without an extra clone-per-iteration to track
+/// it.
+fn collect_tostream_events(
+    value: &OwnedValue,
+    path: &mut Vec<OwnedValue>,
+    events: &mut Vec<OwnedValue>,
+) {
     assert_value_tree_depth(path.len());
     match value {
         OwnedValue::Object(entries) if !entries.is_empty() => {
-            let mut last_path = path.to_vec();
             for (key, val) in entries {
-                let mut child_path = path.to_vec();
-                child_path.push(OwnedValue::String(key.clone()));
-                collect_tostream_events(val, &child_path, events);
-                last_path = child_path;
+                path.push(OwnedValue::String(key.clone()));
+                collect_tostream_events(val, path, events);
+                path.pop();
             }
-            events.push(OwnedValue::Array(vec![OwnedValue::Array(last_path)]));
+            if let Some((last_key, _)) = entries.last() {
+                path.push(OwnedValue::String(last_key.clone()));
+                events.push(OwnedValue::Array(vec![OwnedValue::Array(path.clone())]));
+                path.pop();
+            }
         }
         OwnedValue::Array(arr) if !arr.is_empty() => {
-            let mut last_path = path.to_vec();
             for (i, val) in arr.iter().enumerate() {
-                let mut child_path = path.to_vec();
-                child_path.push(OwnedValue::Int(i as i64));
-                collect_tostream_events(val, &child_path, events);
-                last_path = child_path;
+                path.push(OwnedValue::Int(i as i64));
+                collect_tostream_events(val, path, events);
+                path.pop();
             }
-            events.push(OwnedValue::Array(vec![OwnedValue::Array(last_path)]));
+            path.push(OwnedValue::Int((arr.len() - 1) as i64));
+            events.push(OwnedValue::Array(vec![OwnedValue::Array(path.clone())]));
+            path.pop();
         }
         leaf => {
             events.push(OwnedValue::Array(vec![
-                OwnedValue::Array(path.to_vec()),
+                OwnedValue::Array(path.clone()),
                 leaf.clone(),
             ]));
         }
@@ -26071,7 +26100,7 @@ fn builtin_tostream<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let mut events = Vec::new();
-    collect_tostream_events(&owned, &[], &mut events);
+    collect_tostream_events(&owned, &mut Vec::new(), &mut events);
     // Always non-empty: every value (including an empty container or a
     // top-level scalar) produces at least one leaf event -- routed through
     // `collapse_vec` anyway (#1067) so a future change to
@@ -26219,7 +26248,7 @@ fn builtin_paths<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let mut paths = Vec::new();
-    collect_paths(&owned, &[], &mut paths);
+    collect_paths(&owned, &mut Vec::new(), &mut paths);
     // Stream individual paths instead of wrapping in array
     owned_vec_to_result(paths)
 }
@@ -26303,7 +26332,7 @@ fn each_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 
     let mut all_paths = Vec::new();
-    collect_paths(&owned, &[], &mut all_paths);
+    collect_paths(&owned, &mut Vec::new(), &mut all_paths);
 
     for path in all_paths {
         let OwnedValue::Array(path_arr) = &path else {
@@ -26394,9 +26423,14 @@ fn get_value_at_path(value: &OwnedValue, path: &[OwnedValue]) -> Option<OwnedVal
 /// `collect_paths`/`collect_tostream_events` (#1021) already established:
 /// `current_path` grows by exactly one element per descent, so its length
 /// already tracks tree depth without duplicating a counter.
+///
+/// `current_path` is threaded through with push/recurse/pop rather than
+/// clone-and-extend (#1657, mirroring `eval_generic::collect_paths_generic`'s
+/// #701 fix and `collect_paths`'s own #1657 fix above) — every `push` is
+/// matched by exactly one `pop` on every exit path out of that iteration.
 fn collect_leaf_paths(
     value: &OwnedValue,
-    current_path: &[OwnedValue],
+    current_path: &mut Vec<OwnedValue>,
     paths: &mut Vec<OwnedValue>,
 ) {
     assert_value_tree_depth(current_path.len());
@@ -26404,30 +26438,30 @@ fn collect_leaf_paths(
         OwnedValue::Object(entries) => {
             if entries.is_empty() {
                 // Empty object is a leaf
-                paths.push(OwnedValue::Array(current_path.to_vec()));
+                paths.push(OwnedValue::Array(current_path.clone()));
             } else {
                 for (key, val) in entries {
-                    let mut new_path = current_path.to_vec();
-                    new_path.push(OwnedValue::String(key.clone()));
-                    collect_leaf_paths(val, &new_path, paths);
+                    current_path.push(OwnedValue::String(key.clone()));
+                    collect_leaf_paths(val, current_path, paths);
+                    current_path.pop();
                 }
             }
         }
         OwnedValue::Array(arr) => {
             if arr.is_empty() {
                 // Empty array is a leaf
-                paths.push(OwnedValue::Array(current_path.to_vec()));
+                paths.push(OwnedValue::Array(current_path.clone()));
             } else {
                 for (i, val) in arr.iter().enumerate() {
-                    let mut new_path = current_path.to_vec();
-                    new_path.push(OwnedValue::Int(i as i64));
-                    collect_leaf_paths(val, &new_path, paths);
+                    current_path.push(OwnedValue::Int(i as i64));
+                    collect_leaf_paths(val, current_path, paths);
+                    current_path.pop();
                 }
             }
         }
         _ => {
             // Scalar value is a leaf
-            paths.push(OwnedValue::Array(current_path.to_vec()));
+            paths.push(OwnedValue::Array(current_path.clone()));
         }
     }
 }
@@ -26444,7 +26478,7 @@ fn builtin_leaf_paths<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     let owned = to_owned(&value);
     let mut paths = Vec::new();
-    collect_leaf_paths(&owned, &[], &mut paths);
+    collect_leaf_paths(&owned, &mut Vec::new(), &mut paths);
     // Stream individual paths instead of wrapping in array
     owned_vec_to_result(paths)
 }
@@ -55900,13 +55934,13 @@ mod tests {
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
         let mut paths = Vec::new();
-        collect_paths(&under, &[], &mut paths);
+        collect_paths(&under, &mut Vec::new(), &mut paths);
         assert_eq!(paths.len(), MAX_VALUE_TREE_DEPTH - 1);
 
         let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut paths = Vec::new();
-            collect_paths(&over, &[], &mut paths);
+            collect_paths(&over, &mut Vec::new(), &mut paths);
         }));
         assert!(
             result.is_err(),
@@ -55923,13 +55957,13 @@ mod tests {
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
         let mut events = Vec::new();
-        collect_tostream_events(&under, &[], &mut events);
+        collect_tostream_events(&under, &mut Vec::new(), &mut events);
         assert!(!events.is_empty());
 
         let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut events = Vec::new();
-            collect_tostream_events(&over, &[], &mut events);
+            collect_tostream_events(&over, &mut Vec::new(), &mut events);
         }));
         assert!(
             result.is_err(),
@@ -56095,13 +56129,13 @@ mod tests {
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
         let mut paths = Vec::new();
-        collect_leaf_paths(&under, &[], &mut paths);
+        collect_leaf_paths(&under, &mut Vec::new(), &mut paths);
         assert_eq!(paths.len(), 1);
 
         let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut paths = Vec::new();
-            collect_leaf_paths(&over, &[], &mut paths);
+            collect_leaf_paths(&over, &mut Vec::new(), &mut paths);
         }));
         assert!(
             result.is_err(),
@@ -56112,13 +56146,13 @@ mod tests {
         // `Array`'s -- exercise its own boundary too (#1025 code review).
         let under_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH - 1);
         let mut paths = Vec::new();
-        collect_leaf_paths(&under_obj, &[], &mut paths);
+        collect_leaf_paths(&under_obj, &mut Vec::new(), &mut paths);
         assert_eq!(paths.len(), 1);
 
         let over_obj = linear_object_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut paths = Vec::new();
-            collect_leaf_paths(&over_obj, &[], &mut paths);
+            collect_leaf_paths(&over_obj, &mut Vec::new(), &mut paths);
         }));
         assert!(
             result.is_err(),


### PR DESCRIPTION
## Summary

Fixes #1657.

`collect_paths` (`paths`/`paths(f)`), `collect_leaf_paths` (`leaf_paths`), `collect_tostream_events` (`tostream`), and `builtin_tojsonstream`'s local `collect_stream` helper each rebuilt the whole current-depth path prefix via `current_path.to_vec()` before extending it by one component at every visited node, then cloned it again to record into the output — the same clone-per-node anti-pattern #701 (fixed by #1631) eliminated for `PathBranch.path: Vec<Expr>`, just over `Vec<OwnedValue>` (path output) instead of `Vec<Expr>` (path expressions).

All four now thread `current_path`/`path` through with push/recurse/pop, mirroring `eval_generic::collect_paths_generic`'s already-correct pattern — no new data structure needed, exactly as #1657 predicted, since each function serializes one path at a time and never needs a prefix to outlive the recursive call.

`collect_tostream_events` needed one extra adjustment: its closing `[path]` marker used to track the last child's extended path via a clone on every loop iteration. That's now recomputed after the loop instead — `arr.len() - 1` (O(1)) for arrays, `IndexMap::last()` (O(1)) for objects — rather than cloning a path on every iteration just in case it turns out to be the last one.

## Benchmark

New `benches/jq_leaf_paths_clone_bench.rs`, isolating the fix with `[leaf_paths]` (not `[paths]` — see the file's module doc for why `[paths]` is a poor isolator: its per-node recorded output on a plain chain is itself `O(d²)`, regardless of traversal cost) on the same `linear_nest` fixture `jq_recurse_clone_bench.rs` (#668) uses.

A/B'd by scoped-stashing only `src/jq/eval.rs` (`--quick` mode; sequential before/after, not per-repetition interleaved, so treat the numbers as indicative — but the effect is orders of magnitude, far past anything thermal noise could produce):

| depth | before (O(d²)) | after (O(d)) |
|-------|-----------------|--------------|
| 100   | 115 µs          | 17 µs        |
| 200   | 460 µs          | 42-43 µs     |
| 300   | 970 µs          | 66-75 µs     |
| 375   | 1.48 ms         | 87-103 µs    |

Speedup grows with depth (~7-11x at 100, ~14-17x at 375) — the signature of an algorithmic fix, not a constant-factor one.

## Test plan

- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, including `yq_golden_tests` and the `#1021`/`#1025` depth-limit panic tests for all four functions) — all green, no behavioral change
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo doc --no-deps --features cli,simd,regex,serde`
- [x] `./scripts/build.sh` (release build + bench-compare crate)
- [x] `cargo bench --bench jq_leaf_paths_clone_bench` — confirms current O(d²) shape before the fix, near-linear after