### PR TITLE
fix(jq): guard combinations(n)'s multi-output arity sum against overflow

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -864,6 +864,19 @@ unaffected. This guard is symmetric across jq and yq mode (yq reaches it only be
 `--jq-extensions`, per #1650), with no additional yq-specific cap to record in
 [yq Limitations](../yq/limitations.md).
 
+`combinations(n)` has a fourth, independent overflow site (#1720), found reviewing #1669's
+own fix: a multi-output `n` expression (e.g. `combinations((a, b, c))`) sums each output's
+arity into a running `usize` total *before* any of the guards above ever run, and that sum
+itself can overflow with as few as two large outputs — `[1] |
+combinations((9223372036854775807, 9223372036854775807, 3))` aborted a debug build
+(`attempt to add with overflow`) and silently wrapped to a wrong answer in release, neither
+of which the allocation guards above touch, since they all assume an already-summed,
+already-valid `n`. Real jq hangs on this exact shape rather than erroring (confirmed live,
+`timeout 10 jq -c 'combinations((9223372036854775807, 9223372036854775807, 3))' <<< '[1]'`
+against the pinned jq 1.7.1 binary), so refusing with a catchable error is the same
+"would take the host process down" exception as the rest of this entry, not a new kind of
+divergence.
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13751,6 +13751,14 @@ fn cannot_allocate_combinations_count(n: usize) -> EvalError {
     EvalError::new(format!("Cannot allocate {n} elements for combinations"))
 }
 
+/// Distinct from both of the above: those blame a *valid* `n` that is too
+/// large to allocate for; this fires earlier, while summing `n`'s own
+/// per-output arities together, before there is a valid `n` to blame at all
+/// (#1720).
+fn combinations_arity_overflow() -> EvalError {
+    EvalError::new("combinations(n): n's arity overflowed while summing multiple outputs")
+}
+
 /// Evaluate `E[K]` — indexing by a computed key.
 ///
 /// jq compiles this as `K as $k | E | .[$k]`, and three consequences of that
@@ -30712,13 +30720,29 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // two outputs, so `combinations(1.5)` is `combinations(2)`.
     let mut n = 0usize;
     for n_value in &n_values {
-        n += match range_num(n_value) {
+        let arity = match range_num(n_value) {
             Ok(RangeNum::Int(i)) => i.max(0) as usize,
             Ok(RangeNum::Float(f)) if f > 0.0 => f.ceil() as usize,
             Ok(RangeNum::Float(_)) => 0,
             Err(_) if optional => return QueryResult::None,
             Err(e) => return QueryResult::Error(e),
         };
+        // #1720: two or more large per-output arities can overflow this
+        // running sum before `n` itself is even fully computed -- a
+        // different failure point from the allocation guards below, which
+        // all assume an already-valid `n`. `EvalError::new` (not gated by
+        // the local `optional` flag, same as the allocation guards below):
+        // confirmed live that a trailing `?` at the call site still catches
+        // it, matching those guards' own catchable behavior -- `optional`
+        // only short-circuits `range_num`'s own type-check errors above,
+        // not a capacity failure like this one. Real jq hangs indefinitely
+        // on this exact shape rather than erroring (confirmed live,
+        // ADR-0018) -- raising here instead is the documented "would take
+        // the host process down" exception.
+        let Some(next) = n.checked_add(arity) else {
+            return QueryResult::Error(combinations_arity_overflow());
+        };
+        n = next;
     }
 
     // Input must be an array

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23184,6 +23184,70 @@ fn test_jq_combinations_n_moderate_n_large_base_array_does_not_abort_1669() -> R
     Ok(())
 }
 
+/// #1720: a multi-output `n` expression sums each output's arity into a
+/// running `usize` total *before* any of #1669's allocation guards above
+/// ever run -- that sum itself can overflow with as few as two large
+/// outputs, independent of every guard above (all of which assume an
+/// already-summed, already-valid `n`). Confirmed live before this fix:
+/// `[1] | combinations((9223372036854775807, 9223372036854775807, 3))`
+/// aborted a debug build (`attempt to add with overflow`) and silently
+/// wrapped to a wrong answer (rather than erroring) in release. Real jq
+/// hangs on this exact shape instead of erroring (confirmed live against
+/// the pinned jq 1.7.1 binary, ADR-0018), so this is the same "would take
+/// the host process down" exception `docs/compliance/jq/limitations.md`
+/// already documents for #1669, not a new divergence.
+#[test]
+fn test_jq_combinations_n_arity_sum_overflow_does_not_abort_1720() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "combinations((9223372036854775807, 9223372036854775807, 3))",
+        ],
+        Some("[1]"),
+    )?;
+    assert_eq!(stdout, "");
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("RUST_BACKTRACE"),
+        "stderr: {stderr:?}"
+    );
+    assert!(stderr.contains("arity overflowed"), "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1720 review: a trailing `?` at the call site catches the new overflow
+/// error the same way it already catches #1669's sibling allocation-guard
+/// errors (`EvalError::new`, not specially marked uncatchable) -- suppressed
+/// to no output rather than propagating, consistent behavior across every
+/// guard this function raises.
+#[test]
+fn test_jq_combinations_n_arity_sum_overflow_caught_by_optional_1720() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "combinations((9223372036854775807, 9223372036854775807, 3))?",
+        ],
+        Some("[1]"),
+    )?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1720 review: this fix must not disturb ordinary multi-output `n` --
+/// arities that sum without overflowing still take the documented sum-of-
+/// arities path (`[1,2] | [combinations((1,2))] | length` == `combinations(3)`
+/// == 8, per `builtin_combinations_n`'s own doc comment), not per-output
+/// fan-out (which would give 2^1 + 2^2 == 6 instead).
+#[test]
+fn test_jq_combinations_n_multi_output_arity_sums_not_fans_out() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[combinations((1,2))] | length"], Some("[1,2]"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "8");
+    Ok(())
+}
+
 /// #1669 review: `cartesian_product`'s only other coverage exercises the
 /// overflow-refusal path below (`try_reserve_product` failing before the
 /// loop body ever runs at all) -- this repo had no permanent test at any


### PR DESCRIPTION
## Summary

- `builtin_combinations_n`'s arity-summing loop (`src/jq/eval.rs`) used plain `usize +=` with no overflow guard, unlike every allocation guard #1669 hardened a few lines below it in the same function.
- Two or more large outputs from a multi-output `n` expression (e.g. `combinations((a, b, c))`) overflow this running sum: `attempt to add with overflow` panic in debug builds, a silently wrapped **wrong answer** in release builds.
- Real jq hangs indefinitely on this exact shape rather than erroring (confirmed live against the pinned jq 1.7.1 binary: `timeout 10 jq -c 'combinations((9223372036854775807, 9223372036854775807, 3))' <<< '[1]'` times out), so refusing with a catchable error is the same "would take the host process down" exception ADR-0018 already carves out for #1669's sibling guards — documented as an extension of that existing entry in `docs/compliance/jq/limitations.md`, not a new divergence.

## Repro (before fix)

```console
$ echo '[1]' | succinctly jq -c 'combinations((9223372036854775807, 9223372036854775807, 3))'
thread 'main' panicked at src/jq/eval.rs:...: attempt to add with overflow   # debug build

$ echo '[1,2]' | succinctly jq -c 'combinations((9223372036854775807, 9223372036854775807, 3)) | length'
1   # release build — silently wrong, no error
```

## After fix

```console
$ echo '[1]' | succinctly jq -c 'combinations((9223372036854775807, 9223372036854775807, 3))'
jq: error (at <stdin>:1): combinations(n): n's arity overflowed while summing multiple outputs
```
Exit 5 (catchable), matching in both debug and release builds, and in `succinctly yq --jq-extensions` mode too (shared generic function).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo doc --no-deps --all-features` (no warnings)
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (`no_std` compiles)
- [x] Three new regression tests: overflow raises a catchable error (`test_jq_combinations_n_arity_sum_overflow_does_not_abort_1720`), a trailing `?` still catches it consistently with sibling guards (`test_jq_combinations_n_arity_sum_overflow_caught_by_optional_1720`), and ordinary multi-output `n` still sums arities correctly rather than fanning out (`test_jq_combinations_n_multi_output_arity_sums_not_fans_out`)
- [x] `omni-dev coverage diff`: 100% patch coverage (7/7 new lines)
- [x] Manually verified against the exact repro in both debug and release builds, plus `succinctly yq --jq-extensions` mode
- [x] Verified real jq's own behavior on this exact input (hangs, confirmed via `timeout`) before choosing to diverge, per ADR-0018

Fixes #1720