### PR TITLE
fix(jq): @base64d matches jq's UTF-8 substitution rule, not WHATWG's

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -199,7 +199,7 @@ recorded in prose instead rather than dropped silently.
 
 ## An open gap in jq's own UTF-8 replacement-character substitution
 
-`substitute_invalid_utf8_jq_style` ([src/text/utf8/mod.rs](../../src/text/utf8/mod.rs),
+`substitute_invalid_utf8_jq_style` ([src/text/utf8/mod.rs](../../../src/text/utf8/mod.rs),
 #1617) matches jq 1.7.1's maximal-subpart substitution rule for document/raw-input decode,
 and — since #1719 — for `@base64d`/`@urid`'s own invalid-UTF-8 output too, collapsing a
 structurally-valid overlong/surrogate/out-of-range 3-/4-byte lead to a single U+FFFD where

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -197,6 +197,35 @@ This case is deliberately **absent from the probe corpus**: the captured table i
 file read with `include_str!`, so jq's byte-exact output here is not representable. It is
 recorded in prose instead rather than dropped silently.
 
+## An open gap in jq's own UTF-8 replacement-character substitution
+
+`substitute_invalid_utf8_jq_style` ([src/text/utf8/mod.rs](../../src/text/utf8/mod.rs),
+#1617) matches jq 1.7.1's maximal-subpart substitution rule for document/raw-input decode,
+and — since #1719 — for `@base64d`/`@urid`'s own invalid-UTF-8 output too, collapsing a
+structurally-valid overlong/surrogate/out-of-range 3-/4-byte lead to a single U+FFFD where
+`String::from_utf8_lossy`'s WHATWG rule gives one per byte.
+
+One case remains unmatched everywhere this function is used: when an
+`InvalidContinuationByte`'s rescanned byte lands at a string's *last* byte, real jq
+silently **drops** that byte; succinctly (matching WHATWG) keeps it.
+
+```bash
+$ printf '{"a":"\xe1\x41"}' | jq -c '.a'              # jq drops the 'A'
+"�"
+$ printf '{"a":"\xe1\x41"}' | sjq -c '.a'
+"�A"
+```
+
+This is not new to #1719 — the same wrong answer for this shape existed under the plain
+WHATWG fallback `@base64d`/`@urid` used before it (byte-identical output, confirmed live,
+both pre- and post-#1719). Filed as
+[#1717](https://github.com/rust-works/succinctly/issues/1717), likely an off-by-one in
+jq's own end-of-buffer lookahead rather than a designed rule; per ADR-0018 rule 4 the
+correct resolution, if picked up, is bug-for-bug replication rather than "fixing" the
+substitution into the more sensible WHATWG-consistent shape. See
+[docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md) for the fuller
+substitution-mechanism history.
+
 ## Conversion diagnostics beyond a single token
 
 jq implements `tonumber` and `fromjson` by handing the string to its JSON parser, so a

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -540,7 +540,15 @@ otherwise already correct, and it can be reverted independently if the perf gate
   off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, per ADR-0018
   rule 4 the correct resolution if picked up is bug-for-bug replication, not "fixing" it.
 - Scope is document input only. `--raw-input` shares the jq path (jq substitutes there
-  too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched.
+  too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched. #1719 later routed
+  `@base64d`/`@urid`'s jq-mode output through this same `substitute_invalid_utf8_jq_style`
+  call for the overlong/surrogate/out-of-range case those builtins previously got wrong
+  too -- and, as an unavoidable side effect of sharing the one function, they also inherit
+  #1717's still-open quirk above. This isn't new exposure: both builtins already gave the
+  same wrong (WHATWG) answer for #1717's specific shape before #1719, since
+  `String::from_utf8_lossy` and `substitute_invalid_utf8_jq_style` agree on that one case
+  (confirmed live, byte-identical output pre/post #1719 for `"4UE=" | @base64d`) -- #1719
+  changes zero bytes of output for #1717's shape, only for the shape it actually targets.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in
   review. The substitution originally ran at read time, before `validate_json_input`, so
   the strict validator was handed an already-repaired document: `sjq --validate` exited 0

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -539,16 +539,13 @@ otherwise already correct, and it can be reverted independently if the perf gate
   Filed as [#1717](https://github.com/rust-works/succinctly/issues/1717); likely an
   off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, per ADR-0018
   rule 4 the correct resolution if picked up is bug-for-bug replication, not "fixing" it.
-- Scope is document input only. `--raw-input` shares the jq path (jq substitutes there
-  too); DSV input, `--arg`/`--argjson` and `--rawfile` are untouched. #1719 later routed
-  `@base64d`/`@urid`'s jq-mode output through this same `substitute_invalid_utf8_jq_style`
-  call for the overlong/surrogate/out-of-range case those builtins previously got wrong
-  too -- and, as an unavoidable side effect of sharing the one function, they also inherit
-  #1717's still-open quirk above. This isn't new exposure: both builtins already gave the
-  same wrong (WHATWG) answer for #1717's specific shape before #1719, since
-  `String::from_utf8_lossy` and `substitute_invalid_utf8_jq_style` agree on that one case
-  (confirmed live, byte-identical output pre/post #1719 for `"4UE=" | @base64d`) -- #1719
-  changes zero bytes of output for #1717's shape, only for the shape it actually targets.
+- Scope was document input only until #1719 also routed `@base64d`/`@urid`'s jq-mode
+  output through this same `substitute_invalid_utf8_jq_style` call (for the
+  overlong/surrogate/out-of-range case), inheriting the #1717 quirk above as an
+  unavoidable side effect -- not new exposure, since `String::from_utf8_lossy` already
+  gave the identical wrong answer for #1717's specific shape before #1719 (byte-identical
+  output pre/post, confirmed live). `--raw-input` shares the jq path too (jq substitutes
+  there as well); DSV input, `--arg`/`--argjson` and `--rawfile` remain untouched.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in
   review. The substitution originally ran at read time, before `validate_json_input`, so
   the strict validator was handed an already-repaired document: `sjq --validate` exited 0

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -189,12 +189,17 @@ pub trait EvalSemantics: Copy + Default {
     /// diverge from.
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool;
 
-    /// If true (jq), decoding invalid UTF-8 bytes to a lossy `String`
-    /// (`@base64d`/`@urid`'s own decode, #1719; also document/raw-input
-    /// decode via `substitute_invalid_utf8_jq_style` directly, #1617) uses
-    /// jq's maximal-subpart rule: a structurally-valid overlong/surrogate/
-    /// out-of-range 3-/4-byte lead collapses to a single U+FFFD, live-
-    /// verified against jq 1.7.1 (`\xe0\x80\x80` -> one U+FFFD, not three).
+    /// If true (jq), `@base64d`/`@urid`'s own lossy-decode arm (#1719, the
+    /// sole reader of this const -- see `owned_string_from_decoded_bytes`)
+    /// uses jq's maximal-subpart rule: a structurally-valid overlong/
+    /// surrogate/out-of-range 3-/4-byte lead collapses to a single U+FFFD,
+    /// live-verified against jq 1.7.1 (`\xe0\x80\x80` -> one U+FFFD, not
+    /// three). Document/raw-input decode (#1617) uses this same rule too,
+    /// via a direct, unconditional call to `substitute_invalid_utf8_jq_style`
+    /// in the jq-only `jq_runner.rs` binary -- not gated on this const,
+    /// since that file has no `S: EvalSemantics` generic to read it from,
+    /// but it agrees with `S = JqSemantics`'s value here by construction
+    /// (jq-only binary, jq-only behavior).
     ///
     /// If false (yq), plain `String::from_utf8_lossy` (WHATWG's rule, one
     /// U+FFFD per byte) is used instead -- yq has no oracle-matching rule
@@ -8668,15 +8673,9 @@ fn yq_stringify_scalar_or_empty<S: EvalSemantics>(value: &OwnedValue) -> String 
 /// never error on bad UTF-8" decode policy has one definition instead of
 /// two independently-copy-pasted tails.
 ///
-/// Note this is necessarily an approximation of real yq's own behavior for
-/// input that decodes to *invalid* UTF-8 (e.g. `"%FF" | @urid`): real yq
-/// (backed by Go, whose strings are arbitrary byte sequences) passes such
-/// bytes through unchanged, but Rust's `String` cannot hold invalid UTF-8
-/// at all, so lossy substitution is the closest correct representation
-/// available here, not a verified oracle match for that specific case.
-///
-/// Which lossy substitution rule the invalid-UTF-8 arm uses is per-mode --
-/// see `EvalSemantics::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE` (#1719).
+/// Which lossy substitution rule the invalid-UTF-8 arm uses is per-mode,
+/// and neither is a verified oracle match on every input -- see
+/// `EvalSemantics::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE` (#1719).
 fn owned_string_from_decoded_bytes<S: EvalSemantics>(bytes: Vec<u8>) -> String {
     String::from_utf8(bytes).unwrap_or_else(|e| {
         if S::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -188,6 +188,27 @@ pub trait EvalSemantics: Copy + Default {
     /// `if`/`then`/`else` outright, so there is no yq answer for it to
     /// diverge from.
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool;
+
+    /// If true (jq), decoding invalid UTF-8 bytes to a lossy `String`
+    /// (`@base64d`/`@urid`'s own decode, #1719; also document/raw-input
+    /// decode via `substitute_invalid_utf8_jq_style` directly, #1617) uses
+    /// jq's maximal-subpart rule: a structurally-valid overlong/surrogate/
+    /// out-of-range 3-/4-byte lead collapses to a single U+FFFD, live-
+    /// verified against jq 1.7.1 (`\xe0\x80\x80` -> one U+FFFD, not three).
+    ///
+    /// If false (yq), plain `String::from_utf8_lossy` (WHATWG's rule, one
+    /// U+FFFD per byte) is used instead -- yq has no oracle-matching rule
+    /// to switch to here: real yq (backed by Go) passes invalid-UTF-8
+    /// bytes through unchanged, which Rust's `String` cannot represent at
+    /// all, so this is the closest available approximation, not a verified
+    /// oracle match.
+    ///
+    /// Neither rule fully matches jq on every input: `substitute_invalid_utf8_jq_style`
+    /// has its own separate, deliberately-unmatched gap (#1717) where jq
+    /// drops a byte this codebase keeps -- see
+    /// docs/compliance/jq/limitations.md's "An open gap in jq's own UTF-8
+    /// replacement-character substitution".
+    const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -214,6 +235,7 @@ impl EvalSemantics for JqSemantics {
     const COLLAPSE_DUPLICATE_KEYS: bool = true;
     const MAX_STRING_REPEAT_BYTES: Option<u128> = None;
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool = false;
+    const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = true;
 }
 
 /// yq-compatible evaluation semantics.
@@ -242,6 +264,7 @@ impl EvalSemantics for YqSemantics {
     const COLLAPSE_DUPLICATE_KEYS: bool = false;
     const MAX_STRING_REPEAT_BYTES: Option<u128> = Some(10 * 1024 * 1024);
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool = true;
+    const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = false;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -8652,16 +8675,11 @@ fn yq_stringify_scalar_or_empty<S: EvalSemantics>(value: &OwnedValue) -> String 
 /// at all, so lossy substitution is the closest correct representation
 /// available here, not a verified oracle match for that specific case.
 ///
-/// In jq mode, the invalid-UTF-8 arm uses jq's own maximal-subpart
-/// substitution rule (`substitute_invalid_utf8_jq_style`, #1617) rather than
-/// `String::from_utf8_lossy`'s WHATWG rule -- real jq's `@base64d` collapses
-/// an overlong/surrogate/out-of-range 3-/4-byte lead to one U+FFFD, where
-/// WHATWG emits one per byte (#1719). yq mode is unaffected: yq has no
-/// oracle-matching rule to switch to here (see the note above), so it keeps
-/// the existing lossy fallback.
+/// Which lossy substitution rule the invalid-UTF-8 arm uses is per-mode --
+/// see `EvalSemantics::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE` (#1719).
 fn owned_string_from_decoded_bytes<S: EvalSemantics>(bytes: Vec<u8>) -> String {
     String::from_utf8(bytes).unwrap_or_else(|e| {
-        if S::TAG == EvalTag::Jq {
+        if S::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE {
             crate::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
         } else {
             String::from_utf8_lossy(e.as_bytes()).into_owned()
@@ -8682,6 +8700,12 @@ fn owned_string_from_decoded_bytes<S: EvalSemantics>(bytes: Vec<u8>) -> String {
 /// real yq); [`format_uri`]'s own unconditional stringification (in both
 /// jq and yq mode) is a separate, pre-existing divergence from real yq,
 /// not touched here.
+///
+/// Percent-decoded bytes that turn out to be invalid UTF-8 go through
+/// [`owned_string_from_decoded_bytes`], whose substitution rule is
+/// per-mode (`EvalSemantics::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE`,
+/// #1719) even here, despite `@urid` itself having no jq oracle to verify
+/// against -- "mode decides" per ADR-0018 applies regardless.
 fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<String, EvalError> {
     let s = match value {
         OwnedValue::String(s) => s.clone(),
@@ -9179,25 +9203,20 @@ fn format_base64d<S: EvalSemantics>(
 
     // Lossy, not strict: real jq/yq's own `@base64d` never errors on
     // invalid UTF-8 in the decoded bytes -- it substitutes the standard
-    // replacement character, confirmed live against both oracles
-    // (`"null" | @base64d` succeeds in jq 1.7.1, not an error). This
+    // replacement character (confirmed live: real jq 1.7.1 gives
+    // `"\u{fffd}\u{fffd}"` for `"null" | @base64d`, not an error). This
     // surfaced while adding this function's `S` parameter (#1109): yq
     // mode's new scalar-stringification path (`null`/`true`/... above)
     // reaches this exact case for the first time, and the strict
     // conversion previously here would have produced a different wrong
     // error instead of matching the oracle.
     //
-    // Note the exact byte sequence real jq 1.7.1 emits for `"null"` is
-    // `"\u{fffd}\u{fffd}"` (two U+FFFD, no trailing byte) -- an earlier
-    // version of this comment claimed a trailing `e` that live-testing
-    // against the pinned binary (2026-08-27, re-verifying #1719) disproves.
-    // That third byte is the still-open #1717 quirk: jq drops the byte a
-    // rescan lands on when it's the string's very last byte, which neither
-    // `substitute_invalid_utf8_jq_style` (#1617/#1719, jq mode below) nor
-    // plain `String::from_utf8_lossy` (yq mode) replicates -- both keep it,
-    // so this specific example does not fully round-trip the oracle either
-    // way. #1719's fix is scoped to the overlong/surrogate/out-of-range
-    // collapse rule only; see `test_jq_base64d_invalid_utf8_is_lossy_not_error_1146`.
+    // That value does not fully round-trip the oracle even after #1719:
+    // succinctly's own decode of `"null"` keeps a third byte real jq drops
+    // (the still-open #1717 quirk -- see
+    // docs/compliance/jq/limitations.md's "An open gap in jq's own UTF-8
+    // replacement-character substitution"). #1719's fix below is scoped to
+    // the overlong/surrogate/out-of-range collapse rule only.
     Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8651,8 +8651,22 @@ fn yq_stringify_scalar_or_empty<S: EvalSemantics>(value: &OwnedValue) -> String 
 /// bytes through unchanged, but Rust's `String` cannot hold invalid UTF-8
 /// at all, so lossy substitution is the closest correct representation
 /// available here, not a verified oracle match for that specific case.
-fn owned_string_from_decoded_bytes(bytes: Vec<u8>) -> String {
-    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+///
+/// In jq mode, the invalid-UTF-8 arm uses jq's own maximal-subpart
+/// substitution rule (`substitute_invalid_utf8_jq_style`, #1617) rather than
+/// `String::from_utf8_lossy`'s WHATWG rule -- real jq's `@base64d` collapses
+/// an overlong/surrogate/out-of-range 3-/4-byte lead to one U+FFFD, where
+/// WHATWG emits one per byte (#1719). yq mode is unaffected: yq has no
+/// oracle-matching rule to switch to here (see the note above), so it keeps
+/// the existing lossy fallback.
+fn owned_string_from_decoded_bytes<S: EvalSemantics>(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes).unwrap_or_else(|e| {
+        if S::TAG == EvalTag::Jq {
+            crate::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
+        } else {
+            String::from_utf8_lossy(e.as_bytes()).into_owned()
+        }
+    })
 }
 
 /// @urid - URI/percent decode
@@ -8715,7 +8729,7 @@ fn format_urid<S: EvalSemantics>(value: &OwnedValue, optional: bool) -> Result<S
         result.push(bytes[i]);
         i += 1;
     }
-    Ok(owned_string_from_decoded_bytes(result))
+    Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 
 /// Quote a CSV/DSV string field: wrap in `"..."`, doubling inner `"`.
@@ -9066,7 +9080,7 @@ fn format_base64d<S: EvalSemantics>(
             _ => unreachable!("a full quantum always flushes before the loop can exit here"),
         }
 
-        return Ok(owned_string_from_decoded_bytes(result));
+        return Ok(owned_string_from_decoded_bytes::<S>(result));
     }
 
     // Real jq truncates at the *first* `=` in the (whitespace-
@@ -9172,7 +9186,7 @@ fn format_base64d<S: EvalSemantics>(
     // (`null`/`true`/... above) reaches this exact case for the first
     // time, and the strict conversion previously here would have produced
     // a different wrong error instead of matching the oracle.
-    Ok(owned_string_from_decoded_bytes(result))
+    Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 
 /// @html - HTML entity escape
@@ -40614,6 +40628,20 @@ mod tests {
         query!(br#""aGVsbG8=""#, "@base64d",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "hello");
+            }
+        );
+    }
+
+    #[test]
+    fn test_format_base64d_overlong_collapses_to_one_fffd_1719() {
+        // #1719: an overlong 3-byte lead decoded from base64 ("4ICA" ==
+        // [0xE0, 0x80, 0x80]) must collapse to one U+FFFD in jq mode, same
+        // as #1617's document-decode fix -- not one per byte, which is
+        // what `String::from_utf8_lossy` (and this codebase, pre-#1719)
+        // would give. Confirmed live against jq 1.7.1.
+        query!(br#""4ICA""#, "@base64d",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "\u{FFFD}");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9180,12 +9180,24 @@ fn format_base64d<S: EvalSemantics>(
     // Lossy, not strict: real jq/yq's own `@base64d` never errors on
     // invalid UTF-8 in the decoded bytes -- it substitutes the standard
     // replacement character, confirmed live against both oracles
-    // (`"null" | @base64d` succeeds as `"\u{fffd}\u{fffd}e"` in jq 1.7.1,
-    // not an error). This surfaced while adding this function's `S`
-    // parameter (#1109): yq mode's new scalar-stringification path
-    // (`null`/`true`/... above) reaches this exact case for the first
-    // time, and the strict conversion previously here would have produced
-    // a different wrong error instead of matching the oracle.
+    // (`"null" | @base64d` succeeds in jq 1.7.1, not an error). This
+    // surfaced while adding this function's `S` parameter (#1109): yq
+    // mode's new scalar-stringification path (`null`/`true`/... above)
+    // reaches this exact case for the first time, and the strict
+    // conversion previously here would have produced a different wrong
+    // error instead of matching the oracle.
+    //
+    // Note the exact byte sequence real jq 1.7.1 emits for `"null"` is
+    // `"\u{fffd}\u{fffd}"` (two U+FFFD, no trailing byte) -- an earlier
+    // version of this comment claimed a trailing `e` that live-testing
+    // against the pinned binary (2026-08-27, re-verifying #1719) disproves.
+    // That third byte is the still-open #1717 quirk: jq drops the byte a
+    // rescan lands on when it's the string's very last byte, which neither
+    // `substitute_invalid_utf8_jq_style` (#1617/#1719, jq mode below) nor
+    // plain `String::from_utf8_lossy` (yq mode) replicates -- both keep it,
+    // so this specific example does not fully round-trip the oracle either
+    // way. #1719's fix is scoped to the overlong/surrogate/out-of-range
+    // collapse rule only; see `test_jq_base64d_invalid_utf8_is_lossy_not_error_1146`.
     Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 
@@ -40642,6 +40654,21 @@ mod tests {
         query!(br#""4ICA""#, "@base64d",
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "\u{FFFD}");
+            }
+        );
+    }
+
+    #[test]
+    fn test_format_base64d_yq_mode_keeps_per_byte_lossy_1719() {
+        // Sibling of the jq-mode test above: #1719 only switched jq mode's
+        // substitution rule. yq mode has no oracle-matching rule to switch
+        // to (real yq passes invalid-UTF-8 bytes through unchanged, which
+        // Rust's `String` can't represent), so it must keep emitting one
+        // U+FFFD per byte here -- pinned so a future refactor collapsing
+        // the `S::TAG` branch can't silently apply jq's rule to yq too.
+        yq_query!(br#""4ICA""#, "@base64d",
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "\u{FFFD}\u{FFFD}\u{FFFD}");
             }
         );
     }

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -735,7 +735,6 @@ pub fn format_byte(byte: u8) -> String {
 /// rule 4, bug-for-bug replication is the correct resolution if picked up,
 /// not "fixing" it into the more sensible WHATWG-consistent shape.
 ///
-
 /// A single left-to-right scan, not a loop over [`validate_utf8`]: that
 /// function's AVX2 path has no early exit (it scans every 32-byte block of
 /// its input before checking for an error at all, since its job is a

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -726,6 +726,16 @@ pub fn format_byte(byte: u8) -> String {
 /// collapsing `0xF0`-`0xF4` case and would be wrongly collapsed by a rule
 /// keyed on the error kind alone).
 ///
+/// **Known remaining gap (#1717, not fixed here):** the "agree on every
+/// other kind" claim above is not quite exact for `InvalidContinuationByte`.
+/// When the rescanned byte after an invalid lead lands at the input's very
+/// last byte, real jq silently drops it; this function (like WHATWG) keeps
+/// it as its own literal character. Likely an off-by-one in jq's own
+/// end-of-buffer lookahead rather than a designed rule -- per ADR-0018
+/// rule 4, bug-for-bug replication is the correct resolution if picked up,
+/// not "fixing" it into the more sensible WHATWG-consistent shape.
+///
+
 /// A single left-to-right scan, not a loop over [`validate_utf8`]: that
 /// function's AVX2 path has no early exit (it scans every 32-byte block of
 /// its input before checking for an error at all, since its job is a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20566,6 +20566,22 @@ fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> 
     Ok(())
 }
 
+/// #1719 also switched `@urid`'s jq-mode invalid-UTF-8 substitution rule
+/// (same `owned_string_from_decoded_bytes` call site as `@base64d`), even
+/// though `@urid` itself has no real jq oracle to verify against -- "mode
+/// decides" applies regardless (see `format_urid`'s own doc comment). An
+/// overlong percent-decoded 3-byte lead now collapses to one U+FFFD in jq
+/// mode, same as the `%FF` single-invalid-byte case above stayed
+/// unaffected (WHATWG and jq's rule already agreed on that shape).
+#[test]
+fn test_jq_urid_overlong_percent_decode_collapses_to_one_fffd_1719() -> Result<()> {
+    let (out, _stderr, code) =
+        run_jq_stdin_with_stderr("@urid | explode", "\"%E0%80%80\"", &["-c"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[65533]");
+    Ok(())
+}
+
 /// #1138: real jq has no `@urid` at all (it's a succinctly extension
 /// reachable in both modes, per `format_urid`'s own doc comment), so
 /// there's no jq oracle to preserve the old silent-passthrough behavior

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17540,9 +17540,12 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
 }
 
 /// `@base64d` never errors on invalid UTF-8 in the decoded bytes -- it
-/// substitutes the replacement character, matching real jq/yq (confirmed
-/// live: `"null" | @base64d` succeeds as `"��e"` in jq 1.7.1
-/// rather than erroring).
+/// substitutes the replacement character, matching real yq (confirmed live:
+/// `"null" | @base64d` succeeds as `"��e"` in yq v4.53.3 rather
+/// than erroring). This is yq mode's own WHATWG-lossy fallback, unaffected
+/// by #1719 (jq mode only) -- real jq 1.7.1 gives a different value here,
+/// `"��"` with no trailing `e` (the #1717 quirk, unrelated to
+/// this test), so do not read the value below as a cross-mode oracle match.
 #[test]
 fn test_base64d_invalid_utf8_is_lossy_not_error_1109() -> Result<()> {
     let (out, code) = run_yq_stdin("@base64d", r#""null""#, &["-o", "json"])?;
@@ -20374,12 +20377,42 @@ fn test_jq_base64d_invalid_trailing_byte_uses_invalid_data_message_1146() -> Res
 /// jq mode's lossy-UTF-8-substitution path (the case `bytes_to_string_lossy`/
 /// `owned_string_from_decoded_bytes` exists to handle) previously had no
 /// regression test -- only the yq-mode variant was covered.
+///
+/// `base64_decode_lossy` computes the WHATWG rule, not jq's own
+/// maximal-subpart rule (#1617/#1719) -- they happen to agree here because
+/// "null" decodes to a byte sequence that hits #1717's still-open quirk
+/// (jq drops the final rescanned byte at a string's last byte; neither
+/// substitution rule replicates that drop, so both land on the same
+/// 3-codepoint answer, not jq 1.7.1's real 2-codepoint one). This test
+/// therefore does not prove full jq-oracle parity for this input -- see
+/// `owned_string_from_decoded_bytes`'s doc comment in `src/jq/eval.rs`.
 #[test]
 fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"null\"", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     let expected = base64_decode_lossy("null");
     assert_eq!(out.trim(), format!("{expected:?}"));
+    Ok(())
+}
+
+/// #1717, reached via `@base64d` -- pins the CURRENT (known-divergent from
+/// real jq) behavior, not a target to match. Base64 "4UE=" decodes to raw
+/// bytes `[0xE1, 0x41]`: a 3-byte lead followed by an invalid continuation
+/// byte ('A') at the string's last byte. Real jq 1.7.1 drops that trailing
+/// byte entirely (`echo '"4UE="' | jq -c '@base64d|explode'` -> `[65533]`);
+/// succinctly keeps it (`[65533,65]`), matching `String::from_utf8_lossy`'s
+/// WHATWG answer -- unaffected by #1719, since jq-style substitution
+/// (#1617/#1719) agrees with WHATWG on this specific shape (confirmed live,
+/// byte-identical output before and after #1719). This pins the status quo
+/// so a future #1717 fix has a base64d-reachable regression test to update,
+/// and so nobody accidentally "fixes" this call site alone without #1717's
+/// own document-decode call sites (see docs/compliance/jq/limitations.md
+/// § "An open gap in jq's own UTF-8 replacement-character substitution").
+#[test]
+fn test_jq_base64d_drops_trailing_byte_quirk_unaffected_1717() -> Result<()> {
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"4UE=\"", &["-c"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[65533,65]");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #1719.

Found while reviewing #1617 (PR #1718). `owned_string_from_decoded_bytes` (`src/jq/eval.rs`), which backs `@base64d` and `@urid`, always fell back to `String::from_utf8_lossy`'s WHATWG maximal-subpart rule on invalid UTF-8 — the same bug class #1617 fixed for document/raw-input decode, just not carried through to this call site. Real jq's `@base64d` collapses an overlong/surrogate/out-of-range 3-/4-byte lead to one U+FFFD; WHATWG (and this function, pre-fix) emits one per byte.

```bash
$ printf '\xe0\x80\x80' | base64          # 4ICA
$ echo '"4ICA"' | jq -r '@base64d' | xxd
00000000: efbf bd0a                                ....        # ONE U+FFFD
$ echo '"4ICA"' | succinctly jq -r '@base64d' | xxd   # before this fix
00000000: efbf bdef bfbd efbf bd0a                 ..........  # THREE U+FFFD
```

## Changes

Made `owned_string_from_decoded_bytes` generic over `EvalSemantics` and dispatch on `S::TAG` (per this repo's per-mode behavioral-rule convention, ADR-0018 rule 2): jq mode now reuses `substitute_invalid_utf8_jq_style` (#1617); yq mode keeps the existing lossy fallback, since it has no oracle-matching rule to switch to — real yq passes invalid-UTF-8 bytes through unchanged, which Rust's `String` can't represent at all (documented in the function's own pre-existing doc comment).

Generic dispatch (rather than special-casing one call site) naturally covers all three call sites correctly:
- `format_urid`'s call (yq-only in practice) — unaffected, resolves to the lossy arm.
- `format_base64d`'s yq-mode branch — unaffected, resolves to the lossy arm (yq mode returns early before jq's own decode loop runs).
- `format_base64d`'s jq-mode branch (only reachable after the yq early-return, so implicitly jq-only) — now matches the oracle.

## Test plan

- [x] Live-verified against the pinned jq 1.7.1 binary (`/usr/bin/jq`).
- [x] Added `test_format_base64d_overlong_collapses_to_one_fffd_1719`, mirroring #1617's `three_byte_overlong_collapses_to_one_fffd` test.
- [x] Confirmed yq mode's `@base64d`/`@urid` output is byte-for-byte unchanged (still lossy, three U+FFFD).
- [x] `cargo build --features cli`, `cargo test --features cli,simd,regex,serde` (full suite, 2897+ passed), both clippy legs, `cargo build --no-default-features`, `cargo doc --no-deps --all-features` (`-D warnings`), `cargo fmt --check` all clean.

Closes #1719.


## Round 2 (code review)

Nine finder agents plus a gap sweep converged on one real, high-value finding: `substitute_invalid_utf8_jq_style` (#1617), which this PR newly wires into `@base64d`/`@urid`, has a separate, already-tracked gap (#1717 — jq drops the rescanned byte after an invalid lead when it lands at a string's last byte) that this PR's own "matches jq's UTF-8 substitution rule" claim didn't scope around.

I independently live-verified the core question this raised: **is this a regression this PR introduces?** No — `main` (pre-fix, WHATWG) and this branch (jq-style substitution) give byte-identical output for #1717's specific shape through `@base64d` (`echo '"4UE="' | ... jq -c '@base64d|explode'` → `[65533,65]` on both, vs. real jq's `[65533]`). #1719 changes zero bytes for that shape — only for the overlong/surrogate/out-of-range collapse it actually targets. Confirmed with a fresh build of `main` at the time, not from memory.

Fixed:
- Corrected a pre-existing wrong "confirmed live" doc-comment claim (said jq 1.7.1 gives `"\u{fffd}\u{fffd}e"` for `"null"|@base64d`; the pinned binary actually gives `"\u{fffd}\u{fffd}"`, no trailing byte) and scoped #1719's fix precisely in the same comment.
- Fixed an identical wrong "in jq 1.7.1" mislabel on a *yq*-mode test's doc comment — the asserted value is correct for real yq (confirmed live against v4.53.3), just wrongly attributed to jq.
- Added a #1717 caveat comment to the pre-existing jq-mode test that happened to already assert this value, so it isn't mistaken for full oracle parity.
- Added a new jq-mode CLI test pinning the *current* (unchanged, known-divergent) #1717 behavior through `@base64d` specifically, and a yq-mode sibling to the new overlong-collapse test locking in continued per-byte lossy output there.
- Recorded the gap in `docs/compliance/jq/limitations.md` (new section) and updated `docs/plan/decode-failure-routing.md`'s stale scope note (it previously said the #1617/#1717 substitution was document-input-only).

**Known, non-blocking gap**: one commit's subject line (`docs(jq),test(jq): ...`) uses two comma-joined types instead of a single `type(scope):` — confirmed via `omni-dev git commit message lint --verbose` (real error, not the CI job's own current infra failure). Left as-is per this session's standing git-safety rule against amending a pushed branch; `Commit Message Lint` isn't a required merge-queue check.


## Round 3 (code review)

A second full review round on the round-2 fixes converged (across multiple independent finder agents) on:

- **Polarity inconsistency**: the new `S::TAG == EvalTag::Jq` comparison was the file's only one of that polarity — 46 sites use `== EvalTag::Yq`. Confirmed by grep, fixed by flipping the branch.
- **Architectural fit**: the substitution-rule policy was left as an inline `S::TAG` check, where every other per-mode policy fact in this codebase lives as a documented named const on `EvalSemantics` (16 siblings, including a single-call-site precedent for exactly this shape, `SELECT_EMITS_ONCE_IF_ANY_TRUTHY` from #1613). Promoted to `EvalSemantics::UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE`, matching the established convention and making the rule discoverable from the trait definition rather than only inside one leaf function.
- **`@urid` coverage gap**: `@urid` shares the same call site and so also silently switched its jq-mode substitution rule, despite having no real jq oracle to justify the choice by (jq has no `@urid` at all). Added a regression test for the overlong-collapse case and a cross-reference note on `format_urid`'s own doc comment.
- **Documentation redundancy**: the #1717 explanation had grown to ~6 near-duplicate restatements across 3 files (one of which — a source comment — had already drifted stale once mid-review). Trimmed to pointers back to the compliance-doc entry rather than re-deriving the mechanism each time.

Re-ran the full local verification suite (build, full test suite at reduced parallelism to filter out this machine's concurrent-load flakes, both clippy legs, `--no-default-features`, `cargo doc -D warnings`, `cargo fmt --check`) — all clean.


## Round 4 (code review)

A third full review round, mostly converging clean (10 finder agents, several with empirical verification — disassembly confirming the const branch is dead-code-eliminated per instantiation, 3000-case live fuzzing of `@base64d`/`@urid` with zero panics). Three real, small issues found and fixed:

- **Broken markdown link**: the new compliance-doc entry linked `src/text/utf8/mod.rs` with a two-level relative path (`../../`) where three were needed from `docs/compliance/jq/`, resolving to the nonexistent `docs/src/text/utf8/mod.rs`. CI's own `Check Links` job would have failed on this. Fixed.
- **Duplicated doc paragraph**: the new const's doc comment re-derived `owned_string_from_decoded_bytes`'s pre-existing "yq is an approximation of Go's arbitrary-byte strings" explanation almost word-for-word. Trimmed the older copy to a pointer at the new, more discoverable home.
- **Doc overclaim**: the new const's doc comment implied document/raw-input decode (#1617, which lives in the jq-only `jq_runner.rs` binary with no `S: EvalSemantics` in scope) is *governed* by this const, when it actually calls `substitute_invalid_utf8_jq_style` directly and unconditionally — the two paths only agree because `jq_runner.rs` is a jq-only binary, not because any shared code enforces it. Reworded to state that precisely.

Also, since a source-of-truth gap kept getting flagged across rounds 2-4 (the #1717 caveat explained at every downstream call site but never at `substitute_invalid_utf8_jq_style`'s own definition): added it there for the first time, so `cargo doc`/go-to-definition surfaces it directly instead of only through re-explanations at each caller.
