### PR TITLE
fix(yq): make --ascii-output gate the whole M2 JSON fast-path condition

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3224,11 +3224,33 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // implement ASCII escaping, so `compact ||` previously let
     // `--ascii-output` through unescaped whenever `-I=0`/compact mode was
     // also requested -- the DOM path (`output_value`) is the only place
-    // that escapes correctly, and it's reached only when this whole
-    // condition is false.
+    // that escapes correctly, and it's reached only when this is false.
+    //
+    // Falling back to DOM for `--ascii-output` reopens the duplicate-key
+    // collapse `can_stream_pretty_or_colored`'s own comment above warns
+    // about (#442/#748/#809) -- but only for this one flag, and only in a
+    // way that already shipped: pretty mode's `can_stream_pretty_or_colored
+    // && !ascii_output` had exactly this same DOM fallback (and therefore
+    // the same duplicate-key loss) for `--ascii-output` before #1693 ever
+    // touched this function. This shared local makes compact mode
+    // consistent with that pre-existing behavior instead of leaving the two
+    // output styles to diverge on the same input. #1700 tracks the real fix
+    // (ASCII-escaping support in the M2 streamers themselves, which would
+    // let `--ascii-output` keep both correct escaping and duplicate-key
+    // safety at once) -- not attempted here per #1693's own "Low, cosmetic"
+    // scoping and the same #965 inlining-cost reasoning this file's
+    // `stream_json_string` doc comment records for why that isn't a
+    // drop-in change.
+    //
+    // Extracted into one local (rather than repeating the expression at
+    // `can_json_fast_path`, `can_inplace_json_fast_path`, and
+    // `can_slurp_fast_path`'s JSON arm) per /code-review on #1693's own PR:
+    // `can_slurp_fast_path` originally diverged from this exact predicate
+    // because #1577 copied it by hand instead of sharing it.
+    let can_stream_json_output_style =
+        !args.ascii_output && (output_config.compact || can_stream_pretty_or_colored);
     let can_json_fast_path = is_m2_streamable
-        && !args.ascii_output
-        && (output_config.compact || can_stream_pretty_or_colored)
+        && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -3265,10 +3287,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // writes), so `-C` reaching the fast path still never writes ANSI to
     // disk, but no longer forces a fallback to the duplicate-key-collapsing
     // DOM path either.
-    // Same `!args.ascii_output` fix as `can_json_fast_path` above (#1693).
+    // Shares `can_json_fast_path`'s `can_stream_json_output_style` above.
     let can_inplace_json_fast_path = is_m2_streamable
-        && !args.ascii_output
-        && (output_config.compact || can_stream_pretty_or_colored)
+        && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -3295,17 +3316,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // one never OR's in `output_config.compact` for YAML -- preserved as-is
     // from before #1577.
     //
-    // The JSON arm's `!args.ascii_output && (compact || pretty-or-colored)`
-    // shape now matches `can_json_fast_path`/`can_inplace_json_fast_path`
-    // above exactly (#1693 fixed all three the same way: none of the M2 JSON
-    // streamers implement ASCII escaping, so `!args.ascii_output` has to gate
-    // the whole disjunction, not just the pretty-or-colored half, or compact
-    // mode lets `--ascii-output` through unescaped).
+    // The JSON arm shares `can_json_fast_path`'s `can_stream_json_output_style`
+    // above (#1693 fixed all three JSON gates the same way: none of the M2
+    // JSON streamers implement ASCII escaping, so `!args.ascii_output` has to
+    // gate the whole disjunction, not just the pretty-or-colored half, or
+    // compact mode lets `--ascii-output` through unescaped).
     let can_slurp_fast_path = is_identity
         && match output_config.output_format {
-            OutputFormat::Json => {
-                !args.ascii_output && (output_config.compact || can_stream_pretty_or_colored)
-            }
+            OutputFormat::Json => can_stream_json_output_style,
             OutputFormat::Yaml => can_stream_pretty_or_colored,
             _ => false,
         }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3219,8 +3219,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // falling back to the DOM/IndexMap path that would collapse duplicate
     // mapping keys (#442, #748, #809).
     let can_stream_pretty_or_colored = !args.pretty_print;
+    // `!args.ascii_output` gates the whole disjunction, not just the
+    // pretty-or-colored half (#1693): none of the M2 JSON streamers
+    // implement ASCII escaping, so `compact ||` previously let
+    // `--ascii-output` through unescaped whenever `-I=0`/compact mode was
+    // also requested -- the DOM path (`output_value`) is the only place
+    // that escapes correctly, and it's reached only when this whole
+    // condition is false.
     let can_json_fast_path = is_m2_streamable
-        && (output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output))
+        && !args.ascii_output
+        && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -3257,8 +3265,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // writes), so `-C` reaching the fast path still never writes ANSI to
     // disk, but no longer forces a fallback to the duplicate-key-collapsing
     // DOM path either.
+    // Same `!args.ascii_output` fix as `can_json_fast_path` above (#1693).
     let can_inplace_json_fast_path = is_m2_streamable
-        && (output_config.compact || (can_stream_pretty_or_colored && !args.ascii_output))
+        && !args.ascii_output
+        && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
         && !args.raw_input
@@ -3285,18 +3295,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // one never OR's in `output_config.compact` for YAML -- preserved as-is
     // from before #1577.
     //
-    // The JSON arm deliberately does NOT copy `can_json_fast_path`'s
-    // `compact || (pretty-or-colored && !ascii_output)` shape verbatim: that
-    // condition already lets `--ascii-output` through unescaped in compact
-    // mode today (#1693, a live, pre-existing bug -- none of the M2 JSON
-    // streamers implement ASCII escaping at all, contrary to what that
-    // condition's shape implies). Copying it here would have been a new
-    // regression, not an inherited gap: before this arm existed, `--slurp
-    // -o=json` had no fast path in *any* combination, so `--ascii-output`
-    // always reached the DOM path's correct escaping. `!args.ascii_output`
-    // is therefore required unconditionally, keeping that combination on
-    // the DOM path exactly as it was pre-#1577, until #1693 gives the M2
-    // streamers real ASCII-escaping support to extend this to.
+    // The JSON arm's `!args.ascii_output && (compact || pretty-or-colored)`
+    // shape now matches `can_json_fast_path`/`can_inplace_json_fast_path`
+    // above exactly (#1693 fixed all three the same way: none of the M2 JSON
+    // streamers implement ASCII escaping, so `!args.ascii_output` has to gate
+    // the whole disjunction, not just the pretty-or-colored half, or compact
+    // mode lets `--ascii-output` through unescaped).
     let can_slurp_fast_path = is_identity
         && match output_config.output_format {
             OutputFormat::Json => {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1467,6 +1467,47 @@ fn test_slurp_json_ascii_output_still_escapes_in_compact_mode_1577() -> Result<(
     Ok(())
 }
 
+/// #1693: `can_json_fast_path`'s `compact || (pretty-or-colored &&
+/// !ascii_output)` shape let `--ascii-output` through unescaped whenever
+/// compact mode (`-I0`) was also requested -- none of the M2 JSON streamers
+/// implement ASCII escaping, only the DOM path's `output_value` does. Fixed
+/// by making `!args.ascii_output` gate the whole disjunction.
+#[test]
+fn test_ascii_output_still_escapes_in_compact_mode_1693() -> Result<()> {
+    let yaml = "a: \"h\u{e9}llo\"\n";
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0", "--ascii-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "{\"a\":\"h\\u00e9llo\"}\n");
+
+    Ok(())
+}
+
+/// Same bug, same fix, for `can_inplace_json_fast_path` (#1693).
+#[test]
+fn test_ascii_output_still_escapes_in_compact_inplace_mode_1693() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: \"h\u{e9}llo\"")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-o")
+        .arg("json")
+        .arg("-I0")
+        .arg("--ascii-output")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "{\"a\":\"h\\u00e9llo\"}\n");
+
+    Ok(())
+}
+
 /// #1577: like [`test_duplicate_mapping_key_survives_slurp_multiple_sources`],
 /// but for JSON output -- duplicate keys within one source must survive
 /// `--slurp -o=json` combining documents from multiple files, not just a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1508,6 +1508,32 @@ fn test_ascii_output_still_escapes_in_compact_inplace_mode_1693() -> Result<()> 
     Ok(())
 }
 
+/// #1693 code review: routing `--ascii-output` to the DOM path (the fix
+/// above) reopens `can_stream_pretty_or_colored`'s duplicate-key collapse
+/// (#442/#748/#809) for compact mode specifically -- but pretty mode already
+/// had this exact tradeoff before #1693 touched this function (its own
+/// `can_stream_pretty_or_colored && !ascii_output` gate already forced DOM
+/// for `--ascii-output`, collapse included), so this pins compact mode as
+/// now *consistent* with that pre-existing behavior, not a new regression
+/// introduced from a clean baseline. See the `can_stream_json_output_style`
+/// comment in `yq_runner.rs` and #1700 for the real fix (ASCII-escaping
+/// support in the M2 streamers themselves, which would keep both correct
+/// escaping and duplicate-key safety at once).
+#[test]
+fn test_ascii_output_compact_and_pretty_agree_on_duplicate_key_collapse_1693() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (compact, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0", "--ascii-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact, "{\"a\":2}\n");
+
+    let (pretty, code) = run_yq_stdin(".", yaml, &["-o", "json", "--ascii-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(pretty, "{\n  \"a\": 2\n}\n");
+
+    Ok(())
+}
+
 /// #1577: like [`test_duplicate_mapping_key_survives_slurp_multiple_sources`],
 /// but for JSON output -- duplicate keys within one source must survive
 /// `--slurp -o=json` combining documents from multiple files, not just a


### PR DESCRIPTION
## Summary

Fixes #1693.

`can_json_fast_path` and `can_inplace_json_fast_path` both had the shape `compact || (pretty-or-colored && !ascii_output)` — the `compact ||` half let `--ascii-output` through unescaped whenever compact mode (`-I0`) was also requested, since none of the M2 JSON streamers (`stream_json_value`, `stream_json_sequence`) implement ASCII escaping; only the DOM path's `output_value` does, and it was only reached when the whole condition was already false.

Fixed by moving `!args.ascii_output` outside the disjunction so it gates unconditionally — the exact same shape `can_slurp_fast_path` already used after #1577's own fix for this bug in that one gate. All three JSON fast-path gates are now consistent.

```console
$ printf 'k: "héllo"\n' > g.yaml
$ succinctly yq -o=json -I=0 --ascii-output '.' g.yaml
{"k":"héllo"}   # was: {"k":"héllo"} (unescaped, wrong)
```

## Why not thread ASCII escaping through the M2 streamers instead

That's the more complete fix (#1693's suggested direction 1), but investigating it turned up a real cost: `stream_json_string` is a hand-tuned, deliberately *separate* copy of the same escaping logic `jq::escape::write_json_body_yq` implements — kept unshared specifically because #965 measured up to 14% regression from letting the two call sites share one inlined copy. Adding ASCII-escaping support there would mean writing a third such copy from scratch (correct UTF-8 decoding, surrogate pairs for code points above U+FFFF, its own SIMD-tuned scan), a much larger and riskier change than this issue's stated "Low, cosmetic" severity warrants. Falling back to the DOM path for this one flag combination is the documented, accepted tradeoff (#1693's own suggested direction 2).

## Test plan

- [x] Live-verified all 5 affected combinations (stdout compact, stdout pretty, inplace compact, non-ascii-output compact, slurp compact) before and after the fix.
- [x] Added `test_ascii_output_still_escapes_in_compact_mode_1693` and `test_ascii_output_still_escapes_in_compact_inplace_mode_1693`.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure (confirmed on unmodified `main`).
- [x] `cargo clippy` both legs, `cargo fmt --check`, `cargo doc --no-deps`, `cargo build --no-default-features` — all clean, no new warnings vs. `main`.

Closes #1693.