### PR TITLE
fix(yq): make bare del(.)/del(.?) match real yq's root-delete rule

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27724,6 +27724,25 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 YqDelSliceOutcome::Noop => continue,
                 YqDelSliceOutcome::NotApplicable => path,
             };
+            // yq's root-delete rule (#1702): real yq deletes the whole
+            // document and emits nothing for a bare `del(.)` (no `?`
+            // anywhere), and treats `del(.?)` as a full no-op — the
+            // optional root delete never fires. `succinctly` previously
+            // followed jq's model for both (`del(.)` => `null`,
+            // `del(.?)` => `null`), which is correct for `succinctly jq`
+            // but not `succinctly yq`. Checked here, ahead of
+            // `delete_at_path`, rather than inside its `Expr::Identity`
+            // arm, since that arm has no way to signal "no output at
+            // all" through its `Result<(), EvalError>` return type.
+            if S::TAG == EvalTag::Yq {
+                match effective_path {
+                    Expr::Identity => return QueryResult::None,
+                    Expr::Optional(inner) if matches!(inner.as_ref(), Expr::Identity) => {
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
             if let Err(e) =
                 delete_at_path(&mut result, effective_path, false, S::TAG == EvalTag::Yq)
             {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22933,3 +22933,16 @@ fn test_parent_n_non_numeric_argument_reports_real_type_name_1487() -> Result<()
     );
     Ok(())
 }
+
+/// #1702 fixed `del(.)`/`del(.?)` to emit nothing / no-op in yq mode; confirm
+/// `succinctly jq` still follows real jq's own model unchanged — both
+/// produce `null` on any target.
+#[test]
+fn test_jq_mode_root_del_still_null_after_1702() -> Result<()> {
+    for expr in ["del(.)", "del(.?)"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", expr], Some(r#"{"a":1}"#))?;
+        assert_eq!(stdout.trim(), "null", "expr={expr} stderr: {stderr:?}");
+        assert_eq!(code, 0, "expr={expr} stderr: {stderr:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18439,6 +18439,46 @@ fn test_1162_bare_root_object_slice_del_is_noop() -> Result<()> {
     Ok(())
 }
 
+/// A bare, non-optional `del(.)` deletes the whole document and emits
+/// *nothing* in real yq — not even `null` — unlike `succinctly jq`/real jq,
+/// which both produce `null` (#1702, verified live against yq v4.53.3 on
+/// scalar/array/object targets alike).
+#[test]
+fn test_1702_yq_bare_root_del_emits_nothing() -> Result<()> {
+    for input in [r#"{"a":1}"#, r"[1,2,3]", r"5"] {
+        let (out, code) = run_yq_stdin("del(.)", input, &["-o=json"])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "", "input was {input}");
+    }
+    Ok(())
+}
+
+/// `del(.?)` — the root's own `.` marked optional — is a full no-op in real
+/// yq: the original value passes through unchanged, unlike `succinctly
+/// jq`/real jq's `null` (#1702, verified live).
+#[test]
+fn test_1702_yq_optional_root_del_is_noop() -> Result<()> {
+    for input in [r#"{"a":1}"#, r"[1,2,3]", r"5"] {
+        let (out, code) = run_yq_stdin("del(.?)", input, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim(), input);
+    }
+    Ok(())
+}
+
+/// A comma naming the root alongside another path (`del(., .c)`) already
+/// collapses to a single root-delete branch upstream (#1651's
+/// `short_circuit_del_root`) before #1702's check ever runs — confirming the
+/// two fixes compose rather than double-handling the same shape. Real yq
+/// emits nothing here too (verified live).
+#[test]
+fn test_1702_yq_comma_with_root_del_emits_nothing() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(., .c)", r#"{"a":1,"c":2}"#, &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "");
+    Ok(())
+}
+
 /// A comma-grouped multi-path `del()` (`delete_expr_paths_at`'s own sibling-
 /// grouping walker, a completely separate code path from the single-path
 /// case above) gets the same widened rule for each resolved path


### PR DESCRIPTION
## Summary
Real yq treats `del()` on the document root specially, and differently depending on
whether it's wrapped in `?`:
- A bare `del(.)` (no `?` anywhere) deletes the whole document and emits **nothing** —
  not even `null`.
- `del(.?)` (the path's own `.` marked optional) is a **full no-op** — the original
  value passes through unchanged.

`succinctly yq` previously followed jq's own model for both (`del(.)`/`del(.?)` =>
`null`), which is correct for `succinctly jq` but not `succinctly yq`.

`builtin_del`'s per-path loop now checks, in yq mode, whether the resolved path is a
bare root `Identity` (returns `QueryResult::None` directly — `delete_at_path`'s
`Result<(), EvalError>` has no way to signal "no output") or an `Optional`-wrapped
root `Identity` (skips the delete, leaving the accumulated result untouched).
`#1651`'s existing short-circuit already collapses a comma naming the root alongside
another path (`del(., .c)`) to a single root `Identity` before this check runs, so
that shape composes for free.

Fixes #1702

## Test plan
- [x] Live-verified all repro cases from the issue against yq v4.53.3 (scalar, array, object targets)
- [x] Live-verified `del(., .c)` comma-with-root composes correctly with #1651's short-circuit
- [x] Confirmed `succinctly jq` mode is unaffected — `del(.)`/`del(.?)` still produce `null`
- [x] Added regression tests in `tests/yq_cli_tests.rs` (bare root, optional root, comma-with-root) and `tests/jq_cli_tests.rs` (jq-mode-unaffected)
- [x] `cargo test --features cli,regex` — full suite green (2895+ tests, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo build --no-default-features` — no_std build clean
- [x] Patch coverage: 100% (7/7 new lines)