### PR TITLE
refactor(jq): consolidate decode-failure/uncatchable checks

### DIFF
--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1014,9 +1014,10 @@ impl EvalError {
     /// *where* the error was caught (a bare postfix `?` on the primitive
     /// that raised it vs. anything else), both of these mean the same thing
     /// at every call site that checks them: never suppressed by `?`, never
-    /// handed to a `catch` handler. A future always-uncatchable error class
-    /// only needs to be added here, not hand-copied into every `?`/`try`
-    /// dispatch that currently ANDs the two checks together.
+    /// handed to a `catch` handler. Only `resolve_node`'s `Expr::Try` arm
+    /// ANDs the two checks together today, but a future always-uncatchable
+    /// error class only needs to be added here, not hand-copied into
+    /// whichever `?`/`try` dispatch sites grow the same check next.
     pub fn is_uncatchable(&self) -> bool {
         self.is_invalid_path_expression() || self.is_decode_failure()
     }

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1007,6 +1007,20 @@ impl EvalError {
         )
     }
 
+    /// Whether this error class is *always* uncatchable, with no positional
+    /// nuance — [`Self::is_invalid_path_expression`] or
+    /// [`Self::is_decode_failure`]. Unlike
+    /// [`Self::is_untracked_navigation_error`], which genuinely depends on
+    /// *where* the error was caught (a bare postfix `?` on the primitive
+    /// that raised it vs. anything else), both of these mean the same thing
+    /// at every call site that checks them: never suppressed by `?`, never
+    /// handed to a `catch` handler. A future always-uncatchable error class
+    /// only needs to be added here, not hand-copied into every `?`/`try`
+    /// dispatch that currently ANDs the two checks together.
+    pub fn is_uncatchable(&self) -> bool {
+        self.is_invalid_path_expression() || self.is_decode_failure()
+    }
+
     /// `Cannot check whether <container> has a <key type> key`.
     pub fn cannot_check_has(container_type: &str, key_type: &str) -> Self {
         Self::new(format!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17959,10 +17959,10 @@ fn resolve_node<'a, S: EvalSemantics>(
             // only a genuine error or a break (below) reaches `catch`;
             // everything else propagates unchanged, as does an
             // invalid-path-expression complaint (#530) and, per the same
-            // reasoning, a decode failure (#1247, #1620).
-            Err((prefix, EvalEscape::Error(e)))
-                if !e.is_invalid_path_expression() && !e.is_decode_failure() =>
-            {
+            // reasoning, a decode failure (#1247, #1620) — both always
+            // uncatchable, with no positional nuance either shares with
+            // `is_untracked_navigation_error` above.
+            Err((prefix, EvalEscape::Error(e))) if !e.is_uncatchable() => {
                 resolve_catch::<S>(catch.as_deref(), prefix, e.payload())
             }
             // `catch` catches a `break` the same way it catches a raised

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -380,10 +380,12 @@ fn to_owned_for_diagnostic<V: DocumentValue>(value: &V, cursor: Option<V::Cursor
 
 /// The shared "is this a decode failure, an optional no-op, or a genuine
 /// type error" three-way check every native-arm dispatcher (`Iterate`,
-/// `Map`, `Length`, `Keys`, `KeysUnsorted`, `ToNumber`) needs once its own
-/// type-specific branches are exhausted -- decode-failure must be checked
-/// *before* `optional` (#1620), not after, so `.a?` on an undecodable
-/// string still raises rather than silently swallowing it.
+/// `Map`, `Length`, `Keys`, `KeysUnsorted`, `ToEntries`, `ToNumber`) needs
+/// once its own type-specific branches are exhausted -- decode-failure must
+/// be checked *before* `optional` (#1620), not after, so `.a?` on an
+/// undecodable string still raises rather than silently swallowing it.
+/// `ToEntries` passes `optional: false` unconditionally rather than
+/// threading it through -- see that call site's own comment for why.
 ///
 /// `fallback` is only called for the genuine type-error case, so it can
 /// build a builtin-specific `EvalError` (`cannot_iterate_with`,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -378,6 +378,31 @@ fn to_owned_for_diagnostic<V: DocumentValue>(value: &V, cursor: Option<V::Cursor
     to_owned_with_cursor(value, cursor).unwrap_or(OwnedValue::Null)
 }
 
+/// The shared "is this a decode failure, an optional no-op, or a genuine
+/// type error" three-way check every native-arm dispatcher (`Iterate`,
+/// `Map`, `Length`, `Keys`, `KeysUnsorted`, `ToNumber`) needs once its own
+/// type-specific branches are exhausted -- decode-failure must be checked
+/// *before* `optional` (#1620), not after, so `.a?` on an undecodable
+/// string still raises rather than silently swallowing it.
+///
+/// `fallback` is only called for the genuine type-error case, so it can
+/// build a builtin-specific `EvalError` (`cannot_iterate_with`,
+/// `has_no_length`, ...) without paying for it on the two more common
+/// exits above.
+fn decode_failure_or<V: DocumentValue>(
+    value: &V,
+    optional: bool,
+    fallback: impl FnOnce() -> GenericResult<V>,
+) -> GenericResult<V> {
+    if let Some(reason) = value.string_decode_error() {
+        GenericResult::Error(EvalError::decode_failure(reason))
+    } else if optional {
+        GenericResult::None
+    } else {
+        fallback()
+    }
+}
+
 /// The jq `type` name for `value` at `cursor`, resolving an explicit YAML
 /// tag first (e.g. `!!str 1` is `"string"`, not `"number"` — issue #747)
 /// and falling back to [`DocumentValue::type_name`] otherwise. Mirrors
@@ -3811,15 +3836,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     }
                     Err(err) => GenericResult::Error(err),
                 }
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate_with(
-                    S::TAG,
-                    &to_owned_for_diagnostic(&value, cursor),
-                ))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::cannot_iterate_with(
+                        S::TAG,
+                        &to_owned_for_diagnostic(&value, cursor),
+                    ))
+                })
             }
         }
 
@@ -6653,15 +6676,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     None => LazySource::Values(fields),
                 };
                 GenericResult::LazySeq(LazySeq::new(source).push_map(f, S::TAG))
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_iterate_with(
-                    S::TAG,
-                    &to_owned_for_diagnostic(&value, cursor),
-                ))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::cannot_iterate_with(
+                        S::TAG,
+                        &to_owned_for_diagnostic(&value, cursor),
+                    ))
+                })
             }
         }
 
@@ -6830,14 +6851,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 })
             } else if let Some(f) = value.as_f64() {
                 GenericResult::Owned(OwnedValue::Float(f.abs()))
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_length(&to_owned_for_diagnostic(
-                    &value, cursor,
-                )))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::has_no_length(&to_owned_for_diagnostic(
+                        &value, cursor,
+                    )))
+                })
             }
         }
 
@@ -6861,14 +6880,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // yet; `length`, `.[]`, `.[n]`, `first`, and `last` can all
                 // answer directly from `len` (see the `Pipe` dispatch below).
                 GenericResult::LazyIndexRange(elements.len())
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
-                    &value, cursor,
-                )))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                        &value, cursor,
+                    )))
+                })
             }
         }
 
@@ -6887,14 +6904,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(elements) = value.as_array() {
                 // Same laziness as the array branch of `Keys` above (#684).
                 GenericResult::LazyIndexRange(elements.len())
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
-                    &value, cursor,
-                )))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                        &value, cursor,
+                    )))
+                })
             }
         }
 
@@ -6977,18 +6992,19 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     entries.push(OwnedValue::Object(entry));
                 }
                 GenericResult::Owned(OwnedValue::Array(entries))
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
             } else {
-                // No `optional`-guarded arm here: `Builtin::ToEntries` isn't
-                // `IndexExpr`/`SliceExpr`, so #693's dispatch never forces
-                // `optional = true` into this native arm — `to_entries?`
-                // evaluates it at the ambient `optional` (normally `false`)
-                // and lets the outer `Expr::Optional`/`eval_try`-style catch
-                // convert the resulting `Error` to `None` once instead.
-                GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
-                    &value, cursor,
-                )))
+                // `optional: false` unconditionally: `Builtin::ToEntries`
+                // isn't `IndexExpr`/`SliceExpr`, so #693's dispatch never
+                // forces `optional = true` into this native arm --
+                // `to_entries?` evaluates it at the ambient `optional`
+                // (normally `false`) and lets the outer
+                // `Expr::Optional`/`eval_try`-style catch convert the
+                // resulting `Error` to `None` once instead.
+                decode_failure_or(&value, false, || {
+                    GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
+                        &value, cursor,
+                    )))
+                })
             }
         }
 
@@ -7185,14 +7201,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     Err(_) if optional => GenericResult::None,
                     Err(e) => GenericResult::Error(e),
                 }
-            } else if let Some(reason) = value.string_decode_error() {
-                GenericResult::Error(EvalError::decode_failure(reason))
-            } else if optional {
-                GenericResult::None
             } else {
-                GenericResult::Error(EvalError::cannot_parse_as_number(&to_owned_for_diagnostic(
-                    &value, cursor,
-                )))
+                decode_failure_or(&value, optional, || {
+                    GenericResult::Error(EvalError::cannot_parse_as_number(
+                        &to_owned_for_diagnostic(&value, cursor),
+                    ))
+                })
             }
         }
 


### PR DESCRIPTION
## Summary

Two maintainability regressions from PR #1647 (#1620's decode-failure ordering fix),
filed as #1661 during that PR's own review. Neither is a correctness bug -- both are
follow-ups on the shape of that fix.

### 1. A shared helper was deleted in favor of 7 hand-duplicated inline copies

`eval_generic.rs` used to have one helper deciding "is this a decode failure or a
genuine type mismatch". PR #1647 deleted it and inlined the equivalent branch by hand
at 7 separate `eval_builtin` arms (`Expr::Iterate`, `Builtin::Map`, `Length`, `Keys`,
`KeysUnsorted`, `ToEntries`, `ToNumber`). A future change to this rule, or a new
dispatch arm needing the same check, would have to be applied by hand at 7 sites with
no compiler check that all 7 stay consistent.

Restored as `decode_failure_or(value, optional, fallback)`, used at all 7 sites. Each
site's own builtin-specific error (`cannot_iterate_with`, `has_no_length`,
`has_no_keys`, `cannot_parse_as_number`) moves into the `fallback` closure, called only
on the genuine type-error exit. `ToEntries` (which never gates on `optional` -- see its
own preserved comment on why) passes `optional: false` literally, keeping identical
behavior.

### 2. `resolve_node`'s catch arm ANDs two semantically-identical "always uncatchable" flags

```rust
Err((prefix, EvalEscape::Error(e)))
    if !e.is_invalid_path_expression() && !e.is_decode_failure() =>
```

Both flags mean the same thing at this call site -- "this error class is always
uncatchable, no positional nuance" -- unlike the file's third such predicate,
`is_untracked_navigation_error`, which genuinely is position-dependent (a bare postfix
`?` on the primitive that raised it) and is left untouched at its own two call sites.

Added `EvalError::is_uncatchable()` (`error.rs`), ORing the two, and collapsed the
`eval.rs` call site to `!e.is_uncatchable()`.

## Test plan

- [x] Pure refactor, no behavior change intended -- full `cargo test` unchanged
      (2926+ lib tests, 1015 jq_cli_tests, 204+64 eval-generic tests, all passing;
      one transient failure on the first full run under concurrent-session
      contention, confirmed spurious by two clean re-runs)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build --no-default-features` (no_std) -- builds, no new warnings
- [x] Grepped for other ANDed occurrences of the same two flags -- none found

Fixes #1661
