### PR TITLE
ci: pin omni-dev-commit-check's version, skip its failing latest-resolution call

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -25,3 +25,11 @@ jobs:
         with:
           command: lint
           strict: true
+          # Pin, matching ci.yml's omni-dev-coverage-check precedent: `rust-works/omni-dev`
+          # is a private repo, so `version: latest`'s own resolution step -- an
+          # unauthenticated-for-us call to its GitHub releases API -- 404s under the
+          # workflow's own repo-scoped token, which has no cross-repo visibility into a
+          # different private repo. Pinning skips that call entirely. `lint` itself needs
+          # omni-dev >= 0.40.0 (see the action's own `command` input doc); 0.41.0 is the
+          # latest release as of this pin.
+          version: 0.41.0


### PR DESCRIPTION
## Description

`Commit Message Lint` has been failing on every open PR (confirmed on #1672, #1729, #1727)
at its own setup step — not on any real commit-message finding. The `omni-dev-commit-check`
action's `version: latest` default triggers a call to
`https://api.github.com/repos/rust-works/omni-dev/releases/latest`, which returns `Not
Found` three times in a row and aborts the job before `command: lint` ever runs.

`rust-works/omni-dev` is a private repo, and `commit-lint.yml` passes no `github-token`
input, so the action falls back to `${{ github.token }}` — the default token, auto-scoped
to `succinctly` only, with no visibility into a different private repo. Confirmed live:
the identical API call with my own, broader-scoped token succeeds and returns `v0.41.0`.

`ci.yml`'s `omni-dev-coverage-check` step already sidesteps the identical problem by
pinning `version: 0.38.0` instead of `latest` — confirmed currently passing on #1672's own
coverage jobs. This PR applies the same fix to `commit-lint.yml`: pinning skips the
failing resolution call entirely, since it only runs when `version == "latest"`.
`command: lint` needs omni-dev >= 0.40.0 per the action's own input doc; `0.41.0` is the
current latest release.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement
- [x] CI/CD changes

## Related Issue
None filed — found while investigating an unrelated PR's failing check.

## Changes Made
- `.github/workflows/commit-lint.yml`: pin `omni-dev-commit-check`'s `version` to `0.41.0`
  instead of letting it default to `latest`.

## Testing

**Automated Testing:**
- [x] All existing tests pass (config-only change, no code touched)
- [ ] New tests added for new functionality

### Test Commands
This is a workflow-config-only change; the real test is this PR's own `Commit Message
Lint` check turning green, and the fact that `ci.yml`'s `omni-dev-coverage-check` step
already proves the pinned-version path works end-to-end against this same private repo
(resolution *and* binary download) on #1672's currently-passing coverage jobs.

## Performance Impact
- [x] No performance impact

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

Found and reproduced this while working on an unrelated PR (#1672) — checked two other
open PRs and both showed the identical failure signature, so this looks like it started
affecting every PR recently rather than being specific to one branch.
