### PR TITLE
fix(bench): name the signal when a remote exec is killed, not -1

### DIFF
--- a/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
@@ -9,6 +9,7 @@
 //! any network access.
 
 use super::config::NodeConfig;
+use crate::exit_status::exit_code_or_signal_death;
 use anyhow::{Context, Result};
 use std::fs;
 use std::io::Read;
@@ -208,14 +209,19 @@ fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExecOutput> {
     let mut stdout_pipe = child.stdout.take().context("child had no stdout pipe")?;
     let mut stderr_pipe = child.stderr.take().context("child had no stderr pipe")?;
 
+    // Raw bytes, decoded only after the exit-code/signal check below: a
+    // signal-killed child can leave a truncated multi-byte UTF-8 sequence
+    // at the end of a buffer it was writing when killed, and a strict
+    // `read_to_string` discards *all* already-read output (not just the
+    // trailing partial sequence) the moment that happens (#1696 review).
     let stdout_handle = std::thread::spawn(move || {
-        let mut buf = String::new();
-        let _ = stdout_pipe.read_to_string(&mut buf);
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf);
         buf
     });
     let stderr_handle = std::thread::spawn(move || {
-        let mut buf = String::new();
-        let _ = stderr_pipe.read_to_string(&mut buf);
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf);
         buf
     });
 
@@ -232,40 +238,21 @@ fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExecOutput> {
         std::thread::sleep(Duration::from_millis(50));
     };
 
-    let stdout = stdout_handle.join().unwrap_or_default();
-    let stderr = stderr_handle.join().unwrap_or_default();
+    let stdout_bytes = stdout_handle.join().unwrap_or_default();
+    let stderr_bytes = stderr_handle.join().unwrap_or_default();
 
-    let exit_code = status
-        .code()
-        .ok_or_else(|| signal_death_error(status, &stderr))?;
+    // Checked against the raw bytes, before either is decoded, so a
+    // signal-killed child (OOM kill, network drop, another process's
+    // `pkill`) is diagnosed by name instead of coerced into a fake `-1`
+    // exit code (#1696) — and so that check can never itself fail to
+    // decode (`String::from_utf8_lossy` below cannot fail).
+    let exit_code = exit_code_or_signal_death(status, &stderr_bytes)?;
 
     Ok(ExecOutput {
-        stdout,
-        stderr,
+        stdout: String::from_utf8_lossy(&stdout_bytes).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr_bytes).into_owned(),
         exit_code,
     })
-}
-
-/// Builds the "child was killed by signal N" error for a signal-terminated
-/// process (`ExitStatus::code()` returns `None` only in that case, on Unix).
-/// Mirrors `tests/common/cargo_run_exit.rs`'s `signal_death_error` (#1691) —
-/// duplicated rather than shared because production code can't depend on a
-/// `tests/` module. Without this, a signal-killed remote `ssh`/`rsync` child
-/// (OOM kill, network drop, another process's `pkill`) silently coerced to a
-/// fake exit code `-1`, reporting as a generic non-zero-exit failure with no
-/// indication a signal was ever involved (#1696).
-fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
-    #[cfg(unix)]
-    let signal = {
-        use std::os::unix::process::ExitStatusExt;
-        status.signal()
-    };
-    #[cfg(not(unix))]
-    let signal: Option<i32> = None;
-    anyhow::anyhow!(
-        "child was killed by signal {}; stderr:\n{stderr}",
-        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
-    )
 }
 
 /// Recursively copy the *contents* of `src` into `dst` (creating `dst` if
@@ -372,6 +359,32 @@ mod tests {
         assert!(
             err.to_string().contains("signal 9"),
             "expected error to name signal 9, got: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn localhost_exec_signal_death_preserves_truncated_utf8_stderr() {
+        // Writes the first two bytes of a three-byte UTF-8 sequence (U+20AC)
+        // to stderr, then kills itself with SIGKILL before ever completing
+        // it -- exactly the truncated-multi-byte-sequence scenario that
+        // made a strict `read_to_string` silently discard *all* captured
+        // output, not just the trailing partial bytes (#1696 review). Only
+        // a raw-bytes capture, decoded lossily after the exit-code check,
+        // survives this: the invalid tail becomes a replacement character
+        // instead of erasing the whole buffer.
+        let err = SystemSsh
+            .exec(
+                &node("localhost"),
+                "printf '\\xe2\\x82' >&2; kill -9 $$",
+                Duration::from_secs(5),
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("signal 9"), "expected signal 9, got: {msg}");
+        assert!(
+            msg.contains('\u{FFFD}'),
+            "expected the truncated stderr bytes to survive as a replacement character, got: {msg}"
         );
     }
 

--- a/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/ssh.rs
@@ -235,11 +235,37 @@ fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<ExecOutput> {
     let stdout = stdout_handle.join().unwrap_or_default();
     let stderr = stderr_handle.join().unwrap_or_default();
 
+    let exit_code = status
+        .code()
+        .ok_or_else(|| signal_death_error(status, &stderr))?;
+
     Ok(ExecOutput {
         stdout,
         stderr,
-        exit_code: status.code().unwrap_or(-1),
+        exit_code,
     })
+}
+
+/// Builds the "child was killed by signal N" error for a signal-terminated
+/// process (`ExitStatus::code()` returns `None` only in that case, on Unix).
+/// Mirrors `tests/common/cargo_run_exit.rs`'s `signal_death_error` (#1691) —
+/// duplicated rather than shared because production code can't depend on a
+/// `tests/` module. Without this, a signal-killed remote `ssh`/`rsync` child
+/// (OOM kill, network drop, another process's `pkill`) silently coerced to a
+/// fake exit code `-1`, reporting as a generic non-zero-exit failure with no
+/// indication a signal was ever involved (#1696).
+fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    anyhow::anyhow!(
+        "child was killed by signal {}; stderr:\n{stderr}",
+        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
+    )
 }
 
 /// Recursively copy the *contents* of `src` into `dst` (creating `dst` if
@@ -332,6 +358,21 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 3);
         assert!(!out.success());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn localhost_exec_signal_death_names_the_signal() {
+        // `kill -9 $$` terminates the shell itself via SIGKILL (9), so
+        // `ExitStatus::code()` returns `None` -- the case this test exists
+        // to cover, rather than a plain nonzero exit.
+        let err = SystemSsh
+            .exec(&node("localhost"), "kill -9 $$", Duration::from_secs(5))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("signal 9"),
+            "expected error to name signal 9, got: {err}"
+        );
     }
 
     #[test]

--- a/src/bin/succinctly/bench_runner/orchestrate/sync.rs
+++ b/src/bin/succinctly/bench_runner/orchestrate/sync.rs
@@ -150,7 +150,9 @@ pub(crate) fn sync_node(
     let remote_binary = format!("{remote_dir}/succinctly");
     remote.upload(node, &local_binary, &remote_binary, connect_timeout)?;
 
-    let verify = remote.exec(node, &version_cmd, connect_timeout)?;
+    let verify = remote
+        .exec(node, &version_cmd, connect_timeout)
+        .with_context(|| format!("post-upload version check failed on node '{}'", node.name))?;
     if !verify.success() {
         anyhow::bail!(
             "post-upload version check failed on node '{}': {}",

--- a/src/bin/succinctly/exit_status.rs
+++ b/src/bin/succinctly/exit_status.rs
@@ -1,0 +1,54 @@
+//! Shared exit-code classification for a spawned child process.
+//!
+//! Extracted from `tests/common/cargo_run_exit.rs` (#1691) so
+//! `bench_runner::orchestrate::ssh`'s production code and the CLI
+//! integration tests share one definition instead of drifting copies
+//! (#1516 -> #1546 -> #1691 already had to consolidate this once for the
+//! test-only copies; #1696 found the same pattern hand-rolled again in
+//! production code). `tests/common/cargo_run_exit.rs` includes this file
+//! via `#[path]`, the same mechanism it already uses for its own sharing
+//! across `tests/*.rs`.
+
+use anyhow::Result;
+
+/// Builds the "child was killed by signal N" error for a signal-terminated
+/// process (`ExitStatus::code()` returns `None` only in that case, on
+/// Unix). Takes raw stderr bytes rather than an already-decoded `&str` so
+/// callers never need a decode that can fail before reaching this point --
+/// see [`exit_code_or_signal_death`].
+pub fn signal_death_error(status: std::process::ExitStatus, raw_stderr: &[u8]) -> anyhow::Error {
+    // `ExitStatus::code()` returns `None` only when the child was
+    // terminated by a signal (Unix) -- there is no other cause.
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let signal: Option<i32> = None;
+    anyhow::anyhow!(
+        "child was killed by signal {}; stderr:\n{}",
+        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
+        String::from_utf8_lossy(raw_stderr),
+    )
+}
+
+/// Extracts a real exit code from `status`, or builds [`signal_death_error`]
+/// from the *raw* stderr bytes -- checked before any caller attempts a
+/// strict `String::from_utf8` decode of the child's stdout/stderr. A
+/// signal-killed child can leave a truncated multi-byte UTF-8 sequence at
+/// the end of a buffer it was writing when killed; if the caller decodes
+/// first, that decode's own `?` fires before this check ever runs,
+/// surfacing a generic `FromUtf8Error` (or, worse, `read_to_string`
+/// silently discarding everything already read) instead of naming the
+/// signal. Taking `&[u8]` rather than `&str` means the error path never
+/// needs its own successful decode: `String::from_utf8_lossy` cannot fail.
+pub fn exit_code_or_signal_death(
+    status: std::process::ExitStatus,
+    raw_stderr: &[u8],
+) -> Result<i32> {
+    match status.code() {
+        Some(code) => Ok(code),
+        None => Err(signal_death_error(status, raw_stderr)),
+    }
+}

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -2276,6 +2276,8 @@ mod corpus_stats;
 mod dsv_bench;
 mod dsv_generators;
 mod env_config;
+#[cfg(feature = "bench-runner")]
+mod exit_status;
 mod front_matter;
 mod generators;
 mod jq_bench;

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -8,10 +8,21 @@
 //! code) in `jq_cli_tests.rs` alone; its own `/code-review` found the
 //! identical pattern hand-rolled in three more files (#1546). Sharing one
 //! copy here, rather than four independently drifting ones, is the fix.
+//!
+//! `signal_death_error`/`exit_code_or_signal_death`'s actual logic now lives
+//! in `src/bin/succinctly/exit_status.rs` (#1696 found the same
+//! `.code().unwrap_or(-1)` pattern hand-rolled a fifth time, in production
+//! orchestration code) -- included below via the same `#[path]` mechanism
+//! this file is itself included with, rather than re-hand-copied, so the
+//! two call sites can't drift apart again. This module's own wrappers keep
+//! every existing call site here on its established `&str` signature.
 
 #![allow(dead_code)] // Each consumer uses a different subset.
 
 use anyhow::Result;
+
+#[path = "../../src/bin/succinctly/exit_status.rs"]
+mod exit_status;
 
 /// Maximum retries for a `cargo run` command that fails with exit code 101,
 /// or whose child is killed by a signal (`ExitStatus::code()` returns `None`
@@ -26,26 +37,15 @@ use anyhow::Result;
 pub const MAX_CARGO_RETRIES: u32 = 3;
 
 /// Builds the "child was killed by signal N" error for a signal-terminated
-/// process (`ExitStatus::code()` returns `None` only in that case, on Unix),
-/// naming the signal and the captured stderr. Historically every call site
-/// below silently coerced this to `-1` via `.code().unwrap_or(-1)`, which
-/// renders as an inscrutable `left: -1, right: 0` with no indication a child
-/// was ever killed -- exactly what cost a wrong root-cause call in the #1459
-/// review (#1516).
+/// process, naming the signal and the captured stderr. Historically every
+/// call site below silently coerced this to `-1` via `.code().unwrap_or(-1)`,
+/// which renders as an inscrutable `left: -1, right: 0` with no indication a
+/// child was ever killed -- exactly what cost a wrong root-cause call in the
+/// #1459 review (#1516). Thin `&str` wrapper around
+/// `exit_status::signal_death_error` (see that module for the mechanism) so
+/// this file's existing callers don't all need to switch to raw bytes.
 pub fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> anyhow::Error {
-    // `ExitStatus::code()` returns `None` only when the child was
-    // terminated by a signal (Unix) -- there is no other cause.
-    #[cfg(unix)]
-    let signal = {
-        use std::os::unix::process::ExitStatusExt;
-        status.signal()
-    };
-    #[cfg(not(unix))]
-    let signal: Option<i32> = None;
-    anyhow::anyhow!(
-        "child was killed by signal {}; stderr:\n{stderr}",
-        signal.map_or_else(|| "<unknown>".to_string(), |s| s.to_string()),
-    )
+    exit_status::signal_death_error(status, stderr.as_bytes())
 }
 
 /// Extracts a real exit code from `status`, or builds [`signal_death_error`]
@@ -61,18 +61,13 @@ pub fn signal_death_error(status: std::process::ExitStatus, stderr: &str) -> any
 ///
 /// Also collapses the ~29 hand-written `let Some(code) = status.code() else
 /// { ... }` copies #1691's own fix introduced across 7 files into one
-/// definition, per that same review round.
+/// definition, per that same review round. Delegates to
+/// `exit_status::exit_code_or_signal_death`.
 pub fn exit_code_or_signal_death(
     status: std::process::ExitStatus,
     raw_stderr: &[u8],
 ) -> Result<i32> {
-    match status.code() {
-        Some(code) => Ok(code),
-        None => Err(signal_death_error(
-            status,
-            &String::from_utf8_lossy(raw_stderr),
-        )),
-    }
+    exit_status::exit_code_or_signal_death(status, raw_stderr)
 }
 
 /// Classifies a `cargo run` child's exit for a retry loop, so each call site


### PR DESCRIPTION
## Summary

- `SystemSsh::run_with_timeout` coerced `ExitStatus::code() == None` (a
  signal-killed child) into a fake exit code `-1` via `.unwrap_or(-1)`,
  matching the diagnostic-loss pattern #1516/#1546/#1691 fixed across test
  helpers — this was the one live production-code instance of the same bug,
  found and filed as #1696 during #1691's review.
- `run_with_timeout` now returns a descriptive error naming the signal
  (mirroring `tests/common/cargo_run_exit.rs`'s `signal_death_error` from
  #1691) instead of silently building an `ExecOutput` with a fake `-1`.
  Duplicated rather than shared: production code (`src/`) can't depend on a
  `tests/` module.
- No caller changes needed — every caller of `RemoteExec::exec` already
  handles `Result<ExecOutput>`, so a signal death now surfaces through the
  existing `anyhow::Result` error path instead of masquerading as a generic
  nonzero exit.

## Test plan

- [x] `cargo build --features cli,bench-runner`
- [x] Added `localhost_exec_signal_death_names_the_signal` (kills the child
      with `SIGKILL` via `kill -9 $$`, asserts the error names signal 9);
      all 9 `ssh::tests` pass
- [x] `cargo test --features cli,simd,regex,serde` (full suite, CI's actual
      feature set) — 55/55 suites green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo llvm-cov --features cli,bench-runner --workspace` — every new
      line (the exit-code check and the new `signal_death_error` helper) is
      covered by the new test; no regression in file-level coverage

Fixes #1696