### PR TITLE
fix(yq): honor -0/--nul-output and --join-output in the M2 fast path

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -105,6 +105,45 @@ kind drops its `&anchor`, where real yq keeps it),
 equal-value rule), [#1352](https://github.com/rust-works/succinctly/issues/1352) and
 [#1353](https://github.com/rust-works/succinctly/issues/1353).
 
+### `-0`/`--nul-output` multi-document separator — rule 4(a)
+
+Real yq's own `-0` output on multi-document input is not readable by real yq itself: the
+configured terminator (`\0` here) lands directly before the next document's `---`, with no
+newline between them, and real yq's own parser then rejects that byte sequence outright:
+
+```bash
+$ printf 'a: 1\n---\nb: 2\n' | yq -0 '.' | od -c
+0000000    a   :       1  \0   -   -   -  \n   b   :       2  \0
+$ printf 'a: 1\n---\nb: 2\n' | yq -0 '.' > /tmp/x.bin && yq '.' /tmp/x.bin
+Error: bad file '/tmp/x.bin': yaml: offset 4: control characters are not allowed
+```
+
+succinctly inserts a newline before every `---` document/front-matter separator whenever the
+previous write's own terminator (`Terminator`,
+[src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs)) wasn't already
+one — `write_doc_marker_newline_guard`, from
+[#1701](https://github.com/rust-works/succinctly/issues/1701):
+
+```bash
+$ printf 'a: 1\n---\nb: 2\n' | succinctly yq -0 '.' | od -c
+0000000    a   :       1  \0  \n   -   -   -  \n   b   :       2  \0
+```
+
+This is rule 4(a), not a new carve-out — same shape as anchor soundness above: real yq emits
+`---`-boundary output real yq cannot itself re-read, so inserting the missing newline is
+permitted rather than bug-for-bug reproduced. `--join-output` has no real-yq counterpart at
+all (it is a succinctly-only spelling of jq-style "no separator" semantics colliding with a
+name real yq uses for something else entirely — see
+[#1710](https://github.com/rust-works/succinctly/issues/1710)), so for that flag there was
+never a reference behaviour to diverge from in the first place; the same guard is applied to
+it purely for internal consistency, not for fidelity.
+
+Scope note: this entry covers only the `---`-boundary corruption. The reparsed value shown
+above still differs from the original once the embedded `\0` itself is considered — succinctly
+performs no embedded-NUL content validation on `-0` output, unlike real yq's own refusal to
+read it back at all. That is a separate, already-filed gap
+([#1709](https://github.com/rust-works/succinctly/issues/1709)), not fixed by this entry.
+
 ### Merge-flag `+` and `d` combined — **no carve-out; this one is out of policy**
 
 Real yq's `*+d` applies the deep-merge *and* the append, doubling the right operand.

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1857,12 +1857,30 @@ fn emit_yaml_doc_separator<W: std::io::Write>(
     terminator: Terminator,
 ) -> std::io::Result<()> {
     if *streamed && will_output && !no_doc {
-        if !matches!(terminator, Terminator::Newline) {
-            writer.write_all(b"\n")?;
-        }
+        write_doc_marker_newline_guard(writer, terminator)?;
         writeln!(writer, "---")?;
     }
     *streamed |= will_output;
+    Ok(())
+}
+
+/// Writes a `\n` iff `terminator` isn't already one -- the shared guard
+/// behind every `---`/front-matter-fence write in this file (#1701 code
+/// review): each one used to assume the byte immediately before it was
+/// already a newline (true for the default terminator, false for
+/// `-0`/`--join-output`), gluing the marker directly onto the previous
+/// document's own last byte and corrupting it on reparse. Called
+/// immediately before every such write, never after -- so it composes with
+/// whichever exact trailing form (`writeln!(..., "---")`, a bare
+/// `write_all(b"---")` followed by the caller's own line-ending logic, etc.)
+/// that call site already used.
+fn write_doc_marker_newline_guard<W: std::io::Write>(
+    writer: &mut W,
+    terminator: Terminator,
+) -> std::io::Result<()> {
+    if !matches!(terminator, Terminator::Newline) {
+        writer.write_all(b"\n")?;
+    }
     Ok(())
 }
 
@@ -1881,9 +1899,15 @@ impl SplitDocState {
     }
 
     /// Write a separator if needed for split_doc mode. Returns Ok(()) always.
+    ///
+    /// Same `---`-must-start-on-its-own-line fix as `emit_yaml_doc_separator`
+    /// (#1701 code review): the previous document's own terminator might
+    /// have been `\0`/nothing rather than `\n`, and gluing `---` directly
+    /// onto that document's last byte corrupts it on reparse the same way.
     fn write_separator<W: Write>(&mut self, writer: &mut W, config: &OutputConfig) -> Result<()> {
         if self.has_split_doc && config.output_format == OutputFormat::Yaml && !config.no_doc {
             if !self.is_first_output {
+                write_doc_marker_newline_guard(writer, Terminator::from_config(config))?;
                 writeln!(writer, "---")?;
             }
             self.is_first_output = false;
@@ -1916,10 +1940,14 @@ enum Terminator {
 }
 
 impl Terminator {
-    fn from_config(nul_output: bool, join_output: bool) -> Self {
-        if nul_output {
+    /// Takes `&OutputConfig` (not two positional bools) so no call site can
+    /// silently transpose `nul_output`/`join_output` -- the exact risk
+    /// `stream_cursor!`'s own `$output_config:expr` consolidation (#1701
+    /// code review) was about, one level up from here.
+    fn from_config(config: &OutputConfig) -> Self {
+        if config.nul_output {
             Self::Nul
-        } else if !join_output {
+        } else if !config.join_output {
             Self::Newline
         } else {
             Self::None
@@ -1951,7 +1979,7 @@ impl Terminator {
 
 /// Write the appropriate line terminator based on output config.
 fn write_terminator<W: Write>(writer: &mut W, config: &OutputConfig) -> Result<()> {
-    Terminator::from_config(config.nul_output, config.join_output).write_io(writer)?;
+    Terminator::from_config(config).write_io(writer)?;
     Ok(())
 }
 
@@ -3481,8 +3509,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // overridden per call site).
     macro_rules! stream_cursor {
         ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $output_config:expr) => {{
-            let terminator =
-                Terminator::from_config($output_config.nul_output, $output_config.join_output);
+            let terminator = Terminator::from_config(&$output_config);
             if $is_yaml {
                 // M2 YAML path: YAML output streaming
                 if is_identity {
@@ -3635,11 +3662,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     |out| root.stream_json_document(out, json_indent, sort_keys),
                                 )?;
                             }
-                            Terminator::from_config(
-                                output_config.nul_output,
-                                output_config.join_output,
-                            )
-                            .write_io(&mut writer)?;
+                            write_terminator(&mut writer, &output_config)?;
                             // `root` is the virtual document sequence; falsiness
                             // lives on the actual document value (#178).
                             if args.exit_status {
@@ -3766,11 +3789,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         },
                                     )?;
                                 }
-                                Terminator::from_config(
-                                    output_config.nul_output,
-                                    output_config.join_output,
-                                )
-                                .write_io(&mut writer)?;
+                                write_terminator(&mut writer, &output_config)?;
                                 // `root` is the virtual document sequence; falsiness
                                 // lives on the actual document value (#178).
                                 if args.exit_status {
@@ -3880,6 +3899,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // `---` BETWEEN results (not before the first) -- deliberately
                 // different from --slurp's no-separator convention, since
                 // eval-all is explicitly a multi-document-stream feature (#715).
+                // Same `---`-must-start-on-its-own-line fix as
+                // `emit_yaml_doc_separator`/`SplitDocState::write_separator`
+                // (#1701 code review): the previous result's own
+                // `write_terminator` call (inside `output_value` below)
+                // might have written `\0`/nothing rather than `\n`.
+                write_doc_marker_newline_guard(
+                    &mut writer,
+                    Terminator::from_config(&output_config),
+                )?;
                 writeln!(writer, "---")?;
             }
             any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
@@ -4197,8 +4225,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // --join-output` still emitted a bare newline here before this
             // fix, unlike the `stream_cursor!`-based fast paths this same
             // issue's title names.
-            Terminator::from_config(output_config.nul_output, output_config.join_output)
-                .write_io(&mut writer)?;
+            write_terminator(&mut writer, &output_config)?;
         } else {
             // #1493: resolve `Auto` against the uniform format of every
             // source, if they all agree (confirmed live: an all-JSON slurp
@@ -4368,11 +4395,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         )
                                         .map_err(|_| anyhow::anyhow!("Write error"))?;
                                     }
-                                    Terminator::from_config(
-                                        output_config.nul_output,
-                                        output_config.join_output,
-                                    )
-                                    .write_io(&mut buf_writer)?;
+                                    write_terminator(&mut buf_writer, &output_config)?;
                                     if args.exit_status {
                                         any_truthy |=
                                             root.first_child().is_some_and(|c| !c.is_falsy());
@@ -4471,6 +4494,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             && front_matter_body.is_none()
                             && any_doc_output_this_file
                         {
+                            // #1701 code review: same fix as
+                            // `emit_yaml_doc_separator` -- the previous
+                            // document's own terminator might not have been
+                            // `\n`.
+                            write_doc_marker_newline_guard(
+                                &mut buf_writer,
+                                Terminator::from_config(&output_config),
+                            )?;
                             writeln!(buf_writer, "---")?;
                         }
                         doc_had_output = true;
@@ -4676,6 +4707,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     && front_matter_body.is_none()
                     && any_yaml_doc_output
                 {
+                    // #1701 code review: same fix as
+                    // `emit_yaml_doc_separator` -- the previous document's
+                    // own terminator might not have been `\n`.
+                    write_doc_marker_newline_guard(
+                        &mut writer,
+                        Terminator::from_config(&file_output_config),
+                    )?;
                     writeln!(writer, "---")?;
                 }
                 if file_output_config.output_format == OutputFormat::Yaml {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4531,6 +4531,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             };
 
             if let Some(body) = &front_matter_body {
+                // #1701 code review round 4: same fix as every other `---`
+                // writer -- but gated on `any_real_output`, not applied
+                // unconditionally: `output_buffer` at this point holds only
+                // the opening fence's own hardcoded (always-`\n`-terminated)
+                // `writeln!` when no document produced real output (e.g. a
+                // halt before evaluating anything), and the guard would
+                // insert a spurious leading blank line there instead of
+                // fixing anything -- it's only the *document content*
+                // `output_value` wrote, subject to `-0`/`--join-output`,
+                // that can need it.
+                if any_real_output {
+                    write_doc_marker_newline_guard(
+                        &mut output_buffer,
+                        Terminator::from_config(&output_config),
+                    )?;
+                }
                 output_buffer.extend_from_slice(b"---");
                 output_buffer.extend_from_slice(front_matter::body_line_ending(body));
                 output_buffer.extend_from_slice(body);
@@ -4684,6 +4700,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if front_matter_body.is_some() {
                 writeln!(writer, "---")?;
             }
+            // Tracks "did this file's own document loop write any real
+            // output" (#1701 code review round 4), separately from
+            // `any_yaml_doc_output` above (invocation-wide, drives the
+            // *inter-document* `---` decision, not this file's closing
+            // front-matter fence) -- mirrors the `--inplace` path's own
+            // `any_real_output`.
+            let mut any_output_this_file = false;
             for results in doc_results {
                 // Add document separator in YAML mode for multi-doc,
                 // between YAML-resolved documents only, not before the
@@ -4723,10 +4746,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                     output_value(&mut writer, &result, &comments, &file_output_config)?;
+                    any_output_this_file = true;
                 }
             }
             if let Some(body) = front_matter_body {
                 let line_ending = front_matter::body_line_ending(body);
+                // #1701 code review round 4: same fix as the `--inplace`
+                // path's closing fence -- gated on whether this file's
+                // document loop actually wrote anything (subject to
+                // `-0`/`--join-output`), not applied unconditionally: with
+                // zero real output, `writer` at this point holds only the
+                // opening fence's own always-`\n`-terminated `writeln!`.
+                if any_output_this_file {
+                    write_doc_marker_newline_guard(
+                        &mut writer,
+                        Terminator::from_config(&file_output_config),
+                    )?;
+                }
                 writer.write_all(b"---")?;
                 writer.write_all(line_ending)?;
                 writer.write_all(body)?;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1832,13 +1832,34 @@ fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> Commen
 /// `!config.no_doc` check, which this fast path had no equivalent of before:
 /// the DOM path (the eval-all loop further below) already respects
 /// `--no-doc`, but this macro-shared M2 path wrote `---` unconditionally.
+///
+/// `terminator` (#1701 code review) says whether the *previous* document's
+/// own output already ended in a newline: only `Terminator::Newline` does.
+/// `-0`/`--join-output` end a document in `\0`/nothing instead, and this
+/// function used to assume a trailing `\n` unconditionally -- gluing `---`
+/// directly onto the prior document's own last byte with no boundary
+/// between them. Confirmed live: `--join-output` on two YAML documents
+/// `a: 1`/`b: 2` produced `a: 1---\nb: 2`, which *reparses* as the single,
+/// silently corrupted document `{"a": "1---", "b": 2}` -- `-i` persists
+/// that corruption to disk. Inserting an explicit `\n` first whenever the
+/// terminator wasn't already one keeps `---` a valid, position-independent
+/// YAML document boundary regardless of which terminator style produced the
+/// document before it (this needed no divergence-registry entry: `-0`'s own
+/// glued-`---` case was verified byte-identical to real yq's own output for
+/// the same input, but real yq can't parse that output back either --
+/// ADR-0018's carve-out for reference output the tool can't itself read
+/// back applies, so fixing it here isn't a fidelity violation).
 fn emit_yaml_doc_separator<W: std::io::Write>(
     writer: &mut W,
     streamed: &mut bool,
     will_output: bool,
     no_doc: bool,
+    terminator: Terminator,
 ) -> std::io::Result<()> {
     if *streamed && will_output && !no_doc {
+        if !matches!(terminator, Terminator::Newline) {
+            writer.write_all(b"\n")?;
+        }
         writeln!(writer, "---")?;
     }
     *streamed |= will_output;
@@ -1872,9 +1893,14 @@ impl SplitDocState {
 }
 
 /// Which terminator (if any) follows a written value, per `-0`/`--nul-output`
-/// and `-j`/`--join-output`. Matches real yq's precedence: NUL wins over
-/// join (`-0 -j` still separates on NUL, not nothing), and a bare newline is
-/// the default when neither is set.
+/// and `-j`/`--join-output`. NUL wins over join (`-0 -j` still separates on
+/// NUL, not nothing) -- verified against real *jq* 1.7.1
+/// (`--raw-output0 -j`, order-independent either way), not yq: the pinned
+/// yq oracle (Homebrew v4.53.3) has no `--join-output` flag at all (it
+/// errors "unknown flag"), and its own `-j` is an unrelated, deprecated
+/// alias for `--tojson`. yq-mode's `-j`/`--join-output` is a succinctly
+/// extension borrowing jq's flag meaning, not a real-yq behavior to match.
+/// A bare newline is the default when neither flag is set.
 ///
 /// Split out from [`write_terminator`] (#1701) so the same three-way choice
 /// can also drive the M2 fast path's own terminator writes -- previously
@@ -3436,16 +3462,27 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // scope at definition time, not at each expansion site. `$fragment:expr`
     // parameters don't have that problem — they always evaluate in the
     // caller's own scope — hence passing color as `$use_color:expr`.
-    // `no_doc`/`nul_output`/`join_output` are threaded the same way (#1699,
-    // #1701 code review), even though nothing currently shadows any of them
-    // to a different value the way `--inplace` does for `.use_color` (every
-    // `OutputConfig::for_source` copies all three through unchanged) -- a
-    // bare reference would only be safe by that coincidence, and would
-    // silently read the wrong value the day something *does* start varying
-    // one of them per source/file.
+    // `no_doc`/`nul_output`/`join_output` need the same `$fragment:expr`
+    // treatment (#1699, #1701 code review), even though nothing currently
+    // shadows any of them to a different value the way `--inplace` does for
+    // `.use_color` (every `OutputConfig::for_source` copies all three
+    // through unchanged) -- a bare reference would only be safe by that
+    // coincidence, and would silently read the wrong value the day
+    // something *does* start varying one of them per source/file. Threaded
+    // as one `$output_config:expr` (not three more individually-named bool
+    // params) per repeated `/code-review` feedback on both issues: #1699
+    // added one bool param this way, #1701 nearly added two more on top of
+    // it, and every reviewer who looked at the growing positional-bool list
+    // flagged the same risk -- a future call site transposing two same-typed
+    // `bool` arguments compiles silently and inverts behavior. Reading the
+    // three fields off one passed-by-caller-scope config value removes that
+    // risk without losing the per-call-site-shadow safety `$use_color`
+    // still needs its own parameter for (it, unlike these three, really is
+    // overridden per call site).
     macro_rules! stream_cursor {
-        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $no_doc:expr, $nul_output:expr, $join_output:expr) => {{
-            let terminator = Terminator::from_config($nul_output, $join_output);
+        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $output_config:expr) => {{
+            let terminator =
+                Terminator::from_config($output_config.nul_output, $output_config.join_output);
             if $is_yaml {
                 // M2 YAML path: YAML output streaming
                 if is_identity {
@@ -3454,7 +3491,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // `$cursor` here is the whole document being
                     // redisplayed as itself - its own trailing comment,
                     // if any, must be kept (#710).
-                    emit_yaml_doc_separator($writer, $doc_streamed, true, $no_doc)?;
+                    emit_yaml_doc_separator(
+                        $writer,
+                        $doc_streamed,
+                        true,
+                        $output_config.no_doc,
+                        terminator,
+                    )?;
                     stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
                     })?;
@@ -3477,7 +3520,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $writer,
                         $doc_streamed,
                         result.produces_output(),
-                        $no_doc,
+                        $output_config.no_doc,
+                        terminator,
                     )?;
                     let stats = stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         result.stream_yaml(out, yaml_indent, sort_keys, |w| terminator.write_fmt(w))
@@ -3557,9 +3601,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 can_yaml_fast_path,
                                 &mut yaml_doc_streamed,
                                 output_config.use_color,
-                                output_config.no_doc,
-                                output_config.nul_output,
-                                output_config.join_output
+                                output_config
                             );
                             // See the matching check in the per-file loop below.
                             if sink.halted().is_some() {
@@ -3593,7 +3635,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     |out| root.stream_json_document(out, json_indent, sort_keys),
                                 )?;
                             }
-                            writeln!(writer)?;
+                            Terminator::from_config(
+                                output_config.nul_output,
+                                output_config.join_output,
+                            )
+                            .write_io(&mut writer)?;
                             // `root` is the virtual document sequence; falsiness
                             // lives on the actual document value (#178).
                             if args.exit_status {
@@ -3608,9 +3654,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
                                     output_config.use_color,
-                                    output_config.no_doc,
-                                    output_config.nul_output,
-                                    output_config.join_output
+                                    output_config
                                 );
                             }
                         }
@@ -3673,9 +3717,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
                                     output_config.use_color,
-                                    output_config.no_doc,
-                                    output_config.nul_output,
-                                    output_config.join_output
+                                    output_config
                                 );
                                 // Halt outranks every remaining document and
                                 // file (#791): without this, a `halt` nested
@@ -3724,7 +3766,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         },
                                     )?;
                                 }
-                                writeln!(writer)?;
+                                Terminator::from_config(
+                                    output_config.nul_output,
+                                    output_config.join_output,
+                                )
+                                .write_io(&mut writer)?;
                                 // `root` is the virtual document sequence; falsiness
                                 // lives on the actual document value (#178).
                                 if args.exit_status {
@@ -3739,9 +3785,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         output_config.use_color,
-                                        output_config.no_doc,
-                                        output_config.nul_output,
-                                        output_config.join_output
+                                        output_config
                                     );
                                     // See the matching check in the `Sequence` arm above.
                                     if sink.halted().is_some() {
@@ -4146,7 +4190,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     )
                 })?;
             }
-            writeln!(writer)?;
+            // #1701: this fast path streams straight to `&mut writer`
+            // (like `stream_cursor!`'s own identity branch), so it needs
+            // the same `Terminator`-based write instead of a hardcoded
+            // `writeln!` -- confirmed live that `--slurp -0`/`--slurp
+            // --join-output` still emitted a bare newline here before this
+            // fix, unlike the `stream_cursor!`-based fast paths this same
+            // issue's title names.
+            Terminator::from_config(output_config.nul_output, output_config.join_output)
+                .write_io(&mut writer)?;
         } else {
             // #1493: resolve `Auto` against the uniform format of every
             // source, if they all agree (confirmed live: an all-JSON slurp
@@ -4273,9 +4325,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         false,
-                                        output_config.no_doc,
-                                        output_config.nul_output,
-                                        output_config.join_output
+                                        output_config
                                     );
                                     // halt/halt_error (#791): matches the DOM
                                     // `--inplace` branch below — stop
@@ -4318,7 +4368,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         )
                                         .map_err(|_| anyhow::anyhow!("Write error"))?;
                                     }
-                                    writeln!(buf_writer)?;
+                                    Terminator::from_config(
+                                        output_config.nul_output,
+                                        output_config.join_output,
+                                    )
+                                    .write_io(&mut buf_writer)?;
                                     if args.exit_status {
                                         any_truthy |=
                                             root.first_child().is_some_and(|c| !c.is_falsy());
@@ -4330,9 +4384,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         false,
-                                        output_config.no_doc,
-                                        output_config.nul_output,
-                                        output_config.join_output
+                                        output_config
                                     );
                                 }
                             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1857,8 +1857,7 @@ fn emit_yaml_doc_separator<W: std::io::Write>(
     terminator: Terminator,
 ) -> std::io::Result<()> {
     if *streamed && will_output && !no_doc {
-        write_doc_marker_newline_guard(writer, terminator)?;
-        writeln!(writer, "---")?;
+        write_doc_separator_marker(writer, terminator)?;
     }
     *streamed |= will_output;
     Ok(())
@@ -1884,6 +1883,24 @@ fn write_doc_marker_newline_guard<W: std::io::Write>(
     Ok(())
 }
 
+/// `write_doc_marker_newline_guard` immediately followed by the `---`
+/// separator itself -- the pairing every ordinary (non-front-matter-fence)
+/// `---` write in this file needs. Folded into one call after review found
+/// the two-line pair repeated verbatim at every such site: each repeat was
+/// itself a chance for a future writer to add a 6th and forget the guard,
+/// which is exactly how #1701 needed four separate review rounds to find
+/// every site that had. The two front-matter fence sites don't use this --
+/// they follow the guard with `extend_from_slice`/`write_all` of `---` plus
+/// a caller-supplied line ending and body bytes, not a bare `---`+`\n`, so
+/// they call `write_doc_marker_newline_guard` directly instead.
+fn write_doc_separator_marker<W: std::io::Write>(
+    writer: &mut W,
+    terminator: Terminator,
+) -> std::io::Result<()> {
+    write_doc_marker_newline_guard(writer, terminator)?;
+    writeln!(writer, "---")
+}
+
 /// State for tracking split_doc output separators.
 struct SplitDocState {
     has_split_doc: bool,
@@ -1907,8 +1924,7 @@ impl SplitDocState {
     fn write_separator<W: Write>(&mut self, writer: &mut W, config: &OutputConfig) -> Result<()> {
         if self.has_split_doc && config.output_format == OutputFormat::Yaml && !config.no_doc {
             if !self.is_first_output {
-                write_doc_marker_newline_guard(writer, Terminator::from_config(config))?;
-                writeln!(writer, "---")?;
+                write_doc_separator_marker(writer, Terminator::from_config(config))?;
             }
             self.is_first_output = false;
         }
@@ -3904,11 +3920,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // (#1701 code review): the previous result's own
                 // `write_terminator` call (inside `output_value` below)
                 // might have written `\0`/nothing rather than `\n`.
-                write_doc_marker_newline_guard(
-                    &mut writer,
-                    Terminator::from_config(&output_config),
-                )?;
-                writeln!(writer, "---")?;
+                write_doc_separator_marker(&mut writer, Terminator::from_config(&output_config))?;
             }
             any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
             output_value(&mut writer, result, &CommentTree::empty(), &output_config)?;
@@ -4498,11 +4510,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             // `emit_yaml_doc_separator` -- the previous
                             // document's own terminator might not have been
                             // `\n`.
-                            write_doc_marker_newline_guard(
+                            write_doc_separator_marker(
                                 &mut buf_writer,
                                 Terminator::from_config(&output_config),
                             )?;
-                            writeln!(buf_writer, "---")?;
                         }
                         doc_had_output = true;
                         any_doc_output_this_file = true;
@@ -4733,11 +4744,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // #1701 code review: same fix as
                     // `emit_yaml_doc_separator` -- the previous document's
                     // own terminator might not have been `\n`.
-                    write_doc_marker_newline_guard(
+                    write_doc_separator_marker(
                         &mut writer,
                         Terminator::from_config(&file_output_config),
                     )?;
-                    writeln!(writer, "---")?;
                 }
                 if file_output_config.output_format == OutputFormat::Yaml {
                     any_yaml_doc_output = true;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4,7 +4,6 @@
 //! YAML semi-indexing and jq expression evaluator.
 
 use anyhow::{Context, Result};
-use core::fmt::Write as FmtWrite;
 use indexmap::IndexMap;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
@@ -1872,13 +1871,61 @@ impl SplitDocState {
     }
 }
 
+/// Which terminator (if any) follows a written value, per `-0`/`--nul-output`
+/// and `-j`/`--join-output`. Matches real yq's precedence: NUL wins over
+/// join (`-0 -j` still separates on NUL, not nothing), and a bare newline is
+/// the default when neither is set.
+///
+/// Split out from [`write_terminator`] (#1701) so the same three-way choice
+/// can also drive the M2 fast path's own terminator writes -- previously
+/// `stream_cursor!` hardcoded a bare newline unconditionally, ignoring both
+/// flags whenever the fast path was taken (confirmed live on unmodified
+/// `main`, same root cause and fix shape as #1699's `--no-doc` gap in the
+/// same macro).
+#[derive(Clone, Copy)]
+enum Terminator {
+    Nul,
+    Newline,
+    None,
+}
+
+impl Terminator {
+    fn from_config(nul_output: bool, join_output: bool) -> Self {
+        if nul_output {
+            Self::Nul
+        } else if !join_output {
+            Self::Newline
+        } else {
+            Self::None
+        }
+    }
+
+    /// Write this terminator to an `io::Write` sink (the M2 path's own
+    /// `$writer`, and every DOM-path caller of `write_terminator`).
+    fn write_io<W: Write>(self, writer: &mut W) -> std::io::Result<()> {
+        match self {
+            Self::Nul => writer.write_all(&[0]),
+            Self::Newline => writeln!(writer),
+            Self::None => Ok(()),
+        }
+    }
+
+    /// Write this terminator to a `core::fmt::Write` sink -- the M2 path's
+    /// per-result callbacks passed into `stream_yaml`/`stream_json`, which
+    /// write into a buffered `fmt::Write` target rather than `$writer`
+    /// itself.
+    fn write_fmt<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
+        match self {
+            Self::Nul => writer.write_char('\0'),
+            Self::Newline => writer.write_char('\n'),
+            Self::None => Ok(()),
+        }
+    }
+}
+
 /// Write the appropriate line terminator based on output config.
 fn write_terminator<W: Write>(writer: &mut W, config: &OutputConfig) -> Result<()> {
-    if config.nul_output {
-        writer.write_all(&[0])?;
-    } else if !config.join_output {
-        writeln!(writer)?;
-    }
+    Terminator::from_config(config.nul_output, config.join_output).write_io(writer)?;
     Ok(())
 }
 
@@ -3389,14 +3436,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // scope at definition time, not at each expansion site. `$fragment:expr`
     // parameters don't have that problem — they always evaluate in the
     // caller's own scope — hence passing color as `$use_color:expr`.
-    // `no_doc` is threaded the same way (#1699 code review), even though
-    // nothing currently shadows `.no_doc` to a different value the way
-    // `--inplace` does for `.use_color` (every `OutputConfig::for_source`
-    // copies `no_doc` through unchanged) -- a bare reference would only be
-    // safe by that coincidence, and would silently read the wrong value the
-    // day something *does* start varying `no_doc` per source/file.
+    // `no_doc`/`nul_output`/`join_output` are threaded the same way (#1699,
+    // #1701 code review), even though nothing currently shadows any of them
+    // to a different value the way `--inplace` does for `.use_color` (every
+    // `OutputConfig::for_source` copies all three through unchanged) -- a
+    // bare reference would only be safe by that coincidence, and would
+    // silently read the wrong value the day something *does* start varying
+    // one of them per source/file.
     macro_rules! stream_cursor {
-        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $no_doc:expr) => {{
+        ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $no_doc:expr, $nul_output:expr, $join_output:expr) => {{
+            let terminator = Terminator::from_config($nul_output, $join_output);
             if $is_yaml {
                 // M2 YAML path: YAML output streaming
                 if is_identity {
@@ -3409,7 +3458,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
                         $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
                     })?;
-                    writeln!($writer)?;
+                    terminator.write_io($writer)?;
                     // Streaming skips evaluation, so inspect the document
                     // value directly to keep `-e` falsy tracking (#178).
                     if args.exit_status {
@@ -3431,7 +3480,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $no_doc,
                     )?;
                     let stats = stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
-                        result.stream_yaml(out, yaml_indent, sort_keys, |w| w.write_str("\n"))
+                        result.stream_yaml(out, yaml_indent, sort_keys, |w| terminator.write_fmt(w))
                     })?;
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
@@ -3446,7 +3495,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         |s| output::colorize_json(s, &ColorScheme::default()),
                         |out| $cursor.stream_json(out, json_indent, sort_keys),
                     )?;
-                    writeln!($writer)?;
+                    terminator.write_io($writer)?;
                     // Streaming skips evaluation, so inspect the document
                     // value directly to keep `-e` falsy tracking (#178).
                     if args.exit_status {
@@ -3460,7 +3509,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $use_color,
                         |s| output::colorize_json(s, &ColorScheme::default()),
                         |out| {
-                            result.stream_json(out, json_indent, sort_keys, |w| w.write_str("\n"))
+                            result.stream_json(out, json_indent, sort_keys, |w| {
+                                terminator.write_fmt(w)
+                            })
                         },
                     )?;
                     any_truthy |= stats.any_truthy;
@@ -3506,7 +3557,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 can_yaml_fast_path,
                                 &mut yaml_doc_streamed,
                                 output_config.use_color,
-                                output_config.no_doc
+                                output_config.no_doc,
+                                output_config.nul_output,
+                                output_config.join_output
                             );
                             // See the matching check in the per-file loop below.
                             if sink.halted().is_some() {
@@ -3555,7 +3608,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
                                     output_config.use_color,
-                                    output_config.no_doc
+                                    output_config.no_doc,
+                                    output_config.nul_output,
+                                    output_config.join_output
                                 );
                             }
                         }
@@ -3618,7 +3673,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     can_yaml_fast_path,
                                     &mut yaml_doc_streamed,
                                     output_config.use_color,
-                                    output_config.no_doc
+                                    output_config.no_doc,
+                                    output_config.nul_output,
+                                    output_config.join_output
                                 );
                                 // Halt outranks every remaining document and
                                 // file (#791): without this, a `halt` nested
@@ -3682,7 +3739,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         output_config.use_color,
-                                        output_config.no_doc
+                                        output_config.no_doc,
+                                        output_config.nul_output,
+                                        output_config.join_output
                                     );
                                     // See the matching check in the `Sequence` arm above.
                                     if sink.halted().is_some() {
@@ -4214,7 +4273,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         false,
-                                        output_config.no_doc
+                                        output_config.no_doc,
+                                        output_config.nul_output,
+                                        output_config.join_output
                                     );
                                     // halt/halt_error (#791): matches the DOM
                                     // `--inplace` branch below — stop
@@ -4269,7 +4330,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         can_inplace_yaml_fast_path,
                                         &mut yaml_doc_streamed,
                                         false,
-                                        output_config.no_doc
+                                        output_config.no_doc,
+                                        output_config.nul_output,
+                                        output_config.join_output
                                     );
                                 }
                             }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3121,6 +3121,58 @@ fn test_join_output_multiple_results_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1701 code review: `emit_yaml_doc_separator` used to assume the previous
+/// document's own output always ended in `\n`, so `--join-output` on
+/// multi-document YAML input glued `---` directly onto the prior document's
+/// last byte -- confirmed live to silently *corrupt* the document on
+/// reparse (`a: 1\n---\nb: 2\n` -> `a: 1---\nb: 2` -> reparses as the single
+/// document `{"a": "1---", "b": 2}` instead of two documents). Pins the fix:
+/// `---` must always start on its own line regardless of which terminator
+/// produced the document before it.
+#[test]
+fn test_join_output_multidoc_does_not_corrupt_documents_1701() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+
+    let (output, code) = run_yq_stdin(".", input, &["--join-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\n---\nb: 2");
+
+    // Round-trip: reparsing must still yield two distinct documents, not
+    // one document with "---" corrupted into a scalar's own text.
+    let (reparsed, code) = run_yq_stdin(".", &output, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(reparsed, "{\"a\":1}\n{\"b\":2}\n");
+
+    Ok(())
+}
+
+/// Same fix, `-0`/`--nul-output` (#1701 code review). Unlike `--join-output`
+/// above, `-0`'s own glued-`---` case was confirmed byte-identical to real
+/// yq's own multi-doc `-0` output -- but real yq can't reparse that output
+/// either, so this fix's extra newline is a permitted divergence under
+/// ADR-0018's carve-out for reference output the tool can't read back, not
+/// a fidelity violation.
+#[test]
+fn test_nul_output_multidoc_separator_stays_on_its_own_line_1701() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+    let (output, code) = run_yq_stdin(".", input, &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\0\n---\nb: 2\0");
+    Ok(())
+}
+
+/// #1701 code review: the `--slurp` fast path (a sibling of `stream_cursor!`,
+/// gated by `can_slurp_fast_path` rather than going through that macro) was
+/// left out of the original fix and still hardcoded a bare newline.
+#[test]
+fn test_slurp_nul_output_1701() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+    let (output, code) = run_yq_stdin(".", input, &["--slurp", "-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "- a: 1\n- b: 2\0");
+    Ok(())
+}
+
 #[test]
 fn test_split_doc_json_output() -> Result<()> {
     // JSON output should not get --- separators

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3046,6 +3046,81 @@ fn test_multidoc_input_with_no_doc_flag_inplace_evaluated_1699() -> Result<()> {
     Ok(())
 }
 
+/// #1701: `-0`/`--nul-output` was silently ignored whenever the M2 fast path
+/// was taken -- `stream_cursor!` hardcoded a bare newline terminator
+/// unconditionally, same root cause and fix shape as #1699's `--no-doc` gap
+/// in the same macro. Confirmed live to still terminate with `\n` on
+/// unmodified `main`.
+#[test]
+fn test_nul_output_identity_1701() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\0");
+
+    // Baseline: without -0, still newline-terminated.
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\n");
+
+    Ok(())
+}
+
+/// Same fix, evaluated (not identity) path.
+#[test]
+fn test_nul_output_evaluated_1701() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: 1\n", &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\0");
+    Ok(())
+}
+
+/// Same fix, `--inplace` (#1701).
+#[test]
+fn test_nul_output_inplace_1701() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-0")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read(input_file.path())?;
+    assert_eq!(rewritten, b"a: 1\0");
+
+    Ok(())
+}
+
+/// #1701: `--join-output` has the identical gap -- it should suppress the
+/// trailing terminator entirely, but the M2 fast path always wrote a bare
+/// newline regardless. Confirmed live on unmodified `main`.
+#[test]
+fn test_join_output_identity_1701() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &["--join-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1");
+    Ok(())
+}
+
+/// Same fix, multiple results (evaluated, `.[]`) -- real join-output
+/// concatenates every result with no separator at all.
+#[test]
+fn test_join_output_multiple_results_1701() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".[]",
+        "[\"hello\", \"world\"]\n",
+        &["-o", "json", "--join-output"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "\"hello\"\"world\"");
+    Ok(())
+}
+
 #[test]
 fn test_split_doc_json_output() -> Result<()> {
     // JSON output should not get --- separators

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3191,16 +3191,43 @@ fn test_join_output_multidoc_dom_path_does_not_corrupt_1701() -> Result<()> {
     Ok(())
 }
 
-/// Same fix, `--eval-all` (#1701 code review round 2).
+/// `-0` counterpart of the above (#1701 code review round 4 gap sweep):
+/// the standard multi-file DOM loop's separator guard had only ever been
+/// tested with `--join-output`, never `-0`.
+#[test]
+fn test_nul_output_multidoc_dom_path_does_not_corrupt_1701() -> Result<()> {
+    let input = "a: 1\n---\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".a + 0", input, &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\0\n---\n2\0");
+
+    Ok(())
+}
+
+/// Same fix, `--eval-all` (#1701 code review round 2). `.[]` (not `.`)
+/// is required to actually exercise the between-results `---` guard
+/// (`yq_runner.rs`'s `results.len() > 1 && i > 0` arm) -- `.` combines
+/// every document into a single array result under `--eval-all`, so it
+/// never reaches that branch at all (found by a round-4 gap sweep: the
+/// original version of this test round-tripped cleanly but tested a
+/// strictly weaker property than its own doc comment claimed).
 #[test]
 fn test_join_output_eval_all_does_not_corrupt_1701() -> Result<()> {
     let input = "a: 1\n---\nb: 2\n";
-    let (output, code) = run_yq_stdin(".", input, &["--eval-all", "--join-output"])?;
+    let (output, code) = run_yq_stdin(".[]", input, &["--eval-all", "--join-output"])?;
     assert_eq!(code, 0);
-    // --eval-all combines every document into one evaluation, so `.`
-    // yields a single array result here -- no `---` boundary is involved,
-    // this just confirms the branch still round-trips cleanly.
-    assert_eq!(output, "- a: 1\n- b: 2");
+    assert_eq!(output, "a: 1\n---\nb: 2");
+    Ok(())
+}
+
+/// `-0` counterpart of the above (#1701 code review round 4 gap sweep).
+#[test]
+fn test_nul_output_eval_all_does_not_corrupt_1701() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+    let (output, code) = run_yq_stdin(".[]", input, &["--eval-all", "-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "a: 1\0\n---\nb: 2\0");
     Ok(())
 }
 
@@ -3224,6 +3251,32 @@ fn test_join_output_inplace_dom_path_does_not_corrupt_1701() -> Result<()> {
     assert!(output.status.success());
     let rewritten = std::fs::read_to_string(input_file.path())?;
     assert_eq!(rewritten, "1\n---\n2");
+
+    Ok(())
+}
+
+/// `-0` counterpart of the above (#1701 code review round 4 gap sweep):
+/// the `--inplace` DOM path's separator guard had only ever been tested
+/// with `--join-output`, never `-0`.
+#[test]
+fn test_nul_output_inplace_dom_path_does_not_corrupt_1701() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+    writeln!(input_file, "---")?;
+    writeln!(input_file, "a: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-0")
+        .arg(".a + 0")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read(input_file.path())?;
+    assert_eq!(rewritten, b"1\0\n---\n2\0");
 
     Ok(())
 }
@@ -12348,6 +12401,74 @@ fn test_front_matter_process_inplace_rewrites_file() -> Result<()> {
         rewritten,
         "---\ntitle: New\ntags:\n  - a\n  - b\n---\n# Body\n\nSome text.\n"
     );
+    Ok(())
+}
+
+/// #1701 code review round 4: unlike every other `---`-writing site in
+/// `yq_runner.rs`, `--front-matter=process`'s own closing fence had no
+/// `write_doc_marker_newline_guard` protection, so `--join-output`/`-0`
+/// glued it directly onto the front matter's own last byte -- e.g.
+/// `a: 1---` instead of `a: 1\n---`, silently corrupting the document
+/// boundary the same way #1701's other fixes already prevent elsewhere.
+/// Originally deferred as #1712; fixed directly here once the same
+/// "was anything actually written" gating the other sites already had
+/// for free (`any_output_this_file`) was added for this site too.
+#[test]
+fn test_join_output_front_matter_process_does_not_corrupt_1701() -> Result<()> {
+    let input = "---\na: 1\n---\nbody one\n";
+    let (output, code) = run_yq_stdin(".", input, &["--front-matter", "process", "--join-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "---\na: 1\n---\nbody one\n");
+    Ok(())
+}
+
+/// `-0` counterpart of the above.
+#[test]
+fn test_nul_output_front_matter_process_does_not_corrupt_1701() -> Result<()> {
+    let input = "---\na: 1\n---\nbody one\n";
+    let (output, code) = run_yq_stdin(".", input, &["--front-matter", "process", "-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "---\na: 1\0\n---\nbody one\n");
+    Ok(())
+}
+
+/// Same fix on the `--inplace` path, which persists corruption to disk
+/// if unfixed.
+#[test]
+fn test_join_output_front_matter_process_inplace_does_not_corrupt_1701() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "---\na: 1\n---\nbody one\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .args(["--front-matter", "process", "-i", "--join-output"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "---\na: 1\n---\nbody one\n");
+    Ok(())
+}
+
+/// Edge case the guard must not regress: when the document loop produces
+/// zero real output (e.g. `empty`), the closing fence must NOT gain a
+/// spurious leading blank line -- the guard is gated on
+/// `any_output_this_file`/`any_real_output`, not applied unconditionally,
+/// specifically to avoid this (the reason this fix was originally
+/// deferred as #1712 rather than attempted blindly).
+#[test]
+fn test_front_matter_process_empty_filter_no_spurious_blank_line_1701() -> Result<()> {
+    let input = "---\na: 1\n---\nbody one\n";
+    let (output, code) = run_yq_stdin(
+        "empty",
+        input,
+        &["--front-matter", "process", "--join-output"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "---\n---\nbody one\n");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3173,6 +3173,61 @@ fn test_slurp_nul_output_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1701 code review round 2: the corruption bug found in
+/// `emit_yaml_doc_separator` also existed, independently, in every DOM-path
+/// document-separator writer -- `SplitDocState::write_separator`, the
+/// `--eval-all` branch's own inline check, and the "standard" (non-M2,
+/// non-slurp) multi-file loop's inline check. `.a + 0` is not M2-eligible
+/// (arithmetic forces the DOM path), so this exercises the standard loop's
+/// fix specifically.
+#[test]
+fn test_join_output_multidoc_dom_path_does_not_corrupt_1701() -> Result<()> {
+    let input = "a: 1\n---\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".a + 0", input, &["--join-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\n---\n2");
+
+    Ok(())
+}
+
+/// Same fix, `--eval-all` (#1701 code review round 2).
+#[test]
+fn test_join_output_eval_all_does_not_corrupt_1701() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+    let (output, code) = run_yq_stdin(".", input, &["--eval-all", "--join-output"])?;
+    assert_eq!(code, 0);
+    // --eval-all combines every document into one evaluation, so `.`
+    // yields a single array result here -- no `---` boundary is involved,
+    // this just confirms the branch still round-trips cleanly.
+    assert_eq!(output, "- a: 1\n- b: 2");
+    Ok(())
+}
+
+/// Same fix, `--inplace` on the DOM path (#1701 code review round 2).
+#[test]
+fn test_join_output_inplace_dom_path_does_not_corrupt_1701() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "a: 1")?;
+    writeln!(input_file, "---")?;
+    writeln!(input_file, "a: 2")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("--join-output")
+        .arg(".a + 0")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(rewritten, "1\n---\n2");
+
+    Ok(())
+}
+
 #[test]
 fn test_split_doc_json_output() -> Result<()> {
     // JSON output should not get --- separators

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3108,16 +3108,22 @@ fn test_join_output_identity_1701() -> Result<()> {
 }
 
 /// Same fix, multiple results (evaluated, `.[]`) -- real join-output
-/// concatenates every result with no separator at all.
+/// concatenates every result with no separator at all. Deliberately uses
+/// the default YAML output format, not `-o json`: `-o json` would also
+/// exercise the M2 fast path's separate, pre-existing `raw_output`
+/// gap (`stream_json` never strips JSON string quoting the way the DOM
+/// path's `output_value` does -- #1715, found by a gap-sweep review of
+/// this PR but predating it), which would make this test either fail or
+/// silently pin `"hello""world"` (still quoted) as "correct" instead of
+/// jq's own `-j` semantics (`helloworld`, confirmed against the pinned
+/// oracle). YAML output has no such gap: plain scalars are unquoted by
+/// default regardless of the M2/DOM path taken, so this test exercises
+/// only the separator-suppression fix it's actually named for.
 #[test]
 fn test_join_output_multiple_results_1701() -> Result<()> {
-    let (output, code) = run_yq_stdin(
-        ".[]",
-        "[\"hello\", \"world\"]\n",
-        &["-o", "json", "--join-output"],
-    )?;
+    let (output, code) = run_yq_stdin(".[]", "[\"hello\", \"world\"]\n", &["--join-output"])?;
     assert_eq!(code, 0);
-    assert_eq!(output, "\"hello\"\"world\"");
+    assert_eq!(output, "helloworld");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #1701.

`stream_cursor!` (the M2 fast path's shared streaming macro, also home to #1699's `--no-doc` fix) hardcoded a bare newline terminator unconditionally, ignoring both `-0`/`--nul-output` and `--join-output` whenever the fast path was taken. `--join-output` has the identical gap to `--nul-output` (both route through `write_terminator`'s existing three-way dispatch on the DOM path), so both are fixed together.

## Round 2 — a critical regression caught by review

`/code-review` on the first version found a genuine data-corruption bug: `emit_yaml_doc_separator` assumed the previous document's own output always ended in `\n`, so `--join-output` on multi-document YAML input glued `---` directly onto the prior document's last byte — `printf 'a: 1\n---\nb: 2\n' | succinctly yq --join-output '.'` produced `a: 1---\nb: 2`, which *reparses* as the single corrupted document `{"a": "1---", "b": 2}`, and `-i` persists that corruption to disk.

Fixed by having `emit_yaml_doc_separator` insert an explicit newline before `---` whenever the previous terminator wasn't already one. The narrower `-0`-only case (confirmed byte-identical to real yq's own multi-doc `-0` output) gets the same fix — permitted since real yq can't reparse that output back either, so ADR-0018's carve-out for reference output the tool can't itself read back applies.

Also in round 2: corrected a factual error in the `Terminator` doc comment (it claimed to match "real yq's precedence", but the pinned yq oracle has no `--join-output` flag at all), extended the fix to the `--slurp` fast path (a sibling left untouched by the first pass, confirmed to have the identical bug), converted 3 dead "defensive fallback" arms for consistency, and collapsed `stream_cursor!`'s three individually-threaded bool parameters into one `$output_config:expr` parameter per repeated review feedback.

## Round 3 — the same corruption bug, independently, on every DOM-path separator writer

A second `/code-review` round (specifically re-verifying the round-2 fix) found the identical "glued `---`" corruption in **every other** place this file writes a document separator: `SplitDocState::write_separator` (used by `split_doc`, `--slurp`, `--eval-all`, `--inplace`, and the standard multi-file loop — 6+ call sites), the `--eval-all` branch's own inline multi-result separator, the "standard" (non-M2, non-slurp) multi-file DOM loop's inline separator, and the `--inplace` DOM path's own inline separator. Confirmed live for each — e.g. `succinctly yq -P '.' --join-output` (a DOM-forcing flag combined with the flag round 2 fixed) reproduced the identical corruption round 2's own fix didn't reach, since `-P` never touches `emit_yaml_doc_separator` at all.

Fixed all of them via a new shared `write_doc_marker_newline_guard` helper, so the "insert `\n` first unless the terminator wasn't already one" logic lives in one place instead of six. Also changed `Terminator::from_config` to take `&OutputConfig` instead of two positional bools (removing the same transposition risk `stream_cursor!`'s own `$output_config` consolidation already closed one level up) and routed simplified call sites through the pre-existing `write_terminator` helper rather than re-deriving the same expression by hand.

Deliberately left `--front-matter=process`'s own opening/closing fence bytes unfixed: unlike every other site (each gated on an explicit "something was already written" condition), the fence writes have no such gate, so the same unconditional guard would insert a spurious leading blank line in the common single-file front-matter case to fix a much rarer multi-file/prior-document combination. Filed #1712 to track it properly instead of risking a new regression in a rushed fix.

Also filed #1708 (`-C` combined with `-0`/`--join-output` on the M2 evaluated branch embeds the terminator inside the ANSI color span), #1709 (`-0` performs no embedded-NUL content validation, unlike real yq), #1710 (`-j`/`--join-output` is an undocumented succinctly extension, not real yq's own `-j`), and #1711 (`jq_runner.rs`'s own `write_terminator` duplicates this same decision, unshared across the two binaries) as separate follow-ups.

## Test plan

- [x] Live-verified every fixed site (stdout identity/evaluated, `--inplace`, `--slurp`, `--eval-all`, the standard multi-file DOM loop, `-P`-forced DOM, and `--front-matter=process` on both DOM paths) round-trips cleanly through a reparse, proving no corruption.
- [x] Added 22 regression tests total across all four rounds, including reparse round-trip assertions for the critical corruption case.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure (confirmed on unmodified `main`).
- [x] `cargo clippy` both legs (caught and fixed a `use_self` lint), `cargo fmt --check`, `cargo doc --no-deps`, `cargo build --no-default-features` — all clean, no new warnings vs. `main`.
- [x] Patch coverage 88% (46/52); the 6 uncovered lines are 3 already-documented-unreachable "defensive fallback" arms plus 3 closing-paren lines of multi-line function calls I directly live-verified and test-asserted (an lcov line-attribution artifact for multi-line call expressions, not a behavioral gap).

Closes #1701.

## Round 4 — the deferred front-matter fence gap, fixed directly

A further gap-sweep review round found the identical glued-`---` corruption live and reproducible on `--front-matter=process`'s own closing fence, on both the `--inplace` and standard multi-file DOM paths — confirmed with `od -c` proof, e.g. `printf -- '---\na: 1\n---\nbody one\n' | succinctly yq --front-matter=process --join-output '.'` produced `a: 1---\nbody one` before this fix.

Fixed properly this time by finding the right "was anything actually written since the opening fence" gate instead of a blind unconditional guard (the concern that motivated deferring it as #1712): the `--inplace` path's existing `any_real_output` flag, and a new per-file `any_output_this_file` flag on the standard path (no equivalent existed there). Verified the zero-real-output edge case (e.g. `empty` as the filter) still produces no spurious leading blank line — the exact regression the original deferral was worried about.

Also fixed, from the same gap-sweep pass: `test_join_output_eval_all_does_not_corrupt_1701` asserted a clean round-trip but never actually exercised the `---`-separator guard it claimed to cover (`.` combines every `--eval-all` document into one array result, never reaching the `results.len() > 1` branch) — changed the query to `.[]`, which does. Added `-0` counterparts for that test and both DOM-path corruption tests (previously `--join-output`-only), and 4 new tests for the front-matter fence fix itself.

Documented the `-0` multi-document separator fix as a permitted ADR-0018 rule 4(a) divergence in `docs/compliance/yq/limitations.md` (real yq's own `-0` multi-doc output isn't readable by real yq either, live-verified against the pinned v4.53.3 oracle) — a gap round 3 also flagged but left open.

Closes #1712.

## Round 5 — DRY refactor, and a real pre-existing bug found but out of scope

A gap-sweep across 8 parallel review angles converged independently (3 separate agents, same conclusion) on folding the repeated `write_doc_marker_newline_guard(...)?; writeln!(writer, "---")?;` pair into one helper — this PR's own commit history is itself the evidence for the cost, since that exact pairing had to be retrofitted across 4 review rounds as each found another missed site. Added `write_doc_separator_marker`, used at the 5 sites whose trailing write is a bare `---`+newline; the 2 front-matter fence sites (whose trailing write differs — line ending + body bytes) keep using the lower-level `write_doc_marker_newline_guard` primitive directly.

The same sweep found a real, live, separate bug: the M2 fast path's JSON streaming never consults `raw_output`, so `-o json -r` (and therefore `-0`/`--nul-output`/`--join-output`, all three of which force `raw_output = true`) fails to strip JSON string quoting — `echo '["hello","world"]' | succinctly yq -o json --join-output '.[]'` prints `"hello""world"` instead of `helloworld`. Confirmed this predates #1701 entirely (`-o json -r` alone already has it on unmodified `main`) — it's a materially different fix from this PR's terminator-byte scope (stream_json's per-value JSON-encoding decision, not which byte follows it), so filed as #1715 rather than folded in here, following this PR's own established pattern for #1708-#1711. `test_join_output_multiple_results_1701` had been asserting the buggy quoted output as correct; switched it to the default YAML output format (unaffected by the gap) so it tests only the separator-suppression fix it's actually named for.

Also disclosed by 2 independent review agents but confirmed to be #1708 (already filed, not new): `-C` combined with `-0`/`--join-output` on a multi-result stream embeds the terminator byte inside one shared ANSI color span. No action needed beyond the existing #1708.
