### PR TITLE
fix(jq): extend --jq-extensions gate to 14 more real-yq-lexer-rejected builtins

### DIFF
--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -366,18 +366,27 @@ match, `succinctly yq` rejects them too by default (a parse error naming
 `--jq-extensions`); passing the flag opts back into the jq-compatible
 surface (#1512):
 
-| Builtin                                           | Description                               |
-|---------------------------------------------------|-------------------------------------------|
-| `paths`, `paths(f)`, `leaf_paths`                 | Paths to every node / every leaf node     |
-| `getpath(path)`                                   | Value at a path array                     |
-| `tostream`, `fromstream(f)`, `truncate_stream(f)` | Streaming event representation            |
-| `IN(s)`, `IN(src; s)`                             | Membership test                           |
-| `ltrimstr(s)`                                     | Strip a leading string prefix             |
-| `limit(n; f)`                                     | First `n` outputs of `f`                  |
-| `isempty(f)`                                      | True if `f` produces no output            |
-| `debug`, `debug(msg)`                             | Print to stderr, pass value through       |
-| `infinite`, `isnan`                               | IEEE 754 infinity literal / NaN test      |
-| `gsub(re; s)`, `scan(re)`, `splits(re)`           | Not real yq builtins at any arity (#1436) |
+| Builtin                                              | Description                                   |
+|------------------------------------------------------|-----------------------------------------------|
+| `paths`, `paths(f)`, `leaf_paths`                    | Paths to every node / every leaf node         |
+| `getpath(path)`                                      | Value at a path array                         |
+| `tostream`, `fromstream(f)`, `truncate_stream(f)`    | Streaming event representation                |
+| `IN(s)`, `IN(src; s)`                                | Membership test                               |
+| `ltrimstr(s)`                                        | Strip a leading string prefix                 |
+| `limit(n; f)`                                        | First `n` outputs of `f`                      |
+| `isempty(f)`                                         | True if `f` produces no output                |
+| `debug`, `debug(msg)`                                | Print to stderr, pass value through           |
+| `infinite`, `isnan`                                  | IEEE 754 infinity literal / NaN test          |
+| `gsub(re; s)`, `scan(re)`, `splits(re)`              | Not real yq builtins at any arity (#1436)     |
+| `inside(s)`                                          | Membership test, `contains`'s inverse         |
+| `startswith(s)`, `endswith(s)`                       | String prefix / suffix test                   |
+| `rtrimstr(s)`                                        | Strip a trailing string suffix                |
+| `index(s)`, `rindex(s)`, `indices(s)`                | First / last / all match positions            |
+| `range(n)`, `range(from; to)`, `range(from; to; by)` | Numeric generator                             |
+| `nth(n)`, `nth(n; f)`                                | The `n`th value / output of `f`               |
+| `combinations`, `combinations(n)`                    | Cartesian product of an array of arrays       |
+| `pow(base; exp)`                                     | Exponentiation                                |
+| `strftime(fmt)`, `strptime(fmt)`                     | Broken-down-time formatting / parsing (#1650) |
 
 ```bash
 echo '{}' | succinctly yq 'paths'

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -386,6 +386,7 @@ surface (#1512):
 | `nth(n)`, `nth(n; f)`                                | The `n`th value / output of `f`               |
 | `combinations`, `combinations(n)`                    | Cartesian product of an array of arrays       |
 | `pow(base; exp)`                                     | Exponentiation                                |
+| `bsearch(target)`                                    | Binary search index in a sorted array         |
 | `strftime(fmt)`, `strptime(fmt)`                     | Broken-down-time formatting / parsing (#1650) |
 
 ```bash

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1387,6 +1387,7 @@ impl<'a> Parser<'a> {
                 } else if self.matches_keyword("repeat") {
                     self.parse_repeat_expr()
                 } else if self.matches_keyword("range") {
+                    self.reject_unless_jq_extensions("range")?;
                     self.parse_range_expr()
                 } else if self.matches_keyword("first") {
                     self.parse_first_expr()
@@ -2538,6 +2539,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Ltrimstr(Box::new(s))));
         }
         if self.matches_keyword("rtrimstr") {
+            self.reject_unless_jq_extensions("rtrimstr")?;
             self.consume_keyword("rtrimstr");
             self.skip_ws();
             self.expect('(')?;
@@ -2548,6 +2550,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Rtrimstr(Box::new(s))));
         }
         if self.matches_keyword("startswith") {
+            self.reject_unless_jq_extensions("startswith")?;
             self.consume_keyword("startswith");
             self.skip_ws();
             self.expect('(')?;
@@ -2558,6 +2561,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Startswith(Box::new(s))));
         }
         if self.matches_keyword("endswith") {
+            self.reject_unless_jq_extensions("endswith")?;
             self.consume_keyword("endswith");
             self.skip_ws();
             self.expect('(')?;
@@ -2756,6 +2760,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Contains(Box::new(b))));
         }
         if self.matches_keyword("inside") {
+            self.reject_unless_jq_extensions("inside")?;
             self.consume_keyword("inside");
             self.skip_ws();
             self.expect('(')?;
@@ -2895,6 +2900,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Test(Box::new(re))));
         }
         if self.matches_keyword("indices") {
+            self.reject_unless_jq_extensions("indices")?;
             self.consume_keyword("indices");
             self.skip_ws();
             self.expect('(')?;
@@ -2906,6 +2912,7 @@ impl<'a> Parser<'a> {
         }
         // Check index before rindex since rindex contains "index"
         if self.matches_keyword("rindex") {
+            self.reject_unless_jq_extensions("rindex")?;
             self.consume_keyword("rindex");
             self.skip_ws();
             self.expect('(')?;
@@ -2916,6 +2923,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Rindex(Box::new(s))));
         }
         if self.matches_keyword("index") {
+            self.reject_unless_jq_extensions("index")?;
             self.consume_keyword("index");
             self.skip_ws();
             self.expect('(')?;
@@ -3186,6 +3194,7 @@ impl<'a> Parser<'a> {
         }
         // pow(base; exp)
         if self.matches_keyword("pow") {
+            self.reject_unless_jq_extensions("pow")?;
             self.consume_keyword("pow");
             self.skip_ws();
             self.expect('(')?;
@@ -3362,6 +3371,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Transpose));
         }
         if self.matches_keyword("bsearch") {
+            self.reject_unless_jq_extensions("bsearch")?;
             self.consume_keyword("bsearch");
             self.skip_ws();
             self.expect('(')?;
@@ -3601,6 +3611,7 @@ impl<'a> Parser<'a> {
         // nth(n; expr) or nth(n) - output only the nth value (0-indexed)
         // nth(n) without second arg is already handled by Phase 5 Builtin::Nth
         if self.matches_keyword("nth") {
+            self.reject_unless_jq_extensions("nth")?;
             self.consume_keyword("nth");
             self.skip_ws();
             self.expect('(')?;
@@ -3660,6 +3671,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Mktime));
         }
         if self.matches_keyword("strftime") {
+            self.reject_unless_jq_extensions("strftime")?;
             self.consume_keyword("strftime");
             self.skip_ws();
             self.expect('(')?;
@@ -3670,6 +3682,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Strftime(Box::new(fmt))));
         }
         if self.matches_keyword("strptime") {
+            self.reject_unless_jq_extensions("strptime")?;
             self.consume_keyword("strptime");
             self.skip_ws();
             self.expect('(')?;
@@ -3718,6 +3731,7 @@ impl<'a> Parser<'a> {
 
         // Phase 17: Combinations
         if self.matches_keyword("combinations") {
+            self.reject_unless_jq_extensions("combinations")?;
             self.consume_keyword("combinations");
             self.skip_ws();
             if self.peek() == Some('(') {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1321,14 +1321,36 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
     Ok(())
 }
 
-/// #1512: `succinctly yq` rejects jq-only builtins real yq's lexer lacks by
-/// default -- a parse error mentioning `--jq-extensions`, not the CLI
-/// silently accepting broader syntax than the reference it's meant to
+/// #1512/#1650: `succinctly yq` rejects jq-only builtins real yq's lexer
+/// lacks by default -- a parse error mentioning `--jq-extensions`, not the
+/// CLI silently accepting broader syntax than the reference it's meant to
 /// match. Covers both `try_parse_builtin`'s ordinary gate (`paths`,
-/// `getpath`) and `limit`'s special-cased one in `parse_primary`.
+/// `getpath`) and `limit`'s special-cased one in `parse_primary`, plus the
+/// 14 names #1650 added to close the gap `docs/compliance/yq/limitations.md`'s
+/// own fan-out table had been documenting as ungated all along (`inside`,
+/// `startswith`, `endswith`, `rtrimstr`, `index`, `rindex`, `indices`,
+/// `range`, `nth`, `combinations`, `pow`, `strftime`, `strptime`, `bsearch`).
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
-    for filter in ["paths", "getpath([])", "limit(1; .)"] {
+    for filter in [
+        "paths",
+        "getpath([])",
+        "limit(1; .)",
+        "inside(\"a\")",
+        "startswith(\"a\")",
+        "endswith(\"a\")",
+        "rtrimstr(\"a\")",
+        "index(\"a\")",
+        "rindex(\"a\")",
+        "indices(\"a\")",
+        "range(1)",
+        "nth(1; .)",
+        "combinations",
+        "pow(2;3)",
+        "strftime(\"%Y\")",
+        "strptime(\"%Y\")",
+        "bsearch(1)",
+    ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
         assert!(
@@ -1339,12 +1361,36 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     Ok(())
 }
 
-/// #1512: the CLI flag actually reaches the parser -- `--jq-extensions`
-/// makes the same three filters succeed end to end through the real
-/// `succinctly yq` binary, not just through the parser's own unit tests.
+/// #1512/#1650: the CLI flag actually reaches the parser -- `--jq-extensions`
+/// makes the same filters succeed end to end through the real `succinctly
+/// yq` binary, not just through the parser's own unit tests.
 #[test]
 fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
-    for filter in ["paths", "getpath([])", "limit(1; .)"] {
+    // The #1650 additions are self-contained (their own literal input via
+    // `X | f`) rather than operating on the shared `.` document below --
+    // several need a specific type (`inside`/`startswith`/... need a
+    // string, `bsearch` a sorted array) that `.` (the object `{a: 1}`)
+    // doesn't satisfy, and the point here is confirming each builtin runs
+    // to completion once gated open, not exercising every input shape.
+    for filter in [
+        "paths",
+        "getpath([])",
+        "limit(1; .)",
+        "\"abc\" | inside(\"a\")",
+        "\"abc\" | startswith(\"a\")",
+        "\"abc\" | endswith(\"c\")",
+        "\"abc\" | rtrimstr(\"c\")",
+        "\"abc\" | index(\"b\")",
+        "\"abc\" | rindex(\"b\")",
+        "\"abc\" | indices(\"b\")",
+        "range(1)",
+        "nth(1; .)",
+        "[[1],[2]] | combinations",
+        "pow(2;3)",
+        "0 | strftime(\"%Y\")",
+        "\"2020\" | strptime(\"%Y\")",
+        "[1,2,3] | bsearch(2)",
+    ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
         assert_eq!(
@@ -2771,7 +2817,11 @@ fn test_raw_input_split() -> Result<()> {
 #[test]
 fn test_raw_input_select() -> Result<()> {
     let input = "apple\nbanana\navocado\ncherry";
-    let (output, exit_code) = run_yq_stdin("select(startswith(\"a\"))", input, &["-R"])?;
+    let (output, exit_code) = run_yq_stdin(
+        "select(startswith(\"a\"))",
+        input,
+        &["-R", "--jq-extensions"],
+    )?;
     assert_eq!(exit_code, 0);
     assert_eq!(output, "apple\navocado\n");
     Ok(())
@@ -12552,7 +12602,7 @@ fn test_split_exp_with_null_input() -> Result<()> {
     );
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .arg("yq")
-        .args(["-n", "--split-exp", &pattern])
+        .args(["-n", "--split-exp", &pattern, "--jq-extensions"])
         .arg("range(3)")
         .stdin(Stdio::null())
         .output()?;
@@ -13760,8 +13810,11 @@ fn test_split_exp_writes_every_result_in_a_multi_value_halt_prefix_yaml() -> Res
         "\"{}/f\" + ($index|tostring) + \".yml\"",
         dir.path().display()
     );
-    let (stdout, stderr, code) =
-        run_yq_split("range(3), halt", "x: 1\n", &["--split-exp", &pattern])?;
+    let (stdout, stderr, code) = run_yq_split(
+        "range(3), halt",
+        "x: 1\n",
+        &["--split-exp", &pattern, "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout, "");
 
@@ -13784,7 +13837,7 @@ fn test_split_exp_writes_every_result_in_a_multi_value_halt_prefix_json() -> Res
     let (stdout, stderr, code) = run_yq_split(
         "range(3), halt",
         "5",
-        &["--split-exp", &pattern, "-p", "json"],
+        &["--split-exp", &pattern, "-p", "json", "--jq-extensions"],
     )?;
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout, "");
@@ -21229,8 +21282,11 @@ fn test_yq_string_interpolation_path_context_optional_threaded_through_rest_1403
 /// has real CI signal here rather than only in `jq_cli_tests.rs`.
 #[test]
 fn test_yq_nth_stream_empty_n_argument_produces_no_output_1408() -> Result<()> {
-    let (output, stderr, code) =
-        run_yq_stdin_with_stderr("nth(empty; .a,.b)", "a: 1\nb: 2\n", &["-o", "json"])?;
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        "nth(empty; .a,.b)",
+        "a: 1\nb: 2\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "stderr={stderr}");
     assert_eq!(output, "");
     assert_eq!(stderr, "");
@@ -21239,8 +21295,11 @@ fn test_yq_nth_stream_empty_n_argument_produces_no_output_1408() -> Result<()> {
 
 #[test]
 fn test_yq_combinations_n_empty_argument_produces_empty_array_1408() -> Result<()> {
-    let (output, stderr, code) =
-        run_yq_stdin_with_stderr("combinations(empty)", "[1, 2]\n", &["-o", "json"])?;
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        "combinations(empty)",
+        "[1, 2]\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "stderr={stderr}");
     assert_eq!(output.trim(), "[]");
     assert_eq!(stderr, "");
@@ -22233,18 +22292,24 @@ fn test_yq_contains_any_container_operand_kind_mismatch_still_errors_1649() -> R
 /// and shares the same kind-mismatch rule, gated the same way even though
 /// real yq has no `inside` at all (lexer-rejected) to verify it against --
 /// this is an internal-consistency check with `contains`, not yq parity.
-/// (`inside` itself is currently reachable in yq mode without
-/// `--jq-extensions`, a separate, pre-existing gap tracked by #1650 -- not
-/// this test's concern, which is only whether the kind-mismatch rule
-/// matches `contains`'s own once `inside` is reached at all.)
+/// (`inside` needs `--jq-extensions` to be reachable in yq mode at all,
+/// per #1650 -- this test's concern is only whether the kind-mismatch rule
+/// matches `contains`'s own once `inside` is reached.)
 #[test]
 fn test_yq_inside_shares_contains_kind_mismatch_rule_1649() -> Result<()> {
-    let (out, code) = run_yq_stdin(".x | inside(\"abc\")", "x: 5\n", &["-o", "json"])?;
+    let (out, code) = run_yq_stdin(
+        ".x | inside(\"abc\")",
+        "x: 5\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "output: {out:?}");
     assert_eq!(out.trim(), "false");
 
-    let (_, err, code) =
-        run_yq_stdin_with_stderr(".x | inside(\"abc\")", "x: [1]\n", &["-o", "json"])?;
+    let (_, err, code) = run_yq_stdin_with_stderr(
+        ".x | inside(\"abc\")",
+        "x: [1]\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
     assert_eq!(code, 1, "err: {err:?}");
     assert_eq!(
         err.trim(),


### PR DESCRIPTION
## Summary

- `reject_unless_jq_extensions` (#1512) gated 15 jq-only builtin names real
  yq's lexer rejects outright — but `docs/compliance/yq/limitations.md`'s own
  "Generator-argument fan-out" table had been documenting a second group of
  14 names with the identical "lexer-rejected — the builtin does not exist"
  classification that carried no gate at all: `inside`, `startswith`,
  `endswith`, `rtrimstr`, `index`, `rindex`, `indices`, `range`, `nth`,
  `combinations`, `pow`, `strftime`, `strptime`, `bsearch`. They parsed and
  ran in plain `succinctly yq` with no flag.
- Live-verified each of the 14 against the pinned `yq` v4.53.3 binary before
  touching the gate (per the issue's own caution — some could plausibly have
  had real yq syntax under a different spelling; none did — all 14 confirmed
  `lexer: invalid input text`).
- Added `self.reject_unless_jq_extensions("name")?;` at each builtin's
  existing parse call site, matching the established call-before-consume
  pattern used by the original 15.
- Updated `docs/reference/yq-language.md`'s "Gated jq Builtins" table with
  the 14 new entries.

## Test plan

- [x] Verified all 14 rejected by default and accepted with `--jq-extensions`
      against the built binary directly
- [x] Confirmed no existing test exercised any of the 14 without the flag by
      running the full suite and fixing every resulting failure — 7 existing
      tests (`test_raw_input_select`, `test_split_exp_with_null_input`, both
      `test_split_exp_writes_every_result_in_a_multi_value_halt_prefix_*`,
      `test_yq_combinations_n_empty_argument_produces_empty_array_1408`,
      `test_yq_inside_shares_contains_kind_mismatch_rule_1649`,
      `test_yq_nth_stream_empty_n_argument_produces_no_output_1408`) were
      exercising real, intended extension behavior and needed
      `--jq-extensions` threaded through, not behavior changes
- [x] Extended `test_yq_default_rejects_jq_only_builtins_1512` and
      `test_yq_jq_extensions_flag_enables_jq_only_builtins_1512` (#1512's own
      regression tests, previously sampling only 3 of the 15 original names)
      to cover all 30 gated names — closing a pre-existing gap where neither
      the original 15 nor the new 14 had a test actually asserting the
      rejection message
- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (full suite) — 55/55 green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo llvm-cov` — every new gate call site covered (both the rejection
      and acceptance paths, verified via the two regression tests above)

Fixes #1650