### PR TITLE
docs(yq,test): drop the try/catch comparison from a decode-failure comment

### DIFF
--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -23680,11 +23680,12 @@ fn test_materializing_route_raises_on_colliding_decode_failure_keys_1642() -> Re
     Ok(())
 }
 
-/// #1620: a decode failure must never be suppressed by `?`, matching how
-/// `try`/`catch` already never catches one -- real yq's equivalent is a
-/// parse-time rejection no program could ever catch either. `\q` is not a
-/// YAML escape, so the scalar is structurally valid but undecodable, same
-/// repro as `test_decode_failure_does_not_corrupt_json_output_1247` above.
+/// #1620: a decode failure must never be suppressed by `?` -- real yq's
+/// equivalent is a parse-time rejection no program could ever catch, since
+/// real yq has no `try`/`catch` construct at all to catch it with. `\q` is
+/// not a YAML escape, so the scalar is structurally valid but undecodable,
+/// same repro as `test_decode_failure_does_not_corrupt_json_output_1247`
+/// above.
 ///
 /// `.a?` (no downstream builtin) is deliberately not included: bare field
 /// access never decodes the string at all, so there is no decode failure for


### PR DESCRIPTION
## Summary

A test comment near `test_decode_failure_not_suppressed_by_optional_1620` in
`tests/yq_cli_tests.rs` claimed real yq's decode-failure-can't-be-caught
behavior was "matching how `try`/`catch` already never catches one" — implying
real yq has a `try`/`catch` construct whose "equivalent" behavior was being
matched.

It doesn't. Verified live against the pinned Homebrew `yq` v4.53.3:

```
$ printf 'a: 1\n' | yq 'try .a catch "x"'
Error: 1:1: lexer: invalid input text "try .a catch \"x\""
```

Real yq's lexer has no `try`/`catch` token at all. Per CLAUDE.md's fidelity
rule, a "neither tool has this" claim needs the same oracle verification as
any other jq/yq behavioural claim, and this one wasn't checked before being
written (introduced by PR #1647 for #1620).

The substantive point — that a decode failure is an unconditional YAML
parse-time rejection real yq performs before any program runs, so no
program-level mechanism could ever catch it — is correct and unchanged. Only
the try/catch comparison framing is dropped.

## Test plan

- [x] Verified the try/catch claim live against pinned `yq` v4.53.3
- [x] `cargo test test_decode_failure_not_suppressed_by_optional_1620` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Grepped repo for other occurrences of the same framing — none found

Fixes #1662
