### PR TITLE
docs(yq): document --tab as a write-only extension (#1684)

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -419,7 +419,7 @@ succinctly yq '.users[]' input.yaml
 - `-M, --no-colors`: Disable colorized output
 - `-N, --no-doc`: Don't print document separators (`---`)
 - `-P, --prettyPrint`: Pretty print, expand flow styles to block style
-- `--tab`: Use tabs for indentation
+- `--tab`: Use tabs for indentation (write-only — see [yq Language Reference § Known Limitations](../reference/yq-language.md#known-limitations))
 - `-a, --ascii-output`: Output ASCII only, escaping non-ASCII as `\uXXXX`
 - `--split-exp <EXPR>`: Split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index; `--arg`/`--argjson` values and `$ARGS` are also available, same as the main filter). Suppresses stdout. Long-only, unlike real yq's `-s`/`--split-exp` — succinctly's `-s` is already `--slurp` (#715). Incompatible with `--slurp`, `--inplace`, `--front-matter`; `--raw-input` not yet supported
 

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -432,7 +432,7 @@ same kind of thing as the rest of this table — extra, off by default.
 | `-i, --inplace`       | Update file in place                          |
 | `-0, --nul-output`    | Use NUL separator instead of newline          |
 | `--no-doc`            | Omit document separators (`---`)              |
-| `--tab`               | Use tabs for indentation                      |
+| `--tab`               | Use tabs for indentation (write-only — see [Known Limitations](#known-limitations)) |
 | `--split-exp EXPR`    | Split output into one file per result (below) |
 
 ### `--front-matter`
@@ -523,6 +523,7 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 3. **`file_index`/`key`/`document_index` in complex expressions** - Resolve through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, `label`, array literals (`[...]`, since #1302 gave `Expr::Array` its own path-context recursion), and user-defined functions; still return `0` inside object literals (`{...}`) or `any`/`all`
 4. **`--slurp`/`--eval-all` output has no comments** - both combine documents through the `OwnedValue` DOM (which carries no comment data) before evaluating, unlike the default per-document path
 5. **`--front-matter` position builtins use the extracted block's own coordinates** - `at_offset`, `at_position`, `line`, and `column` resolve against the extracted YAML slice, not the original file; a reported `line`/`column` is offset from the file's real line/column by the front-matter header's length
+6. **`--tab` output does not round-trip** - succinctly's own YAML reader (like the wider YAML 1.1/1.2 spec) forbids tab characters in indentation, so any nested `--tab` YAML output cannot be read back by `succinctly yq` itself, or by other spec-strict YAML parsers. Real yq v4.53.3 has no `--tab` flag at all (confirmed live: `unknown flag: --tab`), so this is a succinctly-only extension with no round-trip oracle to satisfy — it is write-only by design (#1684)
 
 ---
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1110,7 +1110,10 @@ pub struct YqCommand {
     #[arg(short = 'P', long = "prettyPrint")]
     pub pretty_print: bool,
 
-    /// Use tabs for indentation
+    /// Use tabs for indentation. Write-only: succinctly's own YAML reader (like
+    /// the wider YAML 1.1/1.2 spec) forbids tab characters in indentation, so
+    /// this flag's YAML output cannot be read back by `succinctly yq` itself,
+    /// or by other spec-strict YAML parsers (#1684).
     #[arg(long)]
     pub tab: bool,
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9406,13 +9406,15 @@ fn test_dom_path_indent_zero_json_output_still_compact_1575() -> Result<()> {
 /// `--tab` output cannot be read back by succinctly's own YAML parser at
 /// *any* indent width or nesting shape — pure, unmixed tab indentation
 /// alone already fails with "tab character used for indentation" on
-/// unmodified `main`, unrelated to `-I0` or this fix (tracked separately as
-/// #1684). This fix's `compute_indent_str` change makes `--tab -I=0`
-/// combined with a compact block-sequence item newly mix 2 literal spaces
-/// (the sequence item's own fixed `- `-width offset, #785/#1362) with
-/// tab-based per-level indent on the same line — pinning that exact,
-/// still-broken output here so a future change to either side doesn't
-/// silently shift it without updating #1684's own investigation.
+/// unmodified `main`, unrelated to `-I0` or this fix. This is now a
+/// deliberate, documented limitation (docs/reference/yq-language.md §
+/// Known Limitations, #1684), not a bug to fix: real yq has no `--tab`
+/// flag at all, so there's no round-trip oracle to satisfy. This fix's
+/// `compute_indent_str` change makes `--tab -I=0` combined with a compact
+/// block-sequence item mix 2 literal spaces (the sequence item's own
+/// fixed `- `-width offset, #785/#1362) with tab-based per-level indent on
+/// the same line — pinning that exact output here so a future change to
+/// either side doesn't silently shift it.
 #[test]
 fn test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575() -> Result<()> {
     let yaml = "a:\n  b:\n    c: 1\n";
@@ -9420,9 +9422,34 @@ fn test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(out, "- key: a\n  value:\n  \tb:\n  \t\tc: 1\n");
 
-    // Read-back still fails — see #1684, not attempted here.
+    // Read-back fails by design — see #1684 and
+    // test_tab_output_does_not_round_trip_through_own_reader_1684 below.
     let (_, stderr, code) =
         run_yq_stdin_with_stderr(".[0].value", &out, &["-o=yaml", "-I=0", "--tab"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("tab character used for indentation"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #1684: `--tab` output is write-only — succinctly's own YAML reader (like
+/// the wider YAML 1.1/1.2 spec) forbids tab characters in indentation, so
+/// *any* nested `--tab` output fails to read back, not just the `-I0`/
+/// compact-sequence-item interaction pinned above by
+/// [`test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575`]. This is a
+/// deliberate, documented limitation (docs/reference/yq-language.md §
+/// Known Limitations), not a bug: real yq has no `--tab` flag to serve as
+/// a round-trip oracle.
+#[test]
+fn test_tab_output_does_not_round_trip_through_own_reader_1684() -> Result<()> {
+    let yaml = "a:\n  b:\n    c:\n      d: 1\n";
+    let (out, code) = run_yq_stdin(".", yaml, &["-o=yaml", "--tab"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\n\tb:\n\t\tc:\n\t\t\td: 1\n");
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a.b.c.d", &out, &["--tab"])?;
     assert_ne!(code, 0);
     assert!(
         stderr.contains("tab character used for indentation"),


### PR DESCRIPTION
## Summary

`succinctly yq -o=yaml --tab` writes tab-indented YAML, but succinctly's own YAML reader unconditionally rejects any tab character used for indentation, at any nesting depth — so `--tab` output can never round-trip through the tool itself (#1684).

`--tab` is a succinctly-only extension (real yq v4.53.3 has no such flag at all — confirmed live, `unknown flag: --tab`), so there's no reference-tool round-trip behavior to match, and per ADR-0018 extensions are exempt from the divergence-recording rule that would otherwise apply.

Investigated making the reader accept tab indentation instead, but that touches a heavily-tested, SIMD-optimized hot path with no compatibility pressure forcing it:
- `count_indent` in `src/yaml/parser.rs` is the only indentation-width funnel on the default read path, feeding a plain `usize` `indent_stack` compared via `>`/`<`/`==` throughout block parsing.
- A second, independent implementation (`src/yaml/validate.rs`, used only by `--validate`) would need to change in lockstep.
- Three more independent space-only SIMD/scalar scanners (`src/yaml/simd/{x86,neon,scalar}.rs`) handle the unrelated block-scalar-end problem and would need a deliberate decision to stay untouched.
- The DOM writer's compact block-sequence-item offset is hardcoded to 2 literal ASCII spaces by deliberate design (#785), and two existing tests already pin the resulting mixed space+tab output as intentional/self-consistent — accepting tabs would force revisiting that too.

So this PR takes the lower-risk path: keep the reader spec-compliant, and make `--tab`'s write-only nature an explicit, documented, tested fact.

- Update `--tab`'s CLI help text (`src/bin/succinctly/main.rs`) to state the limitation directly.
- Add a "Known Limitations" entry and CLI Options table note in `docs/reference/yq-language.md`, and a matching note in `docs/guides/cli.md`.
- Reframe the existing test that already pinned this exact bug (`test_dom_path_indent_zero_tab_is_pinned_not_fixed_1575`) so its comment states this is a deliberate limitation, not a pending fix.
- Add a new round-trip test (`test_tab_output_does_not_round_trip_through_own_reader_1684`) covering the plain, default-depth case from the issue's own repro — no existing test covered it (only depth-0 and the `-I0`/compact-mixed case were pinned).

No changes to the YAML parser, validator, SIMD scanners, or the `--tab` writer — this is docs/tests/CLI-help-text only.

## Test plan

- [x] `cargo build --release --features cli` and manually re-ran the issue's exact repro: write still succeeds, read-back still fails with the same error.
- [x] `succinctly yq --help` shows the updated `--tab` description.
- [x] `cargo test --features cli` — full suite green (2895 lib tests + 1232 yq_cli_tests + everything else, 0 failures).
- [x] `cargo clippy --all-targets --features cli -- -D warnings` clean.