### PR TITLE
fix(jq): catch a trailing/empty-gap comma next to a JSON bracket (#1676)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3805,16 +3805,41 @@ fn following_gap_ok(text: &[u8], start: usize, expected: Option<u8>) -> Option<u
 ///
 /// Deliberately narrower than a complete fix: `gap_start` must already be
 /// known cheaply. Callers only have that when the last child is a scalar
-/// (its `text_range()` is a bounded, self-delimiting scan, not the
-/// O(subtree) walk `JsonCursor::text_range`'s own comment describes for a
-/// container) or when the container is empty. When the last child is
-/// itself a container, finding *its* closing bracket costs exactly what
-/// this function's sibling `preceding_gap_ok` was written to avoid, so
-/// callers skip this check in that case rather than pay for it -- the same
+/// (via `scalar_end_pos`, an O(1) length read, not a fresh scan) or when
+/// the container is empty. When the last child is itself a container,
+/// finding *its* closing bracket costs exactly the O(subtree) walk this
+/// function's sibling `preceding_gap_ok` was written to avoid, so callers
+/// skip this check in that case rather than pay for it -- the same
 /// "tracked as a follow-up, not folded in here" trade #1643 already made,
 /// narrowed by one more case rather than eliminated.
 fn trailing_gap_ok(text: &[u8], gap_start: usize, close_char: u8) -> bool {
     matches!(following_gap_ok(text, gap_start, None), Some(pos) if text.get(pos) == Some(&close_char))
+}
+
+/// Cheap end position (one past the last byte) of an already-resolved
+/// scalar `value` known to start at `start` -- `None` for a container or
+/// unresolved value, which callers treat as "can't determine, skip"
+/// (#1676's own deferred case for a container, or a defensively-skipped
+/// unresolved cursor).
+///
+/// Deliberately doesn't call `JsonCursor::text_range()`: every caller here
+/// already resolved `value` via `.value_at(start)` (reusing the *same*
+/// `start` a caller-side `text_position()` already paid for -- see
+/// `check_preceding_delimiter`'s own doc comment on why a second lookup
+/// measured 19-30% slower for #1643), so re-deriving the position and
+/// re-dispatching on the leading byte a second time would silently
+/// reintroduce that exact regression. `raw_bytes()` on a string/number is
+/// already the value's own exact text span; `true`/`false`/`null` are
+/// fixed-width literals.
+fn scalar_end_pos<W: AsRef<[u64]>>(start: usize, value: &StandardJson<'_, W>) -> Option<usize> {
+    match value {
+        StandardJson::String(s) => Some(start + s.raw_bytes().len()),
+        StandardJson::Number(n) => Some(start + n.raw_bytes().len()),
+        StandardJson::Bool(true) => Some(start + 4),
+        StandardJson::Bool(false) => Some(start + 5),
+        StandardJson::Null => Some(start + 4),
+        StandardJson::Array(_) | StandardJson::Object(_) | StandardJson::Error(_) => None,
+    }
 }
 
 /// Array-element wrapper around [`preceding_gap_ok`]: element `index` (0-
@@ -3882,43 +3907,36 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
     match cursor.value() {
         StandardJson::Array(elements) => {
             let mut saw_any = false;
-            let mut last_is_container = false;
             let mut last_gap_end = None;
             for (i, child) in elements.cursor_iter().enumerate() {
                 saw_any = true;
-                if let Some(start) = child.text_position() {
+                let start = child.text_position();
+                if let Some(start) = start {
                     let expected = if i == 0 { None } else { Some(b',') };
                     if !preceding_gap_ok(child.text(), start, expected) {
                         return Err(EvalError::malformed_json_text(child.text()));
                     }
                 }
                 validate_json_delimiters(&child, depth + 1)?;
-                match child.value() {
-                    StandardJson::Array(_) | StandardJson::Object(_) => {
-                        last_is_container = true;
-                        last_gap_end = None;
-                    }
-                    _ => {
-                        last_is_container = false;
-                        last_gap_end = child.text_range().map(|(_, end)| end);
-                    }
-                }
+                // #1676: reuses `start` (already resolved above) via
+                // `value_at` rather than `child.value()`, which would
+                // re-derive it -- see `scalar_end_pos`'s own doc comment.
+                last_gap_end = start.and_then(|s| scalar_end_pos(s, &child.value_at(s)));
             }
             // #1676: trailing `,` (`[1,2,]`) or a stray `,` in an
-            // apparently-empty array (`[,]`) -- see `trailing_gap_ok`'s
-            // own doc comment for why this is skipped when the last
-            // element is itself a container.
-            if !last_is_container {
-                if let Some(open_pos) = cursor.text_position() {
-                    let gap_start = if saw_any {
-                        last_gap_end
-                    } else {
-                        Some(open_pos + 1)
-                    };
-                    if let Some(gap_start) = gap_start {
-                        if !trailing_gap_ok(cursor.text(), gap_start, b']') {
-                            return Err(EvalError::malformed_json_text(cursor.text()));
-                        }
+            // apparently-empty array (`[,]`) -- `last_gap_end` is `None`
+            // both when there's nothing to check yet and when the last
+            // element is itself a container (`scalar_end_pos`'s own doc
+            // comment explains why that case is skipped, not just unknown).
+            if let Some(open_pos) = cursor.text_position() {
+                let gap_start = if saw_any {
+                    last_gap_end
+                } else {
+                    Some(open_pos + 1)
+                };
+                if let Some(gap_start) = gap_start {
+                    if !trailing_gap_ok(cursor.text(), gap_start, b']') {
+                        return Err(EvalError::malformed_json_text(cursor.text()));
                     }
                 }
             }
@@ -3926,14 +3944,14 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
         StandardJson::Object(fields) => {
             let mut remaining = fields;
             let mut field_index = 0usize;
-            let mut last_is_container = false;
             let mut last_gap_end = None;
             while let Some((field, rest)) = remaining.uncons() {
                 let StandardJson::String(k) = field.key() else {
                     return Err(EvalError::malformed_json_text(cursor.text()));
                 };
                 let value_cursor = field.value_cursor();
-                if let Some(value_start) = value_cursor.text_position() {
+                let value_start = value_cursor.text_position();
+                if let Some(value_start) = value_start {
                     let comma_expected = if field_index == 0 { None } else { Some(b',') };
                     if !preceding_gap_ok(cursor.text(), k.start(), comma_expected)
                         || !preceding_gap_ok(cursor.text(), value_start, Some(b':'))
@@ -3942,16 +3960,9 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
                     }
                 }
                 validate_json_delimiters(&value_cursor, depth + 1)?;
-                match value_cursor.value() {
-                    StandardJson::Array(_) | StandardJson::Object(_) => {
-                        last_is_container = true;
-                        last_gap_end = None;
-                    }
-                    _ => {
-                        last_is_container = false;
-                        last_gap_end = value_cursor.text_range().map(|(_, end)| end);
-                    }
-                }
+                // #1676: same `value_at`-reuse discipline as the array arm.
+                last_gap_end =
+                    value_start.and_then(|s| scalar_end_pos(s, &value_cursor.value_at(s)));
                 remaining = rest;
                 field_index += 1;
             }
@@ -3960,17 +3971,15 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
             }
             // #1676: same trailing/empty-gap check as the array arm above,
             // applied to the last field's *value*.
-            if !last_is_container {
-                if let Some(open_pos) = cursor.text_position() {
-                    let gap_start = if field_index > 0 {
-                        last_gap_end
-                    } else {
-                        Some(open_pos + 1)
-                    };
-                    if let Some(gap_start) = gap_start {
-                        if !trailing_gap_ok(cursor.text(), gap_start, b'}') {
-                            return Err(EvalError::malformed_json_text(cursor.text()));
-                        }
+            if let Some(open_pos) = cursor.text_position() {
+                let gap_start = if field_index > 0 {
+                    last_gap_end
+                } else {
+                    Some(open_pos + 1)
+                };
+                if let Some(gap_start) = gap_start {
+                    if !trailing_gap_ok(cursor.text(), gap_start, b'}') {
+                        return Err(EvalError::malformed_json_text(cursor.text()));
                     }
                 }
             }
@@ -4181,35 +4190,30 @@ where
                         };
                         let base = array_scratch.len();
                         // #1676: tracks the last element's own end position
-                        // (cheap for a scalar; skipped for a container --
-                        // see `trailing_gap_ok`'s own doc comment) so a
+                        // (cheap for a scalar; `None` for a container --
+                        // see `scalar_end_pos`'s own doc comment) so a
                         // trailing `,` before `]` (`[1,2,]`) can be caught
-                        // below, before anything is written.
-                        let mut last_is_container = false;
+                        // below, before anything is written. Reuses `pos`
+                        // (already resolved by `check_preceding_delimiter`)
+                        // via `value_at` rather than `child_cursor.value()`,
+                        // which would re-derive the same position a second
+                        // time -- see `scalar_end_pos`'s own doc comment on
+                        // why that matters on this hot path specifically.
                         let mut last_gap_end = None;
                         for (i, child_cursor) in elements.cursor_iter().enumerate() {
                             let pos = check_preceding_delimiter(&child_cursor, i)?;
                             array_scratch
                                 .push((child_cursor.bp_position(), pos.unwrap_or(usize::MAX)));
-                            match child_cursor.value() {
-                                StandardJson::Array(_) | StandardJson::Object(_) => {
-                                    last_is_container = true;
-                                    last_gap_end = None;
-                                }
-                                _ => {
-                                    last_is_container = false;
-                                    last_gap_end = child_cursor.text_range().map(|(_, end)| end);
-                                }
-                            }
+                            last_gap_end =
+                                pos.and_then(|s| scalar_end_pos(s, &child_cursor.value_at(s)));
                         }
-                        if !last_is_container {
-                            if let Some(gap_start) = last_gap_end {
-                                if !trailing_gap_ok(c.text(), gap_start, b']') {
-                                    return Err(MalformedJsonError(
-                                        EvalError::malformed_json_text(c.text()),
-                                    )
-                                    .into());
-                                }
+                        if let Some(gap_start) = last_gap_end {
+                            if !trailing_gap_ok(c.text(), gap_start, b']') {
+                                array_scratch.truncate(base);
+                                return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                    c.text(),
+                                ))
+                                .into());
                             }
                         }
                         if compact {
@@ -4328,7 +4332,6 @@ where
                         let mut field_index = 0usize;
                         // #1676: mirrors the array arm's own tracking, for
                         // the last field's *value* rather than an element.
-                        let mut last_is_container = false;
                         let mut last_gap_end = None;
                         while let Some((field, rest)) = remaining.uncons() {
                             // The `_` arm is *not* unreachable, whatever this
@@ -4376,18 +4379,11 @@ where
                                 }
                             }
                             // #1676: same last-child tracking as the array
-                            // arm, applied to this field's value.
-                            match field.value_cursor().value() {
-                                StandardJson::Array(_) | StandardJson::Object(_) => {
-                                    last_is_container = true;
-                                    last_gap_end = None;
-                                }
-                                _ => {
-                                    last_is_container = false;
-                                    last_gap_end =
-                                        field.value_cursor().text_range().map(|(_, end)| end);
-                                }
-                            }
+                            // arm, reusing `value_start` via `value_at`
+                            // rather than `field.value_cursor().value()`,
+                            // which would re-derive it.
+                            last_gap_end = value_start
+                                .and_then(|s| scalar_end_pos(s, &field.value_cursor().value_at(s)));
                             let (raw, escaped) = k.raw_and_escaped();
                             scratch.push(PreparedField {
                                 key_bp: field.key_cursor().bp_position(),
@@ -4417,15 +4413,13 @@ where
                             ))
                             .into());
                         }
-                        if !last_is_container {
-                            if let Some(gap_start) = last_gap_end {
-                                if !trailing_gap_ok(frame.text, gap_start, b'}') {
-                                    scratch.truncate(base);
-                                    return Err(MalformedJsonError(
-                                        EvalError::malformed_json_text(frame.text),
-                                    )
-                                    .into());
-                                }
+                        if let Some(gap_start) = last_gap_end {
+                            if !trailing_gap_ok(frame.text, gap_start, b'}') {
+                                scratch.truncate(base);
+                                return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                    frame.text,
+                                ))
+                                .into());
                             }
                         }
                         let collapsed = if config.jq_compat {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3764,6 +3764,59 @@ fn preceding_gap_ok(text: &[u8], child_start: usize, expected: Option<u8>) -> bo
     found == expected
 }
 
+/// Forward-scan mirror of [`preceding_gap_ok`], used to catch the trailing
+/// half of #1643's own deferred gap (#1676): a `,`/`:` sitting between a
+/// container's last real child and its closing bracket (`{"a":1,}`,
+/// `[1,2,]`), or inside an apparently-empty container (`{,}`, `[,]`).
+///
+/// Scans *forward* from `start` -- a position every caller here obtains
+/// cheaply (a scalar child's own `text_range().1`, or `open_pos + 1` for a
+/// genuinely empty container) -- exactly as bounded as `preceding_gap_ok`'s
+/// backward scan: it stops the instant it reaches real content, so its cost
+/// is the size of the gap itself, never the container's remaining text.
+///
+/// Returns the position of the first non-whitespace, non-delimiter byte on
+/// success (so the caller can confirm it's the expected closing bracket),
+/// or `None` if the gap holds a doubled delimiter or one that doesn't match
+/// `expected`.
+fn following_gap_ok(text: &[u8], start: usize, expected: Option<u8>) -> Option<usize> {
+    let mut i = start;
+    let mut found = None;
+    while i < text.len() {
+        match text[i] {
+            b @ (b',' | b':') => {
+                if found.is_some() {
+                    return None; // doubled delimiter
+                }
+                found = Some(b);
+                i += 1;
+            }
+            b if b.is_ascii_whitespace() => i += 1,
+            _ => break, // reached real content -- a value, or the closing bracket
+        }
+    }
+    (found == expected).then_some(i)
+}
+
+/// Whether a container closes cleanly once its last real child's own text
+/// has ended at `gap_start` (or `gap_start` is `open_pos + 1`, for a
+/// genuinely empty container): no trailing `,`/`:` before the matching
+/// closing bracket (#1676).
+///
+/// Deliberately narrower than a complete fix: `gap_start` must already be
+/// known cheaply. Callers only have that when the last child is a scalar
+/// (its `text_range()` is a bounded, self-delimiting scan, not the
+/// O(subtree) walk `JsonCursor::text_range`'s own comment describes for a
+/// container) or when the container is empty. When the last child is
+/// itself a container, finding *its* closing bracket costs exactly what
+/// this function's sibling `preceding_gap_ok` was written to avoid, so
+/// callers skip this check in that case rather than pay for it -- the same
+/// "tracked as a follow-up, not folded in here" trade #1643 already made,
+/// narrowed by one more case rather than eliminated.
+fn trailing_gap_ok(text: &[u8], gap_start: usize, close_char: u8) -> bool {
+    matches!(following_gap_ok(text, gap_start, None), Some(pos) if text.get(pos) == Some(&close_char))
+}
+
 /// Array-element wrapper around [`preceding_gap_ok`]: element `index` (0-
 /// based) must be preceded by `,`, except the first, which must be
 /// preceded by nothing (#1643).
@@ -3828,7 +3881,11 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
     assert_nesting_depth(depth);
     match cursor.value() {
         StandardJson::Array(elements) => {
+            let mut saw_any = false;
+            let mut last_is_container = false;
+            let mut last_gap_end = None;
             for (i, child) in elements.cursor_iter().enumerate() {
+                saw_any = true;
                 if let Some(start) = child.text_position() {
                     let expected = if i == 0 { None } else { Some(b',') };
                     if !preceding_gap_ok(child.text(), start, expected) {
@@ -3836,11 +3893,41 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
                     }
                 }
                 validate_json_delimiters(&child, depth + 1)?;
+                match child.value() {
+                    StandardJson::Array(_) | StandardJson::Object(_) => {
+                        last_is_container = true;
+                        last_gap_end = None;
+                    }
+                    _ => {
+                        last_is_container = false;
+                        last_gap_end = child.text_range().map(|(_, end)| end);
+                    }
+                }
+            }
+            // #1676: trailing `,` (`[1,2,]`) or a stray `,` in an
+            // apparently-empty array (`[,]`) -- see `trailing_gap_ok`'s
+            // own doc comment for why this is skipped when the last
+            // element is itself a container.
+            if !last_is_container {
+                if let Some(open_pos) = cursor.text_position() {
+                    let gap_start = if saw_any {
+                        last_gap_end
+                    } else {
+                        Some(open_pos + 1)
+                    };
+                    if let Some(gap_start) = gap_start {
+                        if !trailing_gap_ok(cursor.text(), gap_start, b']') {
+                            return Err(EvalError::malformed_json_text(cursor.text()));
+                        }
+                    }
+                }
             }
         }
         StandardJson::Object(fields) => {
             let mut remaining = fields;
             let mut field_index = 0usize;
+            let mut last_is_container = false;
+            let mut last_gap_end = None;
             while let Some((field, rest)) = remaining.uncons() {
                 let StandardJson::String(k) = field.key() else {
                     return Err(EvalError::malformed_json_text(cursor.text()));
@@ -3855,11 +3942,37 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
                     }
                 }
                 validate_json_delimiters(&value_cursor, depth + 1)?;
+                match value_cursor.value() {
+                    StandardJson::Array(_) | StandardJson::Object(_) => {
+                        last_is_container = true;
+                        last_gap_end = None;
+                    }
+                    _ => {
+                        last_is_container = false;
+                        last_gap_end = value_cursor.text_range().map(|(_, end)| end);
+                    }
+                }
                 remaining = rest;
                 field_index += 1;
             }
             if remaining.ends_unpaired() {
                 return Err(EvalError::malformed_json_text(cursor.text()));
+            }
+            // #1676: same trailing/empty-gap check as the array arm above,
+            // applied to the last field's *value*.
+            if !last_is_container {
+                if let Some(open_pos) = cursor.text_position() {
+                    let gap_start = if field_index > 0 {
+                        last_gap_end
+                    } else {
+                        Some(open_pos + 1)
+                    };
+                    if let Some(gap_start) = gap_start {
+                        if !trailing_gap_ok(cursor.text(), gap_start, b'}') {
+                            return Err(EvalError::malformed_json_text(cursor.text()));
+                        }
+                    }
+                }
             }
         }
         _ => {}
@@ -3975,8 +4088,12 @@ where
             use succinctly::json::light::StandardJson;
             // #1643: reuse the caller's `text_position()` lookup when it
             // handed one in, instead of `value()` redoing it -- see
-            // `known_text_pos`'s own doc comment above.
-            let resolved = match known_text_pos.or_else(|| c.text_position()) {
+            // `known_text_pos`'s own doc comment above. Kept as its own
+            // binding (rather than only inside the `Some` arm below) so the
+            // container arms further down can reuse it for #1676's
+            // trailing/empty-gap check without a second rank/select call.
+            let container_pos = known_text_pos.or_else(|| c.text_position());
+            let resolved = match container_pos {
                 Some(text_pos) => c.value_at(text_pos),
                 None => StandardJson::Error("invalid cursor position"),
             };
@@ -4013,6 +4130,17 @@ where
                 }
                 StandardJson::Array(elements) => {
                     if elements.is_empty() {
+                        // #1676: a stray `,`/`:` inside an apparently-empty
+                        // array (`[,]`) -- cheap since there's no subtree
+                        // to scan, just the gap between `[` and `]`.
+                        if let Some(open_pos) = container_pos {
+                            if !trailing_gap_ok(c.text(), open_pos + 1, b']') {
+                                return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                    c.text(),
+                                ))
+                                .into());
+                            }
+                        }
                         out.write_all(b"[]")?;
                     } else {
                         // #1643: validate every element's preceding
@@ -4052,10 +4180,37 @@ where
                             index: c.index(),
                         };
                         let base = array_scratch.len();
+                        // #1676: tracks the last element's own end position
+                        // (cheap for a scalar; skipped for a container --
+                        // see `trailing_gap_ok`'s own doc comment) so a
+                        // trailing `,` before `]` (`[1,2,]`) can be caught
+                        // below, before anything is written.
+                        let mut last_is_container = false;
+                        let mut last_gap_end = None;
                         for (i, child_cursor) in elements.cursor_iter().enumerate() {
                             let pos = check_preceding_delimiter(&child_cursor, i)?;
                             array_scratch
                                 .push((child_cursor.bp_position(), pos.unwrap_or(usize::MAX)));
+                            match child_cursor.value() {
+                                StandardJson::Array(_) | StandardJson::Object(_) => {
+                                    last_is_container = true;
+                                    last_gap_end = None;
+                                }
+                                _ => {
+                                    last_is_container = false;
+                                    last_gap_end = child_cursor.text_range().map(|(_, end)| end);
+                                }
+                            }
+                        }
+                        if !last_is_container {
+                            if let Some(gap_start) = last_gap_end {
+                                if !trailing_gap_ok(c.text(), gap_start, b']') {
+                                    return Err(MalformedJsonError(
+                                        EvalError::malformed_json_text(c.text()),
+                                    )
+                                    .into());
+                                }
+                            }
                         }
                         if compact {
                             out.write_all(b"[")?;
@@ -4112,6 +4267,17 @@ where
                 }
                 StandardJson::Object(fields) => {
                     if fields.is_empty() {
+                        // #1676: a stray `,`/`:` inside an apparently-empty
+                        // object (`{,}`) -- same reasoning as the array
+                        // arm's own empty-case check above.
+                        if let Some(open_pos) = container_pos {
+                            if !trailing_gap_ok(c.text(), open_pos + 1, b'}') {
+                                return Err(MalformedJsonError(EvalError::malformed_json_text(
+                                    c.text(),
+                                ))
+                                .into());
+                            }
+                        }
                         out.write_all(b"{}")?;
                     } else {
                         // #1385: jq collapses a repeated key to its first
@@ -4160,6 +4326,10 @@ where
                         // walk, just keeping its own tail.
                         let mut remaining = fields;
                         let mut field_index = 0usize;
+                        // #1676: mirrors the array arm's own tracking, for
+                        // the last field's *value* rather than an element.
+                        let mut last_is_container = false;
+                        let mut last_gap_end = None;
                         while let Some((field, rest)) = remaining.uncons() {
                             // The `_` arm is *not* unreachable, whatever this
                             // comment used to claim: nothing enforces the JSON
@@ -4205,6 +4375,19 @@ where
                                     .into());
                                 }
                             }
+                            // #1676: same last-child tracking as the array
+                            // arm, applied to this field's value.
+                            match field.value_cursor().value() {
+                                StandardJson::Array(_) | StandardJson::Object(_) => {
+                                    last_is_container = true;
+                                    last_gap_end = None;
+                                }
+                                _ => {
+                                    last_is_container = false;
+                                    last_gap_end =
+                                        field.value_cursor().text_range().map(|(_, end)| end);
+                                }
+                            }
                             let (raw, escaped) = k.raw_and_escaped();
                             scratch.push(PreparedField {
                                 key_bp: field.key_cursor().bp_position(),
@@ -4233,6 +4416,17 @@ where
                                 frame.text,
                             ))
                             .into());
+                        }
+                        if !last_is_container {
+                            if let Some(gap_start) = last_gap_end {
+                                if !trailing_gap_ok(frame.text, gap_start, b'}') {
+                                    scratch.truncate(base);
+                                    return Err(MalformedJsonError(
+                                        EvalError::malformed_json_text(frame.text),
+                                    )
+                                    .into());
+                                }
+                            }
                         }
                         let collapsed = if config.jq_compat {
                             collapse_duplicate_fields(&scratch[base..], &frame)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17056,14 +17056,17 @@ fn test_jq_trailing_leading_comma_now_rejected_1676() -> Result<()> {
 /// doc comment already explains is too expensive to pay unconditionally.
 /// Pinned here, same discipline as #1643's own now-fixed gap test above, so
 /// a future fix for *this* narrower residual updates this test rather than
-/// silently landing uncovered. Real jq rejects both (confirmed live against
-/// `/usr/bin/jq` 1.7.1): `{"a":[1,2],}` and `[[1,2],]` are both parse
-/// errors there.
+/// silently landing uncovered. Real jq rejects all four (confirmed live
+/// against `/usr/bin/jq` 1.7.1), including the empty-inner-container variant
+/// (`[[],]`, `{"a":{},}`) -- an empty container is still a container for
+/// `scalar_end_pos`'s purposes, so it hits the same skip.
 #[test]
 fn test_jq_trailing_comma_after_container_last_child_still_a_known_gap_1676() -> Result<()> {
     for (input, expected) in [
         (r#"{"a":[1,2],}"#, r#"{"a":[1,2]}"#),
         ("[[1,2],]", "[[1,2]]"),
+        ("[[],]", "[[]]"),
+        (r#"{"a":{},}"#, r#"{"a":{}}"#),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
         assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
@@ -17087,13 +17090,25 @@ fn test_jq_missing_delimiter_raises_under_sort_keys_color_and_slurp_1643() -> Re
         vec!["-C", "-c", "."],
         vec!["-c", "--slurp", "."],
     ] {
-        let (out, stderr, code) = run_jq_full(&args, Some(r#"{"a" 1}"#))?;
-        assert_eq!(code, 5, "{args:?}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{args:?}: unexpected output {out:?}");
-        assert!(
-            stderr.contains("Invalid JSON text"),
-            "{args:?}: stderr: {stderr:?}"
-        );
+        // Object and array shapes both exercise `validate_json_delimiters`,
+        // but its two arms are independent code paths -- only the object
+        // shape was covered here before #1676 touched (and thus surfaced
+        // the gap in) the array arm's own neighboring lines.
+        for input in [r#"{"a" 1}"#, "[1 2,3]"] {
+            let (out, stderr, code) = run_jq_full(&args, Some(input))?;
+            assert_eq!(
+                code, 5,
+                "{args:?} {input}: out: {out:?}, stderr: {stderr:?}"
+            );
+            assert!(
+                out.trim().is_empty(),
+                "{args:?} {input}: unexpected output {out:?}"
+            );
+            assert!(
+                stderr.contains("Invalid JSON text"),
+                "{args:?} {input}: stderr: {stderr:?}"
+            );
+        }
     }
 
     Ok(())
@@ -17157,10 +17172,14 @@ fn test_jq_doubled_trailing_comma_rejected_1676() -> Result<()> {
 
 /// #1676: the success side of `validate_json_delimiters`'s new trailing-gap
 /// check on the `-S`/`-C`/`--slurp` fallback path -- a structurally *valid*
-/// container (clean trailing gap) reached via a leniency trigger elsewhere
-/// in the same document (`serde_json` rejects the leading zero, routing to
-/// `find_json_values` + `validate_json_delimiters` same as the malformed
-/// cases above), covering both a scalar and a container last child/value.
+/// container reached via a leniency trigger elsewhere in the same document
+/// (`serde_json` rejects the leading zero, routing to `find_json_values` +
+/// `validate_json_delimiters` same as the malformed cases above). Covers
+/// both a scalar last element/value (where `trailing_gap_ok` actually runs
+/// and must correctly say "clean") and a container one (`[01,[2,3]]` etc. --
+/// where the check is skipped per `scalar_end_pos`'s own doc comment, so
+/// these two cases only confirm the *skip* itself doesn't wrongly reject,
+/// not that `trailing_gap_ok`'s own logic is exercised for a container).
 #[test]
 fn test_jq_wellformed_trailing_gap_survives_leniency_fallback_1676() -> Result<()> {
     for (input, expected) in [

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17137,6 +17137,46 @@ fn test_jq_trailing_comma_raises_under_sort_keys_color_and_slurp_1676() -> Resul
     Ok(())
 }
 
+/// #1676: a *doubled* trailing/leading delimiter (`[1,2,,]`, `{"a":1,,}`) --
+/// `following_gap_ok`'s own doubled-delimiter arm, the forward-scan mirror
+/// of `preceding_gap_ok`'s existing one.
+#[test]
+fn test_jq_doubled_trailing_comma_rejected_1676() -> Result<()> {
+    for input in ["[1,2,,]", r#"{"a":1,,}"#] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1676: the success side of `validate_json_delimiters`'s new trailing-gap
+/// check on the `-S`/`-C`/`--slurp` fallback path -- a structurally *valid*
+/// container (clean trailing gap) reached via a leniency trigger elsewhere
+/// in the same document (`serde_json` rejects the leading zero, routing to
+/// `find_json_values` + `validate_json_delimiters` same as the malformed
+/// cases above), covering both a scalar and a container last child/value.
+#[test]
+fn test_jq_wellformed_trailing_gap_survives_leniency_fallback_1676() -> Result<()> {
+    for (input, expected) in [
+        ("[01,2]", "[1,2]"),
+        ("[01,[2,3]]", "[1,[2,3]]"),
+        (r#"{"a":01,"b":2}"#, r#"{"a":1,"b":2}"#),
+        (r#"{"a":01,"b":[2,3]}"#, r#"{"a":1,"b":[2,3]}"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-S", "-c", "."], Some(input))?;
+        assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
 /// #1643 follow-up: a malformed value elsewhere in a multi-value stream
 /// (not just the first) is still caught under `-S`, since
 /// `parse_json_stream`'s fallback validates every span it materializes,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16998,20 +16998,72 @@ fn test_jq_wellformed_documents_unaffected_by_1643() -> Result<()> {
     Ok(())
 }
 
-/// #1643: known, documented gap -- a trailing/leading comma next to a
-/// bracket (rather than between two real children) is not yet caught.
-/// Catching it needs the *closing* bracket's text position, which has no
-/// cheap lookup today (IB only marks opening positions); see
-/// `preceding_gap_ok`'s doc comment in `jq_runner.rs` for why. Pinned here
-/// so a future fix for this class updates this test rather than being
-/// silently covered by a coincidence.
+/// #1676: #1643's own deferred trailing/leading-comma gap is now caught --
+/// a `,`/`:` next to a bracket (rather than between two real children),
+/// whether after the last real child (`{"a":1,}`, `[1,2,]`) or inside an
+/// apparently-empty container (`{,}`, `[,]`). Was previously silently
+/// accepted (exit 0, comma dropped); see `trailing_gap_ok`'s doc comment in
+/// `jq_runner.rs` for the scoped fix. Verified against `/usr/bin/jq` 1.7.1,
+/// which rejects every one of these at exit 5.
 #[test]
-fn test_jq_trailing_leading_comma_still_a_known_gap_1643() -> Result<()> {
+fn test_jq_trailing_leading_comma_now_rejected_1676() -> Result<()> {
+    for input in [
+        r#"{"a":1,}"#,
+        "[1,2,]",
+        "{,}",
+        "[,]",
+        r#"{"a":1, "b":2,}"#,
+        "{  ,  }",
+        "[  ,  ]",
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    // Same check, but the trailing comma is on a *nested* array, one level
+    // inside an otherwise well-formed root object/array. Not held to the
+    // no-partial-output guarantee above: that guarantee is specific to the
+    // *root* value's own container arm validating before writing its own
+    // opening bracket (`test_jq_malformed_object_leaves_no_partial_output_
+    // 1194`) -- a nested child's own malformation is only discovered when
+    // the recursive `print_json` call reaches it, by which point the
+    // well-formed root prefix (`{"a":`) is already on stdout. Pre-existing
+    // for every other malformed-nested-child case too (verified against
+    // e.g. `{"a":[1 2]}`'s own missing-comma error), not something this fix
+    // introduces.
+    for input in [r#"{"a":[1,2,]}"#, "[[1,2,]]"] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1676's own remaining, deliberately deferred gap: a trailing comma right
+/// before a container's closing bracket is only caught when the last real
+/// child is a scalar or the container is empty -- catching it when the last
+/// child is *itself* a container would need that child's own closing
+/// bracket's text position, the same O(subtree) lookup `preceding_gap_ok`'s
+/// doc comment already explains is too expensive to pay unconditionally.
+/// Pinned here, same discipline as #1643's own now-fixed gap test above, so
+/// a future fix for *this* narrower residual updates this test rather than
+/// silently landing uncovered. Real jq rejects both (confirmed live against
+/// `/usr/bin/jq` 1.7.1): `{"a":[1,2],}` and `[[1,2],]` are both parse
+/// errors there.
+#[test]
+fn test_jq_trailing_comma_after_container_last_child_still_a_known_gap_1676() -> Result<()> {
     for (input, expected) in [
-        (r#"{"a":1,}"#, r#"{"a":1}"#),
-        ("[1,2,]", "[1,2]"),
-        ("{,}", "{}"),
-        ("[,]", "[]"),
+        (r#"{"a":[1,2],}"#, r#"{"a":[1,2]}"#),
+        ("[[1,2],]", "[[1,2]]"),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
         assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
@@ -17042,6 +17094,44 @@ fn test_jq_missing_delimiter_raises_under_sort_keys_color_and_slurp_1643() -> Re
             stderr.contains("Invalid JSON text"),
             "{args:?}: stderr: {stderr:?}"
         );
+    }
+
+    Ok(())
+}
+
+/// #1676, same shape as the missing-delimiter test above: on the
+/// `-S`/`-C`/`--slurp` fallback path, `serde_json`'s own strict pass
+/// already rejects a trailing/leading comma outright (`parse_json_stream`
+/// only ever reaches `json_bytes_to_owned_value_checked` after that strict
+/// pass has *failed*) -- so unlike the default path, this one was never
+/// silently accepting these inputs. What was missing is `validate_json_
+/// delimiters`'s own trailing/empty-gap check, which the lenient re-scan
+/// this path falls back to (`find_json_values`) needs independently: that
+/// scanner finds `{"a":1,}` as one balanced span regardless of the comma,
+/// and before this fix nothing downstream re-validated it. Confirmed by
+/// building pre-fix and observing exit 0 here.
+#[test]
+fn test_jq_trailing_comma_raises_under_sort_keys_color_and_slurp_1676() -> Result<()> {
+    for args in [
+        vec!["-S", "."],
+        vec!["-C", "-c", "."],
+        vec!["-c", "--slurp", "."],
+    ] {
+        for input in [r#"{"a":1,}"#, "[1,2,]", "{,}", "[,]"] {
+            let (out, stderr, code) = run_jq_full(&args, Some(input))?;
+            assert_eq!(
+                code, 5,
+                "{args:?} {input}: out: {out:?}, stderr: {stderr:?}"
+            );
+            assert!(
+                out.trim().is_empty(),
+                "{args:?} {input}: unexpected output {out:?}"
+            );
+            assert!(
+                stderr.contains("Invalid JSON text"),
+                "{args:?} {input}: stderr: {stderr:?}"
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

#1643's own delimiter check (`preceding_gap_ok`) only validated the gap
between two real children, deliberately leaving a `,`/`:` next to a closing
bracket uncaught (`{"a":1,}`, `[1,2,]`) or inside an apparently-empty
container (`{,}`, `[,]`) — both silently accepted at exit 0 where real jq
(pinned 1.7.1) rejects them at exit 5.

- Adds `following_gap_ok`, a forward-scan mirror of the existing backward
  `preceding_gap_ok`, and `trailing_gap_ok`, which applies it once per
  container using the last real child's own end position.
- **Deliberately scoped**: the end position is only used when it's cheap —
  a scalar last child (self-delimiting, bounded scan) or an empty
  container. When the last child is itself a container, the check is
  skipped rather than pay for finding *its* closing bracket's text
  position (the same O(subtree) cost `preceding_gap_ok`'s own doc comment
  explains is too expensive). That narrower residual (`{"a":[1,2],}`,
  `[[1,2],]`) is pinned with its own regression test, same discipline
  #1643 used for this whole class originally.
- Wired into both the default `print_json` path and the `-S`/`-C`/`--slurp`
  fallback's `validate_json_delimiters` — the latter was independently
  broken (confirmed by building pre-fix and observing exit 0), since
  `find_json_values`'s lenient re-scan finds `{"a":1,}` as one balanced
  span regardless of the comma.

Closes #1676.

## Coverage

Patch coverage on `jq_runner.rs`: **94.87%** (111/117 new lines). The
remaining 6 uncovered lines are all bare closing-brace lines immediately
following a `return` inside nested `if`/`if let` blocks — verified via raw
`lcov` `DA:` hit counts that both the success and failure branches around
each one are genuinely exercised (e.g. one pair shows 6 failure hits + 3
success hits on the surrounding statement lines, with only the brace-only
line itself at 0), matching an already-established pattern elsewhere in
this same function (`print_json`'s empty-container checks) — an
llvm-cov region-mapping artifact for consecutive brace-only lines, not a
real gap.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, twice —
      first run hit the known #935 machine-contention stall on an
      unrelated test, second run fully green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against `/usr/bin/jq` 1.7.1 directly for every repro
      shape (trailing comma, empty-with-comma, doubled comma, nested,
      leniency-fallback success cases)
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 94.87% patch coverage,
      remainder explained above