### PR TITLE
fix(yq): raise instead of silently dropping a colliding complex-key value

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -786,6 +786,35 @@ another key of the same name and cannot be represented
 An *ordinary* repeated key (no decode failure on either side) is unaffected and still
 collapses to its last value, matching yq's normal duplicate-key handling.
 
+**`--slurp`/`--eval-all`/`--inplace`'s own DOM fallback catches a second, wider trigger
+the paragraph above's routes do not, as of
+[#1749](https://github.com/rust-works/succinctly/issues/1749).** Those three flags
+materialize through a separate, `YamlCursor`-native conversion
+(`yaml_to_owned_value` in
+[src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs)), not the
+`DocumentValue`-generic path `--arg`/`-P`/`.,.,` use. It reuses the same
+`DisplayKeyGuard`/`colliding_display_key_error` machinery, but drives it with its own
+`YamlValue::key_string_kind` classification, which also flags a **complex** key
+(mapping, sequence, `null`, or a non-scalar/dangling alias -- not just a decode-failure
+string) as a fallback spelling. Real yq keeps both entries in this case too (its
+underlying representation isn't a plain map); succinctly's `OwnedValue::Object`
+structurally cannot, so this raises rather than silently discarding one:
+
+```console
+$ printf '? [1,2]\n: a\n? [3,4]\n: b\n' | succinctly yq --slurp '.[0]'
+Error: object key "" is ambiguous: an undecodable key's display form collides with
+another key of the same name and cannot be represented
+```
+
+**This wider trigger is currently `--slurp`/`--eval-all`/`--inplace`-only.** The
+`--arg`/`-P` route's own `key_display_string_kind` (JSON-oriented, shared across every
+`DocumentValue` implementor) does not yet recognize a YAML complex key as fallback --
+only a decode-failure string key, same as the paragraph above -- so the identical input
+through `--arg`/`-P` still silently drops one entry rather than raising. Tracked as
+[#1753](https://github.com/rust-works/succinctly/issues/1753), along with a related gap
+in the `load()` builtin's own separate YAML-mapping conversion, which has no collision
+guard at all.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,8 +9,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, resolve_display_key, DisplayKeyGuard, DocumentCursor, DocumentElements,
-    DocumentFields, DocumentValue, IndentSpec,
+    colliding_display_key_error, effective_keys, resolve_display_key, DisplayKeyGuard,
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
@@ -333,11 +333,7 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
                 let (key, is_fallback) = field.key().key_string_kind();
                 let key = key.into_owned();
                 if !guard.check(&map, &key, is_fallback) {
-                    anyhow::bail!(
-                        "mapping key \"{key}\" is ambiguous: a complex or undecodable \
-                         key's display form collides with another key of the same name \
-                         and cannot be represented"
-                    );
+                    return Err(anyhow::anyhow!("{}", colliding_display_key_error(&key)));
                 }
                 let value = yaml_to_owned_value(field.value_cursor())?;
                 map.insert(key, value);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -318,11 +318,27 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
         }
         YamlValue::Mapping(fields) => {
             let mut map = IndexMap::new();
+            // #1749: two complex/undecodable keys (e.g. two different
+            // sequence keys) both stringify to "" per #222 -- real yq's own
+            // streaming/DOM paths keep both entries (its underlying
+            // representation isn't a plain map), but `OwnedValue::Object`'s
+            // `IndexMap<String, _>` cannot hold two values under one key.
+            // Guarding against that silent overwrite the same way
+            // #1642/#1738 guard a JSON decode-failure collision: an
+            // *ordinary* repeated genuine key still overwrites without
+            // complaint (matching jq's own last-key-wins), only a
+            // fallback-spelling collision raises.
+            let mut guard = DisplayKeyGuard::default();
             for field in fields {
-                // Keys follow yq semantics (#222): alias-to-scalar resolves to
-                // its content, any other complex key stringifies to "", and the
-                // entry is always kept — matching the streaming/DOM emit paths.
-                let key = field.key().key_string().into_owned();
+                let (key, is_fallback) = field.key().key_string_kind();
+                let key = key.into_owned();
+                if !guard.check(&map, &key, is_fallback) {
+                    anyhow::bail!(
+                        "mapping key \"{key}\" is ambiguous: a complex or undecodable \
+                         key's display form collides with another key of the same name \
+                         and cannot be represented"
+                    );
+                }
                 let value = yaml_to_owned_value(field.value_cursor())?;
                 map.insert(key, value);
             }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -855,11 +855,21 @@ impl DisplayKeyGuard {
 }
 
 /// The error for two keys that collide only because a decode-failure key's
-/// display fallback (#1642) matches another key's spelling. #1385 forbids
-/// treating them as the same key, but a display-keyed map has no way to
-/// hold both, so this is what `to_owned`/`materialize` raise instead of
-/// silently dropping one of them -- see [`DisplayKeyGuard`].
-pub(crate) fn colliding_display_key_error(key: &str) -> EvalError {
+/// display fallback (#1642) matches another key's spelling.
+///
+/// #1385 forbids treating them as the same key, but a display-keyed map has
+/// no way to hold both, so this is what `to_owned`/`materialize` raise
+/// instead of silently dropping one of them -- see [`DisplayKeyGuard`].
+///
+/// `pub`, not `pub(crate)`: `succinctly-cli`'s `yq_runner.rs`
+/// (`yaml_to_owned_value`, #1749) reuses this directly rather than
+/// hand-writing a second, wording-drift-prone copy of the same message --
+/// same reasoning [`DisplayKeyGuard::check`] itself is `pub` for. The
+/// wording says "object key", which still reads correctly for a YAML
+/// mapping key (a YAML document *is* the object/mapping distinction JSON
+/// doesn't have, but "object" is the neutral term this message already
+/// uses for JSON's own object keys).
+pub fn colliding_display_key_error(key: &str) -> EvalError {
     EvalError::decode_failure(alloc::format!(
         "object key \"{key}\" is ambiguous: an undecodable key's display form \
          collides with another key of the same name and cannot be represented"

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -831,18 +831,20 @@ pub struct DisplayKeyGuard {
 
 impl DisplayKeyGuard {
     /// Checks `key` (with the `is_fallback` flag from
-    /// [`key_display_string_kind`]) against every key already present in
-    /// `map` and every fallback key this guard has already approved.
-    /// Returns `true` when it is safe to insert (a fresh key, or an
-    /// ordinary repeat); `false` when inserting would silently collapse two
-    /// keys that must stay distinct, in which case the caller should raise
-    /// instead.
-    pub(crate) fn check<T>(
-        &mut self,
-        map: &IndexMap<String, T>,
-        key: &str,
-        is_fallback: bool,
-    ) -> bool {
+    /// [`key_display_string_kind`], or an equivalent per-format classifier --
+    /// see `YamlValue::key_string_kind` for YAML's own, #1749) against every
+    /// key already present in `map` and every fallback key this guard has
+    /// already approved. Returns `true` when it is safe to insert (a fresh
+    /// key, or an ordinary repeat); `false` when inserting would silently
+    /// collapse two keys that must stay distinct, in which case the caller
+    /// should raise instead.
+    ///
+    /// `pub`, not `pub(crate)`: `succinctly-cli`'s `yq_runner.rs`
+    /// (`yaml_to_owned_value`, a `YamlCursor`-native materializer that
+    /// doesn't go through the `DocumentValue`/`resolve_display_key` path)
+    /// needs to drive this guard itself with its own `is_fallback`
+    /// classification, same reasoning the struct itself is `pub` for.
+    pub fn check<T>(&mut self, map: &IndexMap<String, T>, key: &str, is_fallback: bool) -> bool {
         let collides = map.contains_key(key)
             && (is_fallback || self.fallback_keys.iter().any(|seen| seen.as_str() == key));
         if !collides && is_fallback {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -830,9 +830,9 @@ pub struct DisplayKeyGuard {
 }
 
 impl DisplayKeyGuard {
-    /// Checks `key` (with the `is_fallback` flag from
-    /// [`key_display_string_kind`], or an equivalent per-format classifier --
-    /// see `YamlValue::key_string_kind` for YAML's own, #1749) against every
+    /// Checks `key` (with the `is_fallback` flag from `key_display_string_kind`
+    /// [private, JSON's own], or an equivalent per-format classifier -- see
+    /// `YamlValue::key_string_kind` for YAML's own, #1749) against every
     /// key already present in `map` and every fallback key this guard has
     /// already approved. Returns `true` when it is safe to insert (a fresh
     /// key, or an ordinary repeat); `false` when inserting would silently

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6171,25 +6171,28 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
     /// (which is `false` here) or an ordinary non-empty key (also `false`).
     pub fn key_string_kind(&self) -> (Cow<'a, str>, bool) {
         match self {
-            YamlValue::String(s) => match s.as_str() {
-                Ok(text) => (text, false),
-                Err(_) => (Cow::Borrowed(""), true),
-            },
+            YamlValue::String(s) => string_key_kind(s),
             YamlValue::Alias {
                 target: Some(target),
                 ..
-            } => {
-                if let YamlValue::String(s) = target.value() {
-                    match s.as_str() {
-                        Ok(text) => (text, false),
-                        Err(_) => (Cow::Borrowed(""), true),
-                    }
-                } else {
-                    (Cow::Borrowed(""), true)
-                }
-            }
+            } => match target.value() {
+                YamlValue::String(s) => string_key_kind(&s),
+                _ => (Cow::Borrowed(""), true),
+            },
             _ => (Cow::Borrowed(""), true),
         }
+    }
+}
+
+/// The [`key_string_kind`](YamlValue::key_string_kind) result for a genuine
+/// `String` key: its decoded content on success, or the shared `""`
+/// fallback (marked `is_fallback`) on a decode failure. Shared by
+/// `key_string_kind`'s direct-`String` and `Alias`-to-`String` arms so the
+/// two don't drift independently.
+fn string_key_kind<'a>(s: &YamlString<'a>) -> (Cow<'a, str>, bool) {
+    match s.as_str() {
+        Ok(text) => (text, false),
+        Err(_) => (Cow::Borrowed(""), true),
     }
 }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6152,19 +6152,43 @@ impl<'a, W: AsRef<[u64]>> YamlValue<'a, W> {
     ///
     /// Never fails; returns `""` rather than erroring so keys are never lost.
     pub fn key_string(&self) -> Cow<'a, str> {
+        self.key_string_kind().0
+    }
+
+    /// [`key_string`](Self::key_string), plus whether the `""` returned is
+    /// the **fallback** spelling (`true`) rather than a genuine decode
+    /// (`false`) -- mirrors JSON's own `key_display_string_kind` (#1642),
+    /// which this format can't share a definition with: JSON's fallback
+    /// case is specifically a *decode failure*, distinguished from a
+    /// successful decode by checking `string_decode_error()` before
+    /// `key_string()`; YAML's `key_string()` above never returns `None` at
+    /// all (#222 -- a complex/undecodable key stringifies to `""` rather
+    /// than being dropped), so there is no separate decode-failure signal
+    /// to check first. This walks the same branches `key_string()` does,
+    /// just keeping track of *which* one produced the `""`, so a caller
+    /// building a display-keyed map (#1749) can tell a complex/undecodable
+    /// key's fallback `""` apart from a genuine empty-string key `""`
+    /// (which is `false` here) or an ordinary non-empty key (also `false`).
+    pub fn key_string_kind(&self) -> (Cow<'a, str>, bool) {
         match self {
-            YamlValue::String(s) => s.as_str().unwrap_or(Cow::Borrowed("")),
+            YamlValue::String(s) => match s.as_str() {
+                Ok(text) => (text, false),
+                Err(_) => (Cow::Borrowed(""), true),
+            },
             YamlValue::Alias {
                 target: Some(target),
                 ..
             } => {
                 if let YamlValue::String(s) = target.value() {
-                    s.as_str().unwrap_or(Cow::Borrowed(""))
+                    match s.as_str() {
+                        Ok(text) => (text, false),
+                        Err(_) => (Cow::Borrowed(""), true),
+                    }
                 } else {
-                    Cow::Borrowed("")
+                    (Cow::Borrowed(""), true)
                 }
             }
-            _ => Cow::Borrowed(""),
+            _ => (Cow::Borrowed(""), true),
         }
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1568,6 +1568,42 @@ fn test_yaml_native_dom_raises_on_colliding_complex_key_1749() -> Result<()> {
     Ok(())
 }
 
+/// #1749 sibling: a *decode-failure* string key (an invalid escape, falling
+/// back to `""` the same way a complex key does) colliding with another key
+/// of the same fallback spelling raises too -- `YamlValue::key_string_kind`'s
+/// `String`/decode-failure branch, not just its complex-key branches.
+#[test]
+fn test_yaml_native_dom_raises_on_colliding_decode_failure_key_1749() -> Result<()> {
+    let yaml = "\"a\\qb\": 1\n\"a\\zc\": 2\n";
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--slurp"])?;
+    assert_eq!(code, 1, "--slurp should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    Ok(())
+}
+
+/// #1749 sibling: an *alias* key whose target is itself a decode-failure
+/// string colliding with a direct decode-failure key -- `key_string_kind`'s
+/// `Alias`-to-`String` branch specifically, not the direct `String` branch
+/// the test above covers.
+#[test]
+fn test_yaml_native_dom_raises_on_colliding_alias_to_decode_failure_key_1749() -> Result<()> {
+    let yaml = "&x \"a\\qb\": 1\n*x: 2\n";
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--slurp"])?;
+    assert_eq!(code, 1, "--slurp should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1749 sibling: an *ordinary* repeated scalar key (neither side complex)
 /// must keep overwriting without complaint through the same DOM path --
 /// only a complex/undecodable key's fallback spelling is refused, matching

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1515,6 +1515,42 @@ fn test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738() -
     Ok(())
 }
 
+/// #1749 sibling: `DisplayKeyGuard::check`'s own contract is "a fallback
+/// spelling on *either side* of the collision is refused" (`document.rs`'s
+/// own doc comment) -- not just fallback-vs-fallback. Pins both orders: a
+/// genuine `""` key followed by a complex key that also stringifies to
+/// `""`, and the reverse.
+#[test]
+fn test_yaml_native_dom_raises_on_genuine_then_fallback_empty_key_1749() -> Result<()> {
+    for yaml in ["\"\": 1\n? [1,2]\n: 2\n", "? [1,2]\n: 1\n\"\": 2\n"] {
+        let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--slurp"])?;
+        assert_eq!(code, 1, "{yaml:?} should raise, stderr: {stderr}");
+        assert!(
+            stderr.contains("ambiguous"),
+            "{yaml:?}: expected an 'ambiguous' error, got: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1749 sibling: three (not just two) colliding complex keys -- pins that
+/// the guard fires at the second occurrence regardless of how many more
+/// would have followed, not just "eventually, somehow" for exactly two.
+#[test]
+fn test_yaml_native_dom_raises_on_three_colliding_complex_keys_1749() -> Result<()> {
+    let yaml = "? [1,2]\n: a\n? [3,4]\n: b\n? [5,6]\n: c\n";
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--slurp"])?;
+    assert_eq!(code, 1, "should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1749: `yaml_to_owned_value`'s own `Mapping` arm (`--slurp`/`--eval-all`/
 /// `--inplace`'s DOM fallback) is `YamlCursor`-native, not
 /// `DocumentValue`-generic, so it isn't one of the call sites #1738 fixed --

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1515,6 +1515,74 @@ fn test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738() -
     Ok(())
 }
 
+/// #1749: `yaml_to_owned_value`'s own `Mapping` arm (`--slurp`/`--eval-all`/
+/// `--inplace`'s DOM fallback) is `YamlCursor`-native, not
+/// `DocumentValue`-generic, so it isn't one of the call sites #1738 fixed --
+/// found while reviewing that PR. Two different complex (non-scalar) keys
+/// both stringify to `""` under yq's own key-display rule (#222); real yq's
+/// streaming output (and succinctly's own, confirmed unaffected by
+/// `test_duplicate_mapping_key_survives_yaml_output`-style checks) just
+/// emits the resulting duplicate key twice, but `OwnedValue::Object`'s
+/// `IndexMap` cannot. Before this fix, `.[0]` here silently returned
+/// `{"": "b"}`, dropping `"a"` with no error at all (exit 0).
+#[test]
+fn test_yaml_native_dom_raises_on_colliding_complex_key_1749() -> Result<()> {
+    let yaml = "? [1,2]\n: a\n? [3,4]\n: b\n";
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--slurp"])?;
+    assert_eq!(code, 1, "--slurp should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(".[0]", yaml, &["--eval-all"])?;
+    assert_eq!(code, 1, "--eval-all should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    // `-P` forces the DOM path the same way an assignment or `--arg` would
+    // -- see the #1738 test above's identical note.
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{yaml}")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg("-P")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        !output.status.success(),
+        "--inplace -P should raise, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("ambiguous"),
+        "expected an 'ambiguous' error, got: {stderr}"
+    );
+
+    Ok(())
+}
+
+/// #1749 sibling: an *ordinary* repeated scalar key (neither side complex)
+/// must keep overwriting without complaint through the same DOM path --
+/// only a complex/undecodable key's fallback spelling is refused, matching
+/// #1738's own "ordinary repeat still overwrites" rule for JSON.
+#[test]
+fn test_yaml_native_dom_ordinary_repeated_key_still_overwrites_1749() -> Result<()> {
+    let yaml = "a: 1\na: 2\n";
+
+    let (output, code) = run_yq_stdin(".[0]", yaml, &["--slurp", "-o=json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":2}"#);
+
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
## Summary

`yaml_to_owned_value`'s `Mapping` arm (the DOM materializer backing `--slurp`,
`--eval-all`, and `--inplace`'s DOM fallback path) did a bare
`map.insert(key, value)` with no collision guard. Two different complex
(non-scalar) YAML keys — e.g. two different sequence keys — both stringify to
`""` per #222's own documented key-display rule. Real yq's streaming/DOM
paths keep both entries (its underlying representation isn't a plain map),
but `OwnedValue::Object`'s `IndexMap<String, _>` structurally cannot hold two
entries under one key, so the second insert silently overwrote the first
with no error at all (exit 0):

```console
$ printf '? [1,2]\n: a\n? [3,4]\n: b\n' | succinctly yq --slurp '.[0]' -o=json
{
  "": "b"
}
```

This is a `YamlCursor`-native materializer, not `DocumentValue`-generic, so
it wasn't one of the call sites #1738 (PR #1748) fixed for the analogous
JSON decode-failure case — found while reviewing that PR.

## Approach

Verified against real yq (v4.53.3, `eval-all`/`-i`) before picking a
direction: both keep both entries in a representation succinctly's
`IndexMap`-backed `OwnedValue` can't structurally match, so — matching the
#1642/#1738 precedent for the same class of problem — this raises a clear
error instead of silently dropping, rather than attempting to fake
duplicate-key preservation in a data structure that can't hold it.

- Added `YamlValue::key_string_kind()`, splitting `key_string()`'s own
  classification to also report whether the `""` it returned is a
  **fallback** (complex/undecodable key) rather than a genuine decode —
  mirrors JSON's `key_display_string_kind`.
- Widened `DisplayKeyGuard::check` from `pub(crate)` to `pub` so
  `yq_runner.rs` (a separate binary crate) can drive it directly with YAML's
  own classification, reusing the same collision policy #1642/#1738 already
  established: an **ordinary** repeated genuine key still overwrites
  (matching jq's own last-key-wins), only a fallback-spelling collision on
  either side raises.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green; one
      run hit two spurious `signal 9`-killed child-process failures under
      heavy concurrent-session load on this machine, both confirmed to pass
      in isolation and unrelated to this change — neither test touches YAML
      mapping keys)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Live-verified against `/usr/bin/jq`-equivalent real `yq` v4.53.3 for
      the repro and the direction decision
- [x] Regression tests for: colliding complex keys, colliding decode-failure
      string keys, colliding alias-to-decode-failure-string keys, and an
      ordinary repeated scalar key (confirms it still overwrites, not raises)
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 100% patch coverage
      (18/18 new lines)