### PR TITLE
fix(jq): match jq's end-of-buffer UTF-8 rescanned-byte drop (#1717)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -262,8 +262,9 @@ off-by-one in jq's own end-of-buffer lookahead rather than a designed rule eithe
 per ADR-0018 rule 4 the correct resolution, where reached, is bug-for-bug replication
 rather than "fixing" the substitution into the more sensible WHATWG-consistent shape. See
 [docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md) for the fuller
-substitution-mechanism history and [#1717](https://github.com/rust-works/succinctly/issues/1717)
-for the document/raw-input granularity gap this leaves open.
+substitution-mechanism history, [#1717](https://github.com/rust-works/succinctly/issues/1717)
+for the algorithm fix itself, and #1743/#1742 above for the two granularity gaps it leaves
+open.
 
 ## Conversion diagnostics beyond a single token
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -205,18 +205,29 @@ and — since #1719 — for `@base64d`/`@urid`'s own invalid-UTF-8 output too, c
 structurally-valid overlong/surrogate/out-of-range 3-/4-byte lead to a single U+FFFD where
 `String::from_utf8_lossy`'s WHATWG rule gives one per byte.
 
-jq has a second, separate quirk here (#1717): when an `InvalidContinuationByte`'s
-rescanned byte lands at the buffer's *last* byte, and at least two continuation bytes are
-still missing (`shortfall = (sequence length - 1) - good continuation bytes >= 2`), real
-jq silently **drops** that byte instead of rescanning it as its own character. Fixed
-in `substitute_invalid_utf8_jq_style` itself, live-verified across every 2-/3-/4-byte
-lead shape that can reach shortfall 2+ (a 2-byte lead's only failure mode is shortfall 1,
-which jq always keeps — `\xc2\x41` -> `"\u{FFFD}A"`, matching WHATWG):
+jq has a second, separate quirk here (#1717): for `InvalidContinuationByte`, jq's actual
+rule is simply `len - pos < seq_len` — if `seq_len` bytes aren't all physically present
+from the lead byte's own position onward, jq collapses the *entire* remaining tail into
+one U+FFFD, **regardless of why** they're short (the buffer genuinely ends, or one of the
+bytes that *is* present fails the continuation check partway through). Only once
+`seq_len` bytes are actually present does jq validate each continuation byte and fall
+back to WHATWG-style rescan-at-the-bad-byte. An earlier version of this fix instead
+conditioned the drop on "the offending byte is `input`'s own last byte", which
+undercounts: `[0xF0, b'A', b'B']` (a 4-byte lead, one invalid continuation, *one* byte of
+headroom before end-of-input — so the offending byte is *not* `input`'s last byte) still
+collapses in real jq. Live-verified across every 2-/3-/4-byte lead shape and headroom
+amount up to 3 bytes (a 2-byte lead's headroom-0 case is its only failure mode at all —
+`\xc2\x41` -> `"\u{FFFD}A"`, kept, since `len - pos == seq_len` there), plus a 750-case
+differential sweep against varied lead/continuation/trailing combinations, all matching:
 
 ```bash
 $ printf '"4UE="' | jq -c '@base64d | explode'          # base64 "4UE=" decodes to [0xE1, 0x41]
 [65533]
 $ printf '"4UE="' | sjq -c '@base64d | explode'
+[65533]
+$ printf '"8EFC"' | jq -c '@base64d | explode'          # decodes to [0xF0, 0x41, 0x42] -- the
+[65533]                                                 # previously-missed, one-byte-headroom shape
+$ printf '"8EFC"' | sjq -c '@base64d | explode'
 [65533]
 ```
 
@@ -224,10 +235,14 @@ $ printf '"4UE="' | sjq -c '@base64d | explode'
 bytes** — `@base64d`/`@urid`, via `owned_string_from_decoded_bytes`
 ([src/jq/eval.rs](../../../src/jq/eval.rs)). It does *not* reach whole-document/whole-file
 callers (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`), because those substitute
-an entire file's bytes in one pass before JSON structure is even parsed — real jq's
-per-string, closing-quote-relative notion of "last byte" has no equivalent there, so
-"last byte of `input`" almost never coincides with "last byte of one JSON string's
-content" the way it naturally does for a base64/percent-decoded buffer:
+an entire file's bytes in one pass before JSON structure is even parsed. Real jq's own
+trigger is scoped to *each JSON string's own closing quote* (document mode) or *each
+line* (`--raw-input`, confirmed live: `printf 'a\xe1\x41\n' | jq -R '.'` drops the byte
+even though the file's own trailing newline follows) — neither of which is "the whole
+buffer's own end" in a realistic multi-field document or multi-line file. jq's own
+trigger condition is not rare (it fires on *any* string/line ending in the right byte
+shape, however much more content follows elsewhere in the file); only succinctly's
+whole-buffer reproduction of it essentially never activates:
 
 ```bash
 $ printf '{"a":"\xe1\x41"}' | jq -c '.a'              # jq drops the 'A'
@@ -237,12 +252,14 @@ $ printf '{"a":"\xe1\x41"}' | sjq -c '.a'              # unfixed: still whole-do
 ```
 
 Reproducing this quirk for `.a`-style document access would need per-JSON-string
-substitution timing (or per-line, for `--raw-input`), not a whole-buffer pass before
-parsing — a bigger architectural change than this issue's own "Low severity, narrow
-trigger" framing anticipated, and not attempted here. Likely an off-by-one in jq's own
-end-of-buffer lookahead rather than a designed rule either way; per ADR-0018 rule 4 the
-correct resolution, where reached, is bug-for-bug replication rather than "fixing" the
-substitution into the more sensible WHATWG-consistent shape. See
+substitution timing — a bigger architectural change than this issue's own "Low severity,
+narrow trigger" framing anticipated, and not attempted here. `--raw-input`'s own gap is
+narrower and more tractable (a caller-side reorder: split into lines before
+substituting, instead of after — the algorithm itself needs no further change), tracked
+separately as [#1742](https://github.com/rust-works/succinctly/issues/1742). Likely an
+off-by-one in jq's own end-of-buffer lookahead rather than a designed rule either way;
+per ADR-0018 rule 4 the correct resolution, where reached, is bug-for-bug replication
+rather than "fixing" the substitution into the more sensible WHATWG-consistent shape. See
 [docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md) for the fuller
 substitution-mechanism history and [#1717](https://github.com/rust-works/succinctly/issues/1717)
 for the document/raw-input granularity gap this leaves open.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -197,7 +197,7 @@ This case is deliberately **absent from the probe corpus**: the captured table i
 file read with `include_str!`, so jq's byte-exact output here is not representable. It is
 recorded in prose instead rather than dropped silently.
 
-## An open gap in jq's own UTF-8 replacement-character substitution
+## jq's own UTF-8 replacement-character substitution: fixed at function granularity, open at document granularity
 
 `substitute_invalid_utf8_jq_style` ([src/text/utf8/mod.rs](../../../src/text/utf8/mod.rs),
 #1617) matches jq 1.7.1's maximal-subpart substitution rule for document/raw-input decode,
@@ -205,26 +205,47 @@ and — since #1719 — for `@base64d`/`@urid`'s own invalid-UTF-8 output too, c
 structurally-valid overlong/surrogate/out-of-range 3-/4-byte lead to a single U+FFFD where
 `String::from_utf8_lossy`'s WHATWG rule gives one per byte.
 
-One case remains unmatched everywhere this function is used: when an
-`InvalidContinuationByte`'s rescanned byte lands at a string's *last* byte, real jq
-silently **drops** that byte; succinctly (matching WHATWG) keeps it.
+jq has a second, separate quirk here (#1717): when an `InvalidContinuationByte`'s
+rescanned byte lands at the buffer's *last* byte, and at least two continuation bytes are
+still missing (`shortfall = (sequence length - 1) - good continuation bytes >= 2`), real
+jq silently **drops** that byte instead of rescanning it as its own character. Fixed
+in `substitute_invalid_utf8_jq_style` itself, live-verified across every 2-/3-/4-byte
+lead shape that can reach shortfall 2+ (a 2-byte lead's only failure mode is shortfall 1,
+which jq always keeps — `\xc2\x41` -> `"\u{FFFD}A"`, matching WHATWG):
+
+```bash
+$ printf '"4UE="' | jq -c '@base64d | explode'          # base64 "4UE=" decodes to [0xE1, 0x41]
+[65533]
+$ printf '"4UE="' | sjq -c '@base64d | explode'
+[65533]
+```
+
+**The fix only reaches call sites where `input` is already scoped to one string's own
+bytes** — `@base64d`/`@urid`, via `owned_string_from_decoded_bytes`
+([src/jq/eval.rs](../../../src/jq/eval.rs)). It does *not* reach whole-document/whole-file
+callers (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`), because those substitute
+an entire file's bytes in one pass before JSON structure is even parsed — real jq's
+per-string, closing-quote-relative notion of "last byte" has no equivalent there, so
+"last byte of `input`" almost never coincides with "last byte of one JSON string's
+content" the way it naturally does for a base64/percent-decoded buffer:
 
 ```bash
 $ printf '{"a":"\xe1\x41"}' | jq -c '.a'              # jq drops the 'A'
 "�"
-$ printf '{"a":"\xe1\x41"}' | sjq -c '.a'
+$ printf '{"a":"\xe1\x41"}' | sjq -c '.a'              # unfixed: still whole-document-scoped
 "�A"
 ```
 
-This is not new to #1719 — the same wrong answer for this shape existed under the plain
-WHATWG fallback `@base64d`/`@urid` used before it (byte-identical output, confirmed live,
-both pre- and post-#1719). Filed as
-[#1717](https://github.com/rust-works/succinctly/issues/1717), likely an off-by-one in
-jq's own end-of-buffer lookahead rather than a designed rule; per ADR-0018 rule 4 the
-correct resolution, if picked up, is bug-for-bug replication rather than "fixing" the
+Reproducing this quirk for `.a`-style document access would need per-JSON-string
+substitution timing (or per-line, for `--raw-input`), not a whole-buffer pass before
+parsing — a bigger architectural change than this issue's own "Low severity, narrow
+trigger" framing anticipated, and not attempted here. Likely an off-by-one in jq's own
+end-of-buffer lookahead rather than a designed rule either way; per ADR-0018 rule 4 the
+correct resolution, where reached, is bug-for-bug replication rather than "fixing" the
 substitution into the more sensible WHATWG-consistent shape. See
 [docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md) for the fuller
-substitution-mechanism history.
+substitution-mechanism history and [#1717](https://github.com/rust-works/succinctly/issues/1717)
+for the document/raw-input granularity gap this leaves open.
 
 ## Conversion diagnostics beyond a single token
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -253,7 +253,8 @@ $ printf '{"a":"\xe1\x41"}' | sjq -c '.a'              # unfixed: still whole-do
 
 Reproducing this quirk for `.a`-style document access would need per-JSON-string
 substitution timing — a bigger architectural change than this issue's own "Low severity,
-narrow trigger" framing anticipated, and not attempted here. `--raw-input`'s own gap is
+narrow trigger" framing anticipated, and not attempted here; tracked separately as
+[#1743](https://github.com/rust-works/succinctly/issues/1743). `--raw-input`'s own gap is
 narrower and more tractable (a caller-side reorder: split into lines before
 substituting, instead of after — the algorithm itself needs no further change), tracked
 separately as [#1742](https://github.com/rust-works/succinctly/issues/1742). Likely an

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -549,7 +549,9 @@ otherwise already correct, and it can be reverted independently if the perf gate
   coincides with "end of the whole buffer" the way it does for a base64/percent-decoded
   buffer -- the example above is still accurate post-#1717, even though jq's own trigger
   is not rare (it fires on any string ending in the right byte shape, however much more
-  content follows in the rest of the file).
+  content follows in the rest of the file). Closing this gap would need per-JSON-string
+  substitution timing, tracked separately as
+  [#1743](https://github.com/rust-works/succinctly/issues/1743).
 - Scope was document input only until #1719 also routed `@base64d`/`@urid`'s jq-mode
   output through this same `substitute_invalid_utf8_jq_style` call (for the
   overlong/surrogate/out-of-range case). At the time, this inherited the #1717 quirk

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -533,8 +533,11 @@ otherwise already correct, and it can be reverted independently if the perf gate
   writing invalid UTF-8 to stdout, and the non-lazy path refused the file outright with
   `Failed to read file` when the read had in fact succeeded.
   **Not byte-identical even now, for this document-decode path specifically**: #1617's
-  own review found a separate, narrower jq quirk -- when an `InvalidContinuationByte`
-  error's rescanned byte lands at a string's *last* byte, real jq silently drops it
+  own review found a separate, narrower jq quirk -- jq's actual rule for
+  `InvalidContinuationByte` is `len - pos < seq_len` (not enough total bytes remain from
+  the lead byte's own position to satisfy the declared sequence length, whether the
+  buffer genuinely ends or an intervening byte is simply invalid); when that holds, jq
+  silently drops the *entire* remaining tail rather than keeping and rescanning it
   (`\xe1\x41` at a string's end -> `"�"` in jq, `"�A"` here, matching
   `String::from_utf8_lossy`'s own answer). Filed and later fixed *in the algorithm
   itself* as [#1717](https://github.com/rust-works/succinctly/issues/1717) -- likely an
@@ -542,9 +545,11 @@ otherwise already correct, and it can be reverted independently if the perf gate
   bug-for-bug per ADR-0018 rule 4. The fix reaches `@base64d`/`@urid` (#1719, whose own
   `input` is already scoped to one decoded string) but not this whole-document decode
   path: `utf8_lossy_document` substitutes the entire file's bytes in one pass before
-  JSON structure is parsed, so "last byte of `input`" essentially never coincides with
-  "last byte of one JSON string" the way it does for a base64/percent-decoded buffer --
-  the example above is still accurate post-#1717.
+  JSON structure is parsed, so jq's own per-string trigger point essentially never
+  coincides with "end of the whole buffer" the way it does for a base64/percent-decoded
+  buffer -- the example above is still accurate post-#1717, even though jq's own trigger
+  is not rare (it fires on any string ending in the right byte shape, however much more
+  content follows in the rest of the file).
 - Scope was document input only until #1719 also routed `@base64d`/`@urid`'s jq-mode
   output through this same `substitute_invalid_utf8_jq_style` call (for the
   overlong/surrogate/out-of-range case). At the time, this inherited the #1717 quirk
@@ -552,9 +557,14 @@ otherwise already correct, and it can be reverted independently if the perf gate
   identical wrong answer for #1717's specific shape before #1719 (byte-identical output
   pre/post, confirmed live). #1717's later fix changed that: `@base64d`/`@urid` now match
   jq exactly for this quirk too, since the function's own `input` is naturally scoped to
-  one decoded string already. `--raw-input` shares the jq path too (jq substitutes there
-  as well, at whole-file granularity like `utf8_lossy_document` -- unfixed, same
-  granularity mismatch); DSV input, `--arg`/`--argjson` and `--rawfile` remain untouched.
+  one decoded string already. `--raw-input` shares the jq path too, but real jq's own
+  `-R` (non-slurp) trigger is scoped *per line*, not per whole file (live-verified:
+  `printf 'a\xe1\x41\n' | jq -R '.'` drops the byte on a single-line file with an
+  ordinary trailing newline) -- `get_inputs` substitutes the whole raw buffer before
+  splitting into lines, so this is unfixed for a different, more tractable reason than
+  `utf8_lossy_document`'s genuine per-JSON-string granularity gap, tracked separately as
+  [#1742](https://github.com/rust-works/succinctly/issues/1742); DSV input,
+  `--arg`/`--argjson` and `--rawfile` remain untouched.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in
   review. The substitution originally ran at read time, before `validate_json_input`, so
   the strict validator was handed an already-repaired document: `sjq --validate` exited 0

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -532,20 +532,29 @@ otherwise already correct, and it can be reverted independently if the perf gate
   This also fixed two bugs in the opposite direction: the lazy path echoed the raw bytes,
   writing invalid UTF-8 to stdout, and the non-lazy path refused the file outright with
   `Failed to read file` when the read had in fact succeeded.
-  **Not byte-identical even now**: #1617's own review found a separate, narrower jq quirk
-  it does not attempt to match -- when an `InvalidContinuationByte` error's rescanned byte
-  lands at a string's *last* byte, real jq silently drops it (`\xe1\x41` at a string's end
-  -> `"�"` in jq, `"�A"` here, matching `String::from_utf8_lossy`'s own answer).
-  Filed as [#1717](https://github.com/rust-works/succinctly/issues/1717); likely an
-  off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, per ADR-0018
-  rule 4 the correct resolution if picked up is bug-for-bug replication, not "fixing" it.
+  **Not byte-identical even now, for this document-decode path specifically**: #1617's
+  own review found a separate, narrower jq quirk -- when an `InvalidContinuationByte`
+  error's rescanned byte lands at a string's *last* byte, real jq silently drops it
+  (`\xe1\x41` at a string's end -> `"�"` in jq, `"�A"` here, matching
+  `String::from_utf8_lossy`'s own answer). Filed and later fixed *in the algorithm
+  itself* as [#1717](https://github.com/rust-works/succinctly/issues/1717) -- likely an
+  off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, reproduced
+  bug-for-bug per ADR-0018 rule 4. The fix reaches `@base64d`/`@urid` (#1719, whose own
+  `input` is already scoped to one decoded string) but not this whole-document decode
+  path: `utf8_lossy_document` substitutes the entire file's bytes in one pass before
+  JSON structure is parsed, so "last byte of `input`" essentially never coincides with
+  "last byte of one JSON string" the way it does for a base64/percent-decoded buffer --
+  the example above is still accurate post-#1717.
 - Scope was document input only until #1719 also routed `@base64d`/`@urid`'s jq-mode
   output through this same `substitute_invalid_utf8_jq_style` call (for the
-  overlong/surrogate/out-of-range case), inheriting the #1717 quirk above as an
-  unavoidable side effect -- not new exposure, since `String::from_utf8_lossy` already
-  gave the identical wrong answer for #1717's specific shape before #1719 (byte-identical
-  output pre/post, confirmed live). `--raw-input` shares the jq path too (jq substitutes
-  there as well); DSV input, `--arg`/`--argjson` and `--rawfile` remain untouched.
+  overlong/surrogate/out-of-range case). At the time, this inherited the #1717 quirk
+  above unfixed -- not new exposure, since `String::from_utf8_lossy` already gave the
+  identical wrong answer for #1717's specific shape before #1719 (byte-identical output
+  pre/post, confirmed live). #1717's later fix changed that: `@base64d`/`@urid` now match
+  jq exactly for this quirk too, since the function's own `input` is naturally scoped to
+  one decoded string already. `--raw-input` shares the jq path too (jq substitutes there
+  as well, at whole-file granularity like `utf8_lossy_document` -- unfixed, same
+  granularity mismatch); DSV input, `--arg`/`--argjson` and `--rawfile` remain untouched.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in
   review. The substitution originally ran at read time, before `validate_json_input`, so
   the strict validator was handed an already-repaired document: `sjq --validate` exited 0

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -213,10 +213,17 @@ pub trait EvalSemantics: Copy + Default {
     /// -- one already-isolated string's bytes, which is exactly what
     /// `@base64d`/`@urid` decode to. `jq_runner.rs`'s document/raw-input
     /// callers do *not* gain that particular match: they substitute a
-    /// whole file/document buffer in one pass, so "last byte of input"
-    /// essentially never coincides with "last byte of one JSON string" the
-    /// way it does here -- see docs/compliance/jq/limitations.md's "An
-    /// open gap in jq's own UTF-8 replacement-character substitution".
+    /// whole file/document buffer in one pass, before real jq's own
+    /// per-string (document mode) or per-line (`--raw-input`, live-
+    /// verified) scoping ever applies -- "last byte of the whole buffer"
+    /// essentially never coincides with jq's own trigger point in a
+    /// realistic multi-field document or multi-line file, even though
+    /// jq's own trigger itself is not rare at all (it fires on *any*
+    /// string/line ending in the right byte shape, however much more
+    /// content follows). See docs/compliance/jq/limitations.md's "jq's
+    /// own UTF-8 replacement-character substitution: fixed at function
+    /// granularity, open at document granularity" and #1742 for the
+    /// separate, more tractable raw-input caller-ordering gap.
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool;
 }
 
@@ -9233,10 +9240,10 @@ fn format_base64d<S: EvalSemantics>(
     //
     // In jq mode this now round-trips the oracle exactly, including the
     // #1717 end-of-buffer drop quirk (`"null"`'s decoded bytes happen to
-    // hit that exact shape) -- see
-    // docs/compliance/jq/limitations.md's "An open gap in jq's own UTF-8
-    // replacement-character substitution" for the one place that quirk is
-    // still open (document/raw-input decode, a different granularity).
+    // hit that exact shape) -- see docs/compliance/jq/limitations.md's
+    // "fixed at function granularity, open at document granularity"
+    // section for the one place that quirk is still open (document/
+    // raw-input decode, a different granularity).
     Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -208,11 +208,15 @@ pub trait EvalSemantics: Copy + Default {
     /// all, so this is the closest available approximation, not a verified
     /// oracle match.
     ///
-    /// Neither rule fully matches jq on every input: `substitute_invalid_utf8_jq_style`
-    /// has its own separate, deliberately-unmatched gap (#1717) where jq
-    /// drops a byte this codebase keeps -- see
-    /// docs/compliance/jq/limitations.md's "An open gap in jq's own UTF-8
-    /// replacement-character substitution".
+    /// `substitute_invalid_utf8_jq_style` also matches jq's separate
+    /// end-of-buffer drop quirk (#1717) at this function's own granularity
+    /// -- one already-isolated string's bytes, which is exactly what
+    /// `@base64d`/`@urid` decode to. `jq_runner.rs`'s document/raw-input
+    /// callers do *not* gain that particular match: they substitute a
+    /// whole file/document buffer in one pass, so "last byte of input"
+    /// essentially never coincides with "last byte of one JSON string" the
+    /// way it does here -- see docs/compliance/jq/limitations.md's "An
+    /// open gap in jq's own UTF-8 replacement-character substitution".
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool;
 }
 
@@ -9227,12 +9231,12 @@ fn format_base64d<S: EvalSemantics>(
     // conversion previously here would have produced a different wrong
     // error instead of matching the oracle.
     //
-    // That value does not fully round-trip the oracle even after #1719:
-    // succinctly's own decode of `"null"` keeps a third byte real jq drops
-    // (the still-open #1717 quirk -- see
+    // In jq mode this now round-trips the oracle exactly, including the
+    // #1717 end-of-buffer drop quirk (`"null"`'s decoded bytes happen to
+    // hit that exact shape) -- see
     // docs/compliance/jq/limitations.md's "An open gap in jq's own UTF-8
-    // replacement-character substitution"). #1719's fix below is scoped to
-    // the overlong/surrogate/out-of-range collapse rule only.
+    // replacement-character substitution" for the one place that quirk is
+    // still open (document/raw-input decode, a different granularity).
     Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -2944,9 +2944,10 @@ mod substitute_invalid_utf8_jq_style_tests {
         );
         // Genuine truncation (every available byte IS a valid
         // continuation, there just aren't enough of them) must still
-        // collapse to one U+FFFD, not regress to per-byte. Unaffected by
-        // #1717 -- a completely different branch (`invalid_subpart_end`'s
-        // "ran out of bytes" case, not "hit an invalid byte").
+        // collapse to one U+FFFD, not regress to per-byte. Same
+        // `len - pos < seq_len` condition #1717 fixed above -- there's no
+        // separate "ran out of bytes" branch left to distinguish it from,
+        // just a different reason the condition happens to hold.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0x80]), "\u{FFFD}");
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80]),
@@ -3176,14 +3177,14 @@ mod substitute_invalid_utf8_jq_style_tests {
             substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80, b'A']),
             "\u{FFFD}A"
         );
-        // 4-byte lead, good=1, *two* bytes of headroom (len - pos == 4 ==
+        // 4-byte lead, good=1, *one* byte of headroom (len - pos == 4 ==
         // seq_len) -- the sibling of the previously-missed drop case above,
         // one byte further along the same axis: kept, not dropped.
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A', b'B']),
             "\u{FFFD}AB"
         );
-        // 4-byte lead, good=0, three bytes of headroom (len - pos == 4 ==
+        // 4-byte lead, good=0, two bytes of headroom (len - pos == 4 ==
         // seq_len): kept, exactly as
         // `invalid_continuation_byte_rescans_the_offending_byte` above
         // already covers for the 3-byte-lead sibling.

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -726,14 +726,39 @@ pub fn format_byte(byte: u8) -> String {
 /// collapsing `0xF0`-`0xF4` case and would be wrongly collapsed by a rule
 /// keyed on the error kind alone).
 ///
-/// **Known remaining gap (#1717, not fixed here):** the "agree on every
-/// other kind" claim above is not quite exact for `InvalidContinuationByte`.
-/// When the rescanned byte after an invalid lead lands at the input's very
-/// last byte, real jq silently drops it; this function (like WHATWG) keeps
-/// it as its own literal character. Likely an off-by-one in jq's own
-/// end-of-buffer lookahead rather than a designed rule -- per ADR-0018
-/// rule 4, bug-for-bug replication is the correct resolution if picked up,
-/// not "fixing" it into the more sensible WHATWG-consistent shape.
+/// The "agree on every other kind" claim above has one more exception,
+/// fixed by #1717: for `InvalidContinuationByte`, when `seq_len` bytes
+/// are not all physically present from the lead's own position onward
+/// (`len - pos < seq_len`) -- whether because `input` genuinely ends
+/// early, or because one of the bytes that *is* present fails the
+/// continuation check -- real jq collapses the *entire* remaining tail
+/// into one U+FFFD, dropping every byte in it, rather than keeping and
+/// rescanning whatever came after the invalid one. This function now
+/// replicates that (see `invalid_subpart_end`'s own doc comment for the
+/// exact condition and a live-verified byte-shape matrix). Likely an
+/// off-by-one in jq's own end-of-buffer lookahead rather than a designed
+/// rule -- reproduced bug-for-bug per ADR-0018 rule 4, not "fixed" into
+/// the more sensible WHATWG-consistent shape.
+///
+/// This function's own fix is granularity-independent -- it only cares
+/// about how many bytes remain in `input` from the lead's own position --
+/// so it correctly reaches every caller where `input` is already scoped
+/// to one decoded JSON string (`@base64d`/`@urid`, #1719). It does *not*
+/// reach `jq_runner.rs`'s document/raw-input callers (`utf8_lossy_document`,
+/// `get_inputs`), which substitute a whole file/document buffer in one
+/// pass before JSON structure is parsed: real jq's own condition is
+/// scoped to *each JSON string's own closing quote* (document mode) or
+/// *each line* (raw-input mode, confirmed live: `printf 'a\xe1\x41\n' |
+/// jq -R '.'` drops the byte even though it's followed by the file's own
+/// trailing newline) -- neither of which is "the whole buffer's own end"
+/// in a realistic multi-field document or multi-line file, so this fix
+/// essentially never activates there, even though jq's own trigger
+/// condition is not rare at all (it fires on *any* string/line ending in
+/// the right byte shape, however much more content follows in the rest
+/// of the file). See `docs/compliance/jq/limitations.md`'s "fixed at
+/// function granularity, open at document granularity" section for the
+/// live-verified detail, and #1742 for the separate, more tractable
+/// raw-input caller-ordering gap this leaves open.
 ///
 /// A single left-to-right scan, not a loop over [`validate_utf8`]: that
 /// function's AVX2 path has no early exit (it scans every 32-byte block of
@@ -826,56 +851,42 @@ fn invalid_subpart_end(input: &[u8], pos: usize, len: usize) -> Option<usize> {
         return Some(pos + 1);
     }
 
-    // How many continuation bytes this sequence needs vs. how many bytes
-    // are even left in `input` -- bounding the scan below on whichever is
-    // smaller is what makes "ran out of bytes" and "hit a bad byte before
-    // running out" distinguishable, instead of a length check alone
-    // (`pos + seq_len > len`) mistaking the *former* for the latter and
-    // swallowing a following valid byte that was never part of this
-    // sequence at all (e.g. `[0xE1, b'A']`: too short for a 3-byte
-    // sequence, but `b'A'` right there is not a continuation byte either
-    // -- the fix, not a truncation).
-    let available = (len - pos - 1).min(seq_len - 1);
-    let mut good_continuations = 0;
-    while good_continuations < available
-        && is_continuation_byte(input[pos + 1 + good_continuations])
-    {
-        good_continuations += 1;
+    // #1617/#1717, unified: real jq's rule is not "was every available byte
+    // a valid continuation" -- it's simpler than that. jq first checks
+    // whether `seq_len` bytes are even physically present from `pos`
+    // onward at all. If not, it can never complete this sequence no matter
+    // what those bytes contain, so it collapses the *entire* remaining
+    // tail into one U+FFFD unconditionally -- even when one of the
+    // available bytes would, on its own, have been a perfectly good ASCII
+    // character to keep and rescan. Only once `seq_len` bytes are actually
+    // present does jq bother validating each continuation byte
+    // individually and doing WHATWG-style rescan-at-the-bad-byte.
+    //
+    // This one condition subsumes what used to be two separate branches
+    // here (a "ran out of bytes, every byte present was a good
+    // continuation" case, and a narrower "shortfall >= 2 AND at the
+    // absolute last byte" special case for #1717): both turned out to be
+    // instances of the same simpler rule. The previous, narrower #1717
+    // condition undercounted -- live-verified against jq 1.7.1, which
+    // also collapses `[0xF0, b'A', b'B']` (a 4-byte lead, one invalid
+    // continuation, *one* byte of headroom before end-of-input) to a
+    // single U+FFFD, which `rescan_pos == len - 1` alone does not catch
+    // (`rescan_pos` there is `len - 2`, not `len - 1`).
+    if len - pos < seq_len {
+        return Some(len);
     }
-    if good_continuations < seq_len - 1 {
-        if pos + 1 + good_continuations == len {
-            // Ran out of *bytes*, not because one was invalid -- every
-            // byte that *was* available was a valid continuation, there
-            // just weren't enough of them. Only reachable at the very
-            // end of `input`, so the whole remaining tail is one
-            // maximal subpart.
-            return Some(len);
+
+    // `seq_len` bytes are confirmed present; find the first one (if any)
+    // that isn't a valid continuation byte. Safe to index unconditionally
+    // for `i` in `1..seq_len`: the check above guarantees `pos + seq_len
+    // - 1 <= len - 1`.
+    for i in 1..seq_len {
+        if !is_continuation_byte(input[pos + i]) {
+            // WHATWG-style: the subpart is the lead plus whatever
+            // continuations came before this one; the offending byte
+            // itself is rescanned next iteration, not skipped.
+            return Some(pos + i);
         }
-        // Ran out because the next byte specifically isn't a valid
-        // continuation byte, with more input still available: the
-        // subpart is the lead plus whatever continuations were already
-        // good; the offending byte itself is rescanned next iteration,
-        // not skipped (WHATWG restarts scanning there).
-        //
-        // #1717: real jq instead *drops* that rescanned byte -- silently,
-        // with no U+FFFD of its own -- when both (a) it is the very last
-        // byte of `input` and (b) at least two continuation bytes are
-        // still missing (`shortfall`). Live-verified across every lead
-        // length that can produce a shortfall of 2+ (2-byte leads only
-        // ever reach shortfall 1, so never trigger this): shortfall 1
-        // always keeps the byte regardless of lead length (`\xe1\x80\x41`
-        // -> `"\u{FFFD}A"`, `\xf0\x90\x80\x41` -> `"\u{FFFD}A"`);
-        // shortfall 2+ drops it only at end-of-input (`\xe1\x41` ->
-        // `"\u{FFFD}"`, `\xf0\x41`/`\xf0\x80\x41` -> `"\u{FFFD}"`) and
-        // keeps it the moment any byte follows (`\xe1\x41\x42` ->
-        // `"\u{FFFD}AB"`, `\xf0\x41\x42\x43` -> `"\u{FFFD}ABC"`). Likely an
-        // off-by-one in jq's own end-of-buffer lookahead, not a designed
-        // rule -- reproduced bug-for-bug per ADR-0018 rule 4.
-        let shortfall = (seq_len - 1) - good_continuations;
-        if shortfall >= 2 && pos + 1 + good_continuations == len - 1 {
-            return Some(len);
-        }
-        return Some(pos + 1 + good_continuations);
     }
 
     // Every continuation byte already confirmed present and well-formed
@@ -2904,22 +2915,23 @@ mod substitute_invalid_utf8_jq_style_tests {
     /// mechanism (a truncation collapse, not a rescanned-byte decision).
     ///
     /// The four assertions below all happen to land in #1717's own
-    /// drop-the-rescanned-byte territory (shortfall >= 2, byte is at the
-    /// absolute end of `input`) -- confirmed live against jq 1.7.1 --
-    /// so their *answer* now agrees with a one-U+FFFD collapse too. That
-    /// is not a coincidence this test stops distinguishing: it still
-    /// exercises the original bug's actual failure mode, because the old
-    /// truncation-misclassification bug did not require end-of-input at
-    /// all, and would have collapsed these same vectors even with
-    /// trailing content following (see
+    /// drop-the-whole-tail territory (`len - pos < seq_len`) -- confirmed
+    /// live against jq 1.7.1 -- so their *answer* now agrees with a
+    /// one-U+FFFD collapse too. That is not a coincidence this test stops
+    /// distinguishing: it still exercises the original bug's actual
+    /// failure mode, because the old truncation-misclassification bug did
+    /// not require end-of-input at all, and would have collapsed these
+    /// same vectors even with trailing content following (see
     /// `any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior`,
-    /// which pins exactly that: trailing content is kept, not swallowed).
+    /// which pins exactly that: trailing content is kept, not swallowed,
+    /// once enough bytes are present for the full sequence).
     #[test]
     fn invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte() {
-        // #1717: at the absolute end of input with shortfall >= 2, jq (and
-        // now this function) drops the rescanned byte rather than keeping
-        // it -- see the dedicated `drops_the_rescanned_byte_at_end_of_input_*`
-        // test above for the isolated case-by-case breakdown.
+        // #1717: whenever fewer than `seq_len` bytes remain from the lead
+        // onward, jq (and now this function) collapses the whole tail
+        // rather than keeping and rescanning whatever's left -- see the
+        // dedicated `drops_the_rescanned_byte_at_end_of_input_*` test
+        // above for the isolated case-by-case breakdown.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}");
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}");
         assert_eq!(
@@ -3118,61 +3130,68 @@ mod substitute_invalid_utf8_jq_style_tests {
         );
     }
 
-    /// #1717: at the very end of `input` (nothing follows the rescanned
-    /// byte at all), real jq silently drops it instead of rescanning it --
-    /// but only when at least 2 continuation bytes are still missing
-    /// (`shortfall = (seq_len - 1) - good_continuations >= 2`). Live-
-    /// verified across every lead length that can reach shortfall 2+: a
-    /// 2-byte lead never can (its only failure mode is shortfall 1), so
-    /// this quirk is 3-/4-byte-lead-only.
+    /// #1717: real jq's rule is `len - pos < seq_len` -- if `seq_len`
+    /// bytes aren't all physically present from the lead's own position
+    /// onward, jq collapses the *entire* remaining tail into one U+FFFD,
+    /// regardless of *why* they're short (buffer truly ends, or one byte
+    /// present fails the continuation check). An earlier, narrower version
+    /// of this fix conditioned the drop on "the offending byte is
+    /// `input`'s last byte", which undercounts: `[0xF0, b'A', b'B']`
+    /// (4-byte lead, invalid continuation, *one* byte of headroom before
+    /// end-of-input -- so the offending byte is *not* the last byte) still
+    /// collapses in real jq, live-verified, and is the case that earlier
+    /// version got wrong. The shortfall=2-via-3-byte-lead case
+    /// (`[0xE1, b'A']`) and shortfall=3-via-4-byte-lead, zero-headroom case
+    /// (`[0xF0, b'A']`) are already pinned by
+    /// `invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte`
+    /// above; this adds the remaining shapes that test doesn't cover,
+    /// including the previously-missed one.
     #[test]
-    fn drops_the_rescanned_byte_at_end_of_input_when_shortfall_is_two_or_more() {
-        // 3-byte lead, good=0 (shortfall=2): dropped.
-        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}");
-        // 4-byte lead, good=0 (shortfall=3): dropped.
-        assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}");
-        // 4-byte lead, good=1 (shortfall=2): dropped.
+    fn drops_the_whole_tail_when_fewer_than_seq_len_bytes_remain_from_the_lead() {
+        // 4-byte lead, good=1, zero headroom (len - pos == 3 < seq_len == 4).
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A']),
             "\u{FFFD}"
         );
-        // The dropped byte need not be plain ASCII -- it's consumed
-        // wholesale, not re-decoded, so it gets no U+FFFD of its own either.
+        // 4-byte lead, good=0, *one byte of headroom* (len - pos == 3 <
+        // seq_len == 4) -- the shape the narrower pre-fix condition missed.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, b'A', b'B']),
+            "\u{FFFD}"
+        );
+        // The dropped bytes need not be plain ASCII -- they're consumed
+        // wholesale, not re-decoded, so they get no U+FFFD of their own.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0xFF]), "\u{FFFD}");
     }
 
     #[test]
-    fn keeps_the_rescanned_byte_at_end_of_input_when_shortfall_is_exactly_one() {
-        // 2-byte lead, good=0 (shortfall=1, the only case a 2-byte lead
-        // can reach): kept.
+    fn keeps_and_rescans_once_seq_len_bytes_are_present() {
+        // 2-byte lead, good=0 (len - pos == 2 == seq_len): kept.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xC2, b'A']), "\u{FFFD}A");
-        // 3-byte lead, good=1 (shortfall=1): kept.
+        // 3-byte lead, good=1 (len - pos == 3 == seq_len): kept.
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xE1, 0x80, b'A']),
             "\u{FFFD}A"
         );
-        // 4-byte lead, good=2 (shortfall=1): kept.
+        // 4-byte lead, good=2 (len - pos == 4 == seq_len): kept.
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80, b'A']),
             "\u{FFFD}A"
         );
-    }
-
-    #[test]
-    fn any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior() {
-        // Same shortfall-2+ shapes as the drop test above, but with one
-        // more byte after the rescanned position -- no longer "at the end
-        // of input", so the byte is kept and rescanned normally, exactly
-        // as `invalid_continuation_byte_rescans_the_offending_byte` above
-        // already covers for the shortfall=2 (3-byte-lead) case. This adds
-        // the shortfall=3/shortfall=2-via-4-byte-lead siblings.
-        assert_eq!(
-            substitute_invalid_utf8_jq_style(&[0xF0, b'A', b'B', b'C']),
-            "\u{FFFD}ABC"
-        );
+        // 4-byte lead, good=1, *two* bytes of headroom (len - pos == 4 ==
+        // seq_len) -- the sibling of the previously-missed drop case above,
+        // one byte further along the same axis: kept, not dropped.
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A', b'B']),
             "\u{FFFD}AB"
+        );
+        // 4-byte lead, good=0, three bytes of headroom (len - pos == 4 ==
+        // seq_len): kept, exactly as
+        // `invalid_continuation_byte_rescans_the_offending_byte` above
+        // already covers for the 3-byte-lead sibling.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, b'A', b'B', b'C']),
+            "\u{FFFD}ABC"
         );
     }
 
@@ -3181,7 +3200,8 @@ mod substitute_invalid_utf8_jq_style_tests {
         // #1717 is specific to InvalidContinuationByte on a structurally-
         // valid lead; is_never_valid_lead_byte (0xC0/0xC1/0xF5-0xF7) is
         // handled earlier in invalid_subpart_end and never reaches the
-        // shortfall check at all, so this stays exactly as before.
+        // `len - pos < seq_len` check at all, so this stays exactly as
+        // before.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xC0, b'A']), "\u{FFFD}A");
     }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -757,8 +757,8 @@ pub fn format_byte(byte: u8) -> String {
 /// the right byte shape, however much more content follows in the rest
 /// of the file). See `docs/compliance/jq/limitations.md`'s "fixed at
 /// function granularity, open at document granularity" section for the
-/// live-verified detail, and #1742 for the separate, more tractable
-/// raw-input caller-ordering gap this leaves open.
+/// live-verified detail, #1743 for the document-mode gap, and #1742 for
+/// the separate, more tractable raw-input caller-ordering gap.
 ///
 /// A single left-to-right scan, not a loop over [`validate_utf8`]: that
 /// function's AVX2 path has no early exit (it scans every 32-byte block of
@@ -2922,16 +2922,16 @@ mod substitute_invalid_utf8_jq_style_tests {
     /// failure mode, because the old truncation-misclassification bug did
     /// not require end-of-input at all, and would have collapsed these
     /// same vectors even with trailing content following (see
-    /// `any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior`,
-    /// which pins exactly that: trailing content is kept, not swallowed,
-    /// once enough bytes are present for the full sequence).
+    /// `keeps_and_rescans_once_seq_len_bytes_are_present`, which pins
+    /// exactly that: trailing content is kept, not swallowed, once enough
+    /// bytes are present for the full sequence).
     #[test]
-    fn invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte() {
+    fn invalid_continuation_boundary_detection_matches_jq_near_eof() {
         // #1717: whenever fewer than `seq_len` bytes remain from the lead
         // onward, jq (and now this function) collapses the whole tail
         // rather than keeping and rescanning whatever's left -- see the
-        // dedicated `drops_the_rescanned_byte_at_end_of_input_*` test
-        // above for the isolated case-by-case breakdown.
+        // dedicated `drops_the_whole_tail_when_fewer_than_seq_len_bytes_remain_from_the_lead`
+        // test below for the isolated case-by-case breakdown.
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}");
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}");
         assert_eq!(
@@ -3141,18 +3141,16 @@ mod substitute_invalid_utf8_jq_style_tests {
     /// end-of-input -- so the offending byte is *not* the last byte) still
     /// collapses in real jq, live-verified, and is the case that earlier
     /// version got wrong. The shortfall=2-via-3-byte-lead case
-    /// (`[0xE1, b'A']`) and shortfall=3-via-4-byte-lead, zero-headroom case
-    /// (`[0xF0, b'A']`) are already pinned by
-    /// `invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte`
-    /// above; this adds the remaining shapes that test doesn't cover,
-    /// including the previously-missed one.
+    /// (`[0xE1, b'A']`), shortfall=3-via-4-byte-lead zero-headroom case
+    /// (`[0xF0, b'A']`), and 4-byte-lead-good=1-zero-headroom case
+    /// (`[0xF0, 0x80, b'A']`, indistinguishable from `[0xF0, 0x90, b'A']`
+    /// there since `is_continuation_byte` treats the whole 0x80-0xBF range
+    /// alike) are already pinned by
+    /// `invalid_continuation_boundary_detection_matches_jq_near_eof` above;
+    /// this adds the one shape that test doesn't cover -- the previously-
+    /// missed, one-byte-of-headroom case.
     #[test]
     fn drops_the_whole_tail_when_fewer_than_seq_len_bytes_remain_from_the_lead() {
-        // 4-byte lead, good=1, zero headroom (len - pos == 3 < seq_len == 4).
-        assert_eq!(
-            substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A']),
-            "\u{FFFD}"
-        );
         // 4-byte lead, good=0, *one byte of headroom* (len - pos == 3 <
         // seq_len == 4) -- the shape the narrower pre-fix condition missed.
         assert_eq!(

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -856,6 +856,25 @@ fn invalid_subpart_end(input: &[u8], pos: usize, len: usize) -> Option<usize> {
         // subpart is the lead plus whatever continuations were already
         // good; the offending byte itself is rescanned next iteration,
         // not skipped (WHATWG restarts scanning there).
+        //
+        // #1717: real jq instead *drops* that rescanned byte -- silently,
+        // with no U+FFFD of its own -- when both (a) it is the very last
+        // byte of `input` and (b) at least two continuation bytes are
+        // still missing (`shortfall`). Live-verified across every lead
+        // length that can produce a shortfall of 2+ (2-byte leads only
+        // ever reach shortfall 1, so never trigger this): shortfall 1
+        // always keeps the byte regardless of lead length (`\xe1\x80\x41`
+        // -> `"\u{FFFD}A"`, `\xf0\x90\x80\x41` -> `"\u{FFFD}A"`);
+        // shortfall 2+ drops it only at end-of-input (`\xe1\x41` ->
+        // `"\u{FFFD}"`, `\xf0\x41`/`\xf0\x80\x41` -> `"\u{FFFD}"`) and
+        // keeps it the moment any byte follows (`\xe1\x41\x42` ->
+        // `"\u{FFFD}AB"`, `\xf0\x41\x42\x43` -> `"\u{FFFD}ABC"`). Likely an
+        // off-by-one in jq's own end-of-buffer lookahead, not a designed
+        // rule -- reproduced bug-for-bug per ADR-0018 rule 4.
+        let shortfall = (seq_len - 1) - good_continuations;
+        if shortfall >= 2 && pos + 1 + good_continuations == len - 1 {
+            return Some(len);
+        }
         return Some(pos + 1 + good_continuations);
     }
 
@@ -2881,25 +2900,41 @@ mod substitute_invalid_utf8_jq_style_tests {
     /// continuation byte happened to fall near the end of `input` --
     /// short of `seq_len` total remaining bytes, but not because input
     /// ran out -- the old code misclassified it as truncation and
-    /// swallowed the *whole* remaining tail into one U+FFFD, silently
-    /// dropping valid trailing bytes it should have kept and rescanned
-    /// (e.g. `[0xE1, b'A']` gave `"\u{FFFD}"`, discarding `'A'`, instead
-    /// of `"\u{FFFD}A"`).
+    /// swallowed the *whole* remaining tail into one U+FFFD by the wrong
+    /// mechanism (a truncation collapse, not a rescanned-byte decision).
+    ///
+    /// The four assertions below all happen to land in #1717's own
+    /// drop-the-rescanned-byte territory (shortfall >= 2, byte is at the
+    /// absolute end of `input`) -- confirmed live against jq 1.7.1 --
+    /// so their *answer* now agrees with a one-U+FFFD collapse too. That
+    /// is not a coincidence this test stops distinguishing: it still
+    /// exercises the original bug's actual failure mode, because the old
+    /// truncation-misclassification bug did not require end-of-input at
+    /// all, and would have collapsed these same vectors even with
+    /// trailing content following (see
+    /// `any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior`,
+    /// which pins exactly that: trailing content is kept, not swallowed).
     #[test]
     fn invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte() {
-        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}A");
-        assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}A");
+        // #1717: at the absolute end of input with shortfall >= 2, jq (and
+        // now this function) drops the rescanned byte rather than keeping
+        // it -- see the dedicated `drops_the_rescanned_byte_at_end_of_input_*`
+        // test above for the isolated case-by-case breakdown.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}");
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}");
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x90, b'A']),
-            "\u{FFFD}A"
+            "\u{FFFD}"
         );
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[b'X', 0xE1, b'A']),
-            "X\u{FFFD}A"
+            "X\u{FFFD}"
         );
         // Genuine truncation (every available byte IS a valid
         // continuation, there just aren't enough of them) must still
-        // collapse to one U+FFFD, not regress to per-byte.
+        // collapse to one U+FFFD, not regress to per-byte. Unaffected by
+        // #1717 -- a completely different branch (`invalid_subpart_end`'s
+        // "ran out of bytes" case, not "hit an invalid byte").
         assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0x80]), "\u{FFFD}");
         assert_eq!(
             substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80]),
@@ -3081,6 +3116,73 @@ mod substitute_invalid_utf8_jq_style_tests {
             substitute_invalid_utf8_jq_style(&[0xE1, 0x80, 0x41, b'b', b'c']),
             "\u{FFFD}Abc"
         );
+    }
+
+    /// #1717: at the very end of `input` (nothing follows the rescanned
+    /// byte at all), real jq silently drops it instead of rescanning it --
+    /// but only when at least 2 continuation bytes are still missing
+    /// (`shortfall = (seq_len - 1) - good_continuations >= 2`). Live-
+    /// verified across every lead length that can reach shortfall 2+: a
+    /// 2-byte lead never can (its only failure mode is shortfall 1), so
+    /// this quirk is 3-/4-byte-lead-only.
+    #[test]
+    fn drops_the_rescanned_byte_at_end_of_input_when_shortfall_is_two_or_more() {
+        // 3-byte lead, good=0 (shortfall=2): dropped.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, b'A']), "\u{FFFD}");
+        // 4-byte lead, good=0 (shortfall=3): dropped.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xF0, b'A']), "\u{FFFD}");
+        // 4-byte lead, good=1 (shortfall=2): dropped.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A']),
+            "\u{FFFD}"
+        );
+        // The dropped byte need not be plain ASCII -- it's consumed
+        // wholesale, not re-decoded, so it gets no U+FFFD of its own either.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xE1, 0xFF]), "\u{FFFD}");
+    }
+
+    #[test]
+    fn keeps_the_rescanned_byte_at_end_of_input_when_shortfall_is_exactly_one() {
+        // 2-byte lead, good=0 (shortfall=1, the only case a 2-byte lead
+        // can reach): kept.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xC2, b'A']), "\u{FFFD}A");
+        // 3-byte lead, good=1 (shortfall=1): kept.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xE1, 0x80, b'A']),
+            "\u{FFFD}A"
+        );
+        // 4-byte lead, good=2 (shortfall=1): kept.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x90, 0x80, b'A']),
+            "\u{FFFD}A"
+        );
+    }
+
+    #[test]
+    fn any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior() {
+        // Same shortfall-2+ shapes as the drop test above, but with one
+        // more byte after the rescanned position -- no longer "at the end
+        // of input", so the byte is kept and rescanned normally, exactly
+        // as `invalid_continuation_byte_rescans_the_offending_byte` above
+        // already covers for the shortfall=2 (3-byte-lead) case. This adds
+        // the shortfall=3/shortfall=2-via-4-byte-lead siblings.
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, b'A', b'B', b'C']),
+            "\u{FFFD}ABC"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_style(&[0xF0, 0x80, b'A', b'B']),
+            "\u{FFFD}AB"
+        );
+    }
+
+    #[test]
+    fn never_valid_lead_byte_at_end_is_unaffected_by_the_drop_quirk() {
+        // #1717 is specific to InvalidContinuationByte on a structurally-
+        // valid lead; is_never_valid_lead_byte (0xC0/0xC1/0xF5-0xF7) is
+        // handled earlier in invalid_subpart_end and never reaches the
+        // shortfall check at all, so this stays exactly as before.
+        assert_eq!(substitute_invalid_utf8_jq_style(&[0xC0, b'A']), "\u{FFFD}A");
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22806,6 +22806,35 @@ fn test_utf8_never_valid_lead_stays_one_fffd_per_byte_1617() -> Result<()> {
     Ok(())
 }
 
+/// #1717's fix reaches `@base64d`/`@urid` (#1719, see `yq_cli_tests.rs`'s
+/// own `test_jq_base64d_drops_*_1717` tests) but *not* this whole-document
+/// decode path (`utf8_lossy_document`) -- real jq's own trigger is scoped
+/// to each JSON string's own closing quote, but `utf8_lossy_document`
+/// substitutes the entire file's bytes in one pass before JSON structure
+/// is even parsed, so "last byte of the whole file" essentially never
+/// coincides with jq's actual trigger point. Pins the CURRENT (still
+/// divergent from jq) behavior as a deliberate regression guard, not a
+/// target to match -- see docs/compliance/jq/limitations.md's "fixed at
+/// function granularity, open at document granularity" section and #1743,
+/// which tracks closing this specific gap.
+#[test]
+fn test_invalid_utf8_document_drop_quirk_still_diverges_from_jq_1717() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{\"a\":\"\xe1\x41\"}")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    // Real jq 1.7.1 drops the 'A' entirely (confirmed live): `"\u{fffd}"`.
+    // succinctly keeps it -- `utf8_lossy_document` substitutes the whole
+    // file, and 'A' is not that whole file's own last byte (the closing
+    // `"}"` still follows it), so #1717's fix never activates here.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a", path], None).unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"\u{fffd}A\"");
+    Ok(())
+}
+
 /// #1617 on the `-R`/raw-input decode path (`get_inputs`'s own copy of the
 /// substitution, separate from `utf8_lossy_document`'s document-mode copy)
 /// -- both call the same shared `substitute_invalid_utf8_jq_style`, but

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17544,8 +17544,10 @@ fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
 /// `"null" | @base64d` succeeds as `"��e"` in yq v4.53.3 rather
 /// than erroring). This is yq mode's own WHATWG-lossy fallback, unaffected
 /// by #1719 (jq mode only) -- real jq 1.7.1 gives a different value here,
-/// `"��"` with no trailing `e` (the #1717 quirk, unrelated to
-/// this test), so do not read the value below as a cross-mode oracle match.
+/// `"��"` with no trailing `e`. jq mode now reproduces that value
+/// exactly (#1717, fixed), but yq mode has no oracle-matching rule to
+/// switch to, so it keeps this WHATWG value; do not read it as a
+/// cross-mode oracle match.
 #[test]
 fn test_base64d_invalid_utf8_is_lossy_not_error_1109() -> Result<()> {
     let (out, code) = run_yq_stdin("@base64d", r#""null""#, &["-o", "json"])?;
@@ -20378,41 +20380,42 @@ fn test_jq_base64d_invalid_trailing_byte_uses_invalid_data_message_1146() -> Res
 /// `owned_string_from_decoded_bytes` exists to handle) previously had no
 /// regression test -- only the yq-mode variant was covered.
 ///
-/// `base64_decode_lossy` computes the WHATWG rule, not jq's own
-/// maximal-subpart rule (#1617/#1719) -- they happen to agree here because
-/// "null" decodes to a byte sequence that hits #1717's still-open quirk
-/// (jq drops the final rescanned byte at a string's last byte; neither
-/// substitution rule replicates that drop, so both land on the same
-/// 3-codepoint answer, not jq 1.7.1's real 2-codepoint one). This test
-/// therefore does not prove full jq-oracle parity for this input -- see
-/// `owned_string_from_decoded_bytes`'s doc comment in `src/jq/eval.rs`.
+/// "null" decodes to `[0x9E, 0xE9, 0x65]`: a stray continuation byte (one
+/// U+FFFD on its own), then a 3-byte lead (0xE9) whose sole continuation
+/// candidate (0x65, `'e'`) is both invalid *and* the buffer's last byte --
+/// exactly #1717's shortfall-2-at-end shape. `base64_decode_lossy`
+/// (WHATWG) does not model that drop and so no longer matches this
+/// call's own asserted value below; the literal replaces it, matching
+/// jq 1.7.1 exactly (`printf '"null"' | jq -j '@base64d'` ->
+/// two U+FFFD, no trailing `e`, confirmed live).
 #[test]
 fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"null\"", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
-    let expected = base64_decode_lossy("null");
-    assert_eq!(out.trim(), format!("{expected:?}"));
+    assert_eq!(out.trim(), "\"\u{fffd}\u{fffd}\"");
     Ok(())
 }
 
-/// #1717, reached via `@base64d` -- pins the CURRENT (known-divergent from
-/// real jq) behavior, not a target to match. Base64 "4UE=" decodes to raw
-/// bytes `[0xE1, 0x41]`: a 3-byte lead followed by an invalid continuation
-/// byte ('A') at the string's last byte. Real jq 1.7.1 drops that trailing
-/// byte entirely (`echo '"4UE="' | jq -c '@base64d|explode'` -> `[65533]`);
-/// succinctly keeps it (`[65533,65]`), matching `String::from_utf8_lossy`'s
-/// WHATWG answer -- unaffected by #1719, since jq-style substitution
-/// (#1617/#1719) agrees with WHATWG on this specific shape (confirmed live,
-/// byte-identical output before and after #1719). This pins the status quo
-/// so a future #1717 fix has a base64d-reachable regression test to update,
-/// and so nobody accidentally "fixes" this call site alone without #1717's
-/// own document-decode call sites (see docs/compliance/jq/limitations.md
-/// § "An open gap in jq's own UTF-8 replacement-character substitution").
+/// #1717, reached via `@base64d`. Base64 "4UE=" decodes to raw bytes
+/// `[0xE1, 0x41]`: a 3-byte lead followed by an invalid continuation byte
+/// ('A') at the string's last byte -- shortfall 2, at end. Real jq 1.7.1
+/// drops that trailing byte entirely
+/// (`echo '"4UE="' | jq -c '@base64d|explode'` -> `[65533]`), and
+/// `succinctly` now matches exactly, via `owned_string_from_decoded_bytes`
+/// (`src/jq/eval.rs`) calling the fixed `substitute_invalid_utf8_jq_style`
+/// (`src/text/utf8/mod.rs`). Document/raw-input decode
+/// (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`) does *not* gain
+/// this fix -- it substitutes a whole file/document buffer at once, so
+/// "last byte of input" almost never coincides with "last byte of one
+/// JSON string's own content" the way it naturally does here, where
+/// `input` already *is* one decoded string's bytes. See
+/// docs/compliance/jq/limitations.md § "An open gap in jq's own UTF-8
+/// replacement-character substitution" for the granularity distinction.
 #[test]
-fn test_jq_base64d_drops_trailing_byte_quirk_unaffected_1717() -> Result<()> {
+fn test_jq_base64d_drops_trailing_byte_quirk_fixed_1717() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"4UE=\"", &["-c"])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "[65533,65]");
+    assert_eq!(out.trim(), "[65533]");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20382,12 +20382,13 @@ fn test_jq_base64d_invalid_trailing_byte_uses_invalid_data_message_1146() -> Res
 ///
 /// "null" decodes to `[0x9E, 0xE9, 0x65]`: a stray continuation byte (one
 /// U+FFFD on its own), then a 3-byte lead (0xE9) whose sole continuation
-/// candidate (0x65, `'e'`) is both invalid *and* the buffer's last byte --
-/// exactly #1717's shortfall-2-at-end shape. `base64_decode_lossy`
-/// (WHATWG) does not model that drop and so no longer matches this
-/// call's own asserted value below; the literal replaces it, matching
-/// jq 1.7.1 exactly (`printf '"null"' | jq -j '@base64d'` ->
-/// two U+FFFD, no trailing `e`, confirmed live).
+/// candidate (0x65, `'e'`) is both invalid and the buffer's last byte --
+/// `len - pos == 2 < seq_len == 3`, exactly #1717's drop-the-whole-tail
+/// shape. `base64_decode_lossy` (WHATWG) does not model that drop and so
+/// no longer matches this call's own asserted value below; the literal
+/// replaces it, matching jq 1.7.1 exactly
+/// (`printf '"null"' | jq -j '@base64d'` -> two U+FFFD, no trailing `e`,
+/// confirmed live).
 #[test]
 fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"null\"", &[])?;
@@ -20398,22 +20399,45 @@ fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
 
 /// #1717, reached via `@base64d`. Base64 "4UE=" decodes to raw bytes
 /// `[0xE1, 0x41]`: a 3-byte lead followed by an invalid continuation byte
-/// ('A') at the string's last byte -- shortfall 2, at end. Real jq 1.7.1
-/// drops that trailing byte entirely
+/// ('A'), with no bytes at all remaining after it -- `len - pos == 2 <
+/// seq_len == 3`. Real jq 1.7.1 drops that trailing byte entirely
 /// (`echo '"4UE="' | jq -c '@base64d|explode'` -> `[65533]`), and
 /// `succinctly` now matches exactly, via `owned_string_from_decoded_bytes`
 /// (`src/jq/eval.rs`) calling the fixed `substitute_invalid_utf8_jq_style`
 /// (`src/text/utf8/mod.rs`). Document/raw-input decode
 /// (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`) does *not* gain
-/// this fix -- it substitutes a whole file/document buffer at once, so
-/// "last byte of input" almost never coincides with "last byte of one
-/// JSON string's own content" the way it naturally does here, where
-/// `input` already *is* one decoded string's bytes. See
-/// docs/compliance/jq/limitations.md § "An open gap in jq's own UTF-8
-/// replacement-character substitution" for the granularity distinction.
+/// this fix -- it substitutes a whole file/document buffer at once,
+/// before real jq's own per-string (document mode) or per-line
+/// (`--raw-input`) trigger point ever applies, so "last byte of input"
+/// almost never coincides with jq's own trigger the way it naturally
+/// does here, where `input` already *is* one decoded string's bytes
+/// (jq's own trigger is not rare -- it fires on any string/line ending
+/// in the right byte shape, however much more content follows; only
+/// succinctly's whole-buffer reproduction of it is). See #1742 for the
+/// separate, more tractable raw-input caller-ordering gap, and
+/// docs/compliance/jq/limitations.md's "fixed at function granularity,
+/// open at document granularity" section for the full detail.
 #[test]
 fn test_jq_base64d_drops_trailing_byte_quirk_fixed_1717() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"4UE=\"", &["-c"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[65533]");
+    Ok(())
+}
+
+/// #1717's actual rule is `len - pos < seq_len` (not enough total bytes
+/// present for the declared sequence length), not "the offending byte is
+/// `input`'s own last byte" -- an earlier, narrower version of the fix
+/// used the latter and missed this exact shape. Base64 "8EFC" decodes to
+/// `[0xF0, 0x41, 0x42]`: a 4-byte lead, an invalid continuation ('A'),
+/// and *one* trailing byte ('B') -- so the invalid byte itself is not
+/// `input`'s last byte, yet real jq still collapses the whole tail
+/// (`printf '"8EFC"' | jq -c '@base64d | explode'` -> `[65533]`, dropping
+/// both 'A' and 'B'). Found by code review via a 1200-case differential
+/// sweep against jq 1.7.1; independently re-verified live before fixing.
+#[test]
+fn test_jq_base64d_drops_whole_tail_when_one_byte_short_of_seq_len_1717() -> Result<()> {
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"8EFC\"", &["-c"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[65533]");
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #1717.

`substitute_invalid_utf8_jq_style`'s `InvalidContinuationByte` handling kept the rescanned byte as its own literal character even when real jq silently drops it. Live-verified the exact condition across every lead length that can trigger it:

```bash
$ printf '"4UE="' | jq -c '@base64d | explode'        # base64 "4UE=" decodes to [0xE1, 0x41]
[65533]
$ printf '"4UE="' | sjq -c '@base64d | explode'        # before this fix
[65533,65]
$ printf '"4UE="' | sjq -c '@base64d | explode'        # after this fix
[65533]
```

jq drops the byte only when **both**: it's the absolute last byte of `input`, **and** at least 2 continuation bytes are still missing (`shortfall = (sequence length - 1) - good continuation bytes >= 2`). A 2-byte lead's only failure mode is shortfall 1, so it can never trigger this; shortfall 1 always keeps the byte regardless of lead length; any byte following the rescanned position restores normal keep-and-rescan behavior. Probed with a dozen+ live-oracle cases across 2-/3-/4-byte leads, varying `good`, with and without trailing content — matrix in the commit message and the new unit tests.

## Scope

The fix reaches every call site where `input` is already scoped to **one decoded string's own bytes** — `@base64d`/`@urid` (#1719's `owned_string_from_decoded_bytes`), now confirmed to match jq exactly, including a `"null"|@base64d` case an existing test happened to already exercise this exact shape through (its assertion is updated, not just its comment).

It does **not** reach `jq_runner.rs`'s document/raw-input decode (`utf8_lossy_document`, `get_inputs`): those substitute an entire file's bytes in one pass *before* JSON structure is parsed, so "last byte of `input`" essentially never coincides with "last byte of one JSON string" the way it naturally does at the per-string granularity above. Reproducing the quirk there would need per-JSON-string (or per-line, for `--raw-input`) substitution timing — a bigger architectural change than this issue's own "Low severity, narrow trigger" framing anticipated, and not attempted here. This is documented, not silently left stale — `docs/compliance/jq/limitations.md`'s existing "open gap" section is rewritten to describe the new fixed/open split precisely, with a still-accurate live repro for the unfixed document-decode path.

## Changes

- `src/text/utf8/mod.rs`: the fix itself, in `invalid_subpart_end`'s `InvalidContinuationByte` branch. New tests: `drops_the_rescanned_byte_at_end_of_input_when_shortfall_is_two_or_more`, `keeps_the_rescanned_byte_at_end_of_input_when_shortfall_is_exactly_one`, `any_trailing_byte_after_the_rescanned_byte_restores_normal_keep_behavior`, `never_valid_lead_byte_at_end_is_unaffected_by_the_drop_quirk`. Updated an existing test (`invalid_continuation_near_eof_does_not_swallow_a_trailing_valid_byte`) whose vectors happened to land squarely in the new drop territory — its own doc comment explains why its *answer* changed while the *bug it originally regression-tests* (a different, older truncation-misclassification issue) did not reappear.
- `src/jq/eval.rs`: updated two doc comments (the `UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE` trait const, and `format_base64d`'s own comment) that described this as a "still-open"/"deliberately-unmatched" gap — no longer accurate now that the algorithm and its per-string call sites are fixed.
- `tests/yq_cli_tests.rs`: `test_jq_base64d_invalid_utf8_is_lossy_not_error_1146`'s assertion changed from the stale WHATWG-computed value to the literal correct one (dropping the now-inapplicable `base64_decode_lossy` call for this specific test, since jq mode no longer uses that rule for this shape). `test_jq_base64d_drops_trailing_byte_quirk_unaffected_1717` renamed to `..._fixed_1717` and its assertion updated to match jq. A yq-mode test's doc comment corrected to not imply jq's value is still divergent.
- `docs/compliance/jq/limitations.md`, `docs/plan/decode-failure-routing.md`: rewritten to describe the fixed/open split precisely instead of a blanket "known gap".

## Test plan

- [x] Live-verified against the pinned jq 1.7.1 binary (`/usr/bin/jq`) across a dozen+ cases spanning 2-/3-/4-byte leads, varying shortfall, with and without trailing content.
- [x] `cargo build --features cli`, full `cargo test --features cli,simd,regex,serde` (interleaved at reduced parallelism to filter this machine's concurrent-load flakes — all 0 failed), both clippy legs, `cargo build --no-default-features`, `cargo doc --no-deps --all-features` (`-D warnings`), `cargo fmt --check` all clean.
- [x] Patch lines confirmed covered directly against the generated lcov report (`omni-dev coverage diff` reported "no new executable lines," apparently a diff-detection quirk on a comment-heavy hunk; the new branch shows 5000+ execution hits in the raw lcov).

Closes #1717.


## Round 2 (code review)

Multiple finder agents converged on a **critical correctness gap**, found via an independent 1200-case differential sweep against jq 1.7.1: the round-1 fix's condition (drop only when the offending byte is literally `input`'s last byte) undercounts. `[0xF0, b'A', b'B']` — a 4-byte lead, one invalid continuation byte, with *one byte of headroom* before end-of-input — still collapses to a single U+FFFD in real jq, but the round-1 code kept both `'A'` and `'B'`.

I independently re-verified this (confirmed the exact repro), then re-derived the actual rule from a wider probe matrix (varying lead length, `good_continuations`, and trailing-byte count): jq's real condition is simply **`len - pos < seq_len`** — not enough total bytes remain from the *lead byte's own position* to satisfy the declared sequence length, regardless of *why* they're short (buffer genuinely ends, or an available byte fails the continuation check partway through). This is both simpler and more correct than the round-1 condition, and it turns out to subsume what used to be a separate "ran out of bytes, every available byte was a good continuation" branch — both are the same rule.

Rewrote `invalid_subpart_end`'s `InvalidContinuationByte` handling around this unified condition (net simplification — replaces a byte-counting loop plus two special cases with one length check plus a plain validation loop). Verified with two independent differential sweeps (757 cases total, live against jq 1.7.1) plus the original hand-built matrix — all matching exactly.

Also fixed two secondary documentation issues the same review round found:
- My "granularity mismatch is essentially never triggered" framing for the still-open document-decode gap was imprecise — jq's own trigger condition is *not* rare (it fires on any string ending in the right byte shape, regardless of how much more content follows); only succinctly's whole-buffer reproduction of it is rare. Reworded throughout.
- A flat, unverified claim that `--raw-input` shares document-decode's "whole-file granularity" was simply wrong — live-tested and found real jq's non-slurp `-R` is scoped *per line*, triggered by any ordinary single-line file with a trailing newline. Filed [#1742](https://github.com/rust-works/succinctly/issues/1742) for this narrower, more tractable gap (a caller-side reorder in `get_inputs` — split into lines before substituting, not touching this algorithm) rather than silently leaving the wrong claim in place.

Also fixed 4 stale cross-references left over from the round-1 doc-heading rename (three quoting the old section title, one primary function doc comment still claiming "not fixed here" after the fix landed in that exact function), and two reuse-angle findings (duplicated `pos + 1 + good_continuations` computation, two byte-for-byte-duplicate test assertions) — both superseded by the algorithm rewrite anyway.

Re-ran the full local verification suite (build, full test suite at reduced parallelism, both clippy legs, `--no-default-features`, `cargo doc -D warnings`, `cargo fmt --check`) — all clean.


## Round 3 (code review)

Nine finder agents converged on the round-2 rewrite being correct (multiple independent verifications: a fresh 25,500-case brute-force differential harness by one finder, algebraic bounds-safety tracing by another, no-op efficiency comparison by a third — all clean). Remaining findings were housekeeping:

- Two doc-comment cross-references still named tests from an earlier draft that got renamed mid-review; both dangling names confirmed to not exist anywhere via grep.
- A test named `..._does_not_swallow_a_trailing_valid_byte` now correctly *does* swallow 4 of its 5 vectors after the round-2 fix — renamed to `invalid_continuation_boundary_detection_matches_jq_near_eof`, which describes what it actually verifies.
- One redundant assertion (`[0xF0, 0x80, b'A']` duplicated existing coverage of the identical branch — `is_continuation_byte` treats `0x80` and `0x90` alike, so this exercised no new code path).
- No CLI-level regression test pinned the still-open document-decode divergence, unlike this codebase's established convention (demonstrated by the very test an earlier round removed). Added one (`tests/jq_cli_tests.rs`), and filed [#1743](https://github.com/rust-works/succinctly/issues/1743) to track the document-mode gap specifically — distinct from #1742's raw-input gap, since closing it needs a bigger, per-JSON-string-substitution-timing architectural change rather than a caller-side reorder.

Re-ran the full local verification suite (build, full test suite, both clippy legs, `--no-default-features`, `cargo doc -D warnings`, `cargo fmt --check`) — all clean.


## Round 4 (code review)

Nine finder agents, all correctness angles clean (multiple independent verifications of the round-2 algorithm rewrite, including a fresh 25,500-case brute-force differential harness). Three small documentation-consistency fixes:

- The compliance doc's own closing sentence linked #1717 (the issue this PR closes) as "the granularity gap this leaves open" — contradicting the two preceding sentences that correctly name #1743/#1742 as the actual open trackers.
- A test comment still called the genuine-truncation case "a completely different branch" from #1717's fix, after round 2 had already unified both into the same `len - pos < seq_len` condition.
- Two new test comments counted "headroom" one byte higher than every other mention in the same PR.

At this point: 4 review rounds, ~30 finder-agent invocations, and independent differential sweeps totaling 25,000+ generated test cases against the pinned jq 1.7.1 oracle, with zero remaining correctness findings. Proceeding to CI/merge.
