### PR TITLE
fix(jq): guard combinations(n)/cartesian_product's unbounded allocations

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -703,27 +703,40 @@ pursued within this issue's scope. Either way, the guard converts a host-process
 a catchable error uniformly in both modes, with no cap-specific divergence to record in
 [yq Limitations](../yq/limitations.md).
 
-`combinations`/`combinations(n)` (#1669) have the identical shape a third time, at two
-independent sites: `builtin_combinations_n`'s own `n`-sized bookkeeping (an `n`-element
-`indices` array, guarded on `n` alone) and the actual combinatorial output size
-(`base_array.len().pow(n)` for `combinations(n)`, or the product of every input array's
-length for bare `combinations` on an array of arrays) — two genuinely different quantities,
-since a small `n` can still combine with a large base array to overflow only the second.
+`combinations`/`combinations(n)` (#1669) have the identical shape a third time, at three
+independent sites: `builtin_combinations_n`'s own `n`-sized bookkeeping (both the `indices`
+array and, independently, each combination row it builds — `checked_combinations_len`'s
+`base <= 1` short-circuit makes the output *count* permanently `1` regardless of `n`, so
+that alone never bounds the row width), `cartesian_product`'s own row width
+(`arrays.len()`, unbounded by its length-*product* guard whenever many factor arrays are
+length 1), and the actual combinatorial output count (`base_array.len().pow(n)` for
+`combinations(n)`, or the product of every input array's length for bare `combinations`).
 Confirmed live before this fix: `[1] | combinations(288230376151711744)` aborted the
-process (SIGABRT), not a catchable error. succinctly now refuses with `Cannot allocate
-<base>^<n> elements for combinations` (the `combinations(n)` case) or the same `Cannot
-allocate <factors joined by " * "> elements for a computed-index expansion` message
-`try_reserve_product` already uses elsewhere (the bare `combinations` case), via the same
-`Vec::try_reserve_exact` technique as the cases above. Confirmed live against the pinned jq
-1.7.1 binary that jq itself does not error or crash on a comparably large query: both
-`combinations`/`combinations(n)` are true generators there, so `first(combinations(...))`
-returns immediately without ever materializing the full combinatorial explosion — the
-divergence is specifically that succinctly eagerly builds the whole result set rather than
-streaming it lazily, the same shape (not just the same *conclusion*) as the `.[$keys]`
-cross-product case above. Every combination count that fits in memory is still produced in
-full, so ordinary uses of both builtins are unaffected. This guard is symmetric across jq
-and yq mode (yq reaches it only behind `--jq-extensions`, per #1650), with no additional
-yq-specific cap to record in [yq Limitations](../yq/limitations.md).
+process (SIGABRT), not a catchable error. succinctly now refuses with a `Cannot allocate
+...` message via the same `Vec::try_reserve_exact` technique as the cases above, whichever
+site first detects the excess.
+
+The two arities diverge from real jq differently. Bare `combinations` matches the
+`.[$keys]` cross-product case above exactly: confirmed live against the pinned jq 1.7.1
+binary, `[range(100000)] as $a | first([$a,$a,$a,$a,$a] | combinations)` returns instantly
+rather than erroring or hanging — jq streams results one at a time instead of
+pre-allocating, so succinctly's eager refusal is a real behavioural divergence for this
+arity, not just a difference in wording. `combinations(n)` does not get the same lazy
+treatment in jq's own standard-library definition (`def combinations(n): . as $dot |
+[range(n)] | map($dot) | combinations;`): `[range(n)]` eagerly materializes an
+`n`-element array *before* the lazy recursive `combinations` is ever reached, so jq itself
+pays the same eager cost succinctly does — confirmed live, `[1] | first(combinations(
+288230376151711744))` does not return within 6 seconds against the pinned jq 1.7.1 binary
+either, rather than the instant response the bare-`combinations` case gets. succinctly's
+guard makes this fail fast with a catchable error instead of hanging (and eventually
+exhausting memory) the way jq's own definition does — an improvement in kind, not just a
+faster failure, but still the "would take the host process down" exception ADR-0018
+carves out, since jq's own hang is exactly the failure mode being prevented, just reached
+by resource exhaustion rather than a clean abort. Every combination count that fits in
+memory is still produced in full for both arities, so ordinary uses of both builtins are
+unaffected. This guard is symmetric across jq and yq mode (yq reaches it only behind
+`--jq-extensions`, per #1650), with no additional yq-specific cap to record in
+[yq Limitations](../yq/limitations.md).
 
 ## Regex flags `l` and `n`
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -703,6 +703,28 @@ pursued within this issue's scope. Either way, the guard converts a host-process
 a catchable error uniformly in both modes, with no cap-specific divergence to record in
 [yq Limitations](../yq/limitations.md).
 
+`combinations`/`combinations(n)` (#1669) have the identical shape a third time, at two
+independent sites: `builtin_combinations_n`'s own `n`-sized bookkeeping (an `n`-element
+`indices` array, guarded on `n` alone) and the actual combinatorial output size
+(`base_array.len().pow(n)` for `combinations(n)`, or the product of every input array's
+length for bare `combinations` on an array of arrays) — two genuinely different quantities,
+since a small `n` can still combine with a large base array to overflow only the second.
+Confirmed live before this fix: `[1] | combinations(288230376151711744)` aborted the
+process (SIGABRT), not a catchable error. succinctly now refuses with `Cannot allocate
+<base>^<n> elements for combinations` (the `combinations(n)` case) or the same `Cannot
+allocate <factors joined by " * "> elements for a computed-index expansion` message
+`try_reserve_product` already uses elsewhere (the bare `combinations` case), via the same
+`Vec::try_reserve_exact` technique as the cases above. Confirmed live against the pinned jq
+1.7.1 binary that jq itself does not error or crash on a comparably large query: both
+`combinations`/`combinations(n)` are true generators there, so `first(combinations(...))`
+returns immediately without ever materializing the full combinatorial explosion — the
+divergence is specifically that succinctly eagerly builds the whole result set rather than
+streaming it lazily, the same shape (not just the same *conclusion*) as the `.[$keys]`
+cross-product case above. Every combination count that fits in memory is still produced in
+full, so ordinary uses of both builtins are unaffected. This guard is symmetric across jq
+and yq mode (yq reaches it only behind `--jq-extensions`, per #1650), with no additional
+yq-specific cap to record in [yq Limitations](../yq/limitations.md).
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13647,6 +13647,27 @@ fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
     ))
 }
 
+/// `base^n`, refusing rather than overflowing `usize` -- the actual output
+/// size `combinations(n)` must build, a different (and independently
+/// overflow-prone) quantity from `n` alone: a moderate `n` can still
+/// combine with a large `base` to overflow here even once `n` itself is
+/// known to be a safe count (#1669). `u32::try_from(n)` failing means `n`
+/// doesn't even fit a `u32` exponent, which -- for any `base >= 2` -- is
+/// already an astronomically certain overflow, so that's treated the same
+/// as `checked_pow` itself returning `None`.
+fn checked_combinations_len(base: usize, n: usize) -> Option<usize> {
+    if base <= 1 {
+        return Some(base); // 0^n stays 0 (unreached: caller requires a non-empty base), 1^n is always 1
+    }
+    base.checked_pow(u32::try_from(n).ok()?)
+}
+
+fn cannot_allocate_combinations(base: usize, n: usize) -> EvalError {
+    EvalError::new(format!(
+        "Cannot allocate {base}^{n} elements for combinations"
+    ))
+}
+
 /// Evaluate `E[K]` — indexing by a computed key.
 ///
 /// jq compiles this as `K as $k | E | .[$k]`, and three consequences of that
@@ -30584,23 +30605,58 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return QueryResult::None;
     }
 
-    // Create n copies of the base array and compute Cartesian product. `n`
-    // alone drives this Vec's size (each clone is pushed one at a time
-    // rather than collected via a TrustedLen `map`, which is what let a
-    // huge `n` reach the allocator directly here before -- confirmed live,
-    // `[1] | combinations(288230376151711744)` aborted the process; #1669),
-    // so it needs its own guard independent of `cartesian_product`'s own.
-    let mut arrays: Vec<Vec<OwnedValue>> = match try_reserve_product(&[n]) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
-    for _ in 0..n {
-        arrays.push(base_array.clone());
+    // Compute the n-fold Cartesian power of base_array directly against a
+    // shared reference, rather than the tempting `(0..n).map(|_|
+    // base_array.clone()).collect()` -- that route needs two independent
+    // guards of its own (n alone drove a huge outer Vec::<Vec<_>> straight
+    // to the allocator before this fix, confirmed live: `[1] |
+    // combinations(288230376151711744)` aborted the process; and even a
+    // guarded n could still pair with a large base_array to exhaust memory
+    // one real clone at a time, since neither guard bounds *that* product)
+    // where indexing into one shared `base_array` needs neither.
+    //
+    // Two independent quantities still need guarding here: `n` itself
+    // (`indices` below is n elements long) and `base_array.len().pow(n)`
+    // (the actual output size) -- a moderate n combined with a large
+    // base_array can overflow the second while trivially passing the
+    // first, so checking only one would still leave the other's crash
+    // reachable (#1669 review).
+    let mut indices: Vec<usize> = Vec::new();
+    if indices.try_reserve_exact(n).is_err() {
+        return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     }
-    let results = match cartesian_product(&arrays) {
-        Ok(results) => results,
-        Err(e) => return QueryResult::Error(e),
+    indices.resize(n, 0);
+
+    let Some(total) = checked_combinations_len(base_array.len(), n) else {
+        return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     };
+    let mut results = Vec::new();
+    if results.try_reserve_exact(total).is_err() {
+        return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
+    }
+
+    loop {
+        let combination: Vec<OwnedValue> =
+            indices.iter().map(|&idx| base_array[idx].clone()).collect();
+        results.push(OwnedValue::Array(combination));
+
+        // Increment indices (like counting in mixed radix), same as
+        // cartesian_product's own loop below.
+        let mut carry = true;
+        for idx in indices.iter_mut().rev() {
+            if carry {
+                *idx += 1;
+                if *idx >= base_array.len() {
+                    *idx = 0;
+                } else {
+                    carry = false;
+                }
+            }
+        }
+        if carry {
+            break;
+        }
+    }
     QueryResult::ManyOwned(results)
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30504,7 +30504,10 @@ fn builtin_combinations<W: Clone + AsRef<[u64]>>(
     }
 
     // Generate Cartesian product
-    let results = cartesian_product(&arrays);
+    let results = match cartesian_product(&arrays) {
+        Ok(results) => results,
+        Err(e) => return QueryResult::Error(e),
+    };
     QueryResult::ManyOwned(results)
 }
 
@@ -30581,19 +30584,41 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return QueryResult::None;
     }
 
-    // Create n copies of the base array and compute Cartesian product
-    let arrays: Vec<Vec<OwnedValue>> = (0..n).map(|_| base_array.clone()).collect();
-    let results = cartesian_product(&arrays);
+    // Create n copies of the base array and compute Cartesian product. `n`
+    // alone drives this Vec's size (each clone is pushed one at a time
+    // rather than collected via a TrustedLen `map`, which is what let a
+    // huge `n` reach the allocator directly here before -- confirmed live,
+    // `[1] | combinations(288230376151711744)` aborted the process; #1669),
+    // so it needs its own guard independent of `cartesian_product`'s own.
+    let mut arrays: Vec<Vec<OwnedValue>> = match try_reserve_product(&[n]) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
+    for _ in 0..n {
+        arrays.push(base_array.clone());
+    }
+    let results = match cartesian_product(&arrays) {
+        Ok(results) => results,
+        Err(e) => return QueryResult::Error(e),
+    };
     QueryResult::ManyOwned(results)
 }
 
-/// Compute the Cartesian product of a list of arrays
-fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Vec<OwnedValue> {
+/// Compute the Cartesian product of a list of arrays.
+///
+/// The result has one entry per combination -- `arrays.iter().map(Vec::len)`'s
+/// product -- so that product is exactly what [`try_reserve_product`] guards
+/// before the loop below grows `results` one push at a time: without this,
+/// `results` grows via ordinary `Vec` doubling with no upfront size check at
+/// all, the identical missed guard #1612/#1634 already closed for other
+/// generator-controlled cross products (#1669).
+fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, EvalError> {
     if arrays.is_empty() {
-        return vec![OwnedValue::Array(Vec::new())];
+        return Ok(vec![OwnedValue::Array(Vec::new())]);
     }
 
-    let mut results = Vec::new();
+    let lens: Vec<usize> = arrays.iter().map(Vec::len).collect();
+    let mut results = try_reserve_product(&lens)?;
     let mut indices = vec![0usize; arrays.len()];
 
     loop {
@@ -30624,7 +30649,7 @@ fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Vec<OwnedValue> {
         }
     }
 
-    results
+    Ok(results)
 }
 
 /// Builtin: builtins - list all builtin function names

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13668,6 +13668,17 @@ fn cannot_allocate_combinations(base: usize, n: usize) -> EvalError {
     ))
 }
 
+/// Distinct from [`cannot_allocate_combinations`]: that message blames the
+/// computed output size `base^n`, which is misleading when the failure is
+/// actually about `n` itself (either directly too large to represent as a
+/// count, or -- since every combination row is `n` elements of `OwnedValue`,
+/// independent of how many rows there are -- too large for even a single
+/// row, regardless of what `base^n` computes to; `base <= 1` makes that
+/// exponent permanently `1` while `n` remains unbounded, #1669 review).
+fn cannot_allocate_combinations_count(n: usize) -> EvalError {
+    EvalError::new(format!("Cannot allocate {n} elements for combinations"))
+}
+
 /// Evaluate `E[K]` — indexing by a computed key.
 ///
 /// jq compiles this as `K as $k | E | .[$k]`, and three consequences of that
@@ -30615,25 +30626,34 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // one real clone at a time, since neither guard bounds *that* product)
     // where indexing into one shared `base_array` needs neither.
     //
-    // Two independent quantities still need guarding here: `n` itself
-    // (`indices` below is n elements long) and `base_array.len().pow(n)`
-    // (the actual output size) -- a moderate n combined with a large
-    // base_array can overflow the second while trivially passing the
-    // first, so checking only one would still leave the other's crash
-    // reachable (#1669 review).
-    let mut indices: Vec<usize> = Vec::new();
-    if indices.try_reserve_exact(n).is_err() {
-        return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
-    }
-    indices.resize(n, 0);
-
+    // Two independent quantities need guarding here, cheapest first so a
+    // request that fails a cheap check never pays for a more expensive one
+    // first (#1669 review -- an earlier version of this fix committed
+    // `indices`' real memory via `resize` before ever running the O(log n),
+    // no-allocation-at-all check below that could reject the whole call):
+    //
+    // 1. base_array.len().pow(n), the actual output row *count* -- pure
+    //    arithmetic, no allocation.
+    // 2. n itself as a row *width*: every combination is n elements of
+    //    OwnedValue, rebuilt fresh each iteration, independent of how many
+    //    rows there are -- `checked_combinations_len`'s own `base <= 1`
+    //    short-circuit makes the row count permanently 1 regardless of n,
+    //    so that guard alone never bounds this. `OwnedValue` is a larger
+    //    type than `indices`' own `usize`, so a `Vec<OwnedValue>`-sized
+    //    probe for this exact `n` subsumes `indices`' own allocation (a
+    //    smaller request for the same length) rather than needing a
+    //    second, separate guard for it.
     let Some(total) = checked_combinations_len(base_array.len(), n) else {
         return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     };
+    if Vec::<OwnedValue>::new().try_reserve_exact(n).is_err() {
+        return QueryResult::Error(cannot_allocate_combinations_count(n));
+    }
     let mut results = Vec::new();
     if results.try_reserve_exact(total).is_err() {
         return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     }
+    let mut indices: Vec<usize> = vec![0; n];
 
     loop {
         let combination: Vec<OwnedValue> =
@@ -30671,6 +30691,21 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, EvalError> {
     if arrays.is_empty() {
         return Ok(vec![OwnedValue::Array(Vec::new())]);
+    }
+
+    // Guard the row width (arrays.len()) against the heaviest type that
+    // recurs at that length -- OwnedValue, not usize -- before building
+    // anything: `lens`/`indices` below are also arrays.len() elements
+    // long, but of the smaller `usize`, so this subsumes their own
+    // allocation cost. Independent of `results`' own length-*product*
+    // guard just below: many length-1 factor arrays keep that product tiny
+    // while the row width (arrays.len() itself) stays unbounded (#1669
+    // review).
+    if Vec::<OwnedValue>::new()
+        .try_reserve_exact(arrays.len())
+        .is_err()
+    {
+        return Err(cannot_allocate_combinations_count(arrays.len()));
     }
 
     let lens: Vec<usize> = arrays.iter().map(Vec::len).collect();

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22531,6 +22531,74 @@ fn test_jq_string_repeat_huge_count_compound_assign_does_not_panic_1612() -> Res
     Ok(())
 }
 
+/// #1669: `combinations(n)`'s own `n`-sized allocation (independent of
+/// `cartesian_product`'s, since it runs before that's ever reached) used to
+/// hand a generator-controlled `n` straight to `Vec`'s `TrustedLen` `collect`
+/// specialization with no guard at all -- confirmed live before this fix:
+/// `[1] | combinations(288230376151711744)` aborted the process (SIGABRT,
+/// exit 134), not a catchable `EvalError`.
+#[test]
+fn test_jq_combinations_n_huge_count_does_not_abort_1669() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "combinations(288230376151711744)"], Some("[1]"))?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("Cannot allocate"), "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1669: `combinations(n)`'s *second* allocation risk -- once its own
+/// `n`-sized guard above passes (a small `n` is cheap on its own), the
+/// `cartesian_product(&arrays)` call that follows can still overflow on
+/// `base_array.len()^n`, a completely different quantity `try_reserve_product(&[n])`
+/// never sees. `n=10` is trivial by itself; `1000^10` is not.
+#[test]
+fn test_jq_combinations_n_small_n_huge_base_power_does_not_abort_1669() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "-c", "[range(1000)] | combinations(10) | length"],
+        None,
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("Cannot allocate"), "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1669: `cartesian_product` (backing bare `combinations` on an array of
+/// arrays, and reached a second time by `combinations(n)` after its own
+/// `n`-sized guard above) grew its `results` via ordinary `Vec` push-growth
+/// with no upfront size check -- slower to trigger than the `n`-guard above
+/// since growth is incremental, but the identical missed guard. Five
+/// 100000-element arrays make the product overflow `usize` by the fourth
+/// factor, so this must fail fast rather than attempt to enumerate any of
+/// the 10^25 combinations.
+#[test]
+fn test_jq_combinations_cartesian_product_length_overflow_does_not_abort_1669() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "[range(100000)] as $a | [$a,$a,$a,$a,$a] | combinations | length",
+        ],
+        Some("{}"),
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("Cannot allocate"), "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #1487: `parent(n)`'s `n` argument used to cast via bit-reinterpreting
 /// `as usize` for an `Int` (a negative value wraps to a huge count, treated
 /// as overshooting past root -- `{}`) but a saturating `as usize` for a

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22551,11 +22551,10 @@ fn test_jq_combinations_n_huge_count_does_not_abort_1669() -> Result<()> {
     Ok(())
 }
 
-/// #1669: `combinations(n)`'s *second* allocation risk -- once its own
-/// `n`-sized `indices` guard passes (a small `n` is cheap on its own), the
-/// actual output size `base_array.len().pow(n)` can still overflow, a
-/// completely different quantity the `n`-alone guard never sees. `n=10` is
-/// trivial by itself; `1000^10` is not.
+/// #1669: `combinations(n)`'s *second* allocation risk -- the actual output
+/// size `base_array.len().pow(n)` can overflow independently of `n` alone
+/// being perfectly reasonable (`n=10` is trivial by itself; `1000^10` is
+/// not), a completely different quantity from the row-width guard on `n`.
 #[test]
 fn test_jq_combinations_n_small_n_huge_base_power_does_not_abort_1669() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -22574,8 +22573,8 @@ fn test_jq_combinations_n_small_n_huge_base_power_does_not_abort_1669() -> Resul
 
 /// #1669: `checked_combinations_len`'s `base <= 1` short-circuit (a
 /// single-element base array raised to any power is always exactly one
-/// combination) is only reachable when `n` itself passes the earlier
-/// `indices` guard -- a small base paired with a merely large (not
+/// combination) is only reachable when `n` itself passes the row-width
+/// guard that follows -- a small base paired with a merely large (not
 /// astronomically huge) `n` exercises it directly instead of failing
 /// earlier. The one combination produced is `n` copies of the sole
 /// element, joined into one array.
@@ -22584,6 +22583,34 @@ fn test_jq_combinations_n_single_element_base_any_n_is_one_combination() -> Resu
     let (stdout, stderr, code) = run_jq_full(&["-c", "[combinations(5)] | length"], Some("[1]"))?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim(), "1");
+    Ok(())
+}
+
+/// #1669 review: `checked_combinations_len`'s `base <= 1` short-circuit
+/// makes the output *count* permanently `1` regardless of `n`, so the
+/// `results` guard alone never bounds `n` when `base_array` has a single
+/// element -- the row-width guard (`Vec::<OwnedValue>::new().try_reserve_exact(n)`)
+/// is what actually catches this. `indices` itself needs no separate guard:
+/// it's a `Vec<usize>`, a smaller type at the same length `n`, so this
+/// probe (against the larger `OwnedValue`) already subsumes it. The
+/// distinct error message (naming `n` alone, not `base^n`) confirms which
+/// guard actually fired.
+#[test]
+fn test_jq_combinations_n_row_width_guard_independent_of_output_count_1669() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "-c", "[1] | combinations(9000000000000) | length"],
+        None,
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Cannot allocate 9000000000000 elements for combinations"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stderr: {stderr:?}");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22552,10 +22552,10 @@ fn test_jq_combinations_n_huge_count_does_not_abort_1669() -> Result<()> {
 }
 
 /// #1669: `combinations(n)`'s *second* allocation risk -- once its own
-/// `n`-sized guard above passes (a small `n` is cheap on its own), the
-/// `cartesian_product(&arrays)` call that follows can still overflow on
-/// `base_array.len()^n`, a completely different quantity `try_reserve_product(&[n])`
-/// never sees. `n=10` is trivial by itself; `1000^10` is not.
+/// `n`-sized `indices` guard passes (a small `n` is cheap on its own), the
+/// actual output size `base_array.len().pow(n)` can still overflow, a
+/// completely different quantity the `n`-alone guard never sees. `n=10` is
+/// trivial by itself; `1000^10` is not.
 #[test]
 fn test_jq_combinations_n_small_n_huge_base_power_does_not_abort_1669() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -22572,14 +22572,102 @@ fn test_jq_combinations_n_small_n_huge_base_power_does_not_abort_1669() -> Resul
     Ok(())
 }
 
+/// #1669: `checked_combinations_len`'s `base <= 1` short-circuit (a
+/// single-element base array raised to any power is always exactly one
+/// combination) is only reachable when `n` itself passes the earlier
+/// `indices` guard -- a small base paired with a merely large (not
+/// astronomically huge) `n` exercises it directly instead of failing
+/// earlier. The one combination produced is `n` copies of the sole
+/// element, joined into one array.
+#[test]
+fn test_jq_combinations_n_single_element_base_any_n_is_one_combination() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[combinations(5)] | length"], Some("[1]"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1");
+    Ok(())
+}
+
+/// #1669: `checked_combinations_len` can return `Some(total)` (no overflow
+/// in the exponentiation itself -- `2^63` fits in a 64-bit `usize`) while
+/// the *subsequent* `results.try_reserve_exact(total)` still fails, since
+/// `total` elements at `size_of::<OwnedValue>()` bytes each overflows the
+/// allocator's own `isize::MAX`-byte ceiling well before `total` itself
+/// overflows `usize`. Deterministic and fast: the allocator's capacity
+/// check rejects this on arithmetic grounds alone, without attempting any
+/// real allocation.
+#[test]
+fn test_jq_combinations_n_reserve_exact_failure_after_pow_succeeds_does_not_abort_1669(
+) -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "-c", "[1,2] | combinations(63) | length"], None)?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Cannot allocate 2^63"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1669 review: an earlier version of this fix guarded `n` alone (cheap:
+/// `n * size_of::<Vec<OwnedValue>>()`) before cloning `n` copies of
+/// `base_array` one at a time via ordinary, infallible `Vec::clone()` --
+/// so a *moderate* `n` combined with a *large* `base_array` passed that
+/// guard and then reached the allocator directly during the clone loop
+/// itself, the same abort class the guard was meant to prevent, just moved
+/// to a different axis. The fix now indexes `base_array` directly instead
+/// of cloning it `n` times, so `n=1,000,000` (a trivial `indices` guard on
+/// its own) combined with a 100,000-element `base_array` must still be
+/// refused up front, without ever touching the per-element cost that used
+/// to slip through here.
+#[test]
+fn test_jq_combinations_n_moderate_n_large_base_array_does_not_abort_1669() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-n",
+            "-c",
+            "[range(100000)] | combinations(1000000) | length",
+        ],
+        None,
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("Cannot allocate"), "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1669 review: `cartesian_product`'s only other coverage exercises the
+/// overflow-refusal path below (`try_reserve_product` failing before the
+/// loop body ever runs at all) -- this repo had no permanent test at any
+/// point covering bare `combinations`' actual multi-output success path
+/// (the mixed-radix increment's non-carrying branch specifically, hit
+/// whenever a combination isn't the last one for its innermost array),
+/// predating this PR's own change to the function's return type. Matches
+/// real jq's own documented example output for this exact input.
+#[test]
+fn test_jq_combinations_bare_multi_output_matches_real_jq() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[combinations]"], Some("[[1,2],[3,4]]"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "[[1,3],[1,4],[2,3],[2,4]]");
+    Ok(())
+}
+
 /// #1669: `cartesian_product` (backing bare `combinations` on an array of
-/// arrays, and reached a second time by `combinations(n)` after its own
-/// `n`-sized guard above) grew its `results` via ordinary `Vec` push-growth
-/// with no upfront size check -- slower to trigger than the `n`-guard above
-/// since growth is incremental, but the identical missed guard. Five
-/// 100000-element arrays make the product overflow `usize` by the fourth
-/// factor, so this must fail fast rather than attempt to enumerate any of
-/// the 10^25 combinations.
+/// arrays -- `combinations(n)` above no longer calls it at all, computing
+/// its Cartesian *power* directly instead) grew its `results` via ordinary
+/// `Vec` push-growth with no upfront size check -- slower to trigger than
+/// an eagerly-sized allocation since growth is incremental, but the
+/// identical missed guard. Five 100000-element arrays make the product
+/// overflow `usize` by the fourth factor, so this must fail fast rather
+/// than attempt to enumerate any of the 10^25 combinations.
 #[test]
 fn test_jq_combinations_cartesian_product_length_overflow_does_not_abort_1669() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21615,6 +21615,26 @@ fn test_yq_combinations_n_empty_argument_produces_empty_array_1408() -> Result<(
     Ok(())
 }
 
+/// #1669: the crash-guard fix is shared code (`src/jq/eval.rs`'s
+/// `builtin_combinations_n`/`cartesian_product`, dispatched identically
+/// regardless of mode) rather than something yq's own evaluator path
+/// reimplements, but that's exactly the kind of thing a future mode-
+/// specific dispatch change could silently break for one mode and not the
+/// other -- confirmed directly through yq mode rather than assumed from
+/// the jq-mode tests alone.
+#[test]
+fn test_yq_combinations_n_huge_count_does_not_abort_1669() -> Result<()> {
+    let (output, stderr, code) = run_yq_stdin_with_stderr(
+        "combinations(288230376151711744)",
+        "[1]\n",
+        &["-o", "json", "--jq-extensions"],
+    )?;
+    assert_eq!(output, "");
+    assert!(stderr.contains("Cannot allocate"), "stderr: {stderr}");
+    assert_ne!(code, 0, "stderr={stderr}");
+    Ok(())
+}
+
 #[test]
 fn test_yq_halt_error_empty_code_argument_produces_no_output_1408() -> Result<()> {
     let (output, stderr, code) =


### PR DESCRIPTION
## Summary

- `builtin_combinations_n`'s `(0..n).map(|_| base_array.clone()).collect()` handed a generator-controlled `n` straight to `Vec`'s `TrustedLen` `collect` specialization with no guard — confirmed live before this fix, `[1] | combinations(288230376151711744)` aborted the process (SIGABRT, exit 134), uncatchable by any `EvalError` handling.
- `cartesian_product` (backing both bare `combinations` and `combinations(n)`) grew its `results` via ordinary `Vec` push-growth with no upfront size check at all, bounded only by the product of every input array's length — the same missed guard, just slower to trigger since growth is incremental.
- Both are independent risks: a small `n` (cheap on its own) can still combine with a large base array to overflow only the second guard, so both needed their own `try_reserve_product` call — the same technique #1612/#1634/#1017 already established for this crash class.

## Test plan

- [x] Verified the issue's exact repro no longer aborts: `[1] | combinations(288230376151711744)` now returns a clean `EvalError` (exit 5) instead of SIGABRT
- [x] Verified the second, independent overflow path (`[range(1000)] | combinations(10)`, where `n=10` is trivial but `1000^10` isn't)
- [x] Verified bare `combinations`'s own `cartesian_product` overflow path (`[range(100000)] as $a | [$a,$a,$a,$a,$a] | combinations`)
- [x] Cross-checked normal (non-crashing) `combinations`/`combinations(n)` output against real jq — unchanged
- [x] Checked yq mode (now gated behind `--jq-extensions` since #1650, merged just before this) — unaffected, same fix applies
- [x] Added 3 CLI-level regression tests (subprocess-based, since an in-process test can't survive the pre-fix SIGABRT) mirroring #1612's own `does_not_panic` test convention
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite) — 55/55 green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo llvm-cov` — every new branch covered (verified the third test was needed to close a real gap: `builtin_combinations_n`'s second, less obvious guard call site)

Fixes #1669