### PR TITLE
fix(yq): honor --no-doc in the M2 fast path's document separator

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1831,8 +1831,8 @@ fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> Commen
 /// `no_doc` suppresses the separator itself while still updating `streamed`
 /// (#1699) -- mirroring `SplitDocState::write_separator`'s existing
 /// `!config.no_doc` check, which this fast path had no equivalent of before:
-/// the DOM path (the eval-all loop above) already respects `--no-doc`, but
-/// this macro-shared M2 path wrote `---` unconditionally.
+/// the DOM path (the eval-all loop further below) already respects
+/// `--no-doc`, but this macro-shared M2 path wrote `---` unconditionally.
 fn emit_yaml_doc_separator<W: std::io::Write>(
     writer: &mut W,
     streamed: &mut bool,
@@ -3389,8 +3389,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // scope at definition time, not at each expansion site. `$fragment:expr`
     // parameters don't have that problem — they always evaluate in the
     // caller's own scope — hence passing color as `$use_color:expr`.
+    // `no_doc` is threaded the same way (#1699 code review), even though
+    // nothing currently shadows `.no_doc` to a different value the way
+    // `--inplace` does for `.use_color` (every `OutputConfig::for_source`
+    // copies `no_doc` through unchanged) -- a bare reference would only be
+    // safe by that coincidence, and would silently read the wrong value the
+    // day something *does* start varying `no_doc` per source/file.
     macro_rules! stream_cursor {
-        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr) => {{
+        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $no_doc:expr) => {{
             if $is_yaml {
                 // M2 YAML path: YAML output streaming
                 if is_identity {
@@ -3399,7 +3405,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // `$cursor` here is the whole document being
                     // redisplayed as itself - its own trailing comment,
                     // if any, must be kept (#710).
-                    emit_yaml_doc_separator($writer, $doc_streamed, true, output_config.no_doc)?;
+                    emit_yaml_doc_separator($writer, $doc_streamed, true, $no_doc)?;
                     stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
                     })?;
@@ -3422,7 +3428,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $writer,
                         $doc_streamed,
                         result.produces_output(),
-                        output_config.no_doc,
+                        $no_doc,
                     )?;
                     let stats = stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         result.stream_yaml(out, yaml_indent, sort_keys, |w| w.write_str("\n"))
@@ -3499,7 +3505,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 &mut writer,
                                 can_yaml_fast_path,
                                 &mut yaml_doc_streamed,
-                                output_config.use_color
+                                output_config.use_color,
+                                output_config.no_doc
                             );
                             // See the matching check in the per-file loop below.
                             if sink.halted().is_some() {
@@ -3547,7 +3554,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     &mut writer,
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
-                                    output_config.use_color
+                                    output_config.use_color,
+                                    output_config.no_doc
                                 );
                             }
                         }
@@ -3609,7 +3617,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     &mut writer,
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
-                                    output_config.use_color
+                                    output_config.use_color,
+                                    output_config.no_doc
                                 );
                                 // Halt outranks every remaining document and
                                 // file (#791): without this, a `halt` nested
@@ -3672,7 +3681,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         &mut writer,
                                         can_yaml_fast_path,
                                         &mut yaml_doc_streamed,
-                                        output_config.use_color
+                                        output_config.use_color,
+                                        output_config.no_doc
                                     );
                                     // See the matching check in the `Sequence` arm above.
                                     if sink.halted().is_some() {
@@ -4203,7 +4213,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         &mut buf_writer,
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
-                                        false
+                                        false,
+                                        output_config.no_doc
                                     );
                                     // halt/halt_error (#791): matches the DOM
                                     // `--inplace` branch below — stop
@@ -4257,7 +4268,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         &mut buf_writer,
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
-                                        false
+                                        false,
+                                        output_config.no_doc
                                     );
                                 }
                             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1827,12 +1827,19 @@ fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> Commen
 /// output: never before the first, and never around a document whose query
 /// yields no results. `will_output` says whether the current document is about
 /// to emit anything; `streamed` records that an earlier document already did.
+///
+/// `no_doc` suppresses the separator itself while still updating `streamed`
+/// (#1699) -- mirroring `SplitDocState::write_separator`'s existing
+/// `!config.no_doc` check, which this fast path had no equivalent of before:
+/// the DOM path (the eval-all loop above) already respects `--no-doc`, but
+/// this macro-shared M2 path wrote `---` unconditionally.
 fn emit_yaml_doc_separator<W: std::io::Write>(
     writer: &mut W,
     streamed: &mut bool,
     will_output: bool,
+    no_doc: bool,
 ) -> std::io::Result<()> {
-    if *streamed && will_output {
+    if *streamed && will_output && !no_doc {
         writeln!(writer, "---")?;
     }
     *streamed |= will_output;
@@ -3392,7 +3399,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // `$cursor` here is the whole document being
                     // redisplayed as itself - its own trailing comment,
                     // if any, must be kept (#710).
-                    emit_yaml_doc_separator($writer, $doc_streamed, true)?;
+                    emit_yaml_doc_separator($writer, $doc_streamed, true, output_config.no_doc)?;
                     stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
                     })?;
@@ -3411,7 +3418,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // output (`GenericResult::Halt`) answers `false`
                     // there; an output-bearing halt
                     // (`GenericResult::Partial`) answers `true`.
-                    emit_yaml_doc_separator($writer, $doc_streamed, result.produces_output())?;
+                    emit_yaml_doc_separator(
+                        $writer,
+                        $doc_streamed,
+                        result.produces_output(),
+                        output_config.no_doc,
+                    )?;
                     let stats = stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         result.stream_yaml(out, yaml_indent, sort_keys, |w| w.write_str("\n"))
                     })?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2979,19 +2979,25 @@ fn test_multidoc_input_with_no_doc_flag_1699() -> Result<()> {
 }
 
 /// Same fix, evaluated (not identity) path -- `emit_yaml_doc_separator`'s
-/// second call site (#1699).
+/// second call site (#1699). `. as $x | $x` was tried first here but turned
+/// out not to reach the M2 path at all (`Expr::As` has no arm in
+/// `can_use_m2_streaming`, so it silently runs the DOM path instead, which
+/// already respected `--no-doc` before this fix -- caught by /code-review:
+/// the test passed identically pre- and post-fix). `.a` is a genuinely
+/// M2-eligible `Expr::Field`, confirmed live by its duplicate-key-preserving
+/// behavior (the DOM/`IndexMap` path collapses duplicates; M2 doesn't).
 #[test]
 fn test_multidoc_input_with_no_doc_flag_evaluated_1699() -> Result<()> {
     let input = "a: 1\n---\nb: 2\n";
 
-    let (output, code) = run_yq_stdin(". as $x | $x", input, &["--no-doc"])?;
+    let (output, code) = run_yq_stdin(".a", input, &["--no-doc"])?;
     assert_eq!(code, 0);
-    assert_eq!(output, "a: 1\nb: 2\n");
+    assert_eq!(output, "1\nnull\n");
 
     Ok(())
 }
 
-/// Same fix, `--inplace` (#1699).
+/// Same fix, `--inplace`'s identity call site (#1699).
 #[test]
 fn test_multidoc_input_with_no_doc_flag_inplace_1699() -> Result<()> {
     let mut input_file = NamedTempFile::new()?;
@@ -3011,6 +3017,31 @@ fn test_multidoc_input_with_no_doc_flag_inplace_1699() -> Result<()> {
     assert!(output.status.success());
     let rewritten = std::fs::read_to_string(input_file.path())?;
     assert_eq!(rewritten, "a: 1\nb: 2\n");
+
+    Ok(())
+}
+
+/// Same fix, `--inplace`'s evaluated call site (#1699) -- the sixth and
+/// last of `stream_cursor!`'s `emit_yaml_doc_separator` invocations.
+#[test]
+fn test_multidoc_input_with_no_doc_flag_inplace_evaluated_1699() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+    writeln!(input_file, "---")?;
+    writeln!(input_file, "b: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("--no-doc")
+        .arg(".a")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "1\nnull\n");
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2956,6 +2956,65 @@ fn test_split_doc_with_no_doc_flag() -> Result<()> {
     Ok(())
 }
 
+/// #1699: unlike [`test_split_doc_with_no_doc_flag`] above (whose `split_doc`
+/// filter routes through `SplitDocState::write_separator`, which already
+/// checked `--no-doc`), a plain multi-document *input* stream with an
+/// identity filter takes the M2 fast path's `stream_cursor!`/
+/// `emit_yaml_doc_separator`, which had no `--no-doc` check at all --
+/// confirmed live to still emit `---` on unmodified `main`.
+#[test]
+fn test_multidoc_input_with_no_doc_flag_1699() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+
+    let (output, code) = run_yq_stdin(".", input, &["--no-doc"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\nb: 2\n");
+
+    // Baseline: without --no-doc, the separator is still there.
+    let (output, code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\n---\nb: 2\n");
+
+    Ok(())
+}
+
+/// Same fix, evaluated (not identity) path -- `emit_yaml_doc_separator`'s
+/// second call site (#1699).
+#[test]
+fn test_multidoc_input_with_no_doc_flag_evaluated_1699() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+
+    let (output, code) = run_yq_stdin(". as $x | $x", input, &["--no-doc"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\nb: 2\n");
+
+    Ok(())
+}
+
+/// Same fix, `--inplace` (#1699).
+#[test]
+fn test_multidoc_input_with_no_doc_flag_inplace_1699() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+    writeln!(input_file, "---")?;
+    writeln!(input_file, "b: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("--no-doc")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "a: 1\nb: 2\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_split_doc_json_output() -> Result<()> {
     // JSON output should not get --- separators


### PR DESCRIPTION
## Summary

Fixes #1699.

`succinctly yq --no-doc` on a multi-document YAML file still emitted `---` separators when the M2 streaming fast path was taken — only the DOM path correctly omitted them. Found by `/code-review` on PR #1698 (#1693) while sweeping the same gate-defining code that PR edited; confirmed live on unmodified `main`, unrelated to that fix.

```console
$ printf 'a: 1\n---\nb: 2\n' > f.yaml
$ succinctly yq --no-doc '.' f.yaml
a: 1
b: 2
```

## Root cause and fix

`emit_yaml_doc_separator` — the M2 fast path's `---` writer, shared by both the stdout and `--inplace` streaming loops via the `stream_cursor!` macro — had no `--no-doc` check at all. Threaded `no_doc` through at both its call sites inside the macro, and — per five independent `/code-review` finders converging on the same finding — as an explicit `$no_doc:expr` macro parameter (matching the established `$use_color:expr` convention) rather than a bare `output_config.no_doc` reference, which would have silently read the macro's *definition-site* binding instead of `--inplace`'s per-file shadow if `no_doc` is ever made source-dependent in the future (harmless today only because `OutputConfig::for_source` currently copies it through unchanged).

The same review also caught a real bug in my own first-draft test: `test_multidoc_input_with_no_doc_flag_evaluated_1699`'s `. as $x | $x` filter never reaches the M2 path at all (`Expr::As` has no arm in `can_use_m2_streaming`), so it silently exercised the DOM path — which already respected `--no-doc` before this fix — and would have passed identically pre-fix. Replaced with `.a`, a genuinely M2-eligible `Expr::Field` (verified live via its duplicate-key-preserving behavior), and added a matching `--inplace`-evaluated test, covering all 6 `stream_cursor!` call sites.

## Coverage note

Patch coverage is 58% (7/12), with the 5 uncovered lines inside a pre-existing `_ => { ... }` match arm the code's own comment documents as "Defensive fallback only: the root cursor ... always reports the virtual document sequence" — i.e. dead in practice via any real CLI invocation, not new dead code introduced here (I only appended the new `no_doc` argument to 3 already-existing, already-untested call sites inside that arm).

## Test plan

- [x] Live-verified stdout (identity + evaluated), `--inplace` (identity + evaluated), and the pre-existing DOM-forcing (`--arg`) path all now agree.
- [x] Added 4 regression tests covering all 6 `stream_cursor!` call sites.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure (confirmed on unmodified `main`), and one transient `run_cli_bin` ENOENT spawn flake on macOS CI (unrelated file, same test passed once already in that run).
- [x] `cargo clippy` both legs, `cargo fmt --check`, `cargo doc --no-deps` — all clean.

Closes #1699.