### PR TITLE
fix(yq): guard --input-format json bridge against colliding decode-failure keys

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,8 +9,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, key_display_string, DocumentCursor, DocumentElements, DocumentFields,
-    DocumentValue, IndentSpec,
+    effective_keys, resolve_display_key, DisplayKeyGuard, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec,
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
@@ -593,14 +593,22 @@ fn gather_input_sources(
 /// clearly-scoped primitive the library exports for this -- everything
 /// else about the walk stays here, matching where `canonicalize_json_numbers`
 /// always lived before this fix, just fused into one pass instead of two.
-fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> OwnedValue {
+///
+/// Returns `Err` when two colliding decode-failure keys (#1642/#1738) would
+/// otherwise silently overwrite one another in the same object -- see
+/// `eval_generic::to_owned_at_depth`'s identical guard, which this function
+/// now shares via [`resolve_display_key`] rather than the hand-rolled
+/// `key_display_string` call it used to make (#1738: that gap meant this,
+/// the `--input-format json` bridge, was the one materializer PR #1672 never
+/// reached).
+fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_canonicalizing_numbers_at_depth(value, 0)
 }
 
 fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     value: &V,
     depth: usize,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     // `assert_nesting_depth` (256, matching `eval_generic::to_owned_at_depth`
     // exactly), not `assert_value_tree_depth` (384) -- this walks a
     // `DocumentCursor`-backed `V` directly, the same recursion shape
@@ -612,23 +620,25 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     // the only pass -- there's no first, 256-guarded `to_owned` call ahead
     // of it anymore to bind the real ceiling).
     assert_nesting_depth(depth);
-    if let Some(fields) = value.as_object() {
+    Ok(if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
+        let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            // `key_display_string`, not `field.key_str()`: a key that will
+            // `resolve_display_key`, not `field.key_str()`: a key that will
             // not *decode* (#1247/#1385) is preserved via its raw source
             // span rather than dropped (#1642) -- this loop used to
             // silently drop such a field under `--slurp`/`--eval-all`/
             // `--inplace` (the only callers of `parse_input`, hence of this
             // function), one short of `length`'s real field count. A key
             // the format's grammar never allowed at all (#1194) is still
-            // dropped, same as before this fix (this function has no error
-            // channel to raise through).
-            if let Some(key) = key_display_string(&field.key) {
+            // dropped, same as before this fix. Two colliding decode-failure
+            // keys now raise instead of silently overwriting one another
+            // (#1642/#1738), matching every other materializer.
+            if let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? {
                 map.insert(
-                    key.into_owned(),
-                    to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1),
+                    key,
+                    to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
                 );
             }
             f = rest;
@@ -638,7 +648,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         let mut items = Vec::new();
         let mut elems = elements;
         while let Some((elem, rest)) = elems.uncons() {
-            items.push(to_owned_canonicalizing_numbers_at_depth(&elem, depth + 1));
+            items.push(to_owned_canonicalizing_numbers_at_depth(&elem, depth + 1)?);
             elems = rest;
         }
         OwnedValue::Array(items)
@@ -671,7 +681,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         // Matches `to_owned_at_depth`'s own `else` arm (#1098) --
         // unaffected by number canonicalization.
         OwnedValue::Null
-    }
+    })
 }
 
 /// Parse input bytes according to the specified format.
@@ -680,7 +690,9 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
         InputFormat::Json => {
             let index = JsonIndex::build(bytes);
             let cursor = index.root(bytes);
-            Ok(vec![to_owned_canonicalizing_numbers(&cursor.value())])
+            let value = to_owned_canonicalizing_numbers(&cursor.value())
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(vec![value])
         }
         InputFormat::Yaml | InputFormat::Auto => {
             // Parse as YAML (Auto defaults to YAML when no extension hint)
@@ -5511,7 +5523,7 @@ mod tests {
         let json = linear_json_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let owned = to_owned_canonicalizing_numbers(&cursor.value());
+        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         let json = linear_json_nest(256);
@@ -5538,7 +5550,7 @@ mod tests {
         let json = br#"{"int": 1, "float": 1.50, "exp": 1e2, "neg": -3, "arr": [1.0, 2], "s": "x", "b": true, "n": null}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned = to_owned_canonicalizing_numbers(&cursor.value());
+        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
         let OwnedValue::Object(map) = owned else {
             panic!("expected an object")
         };
@@ -5589,7 +5601,7 @@ mod tests {
         for json in [br#"{"n": 5.}"#.as_slice(), br#"{"n": .5}"#.as_slice()] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers(&cursor.value());
+            let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };
@@ -5616,7 +5628,7 @@ mod tests {
         ] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers(&cursor.value());
+            let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -805,21 +805,27 @@ pub(crate) fn key_display_string_kind<V: DocumentValue>(key: &V) -> Option<(Cow<
 }
 
 /// Guards a display-keyed `IndexMap` (`to_owned`/`materialize`, #1642)
-/// against silently merging two keys that [`key_display_string_kind`]'s own
-/// contract forbids treating as the same key: a decode-failure key's
-/// fallback spelling colliding with another decode-failure key's, or with
-/// an unrelated key that happens to decode to the identical text. An
-/// `IndexMap<String, _>` has no way to hold two entries under one string,
-/// so letting that insert happen the ordinary way silently drops the
-/// earlier value -- quieter data loss than #1247's original raise, which
-/// this fix relaxed but must not replace with a worse failure mode.
+/// against silently merging two keys that `key_display_string_kind`'s own
+/// contract forbids treating as the same key.
+///
+/// A decode-failure key's fallback spelling can collide with another
+/// decode-failure key's, or with an unrelated key that happens to decode to
+/// the identical text. An `IndexMap<String, _>` has no way to hold two
+/// entries under one string, so letting that insert happen the ordinary way
+/// silently drops the earlier value -- quieter data loss than #1247's
+/// original raise, which this fix relaxed but must not replace with a worse
+/// failure mode.
 ///
 /// An *ordinary* repeated key -- neither side a decode-failure fallback --
 /// still overwrites without complaint here, matching jq's normal
 /// last-key-wins duplicate handling; only a fallback spelling on either
 /// side of the collision is refused.
+///
+/// `pub`, not `pub(crate)`: `succinctly-cli`'s `yq_runner.rs` (a separate
+/// binary crate) constructs one per object via [`resolve_display_key`], same
+/// reasoning [`key_display_string`] itself documents for why it is `pub`.
 #[derive(Default)]
-pub(crate) struct DisplayKeyGuard {
+pub struct DisplayKeyGuard {
     fallback_keys: Vec<String>,
 }
 
@@ -856,6 +862,34 @@ pub(crate) fn colliding_display_key_error(key: &str) -> EvalError {
         "object key \"{key}\" is ambiguous: an undecodable key's display form \
          collides with another key of the same name and cannot be represented"
     ))
+}
+
+/// The full display-key resolution sequence a `to_owned`-shaped materializer
+/// needs for one field, in one call.
+///
+/// Gets the display spelling (`None` when the key does not stringify at all
+/// -- #1194's territory, the caller's own job to handle), guards it against
+/// a colliding decode-failure fallback (#1642), and raises
+/// `colliding_display_key_error` instead of allowing a silent overwrite.
+///
+/// Shared by `eval_generic.rs`'s three `to_owned*_at_depth` conversions,
+/// `lazy.rs`'s `cursor_to_owned_at_depth`, and `succinctly-cli`'s
+/// `yq_runner.rs` `--input-format json` bridge (`pub` for that reason,
+/// same as [`DisplayKeyGuard`] and [`key_display_string`] before it) -- one
+/// definition rather than a fifth hand-copied guard-and-raise sequence.
+pub fn resolve_display_key<V: DocumentValue, T>(
+    key: &V,
+    map: &IndexMap<String, T>,
+    guard: &mut DisplayKeyGuard,
+) -> Result<Option<String>, EvalError> {
+    let Some((key, is_fallback)) = key_display_string_kind(key) else {
+        return Ok(None);
+    };
+    let key = key.into_owned();
+    if !guard.check(map, &key, is_fallback) {
+        return Err(colliding_display_key_error(&key));
+    }
+    Ok(Some(key))
 }
 
 /// An open-addressed set of key hashes: "have I seen this one?" answered

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22,10 +22,10 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, colliding_display_key_error, effective_fields,
-    effective_fields_checked, effective_keys, effective_len_checked, key_display_string,
-    key_display_string_kind, key_is_malformed, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor,
-    DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
+    effective_keys, effective_len_checked, key_display_string, key_is_malformed,
+    resolve_display_key, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
@@ -174,18 +174,9 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             // and that still raises: dropping the field silently is #1194,
             // the disagreement #1385's postmortem names as the thing to
             // avoid.
-            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
+            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
                 return Err(f.malformed_member_error());
             };
-            let key = key.into_owned();
-            // Two decode-failure keys (or a decode-failure key and an
-            // unrelated one) can share a display spelling -- #1385 forbids
-            // treating them as the same key, but this `IndexMap` cannot
-            // hold two entries under one string. Raise rather than let the
-            // insert below silently overwrite the earlier value (#1642).
-            if !guard.check(&map, &key, is_fallback) {
-                return Err(colliding_display_key_error(&key));
-            }
             map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
             f = rest;
         }
@@ -279,15 +270,9 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
             // these two conversions are copies of each other and a fix that
             // moved only one would leave the cursor and value domains
             // disagreeing about whether a document is valid.
-            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
+            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
                 return Err(f.malformed_member_error());
             };
-            let key = key.into_owned();
-            // See `to_owned_at_depth`'s identical guard: two colliding
-            // display-fallback keys must raise, not silently overwrite.
-            if !guard.check(&map, &key, is_fallback) {
-                return Err(colliding_display_key_error(&key));
-            }
             map.insert(
                 key,
                 to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
@@ -725,18 +710,9 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             // source span; still raise on a key the format's grammar never
             // allowed at all (#1194) -- this arm used to silently drop such
             // a field instead of raising, the same swallow #1194 names.
-            let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
+            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
                 return Err(f.malformed_member_error());
             };
-            let key = key.into_owned();
-            // See `to_owned_at_depth`'s identical guard. `map`,
-            // `comment_map` and `key_comment_map` are always populated
-            // together for the same key, so checking `map` alone catches a
-            // collision that would otherwise silently drop the earlier
-            // key's value *and* comment.
-            if !guard.check(&map, &key, is_fallback) {
-                return Err(colliding_display_key_error(&key));
-            }
             let (v, c) = to_owned_with_comments_at_depth(
                 &field.value,
                 Some(&field.value_cursor),

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -28,8 +28,7 @@ use std::borrow::Cow;
 use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
-    colliding_display_key_error, effective_len, key_display_string, key_display_string_kind,
-    DisplayKeyGuard, DistinctKeyCursors,
+    effective_len, key_display_string, resolve_display_key, DisplayKeyGuard, DistinctKeyCursors,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -759,17 +758,7 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 // won't decode is preserved via its raw source span rather
                 // than raised on (#1247/#1642), matching
                 // `length`/`keys_unsorted`/`.`.
-                if let Some((cow, is_fallback)) = key_display_string_kind(&field.key()) {
-                    let key = cow.into_owned();
-                    // Two decode-failure keys (or a decode-failure key and
-                    // an unrelated one) can share a display spelling --
-                    // #1385 forbids treating them as the same key, but this
-                    // `IndexMap` cannot hold two entries under one string.
-                    // Raise rather than silently overwrite the earlier
-                    // value (#1642).
-                    if !guard.check(&map, &key, is_fallback) {
-                        return Err(colliding_display_key_error(&key));
-                    }
+                if let Some(key) = resolve_display_key(&field.key(), &map, &mut guard)? {
                     let value_cursor = field.value_cursor();
                     map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
                 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1485,6 +1485,33 @@ fn test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738() -
         "expected an 'ambiguous' error, got: {stderr}"
     );
 
+    // `--inplace` is `parse_input`'s third caller (per
+    // `to_owned_canonicalizing_numbers`'s own doc comment), but only on its
+    // DOM fallback path -- `-P` forces that path the same way an assignment
+    // or `--arg` would, where a plain M2-streamable filter like `.` or
+    // `keys` (#685) takes a separate fast path that never calls
+    // `parse_input` at all and so can't hit this collision.
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{json}")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-P")
+        .args(["--input-format", "json"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        !output.status.success(),
+        "--inplace -P should raise, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1456,6 +1456,38 @@ fn test_input_format_json_bridge_preserves_decode_failure_key_1642() -> Result<(
     Ok(())
 }
 
+/// #1738: the `--input-format json` bridge's own `DisplayKeyGuard` check
+/// was missing entirely -- unlike every other `to_owned`-shaped
+/// materializer (#1642) -- so a decode-failure key colliding with another
+/// key's display spelling silently overwrote it instead of raising. `"a\q"`
+/// (an invalid `\q` escape, decode failure, falls back to its raw span
+/// `a\q`) and `"a\\q"` (a valid escape that decodes to the identical `a\q`)
+/// collide exactly like eval_generic's own colliding-key tests. Before this
+/// fix, `.[0]` here silently returned `{"a\q": 2}`, one value quietly
+/// dropped, with exit 0.
+#[test]
+fn test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738() -> Result<()> {
+    let json = r#"{"a\q":1,"a\\q":2}"#;
+
+    let (_output, stderr, code) =
+        run_yq_stdin_with_stderr(".[0]", json, &["--input-format", "json", "--slurp"])?;
+    assert_eq!(code, 1, "--slurp should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    let (_output, stderr, code) =
+        run_yq_stdin_with_stderr(".[0]", json, &["--input-format", "json", "--eval-all"])?;
+    assert_eq!(code, 1, "--eval-all should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
## Summary

- `yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth` (the `--input-format json` bridge for `--slurp`/`--eval-all`/`--inplace`) built its `IndexMap` via plain `key_display_string` with no `DisplayKeyGuard`, so two colliding decode-failure keys silently overwrote each other — exit 0, no error, one value quietly lost. PR #1672 added the guard to every other `to_owned`-shaped materializer but missed this one call site.
- Extracted the guard-and-raise sequence (`key_display_string_kind` + `check` + raise-or-insert), previously duplicated four times across `eval_generic.rs` and `lazy.rs`, into one shared `resolve_display_key` helper in `document.rs`. Made `DisplayKeyGuard` `pub` so `yq_runner.rs` (a separate binary crate) can construct one.
- Routed all five call sites — the four existing ones plus the previously-unguarded bridge — through the shared helper.

## Repro (before fix)

```console
$ printf '{"\ud800":1,"\ud800":2}' | succinctly yq --input-format json --slurp '.[0]' -o=json
{"���": 2}
```
Exit 0, value `1` silently dropped.

## After fix

```console
$ printf '{"\ud800":1,"\ud800":2}' | succinctly yq --input-format json --slurp '.[0]' -o=json
Error: object key "���" is ambiguous: an undecodable key's display form collides with another key of the same name and cannot be represented
```
Exit 1, matching the jq-mode path's existing behavior for the identical shape.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 2926+ tests, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo doc --no-deps --all-features` (no warnings)
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (`no_std` compiles)
- [x] New regression test `test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738` covering `--slurp` and `--eval-all`
- [x] `omni-dev coverage diff`: 100% patch coverage (32/32 new lines)
- [x] Manually verified fix against the exact repro in #1738, plus a sanity check that ordinary (non-colliding) objects are unaffected

Fixes #1738