### PR TITLE
fix(ci): compare perf-guard PRs against a merge-base binary, not the stale baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,16 @@ jobs:
   # instead, which is deterministic regardless of runner noise. Not run on
   # macOS: valgrind has no Apple Silicon support at all. Not run in the merge
   # queue for the same reason `bench` isn't (see its own `if`, above).
+  #
+  # On `pull_request` runs this also builds a binary from the PR's own
+  # `git merge-base` and checks against *that* instead of the committed
+  # baseline file (#1582): at this project's merge cadence the file drifts
+  # 1-3% within days from ordinary accumulated changes alone, consuming most
+  # of the 5% threshold before any single PR is measured. A same-run
+  # comparison against the PR's own merge-base cancels that staleness (and
+  # any codegen/toolchain drift) instead of trying to keep the file fresh.
+  # `push` runs (direct pushes to `main`) have no PR/merge-base and fall back
+  # to the file, same as before.
   perf-guard:
     name: Perf Regression Guard (${{ matrix.name }})
     needs: gate
@@ -509,6 +519,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0            # full history for git merge-base (PR fork point) -- #1582
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -527,11 +539,30 @@ jobs:
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
+      # Merge-base commit always builds cleanly -- it's an ancestor of `main`
+      # that already passed this same required CI when it landed. Built into
+      # a separate worktree/target dir so it can't collide with (or poison
+      # the cache of) the PR-head build below.
+      - name: Build merge-base binary
+        if: github.event_name == 'pull_request'
+        run: |
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          echo "Building merge-base binary at $MERGE_BASE for PR-relative perf comparison (#1582)"
+          git worktree add --detach /tmp/perf-guard-merge-base "$MERGE_BASE"
+          cd /tmp/perf-guard-merge-base
+          cargo build --release --features cli
+
       - name: Build release binary
         run: cargo build --release --features cli
 
       - name: Run perf guard
-        run: python3 scripts/perf-guard.py --binary target/release/succinctly --arch "${{ matrix.name }}" --check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            EXTRA_ARGS="--baseline-binary /tmp/perf-guard-merge-base/target/release/succinctly"
+          else
+            EXTRA_ARGS=""
+          fi
+          python3 scripts/perf-guard.py --binary target/release/succinctly --arch "${{ matrix.name }}" --check $EXTRA_ARGS
 
   clippy:
     name: Clippy

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -161,14 +161,19 @@ GitHub Actions runs `rank_select` benchmarks on every PR/push for smoke testing:
 
 **Perf Regression Guard** (issue #1523): a separate CI job measures `succinctly
 jq`/`yq` instruction counts via `valgrind --tool=cachegrind` (`scripts/perf-guard.py`)
-for a fixed query/shape matrix, and fails if any drifts more than 5% from the
-checked-in baseline (`tests/data/perf-guard-baseline.json`). Deterministic
-instruction counts, not wall-clock time, are what make a tight threshold viable on a
-shared, noisy CI runner — this exists because #1385's 2-3x regression shipped through
-`rank_select`-only smoke testing unnoticed. Runs on x86_64 and ARM64-Linux only
-(valgrind has no Apple Silicon support); currently a non-required check while it
-builds a track record. To deliberately update the baseline after a real, understood
-cost change:
+for a fixed query/shape matrix, and fails if any drifts more than 5% from a baseline.
+Deterministic instruction counts, not wall-clock time, are what make a tight threshold
+viable on a shared, noisy CI runner — this exists because #1385's 2-3x regression
+shipped through `rank_select`-only smoke testing unnoticed. Runs on x86_64 and
+ARM64-Linux only (valgrind has no Apple Silicon support); currently a non-required
+check while it builds a track record.
+
+On `pull_request` runs, the baseline is a binary built fresh from the PR's own
+`git merge-base` in the same CI run (`--baseline-binary`), not the committed file —
+see #1582 below for why. On other runs (a direct push to `main`) there is no PR to
+build a merge-base from, so it falls back to the checked-in
+`tests/data/perf-guard-baseline.json`. To deliberately update that file after a real,
+understood cost change:
 
 ```bash
 cargo build --release --features cli
@@ -176,6 +181,20 @@ scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --update-
 ```
 
 (run once per arch you can reach; state the reason in the commit message).
+
+**Why the file isn't the primary comparison (#1582).** At this project's merge
+cadence, the checked-in baseline drifts on its own: rebuilding at the baseline's own
+source commit vs. `main` three days / 147 commits later (55 touching
+`eval.rs`/`json`/`yaml`) showed **+1.0% to +3.2% drift on every one of the six
+queries**, with zero PR involved — ordinary accumulated small changes eating most of
+the 5% budget before any single PR is measured. The obvious first guess — that this is
+the same `codegen-units=16` cross-module placement artifact #1587 found and fixed by
+pinning `codegen-units=1` (see rule 9 below) — does not hold here: rebuilding both
+sides of that same three-day comparison at `codegen-units=1` left the drift the same
+size or larger, not collapsed the way #1587's wall-clock/icache case did. So the fix is
+structural, not a build flag: compare each PR against a binary built from its own
+merge-base in the same run, which cancels staleness (of any cause) instead of trying to
+keep a single checked-in file fresh against a fast-moving `main`.
 
 ---
 
@@ -950,9 +969,18 @@ across hardware.
 Also worth knowing: #595's x86-only 12-28% `block_scalars` anomaly was closed as "expected, no
 action — binary code-layout artifact from the recompile," using cachegrind to show flat
 instruction counts (`Ir`) but rising L1-icache misses (`I1mr`). That diagnosis predates this
-rule and never pinned codegen-units — see #1587 for the re-check. It does not, however, put
-`scripts/perf-guard.py`'s CI gate in question: that gate reads cachegrind `Ir`, which stayed
-flat in the same investigation — only `I1mr`, which perf-guard doesn't gate on, moved.
+rule and never pinned codegen-units — see #1587 for the re-check.
+
+**Update (#1582): `Ir` is not immune to this after all.** The paragraph above once
+concluded that `scripts/perf-guard.py`'s CI gate was safe by construction, since it reads
+`Ir` and #595's `Ir` stayed flat while only `I1mr` moved. #1582 found a case where `Ir`
+itself drifts — 1-3% across every one of perf-guard's six queries between two `main`
+commits three days apart, no single PR responsible — and confirmed with a paired
+`codegen-units=1` rebuild that it is *not* the `codegen-units=16` mechanism this section
+describes (that rebuild left the drift the same size or larger, not collapsed). What
+actually protects the gate now is structural: `pull_request` runs compare against a binary
+built from the PR's own merge-base in the same run, not a file that can go stale — see the
+Perf Regression Guard section above.
 
 ### Building both halves on a remote box
 

--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -316,11 +316,19 @@ def main(argv=None):
     # valid baseline for ARM64-Linux's run or vice versa. None of this
     # applies when `--baseline-binary` is given: `measure_all` below always
     # returns exactly `known_ids`, so there's no file to be stale/incomplete.
+    #
+    # Loaded whenever `--baseline-binary` isn't in play -- including
+    # `--update-baseline` -- because `--update-baseline` merges `measured`
+    # into whatever this dict already holds and then writes the whole thing
+    # back out. Gating the load on `args.check` left `--update-baseline`
+    # starting from `{}` and overwriting the file with only the arch just
+    # measured, silently deleting every other arch's entries (#1582).
     baseline_file = {}
     baseline = {}
     known_ids = {q[0] for q in QUERIES}
-    if args.check and not args.baseline_binary:
+    if not args.baseline_binary:
         baseline_file = load_baseline_file(args.baseline)
+    if args.check and not args.baseline_binary:
         baseline = baseline_file.get(args.arch, {})
         missing = known_ids - set(baseline)
         if missing:

--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -30,6 +30,13 @@ one set of counts per arch, not one shared set):
         prevent). `--arch` must match one of ci.yml's `perf-guard` matrix
         names (currently `x86_64`, `ARM64-Linux`) for the CI job to find it.
 
+`--check` also accepts `--baseline-binary PATH` in place of the default
+`--baseline FILE`: instead of comparing against the checked-in JSON, it
+measures a second binary (also generated fresh, same as `--binary`) and
+compares against that (issue #1582). ci.yml's `perf-guard` job uses this on
+`pull_request` runs, building `--baseline-binary` from the PR's own
+`git merge-base` -- see "Why a baseline binary, not just the file" below.
+
 The query/shape matrix is #1523's own "minimum viable set": #1514's two
 regressions were complementary and each was invisible to the other's own
 signal (one showed only in a `wide`-shaped `keys_unsorted` query, the other
@@ -58,6 +65,18 @@ oversights -- worth revisiting once this guard has a track record:
   or `src/bits/popcount.rs`'s explicit intrinsics is invisible here, the same
   split `bench`'s own default/simd/portable-popcount 3-way matrix exists to
   separate for `rank_select`.
+- The committed `--baseline` file is a *fallback* used only for non-PR runs
+  (a direct push to `main`) and carries a real staleness risk: at this
+  project's merge cadence, `Ir` drifts 1-3% across every query within days
+  from ordinary accumulated changes alone (measured directly: baseline
+  source commit vs. `main` 3 days/147 commits later, 55 of them touching
+  `eval.rs`/`json`/`yaml`). This is *not* a `codegen-units=16` artifact --
+  pinning `codegen-units=1` on both sides of that same comparison left the
+  drift the same size or larger, so #1587's fix for a similar-looking
+  wall-clock/icache issue does not apply here. It is why `--baseline-binary`
+  exists: a same-run comparison against the PR's own merge-base cancels
+  staleness from any cause, instead of trying to keep a checked-in file
+  fresh against a fast-moving `main`.
 
 Standard library only; no third-party dependencies.
 """
@@ -127,8 +146,15 @@ def parse_args(argv=None):
         epilog=EPILOG,
     )
     p.add_argument("--binary", required=True, help="path to the succinctly binary (release build)")
-    p.add_argument("--baseline", default="tests/data/perf-guard-baseline.json",
+    baseline_source = p.add_mutually_exclusive_group()
+    baseline_source.add_argument("--baseline", default="tests/data/perf-guard-baseline.json",
                     help="path to the checked-in baseline file")
+    baseline_source.add_argument("--baseline-binary", default=None,
+                    help="path to a second built binary (e.g. the PR's git merge-base) to "
+                         "measure and compare against instead of --baseline -- cancels drift "
+                         "from any cause shared by both binaries (staleness, codegen shift, "
+                         "toolchain version), since both are built the same way in the same "
+                         "run. Only valid with --check (issue #1582).")
     p.add_argument("--arch", required=True,
                     help="baseline key for this run, e.g. x86_64/ARM64-Linux -- instruction "
                          "counts are architecture-specific (different ISA, different codegen), "
@@ -206,11 +232,13 @@ def measure_query(valgrind_bin, binary, mode, filter_expr, fixture_path, reps):
     return round(statistics.median(counts))
 
 
-def measure_all(binary, valgrind_bin, reps):
+def measure_all(binary, valgrind_bin, reps, label="binary"):
     """Generate each distinct (pattern, size) fixture exactly once -- several
     `QUERIES` rows share one, and regenerating an identical file per row
     would be pure waste -- then measure every query against its fixture.
-    Returns {query_id: median instruction count}."""
+    Returns {query_id: median instruction count}. `label` only affects the
+    printed header, distinguishing this run's output in CI logs when
+    `measure_all` is called twice (current binary, then --baseline-binary)."""
     with tempfile.TemporaryDirectory() as tmp:
         fixture_paths = {}
         for _, pattern, size, _, _ in QUERIES:
@@ -226,6 +254,7 @@ def measure_all(binary, valgrind_bin, reps):
                 fixture_paths[shape] = path
 
         measured = {}
+        print(f"Measuring {label} ({binary}):")
         print(f"{'query':<26} {'instructions':>16}")
         print("-" * 44)
         for query_id, pattern, size, mode, filter_expr in QUERIES:
@@ -270,15 +299,28 @@ def main(argv=None):
     if not os.access(args.binary, os.X_OK):
         sys.exit(f"binary is not executable: {args.binary} (lost its execute bit in transit?)")
 
+    if args.baseline_binary and args.update_baseline:
+        sys.exit("--baseline-binary is only valid with --check -- there's nothing to update "
+                 "a checked-in baseline *from* a transient second binary.")
+    if args.baseline_binary:
+        if not os.path.exists(args.baseline_binary):
+            sys.exit(f"baseline binary not found: {args.baseline_binary}")
+        if not os.access(args.baseline_binary, os.X_OK):
+            sys.exit(f"baseline binary is not executable: {args.baseline_binary} (lost its "
+                     f"execute bit in transit?)")
+
     # Fail fast on a missing/incomplete baseline before running any of the
     # (expensive, cachegrind-instrumented) measurements below. Instruction
     # counts are architecture-specific (different ISA, different codegen),
     # so the baseline file is keyed by `--arch` -- x86_64's counts are not a
-    # valid baseline for ARM64-Linux's run or vice versa.
-    baseline_file = load_baseline_file(args.baseline)
+    # valid baseline for ARM64-Linux's run or vice versa. None of this
+    # applies when `--baseline-binary` is given: `measure_all` below always
+    # returns exactly `known_ids`, so there's no file to be stale/incomplete.
+    baseline_file = {}
     baseline = {}
     known_ids = {q[0] for q in QUERIES}
-    if args.check:
+    if args.check and not args.baseline_binary:
+        baseline_file = load_baseline_file(args.baseline)
         baseline = baseline_file.get(args.arch, {})
         missing = known_ids - set(baseline)
         if missing:
@@ -287,13 +329,22 @@ def main(argv=None):
                 f"-- run with --update-baseline first (and commit the result)."
             )
 
-    measured = measure_all(args.binary, args.valgrind_bin, args.reps)
+    measured = measure_all(args.binary, args.valgrind_bin, args.reps, label="current binary")
 
     if args.update_baseline:
         baseline_file[args.arch] = measured
         save_baseline_file(args.baseline, baseline_file)
         print(f"Wrote {len(measured)} entries for arch {args.arch!r} to {args.baseline}")
         return 0
+
+    if args.baseline_binary:
+        # A same-run comparison against the PR's own merge-base: whatever
+        # staleness the checked-in file would carry (real accumulated drift,
+        # codegen shift, toolchain version) is shared by both binaries here
+        # and cancels out, leaving only what this binary's diff changed
+        # (issue #1582).
+        baseline = measure_all(args.baseline_binary, args.valgrind_bin, args.reps,
+                                label="baseline binary")
 
     stale = set(baseline) - known_ids
     if stale:


### PR DESCRIPTION
## Summary

- `scripts/perf-guard.py` gains `--baseline-binary PATH`: measures a second binary and compares against it instead of the checked-in `tests/data/perf-guard-baseline.json`.
- `.github/workflows/ci.yml`'s `perf-guard` job now builds a binary from the PR's own `git merge-base` on `pull_request` runs and passes it via `--baseline-binary`, isolating what the PR itself changed. `push` runs (direct pushes to `main`) have no PR/merge-base and keep using the file baseline as before.
- Docs updated to match, plus a correction to an earlier claim that perf-guard's `Ir` metric was immune to #1587's codegen-units finding.

## Why

perf-guard's x86_64 leg false-failed PR #1578 at +5.2% on `wide_keys_unsorted`, even though none of that PR's added lines execute on that query (0/67 executable lines covered, confirmed via `cargo llvm-cov`). ARM64-Linux was flat on the same run.

The obvious first guess — a `codegen-units=16` cross-module placement artifact, the same mechanism #1587 diagnosed and fixed for a similar-looking wall-clock/icache issue — does not hold here. Tested directly on `terminus` (7950X):

- Isolating PR #1578's own diff (merge-base vs. PR-head, same toolchain, default profile): drift = **+0.0004%** on `wide_keys_unsorted` — confirms the PR itself didn't regress that query.
- The real driver is **baseline-file staleness**: the committed baseline's own source commit vs. `main` three days/147 commits later (55 touching `eval.rs`/`json`/`yaml`) drifts **+1.0% to +3.2% across all six queries**, no PR involved. Rebuilding that same before/after pair at `codegen-units=1` left the drift the same size or larger — not collapsed the way #1587's case was.

This repo merges too fast (~49 hot-path-touching commits/day) for a manually-updated baseline file to stay within the 5% threshold for more than a few days from ordinary legitimate changes alone. The fix is structural: compare each PR against a binary built from its own merge-base in the same CI run, which cancels staleness of any cause (real drift, codegen shift, toolchain version) instead of trying to keep one checked-in file fresh.

Verified end-to-end on real binaries (not just by inspection): PR #1578's previously-reported +5.2% false positive, isolated the same way, collapses to ~0.0%.

Fixes #1582

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --features regex` — full suite passes (one flaky failure under concurrent machine load, confirmed to pass in isolation and unrelated: this PR touches no Rust source)
- [x] `--baseline-binary` smoke-tested end-to-end against real built binaries (pre/post PR #1578) on `terminus`, confirming ~0% drift for the isolated PR diff and unchanged behavior for the existing file-based `--baseline` path
- [x] `--update-baseline` regression (introduced then fixed during review) verified: the flag no longer silently wipes other arches' entries in the baseline file
- [ ] CI's `perf-guard` job itself — the actual end-to-end check that the merge-base binary builds and compares correctly in the real GitHub Actions environment