### PR TITLE
docs(yq): record -j/--join-output as an open divergence from real yq's own -j

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -210,15 +210,21 @@ not rediscovered from scratch.
 
 ### `-j`/`--join-output` collides with real yq's own `-j`
 
-Not an [extension](#extensions) — real yq's arg parser does accept `-j`, so this fails rule
-5's own test ("changes the behaviour of no filter the reference also accepts"), and none of
-rule 4's four carve-outs (unreadable output, corruption, a discarded write, or taking the
-process down) apply either. It's a plain, unaddressed name collision: `succinctly yq`'s
-`-j`/`--join-output` implements jq-style "no separator, concatenate raw" output (apparently
-ported from `JqCommand`'s own legitimate `-j`, which does match real jq's `-j`). Real yq's
-own `-j` means something else entirely — a deprecated alias for `--tojson` (forces
-`-o=json`, prints a deprecation warning to stderr). The long form, `--join-output`, does not
-exist in real yq at all. Confirmed live against the pinned v4.53.3 binary:
+Not an [extension](#extensions) for the `-j` spelling — real yq's arg parser does accept
+`-j`, so that spelling fails rule 5's own test ("changes the behaviour of no filter the
+reference also accepts"), and none of [ADR-0018](../../adrs/adr-0018.md) rule 4's carve-outs
+apply either (the output is readable, nothing is corrupted or discarded, and no process
+dies). Taken alone, the long form `--join-output` *would* pass rule 5's token test — real yq
+has no such flag at all — but it is not documented as a separate extension here: `-j` and
+`--join-output` are two spellings of the one clap argument, sharing one implementation and
+one behaviour, so a user reaching this feature through the novel long spelling still holds a
+flag whose short alias collides with existing yq surface. The pair is recorded as a single
+open divergence rather than split into "one extension, one bug" by spelling. It's a plain,
+unaddressed name collision: `succinctly yq`'s `-j`/`--join-output` implements jq-style "no
+separator, concatenate raw" output (apparently ported from `JqCommand`'s own legitimate
+`-j`, which does match real jq's `-j`). Real yq's own `-j` means something else entirely — a
+deprecated alias for `--tojson` (forces `-o=json`, prints a deprecation warning to stderr).
+Confirmed live against the pinned v4.53.3 binary:
 
 ```bash
 $ yq -j '.' <<< 'a: 1'
@@ -236,9 +242,10 @@ way gets something unrelated instead. Long-standing (predates #1701, ported alon
 [#1710](https://github.com/rust-works/succinctly/issues/1710) — a documentation-only fix
 (see [docs/guides/cli.md](../../guides/cli.md) for the matching caveat on the flag's own
 listing); remapping `-j` to real yq's actual `--tojson` meaning, which #1710 also raised, is
-a bigger, more disruptive change not attempted there. "Anchor soundness" above discusses this
-same flag from a different angle — why `-0`/`-j` output getting a newline-guarded `---` is a
-*permitted* rule-4(a) divergence, independent of the name-collision question here.
+a bigger, more disruptive change not attempted there. "`-0`/`--nul-output` multi-document
+separator" above discusses this same flag from a different angle — why `-0`/`-j` output
+getting a newline-guarded `---` is a *permitted* rule-4(a) divergence, independent of the
+name-collision question here.
 
 ### Duplicate mapping keys — the format leak and `.[]` collapse are resolved; four narrower gaps remain
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -215,11 +215,9 @@ Not an [extension](#extensions) for the `-j` spelling — real yq's arg parser d
 reference also accepts"), and none of [ADR-0018](../../adrs/adr-0018.md) rule 4's carve-outs
 apply either (the output is readable, nothing is corrupted or discarded, and no process
 dies). Taken alone, the long form `--join-output` *would* pass rule 5's token test — real yq
-has no such flag at all — but it is not documented as a separate extension here: `-j` and
-`--join-output` are two spellings of the one clap argument, sharing one implementation and
-one behaviour, so a user reaching this feature through the novel long spelling still holds a
-flag whose short alias collides with existing yq surface. The pair is recorded as a single
-open divergence rather than split into "one extension, one bug" by spelling. It's a plain,
+has no such flag at all — but `-j` and `--join-output` are two spellings of the one clap
+argument, sharing one implementation and behaviour, so the pair is recorded as a single open
+divergence here rather than split into "one extension, one bug" by spelling. It's a plain,
 unaddressed name collision: `succinctly yq`'s `-j`/`--join-output` implements jq-style "no
 separator, concatenate raw" output (apparently ported from `JqCommand`'s own legitimate
 `-j`, which does match real jq's `-j`). Real yq's own `-j` means something else entirely — a
@@ -241,8 +239,9 @@ way gets something unrelated instead. Long-standing (predates #1701, ported alon
 `JqCommand`'s own `-j`), found and recorded by
 [#1710](https://github.com/rust-works/succinctly/issues/1710) — a documentation-only fix
 (see [docs/guides/cli.md](../../guides/cli.md) for the matching caveat on the flag's own
-listing); remapping `-j` to real yq's actual `--tojson` meaning, which #1710 also raised, is
-a bigger, more disruptive change not attempted there. "`-0`/`--nul-output` multi-document
+listing). Remapping `-j` to real yq's actual `--tojson` meaning, which #1710 also raised, is
+a bigger, more disruptive change not attempted there — tracked separately as
+[#1731](https://github.com/rust-works/succinctly/issues/1731). "`-0`/`--nul-output` multi-document
 separator" above discusses this same flag from a different angle — why `-0`/`-j` output
 getting a newline-guarded `---` is a *permitted* rule-4(a) divergence, independent of the
 name-collision question here.

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -786,6 +786,26 @@ no filter the reference also accepts — an extension is not a divergence.
 **Wholly new syntax, unconditional** — `at_offset`/`at_position`, `@dsv`. Neither jq nor yq
 has anything resembling these; there is no reference token to gate them against.
 
+**A flag name real yq also uses, for something unrelated** — `-j`/`--join-output`. In yq
+mode this implements jq-style "no separator, concatenate raw" output (apparently ported from
+`JqCommand`'s own legitimate `-j`, which does match real jq's `-j`). Real yq's own `-j` means
+something else entirely: a deprecated alias for `--tojson` (forces `-o=json`, prints a
+deprecation warning to stderr); the long form `--join-output` does not exist in real yq at
+all (`Error: unknown flag: --join-output`), confirmed live against the pinned v4.53.3 binary:
+
+```bash
+$ yq -j '.'            <<< 'a: 1'   # Flag --tojson has been deprecated, please use -o=json instead
+                                     # {"a": 1}
+$ yq --join-output '.' <<< 'a: 1'   # Error: unknown flag: --join-output
+```
+
+This is the one extension in this file where the *name itself* collides with real yq surface
+rather than being wholly novel — a user who knows real yq's `-j` and reasonably expects
+`succinctly yq -j` to behave the same way gets something unrelated instead. Long-standing
+(predates #1701, ported alongside `JqCommand`'s own `-j`), found and recorded by
+[#1710](https://github.com/rust-works/succinctly/issues/1710). See
+[docs/guides/cli.md](../../guides/cli.md) for the same caveat on the flag's own listing.
+
 **jq-styled syntax real yq's lexer rejects, gated behind `--jq-extensions`, off by default
 ([#1512](https://github.com/rust-works/succinctly/issues/1512))** — `paths`, `getpath`,
 `leaf_paths`, `tostream`/`fromstream`/`truncate_stream`, `IN`, `ltrimstr`, `limit`,

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -131,12 +131,13 @@ $ printf 'a: 1\n---\nb: 2\n' | succinctly yq -0 '.' | od -c
 
 This is rule 4(a), not a new carve-out — same shape as anchor soundness above: real yq emits
 `---`-boundary output real yq cannot itself re-read, so inserting the missing newline is
-permitted rather than bug-for-bug reproduced. `--join-output` has no real-yq counterpart at
-all (it is a succinctly-only spelling of jq-style "no separator" semantics colliding with a
-name real yq uses for something else entirely — see
-[#1710](https://github.com/rust-works/succinctly/issues/1710)), so for that flag there was
-never a reference behaviour to diverge from in the first place; the same guard is applied to
-it purely for internal consistency, not for fidelity.
+permitted rather than bug-for-bug reproduced. The long form, `--join-output`, has no real-yq
+counterpart at all (`Error: unknown flag: --join-output`), so for *that* spelling there was
+never a reference behaviour to diverge from in the first place. The short form, `-j`, is a
+different story — it collides with a real yq flag of the same name but an unrelated meaning
+(see "`-j`/`--join-output` collides with real yq's own `-j`" below) — but the guard's
+own justification doesn't change either way: it's applied to both spellings purely for
+internal consistency between them, not for fidelity to anything real yq does with `-j`.
 
 Scope note: this entry covers only the `---`-boundary corruption. The reparsed value shown
 above still differs from the original once the embedded `\0` itself is considered — succinctly
@@ -206,6 +207,38 @@ at all. The justification is the spec target, which is why the case belongs here
 
 Representative cases, each live-verified. These are gaps to close, listed here so they are
 not rediscovered from scratch.
+
+### `-j`/`--join-output` collides with real yq's own `-j`
+
+Not an [extension](#extensions) — real yq's arg parser does accept `-j`, so this fails rule
+5's own test ("changes the behaviour of no filter the reference also accepts"), and none of
+rule 4's four carve-outs (unreadable output, corruption, a discarded write, or taking the
+process down) apply either. It's a plain, unaddressed name collision: `succinctly yq`'s
+`-j`/`--join-output` implements jq-style "no separator, concatenate raw" output (apparently
+ported from `JqCommand`'s own legitimate `-j`, which does match real jq's `-j`). Real yq's
+own `-j` means something else entirely — a deprecated alias for `--tojson` (forces
+`-o=json`, prints a deprecation warning to stderr). The long form, `--join-output`, does not
+exist in real yq at all. Confirmed live against the pinned v4.53.3 binary:
+
+```bash
+$ yq -j '.' <<< 'a: 1'
+Flag --tojson has been deprecated, please use -o=json instead
+{
+  "a": 1
+}
+$ yq --join-output '.' <<< 'a: 1'
+Error: unknown flag: --join-output
+```
+
+A user who knows real yq's `-j` and reasonably expects `succinctly yq -j` to behave the same
+way gets something unrelated instead. Long-standing (predates #1701, ported alongside
+`JqCommand`'s own `-j`), found and recorded by
+[#1710](https://github.com/rust-works/succinctly/issues/1710) — a documentation-only fix
+(see [docs/guides/cli.md](../../guides/cli.md) for the matching caveat on the flag's own
+listing); remapping `-j` to real yq's actual `--tojson` meaning, which #1710 also raised, is
+a bigger, more disruptive change not attempted there. "Anchor soundness" above discusses this
+same flag from a different angle — why `-0`/`-j` output getting a newline-guarded `---` is a
+*permitted* rule-4(a) divergence, independent of the name-collision question here.
 
 ### Duplicate mapping keys — the format leak and `.[]` collapse are resolved; four narrower gaps remain
 
@@ -785,26 +818,6 @@ no filter the reference also accepts — an extension is not a divergence.
 
 **Wholly new syntax, unconditional** — `at_offset`/`at_position`, `@dsv`. Neither jq nor yq
 has anything resembling these; there is no reference token to gate them against.
-
-**A flag name real yq also uses, for something unrelated** — `-j`/`--join-output`. In yq
-mode this implements jq-style "no separator, concatenate raw" output (apparently ported from
-`JqCommand`'s own legitimate `-j`, which does match real jq's `-j`). Real yq's own `-j` means
-something else entirely: a deprecated alias for `--tojson` (forces `-o=json`, prints a
-deprecation warning to stderr); the long form `--join-output` does not exist in real yq at
-all (`Error: unknown flag: --join-output`), confirmed live against the pinned v4.53.3 binary:
-
-```bash
-$ yq -j '.'            <<< 'a: 1'   # Flag --tojson has been deprecated, please use -o=json instead
-                                     # {"a": 1}
-$ yq --join-output '.' <<< 'a: 1'   # Error: unknown flag: --join-output
-```
-
-This is the one extension in this file where the *name itself* collides with real yq surface
-rather than being wholly novel — a user who knows real yq's `-j` and reasonably expects
-`succinctly yq -j` to behave the same way gets something unrelated instead. Long-standing
-(predates #1701, ported alongside `JqCommand`'s own `-j`), found and recorded by
-[#1710](https://github.com/rust-works/succinctly/issues/1710). See
-[docs/guides/cli.md](../../guides/cli.md) for the same caveat on the flag's own listing.
 
 **jq-styled syntax real yq's lexer rejects, gated behind `--jq-extensions`, off by default
 ([#1512](https://github.com/rust-works/succinctly/issues/1512))** — `paths`, `getpath`,

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -412,7 +412,7 @@ succinctly yq '.users[]' input.yaml
 - `-o, --output-format <FORMAT>`: Output format: `yaml` (default), `json`, `auto`
 - `-I, --indent <N>`: Indent level (0 for compact output, default: 2)
 - `-r, --unwrapScalar`: Output raw strings without quotes (default for YAML)
-- `-j, --join-output`: Like -r but no newline after each output. **A succinctly extension, not real yq's own `-j`** — real yq's `-j` is a deprecated alias for `--tojson` (forces JSON output, unrelated to line-joining), and `--join-output` doesn't exist in real yq at all (confirmed against the pinned v4.53.3 binary; see [yq Limitations § Extensions](../compliance/yq/limitations.md#extensions)). Unaffected in jq mode below, where `-j`/`--join-output` does match real jq
+- `-j, --join-output`: Like -r but no newline after each output. **`-j` collides with real yq's own `-j`** — real yq's `-j` is a deprecated alias for `--tojson` (forces JSON output, unrelated to line-joining), and `--join-output` doesn't exist in real yq at all (confirmed against the pinned v4.53.3 binary; see [yq Limitations § Open divergences](../compliance/yq/limitations.md#open-divergences-bugs-not-decisions)). Unaffected in jq mode below, where `-j`/`--join-output` does match real jq
 - `-0, --nul-output`: Use NUL char to separate values instead of newline
 - `-S, --sort-keys`: Sort keys of each object on output
 - `-C, --colors`: Force colorized output

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -412,7 +412,7 @@ succinctly yq '.users[]' input.yaml
 - `-o, --output-format <FORMAT>`: Output format: `yaml` (default), `json`, `auto`
 - `-I, --indent <N>`: Indent level (0 for compact output, default: 2)
 - `-r, --unwrapScalar`: Output raw strings without quotes (default for YAML)
-- `-j, --join-output`: Like -r but no newline after each output
+- `-j, --join-output`: Like -r but no newline after each output. **A succinctly extension, not real yq's own `-j`** — real yq's `-j` is a deprecated alias for `--tojson` (forces JSON output, unrelated to line-joining), and `--join-output` doesn't exist in real yq at all (confirmed against the pinned v4.53.3 binary; see [yq Limitations § Extensions](../compliance/yq/limitations.md#extensions)). Unaffected in jq mode below, where `-j`/`--join-output` does match real jq
 - `-0, --nul-output`: Use NUL char to separate values instead of newline
 - `-S, --sort-keys`: Sort keys of each object on output
 - `-C, --colors`: Force colorized output

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1938,9 +1938,10 @@ impl SplitDocState {
 /// (`--raw-output0 -j`, order-independent either way), not yq: the pinned
 /// yq oracle (Homebrew v4.53.3) has no `--join-output` flag at all (it
 /// errors "unknown flag"), and its own `-j` is an unrelated, deprecated
-/// alias for `--tojson`. yq-mode's `-j`/`--join-output` is a succinctly
-/// extension borrowing jq's flag meaning, not a real-yq behavior to match.
-/// A bare newline is the default when neither flag is set.
+/// alias for `--tojson`. yq-mode's `-j`/`--join-output` borrows jq's flag
+/// meaning and collides with real yq's own `-j` — a documented open
+/// divergence (docs/compliance/yq/limitations.md), not a real-yq behavior
+/// to match. A bare newline is the default when neither flag is set.
 ///
 /// Split out from [`write_terminator`] (#1701) so the same three-way choice
 /// can also drive the M2 fast path's own terminator writes -- previously


### PR DESCRIPTION
## Summary

Fixes #1710.

`succinctly yq`'s `-j`/`--join-output` implements jq-style "no separator, concatenate raw" output, apparently ported from `JqCommand`'s own legitimate `-j` (which does match real jq). Real yq's own `-j` means something unrelated: a deprecated alias for `--tojson` (forces JSON output, prints a deprecation warning); `--join-output` doesn't exist in real yq at all. Confirmed live against the pinned v4.53.3 binary:

```console
$ yq -j '.' <<< 'a: 1'
Flag --tojson has been deprecated, please use -o=json instead
{
  "a": 1
}
$ yq --join-output '.' <<< 'a: 1'
Error: unknown flag: --join-output
```

A user who knows real yq's `-j` could reasonably expect `succinctly yq -j` to match it and get something else entirely — neither `docs/guides/cli.md`'s flag listing nor `docs/compliance/yq/limitations.md` mentioned this.

## Scope

Docs-only, per the issue's own suggested fix direction. The bigger question the issue also raises — whether yq mode's `-j` should be remapped to match real yq's actual `--tojson` meaning instead — is explicitly out of scope here (a behavior change, not a documentation fix), and is now tracked separately as #1731. jq mode's own `-j`/`--join-output` is unaffected; it already matches real jq faithfully.

## Changes

- `docs/compliance/yq/limitations.md`: new `### -j/--join-output collides with real yq's own -j` subsection under `## Open divergences (bugs, not decisions)`.
- `docs/guides/cli.md`: caveat added to the yq section's own `-j, --join-output` listing, cross-referencing the limitations page. The jq section's identical-looking listing is untouched (no divergence there).
- `src/bin/succinctly/yq_runner.rs`: doc-comment-only update on the terminator-selection helper, syncing its description of `-j`/`--join-output` to the corrected classification.

## Round 2 (code review)

Round 1 review caught a real classification error in the initial version of this PR:

- **Misclassified as an "Extension"**: the first commit filed this under `## Extensions`, but ADR-0018 rule 5 only permits that category where the reference tool has *no* existing behaviour for the same surface. Real yq's arg parser does accept `-j` — it just means something else — so this fails rule 5's own test, and none of rule 4's carve-outs (unreadable output, corruption, a discarded write, taking the process down) apply either. Moved to a new `## Open divergences (bugs, not decisions)` subsection instead.
- **Wrong output transcript**: the original write-up claimed real yq's `-j` produces compact single-line JSON (`{"a": 1}`); the pinned v4.53.3 binary actually pretty-prints it across 3 lines. Corrected above and in the doc.
- **Stale cross-reference**: an earlier, #1701-era passage in the same file (the anchor-soundness section) had conflated `-j` and `--join-output` as both having "no reference behaviour" — true only for the long form. Rewrote it to distinguish the two spellings and point at the new section.
- `docs/guides/cli.md`'s own caveat and its link target were updated to match (no longer says "extension", links to `#open-divergences-bugs-not-decisions` instead of `#extensions`).

## Round 3 (code review)

A second review pass found four more residual issues, all now fixed:

- **Stale cross-reference**: the new section pointed readers at "Anchor soundness" for the newline-guarded `---` discussion; that content actually lives in the separate `-0`/`--nul-output multi-document separator` section. Fixed the link text.
- **Stale source comment**: `src/bin/succinctly/yq_runner.rs`'s doc comment on the terminator-selection helper still called `-j`/`--join-output` "a succinctly extension" — the exact classification this PR reclassifies in the compliance docs. Synced it to point at the new "open divergence" language instead.
- **Mis-enumerated/miscounted carve-outs**: the new text said "rule 4's four carve-outs (unreadable output, corruption, a discarded write, or taking the process down)" — this both double-counts ADR-0018 rule 4(b) (corruption *and* discarded-write are one condition, not two) and drops rule 4(d) (no expressible portable equivalent) entirely, while also contradicting three other places in the same file that still say "three conditions" (pre-existing drift from ADR-0018's rule-4(d) amendment, filed separately as #1730 since it's out of scope to fix wholesale here). Dropped the specific count rather than re-deriving it incorrectly.
- **`--join-output` alone would pass the extension test**: taken by itself, the long spelling has no real-yq counterpart at all, so it would cleanly qualify as an extension under rule 5. It isn't documented as one because `-j` and `--join-output` are two spellings of the same clap argument with identical behaviour — added a paragraph explaining why the pair is recorded as a single open divergence rather than split "one extension, one bug" by spelling.

## Round 4 (code review)

A third review pass found two prose-level gaps, both now fixed:

- Two adjacent sentences restated the same point about why `-j`/`--join-output` are recorded as one divergence rather than split by spelling — merged into one.
- The "remapping `-j` to `--tojson` is a bigger change not attempted here" aside had no tracking issue, unlike every other "not attempted" gap elsewhere in this file. Filed #1731 and linked it.

A fourth review pass (after Round 4) re-verified all of the above independently against the pinned yq v4.53.3 binary and found no further issues in the code diff itself.

## Test plan

- [x] Live-verified against the pinned yq v4.53.3 binary (multiple independent rounds).
- [x] Verified all relative markdown links/anchors resolve to real files/sections.
- [x] `cargo fmt --all -- --check`, `cargo build --features cli`, full test/clippy suite all clean (docs-only change plus one doc-comment edit).

Closes #1710.
