### PR TITLE
fix(jq): plug decode-failure catchability gaps #1620's sweep missed

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3439,7 +3439,7 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
             // Keep string lazy - use raw bytes reference instead of decoding
             JqValue::String(
                 s.as_str()
-                    .map_err(|e| EvalError::new(format!("{e}")))?
+                    .map_err(|e| EvalError::decode_failure(format!("{e}")))?
                     .to_string(),
             )
         }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3460,7 +3460,9 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
                 let key = match f.key() {
                     StandardJson::String(s) => match s.as_str() {
                         Ok(cow) => cow.to_string(),
-                        Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
+                        Err(e) => {
+                            return Err(EvalError::decode_failure(format!("{e} in object key")))
+                        }
                     },
                     _ => return Err(EvalError::malformed_json_text(parent_cursor.text())),
                 };

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -965,12 +965,34 @@ impl EvalError {
         Self::new(reason)
     }
 
-    /// Whether this is a [`Self::decode_failure`] — see #1620. Every
+    /// Whether this is a [`Self::decode_failure`] — see #1620/#1660. Every
     /// `?`/`try`/`catch` boundary consults this so a decode failure passes
     /// through unmatched instead of being suppressed, the same way
     /// [`Self::is_invalid_path_expression`] exempts its own narrow error
     /// class without leaving the ordinary catchable `Error` channel.
+    ///
+    /// #1660 code review: classifying purely by matching `message` against
+    /// these literal strings collided with a user's own `error("invalid
+    /// escape sequence")` -- live-verified against jq 1.7.1, real jq
+    /// retries/catches/suppresses it as an ordinary error, where the naive
+    /// string match wrongly forced it uncatchable. `self.value.is_some()`
+    /// -- true only for [`Self::from_value`]/[`Self::from_value_with`],
+    /// i.e. exactly `error(v)` -- rules that out first at zero extra
+    /// storage cost: every constructor besides those two routes through
+    /// [`Self::new`], which always leaves `value` `None` (confirmed by
+    /// grep -- `Self { ... }` literal construction exists nowhere else in
+    /// this file), so an internally-raised decode failure is unaffected. A
+    /// dedicated boolean field was tried first instead of this check, but
+    /// `EvalError` had no spare padding to absorb it: the extra 8 bytes
+    /// propagated into `QueryResult`/`Control`'s recursive-materializer
+    /// call frames and turned a previously-controlled "nesting depth
+    /// exceeds limit" panic into a genuine stack overflow during unwind
+    /// (`jq::lazy::tests::into_owned_panics_past_nesting_depth_limit_1021`)
+    /// -- reverted in favor of this zero-size-cost check instead.
     pub fn is_decode_failure(&self) -> bool {
+        if self.value.is_some() {
+            return false;
+        }
         let base = self
             .message
             .strip_suffix(" in object key")

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5698,13 +5698,12 @@ fn builtin_length<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'_, W> {
     match &value {
         StandardJson::Null => QueryResult::Owned(OwnedValue::Int(0)),
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::Int(cow.chars().count() as i64))
-            } else {
-                QueryResult::Owned(OwnedValue::Int(0))
-            }
-        }
+        // #1620/#1660: an undecodable string must raise, not silently
+        // substitute a length of 0.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => QueryResult::Owned(OwnedValue::Int(cow.chars().count() as i64)),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         StandardJson::Array(elements) => {
             QueryResult::Owned(OwnedValue::Int((*elements).count() as i64))
         }
@@ -5744,13 +5743,11 @@ fn builtin_utf8bytelength<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::Int(cow.len() as i64))
-            } else {
-                QueryResult::Owned(OwnedValue::Int(0))
-            }
-        }
+        // #1620/#1660: same decode-failure exclusion as `length`.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => QueryResult::Owned(OwnedValue::Int(cow.len() as i64)),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::no_utf8_byte_length(&to_owned(&value))),
     }
@@ -7540,15 +7537,15 @@ fn builtin_reverse<W: Clone + AsRef<[u64]>>(
             items.reverse();
             QueryResult::Owned(OwnedValue::Array(items))
         }
-        StandardJson::String(s) => {
-            // reverse also works on strings
-            if let Ok(cow) = s.as_str() {
+        // reverse also works on strings. #1620/#1660: an undecodable string
+        // must raise, not silently substitute an empty string.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => {
                 let reversed: String = cow.chars().rev().collect();
                 QueryResult::Owned(OwnedValue::String(reversed))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
             }
-        }
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         // jq: null | reverse => []
         StandardJson::Null => QueryResult::Owned(OwnedValue::Array(Vec::new())),
         _ if optional => QueryResult::None,
@@ -32350,13 +32347,12 @@ fn builtin_trim<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::String(cow.trim().into()))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
-            }
-        }
+        // #1620/#1660: an undecodable string must raise, not silently
+        // substitute an empty string.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => QueryResult::Owned(OwnedValue::String(cow.trim().into())),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new("trim requires string")),
     }
@@ -32368,13 +32364,11 @@ fn builtin_ltrim<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::String(cow.trim_start().into()))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
-            }
-        }
+        // #1620/#1660: same decode-failure exclusion as `trim`.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => QueryResult::Owned(OwnedValue::String(cow.trim_start().into())),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new("ltrim requires string")),
     }
@@ -32386,13 +32380,11 @@ fn builtin_rtrim<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
-                QueryResult::Owned(OwnedValue::String(cow.trim_end().into()))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
-            }
-        }
+        // #1620/#1660: same decode-failure exclusion as `trim`.
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => QueryResult::Owned(OwnedValue::String(cow.trim_end().into())),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new("rtrim requires string")),
     }
@@ -35417,6 +35409,64 @@ mod tests {
             QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(n), _)) => {
                 assert_eq!(n, 2);
             }
+        );
+    }
+
+    /// #1660 code review: `is_decode_failure()` used to classify purely by
+    /// matching `message` against a handful of literal strings (e.g.
+    /// `"invalid escape sequence"`, `"invalid number format"`) -- which
+    /// collided with a user's own `error(...)` raising one of those exact
+    /// strings, wrongly forcing an ordinary, catchable error uncatchable.
+    /// Live-verified against jq 1.7.1: real jq retries/catches/suppresses
+    /// these normally. `EvalError::decode_failure` now sets a dedicated
+    /// field instead of relying on `reason`'s text, so this must retry
+    /// (not propagate) exactly like the "ordinary error" negative control
+    /// above.
+    #[test]
+    fn test_pattern_alternative_retry_not_confused_by_decode_failure_wording_1660() {
+        for wording in [
+            "invalid UTF-8 in string",
+            "invalid number format",
+            "invalid escape sequence in string",
+            "invalid unicode escape sequence",
+            "invalid escape sequence",
+        ] {
+            let expr = format!(
+                ". as {{p:$y}} ?// {{q:$y}} | (if $y==1 then error(\"{wording}\") else $y end)"
+            );
+            query!(
+                b"{\"p\": 1, \"q\": 2}",
+                &expr,
+                QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(n), _)) => {
+                    assert_eq!(n, 2, "wording: {wording}");
+                }
+            );
+        }
+    }
+
+    /// #1660 code review, `try`/`catch` side of the same collision: a
+    /// user's own `error("invalid escape sequence")` must still be
+    /// catchable, matching jq 1.7.1.
+    #[test]
+    fn test_try_catch_not_confused_by_decode_failure_wording_1660() {
+        query!(
+            b"null",
+            "try error(\"invalid escape sequence\") catch \"caught\"",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "caught");
+            }
+        );
+    }
+
+    /// #1660 code review, `?` side of the same collision: a user's own
+    /// `error("invalid number format")?` must still be suppressed, matching
+    /// jq 1.7.1.
+    #[test]
+    fn test_optional_not_confused_by_decode_failure_wording_1660() {
+        query!(
+            b"null",
+            "error(\"invalid number format\")?",
+            QueryResult::None => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3070,6 +3070,12 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         match eval_each::<W, S>(&substituted_body, value.clone(), optional, sink) {
             Flow::Exhausted => return Flow::Exhausted,
             Flow::Stopped { pending } => return Flow::Stopped { pending },
+            // #1620/#1660: same decode-failure exclusion as
+            // `try_pattern_alternatives` -- always propagates, `is_last` or
+            // not.
+            Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+                return Flow::Escaped(Control::Error(e));
+            }
             // #1457: `Break` falls through like `Error`, not immediately
             // like `Halt` -- same live-verified correction
             // `try_pattern_alternatives` itself documents.
@@ -6767,14 +6773,16 @@ fn builtin_ascii_downcase<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => {
                 let lowered: String = cow.chars().map(|c| c.to_ascii_lowercase()).collect();
                 QueryResult::Owned(OwnedValue::String(lowered))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
             }
-        }
+            // #1620/#1660: an undecodable string must raise, not silently
+            // substitute an empty string -- same rule as the sibling string
+            // builtins converted by #1647.
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::new("explode input must be a string")),
     }
@@ -6786,14 +6794,14 @@ fn builtin_ascii_upcase<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match &value {
-        StandardJson::String(s) => {
-            if let Ok(cow) = s.as_str() {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => {
                 let uppered: String = cow.chars().map(|c| c.to_ascii_uppercase()).collect();
                 QueryResult::Owned(OwnedValue::String(uppered))
-            } else {
-                QueryResult::Owned(OwnedValue::String(String::new()))
             }
-        }
+            // #1620/#1660: same decode-failure exclusion as `ascii_downcase`.
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
         _ if optional => QueryResult::None,
         // As `ascii_downcase`: jq defines both as `explode | map(…) | implode`,
         // so both report `explode`'s refusal.
@@ -6827,17 +6835,18 @@ fn builtin_ltrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return QueryResult::Owned(to_owned(&value));
             };
             let result = match &value {
-                StandardJson::String(s) => {
-                    if let Ok(cow) = s.as_str() {
+                StandardJson::String(s) => match s.as_str() {
+                    Ok(cow) => {
                         if cow.starts_with(&prefix) {
                             OwnedValue::String(cow[prefix.len()..].to_string())
                         } else {
                             OwnedValue::String(cow.into_owned())
                         }
-                    } else {
-                        OwnedValue::String(String::new())
                     }
-                }
+                    // #1620/#1660: an undecodable string must raise, not
+                    // silently substitute an empty string.
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
+                },
                 // jq's ltrimstr is total: a non-string input passes through
                 // unchanged.
                 _ => to_owned(&value),
@@ -6866,17 +6875,18 @@ fn builtin_rtrimstr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return QueryResult::Owned(to_owned(&value));
             };
             let result = match &value {
-                StandardJson::String(s) => {
-                    if let Ok(cow) = s.as_str() {
+                StandardJson::String(s) => match s.as_str() {
+                    Ok(cow) => {
                         if cow.ends_with(&suffix) {
                             OwnedValue::String(cow[..cow.len() - suffix.len()].to_string())
                         } else {
                             OwnedValue::String(cow.into_owned())
                         }
-                    } else {
-                        OwnedValue::String(String::new())
                     }
-                }
+                    // #1620/#1660: same decode-failure exclusion as
+                    // `ltrimstr`.
+                    Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
+                },
                 // jq's rtrimstr is total: a non-string input passes through
                 // unchanged.
                 _ => to_owned(&value),
@@ -6903,10 +6913,13 @@ fn builtin_startswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return QueryResult::Error(EvalError::new("startswith() requires string inputs"));
             };
             match &value {
-                StandardJson::String(s) => {
-                    let starts = s.as_str().is_ok_and(|cow| cow.starts_with(&prefix));
-                    QueryResult::Owned(OwnedValue::Bool(starts))
-                }
+                // #1620/#1660: `.is_ok_and(...)` treated a decode `Err` the
+                // same as "no match", silently returning `false` instead of
+                // raising.
+                StandardJson::String(s) => match s.as_str() {
+                    Ok(cow) => QueryResult::Owned(OwnedValue::Bool(cow.starts_with(&prefix))),
+                    Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+                },
                 _ if optional => QueryResult::None,
                 _ => QueryResult::Error(EvalError::new("startswith() requires string inputs")),
             }
@@ -6931,10 +6944,12 @@ fn builtin_endswith<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return QueryResult::Error(EvalError::new("endswith() requires string inputs"));
             };
             match &value {
-                StandardJson::String(s) => {
-                    let ends = s.as_str().is_ok_and(|cow| cow.ends_with(&suffix));
-                    QueryResult::Owned(OwnedValue::Bool(ends))
-                }
+                // #1620/#1660: same decode-failure exclusion as
+                // `startswith`.
+                StandardJson::String(s) => match s.as_str() {
+                    Ok(cow) => QueryResult::Owned(OwnedValue::Bool(cow.ends_with(&suffix))),
+                    Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+                },
                 _ if optional => QueryResult::None,
                 _ => QueryResult::Error(EvalError::new("endswith() requires string inputs")),
             }
@@ -6964,8 +6979,13 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             };
             match &value {
                 StandardJson::String(s) => {
-                    let Ok(cow) = s.as_str() else {
-                        return QueryResult::Owned(OwnedValue::Array(vec![]));
+                    // #1620/#1660: an undecodable string must raise, not
+                    // silently substitute an empty array.
+                    let cow = match s.as_str() {
+                        Ok(cow) => cow,
+                        Err(e) => {
+                            return QueryResult::Error(EvalError::decode_failure(e.message()))
+                        }
                     };
                     // jq: split("") returns each character as a separate element
                     // Rust's split("") includes empty strings at boundaries, so special-case it
@@ -22209,6 +22229,21 @@ fn try_reduce_step_alternatives<S: EvalSemantics>(
         state = update_vals.into_iter().last().unwrap_or(OwnedValue::Null);
         match update_control {
             None => return (state, None),
+            // #1620/#1660: a decode failure always propagates, `is_last` or
+            // not -- mirroring `try_pattern_alternatives`'s own exclusion.
+            // Not currently reachable through any live input: `update` only
+            // ever sees fully-materialized `OwnedValue`s here -- `state`
+            // (round-tripped through `to_json_for_reindex`/`JsonIndex`, but
+            // only ever re-encoding an already-valid Rust `String`) and every
+            // pattern-bound `$var` (spliced in as an already-materialized
+            // literal by `substitute_vars`, built from `input_val: &OwnedValue`
+            // one level up in `eval_reduce`) -- so `.as_str()` can never fail
+            // on anything UPDATE evaluates. Kept for parity with the sibling
+            // functions and as a guard against a future change (e.g. lazy
+            // `$var` binding) reopening a path to a live decode failure here.
+            Some(Control::Error(e)) if e.is_decode_failure() => {
+                return (state, Some(Control::Error(e)));
+            }
             Some(Control::Error(_) | Control::Break(_)) if !is_last => {}
             Some(control) => return (state, Some(control)),
         }
@@ -22658,8 +22693,21 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// than calling this, since its single UPDATE-only retry predates this
 /// helper; consolidating it too is tracked separately (#1570) rather than
 /// attempted here, to keep this fix scoped to the bug it's actually fixing.
+///
+/// #1620/#1660: a decode failure is never retryable, `is_last` or not --
+/// same exclusion as `try_pattern_alternatives`/`eval_try`, applied here
+/// once so neither of this function's two call sites has to remember it
+/// independently. Like `try_reduce_step_alternatives`'s equivalent guard,
+/// not currently reachable through any live input -- both UPDATE and
+/// EXTRACT only ever evaluate fully-materialized `OwnedValue`s here, never a
+/// cursor over the original document's raw bytes. Kept for parity and as a
+/// guard against a future change reopening a path to one.
 fn is_retryable_control(control: &Control, is_last: bool) -> bool {
-    !is_last && matches!(control, Control::Error(_) | Control::Break(_))
+    match control {
+        Control::Error(e) if e.is_decode_failure() => false,
+        Control::Error(_) | Control::Break(_) => !is_last,
+        Control::Halt(_) => false,
+    }
 }
 
 /// Try each `?//`-separated pattern alternative (#1365) for one `foreach`
@@ -33146,6 +33194,13 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 return Ok((carried, None));
             }
             QueryResult::None => return Ok((carried, None)),
+            // #1620/#1660: a decode failure must never be treated as "this
+            // alternative failed to match, try the next one" -- it always
+            // propagates, `is_last` or not, the same way `eval_try` never
+            // suppresses it regardless of whether a `catch` handler exists.
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                return Ok((carried, Some(Control::Error(e))));
+            }
             QueryResult::Error(e) => {
                 if is_last {
                     return Ok((carried, Some(Control::Error(e))));
@@ -33166,6 +33221,11 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Partial(vs, control) => {
                 carried.extend(vs);
                 match control {
+                    // Same #1620/#1660 decode-failure exclusion as the bare
+                    // `Error` arm above.
+                    Control::Error(ref e) if e.is_decode_failure() => {
+                        return Ok((carried, Some(control)));
+                    }
                     Control::Error(_) | Control::Break(_) => {
                         if is_last {
                             return Ok((carried, Some(control)));
@@ -35233,6 +35293,129 @@ mod tests {
             "try (.a | keys) catch \"caught\"",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "caught");
+            }
+        );
+    }
+
+    /// #1660: a `?//`-alternative retry must not treat a decode failure the
+    /// same as an ordinary pattern-match/body failure -- it always
+    /// propagates, even when the current alternative isn't the last one.
+    /// Before the fix, this silently fell through to the second alternative
+    /// (`$y` from `{q:$y}`) and printed `2`.
+    #[test]
+    fn test_pattern_alternative_retry_does_not_swallow_decode_failure_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\", \"p\": 1, \"q\": 2}",
+            ". as {p:$y} ?// {q:$y} | (if $y==1 then (.a|tonumber) else $y end)",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660: same as above, but wrapped in an array collector to force the
+    /// streaming/sink-based `each_as_pattern`/`each_pattern_alternatives`
+    /// dispatch rather than the single-value `eval_as_pattern`/
+    /// `try_pattern_alternatives` path, confirming both twins got the fix.
+    #[test]
+    fn test_pattern_alternative_retry_does_not_swallow_decode_failure_each_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\", \"p\": 1, \"q\": 2}",
+            "[. as {p:$y} ?// {q:$y} | (if $y==1 then (.a|tonumber) else $y end)]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660: `startswith`/`endswith` used `.is_ok_and(...)`, which treats a
+    /// decode `Err` the same as "no match" and silently returns `false`
+    /// instead of raising -- worse than an ordinary suppression, since it
+    /// produces a plausible-looking wrong value rather than an error `?`
+    /// could even suppress.
+    #[test]
+    fn test_startswith_endswith_raise_on_decode_failure_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#".a | startswith("x")"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#".a | endswith("x")"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660: `split` returned an empty array on a decode failure instead of
+    /// raising.
+    #[test]
+    fn test_split_raises_on_decode_failure_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#".a | split(",")"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660: `ascii_downcase`/`ascii_upcase` substituted an empty string on
+    /// a decode failure instead of raising.
+    #[test]
+    fn test_ascii_case_builtins_raise_on_decode_failure_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a | ascii_downcase",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a | ascii_upcase",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660: `ltrimstr`/`rtrimstr` substituted an empty string on a decode
+    /// failure instead of raising, for both the "prefix/suffix matches" and
+    /// "doesn't match" branches (both used to silently vanish into `""`).
+    #[test]
+    fn test_ltrimstr_rtrimstr_raise_on_decode_failure_1660() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#".a | ltrimstr("x")"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#".a | rtrimstr("x")"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #1660 negative control: an *ordinary* error inside a `?//`
+    /// alternative's body must still retry the next alternative, proving
+    /// the new decode-failure exclusion is scoped correctly and doesn't
+    /// suppress the pre-existing #1365 retry behavior for anything else.
+    #[test]
+    fn test_pattern_alternative_retry_still_retries_ordinary_errors_1660() {
+        query!(
+            b"{\"p\": 1, \"q\": 2}",
+            ". as {p:$y} ?// {q:$y} | (if $y==1 then error(\"boom\") else $y end)",
+            QueryResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(n), _)) => {
+                assert_eq!(n, 2);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22683,13 +22683,16 @@ fn eval_owned_input<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// since there's nothing left to fall through to.
 ///
 /// Shared by both of [`try_foreach_step_alternatives`]'s retry decisions
-/// (UPDATE's own, and EXTRACT's -- #1458) so the two can't independently
-/// drift on what counts as retryable, the way `try_pattern_alternatives`'s
-/// own copy of this same predicate already once did (#1457).
-/// [`try_reduce_step_alternatives`] hand-rolls an equivalent match rather
-/// than calling this, since its single UPDATE-only retry predates this
-/// helper; consolidating it too is tracked separately (#1570) rather than
-/// attempted here, to keep this fix scoped to the bug it's actually fixing.
+/// (UPDATE's own, and EXTRACT's -- #1458), and by [`try_pattern_alternatives`]'s
+/// own `Partial` arm (#1660 code review -- that arm used to hand-roll an
+/// identical copy of this exact match, the same drift risk #1457 already
+/// found once in this function's *other* caller before this helper existed)
+/// so none of these call sites can independently drift on what counts as
+/// retryable. [`try_reduce_step_alternatives`] hand-rolls an equivalent
+/// match rather than calling this, since its single UPDATE-only retry
+/// predates this helper; consolidating it too is tracked separately (#1570)
+/// rather than attempted here, to keep this fix scoped to the bug it's
+/// actually fixing.
 ///
 /// #1620/#1660: a decode failure is never retryable, `is_last` or not --
 /// same exclusion as `try_pattern_alternatives`/`eval_try`, applied here
@@ -33210,22 +33213,20 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 continue;
             }
             QueryResult::Halt(code) => return Ok((carried, Some(Control::Halt(code)))),
+            // `is_retryable_control` (#1660 code review): this arm used to
+            // hand-roll the same three-way decode-failure/`is_last`/`Halt`
+            // classification `is_retryable_control` already centralizes for
+            // `try_foreach_step_alternatives`'s two call sites -- reusing it
+            // here instead closes the gap its own doc comment warns about
+            // (a third independently-maintained copy silently diverging,
+            // the way `try_pattern_alternatives`'s pre-#1660 copy of this
+            // exact predicate already once did, #1457).
             QueryResult::Partial(vs, control) => {
                 carried.extend(vs);
-                match control {
-                    // Same #1620/#1660 decode-failure exclusion as the bare
-                    // `Error` arm above.
-                    Control::Error(ref e) if e.is_decode_failure() => {
-                        return Ok((carried, Some(control)));
-                    }
-                    Control::Error(_) | Control::Break(_) => {
-                        if is_last {
-                            return Ok((carried, Some(control)));
-                        }
-                        continue;
-                    }
-                    Control::Halt(_) => return Ok((carried, Some(control))),
+                if is_retryable_control(&control, is_last) {
+                    continue;
                 }
+                return Ok((carried, Some(control)));
             }
         }
     }
@@ -35259,10 +35260,12 @@ mod tests {
 
     /// #1620: `try`/`catch` -- `eval_try`, this module's own native
     /// dispatch for both `Expr::Try` and `Expr::Optional` -- must not catch
-    /// a decode failure either. Uses `tonumber`, not `length`: `eval.rs`'s
-    /// own `builtin_length` silently substitutes `0` on a decode failure
-    /// instead of raising at all -- a separate, `to_owned`-family-shaped gap
-    /// (also not reachable via the CLI), out of #1620's scope.
+    /// a decode failure either. Uses `tonumber`, not `length`: at the time
+    /// this test was written, `eval.rs`'s own `builtin_length` silently
+    /// substituted `0` on a decode failure instead of raising at all -- #1660
+    /// has since fixed that (see `test_length_and_friends_raise_on_decode_failure_1660`
+    /// for `length`'s own coverage), but `tonumber` is kept here rather than
+    /// switched to avoid entangling this test with that unrelated fix.
     #[test]
     fn test_try_catch_does_not_catch_decode_failure_1620() {
         query!(
@@ -35397,6 +35400,32 @@ mod tests {
         );
     }
 
+    /// #1660 code review: `length`/`utf8bytelength`/`reverse`/`trim`/
+    /// `ltrim`/`rtrim` share the exact `if let Ok(cow) = s.as_str() {...}
+    /// else { <silent substitute> }` shape the original sweep fixed for
+    /// `startswith`/`endswith`/`split`/`ascii_downcase`/`ascii_upcase`/
+    /// `ltrimstr`/`rtrimstr`, but were missed from that first pass despite
+    /// being immediately adjacent in the same file.
+    #[test]
+    fn test_length_and_friends_raise_on_decode_failure_1660() {
+        for expr in [
+            ".a | length",
+            ".a | utf8bytelength",
+            ".a | reverse",
+            ".a | trim",
+            ".a | ltrim",
+            ".a | rtrim",
+        ] {
+            query!(
+                b"{\"a\": \"\xff\xfe\"}",
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(e.message.contains("invalid UTF-8"), "expr={expr} message: {}", e.message);
+                }
+            );
+        }
+    }
+
     /// #1660 negative control: an *ordinary* error inside a `?//`
     /// alternative's body must still retry the next alternative, proving
     /// the new decode-failure exclusion is scoped correctly and doesn't
@@ -35418,10 +35447,11 @@ mod tests {
     /// collided with a user's own `error(...)` raising one of those exact
     /// strings, wrongly forcing an ordinary, catchable error uncatchable.
     /// Live-verified against jq 1.7.1: real jq retries/catches/suppresses
-    /// these normally. `EvalError::decode_failure` now sets a dedicated
-    /// field instead of relying on `reason`'s text, so this must retry
-    /// (not propagate) exactly like the "ordinary error" negative control
-    /// above.
+    /// these normally. `is_decode_failure()` now checks `self.value.is_some()`
+    /// first (see its own doc comment in `error.rs`) -- true only for a
+    /// user's `error(v)`, never for an internally-raised decode failure --
+    /// so this must retry (not propagate) exactly like the "ordinary error"
+    /// negative control above.
     #[test]
     fn test_pattern_alternative_retry_not_confused_by_decode_failure_wording_1660() {
         for wording in [

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1313,7 +1313,9 @@ fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
                 let key = match field.key() {
                     StandardJson::String(s) => match s.as_str() {
                         Ok(cow) => cow.to_string(),
-                        Err(e) => return Err(EvalError::new(format!("{e} in object key"))),
+                        Err(e) => {
+                            return Err(EvalError::decode_failure(format!("{e} in object key")))
+                        }
                     },
                     _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
                 };

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1290,7 +1290,7 @@ fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
         StandardJson::String(s) => OwnedValue::String(
             s.as_str()
-                .map_err(|e| EvalError::new(format!("{e}")))?
+                .map_err(|e| EvalError::decode_failure(format!("{e}")))?
                 .to_string(),
         ),
         StandardJson::Array(elements) => {
@@ -4938,6 +4938,20 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
         match eval_each_generic::<S, V>(&substituted_body, value.clone(), optional, cursor, sink) {
             Flow::Exhausted => return Flow::Exhausted,
             Flow::Stopped { pending } => return Flow::Stopped { pending },
+            // #1620/#1660: same decode-failure exclusion as
+            // `eval::each_pattern_alternatives` -- always propagates,
+            // `is_last` or not. Currently unreachable through any live
+            // input: every public entry point dispatches `Expr::AsPattern`
+            // through `eval_single`'s wildcard fallback (which eagerly
+            // materializes the whole scope and bridges to `eval.rs`'s
+            // already-fixed evaluator) rather than this function's own
+            // caller (`each_as_pattern_generic`/`eval_each_generic`), so
+            // this loop never actually runs today. Kept as a stale-twin
+            // parity fix and a guard against a future change reopening a
+            // path to it.
+            Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+                return Flow::Escaped(Control::Error(e));
+            }
             // #1457: `Break` falls through like `Error`, not immediately
             // like `Halt` -- same live-verified correction
             // `eval::each_pattern_alternatives` itself documents.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4940,15 +4940,13 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
             Flow::Stopped { pending } => return Flow::Stopped { pending },
             // #1620/#1660: same decode-failure exclusion as
             // `eval::each_pattern_alternatives` -- always propagates,
-            // `is_last` or not. Currently unreachable through any live
-            // input: every public entry point dispatches `Expr::AsPattern`
-            // through `eval_single`'s wildcard fallback (which eagerly
-            // materializes the whole scope and bridges to `eval.rs`'s
-            // already-fixed evaluator) rather than this function's own
-            // caller (`each_as_pattern_generic`/`eval_each_generic`), so
-            // this loop never actually runs today. Kept as a stale-twin
-            // parity fix and a guard against a future change reopening a
-            // path to it.
+            // `is_last` or not. Live and load-bearing, not merely
+            // stale-twin parity: `first([.p,.q] as [$y] ?// [$z,$y] | ...)`
+            // reaches this loop via `eval_each_generic`'s own native
+            // `Expr::AsPattern` arm (`each_as_pattern_generic`), not
+            // `eval_single`'s wildcard fallback -- confirmed by removing
+            // this arm and observing the exact silently-wrong-value bug
+            // #1660 fixes elsewhere reappear here too.
             Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
                 return Flow::Escaped(Control::Error(e));
             }
@@ -7434,6 +7432,38 @@ mod tests {
                     "caught".to_string(),
                 )))),
             },
+            value,
+        );
+
+        match result {
+            GenericResult::Error(e) => assert!(
+                e.is_decode_failure() && e.message.contains("invalid UTF-8"),
+                "message: {}",
+                e.message
+            ),
+            other => panic!("expected an uncaught decode-failure error, got {other:?}"),
+        }
+    }
+
+    /// #1660: `each_pattern_alternatives_generic`'s own decode-failure
+    /// exclusion, reached via this module's *native* `Expr::AsPattern` arm
+    /// (`each_as_pattern_generic`) rather than the reindex-bridge wildcard
+    /// the two tests above exercise -- `first(...)` drives evaluation
+    /// through `eval_each_generic` directly, which is what actually calls
+    /// into this function. Before the fix, a decode failure inside a
+    /// non-last `?//` alternative's body silently fell through to the next
+    /// alternative here too, exactly like `eval::each_pattern_alternatives`.
+    #[test]
+    fn test_generic_pattern_alternative_retry_does_not_swallow_decode_failure_1660() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\", \"p\": 1, \"q\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let result = eval(
+            &parse("first([.p,.q] as [$y] ?// [$z,$y] | (if $y==1 then (.a|length) else $y end))")
+                .unwrap(),
             value,
         );
 

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -738,7 +738,7 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // eval_generic.rs swallowed the same case as `null`. Both raise
             // now, with the wording #1192 established.
             s.as_str()
-                .map_err(|e| EvalError::new(format!("{e}")))?
+                .map_err(|e| EvalError::decode_failure(format!("{e}")))?
                 .into_owned(),
         ),
         StandardJson::Array(_) => {


### PR DESCRIPTION
## Summary
#1620/PR #1647 gave `EvalError` a `decode_failure()`/`is_decode_failure()` pair so
a decode failure (invalid UTF-8, malformed escape, bad number literal) is never
suppressed by `?`/`try`/`catch`, and swept ~18 `eval.rs` builtin call sites plus
`eval_generic.rs`'s dispatch. This PR closes several gaps a fresh review of that
merged diff found, discovered and fixed across three rounds of adversarial
multi-agent code review:

1. **`try_pattern_alternatives`/`each_pattern_alternatives`** (`. as PATTERN ?//`
   and its streaming twin, both in `eval.rs`) and **`each_pattern_alternatives_generic`**
   (the `eval_generic.rs` twin) — a decode failure inside a non-last alternative's
   body silently fell through to the next alternative instead of propagating. All
   three are **live and confirmed reachable** (verified by disabling each guard in
   turn and watching the wrong retried value reappear).
2. **`try_reduce_step_alternatives`/`try_foreach_step_alternatives`** (the same
   `?//` retry inside `reduce`/`foreach`) — same guard added for parity, but
   tracing the data flow shows UPDATE/EXTRACT only ever see fully-materialized
   `OwnedValue`s — **not reachable through any live input today**, documented as
   such rather than claimed with a misleading test.
3. **13 string builtins** (`startswith`/`endswith`/`split`/`ascii_downcase`/
   `ascii_upcase`/`ltrimstr`/`rtrimstr`/`length`/`utf8bytelength`/`reverse`/`trim`/
   `ltrim`/`rtrim`) silently substituted a default (`false`/`[]`/`""`/`0`) on a
   decode failure instead of raising, the same shape `builtin_test`/`builtin_match`
   were already fixed for.
4. **4 `EvalError::new(format!("{reason} in object key"))`/`format!("{e}")` sites**
   now use the `decode_failure()` constructor explicitly — no behavior change today,
   removes an accidental dependency on message-text coincidence.
5. **A real, live-verified `is_decode_failure()` collision** (pre-existing, but this
   sweep is what plumbed the check into several new call sites where it now bites):
   a user's own `error("invalid escape sequence")` (or any of its 4 sibling
   strings) was misclassified as an internal decode failure, wrongly forcing an
   ordinary, catchable error uncatchable. Confirmed against jq 1.7.1: real jq
   retries/catches/suppresses it normally. Fixed via `self.value.is_some()` — true
   only for `error(v)` (`EvalError::from_value`/`from_value_with`), never for an
   internally-raised decode failure, at zero extra storage cost. (A first attempt
   added a dedicated `bool` field instead; `EvalError` had no spare padding to
   absorb it, and the 8-byte growth turned a previously-controlled "nesting depth
   exceeds limit" panic into a genuine stack overflow during unwind in an existing
   test — reverted in favor of the zero-cost check.)
6. **`try_pattern_alternatives`'s `Partial` arm** hand-rolled the identical
   three-way retry classification `is_retryable_control` already centralizes for
   `try_foreach_step_alternatives` — replaced with a direct call.

**Not included**: the issue's most severe finding — `eval.rs`'s own independent
`to_owned_at_depth` silently drops a malformed object key and coerces an
undecodable dynamic-index string to `""` (corrupting `path()` output, not just
suppressing an error) — requires changing a ~250-call-site function's return type
to `Result`, an order of magnitude larger than the rest of this sweep. Filed
separately as #1728.

Fixes #1660 (partial — remaining scope tracked in #1728)

## Test plan
- [x] Added regression tests in `eval.rs`/`eval_generic.rs`'s own test modules
      (the `query!`/`parse`+`eval` patterns, exercising the library API directly)
      for every live-reachable fix
- [x] Verified every new guard actually changes behavior by temporarily disabling
      it and confirming the corresponding test fails with the old wrong output
- [x] Added negative controls confirming ordinary (non-decode) errors still retry
      `?//` alternatives, and that `error()` calls using decode-failure-like
      wording still retry/catch/suppress normally
- [x] Live-verified the `is_decode_failure()` collision fix against jq 1.7.1
      (three ways: `?//` retry, `try`/`catch`, `?` suppression)
- [x] `cargo test --features cli,regex` — full suite green (2900+ tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo build --no-default-features` — no_std build clean