### PR TITLE
fix(jq): collapse overlong/surrogate/out-of-range UTF-8 to one U+FFFD

### DIFF
--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -507,7 +507,20 @@ otherwise already correct, and it can be reverted independently if the perf gate
 - **`yaml validate`** grew the check too, reusing the `InvalidUtf8` variant that had been
   declared but never constructed — the scanner reads bytes and never decodes them, so
   nothing could ever have produced it.
-- **jq** substitutes U+FFFD and exits 0, byte-identical to jq 1.7.1 on the probes above.
+- **jq** substitutes U+FFFD and exits 0, byte-identical to jq 1.7.1 on the probes above --
+  but "the probes above" turned out not to cover every `Utf8ErrorKind`, and the
+  substitution *algorithm* itself was wrong for three of them. This landed using
+  `String::from_utf8_lossy`, which follows WHATWG's maximal-subpart rule: one U+FFFD per
+  byte once a sequence is known bad. jq 1.7.1 instead collapses a whole *structurally
+  valid* 3- or 4-byte sequence (a lead byte RFC 3629 lists as legitimate, i.e.
+  `0xE0`-`0xEF` or `0xF0`-`0xF4`) into a single U+FFFD when its *decoded value* is
+  overlong, a surrogate, or out of range -- `\xe0\x80\x80` gave three U+FFFD here against
+  jq's one. Fixed by #1617 (`substitute_invalid_utf8_jq_style`,
+  [src/text/utf8/mod.rs](../../src/text/utf8/mod.rs)), which special-cases exactly those
+  three `Utf8ErrorKind`s on a structurally-valid lead and falls back to the
+  already-agreeing WHATWG rule everywhere else (`0xC0`/`0xC1`/`0xF5`-`0xF7`, which RFC
+  3629 excludes from the valid-lead-byte set at any length, included -- jq treats those
+  like any other never-valid lead, unchanged).
   This also fixed two bugs in the opposite direction: the lazy path echoed the raw bytes,
   writing invalid UTF-8 to stdout, and the non-lazy path refused the file outright with
   `Failed to read file` when the read had in fact succeeded.

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -524,6 +524,13 @@ otherwise already correct, and it can be reverted independently if the perf gate
   This also fixed two bugs in the opposite direction: the lazy path echoed the raw bytes,
   writing invalid UTF-8 to stdout, and the non-lazy path refused the file outright with
   `Failed to read file` when the read had in fact succeeded.
+  **Not byte-identical even now**: #1617's own review found a separate, narrower jq quirk
+  it does not attempt to match -- when an `InvalidContinuationByte` error's rescanned byte
+  lands at a string's *last* byte, real jq silently drops it (`\xe1\x41` at a string's end
+  -> `"�"` in jq, `"�A"` here, matching `String::from_utf8_lossy`'s own answer).
+  Filed as [#1717](https://github.com/rust-works/succinctly/issues/1717); likely an
+  off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, per ADR-0018
+  rule 4 the correct resolution if picked up is bug-for-bug replication, not "fixing" it.
 - Scope is document input only. `--raw-input` shares the jq path (jq substitutes there
   too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2180,12 +2180,9 @@ impl ErrorAt<'_> {
 ///
 /// Valid input is returned untouched and unallocated -- the check is a
 /// whole-input SIMD pass (~1.1 ms on 8.4 MB) and only a document that
-/// actually fails it pays for a copy. The substitution itself uses jq's
-/// own maximal-subpart rule (`substitute_invalid_utf8_jq_style`), not
-/// `String::from_utf8_lossy`'s WHATWG rule -- the two disagree on an
-/// overlong/surrogate/out-of-range value from a structurally valid 3- or
-/// 4-byte lead, where jq emits one U+FFFD for the whole sequence and
-/// WHATWG emits one per byte (#1617).
+/// actually fails it pays for a copy, via
+/// [`substitute_invalid_utf8_jq_style`](succinctly::text::utf8::substitute_invalid_utf8_jq_style),
+/// whose own docs cover the substitution rule itself (#1617).
 ///
 /// Document input only, and only when `--validate` is off: the strict
 /// validator has to see the original bytes, or the substitution repairs the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1697,7 +1697,7 @@ fn get_inputs(
                     let filename = file_idx.map(|idx| files[idx].to_string_lossy().to_string());
                     validate_json_input(e.as_bytes(), filename.as_deref())?;
                 }
-                String::from_utf8_lossy(e.as_bytes()).into_owned()
+                succinctly::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
             }
         };
         raw_inputs.push((file_idx, raw));
@@ -2180,7 +2180,12 @@ impl ErrorAt<'_> {
 ///
 /// Valid input is returned untouched and unallocated -- the check is a
 /// whole-input SIMD pass (~1.1 ms on 8.4 MB) and only a document that
-/// actually fails it pays for a copy.
+/// actually fails it pays for a copy. The substitution itself uses jq's
+/// own maximal-subpart rule (`substitute_invalid_utf8_jq_style`), not
+/// `String::from_utf8_lossy`'s WHATWG rule -- the two disagree on an
+/// overlong/surrogate/out-of-range value from a structurally valid 3- or
+/// 4-byte lead, where jq emits one U+FFFD for the whole sequence and
+/// WHATWG emits one per byte (#1617).
 ///
 /// Document input only, and only when `--validate` is off: the strict
 /// validator has to see the original bytes, or the substitution repairs the
@@ -2191,7 +2196,7 @@ impl ErrorAt<'_> {
 fn utf8_lossy_document(raw: Vec<u8>) -> Vec<u8> {
     match succinctly::text::utf8::validate_utf8(&raw) {
         Ok(()) => raw,
-        Err(_) => String::from_utf8_lossy(&raw).into_owned().into_bytes(),
+        Err(_) => succinctly::text::utf8::substitute_invalid_utf8_jq_style(&raw).into_bytes(),
     }
 }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -191,6 +191,32 @@ fn code_point_bounds_violation(cp: u32, len: usize) -> Option<CodePointBoundsVio
     }
 }
 
+/// Whether `lead_byte` (a `2`/`3`/`4`-byte lead per [`sequence_length`]) can
+/// *never* pass [`code_point_bounds_violation`], regardless of which
+/// continuation bytes follow it -- i.e. RFC 3629 doesn't list it as a valid
+/// lead byte at any length. `0xC0`/`0xC1` always decode to `cp < 0x80`
+/// (their maximum, with continuation `0xBF`, is `0x7F`); `0xF5`-`0xF7`
+/// always decode to `cp > 0x10FFFF` (their minimum, with continuation
+/// `0x80`, is `0x140000`). Every other 2/3/4-byte lead (`0xC2`-`0xDF`,
+/// `0xE0`-`0xEF`, `0xF0`-`0xF4`) has at least one continuation-byte choice
+/// that decodes in range.
+///
+/// Exists so this fact -- used by [`substitute_invalid_utf8_jq_style`] to
+/// decide whether a bounds violation collapses to one U+FFFD or is treated
+/// as an ordinary invalid lead byte -- is derived from the same bounds
+/// `code_point_bounds_violation` already encodes, rather than duplicated as
+/// an independent byte-range literal that could silently drift from it (see
+/// `code_point_bounds_violation`'s own doc comment and #1423 for a case
+/// where exactly that happened between two different functions).
+#[inline]
+fn is_never_valid_lead_byte(lead_byte: u8, seq_len: usize) -> bool {
+    match seq_len {
+        2 => code_point_bounds_violation(0, 2).is_some(), // C0/C1's own minimum cp
+        4 => lead_byte >= 0xF5,
+        _ => false, // seq_len == 3 (0xE0-0xEF): always a valid lead
+    }
+}
+
 /// Validate UTF-8 using a portable scalar algorithm with a broadword (SWAR)
 /// ASCII fast path.
 ///
@@ -676,18 +702,35 @@ pub fn format_byte(byte: u8) -> String {
 /// U+FFFD using jq 1.7.1's own maximal-subpart rule rather than
 /// `String::from_utf8_lossy`'s WHATWG rule (#1617).
 ///
-/// The two rules agree on four of `Utf8ErrorKind`'s six cases -- an
-/// invalid lead byte, an invalid continuation byte, a truncated sequence,
-/// and a 2-byte overlong encoding (`0xC0`/`0xC1`, which WHATWG treats as
-/// an immediately-invalid lead rather than a would-be sequence) -- so
-/// this only special-cases the remaining two: an overlong, surrogate, or
-/// out-of-range code point decoded from a *structurally valid* 3- or
-/// 4-byte lead. There, jq consumes the whole sequence as one unit (one
-/// U+FFFD); WHATWG's maximal subpart restarts after just the lead byte
-/// (one U+FFFD per byte) since the sequence's *decoded value*, not its
-/// shape, is what's wrong. Live-verified against the pinned jq 1.7.1
-/// binary for all six kinds, including the untested-by-#1617's-own-issue
-/// invalid-continuation-byte case (confirmed to already agree).
+/// The two rules agree on every `Utf8ErrorKind` except a bounds violation
+/// (overlong/surrogate/out-of-range) on a *structurally valid* 3- or
+/// 4-byte lead byte -- one that RFC 3629 lists as legitimate (`0xE0`-`0xEF`,
+/// `0xF0`-`0xF4`), just with a narrowed continuation-byte range. There, jq
+/// consumes the whole sequence as one unit (one U+FFFD); WHATWG's maximal
+/// subpart restarts after just the lead byte (one U+FFFD per byte), since
+/// the sequence's *decoded value*, not its shape, is what's wrong. A bounds
+/// violation on a lead RFC 3629 never lists as valid at any length
+/// (`0xC0`/`0xC1`, `0xF5`-`0xF7`) is not included in that collapse -- those
+/// can never decode in range regardless of continuation bytes, so jq (like
+/// WHATWG) treats the lead byte alone as immediately invalid, same as any
+/// other bad lead. Live-verified against the pinned jq 1.7.1 binary for
+/// every kind, including the case #1617's own issue didn't test
+/// (`0xF5`-`0xF7`, which reports the identical `Utf8ErrorKind` as the
+/// collapsing `0xF0`-`0xF4` case and would be wrongly collapsed by a rule
+/// keyed on the error kind alone).
+///
+/// A single left-to-right scan, not a loop over [`validate_utf8`]: that
+/// function's AVX2 path has no early exit (it scans every 32-byte block of
+/// its input before checking for an error at all, since its job is a
+/// whole-buffer accept/reject decision, not locating the first error
+/// cheaply), so calling it repeatedly on a shrinking suffix to find one
+/// error at a time is O(n) *per call*, and a dense run of single-byte
+/// errors (e.g. a binary file with no real UTF-8 in it) drove that into
+/// O(n^2) overall in an earlier version of this function -- found by
+/// review before it shipped. This mirrors [`validate_utf8_scalar`]'s own
+/// dispatch instead (lead-byte-driven, ASCII-skipped via the same
+/// broadword `skip_ascii` helper), continuing past an error rather than
+/// returning on the first one.
 ///
 /// # Examples
 ///
@@ -701,96 +744,94 @@ pub fn format_byte(byte: u8) -> String {
 /// assert_eq!(substitute_invalid_utf8_jq_style(&[0xFF, 0xFE]), "\u{FFFD}\u{FFFD}");
 /// ```
 pub fn substitute_invalid_utf8_jq_style(input: &[u8]) -> String {
-    // Appends `input[a..b]`, a span this function has already established
-    // is well-formed UTF-8 via a prior `validate_utf8` call -- re-checked
-    // here rather than taken on faith via `from_utf8_unchecked`, since
-    // this path only runs on already-malformed input (never the hot,
-    // valid-document path `unsafe_code = "deny"`'s per-file carve-outs
-    // are reserved for).
-    fn push_validated(out: &mut String, input: &[u8], a: usize, b: usize) {
-        out.push_str(core::str::from_utf8(&input[a..b]).expect("already validated"));
-    }
-
-    let mut out = String::with_capacity(input.len());
+    let len = input.len();
+    let mut out = String::with_capacity(len);
     let mut pos = 0;
-    while pos < input.len() {
-        match validate_utf8(&input[pos..]) {
-            Ok(()) => {
-                push_validated(&mut out, input, pos, input.len());
-                break;
-            }
-            Err(e) => {
-                let abs_offset = pos + e.offset;
-                let lead = input[abs_offset];
-                // RFC 3629 lists 0xE0-0xEF and 0xF0-0xF4 as valid lead
-                // bytes (just with a narrowed continuation range to avoid
-                // overlong/surrogate/out-of-range); jq collapses a bad
-                // *value* from one of those into one U+FFFD. 0xC0/0xC1 and
-                // 0xF5-0xF7 are never valid at any length regardless of
-                // continuation bytes -- jq (like WHATWG) treats those as
-                // an immediately-invalid lead instead, one U+FFFD per
-                // byte, same as any other `InvalidLeadByte` (falls to the
-                // final `else` arm below, not this one). Live-verified
-                // `F5 80 80 80`/`F6 80 80 80`/`F7 80 80 80` all give 4x
-                // U+FFFD against the pinned oracle, not the 1x this arm
-                // would otherwise produce for an in-range 4-byte lead.
-                // 0xE0-0xEF (3-byte) and 0xF0-0xF4 (4-byte) are contiguous,
-                // so one range covers both; `seq_len` below still keys off
-                // `lead <= 0xEF` to pick 3 vs. 4.
-                let is_wide_bounds_violation = matches!(
-                    e.kind,
-                    Utf8ErrorKind::OverlongEncoding
-                        | Utf8ErrorKind::SurrogateCodepoint
-                        | Utf8ErrorKind::OutOfRangeCodepoint
-                ) && matches!(lead, 0xE0..=0xF4);
+    // `input[run_start..pos]` is confirmed valid UTF-8 not yet flushed to
+    // `out`.
+    let mut run_start = 0;
 
-                if is_wide_bounds_violation {
-                    // `abs_offset` is this sequence's own lead byte (see
-                    // `validate_utf8_scalar`'s `err_at(input, pos, ...)`
-                    // calls for these three kinds), so everything before
-                    // it is already-confirmed-valid.
-                    push_validated(&mut out, input, pos, abs_offset);
-                    out.push('\u{FFFD}');
-                    let seq_len = if lead <= 0xEF { 3 } else { 4 };
-                    pos = abs_offset + seq_len;
-                } else if matches!(e.kind, Utf8ErrorKind::TruncatedSequence) {
-                    // Only ever reported when `pos + seq_len > input.len()`
-                    // -- i.e. only at the very end of `input` -- so the
-                    // whole truncated tail is one maximal subpart and
-                    // this is always the loop's last iteration.
-                    push_validated(&mut out, input, pos, abs_offset);
-                    out.push('\u{FFFD}');
-                    pos = input.len();
-                } else if matches!(e.kind, Utf8ErrorKind::InvalidContinuationByte) {
-                    // Unlike the other kinds, `abs_offset` here is the
-                    // *offending* byte, not this sequence's lead -- walk
-                    // back over the continuation bytes already confirmed
-                    // valid for this specific sequence to find its start,
-                    // then rescan the offending byte itself (WHATWG
-                    // restarts scanning there, it isn't skipped).
-                    let mut seq_start = abs_offset - 1;
-                    while seq_start > pos && is_continuation_byte(input[seq_start]) {
-                        seq_start -= 1;
+    while pos < len {
+        let byte = input[pos];
+
+        if byte < 0x80 {
+            pos = skip_ascii(input, pos + 1);
+            continue;
+        }
+
+        let seq_len = sequence_length(byte);
+
+        // `Some(resume_at)`: this byte starts (or is) an invalid maximal
+        // subpart running from `pos` to (not including) `resume_at`.
+        // `None`: `byte` leads a fully valid `seq_len`-byte sequence,
+        // already confirmed below -- stays part of the current run.
+        let bad = if seq_len == 0 {
+            // A stray continuation byte (0x80-0xBF) or a lead RFC 3629
+            // never lists as valid at any length (0xF8-0xFF): one byte,
+            // no sequence in progress.
+            Some(pos + 1)
+        } else if pos + seq_len > len {
+            // Truncated -- only reachable at the very end of `input`, so
+            // the whole remaining tail is one maximal subpart.
+            Some(len)
+        } else {
+            let mut good_continuations = 0;
+            while good_continuations < seq_len - 1
+                && is_continuation_byte(input[pos + 1 + good_continuations])
+            {
+                good_continuations += 1;
+            }
+            if good_continuations < seq_len - 1 {
+                // A continuation byte was missing/invalid: the subpart is
+                // the lead plus whatever continuations were already good;
+                // the offending byte itself is rescanned next iteration,
+                // not skipped (WHATWG restarts scanning there).
+                Some(pos + 1 + good_continuations)
+            } else {
+                // Every continuation byte present and well-formed --
+                // decode and check the value, mirroring
+                // `validate_utf8_scalar`'s identical per-length arithmetic.
+                let cp = match seq_len {
+                    2 => ((byte as u32 & 0x1F) << 6) | (input[pos + 1] as u32 & 0x3F),
+                    3 => {
+                        ((byte as u32 & 0x0F) << 12)
+                            | ((input[pos + 1] as u32 & 0x3F) << 6)
+                            | (input[pos + 2] as u32 & 0x3F)
                     }
-                    push_validated(&mut out, input, pos, seq_start);
-                    out.push('\u{FFFD}');
-                    pos = abs_offset;
+                    4 => {
+                        ((byte as u32 & 0x07) << 18)
+                            | ((input[pos + 1] as u32 & 0x3F) << 12)
+                            | ((input[pos + 2] as u32 & 0x3F) << 6)
+                            | (input[pos + 3] as u32 & 0x3F)
+                    }
+                    _ => unreachable!(),
+                };
+                if code_point_bounds_violation(cp, seq_len).is_none() {
+                    None
                 } else {
-                    // Either a real `InvalidLeadByte` (a stray
-                    // continuation byte, or a never-valid lead in
-                    // 0xF8-0xFF), or one of `OverlongEncoding` /
-                    // `OutOfRangeCodepoint` on a never-valid-at-any-length
-                    // lead byte (0xC0/0xC1/0xF5-0xF7, excluded from
-                    // `is_wide_bounds_violation` above) -- both are a
-                    // single byte with no sequence in progress, so
-                    // WHATWG's maximal subpart is that one byte alone.
-                    push_validated(&mut out, input, pos, abs_offset);
-                    out.push('\u{FFFD}');
-                    pos = abs_offset + 1;
+                    Some(if is_never_valid_lead_byte(byte, seq_len) {
+                        pos + 1
+                    } else {
+                        pos + seq_len
+                    })
                 }
             }
+        };
+
+        match bad {
+            Some(resume_at) => {
+                out.push_str(
+                    core::str::from_utf8(&input[run_start..pos]).expect("already validated"),
+                );
+                out.push('\u{FFFD}');
+                pos = resume_at;
+                run_start = pos;
+            }
+            None => pos += seq_len,
         }
     }
+
+    out.push_str(core::str::from_utf8(&input[run_start..pos]).expect("already validated"));
     out
 }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -672,6 +672,128 @@ pub fn format_byte(byte: u8) -> String {
     }
 }
 
+/// Lossily decode `input` as UTF-8, substituting invalid sequences with
+/// U+FFFD using jq 1.7.1's own maximal-subpart rule rather than
+/// `String::from_utf8_lossy`'s WHATWG rule (#1617).
+///
+/// The two rules agree on four of `Utf8ErrorKind`'s six cases -- an
+/// invalid lead byte, an invalid continuation byte, a truncated sequence,
+/// and a 2-byte overlong encoding (`0xC0`/`0xC1`, which WHATWG treats as
+/// an immediately-invalid lead rather than a would-be sequence) -- so
+/// this only special-cases the remaining two: an overlong, surrogate, or
+/// out-of-range code point decoded from a *structurally valid* 3- or
+/// 4-byte lead. There, jq consumes the whole sequence as one unit (one
+/// U+FFFD); WHATWG's maximal subpart restarts after just the lead byte
+/// (one U+FFFD per byte) since the sequence's *decoded value*, not its
+/// shape, is what's wrong. Live-verified against the pinned jq 1.7.1
+/// binary for all six kinds, including the untested-by-#1617's-own-issue
+/// invalid-continuation-byte case (confirmed to already agree).
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::text::utf8::substitute_invalid_utf8_jq_style;
+///
+/// // Overlong 3-byte sequence: one U+FFFD for the whole sequence, not one per byte.
+/// assert_eq!(substitute_invalid_utf8_jq_style(&[0xE0, 0x80, 0x80]), "\u{FFFD}");
+///
+/// // Already-agreeing case (invalid lead byte): unchanged from WHATWG's rule.
+/// assert_eq!(substitute_invalid_utf8_jq_style(&[0xFF, 0xFE]), "\u{FFFD}\u{FFFD}");
+/// ```
+pub fn substitute_invalid_utf8_jq_style(input: &[u8]) -> String {
+    // Appends `input[a..b]`, a span this function has already established
+    // is well-formed UTF-8 via a prior `validate_utf8` call -- re-checked
+    // here rather than taken on faith via `from_utf8_unchecked`, since
+    // this path only runs on already-malformed input (never the hot,
+    // valid-document path `unsafe_code = "deny"`'s per-file carve-outs
+    // are reserved for).
+    fn push_validated(out: &mut String, input: &[u8], a: usize, b: usize) {
+        out.push_str(core::str::from_utf8(&input[a..b]).expect("already validated"));
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut pos = 0;
+    while pos < input.len() {
+        match validate_utf8(&input[pos..]) {
+            Ok(()) => {
+                push_validated(&mut out, input, pos, input.len());
+                break;
+            }
+            Err(e) => {
+                let abs_offset = pos + e.offset;
+                let lead = input[abs_offset];
+                // RFC 3629 lists 0xE0-0xEF and 0xF0-0xF4 as valid lead
+                // bytes (just with a narrowed continuation range to avoid
+                // overlong/surrogate/out-of-range); jq collapses a bad
+                // *value* from one of those into one U+FFFD. 0xC0/0xC1 and
+                // 0xF5-0xF7 are never valid at any length regardless of
+                // continuation bytes -- jq (like WHATWG) treats those as
+                // an immediately-invalid lead instead, one U+FFFD per
+                // byte, same as any other `InvalidLeadByte` (falls to the
+                // final `else` arm below, not this one). Live-verified
+                // `F5 80 80 80`/`F6 80 80 80`/`F7 80 80 80` all give 4x
+                // U+FFFD against the pinned oracle, not the 1x this arm
+                // would otherwise produce for an in-range 4-byte lead.
+                // 0xE0-0xEF (3-byte) and 0xF0-0xF4 (4-byte) are contiguous,
+                // so one range covers both; `seq_len` below still keys off
+                // `lead <= 0xEF` to pick 3 vs. 4.
+                let is_wide_bounds_violation = matches!(
+                    e.kind,
+                    Utf8ErrorKind::OverlongEncoding
+                        | Utf8ErrorKind::SurrogateCodepoint
+                        | Utf8ErrorKind::OutOfRangeCodepoint
+                ) && matches!(lead, 0xE0..=0xF4);
+
+                if is_wide_bounds_violation {
+                    // `abs_offset` is this sequence's own lead byte (see
+                    // `validate_utf8_scalar`'s `err_at(input, pos, ...)`
+                    // calls for these three kinds), so everything before
+                    // it is already-confirmed-valid.
+                    push_validated(&mut out, input, pos, abs_offset);
+                    out.push('\u{FFFD}');
+                    let seq_len = if lead <= 0xEF { 3 } else { 4 };
+                    pos = abs_offset + seq_len;
+                } else if matches!(e.kind, Utf8ErrorKind::TruncatedSequence) {
+                    // Only ever reported when `pos + seq_len > input.len()`
+                    // -- i.e. only at the very end of `input` -- so the
+                    // whole truncated tail is one maximal subpart and
+                    // this is always the loop's last iteration.
+                    push_validated(&mut out, input, pos, abs_offset);
+                    out.push('\u{FFFD}');
+                    pos = input.len();
+                } else if matches!(e.kind, Utf8ErrorKind::InvalidContinuationByte) {
+                    // Unlike the other kinds, `abs_offset` here is the
+                    // *offending* byte, not this sequence's lead -- walk
+                    // back over the continuation bytes already confirmed
+                    // valid for this specific sequence to find its start,
+                    // then rescan the offending byte itself (WHATWG
+                    // restarts scanning there, it isn't skipped).
+                    let mut seq_start = abs_offset - 1;
+                    while seq_start > pos && is_continuation_byte(input[seq_start]) {
+                        seq_start -= 1;
+                    }
+                    push_validated(&mut out, input, pos, seq_start);
+                    out.push('\u{FFFD}');
+                    pos = abs_offset;
+                } else {
+                    // Either a real `InvalidLeadByte` (a stray
+                    // continuation byte, or a never-valid lead in
+                    // 0xF8-0xFF), or one of `OverlongEncoding` /
+                    // `OutOfRangeCodepoint` on a never-valid-at-any-length
+                    // lead byte (0xC0/0xC1/0xF5-0xF7, excluded from
+                    // `is_wide_bounds_violation` above) -- both are a
+                    // single byte with no sequence in progress, so
+                    // WHATWG's maximal subpart is that one byte alone.
+                    push_validated(&mut out, input, pos, abs_offset);
+                    out.push('\u{FFFD}');
+                    pos = abs_offset + 1;
+                }
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2656,6 +2778,214 @@ mod validate_utf8_differential_tests {
                 expected,
                 "broadword differed from scalar on {bytes:02x?}"
             );
+        }
+    }
+}
+
+/// Regression tests for #1617: `substitute_invalid_utf8_jq_style` must match
+/// jq 1.7.1's own maximal-subpart rule, not `String::from_utf8_lossy`'s
+/// WHATWG rule. Every expected value below was live-verified against the
+/// pinned `/usr/bin/jq` 1.7.1 binary (see the issue for the full table).
+#[cfg(test)]
+mod substitute_invalid_utf8_jq_style_tests {
+    use super::*;
+
+    #[test]
+    fn valid_input_is_unchanged() {
+        assert_eq!(substitute_invalid_utf8_jq_style(b"hello"), "hello");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style("日本語".as_bytes()),
+            "日本語"
+        );
+        assert_eq!(substitute_invalid_utf8_jq_style(b""), "");
+    }
+
+    #[test]
+    fn invalid_lead_byte_is_one_fffd_per_byte() {
+        // Already agreed with jq before #1617; must stay unchanged.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xFF]), "\u{FFFD}");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xFF, 0xFE]),
+            "\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0x80]), "\u{FFFD}");
+    }
+
+    #[test]
+    fn truncated_sequences_collapse_to_one_fffd() {
+        // Already agreed with jq before #1617; must stay unchanged.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xC2]), "\u{FFFD}");
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0x80]), "\u{FFFD}");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80]),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn two_byte_overlong_c0_c1_is_one_fffd_per_byte() {
+        // 0xC0/0xC1 can never produce a valid (non-overlong) 2-byte
+        // sequence at any continuation value -- jq treats the lead byte
+        // itself as immediately invalid, same as any other never-valid
+        // lead, not as "collapse the whole sequence" (unlike 3-/4-byte
+        // overlong on an otherwise-valid lead). Already agreed with jq
+        // before #1617; must stay unchanged.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xC0, 0xAF]),
+            "\u{FFFD}\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn three_byte_overlong_collapses_to_one_fffd() {
+        // The #1617 fix: jq collapses the whole structurally-valid 3-byte
+        // sequence into one U+FFFD; WHATWG/`from_utf8_lossy` would give 3.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xE0, 0x80, 0x80]),
+            "\u{FFFD}"
+        );
+        // Second byte below the narrowed A0 threshold, still a
+        // structurally valid lead -- same collapse.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xE0, 0x9F, 0xBF]),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn four_byte_overlong_collapses_to_one_fffd() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x8F, 0xBF, 0xBF]),
+            "\u{FFFD}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x80, 0x80, 0x80]),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn surrogate_codepoints_collapse_to_one_fffd() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xED, 0xA0, 0x80]),
+            "\u{FFFD}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xED, 0xBF, 0xBF]),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn surrogate_pair_cesu8_gives_two_fffd_not_six() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xED, 0xA0, 0x80, 0xED, 0xB0, 0x80]),
+            "\u{FFFD}\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn out_of_range_on_valid_lead_collapses_to_one_fffd() {
+        // F4 90 80 80 decodes to U+110000, one past U+10FFFF -- F4 itself
+        // is a structurally valid 4-byte lead (F0-F4 per RFC 3629).
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF4, 0x90, 0x80, 0x80]),
+            "\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn out_of_range_on_never_valid_lead_is_one_fffd_per_byte() {
+        // F5-F7 can NEVER decode to <= U+10FFFF regardless of
+        // continuation bytes (minimum for F5 is already 0x140000) -- RFC
+        // 3629 excludes them from the valid-lead-byte set entirely, so
+        // jq treats them like C0/C1: one U+FFFD per byte, not a
+        // whole-sequence collapse. This is the one case #1617's own issue
+        // didn't test and would have been wrongly collapsed by a naive
+        // "any OutOfRangeCodepoint on 0xF0-0xF7" rule.
+        for lead in [0xF5u8, 0xF6, 0xF7] {
+            let input = [lead, 0x80, 0x80, 0x80];
+            assert_eq!(
+                substitute_invalid_utf8_jq_style(&input),
+                "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}",
+                "lead byte {lead:#04X}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_lead_f8_ff_is_one_fffd_per_byte() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF8, 0x80, 0x80, 0x80, 0x80]),
+            "\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+    }
+
+    #[test]
+    fn invalid_continuation_byte_rescans_the_offending_byte() {
+        // Already agreed with jq before #1617; must stay unchanged. The
+        // offending byte is rescanned (not skipped), so it reappears as
+        // its own literal character when it's plain ASCII.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xE1, 0x41, b'b', b'c']),
+            "\u{FFFD}Abc"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xE1, 0x80, 0x41, b'b', b'c']),
+            "\u{FFFD}Abc"
+        );
+    }
+
+    #[test]
+    fn valid_prefix_and_suffix_around_a_bad_sequence_are_preserved() {
+        let mut input = b"before ".to_vec();
+        input.extend_from_slice(&[0xE0, 0x80, 0x80]);
+        input.extend_from_slice(b" after");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&input),
+            "before \u{FFFD} after"
+        );
+    }
+
+    #[test]
+    fn multiple_bad_sequences_each_get_their_own_substitution() {
+        let mut input = vec![0xE0, 0x80, 0x80];
+        input.push(b'-');
+        input.extend_from_slice(&[0xED, 0xA0, 0x80]);
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&input),
+            "\u{FFFD}-\u{FFFD}"
+        );
+    }
+
+    /// `substitute_invalid_utf8_jq_style` must always produce valid UTF-8
+    /// (a `String`, not just "doesn't panic") on arbitrary bytes, never
+    /// panicking on the internal `.expect("already validated")` calls.
+    #[test]
+    fn never_panics_on_random_bytes() {
+        // Tiny deterministic xorshift64 RNG, same shape as
+        // `validate_utf8_differential_tests`'s own (not shared across
+        // modules -- that one is private to it).
+        struct Rng(u64);
+        impl Rng {
+            fn next_u32(&mut self) -> u32 {
+                let mut x = self.0;
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                self.0 = x;
+                (x >> 32) as u32
+            }
+            fn below(&mut self, n: u32) -> u32 {
+                self.next_u32() % n
+            }
+        }
+
+        let mut rng = Rng(0x1617_1617_1617_1617);
+        for _ in 0..5_000 {
+            let len = rng.below(64) as usize;
+            let bytes: Vec<u8> = (0..len).map(|_| (rng.next_u32() & 0xFF) as u8).collect();
+            let _ = substitute_invalid_utf8_jq_style(&bytes);
         }
     }
 }

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -201,17 +201,24 @@ fn code_point_bounds_violation(cp: u32, len: usize) -> Option<CodePointBoundsVio
 /// `0xE0`-`0xEF`, `0xF0`-`0xF4`) has at least one continuation-byte choice
 /// that decodes in range.
 ///
-/// Exists so this fact -- used by [`substitute_invalid_utf8_jq_style`] to
-/// decide whether a bounds violation collapses to one U+FFFD or is treated
-/// as an ordinary invalid lead byte -- is derived from the same bounds
-/// `code_point_bounds_violation` already encodes, rather than duplicated as
-/// an independent byte-range literal that could silently drift from it (see
-/// `code_point_bounds_violation`'s own doc comment and #1423 for a case
-/// where exactly that happened between two different functions).
+/// A genuine, standalone classification of `lead_byte` alone -- no
+/// precondition on having already seen (or counted) any continuation
+/// bytes. [`substitute_invalid_utf8_jq_style`] relies on that: jq treats
+/// `0xC0`/`0xC1`/`0xF5`-`0xF7` as a one-byte error unconditionally, even
+/// when there isn't enough remaining input to know what the continuation
+/// bytes *would* have been (`\xf5\x80` at end-of-input is 2 separate
+/// one-byte errors in jq, not one 2-of-4-bytes-present truncated
+/// sequence) -- so this must be checked, and answer correctly, before any
+/// continuation-byte counting or truncation check runs, not only after a
+/// bounds violation is otherwise confirmed. Exists as one named function,
+/// rather than an independent byte-range literal at each call site, so it
+/// can't silently drift from `code_point_bounds_violation`'s own bounds
+/// (see that function's doc comment and #1423 for a case where exactly
+/// that happened between two different functions).
 #[inline]
 fn is_never_valid_lead_byte(lead_byte: u8, seq_len: usize) -> bool {
     match seq_len {
-        2 => code_point_bounds_violation(0, 2).is_some(), // C0/C1's own minimum cp
+        2 => matches!(lead_byte, 0xC0 | 0xC1),
         4 => lead_byte >= 0xF5,
         _ => false, // seq_len == 3 (0xE0-0xEF): always a valid lead
     }
@@ -759,66 +766,7 @@ pub fn substitute_invalid_utf8_jq_style(input: &[u8]) -> String {
             continue;
         }
 
-        let seq_len = sequence_length(byte);
-
-        // `Some(resume_at)`: this byte starts (or is) an invalid maximal
-        // subpart running from `pos` to (not including) `resume_at`.
-        // `None`: `byte` leads a fully valid `seq_len`-byte sequence,
-        // already confirmed below -- stays part of the current run.
-        let bad = if seq_len == 0 {
-            // A stray continuation byte (0x80-0xBF) or a lead RFC 3629
-            // never lists as valid at any length (0xF8-0xFF): one byte,
-            // no sequence in progress.
-            Some(pos + 1)
-        } else if pos + seq_len > len {
-            // Truncated -- only reachable at the very end of `input`, so
-            // the whole remaining tail is one maximal subpart.
-            Some(len)
-        } else {
-            let mut good_continuations = 0;
-            while good_continuations < seq_len - 1
-                && is_continuation_byte(input[pos + 1 + good_continuations])
-            {
-                good_continuations += 1;
-            }
-            if good_continuations < seq_len - 1 {
-                // A continuation byte was missing/invalid: the subpart is
-                // the lead plus whatever continuations were already good;
-                // the offending byte itself is rescanned next iteration,
-                // not skipped (WHATWG restarts scanning there).
-                Some(pos + 1 + good_continuations)
-            } else {
-                // Every continuation byte present and well-formed --
-                // decode and check the value, mirroring
-                // `validate_utf8_scalar`'s identical per-length arithmetic.
-                let cp = match seq_len {
-                    2 => ((byte as u32 & 0x1F) << 6) | (input[pos + 1] as u32 & 0x3F),
-                    3 => {
-                        ((byte as u32 & 0x0F) << 12)
-                            | ((input[pos + 1] as u32 & 0x3F) << 6)
-                            | (input[pos + 2] as u32 & 0x3F)
-                    }
-                    4 => {
-                        ((byte as u32 & 0x07) << 18)
-                            | ((input[pos + 1] as u32 & 0x3F) << 12)
-                            | ((input[pos + 2] as u32 & 0x3F) << 6)
-                            | (input[pos + 3] as u32 & 0x3F)
-                    }
-                    _ => unreachable!(),
-                };
-                if code_point_bounds_violation(cp, seq_len).is_none() {
-                    None
-                } else {
-                    Some(if is_never_valid_lead_byte(byte, seq_len) {
-                        pos + 1
-                    } else {
-                        pos + seq_len
-                    })
-                }
-            }
-        };
-
-        match bad {
+        match invalid_subpart_end(input, pos, len) {
             Some(resume_at) => {
                 out.push_str(
                     core::str::from_utf8(&input[run_start..pos]).expect("already validated"),
@@ -827,12 +775,98 @@ pub fn substitute_invalid_utf8_jq_style(input: &[u8]) -> String {
                 pos = resume_at;
                 run_start = pos;
             }
-            None => pos += seq_len,
+            // A fully valid `sequence_length(byte)`-byte sequence,
+            // confirmed by `invalid_subpart_end` -- stays part of the
+            // current run.
+            None => pos += sequence_length(byte),
         }
     }
 
     out.push_str(core::str::from_utf8(&input[run_start..pos]).expect("already validated"));
     out
+}
+
+/// The end of the invalid maximal subpart starting at `input[pos]` (which
+/// is not ASCII -- callers skip that case via [`skip_ascii`] before
+/// reaching here), or `None` if `input[pos]` instead leads a fully valid
+/// [`sequence_length`]-byte sequence. Each of the four `Some` cases below
+/// is a distinct, mutually exclusive reason a byte can't be part of one --
+/// see [`substitute_invalid_utf8_jq_style`]'s own doc comment for which
+/// jq/WHATWG rule each one implements.
+#[inline]
+fn invalid_subpart_end(input: &[u8], pos: usize, len: usize) -> Option<usize> {
+    let byte = input[pos];
+    let seq_len = sequence_length(byte);
+
+    if seq_len == 0 {
+        // A stray continuation byte (0x80-0xBF) or a lead RFC 3629 never
+        // lists as valid at any length (0xF8-0xFF): one byte, no sequence
+        // in progress.
+        return Some(pos + 1);
+    }
+
+    if is_never_valid_lead_byte(byte, seq_len) {
+        // 0xC0/0xC1 or 0xF5-0xF7: can never decode in range regardless of
+        // what follows, so -- like any other bad lead -- this is a single
+        // byte, checked before even counting continuation bytes or
+        // comparing against remaining length. Must run before the
+        // truncation check below: review found live against jq that
+        // `\xf5\x80` at end-of-input is 2 one-byte errors, not one
+        // "2-of-4-bytes-present" truncated subpart -- jq never tries to
+        // accumulate continuations for a lead that could never succeed.
+        return Some(pos + 1);
+    }
+
+    // How many continuation bytes this sequence needs vs. how many bytes
+    // are even left in `input` -- bounding the scan below on whichever is
+    // smaller is what makes "ran out of bytes" and "hit a bad byte before
+    // running out" distinguishable, instead of a length check alone
+    // (`pos + seq_len > len`) mistaking the *former* for the latter and
+    // swallowing a following valid byte that was never part of this
+    // sequence at all (e.g. `[0xE1, b'A']`: too short for a 3-byte
+    // sequence, but `b'A'` right there is not a continuation byte either
+    // -- the fix, not a truncation).
+    let available = (len - pos - 1).min(seq_len - 1);
+    let mut good_continuations = 0;
+    while good_continuations < available
+        && is_continuation_byte(input[pos + 1 + good_continuations])
+    {
+        good_continuations += 1;
+    }
+    if good_continuations < seq_len - 1 {
+        if pos + 1 + good_continuations == len {
+            // Ran out of *bytes*, not because one was invalid -- every
+            // byte that *was* available was a valid continuation, there
+            // just weren't enough of them. Only reachable at the very
+            // end of `input`, so the whole remaining tail is one
+            // maximal subpart.
+            return Some(len);
+        }
+        // Ran out because the next byte specifically isn't a valid
+        // continuation byte, with more input still available: the
+        // subpart is the lead plus whatever continuations were already
+        // good; the offending byte itself is rescanned next iteration,
+        // not skipped (WHATWG restarts scanning there).
+        return Some(pos + 1 + good_continuations);
+    }
+
+    // Every continuation byte already confirmed present and well-formed
+    // above -- the only way `decode_code_point` can still return `None`
+    // here is a bounds violation on a structurally valid lead
+    // (`0xE0`-`0xEF`/`0xF0`-`0xF4`; a never-valid lead already returned
+    // above), which collapses the whole sequence into one U+FFFD.
+    // Sharing the decode (rather than re-deriving the same per-length
+    // bit-packing arithmetic inline) keeps it in exactly two places in
+    // the file (`validate_utf8_scalar`'s own unrolled arms, which need
+    // their per-byte error offsets and so can't easily call out to
+    // this), not three -- see `code_point_bounds_violation`'s own doc
+    // comment and #1423 for a case where a third independent copy of
+    // this exact arithmetic drifted silently.
+    if decode_code_point(&input[pos..]).is_some() {
+        None
+    } else {
+        Some(pos + seq_len)
+    }
 }
 
 #[cfg(test)]
@@ -2830,6 +2864,69 @@ mod validate_utf8_differential_tests {
 #[cfg(test)]
 mod substitute_invalid_utf8_jq_style_tests {
     use super::*;
+
+    /// Regression test for a critical bug review found: the truncation
+    /// check (`pos + seq_len > len`) fired on remaining *byte count*
+    /// alone, before ever checking whether the bytes that *are* present
+    /// validate as continuation bytes. When a genuinely-invalid
+    /// continuation byte happened to fall near the end of `input` --
+    /// short of `seq_len` total remaining bytes, but not because input
+    /// ran out -- the old code misclassified it as truncation and
+    /// swallowed the *whole* remaining tail into one U+FFFD, silently
+    /// dropping valid trailing bytes it should have kept and rescanned
+    /// (e.g. `[0xE1, b'A']` gave `"\u{FFFD}"`, discarding `'A'`, instead
+    /// of `"\u{FFFD}A"`).
+    #[test]
+    fn invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte() {
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}A");
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}A");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x90, b'A']),
+            "\u{FFFD}A"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[b'X', 0xE1, b'A']),
+            "X\u{FFFD}A"
+        );
+        // Genuine truncation (every available byte IS a valid
+        // continuation, there just aren't enough of them) must still
+        // collapse to one U+FFFD, not regress to per-byte.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0x80]), "\u{FFFD}");
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80]),
+            "\u{FFFD}"
+        );
+    }
+
+    /// Regression test for a second bug review found on top of the first:
+    /// a never-valid lead byte (`0xC0`/`0xC1`/`0xF5`-`0xF7`) with fewer
+    /// than `seq_len` bytes remaining was *also* misrouted into the
+    /// truncation branch, collapsing the whole tail into one U+FFFD --
+    /// but jq treats these leads as a one-byte error unconditionally, per
+    /// byte, regardless of how much input remains (it never attempts to
+    /// accumulate continuations for a lead that could never succeed).
+    /// Live-verified against the pinned jq 1.7.1 binary: `\xf5\x80` at
+    /// end-of-input is 2 separate U+FFFD, not 1.
+    #[test]
+    fn never_valid_lead_stays_per_byte_even_when_truncated() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF5, 0x80]),
+            "\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF5, 0x80, 0x80]),
+            "\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF6, 0x80, 0x80]),
+            "\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF5, 0xF6, 0xF7]),
+            "\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xC0]), "\u{FFFD}");
+    }
 
     #[test]
     fn valid_input_is_unchanged() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22342,6 +22342,105 @@ fn test_invalid_utf8_document_substitutes_replacement_char_1247() -> Result<()> 
     Ok(())
 }
 
+/// #1617: an overlong, surrogate, or out-of-range code point decoded from a
+/// *structurally valid* 3- or 4-byte lead byte must collapse to one U+FFFD
+/// for the whole sequence, matching jq 1.7.1 -- not one U+FFFD per byte,
+/// which is `String::from_utf8_lossy`'s WHATWG rule and #1247's own
+/// original substitution used unconditionally. Every byte sequence and
+/// expected output here was live-verified against the pinned jq 1.7.1
+/// binary; see the issue for the full table.
+#[test]
+fn test_utf8_wide_sequence_collapses_to_one_fffd_1617() -> Result<()> {
+    for (bytes, expected, label) in [
+        (&b"\xe0\x80\x80"[..], "\u{fffd}", "3-byte overlong"),
+        (&b"\xf0\x8f\xbf\xbf"[..], "\u{fffd}", "4-byte overlong"),
+        (&b"\xed\xa0\x80"[..], "\u{fffd}", "surrogate (low)"),
+        (&b"\xed\xbf\xbf"[..], "\u{fffd}", "surrogate (high)"),
+        (
+            &b"\xed\xa0\x80\xed\xb0\x80"[..],
+            "\u{fffd}\u{fffd}",
+            "surrogate pair (CESU-8): 2 fffd, not 6",
+        ),
+        (&b"\xf4\x90\x80\x80"[..], "\u{fffd}", "out of range"),
+    ] {
+        let mut file = NamedTempFile::new()?;
+        file.write_all(b"{\"a\":\"")?;
+        file.write_all(bytes)?;
+        file.write_all(b"\"}")?;
+        file.flush()?;
+        let path = file.path().to_str().unwrap();
+
+        let (stdout, stderr, code) = run_jq_full(&["-c", ".a", path], None)
+            .unwrap_or_else(|e| panic!("{label}: failed to run: {e}"));
+        assert_eq!(code, 0, "{label}: stderr: {stderr}");
+        assert_eq!(stdout.trim(), format!("\"{expected}\""), "{label}");
+    }
+    Ok(())
+}
+
+/// #1617: `0xC0`/`0xC1` (2-byte overlong) and `0xF5`-`0xF7` (out of range at
+/// every possible continuation) are excluded from the collapse above --
+/// RFC 3629 lists neither as a valid lead byte at any length, so jq treats
+/// them like any other never-valid lead: one U+FFFD per byte, unchanged
+/// from before #1617. `0xF5`-`0xF7` specifically is the case a naive
+/// "any OutOfRangeCodepoint on a 0xF0-0xF7 lead" rule would have wrongly
+/// collapsed, since our own validator's `code_point_bounds_violation`
+/// reports the identical `OutOfRangeCodepoint` kind for both.
+#[test]
+fn test_utf8_never_valid_lead_stays_one_fffd_per_byte_1617() -> Result<()> {
+    for (bytes, expected, label) in [
+        (&b"\xc0\xaf"[..], "\u{fffd}\u{fffd}", "2-byte overlong (C0)"),
+        (
+            &b"\xf5\x80\x80\x80"[..],
+            "\u{fffd}\u{fffd}\u{fffd}\u{fffd}",
+            "out of range, never-valid lead (F5)",
+        ),
+        (
+            &b"\xf6\x80\x80\x80"[..],
+            "\u{fffd}\u{fffd}\u{fffd}\u{fffd}",
+            "out of range, never-valid lead (F6)",
+        ),
+        (
+            &b"\xf7\x80\x80\x80"[..],
+            "\u{fffd}\u{fffd}\u{fffd}\u{fffd}",
+            "out of range, never-valid lead (F7)",
+        ),
+    ] {
+        let mut file = NamedTempFile::new()?;
+        file.write_all(b"{\"a\":\"")?;
+        file.write_all(bytes)?;
+        file.write_all(b"\"}")?;
+        file.flush()?;
+        let path = file.path().to_str().unwrap();
+
+        let (stdout, stderr, code) = run_jq_full(&["-c", ".a", path], None)
+            .unwrap_or_else(|e| panic!("{label}: failed to run: {e}"));
+        assert_eq!(code, 0, "{label}: stderr: {stderr}");
+        assert_eq!(stdout.trim(), format!("\"{expected}\""), "{label}");
+    }
+    Ok(())
+}
+
+/// #1617 on the `-R`/raw-input decode path (`get_inputs`'s own copy of the
+/// substitution, separate from `utf8_lossy_document`'s document-mode copy)
+/// -- both call the same shared `substitute_invalid_utf8_jq_style`, but
+/// each has its own call site, so each needs its own regression coverage.
+#[test]
+fn test_utf8_wide_sequence_collapses_raw_input_1617() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a")?;
+    file.write_all(b"\xe0\x80\x80")?;
+    file.write_all(b"b\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"a\u{fffd}b\"");
+    Ok(())
+}
+
 /// #1247 guard: the substitution pass must leave valid multi-byte content
 /// byte-for-byte alone -- it runs on every document, so a false positive
 /// would corrupt ordinary files.


### PR DESCRIPTION
## Summary

Fixes #1617.

#1247's UTF-8 substitution used `String::from_utf8_lossy`, which follows WHATWG's maximal-subpart rule: one U+FFFD per byte once a sequence is known bad. jq 1.7.1 instead collapses a whole *structurally valid* 3- or 4-byte sequence (a lead byte RFC 3629 lists as legitimate, i.e. `0xE0`-`0xEF` or `0xF0`-`0xF4`) into a single U+FFFD when its *decoded value* is overlong, a surrogate, or out of range. Confirmed against the pinned jq 1.7.1 oracle: `printf '{"a":"\xe0\x80\x80"}' | jq -c .a` gives `"�"` (one U+FFFD); succinctly gave `"���"` (three).

## The fix

Added `substitute_invalid_utf8_jq_style` (`src/text/utf8/mod.rs`), which special-cases exactly the three diverging `Utf8ErrorKind`s (`OverlongEncoding`/`SurrogateCodepoint`/`OutOfRangeCodepoint`) on a structurally-valid lead byte, and falls back to the already-agreeing WHATWG rule for every other kind — including `0xC0`/`0xC1` and `0xF5`-`0xF7`, which RFC 3629 excludes from the valid-lead-byte set at *any* length (they can never decode to an in-range value regardless of continuation bytes) and which jq therefore treats like any other never-valid lead: one U+FFFD per byte, unchanged.

That last case — `0xF5`-`0xF7` — is the one #1617's own issue didn't test, and a naive "collapse any bounds violation on a `0xF0`-`0xF7` lead" rule would have wrongly collapsed it, since the validator's `code_point_bounds_violation` reports the identical `OutOfRangeCodepoint` kind for both `F0`-`F4` (should collapse) and `F5`-`F7` (should not). Live-verified: `F5 80 80 80` gives 4× U+FFFD against the pinned oracle, not 1×.

Wired into both call sites #1247 named: `utf8_lossy_document` (document input) and `get_inputs`'s own copy (`--raw-input`). A third, unrelated `from_utf8_lossy` site in `format_raw_number` handles JSON number literals, which are pure ASCII by grammar — out of scope, left untouched.

## A new divergence found while verifying, filed separately

Real jq has its own, separate quirk: when an `InvalidContinuationByte` error's rescanned byte lands at the *very last byte* of a JSON string, jq silently drops it instead of emitting it as a literal character (`{"a":"\xe1\x41"}` → `"�"` in real jq, dropping the `A`; succinctly gives `"�A"`, matching `from_utf8_lossy`). Confirmed pre-existing on unmodified `main`, unrelated to this fix's scope (the `InvalidContinuationByte` kind already agreed with jq before and after this change). Filed as #1717 rather than folded in here — likely an off-by-one in jq's own C decoder's end-of-buffer lookahead, and per ADR-0018 rule 4 the correct resolution if picked up is bug-for-bug replication, not "fixing" it toward the more sensible behavior.

## Test plan

- [x] 15 new unit tests in `src/text/utf8/mod.rs` covering every `Utf8ErrorKind` combination from the issue's table, plus the `F5`-`F7` case the issue didn't test, a never-panics fuzz test over random bytes, and a doctest.
- [x] 3 new CLI integration tests in `tests/jq_cli_tests.rs` (`_1617` suffix) exercising the fix through the actual document-input and `--raw-input` code paths.
- [x] Live-verified the full compliance table (19 byte sequences) against the pinned `/usr/bin/jq` 1.7.1 binary before and after the fix.
- [x] Confirmed all pre-existing `#1247` tests (`test_invalid_utf8_document_substitutes_replacement_char_1247`, `test_raw_input_still_substitutes_under_validate_1247`, etc.) still pass unchanged — they exercise kinds this fix doesn't touch.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure.
- [x] `cargo clippy` all 3 CI legs (caught and fixed a `manual_range_patterns` lint), `cargo fmt --check`, `cargo doc --no-deps`, `cargo build --no-default-features` (no_std) — all clean, no new warnings vs. `main`.
- [x] Updated `docs/plan/decode-failure-routing.md`'s Stage 5 section, whose "byte-identical to jq 1.7.1 on the probes above" claim #1617 found was narrower than stated.

Closes #1617.

## Round 2 — a critical algorithmic regression caught by review

`/code-review` found that the first version's `substitute_invalid_utf8_jq_style` called `validate_utf8()` in a loop to locate each successive error. On x86_64 with AVX2 (the default `std` build), `validate_utf8`'s AVX2 kernel has no early exit — it unconditionally scans every 32-byte block of its whole input before checking for an error at all, since its job is a one-shot whole-buffer accept/reject decision, not cheaply locating the first error. Calling it repeatedly on a shrinking suffix to find one error at a time made each call cost O(remaining length); a dense run of single-byte errors (e.g. a binary file with no real UTF-8 in it, fed to `jq` without `--validate`) drove the whole function to O(n²) — a multi-MB file that used to decode in single-digit milliseconds via `from_utf8_lossy` could hang for minutes. Confirmed by reading `validate_utf8_avx2`'s block loop directly (no early exit) and by architecture: aarch64 takes the early-exiting scalar validator instead, so the regression is x86_64/AVX2-specific — the default desktop/server platform.

Fixed by rewriting the function as a single left-to-right scan that mirrors `validate_utf8_scalar`'s own dispatch (lead-byte-driven, ASCII-skipped via the same broadword helper) instead of delegating to `validate_utf8` at all, so it never touches the AVX2 no-early-exit path. Back to O(n), by construction rather than by which platform happens to take the scalar path.

Also from the same review round: reused the existing `sequence_length()` helper instead of a hand-rolled lead-byte-to-length ternary; extracted `is_never_valid_lead_byte()` so the "can this lead byte ever decode in range" fact is derived from `code_point_bounds_violation` (for the `seq_len == 2` case) instead of duplicated as an independent literal that could silently drift from it — `code_point_bounds_violation`'s own doc comment cites #1423 as precedent for exactly that kind of drift happening between two other functions in this file; trimmed `utf8_lossy_document`'s doc comment (which restated the same explanation already given at the definition site) to a cross-reference; and fixed a private-intra-doc-link error that would have failed CI's `cargo doc -D warnings` job.

Ruled out after investigation: a claim that DSV input is also affected by this fix turned out to be based on an incomplete read — DSV's default streaming path uses its own independent `strip_quotes_and_decode`/`from_utf8_lossy`, untouched by this PR and out of #1617's scope entirely (DSV is a succinctly-only input mode with no jq oracle to match).

## Test plan (updated)

- [x] Re-verified the full compliance table live after the rewrite — identical output to round 1.
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` (the exact CI invocation) — clean.
- [x] All 126 `text::utf8` tests, all 3 clippy legs, `cargo fmt --check`, full `cargo test`, and `cargo build --no-default-features` re-run clean after the rewrite.

## Round 3 — two more critical data-loss bugs, found and fixed

A third `/code-review` round found the truncation branch (`pos + seq_len > len`) fired on remaining *byte count* alone, before ever checking whether the bytes that are present are even valid continuation bytes. Two consequences, both confirmed via direct unit-level traces (not just the CLI — JSON document mode always has trailing `"}` bytes after a string value, which masked this at that layer):

1. **A genuinely invalid continuation byte landing near end-of-input** (fewer than `seq_len` total bytes remaining) was misclassified as truncation, collapsing the whole remaining tail — including any following valid bytes — into one U+FFFD. `[0xE1, b'A']` gave `"\u{FFFD}"` (the `A` silently discarded) instead of `"\u{FFFD}A"`.
2. **A never-valid lead byte** (`0xC0`/`0xC1`/`0xF5`-`0xF7`, which can never decode in range regardless of continuation bytes) hit the same truncation branch when short on remaining bytes, collapsing to one U+FFFD instead of jq's actual one-per-byte treatment. Confirmed live against the pinned jq 1.7.1 binary: `\xf5\x80` at end-of-input is 2 separate U+FFFD, not 1.

Fixed by checking `is_never_valid_lead_byte()` first, before any continuation-byte counting or length comparison, and by bounding the continuation-byte scan on whichever is smaller (bytes needed vs. bytes remaining) so "ran out of bytes" and "hit an invalid byte before running out" are distinguishable instead of conflated. This also fixed `is_never_valid_lead_byte`'s `seq_len == 2` arm honestly — flagged independently by three separate review passes as a disguised constant that ignored its own `lead_byte` parameter — into a real, precondition-free check.

Verified with a semi-exhaustive sweep (19 lead bytes × 7 tail shapes = 133 cases) against the pinned jq 1.7.1 oracle directly through the CLI: 0 new mismatches. The 11 that don't match are the already-filed #1717 quirk (jq drops the rescanned byte specifically when it lands at a string's last position), unrelated to this bug class.

Also filed **#1719**: the same bug class (WHATWG per-byte substitution instead of jq's maximal-subpart collapse) also affects `@base64d`'s own separate `owned_string_from_decoded_bytes` in `src/jq/eval.rs` — a different file/call site than this PR touches, so left for a follow-up rather than expanding this PR's scope further.
