### PR TITLE
fix(jq): warn on stderr for a --seq record with no RS byte anywhere

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1087,6 +1087,40 @@ this. Tracked in
 (item 9) as a residual, not silently reintroduced — `each_limit_generic`'s own doc comment
 carries the same note at the call site.
 
+## `--seq`'s malformed-record warning covers one of jq's several message shapes
+
+Real jq warns on stderr ("`jq: ignoring parse error: ...`") whenever it silently drops a
+malformed `--seq` (RFC 7464) record; `succinctly jq` used to drop the record with no
+diagnostic at all. [#1525](https://github.com/rust-works/succinctly/issues/1525) added the
+warning for exactly one of jq's message templates: content with no RS byte anywhere in the
+input, where jq's own reader never resyncs onto anything and reports the abandonment
+unconditionally at EOF ("`Unfinished abandoned text at EOF at line L, column C`") regardless
+of what the content actually is, even fully valid JSON:
+
+```
+$ printf '1 2' | jq --seq -c '.'                  # jq:          jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 3
+$ printf '1 2' | succinctly jq --seq -c '.'       # succinctly:  same (#1525)
+```
+
+A malformed record that *does* start with an RS byte gets one of at least three other jq
+message templates instead, depending on exactly how it's malformed — none implemented yet:
+
+```
+$ printf '\x1e"unterminated\n' | jq --seq -c '.'
+jq: ignoring parse error: Unfinished string at EOF at line 2, column 0
+$ printf '\x1e[1,2\n'          | jq --seq -c '.'
+jq: ignoring parse error: Unfinished JSON term at EOF at line 2, column 0
+$ printf '\x1exyz\n'           | jq --seq -c '.'
+jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)
+```
+
+`succinctly jq --seq` emits nothing on stderr for any of these — output-wise it's already
+correct (RFC 7464's own recommended failure mode, #1093/#1267/#1243: the malformed record is
+dropped either way), the gap is purely the missing diagnostic. Matching these needs enough
+of jq's own incremental-parser failure classification to know which of its internal states a
+segment would have failed in, not just whether it parses — deliberately deferred, tracked in
+[#1723](https://github.com/rust-works/succinctly/issues/1723).
+
 ## Deliberate divergences (ADR-0018 rule 4)
 
 ### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1121,6 +1121,26 @@ of jq's own incremental-parser failure classification to know which of its inter
 segment would have failed in, not just whether it parses — deliberately deferred, tracked in
 [#1723](https://github.com/rust-works/succinctly/issues/1723).
 
+A second, narrower gap `succinctly jq --seq` also deliberately stays silent on: `-n`
+combined with a filter that forces a real read (`input`/`inputs`) turns the identical
+no-RS-byte condition into a **fatal** error on real jq (exit 5), not a warning:
+
+```
+$ printf '1 2' | jq -n --seq -c '[inputs]'
+jq: error (at <stdin>:0): Unfinished abandoned text at EOF at line 1, column 3
+$ printf '1 2' | succinctly jq -n --seq -c '[inputs]'
+[]
+```
+
+`succinctly jq` has never implemented this fatal-vs-warning distinction (predates #1525, not
+a regression); #1525 specifically avoids printing the warning's exact wording in this one
+mode (`!args.null_input` in `seq_no_rs_byte_warning`'s call site,
+[src/bin/succinctly/jq_runner.rs](../../../src/bin/succinctly/jq_runner.rs)), since doing so
+would make the still-wrong exit code/output look like it now matched jq's message. Fixing the
+underlying exit-code divergence properly needs `get_inputs` to be able to raise a real,
+fatal `EvalError` from this specific condition rather than only ever warning or returning
+values — not attempted here.
+
 ## Deliberate divergences (ADR-0018 rule 4)
 
 ### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy

--- a/src/bin/succinctly/front_matter.rs
+++ b/src/bin/succinctly/front_matter.rs
@@ -50,7 +50,12 @@ impl std::error::Error for FrontMatterError {}
 
 /// A leading UTF-8 BOM, if present, sits before the `---` fence rather than
 /// inside it -- common in Markdown files saved by Windows editors.
-const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+///
+/// `pub(crate)` rather than private: `jq_runner.rs`'s own `--seq` "no RS
+/// byte anywhere" diagnostic (#1525) strips the same 3 bytes before its
+/// own line/column count, matching real jq's identical BOM-stripping
+/// there.
+pub(crate) const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
 
 /// Split `input` into its YAML front matter and trailing body.
 ///

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1672,83 +1672,25 @@ fn get_inputs(
     // #1525: real jq warns on stderr when it drops a malformed --seq
     // record; succinctly silently ignored malformed records entirely
     // (RFC 7464's own recommended failure mode, #1243, still correct for
-    // *output*) with no diagnostic. This covers exactly one of jq's
-    // several message shapes: content with no RS byte anywhere at all.
-    // RFC 7464 requires every record to start with one, so jq's --seq
-    // reader never resyncs onto unprefixed content -- it reports the
-    // abandonment unconditionally the instant EOF arrives, regardless of
-    // what the content actually is, even fully valid JSON (oracle-
-    // verified: `printf 'null' | jq --seq '.'` still warns). A malformed
-    // record that *does* start with an RS byte gets one of several other
-    // jq message templates ("Unfinished string at EOF", "Unfinished JSON
-    // term at EOF", "Invalid numeric literal ... (need RS to resync)")
-    // depending on exactly how it's malformed -- and an RS-containing
-    // source combined with a *non-empty* RS-less one still warns with one
-    // of those other templates too, not silence (only the all-empty
-    // sub-case of that combination is handled below, oracle-verified: a
-    // non-empty RS-less file paired with an RS-containing one still gets
-    // one of the un-implemented templates). Matching any of that needs
-    // deeper investigation into jq's own incremental-parser error states
-    // and is intentionally out of scope here; tracked separately (#1723).
-    //
-    // Checked once across every source's *raw* bytes, before UTF-8
-    // substitution (#1617) can inflate the count real jq's own column
-    // arithmetic counts against -- an invalid byte becomes a 3-byte
-    // U+FFFD there, which would overcount the column by 2 for every
-    // substituted byte. `!args.raw_input` and `args.input_dsv.is_none()`
-    // both matter: `-R` takes over raw-text handling entirely (matching
-    // `slurp_eof_line` below's identical priority), and DSV content read
-    // via `-s`/`-n 'inputs'` (the only way DSV input reaches this
-    // function -- non-slurp DSV has its own streaming path that bypasses
-    // `get_inputs` entirely) never contains RFC 7464 records at all, so
-    // neither combination should ever trigger this. `!args.null_input`
-    // also matters: under `-n` combined with a filter that forces a real
-    // read (`force_read_under_null_input`, the only way this function is
-    // even reached with `args.null_input` true), real jq treats this same
-    // condition as a *fatal* error (exit 5), not a warning -- printing the
-    // softer "ignoring parse error" wording there would misrepresent
-    // succinctly's still-unfixed non-fatal behavior as though it now
-    // matched jq; left silent instead until that's fixed properly.
-    //
-    // Real jq treats the whole `--seq` input -- single file, multiple
-    // files, `-s` or not -- as one continuous byte stream for this check:
-    // an RS-less short file combined with an RS-containing one triggers no
-    // warning at all when the RS-less file is empty (a non-empty one still
-    // warns, per above), and two RS-less files together report a
-    // line/column computed from their *concatenation*, not either file's
-    // own content alone (oracle-verified). A leading UTF-8 BOM on the very
-    // first source is stripped before counting, matching real jq
-    // (oracle-verified: `printf '\xef\xbb\xbf1 2' | jq --seq '.'` reports
-    // column 3, not 6).
-    if args.seq
-        && !args.raw_input
-        && args.input_dsv.is_none()
-        && !args.null_input
-        && !raw_bytes.iter().any(|(_, raw)| raw.contains(&0x1E))
-    {
-        const BOM: &[u8] = b"\xEF\xBB\xBF";
-        let mut line = 1usize;
-        let mut column = 0usize;
-        let mut first_source = true;
-        for (_, raw) in &raw_bytes {
-            let bytes = if first_source && raw.starts_with(BOM) {
-                &raw[BOM.len()..]
-            } else {
-                raw.as_slice()
-            };
-            first_source = false;
-            for &b in bytes {
-                if b == b'\n' {
-                    line += 1;
-                    column = 0;
-                } else {
-                    column += 1;
-                }
-            }
+    // *output*) with no diagnostic. `!args.raw_input` and
+    // `args.input_dsv.is_none()` matter: `-R` takes over raw-text
+    // handling entirely (matching `slurp_eof_line` below's identical
+    // priority), and DSV content read via `-s`/`-n 'inputs'` (the only
+    // way DSV input reaches this function -- non-slurp DSV has its own
+    // streaming path that bypasses `get_inputs` entirely) never contains
+    // RFC 7464 records at all, so neither combination should ever trigger
+    // this. `!args.null_input` matters too: under `-n` combined with a
+    // filter that forces a real read (`force_read_under_null_input`, the
+    // only way this function is even reached with `args.null_input` true),
+    // real jq treats the condition `seq_no_rs_byte_warning` checks for as
+    // a *fatal* error (exit 5), not a warning -- printing the softer
+    // "ignoring parse error" wording there would misrepresent succinctly's
+    // separate, still-unfixed non-fatal behavior as though it now matched
+    // jq; left silent instead until that's fixed properly.
+    if args.seq && !args.raw_input && args.input_dsv.is_none() && !args.null_input {
+        if let Some(warning) = seq_no_rs_byte_warning(&raw_bytes) {
+            eprintln!("{warning}");
         }
-        eprintln!(
-            "jq: ignoring parse error: Unfinished abandoned text at EOF at line {line}, column {column}"
-        );
     }
 
     // All reads happen first, then decoding: a later file's read error still
@@ -3039,6 +2981,73 @@ fn seq_stream_trailing_record_is_dropped(raw_inputs: &[(Option<usize>, String)])
         suffix = format!("{raw}{suffix}");
     }
     !suffix.trim().is_empty()
+}
+
+/// Real jq's own stderr warning ("`jq: ignoring parse error: ...`") for a
+/// `--seq` (RFC 7464) input with no RS byte anywhere at all -- one of
+/// jq's several message templates for a dropped malformed record; see
+/// `get_inputs`'s own call site for which combinations must never reach
+/// this at all (`-R`, DSV, `-n` + a forced real read). `None` if `raw_bytes`
+/// contains an RS byte anywhere (a different, unimplemented set of
+/// templates applies then -- #1723) or is fully empty of any source.
+///
+/// A single pass over every source's bytes, bailing out the moment an RS
+/// byte is seen, rather than one pass to check for an RS byte and a
+/// second to count line/column -- the two were separate passes over the
+/// identical bytes in an earlier version of this function, found by
+/// review. Operates on raw bytes, not `--seq`'s later UTF-8-decoded
+/// `String`s: an invalid byte becomes a 3-byte U+FFFD once
+/// `substitute_invalid_utf8_jq_style` (#1617) runs, which would overcount
+/// the column real jq counts against the *original* stream.
+///
+/// A leading UTF-8 BOM is stripped before counting, matching real jq
+/// (oracle-verified: `printf '\xef\xbb\xbf1 2' | jq --seq '.'` reports
+/// column 3, not 6) -- tracked via `bytes_seen_before_this_source == 0`,
+/// not "is this the first element of `raw_bytes`": an earlier version
+/// used the latter and silently failed to strip a BOM that lived in the
+/// first *non-empty* source when preceded by an empty one (found by
+/// review, oracle-verified: `jq --seq -c '.' empty.txt bom.txt` strips
+/// the BOM in the second file, since real jq treats every source as one
+/// continuous stream).
+///
+/// Two narrower gaps deliberately not chased, both apparent artifacts of
+/// jq's own C byte-reader rather than a documented rule: an embedded NUL
+/// byte stops jq's own column count from advancing any further on that
+/// line (oracle-verified: `ab\0cd` reports column 2, not 5), and jq's BOM
+/// detection consumes a *partial*, never-completed `EF`/`EF BB` prefix
+/// too, not just a full 3-byte match. Both are folded into #1723's
+/// existing "matching jq's own incremental-reader internals precisely"
+/// scope rather than given a separate issue.
+fn seq_no_rs_byte_warning(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> Option<String> {
+    let mut line = 1usize;
+    let mut column = 0usize;
+    let mut bytes_seen = 0usize;
+    for (_, raw) in raw_bytes {
+        let bytes = if bytes_seen == 0 {
+            raw.strip_prefix(crate::front_matter::UTF8_BOM)
+                .unwrap_or(raw)
+        } else {
+            raw.as_slice()
+        };
+        for &b in bytes {
+            if b == ASCII_RS {
+                return None;
+            }
+            if b == b'\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += 1;
+            }
+        }
+        bytes_seen += raw.len();
+    }
+    if bytes_seen == 0 && raw_bytes.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "jq: ignoring parse error: Unfinished abandoned text at EOF at line {line}, column {column}"
+    ))
 }
 
 /// Validate that the DSV delimiter is acceptable.
@@ -4602,6 +4611,105 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1525: `seq_no_rs_byte_warning` direct unit coverage. Every expected
+    /// value here was live-verified against the pinned jq 1.7.1 binary
+    /// (see `tests/jq_cli_tests.rs`'s CLI-level `_1525` tests for the
+    /// full-invocation equivalents).
+    mod seq_no_rs_byte_warning_tests {
+        use super::*;
+
+        fn warning(sources: &[&[u8]]) -> Option<String> {
+            let raw_bytes: Vec<(Option<usize>, Vec<u8>)> = sources
+                .iter()
+                .enumerate()
+                .map(|(i, s)| (Some(i), s.to_vec()))
+                .collect();
+            seq_no_rs_byte_warning(&raw_bytes)
+        }
+
+        #[test]
+        fn rs_byte_anywhere_suppresses_the_warning() {
+            assert_eq!(warning(&[b"\x1e1\n"]), None);
+            assert_eq!(warning(&[b"not valid json"]), Some(
+                "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 14"
+                    .to_string()
+            ));
+            // RS in a *later* source still suppresses it for the whole stream.
+            assert_eq!(warning(&[b"junk", b"\x1e1\n"]), None);
+        }
+
+        #[test]
+        fn no_sources_or_all_empty_sources() {
+            assert_eq!(warning(&[]), None);
+            assert_eq!(
+                warning(&[b""]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 0"
+                        .to_string()
+                )
+            );
+            assert_eq!(
+                warning(&[b"", b""]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 0"
+                        .to_string()
+                )
+            );
+        }
+
+        #[test]
+        fn line_and_column_span_multiple_sources() {
+            // "ab" + "cd" concatenated -> one line, column 4.
+            assert_eq!(
+                warning(&[b"ab", b"cd"]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 4"
+                        .to_string()
+                )
+            );
+            // A newline crossing a source boundary still counts correctly.
+            assert_eq!(
+                warning(&[b"ab\n", b"cd"]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 2, column 2"
+                        .to_string()
+                )
+            );
+        }
+
+        #[test]
+        fn leading_bom_is_stripped_even_after_an_empty_source() {
+            const BOM: &[u8] = b"\xEF\xBB\xBF";
+            // BOM as the very first source.
+            assert_eq!(
+                warning(&[&[BOM, b"1 2"].concat()]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 3"
+                        .to_string()
+                )
+            );
+            // Regression: an empty leading source must not stop the BOM in
+            // the next source from being recognized as the stream's own
+            // first bytes.
+            assert_eq!(
+                warning(&[b"", &[BOM, b"1 2"].concat()]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 3"
+                        .to_string()
+                )
+            );
+            // A BOM-*shaped* byte sequence appearing after real content is
+            // just ordinary bytes, not stripped.
+            assert_eq!(
+                warning(&[&[b"x", BOM].concat()]),
+                Some(
+                    "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 4"
+                        .to_string()
+                )
+            );
+        }
+    }
 
     /// #723: direct unit coverage for the TTY-safety narrowing, independent
     /// of a real terminal (which `cargo test` never has one of anyway).

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1669,6 +1669,88 @@ fn get_inputs(
     // -- `-R`, `--seq` and DSV never do, and must not start now.
     let json_input_mode = args.input_dsv.is_none() && !args.raw_input && !args.seq;
 
+    // #1525: real jq warns on stderr when it drops a malformed --seq
+    // record; succinctly silently ignored malformed records entirely
+    // (RFC 7464's own recommended failure mode, #1243, still correct for
+    // *output*) with no diagnostic. This covers exactly one of jq's
+    // several message shapes: content with no RS byte anywhere at all.
+    // RFC 7464 requires every record to start with one, so jq's --seq
+    // reader never resyncs onto unprefixed content -- it reports the
+    // abandonment unconditionally the instant EOF arrives, regardless of
+    // what the content actually is, even fully valid JSON (oracle-
+    // verified: `printf 'null' | jq --seq '.'` still warns). A malformed
+    // record that *does* start with an RS byte gets one of several other
+    // jq message templates ("Unfinished string at EOF", "Unfinished JSON
+    // term at EOF", "Invalid numeric literal ... (need RS to resync)")
+    // depending on exactly how it's malformed -- and an RS-containing
+    // source combined with a *non-empty* RS-less one still warns with one
+    // of those other templates too, not silence (only the all-empty
+    // sub-case of that combination is handled below, oracle-verified: a
+    // non-empty RS-less file paired with an RS-containing one still gets
+    // one of the un-implemented templates). Matching any of that needs
+    // deeper investigation into jq's own incremental-parser error states
+    // and is intentionally out of scope here; tracked separately (#1723).
+    //
+    // Checked once across every source's *raw* bytes, before UTF-8
+    // substitution (#1617) can inflate the count real jq's own column
+    // arithmetic counts against -- an invalid byte becomes a 3-byte
+    // U+FFFD there, which would overcount the column by 2 for every
+    // substituted byte. `!args.raw_input` and `args.input_dsv.is_none()`
+    // both matter: `-R` takes over raw-text handling entirely (matching
+    // `slurp_eof_line` below's identical priority), and DSV content read
+    // via `-s`/`-n 'inputs'` (the only way DSV input reaches this
+    // function -- non-slurp DSV has its own streaming path that bypasses
+    // `get_inputs` entirely) never contains RFC 7464 records at all, so
+    // neither combination should ever trigger this. `!args.null_input`
+    // also matters: under `-n` combined with a filter that forces a real
+    // read (`force_read_under_null_input`, the only way this function is
+    // even reached with `args.null_input` true), real jq treats this same
+    // condition as a *fatal* error (exit 5), not a warning -- printing the
+    // softer "ignoring parse error" wording there would misrepresent
+    // succinctly's still-unfixed non-fatal behavior as though it now
+    // matched jq; left silent instead until that's fixed properly.
+    //
+    // Real jq treats the whole `--seq` input -- single file, multiple
+    // files, `-s` or not -- as one continuous byte stream for this check:
+    // an RS-less short file combined with an RS-containing one triggers no
+    // warning at all when the RS-less file is empty (a non-empty one still
+    // warns, per above), and two RS-less files together report a
+    // line/column computed from their *concatenation*, not either file's
+    // own content alone (oracle-verified). A leading UTF-8 BOM on the very
+    // first source is stripped before counting, matching real jq
+    // (oracle-verified: `printf '\xef\xbb\xbf1 2' | jq --seq '.'` reports
+    // column 3, not 6).
+    if args.seq
+        && !args.raw_input
+        && args.input_dsv.is_none()
+        && !args.null_input
+        && !raw_bytes.iter().any(|(_, raw)| raw.contains(&0x1E))
+    {
+        const BOM: &[u8] = b"\xEF\xBB\xBF";
+        let mut line = 1usize;
+        let mut column = 0usize;
+        let mut first_source = true;
+        for (_, raw) in &raw_bytes {
+            let bytes = if first_source && raw.starts_with(BOM) {
+                &raw[BOM.len()..]
+            } else {
+                raw.as_slice()
+            };
+            first_source = false;
+            for &b in bytes {
+                if b == b'\n' {
+                    line += 1;
+                    column = 0;
+                } else {
+                    column += 1;
+                }
+            }
+        }
+        eprintln!(
+            "jq: ignoring parse error: Unfinished abandoned text at EOF at line {line}, column {column}"
+        );
+    }
+
     // All reads happen first, then decoding: a later file's read error still
     // outranks an earlier file's content error, as it did before.
     let mut raw_inputs: Vec<(Option<usize>, String)> = Vec::with_capacity(raw_bytes.len());
@@ -1701,44 +1783,6 @@ fn get_inputs(
             }
         };
         raw_inputs.push((file_idx, raw));
-    }
-
-    // #1525: real jq warns on stderr when it drops a malformed --seq
-    // record; succinctly silently ignored malformed records entirely
-    // (RFC 7464's own recommended failure mode, #1243, still correct for
-    // *output*) with no diagnostic. This covers exactly one of jq's
-    // several message shapes: content with no RS byte anywhere at all.
-    // RFC 7464 requires every record to start with one, so jq's --seq
-    // reader never resyncs onto unprefixed content -- it reports the
-    // abandonment unconditionally the instant EOF arrives, regardless of
-    // what the content actually is, even fully valid JSON (oracle-
-    // verified: `printf 'null' | jq --seq '.'` still warns). A malformed
-    // record that *does* start with an RS byte gets one of several other
-    // jq message templates ("Unfinished string at EOF", "Unfinished JSON
-    // term at EOF", "Invalid numeric literal ... (need RS to resync)")
-    // depending on exactly how it's malformed -- matching those needs
-    // deeper investigation into jq's own incremental-parser error states
-    // and is intentionally out of scope here; tracked separately (#1723).
-    //
-    // Checked once across every source concatenated, not per file: `-R`
-    // takes over entirely from `--seq` for raw-text mode (`!args.raw_input`
-    // matches the same priority `slurp_eof_line` below already gives it),
-    // and real jq treats the whole `--seq` input -- single file, multiple
-    // files, `-s` or not -- as one continuous byte stream for this check.
-    // Oracle-verified: an RS-less short file combined with an RS-containing
-    // one triggers no warning at all, and two RS-less files together report
-    // a line/column computed from their *concatenation*, not either file's
-    // own content alone.
-    if args.seq && !args.raw_input && !raw_inputs.iter().any(|(_, raw)| raw.contains('\u{1E}')) {
-        let mut combined = String::new();
-        for (_, raw) in &raw_inputs {
-            combined.push_str(raw);
-        }
-        let line = 1 + combined.matches('\n').count();
-        let column = combined.rsplit('\n').next().unwrap_or("").len();
-        eprintln!(
-            "jq: ignoring parse error: Unfinished abandoned text at EOF at line {line}, column {column}"
-        );
     }
 
     let mut locations = InputLocations::new(

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1703,6 +1703,44 @@ fn get_inputs(
         raw_inputs.push((file_idx, raw));
     }
 
+    // #1525: real jq warns on stderr when it drops a malformed --seq
+    // record; succinctly silently ignored malformed records entirely
+    // (RFC 7464's own recommended failure mode, #1243, still correct for
+    // *output*) with no diagnostic. This covers exactly one of jq's
+    // several message shapes: content with no RS byte anywhere at all.
+    // RFC 7464 requires every record to start with one, so jq's --seq
+    // reader never resyncs onto unprefixed content -- it reports the
+    // abandonment unconditionally the instant EOF arrives, regardless of
+    // what the content actually is, even fully valid JSON (oracle-
+    // verified: `printf 'null' | jq --seq '.'` still warns). A malformed
+    // record that *does* start with an RS byte gets one of several other
+    // jq message templates ("Unfinished string at EOF", "Unfinished JSON
+    // term at EOF", "Invalid numeric literal ... (need RS to resync)")
+    // depending on exactly how it's malformed -- matching those needs
+    // deeper investigation into jq's own incremental-parser error states
+    // and is intentionally out of scope here; tracked separately (#1723).
+    //
+    // Checked once across every source concatenated, not per file: `-R`
+    // takes over entirely from `--seq` for raw-text mode (`!args.raw_input`
+    // matches the same priority `slurp_eof_line` below already gives it),
+    // and real jq treats the whole `--seq` input -- single file, multiple
+    // files, `-s` or not -- as one continuous byte stream for this check.
+    // Oracle-verified: an RS-less short file combined with an RS-containing
+    // one triggers no warning at all, and two RS-less files together report
+    // a line/column computed from their *concatenation*, not either file's
+    // own content alone.
+    if args.seq && !args.raw_input && !raw_inputs.iter().any(|(_, raw)| raw.contains('\u{1E}')) {
+        let mut combined = String::new();
+        for (_, raw) in &raw_inputs {
+            combined.push_str(raw);
+        }
+        let line = 1 + combined.matches('\n').count();
+        let column = combined.rsplit('\n').next().unwrap_or("").len();
+        eprintln!(
+            "jq: ignoring parse error: Unfinished abandoned text at EOF at line {line}, column {column}"
+        );
+    }
+
     let mut locations = InputLocations::new(
         files
             .iter()

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3993,6 +3993,122 @@ fn test_seq_ignores_parse_errors() -> Result<()> {
     Ok(())
 }
 
+/// #1525: real jq warns on stderr ("ignoring parse error: Unfinished
+/// abandoned text at EOF at line L, column C") when `--seq` input has no
+/// RS byte anywhere at all -- RFC 7464 requires every record to start
+/// with one, so jq's reader never resyncs onto unprefixed content and
+/// reports the abandonment unconditionally at EOF, regardless of what the
+/// content actually is (even fully valid JSON, per the last case below).
+/// Every expected value was live-verified against the pinned jq 1.7.1
+/// binary.
+#[test]
+fn test_seq_no_rs_byte_warns_1525() -> Result<()> {
+    for (input, expected_line, expected_column) in [
+        ("1 2", 1, 3),
+        ("true false", 1, 10),
+        ("null", 1, 4),
+        ("ab\ncd", 2, 2),
+        ("ab\ncd\n", 3, 0),
+        ("", 1, 0),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))
+            .unwrap_or_else(|e| panic!("input {input:?}: failed to run: {e}"));
+        assert_eq!(code, 0, "input {input:?}: stdout: {stdout}");
+        assert_eq!(
+            stderr.trim(),
+            format!(
+                "jq: ignoring parse error: Unfinished abandoned text at EOF at line {expected_line}, column {expected_column}"
+            ),
+            "input {input:?}"
+        );
+        assert_eq!(stdout, "", "input {input:?}: no value should be output");
+    }
+    Ok(())
+}
+
+/// #1525: a malformed record that *does* start with an RS byte must not
+/// trigger the "no RS byte" warning above -- it's silently dropped per
+/// RFC 7464 (#1093/#1267), with no diagnostic, exactly as before this fix
+/// (jq's own warning for this shape uses a different message template
+/// entirely -- "Invalid numeric literal ... (need RS to resync)" or
+/// "Unfinished string/JSON term at EOF" depending on how it's malformed --
+/// deliberately not attempted here, tracked separately as #1723).
+#[test]
+fn test_seq_malformed_record_with_rs_byte_does_not_warn_1525() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["--seq", "-c", "."], Some("\u{1e}not valid json\n")).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(stderr, "");
+    assert_eq!(stdout, "");
+    Ok(())
+}
+
+/// #1525: an RS-less file combined with an RS-containing one triggers no
+/// warning at all -- real jq treats the whole `--seq` input as one
+/// continuous stream, and the RS-containing file satisfies the "every
+/// record starts with an RS byte" requirement for the stream as a whole.
+#[test]
+fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<()> {
+    let mut valid_file = NamedTempFile::new()?;
+    writeln!(valid_file, "\u{1e}1")?;
+    let mut empty_file = NamedTempFile::new()?;
+    write!(empty_file, "")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
+        .args(["--seq", "-c", "."])
+        .arg(valid_file.path())
+        .arg(empty_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stderr)?, "");
+    // `--seq` RS-prefixes output too (RFC 7464), same as real jq.
+    assert_eq!(String::from_utf8(output.stdout)?.trim(), "\u{1e}1");
+    Ok(())
+}
+
+/// #1525: two RS-less files report a line/column computed from their
+/// *concatenation*, not either file's own content alone -- oracle-verified
+/// against the pinned jq 1.7.1 binary.
+#[test]
+fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
+    let mut file_a = NamedTempFile::new()?;
+    write!(file_a, "ab")?;
+    let mut file_b = NamedTempFile::new()?;
+    write!(file_b, "cd")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
+        .args(["--seq", "-c", "."])
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stderr)?.trim(),
+        "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 4"
+    );
+    Ok(())
+}
+
+/// #1525: `-R --seq` combined lets `-R` take over raw-text handling
+/// entirely (matching this codebase's existing `slurp_eof_line` priority
+/// for the same combination) -- no RS-byte warning, since RFC 7464
+/// record-splitting never applies in raw-input mode.
+#[test]
+fn test_seq_raw_input_combo_does_not_warn_1525() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-R", "--seq", "-c", "."], Some("xyz")).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(stderr, "");
+    // `--seq` RS-prefixes output too (RFC 7464), same as real jq.
+    assert_eq!(stdout.trim(), "\u{1e}\"xyz\"");
+    Ok(())
+}
+
 /// #1213: `--seq`'s error-location reporting stays correct once its
 /// per-value line lookup is incremental (`LineCounter`) instead of a
 /// from-scratch rescan per value -- the erroring record here is deep enough

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4044,23 +4044,28 @@ fn test_seq_malformed_record_with_rs_byte_does_not_warn_1525() -> Result<()> {
 }
 
 /// #1525: an RS-less file combined with an RS-containing one triggers no
-/// warning at all -- real jq treats the whole `--seq` input as one
-/// continuous stream, and the RS-containing file satisfies the "every
-/// record starts with an RS byte" requirement for the stream as a whole.
+/// warning at all when the RS-less file is *empty* -- real jq treats the
+/// whole `--seq` input as one continuous stream, and the RS-containing
+/// file satisfies the "every record starts with an RS byte" requirement
+/// for the stream as a whole. (A *non-empty* RS-less file paired with an
+/// RS-containing one still warns on real jq, with one of the other
+/// message templates #1723 tracks -- not this one; not exercised here.)
+///
+/// Spawns via `spawn_jq_full` (not a bare `Command::new(...).output()`)
+/// for its `ENOENT`-retry protection: other tests in this file rebuild
+/// the shared binary path concurrently (see `MAX_SPAWN_RETRIES`'s own
+/// doc comment, #550).
 #[test]
 fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<()> {
     let mut valid_file = NamedTempFile::new()?;
     writeln!(valid_file, "\u{1e}1")?;
-    let mut empty_file = NamedTempFile::new()?;
-    write!(empty_file, "")?;
+    let empty_file = NamedTempFile::new()?;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("jq")
-        .args(["--seq", "-c", "."])
-        .arg(valid_file.path())
-        .arg(empty_file.path())
-        .stdin(Stdio::null())
-        .output()?;
+    let valid_path = valid_file.path().to_str().unwrap();
+    let empty_path = empty_file.path().to_str().unwrap();
+    let mut cmd = spawn_jq_full(&["--seq", "-c", ".", valid_path, empty_path])?;
+    drop(cmd.stdin.take());
+    let output = cmd.wait_with_output()?;
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8(output.stderr)?, "");
@@ -4071,7 +4076,8 @@ fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<
 
 /// #1525: two RS-less files report a line/column computed from their
 /// *concatenation*, not either file's own content alone -- oracle-verified
-/// against the pinned jq 1.7.1 binary.
+/// against the pinned jq 1.7.1 binary. Spawns via `spawn_jq_full` for its
+/// `ENOENT`-retry protection, same reason as the test above.
 #[test]
 fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
     let mut file_a = NamedTempFile::new()?;
@@ -4079,18 +4085,101 @@ fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
     let mut file_b = NamedTempFile::new()?;
     write!(file_b, "cd")?;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("jq")
-        .args(["--seq", "-c", "."])
-        .arg(file_a.path())
-        .arg(file_b.path())
-        .stdin(Stdio::null())
-        .output()?;
+    let path_a = file_a.path().to_str().unwrap();
+    let path_b = file_b.path().to_str().unwrap();
+    let mut cmd = spawn_jq_full(&["--seq", "-c", ".", path_a, path_b])?;
+    drop(cmd.stdin.take());
+    let output = cmd.wait_with_output()?;
 
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8(output.stderr)?.trim(),
         "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 4"
+    );
+    Ok(())
+}
+
+/// #1525: the reported column counts *raw* bytes, before invalid UTF-8 is
+/// lossily substituted (#1617) -- each substituted byte becomes a 3-byte
+/// U+FFFD, which would overcount the column by 2 per substitution if the
+/// count ran on the substituted string instead. Oracle-verified.
+#[test]
+fn test_seq_no_rs_warning_column_counts_raw_bytes_not_substituted_1525() -> Result<()> {
+    let mut input = Vec::new();
+    input.extend_from_slice(b"ab");
+    input.push(0xFF); // invalid UTF-8 lead byte -> substituted to 3-byte U+FFFD
+    input.extend_from_slice(b"cd");
+
+    let mut cmd = spawn_jq_full(&["--seq", "-c", "."])?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(&input)?;
+    }
+    let output = cmd.wait_with_output()?;
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stderr)?.trim(),
+        "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 5"
+    );
+    Ok(())
+}
+
+/// #1525: `--seq --input-dsv` combined must never fire the RS-byte
+/// warning -- DSV is a succinctly-only extension with no RFC 7464 records
+/// at all. The non-slurp streaming DSV path bypasses `get_inputs`
+/// entirely and was never at risk; `-s` routes through `get_inputs`
+/// instead, which is what the fix's `args.input_dsv.is_none()` guard
+/// covers.
+#[test]
+fn test_seq_dsv_combo_does_not_warn_1525() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["--seq", "--input-dsv", ",", "-s", "-c", "."],
+        Some("a,b\n1,2\n"),
+    )
+    .unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stderr, "");
+    // `--seq` RS-prefixes output too (RFC 7464), same as real jq.
+    assert_eq!(stdout.trim(), "\u{1e}[[\"a\",\"b\"],[\"1\",\"2\"]]");
+    Ok(())
+}
+
+/// #1525: `-n --seq` combined with a filter that forces a real read
+/// (`inputs`) must not print the "ignoring parse error" warning -- real
+/// jq treats this same no-RS-byte condition as a *fatal* error there
+/// (exit 5), not a warning, and succinctly doesn't implement that fatal
+/// path yet (a separate, larger gap than this issue's own scope).
+/// Printing the warning's exact wording in this mode would misrepresent
+/// succinctly's still-unfixed non-fatal behavior as though it matched jq.
+#[test]
+fn test_seq_null_input_with_inputs_does_not_warn_1525() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "--seq", "-c", "[inputs]"], Some("1 2")).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stderr, "");
+    // `--seq` RS-prefixes output too (RFC 7464), same as real jq.
+    assert_eq!(stdout.trim(), "\u{1e}[]");
+    Ok(())
+}
+
+/// #1525: a leading UTF-8 BOM on the very first source is stripped before
+/// line/column counting, matching real jq. Oracle-verified.
+#[test]
+fn test_seq_no_rs_warning_strips_leading_bom_1525() -> Result<()> {
+    let mut input = Vec::new();
+    input.extend_from_slice(b"\xEF\xBB\xBF");
+    input.extend_from_slice(b"1 2");
+
+    let mut cmd = spawn_jq_full(&["--seq", "-c", "."])?;
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(&input)?;
+    }
+    let output = cmd.wait_with_output()?;
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stderr)?.trim(),
+        "jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 3"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #1525.

Real jq warns "ignoring parse error: ..." on stderr when it drops a malformed `--seq` record; succinctly silently dropped it with no diagnostic. This adds exactly one of jq's several message shapes: content with no RS byte anywhere in the input at all.

RFC 7464 requires every record to start with an RS byte, so jq's `--seq` reader never resyncs onto unprefixed content — it reports `Unfinished abandoned text at EOF at line L, column C` unconditionally the instant EOF arrives, regardless of what the content actually is, even fully valid JSON (oracle-verified: `printf 'null' | jq --seq '.'` still warns).

## Scope decision

Live probing against the pinned jq 1.7.1 binary while investigating this issue revealed real jq's `--seq` reader has **at least 4 distinct message templates**, not one — the issue's own repro (`printf '1 2' | jq --seq`) is only the "no RS byte at all" shape. A malformed record that *does* start with an RS byte gets one of several other templates ("Unfinished string at EOF", "Unfinished JSON term at EOF", "Invalid numeric literal ... (need RS to resync)") depending on exactly how it's malformed — matching those needs deeper investigation into jq's own incremental-parser error states (essentially replicating enough of its failure classification to know which state it would have been in), well beyond this issue's original "Low-Medium, moderate but contained" scoping. Also discovered: two syntactically-complete values within one RS-delimited record (`\x1e1 2\n`) parse and output as *two* values with **no warning at all** — a third, distinct behavior.

Scoped this PR to the one case that's both the issue's own literal repro and fully understood/verified: no RS byte anywhere. Filed **#1723** for the mid-stream cases.

## Implementation

Checked once across every source concatenated, not per file: real jq treats the whole `--seq` input — single file, multiple files, `-s` or not — as one continuous byte stream for this check. Oracle-verified: an RS-less short file combined with an RS-containing one triggers no warning at all, and two RS-less files together report a line/column computed from their *concatenation*, not either file's own content alone. `-R --seq` combined is excluded (matching this codebase's existing `slurp_eof_line` priority for the same combination): `-R` takes over raw-text handling entirely, so RFC 7464 record-splitting never applies.

## Test plan

- [x] 5 new regression tests (`_1525` suffix) covering: the basic no-RS-byte case across 6 sub-cases (multi-line, empty, whitespace, a fully-valid value), a malformed record *with* an RS byte (must not warn — different, unfixed message shape), an RS-less source combined with an RS-containing one (must not warn), two RS-less files (concatenated line/column), and `-R --seq` combined (must not warn).
- [x] All 39 pre-existing `--seq`-related tests still pass unchanged.
- [x] Live-verified every new case against the pinned jq 1.7.1 binary before writing the assertion.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure.
- [x] `cargo clippy` all 3 CI legs, `cargo fmt --check`, `cargo doc -D warnings`, `cargo build --no-default-features` (no_std) — all clean.

Closes #1525.

## Round 2 — five real gaps found by review

`/code-review` found the first version had several genuine divergences from real jq, all confirmed live against the pinned 1.7.1 oracle:

1. **Missing `args.input_dsv.is_none()` guard** — `--seq --input-dsv=... -s` (or `-n 'inputs'`) fired a spurious warning on perfectly valid DSV content that never involved RFC 7464 records at all. DSV output was correct; only the diagnostic was wrong.
2. **Column computed from the post-UTF-8-substitution string, not raw bytes** — an invalid byte becomes a 3-byte U+FFFD before the old code saw it, overcounting the column by 2 per substituted byte. Fixed by moving the whole check earlier, onto `raw_bytes` directly before the UTF-8-substitution loop consumes it.
3. **`-n --seq` combined with `input`/`inputs`** — real jq treats a no-RS-byte stream as *fatal* there (exit 5), not a warning. Printing the warning's exact wording made succinctly's separate, still-unfixed exit-code/output divergence look like it now matched jq's message when the underlying behavior remained wrong. Suppressed via `!args.null_input`.
4. **A leading UTF-8 BOM wasn't stripped before counting** — real jq strips it first. Fixed.
5. **The doc comment's "no warning at all" claim** for an RS-less file combined with an RS-containing one was only true for an *empty* RS-less file (a non-empty one still warns, with an unimplemented message template — same #1723 gap). Corrected the wording.

Also: rewrote the two file-based tests to use the existing `spawn_jq_full` retry helper instead of a bare `Command::new(...).output()`, matching this test file's own established `ENOENT`-retry protection (other tests rebuild the shared binary path concurrently, #550) — found by the same review round. Added 4 new regression tests. Added a `docs/compliance/jq/limitations.md` entry recording the still-open #1723 gap, per this repo's own divergence-recording rule — following the file's own established pattern of one topic-specific prose section per known gap.

## Test plan (updated)

- [x] 9 regression tests total (`_1525` suffix), all live-verified against the pinned jq 1.7.1 oracle.
- [x] All 43 pre-existing `--seq`-related tests still pass unchanged.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure.
- [x] `cargo clippy` all 3 CI legs, `cargo fmt --check`, `cargo doc -D warnings`, `cargo build --no-default-features` (no_std) — all clean.

## Round 3 — BOM+empty-source bug, extraction, and one more documented gap

`/code-review` found the BOM-stripping flag tracked "is this the literal first `raw_bytes` entry" rather than "have we seen any bytes of the logical concatenated stream yet" — an empty leading file/source silently disabled BOM stripping for whatever source actually carried it. Real jq treats the whole `--seq` input as one continuous byte stream and strips a BOM at that stream's true first byte regardless of how many empty sources precede it (oracle-verified: `jq --seq -c '.' empty.txt bom.txt` still strips the BOM in the second file). Fixed by tracking cumulative bytes seen instead of loop position.

Also extracted the whole diagnostic into `seq_no_rs_byte_warning`, a small pure function, per review: every comparable helper in this file (`line_at`, `json_seq_ends`, `seq_record_parses`, `seq_trailing_record_is_dropped`) is already extracted and directly unit-tested; the inline version couldn't be. Combined the RS-presence check and the line/column count into one pass instead of two full scans over the same bytes. Reused the existing `ASCII_RS` constant instead of a bare `0x1E` literal, and promoted `front_matter.rs`'s own `UTF8_BOM` constant to `pub(crate)` instead of re-deriving the same 3 bytes locally.

Documented two remaining gaps explicitly, rather than chasing them further: an embedded NUL byte stops jq's own column count from advancing (an artifact of jq's C reader), and jq's BOM detection consumes a partial, never-completed `EF`/`EF BB` prefix too, not just a full 3-byte match — both folded into #1723's existing scope rather than given a separate issue.

Added 4 direct unit tests for `seq_no_rs_byte_warning`. Added a `docs/compliance/jq/limitations.md` paragraph for the `-n`/`inputs` fatal-vs-warning divergence review also found, alongside the existing #1723 entry.

## Test plan (updated)

- [x] 9 CLI-level regression tests + 4 direct unit tests for `seq_no_rs_byte_warning`, all live-verified against the pinned jq 1.7.1 oracle.
- [x] All 43 pre-existing `--seq`-related tests still pass unchanged.
- [x] `cargo test --release --features cli,bench-runner,simd,regex,serde --no-fail-fast` — green except the pre-existing, unrelated `bits::select` `#[should_panic]` release-mode failure.
- [x] `cargo clippy` all 3 CI legs, `cargo fmt --check`, `cargo doc -D warnings`, `cargo build --no-default-features` (no_std) — all clean.
