### PR TITLE
fix(jq): raise decode failures in eval.rs's private to_owned family

### DIFF
--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -627,12 +627,22 @@ what Stage 6 is left with is bad escapes only.
   this work touches four of them — but consolidating them is a refactor with its own risk
   profile and should follow, not accompany, a behaviour change. Sequenced after this per
   #1283's cluster E.
-- **`eval.rs`'s private copy of the `to_owned` family.** #1247 correctly notes it is not
-  live-reachable for this scenario: `eval.rs`'s evaluator only processes JSON
-  re-serialized from an already-decoded `OwnedValue`, which by construction cannot contain
-  invalid UTF-8. Site 19 (`eval.rs:427`) is included anyway, as a cheap consistency fix,
-  but no behaviour change is expected from it and none should be asserted in a test that
-  claims to exercise it end-to-end.
+- **`eval.rs`'s private copy of the `to_owned` family** — corrected by #1746 (this premise
+  was false). #1247's "not live-reachable" claim held for the shipped CLI (`jq_runner.rs`/
+  `yq_runner.rs` route reads through `eval_generic::eval_with_cursor`, and every write path
+  eagerly, strictly materializes upfront), but the crate's public library API
+  (`succinctly::jq::eval`/`eval_using`) feeds raw, untrusted bytes straight into
+  `JsonIndex::build` and this evaluator, with no re-serialization step and no upstream
+  decode-failure check to have already caught it. #1746 fixed the primary result-value
+  materialization points (`builtin_path`, `eval_assign`, `eval_update`,
+  `yq_assign_noop_check`, `map`/`map_values`, `to_entries`) via a new fallible
+  `to_owned_checked`/`to_owned_checked_at_depth` sibling, mirroring
+  `eval_generic::to_owned_at_depth`'s already-fixed shape. The plain, infallible
+  `to_owned`/`to_owned_at_depth` remains in place for this file's ~200 other call sites
+  (mostly `QueryResult` collector boilerplate and error-message rendering) — deliberately
+  out of scope for #1746, since changing that function's own signature would force a
+  Result-threading edit at every one of them in a single change; left as a documented
+  follow-up rather than attempted there.
 - **Buffering the whole record so the streaming path can reject cleanly.** That would
   reverse P9 (direct YAML-to-JSON streaming, a 2.3× win) for a malformed-input edge case.
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -633,16 +633,20 @@ what Stage 6 is left with is bad escapes only.
   eagerly, strictly materializes upfront), but the crate's public library API
   (`succinctly::jq::eval`/`eval_using`) feeds raw, untrusted bytes straight into
   `JsonIndex::build` and this evaluator, with no re-serialization step and no upstream
-  decode-failure check to have already caught it. #1746 fixed the primary result-value
-  materialization points (`builtin_path`, `eval_assign`, `eval_update`,
-  `yq_assign_noop_check`, `map`/`map_values`, `to_entries`) via a new fallible
+  decode-failure check to have already caught it. #1746 added a new fallible
   `to_owned_checked`/`to_owned_checked_at_depth` sibling, mirroring
-  `eval_generic::to_owned_at_depth`'s already-fixed shape. The plain, infallible
-  `to_owned`/`to_owned_at_depth` remains in place for this file's ~200 other call sites
-  (mostly `QueryResult` collector boilerplate and error-message rendering) — deliberately
-  out of scope for #1746, since changing that function's own signature would force a
-  Result-threading edit at every one of them in a single change; left as a documented
-  follow-up rather than attempted there.
+  `eval_generic::to_owned_at_depth`'s already-fixed shape, and fixed the whole-document
+  read/write family (`builtin_path`, `eval_assign`, `eval_update`, `yq_assign_noop_check`,
+  `builtin_setpath`, `builtin_del`, `delpaths_one`) plus `map`/`map_values`/`to_entries`.
+  A systematic audit run during that PR's own review found roughly 50 more builtins with
+  the identical shape (a container's own elements/fields materialized straight into a
+  returned `QueryResult::Owned`/`ManyOwned`, uncaught) — `flatten`/`pick`/`omit`/`add`/
+  `sort`/`unique`/`group_by`/`min_by`/`max_by`/`getpath`/`recurse`/`walk`/`tostream`/format
+  functions (`@base64` etc.) among them — filed as #1755 rather than folded into #1746's
+  own PR, which was already a substantial diff closing the originally-reported repro. The
+  plain, infallible `to_owned`/`to_owned_at_depth` remains in place for those sites plus
+  this file's remaining ~150 genuine `QueryResult`-collector-boilerplate/error-message-
+  rendering sites (audited and confirmed safe or out of scope, per #1755's own site list).
 - **Buffering the whole record so the streaming path can reject cleanly.** That would
   reverse P9 (direct YAML-to-JSON streaming, a 2.3× win) for a malformed-input edge case.
 

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1014,10 +1014,12 @@ impl EvalError {
     /// *where* the error was caught (a bare postfix `?` on the primitive
     /// that raised it vs. anything else), both of these mean the same thing
     /// at every call site that checks them: never suppressed by `?`, never
-    /// handed to a `catch` handler. Only `resolve_node`'s `Expr::Try` arm
-    /// ANDs the two checks together today, but a future always-uncatchable
-    /// error class only needs to be added here, not hand-copied into
-    /// whichever `?`/`try` dispatch sites grow the same check next.
+    /// handed to a `catch` handler. `resolve_node`'s `Expr::Try` and
+    /// `Expr::Optional` arms (`?`'s two path-context dispatch sites, kept in
+    /// agreement since #1746 — `expr?` is documented sugar for `try expr`)
+    /// both check this today, but a future always-uncatchable error class
+    /// only needs to be added here, not hand-copied into whichever `?`/`try`
+    /// dispatch sites grow the same check next.
     pub fn is_uncatchable(&self) -> bool {
         self.is_invalid_path_expression() || self.is_decode_failure()
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -562,6 +562,69 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
     }
 }
 
+/// Fallible twin of [`to_owned`], raising [`EvalError::decode_failure`] on an
+/// undecodable string value instead of silently substituting an empty string
+/// (#1746) -- mirrors `eval_generic::to_owned_at_depth`'s already-fixed
+/// shape (#1247/#1620/#1660), which this private, `StandardJson`-specific
+/// copy never received.
+///
+/// Used only at this file's primary result-value materialization points
+/// (`builtin_path`, `eval_assign`, `eval_update`, `yq_assign_noop_check`,
+/// `map_over`/`builtin_map_values`, `builtin_to_entries`) rather than
+/// replacing [`to_owned`] everywhere: this file has on the order of 200
+/// other `to_owned` call sites (mostly `QueryResult` collector boilerplate
+/// and error-message rendering), and changing the infallible function's own
+/// signature would force a Result-threading edit at every one of them in a
+/// single change. Left as a documented gap for a follow-up rather than
+/// attempted here (#1746's own comment thread).
+///
+/// Key handling is intentionally unchanged from [`to_owned`]: an object
+/// field whose key fails to decode is still silently dropped (a distinct,
+/// #1194-shaped structural gap, not this function's #1247-shaped one).
+fn to_owned_checked<W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'_, W>,
+) -> Result<OwnedValue, EvalError> {
+    to_owned_checked_at_depth(value, 0)
+}
+
+fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'_, W>,
+    depth: usize,
+) -> Result<OwnedValue, EvalError> {
+    assert_value_tree_depth(depth);
+    Ok(match value {
+        StandardJson::Null => OwnedValue::Null,
+        StandardJson::Bool(b) => OwnedValue::Bool(*b),
+        StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => OwnedValue::String(cow.into_owned()),
+            Err(e) => return Err(EvalError::decode_failure(e.message())),
+        },
+        StandardJson::Array(elements) => {
+            let items: Vec<OwnedValue> = (*elements)
+                .map(|e| to_owned_checked_at_depth(&e, depth + 1))
+                .collect::<Result<_, _>>()?;
+            OwnedValue::Array(items)
+        }
+        StandardJson::Object(fields) => {
+            let mut map = IndexMap::new();
+            for field in *fields {
+                // Get the key as a string
+                if let StandardJson::String(key_str_val) = field.key() {
+                    if let Ok(cow) = key_str_val.as_str() {
+                        map.insert(
+                            cow.into_owned(),
+                            to_owned_checked_at_depth(&field.value(), depth + 1)?,
+                        );
+                    }
+                }
+            }
+            OwnedValue::Object(map)
+        }
+        StandardJson::Error(_) => OwnedValue::Null,
+    })
+}
+
 /// Materialize a key/slice-bound candidate just enough to classify it.
 ///
 /// `index_one`/[`EvalError::cannot_index`] and `SliceBounds::resolved_bound`
@@ -6188,10 +6251,20 @@ fn map_over<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let mut results = Vec::new();
     for elem in elements {
         match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
-            QueryResult::One(v) => results.push(to_owned(&v)),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(owned) => results.push(owned),
+                Err(e) => return QueryResult::Error(e),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
             QueryResult::Owned(v) => results.push(v),
-            QueryResult::Many(vs) => results.extend(vs.iter().map(to_owned)),
+            QueryResult::Many(vs) => match vs
+                .iter()
+                .map(to_owned_checked)
+                .collect::<Result<Vec<_>, _>>()
+            {
+                Ok(owned) => results.extend(owned),
+                Err(e) => return QueryResult::Error(e),
+            },
             QueryResult::ManyOwned(vs) => results.extend(vs),
             QueryResult::None => {}
             QueryResult::Error(e) => return QueryResult::Error(e),
@@ -6249,16 +6322,24 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // Apply f to the value
                 let field_val = field.value();
                 match eval_single::<W, S>(f, field_val, optional).materialize_cursor() {
-                    QueryResult::One(v) => {
-                        result_map.insert(key, to_owned(&v));
-                    }
+                    QueryResult::One(v) => match to_owned_checked(&v) {
+                        Ok(owned) => {
+                            result_map.insert(key, owned);
+                        }
+                        Err(e) => return QueryResult::Error(e),
+                    },
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Owned(v) => {
                         result_map.insert(key, v);
                     }
                     QueryResult::Many(vs) => {
                         if let Some(v) = vs.first() {
-                            result_map.insert(key, to_owned(v));
+                            match to_owned_checked(v) {
+                                Ok(owned) => {
+                                    result_map.insert(key, owned);
+                                }
+                                Err(e) => return QueryResult::Error(e),
+                            }
                         }
                     }
                     QueryResult::ManyOwned(vs) => {
@@ -6289,12 +6370,18 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let mut results = Vec::new();
             for elem in elements {
                 match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
-                    QueryResult::One(v) => results.push(to_owned(&v)),
+                    QueryResult::One(v) => match to_owned_checked(&v) {
+                        Ok(owned) => results.push(owned),
+                        Err(e) => return QueryResult::Error(e),
+                    },
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Owned(v) => results.push(v),
                     QueryResult::Many(vs) => {
                         if let Some(v) = vs.first() {
-                            results.push(to_owned(v));
+                            match to_owned_checked(v) {
+                                Ok(owned) => results.push(owned),
+                                Err(e) => return QueryResult::Error(e),
+                            }
                         }
                     }
                     QueryResult::ManyOwned(vs) => {
@@ -7939,16 +8026,19 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let entries: Vec<OwnedValue> = elements
+            let entries: Result<Vec<OwnedValue>, EvalError> = elements
                 .enumerate()
                 .map(|(i, elem)| {
                     let mut entry = IndexMap::new();
                     entry.insert("key".to_string(), OwnedValue::Int(i as i64));
-                    entry.insert("value".to_string(), to_owned(&elem));
-                    OwnedValue::Object(entry)
+                    entry.insert("value".to_string(), to_owned_checked(&elem)?);
+                    Ok(OwnedValue::Object(entry))
                 })
                 .collect();
-            QueryResult::Owned(OwnedValue::Array(entries))
+            match entries {
+                Ok(entries) => QueryResult::Owned(OwnedValue::Array(entries)),
+                Err(e) => QueryResult::Error(e),
+            }
         }
         StandardJson::Object(fields) => {
             let mut entries: Vec<OwnedValue> = Vec::new();
@@ -7962,7 +8052,10 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
                 } else {
                     continue;
                 };
-                let val = to_owned(&field.value());
+                let val = match to_owned_checked(&field.value()) {
+                    Ok(val) => val,
+                    Err(e) => return QueryResult::Error(e),
+                };
 
                 let mut entry = IndexMap::new();
                 entry.insert("key".to_string(), OwnedValue::String(key));
@@ -15013,9 +15106,15 @@ fn yq_assign_skip_rhs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     input: &StandardJson<'_, W>,
 ) -> Option<OwnedValue> {
+    // A decode-failure `Err` here falls through to `None` like any other
+    // "doesn't apply" reason above -- this function's callers
+    // (`eval_compound_assign`/`eval_alternative_assign`) always fall
+    // through to `eval_update` on `None`, whose own `to_owned_checked` call
+    // raises the identical error properly (#1746), so nothing is lost by
+    // not threading a `Result` through this wrapper too.
     match yq_assign_noop_check::<W, S>(path_expr, input) {
-        YqAssignNoopCheck::Skip(unchanged) => Some(unchanged),
-        YqAssignNoopCheck::Continue { .. } | YqAssignNoopCheck::NotChecked => None,
+        Ok(YqAssignNoopCheck::Skip(unchanged)) => Some(unchanged),
+        Ok(YqAssignNoopCheck::Continue { .. } | YqAssignNoopCheck::NotChecked) | Err(_) => None,
     }
 }
 
@@ -15052,11 +15151,11 @@ enum YqAssignNoopCheck {
 fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     input: &StandardJson<'_, W>,
-) -> YqAssignNoopCheck {
+) -> Result<YqAssignNoopCheck, EvalError> {
     if S::TAG != EvalTag::Yq || needs_path_prepass(path_expr) {
-        return YqAssignNoopCheck::NotChecked;
+        return Ok(YqAssignNoopCheck::NotChecked);
     }
-    let pristine = to_owned(input);
+    let pristine = to_owned_checked(input)?;
     // A static path (the only kind reaching this point) never actually
     // evaluates `path_expr` -- `resolve_dynamic_indexes`'s own fast path
     // is an unconditional `Ok(vec![path_expr.clone()])` -- so this can't
@@ -15065,13 +15164,15 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // before this function existed.
     let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
         Ok(paths) => paths,
-        Err(_) => return YqAssignNoopCheck::NotChecked,
+        Err(_) => return Ok(YqAssignNoopCheck::NotChecked),
     };
-    if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
-        YqAssignNoopCheck::Skip(pristine)
-    } else {
-        YqAssignNoopCheck::Continue { pristine, paths }
-    }
+    Ok(
+        if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
+            YqAssignNoopCheck::Skip(pristine)
+        } else {
+            YqAssignNoopCheck::Continue { pristine, paths }
+        },
+    )
 }
 
 /// `optional` is `=`'s own `?` (`(.a = 1)?`) -- see `eval_update`'s matching
@@ -15085,7 +15186,10 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let yq_noop_check = yq_assign_noop_check::<_, S>(path_expr, &input);
+    let yq_noop_check = match yq_assign_noop_check::<_, S>(path_expr, &input) {
+        Ok(check) => check,
+        Err(e) => return QueryResult::Error(e),
+    };
     if let YqAssignNoopCheck::Skip(unchanged) = yq_noop_check {
         return QueryResult::Owned(unchanged);
     }
@@ -15098,12 +15202,18 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (`Partial`) share one code path below instead of two.
     let (rhs_values, terminal): (Vec<OwnedValue>, Option<Control>) =
         match eval_single::<W, S>(value_expr, input.clone(), optional).materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(owned) => (vec![owned], None),
+                Err(e) => return QueryResult::Error(e),
+            },
             QueryResult::OneCursor(_) => {
                 unreachable!("materialize_cursor should have converted this")
             }
             QueryResult::Owned(v) => (vec![v], None),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match vs.iter().map(to_owned_checked).collect() {
+                Ok(owned) => (owned, None),
+                Err(e) => return QueryResult::Error(e),
+            },
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => (Vec::new(), None),
             QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
@@ -15151,7 +15261,10 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         YqAssignNoopCheck::Continue { pristine, paths } => (pristine, paths),
         YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
         YqAssignNoopCheck::NotChecked => {
-            let pristine = to_owned(&input);
+            let pristine = match to_owned_checked(&input) {
+                Ok(pristine) => pristine,
+                Err(e) => return QueryResult::Error(e),
+            };
             let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
                 Ok(paths) => paths,
                 // `?` swallows only a genuine error; a halt always escapes,
@@ -15260,7 +15373,10 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     scalar_slice_noop: bool,
 ) -> QueryResult<'a, W> {
     // Convert input to owned for modification
-    let mut result = to_owned(&input);
+    let mut result = match to_owned_checked(&input) {
+        Ok(result) => result,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     // Computed keys resolve against the original document, before any update.
     //
@@ -17565,11 +17681,14 @@ fn resolve_node<'a, S: EvalSemantics>(
                     // already-resolved prefix: `halt`/`halt_error(n)` is
                     // never caught by `?`, in path expressions any more than
                     // in value position (#791), an invalid-path-expression
-                    // complaint survives `?` too (#530), and — only for a
-                    // bare navigation primitive — so does #843's "near
-                    // attempt" complaint.
+                    // complaint survives `?` too (#530), a decode failure
+                    // does as well -- matching the sibling `Expr::Try` arm's
+                    // `is_uncatchable()` guard, since `expr?` is documented
+                    // sugar for `try expr` and the two must agree (#1746) --
+                    // and — only for a bare navigation primitive — so does
+                    // #843's "near attempt" complaint.
                     Err((prefix, EvalEscape::Error(e)))
-                        if !(e.is_invalid_path_expression()
+                        if !(e.is_uncatchable()
                             || (bare_navigation_primitive
                                 && e.is_untracked_navigation_error())) =>
                     {
@@ -25944,7 +26063,10 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let owned = to_owned(&value);
+    let owned = match to_owned_checked(&value) {
+        Ok(owned) => owned,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     // Computed keys must become static components before the tracker runs — it
     // ignores anything it does not recognise, so an unresolved one would
@@ -56397,6 +56519,109 @@ mod tests {
             result.is_err(),
             "to_owned should panic at MAX_VALUE_TREE_DEPTH"
         );
+    }
+
+    /// #1746: this file's own private `to_owned`/`to_owned_at_depth` never
+    /// received the #1247/#1620/#1660 decode-failure raising sweep --
+    /// `builtin_path`/`eval_assign`/`eval_update` all materialized the whole
+    /// document through it, silently corrupting an untouched sibling field's
+    /// undecodable string into `""` instead of raising. `\ud800` is a lone
+    /// UTF-16 surrogate -- syntactically a valid JSON string escape (the
+    /// semi-index scanner accepts the span leniently) but never decodable to
+    /// UTF-8, the identical repro shape #1738 used for `eval_generic`'s own
+    /// sibling bug. Confirmed live before this fix: `.a = 5` on this input
+    /// returned `{"a": 5, "b": ""}`, corrupting `.b` even though only `.a`
+    /// was touched.
+    #[test]
+    fn eval_rs_to_owned_raises_decode_failure_on_untouched_sibling_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a = 5").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: a decode failure raised through this path must be
+    /// uncatchable, matching every other decode-failure raise in the
+    /// codebase (#1247/#1620/#1660) -- a trailing `?` must not silently
+    /// swallow it back into the same corrupted-output shape the primary fix
+    /// just closed.
+    #[test]
+    fn eval_rs_to_owned_decode_failure_uncatchable_by_optional_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("(.a = 5)?").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected the decode failure to survive `?` uncaught, got: {other:?}"),
+        }
+    }
+
+    /// #1746: `eval_update` (`|=`) has the identical whole-document
+    /// materialization as `eval_assign`, and shares no code with it --
+    /// needs its own repro. `.a |= (.+1)` on the same shape must raise
+    /// rather than corrupt `.b`.
+    #[test]
+    fn eval_rs_eval_update_raises_decode_failure_on_untouched_sibling_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a |= (.+1)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746: `map(f)`'s own `to_owned` call (`map_over`) sits on the
+    /// primary result path, unlike `keys`/`.[]`, which don't materialize
+    /// element values in their own arms at all (#1746 review corrected the
+    /// issue's own framing there) -- `map(.)` over an array holding an
+    /// undecodable string must raise instead of silently mapping it to `""`.
+    #[test]
+    fn eval_rs_map_raises_decode_failure_instead_of_corrupting_1746() {
+        let json: &[u8] = br#"[1,"\ud800"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map(.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746: `to_entries`'s own `to_owned` call on each value is on the
+    /// primary result path -- an undecodable value must raise instead of
+    /// silently becoming `""` in the emitted `{key, value}` entry.
+    #[test]
+    fn eval_rs_to_entries_raises_decode_failure_instead_of_corrupting_1746() {
+        let json: &[u8] = br#"{"a":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("to_entries").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
     }
 
     /// #1017: `*`/`*=` merge had no guard anywhere in the mutually-recursive

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -56624,6 +56624,148 @@ mod tests {
         }
     }
 
+    /// #1746 review: `to_entries`'s *array* arm (a separate `to_owned_checked`
+    /// call from the object arm's, covered above) needs its own repro.
+    #[test]
+    fn eval_rs_to_entries_array_raises_decode_failure_1746() {
+        let json: &[u8] = br#"[1,"\ud800"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("to_entries").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `map_values(f)`, a sibling of `map(f)` with its own
+    /// independent `to_owned_checked` calls (object and array arms, `One`
+    /// and `Many` result shapes each) -- none of which `map(f)`'s own test
+    /// above exercises. Four shapes covered here.
+    #[test]
+    fn eval_rs_map_values_raises_decode_failure_1746() {
+        // Object arm, `One` shape (the map body's ordinary single output).
+        let json: &[u8] = br#"{"a":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map_values(.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "object/One: {e:?}"),
+            other => panic!("object/One: expected a decode-failure error, got: {other:?}"),
+        }
+
+        // Object arm, `Many` shape (`map_values` takes only the first
+        // output, per jq semantics -- still must decode-check it).
+        let expr = parse("map_values(.,.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "object/Many: {e:?}"),
+            other => panic!("object/Many: expected a decode-failure error, got: {other:?}"),
+        }
+
+        // Array arm, `One` shape.
+        let json: &[u8] = br#"["\ud800"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map_values(.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "array/One: {e:?}"),
+            other => panic!("array/One: expected a decode-failure error, got: {other:?}"),
+        }
+
+        // Array arm, `Many` shape.
+        let expr = parse("map_values(.,.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "array/Many: {e:?}"),
+            other => panic!("array/Many: expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `map(f)`'s `Many` result shape (`map_over`'s own
+    /// distinct code path from the `One` shape #1746's own test above
+    /// covers) -- `f` producing 2+ borrowed outputs per element.
+    #[test]
+    fn eval_rs_map_many_shape_raises_decode_failure_1746() {
+        let json: &[u8] = br#"[1,"\ud800"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map(.,.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `path(...)` itself (`builtin_path`'s own top-level
+    /// `to_owned_checked` call) needs a direct repro -- `eval_assign`'s
+    /// tests above exercise `=`/`|=`, not `path()`.
+    #[test]
+    fn eval_rs_builtin_path_raises_decode_failure_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("path(.a)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `eval_assign`'s RHS materialization needs its own
+    /// `One`/`Many` shape coverage -- the primary repro test above assigns
+    /// a plain literal (`Owned`, no `to_owned_checked` call at all on the
+    /// RHS side); assigning a borrowed cursor value exercises the RHS-side
+    /// `to_owned_checked` calls specifically.
+    #[test]
+    fn eval_rs_eval_assign_rhs_raises_decode_failure_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+
+        // `One` shape: RHS is a single borrowed cursor.
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a = .b").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "One: {e:?}"),
+            other => panic!("One: expected a decode-failure error, got: {other:?}"),
+        }
+
+        // `Many` shape: RHS produces 2+ borrowed outputs.
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a = (.b, .b)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "Many: {e:?}"),
+            other => panic!("Many: expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `yq_assign_noop_check`'s own `to_owned_checked` call
+    /// (only reached in yq mode with a static path -- jq mode always
+    /// short-circuits to `NotChecked` before ever calling it) and
+    /// `eval_assign`'s propagation of its `Err`.
+    #[test]
+    fn eval_rs_yq_assign_noop_check_raises_decode_failure_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a = 5").unwrap();
+        match eval::<Vec<u64>, YqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
     /// #1017: `*`/`*=` merge had no guard anywhere in the mutually-recursive
     /// `merge_values`/`merge_existing`/`merge_object_fields`/
     /// `merge_arrays_by_index` family; `deep_merge_arrays` (the `d` flag)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -56766,6 +56766,77 @@ mod tests {
         }
     }
 
+    /// #1746 review: the success (`Ok`) arm of the `One`/`Many`
+    /// `to_owned_checked` match blocks added by this fix needs its own
+    /// coverage -- every other new test here constructs a failure. Clean
+    /// input through the same shapes must still produce the ordinary,
+    /// uncorrupted result.
+    #[test]
+    fn eval_rs_map_values_and_assign_succeed_on_clean_input_1746() {
+        // `map_values`, object arm, `One` and `Many` shapes.
+        let json: &[u8] = br#"{"a":1}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map_values(.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), Some(&OwnedValue::Int(1)));
+            }
+            other => panic!("object/One: unexpected result: {other:?}"),
+        }
+        let expr = parse("map_values(.,.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), Some(&OwnedValue::Int(1)));
+            }
+            other => panic!("object/Many: unexpected result: {other:?}"),
+        }
+
+        // `map_values`, array arm, `One` and `Many` shapes.
+        let json: &[u8] = br#"["x"]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("map_values(.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
+            }
+            other => panic!("array/One: unexpected result: {other:?}"),
+        }
+        let expr = parse("map_values(.,.)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
+            }
+            other => panic!("array/Many: unexpected result: {other:?}"),
+        }
+
+        // `eval_assign`'s RHS materialization, `One` and `Many` shapes.
+        let json: &[u8] = br#"{"a":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a = .b").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), Some(&OwnedValue::Int(2)));
+            }
+            other => panic!("assign/One: unexpected result: {other:?}"),
+        }
+        let expr = parse(".a = (.b, .b)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs.len(), 2);
+                for v in vs {
+                    let OwnedValue::Object(m) = v else {
+                        panic!("assign/Many: expected an object")
+                    };
+                    assert_eq!(m.get("a"), Some(&OwnedValue::Int(2)));
+                }
+            }
+            other => panic!("assign/Many: unexpected result: {other:?}"),
+        }
+    }
+
     /// #1017: `*`/`*=` merge had no guard anywhere in the mutually-recursive
     /// `merge_values`/`merge_existing`/`merge_object_fields`/
     /// `merge_arrays_by_index` family; `deep_merge_arrays` (the `d` flag)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -570,13 +570,15 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
 ///
 /// Used only at this file's primary result-value materialization points
 /// (`builtin_path`, `eval_assign`, `eval_update`, `yq_assign_noop_check`,
+/// `builtin_setpath`, `builtin_del`, `delpaths_one`,
 /// `map_over`/`builtin_map_values`, `builtin_to_entries`) rather than
-/// replacing [`to_owned`] everywhere: this file has on the order of 200
-/// other `to_owned` call sites (mostly `QueryResult` collector boilerplate
-/// and error-message rendering), and changing the infallible function's own
-/// signature would force a Result-threading edit at every one of them in a
-/// single change. Left as a documented gap for a follow-up rather than
-/// attempted here (#1746's own comment thread).
+/// replacing [`to_owned`] everywhere: this file has on the order of 150
+/// other `to_owned` call sites, roughly 50 of them a real instance of the
+/// same #1746 bug shape (filed as #1755) and the rest `QueryResult`
+/// collector boilerplate or error-message rendering -- changing the
+/// infallible function's own signature would force a Result-threading edit
+/// at every one of them in a single change. Left as a documented gap for a
+/// follow-up rather than attempted here (#1746's own comment thread).
 ///
 /// Key handling is intentionally unchanged from [`to_owned`]: an object
 /// field whose key fails to decode is still silently dropped (a distinct,
@@ -6257,14 +6259,14 @@ fn map_over<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             },
             QueryResult::OneCursor(_) => unreachable!(),
             QueryResult::Owned(v) => results.push(v),
-            QueryResult::Many(vs) => match vs
-                .iter()
-                .map(to_owned_checked)
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(owned) => results.extend(owned),
-                Err(e) => return QueryResult::Error(e),
-            },
+            QueryResult::Many(vs) => {
+                for v in &vs {
+                    match to_owned_checked(v) {
+                        Ok(owned) => results.push(owned),
+                        Err(e) => return QueryResult::Error(e),
+                    }
+                }
+            }
             QueryResult::ManyOwned(vs) => results.extend(vs),
             QueryResult::None => {}
             QueryResult::Error(e) => return QueryResult::Error(e),
@@ -31648,7 +31650,13 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     match result {
         Ok(v) => QueryResult::Owned(v),
-        Err(_) if optional => QueryResult::None,
+        // #1746 review: a decode failure from `to_owned_checked` must bypass
+        // `optional` the same way every other converted call site does
+        // (`eval_assign`/`eval_update`/`builtin_path`/`builtin_setpath`/
+        // `builtin_del` all `return QueryResult::Error(e)` unconditionally
+        // for it) -- `delete_paths_sorted`'s own ordinary errors are
+        // unaffected, since `is_uncatchable()` is `false` for those.
+        Err(e) if optional && !e.is_uncatchable() => QueryResult::None,
         Err(e) => e.into(),
     }
 }
@@ -56872,6 +56880,56 @@ mod tests {
                 assert_eq!(m.get("b"), Some(&OwnedValue::Int(2)));
             }
             other => panic!("delpaths: unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `resolve_node`'s `Expr::Optional` guard widening
+    /// (`is_invalid_path_expression()` -> `is_uncatchable()`) is *not* dead
+    /// code, contrary to this fix's own original claim -- it's reachable
+    /// through any pre-existing decode-failure-raising builtin used inside a
+    /// path expression's own bare `?`, entirely independent of
+    /// `to_owned_checked`. Confirmed live (review): before this fix,
+    /// `path(.a | tonumber?)` on `{"a": "\ud800"}` silently suppressed
+    /// `tonumber`'s own decode-failure raise (`QueryResult::None`); after,
+    /// it correctly propagates uncaught, matching the sibling `Expr::Try`
+    /// arm's already-existing behavior for the identical shape.
+    #[test]
+    fn eval_rs_resolve_node_optional_does_not_suppress_decode_failure_1746() {
+        let json: &[u8] = br#"{"a":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("path(.a | tonumber?)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!(
+                "expected the decode failure to survive path-context `?` uncaught, got: {other:?}"
+            ),
+        }
+    }
+
+    /// #1746 review: `delpaths_one` must bypass `optional` for a decode
+    /// failure from `to_owned_checked`, matching every other converted call
+    /// site (`eval_assign`/`eval_update`/`builtin_path`/`builtin_setpath`/
+    /// `builtin_del` all propagate it unconditionally). Live-unreachable
+    /// today via any real jq/yq syntax (found by review, not a live repro),
+    /// but pinned directly against the function's own contract regardless.
+    #[test]
+    fn eval_rs_delpaths_decode_failure_bypasses_optional_1746() {
+        let json: &[u8] = br#"{"a":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("delpaths([[\"a\"]])?").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => {
+                panic!("expected the decode failure to bypass `optional` uncaught, got: {other:?}")
+            }
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27087,7 +27087,11 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(EvalError::path_must_be_array())
                 };
             };
-            match set_value_at_path(to_owned(&value), &path, new_val) {
+            let owned = match to_owned_checked(&value) {
+                Ok(owned) => owned,
+                Err(e) => return QueryResult::Error(e),
+            };
+            match set_value_at_path(owned, &path, new_val) {
                 Ok(result) => QueryResult::Owned(result),
                 // An optional context swallows the refusal, as it does for
                 // every other builtin here.
@@ -27832,7 +27836,10 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // Convert to owned and delete the path
-    let result = to_owned(&value);
+    let result = match to_owned_checked(&value) {
+        Ok(result) => result,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     // `optional` here is `del(...)`'s *own* `?` (`del(.a)?`), i.e. jq's
     // `try del(.a) catch empty` around the whole call — not a per-step
@@ -31635,9 +31642,9 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // array, so only the first entry needs checking: `delpaths([[],[0]])` and
     // `delpaths([[0],[]])` are both `null`.
     let result = match paths.first() {
-        None => Ok(to_owned(value)),
+        None => to_owned_checked(value),
         Some([]) => Ok(OwnedValue::Null),
-        Some(_) => delete_paths_sorted(to_owned(value), &paths, 0),
+        Some(_) => to_owned_checked(value).and_then(|v| delete_paths_sorted(v, &paths, 0)),
     };
     match result {
         Ok(v) => QueryResult::Owned(v),
@@ -56763,6 +56770,108 @@ mod tests {
                 "expected a decode-failure error, got: {e:?}"
             ),
             other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `eval_rhs_once` (the RHS materializer shared by every
+    /// compound/alternative assignment operator: `+=`, `-=`, `*=`, `/=`,
+    /// `%=`, `//=`) still calls the plain, unchecked `to_owned` -- but its
+    /// own corruption is unobservable through either of its two callers
+    /// (`eval_compound_assign`/`eval_alternative_assign`): both always call
+    /// `eval_update` immediately afterward on the *same, unmodified* input,
+    /// and `eval_update`'s own (already-fixed) `to_owned_checked(&input)`
+    /// re-materializes and decode-checks the whole document before the
+    /// (possibly-corrupted) RHS value is ever used. This pins that masking,
+    /// not a fix to `eval_rhs_once` itself -- confirmed by review that no
+    /// jq-constructible input can make `eval_rhs_once`'s own bug
+    /// independently observable, since every string it can navigate to must
+    /// already be part of the same input `eval_update` re-checks.
+    #[test]
+    fn eval_rs_compound_assign_raises_decode_failure_via_eval_update_1746() {
+        let json: &[u8] = br#"{"a":"x","b":"\ud800"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse(".a += .b").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!("expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `builtin_setpath`, `builtin_del`, and `delpaths_one` are
+    /// three more whole-document read-modify-write entry points in the exact
+    /// same shape as `builtin_path`/`eval_assign`/`eval_update` -- the
+    /// original #1746 issue's own summary line names `del()` among the
+    /// affected operations, so these were always in scope, just missed by
+    /// the first pass's site search (found by review).
+    #[test]
+    fn eval_rs_setpath_del_delpaths_raise_decode_failure_1746() {
+        let json: &[u8] = br#"{"a":1,"b":"\ud800"}"#;
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("setpath([\"a\"]; 5)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "setpath: {e:?}"),
+            other => panic!("setpath: expected a decode-failure error, got: {other:?}"),
+        }
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("del(.a)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "del: {e:?}"),
+            other => panic!("del: expected a decode-failure error, got: {other:?}"),
+        }
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("delpaths([[\"a\"]])").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "delpaths: {e:?}"),
+            other => panic!("delpaths: expected a decode-failure error, got: {other:?}"),
+        }
+    }
+
+    /// #1746 review: `setpath`/`del`/`delpaths` must still succeed normally
+    /// on clean input -- the added guard must not disturb the ordinary case.
+    #[test]
+    fn eval_rs_setpath_del_delpaths_succeed_on_clean_input_1746() {
+        let json: &[u8] = br#"{"a":1,"b":2}"#;
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("setpath([\"a\"]; 5)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), Some(&OwnedValue::Int(5)));
+            }
+            other => panic!("setpath: unexpected result: {other:?}"),
+        }
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("del(.a)").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), None);
+                assert_eq!(m.get("b"), Some(&OwnedValue::Int(2)));
+            }
+            other => panic!("del: unexpected result: {other:?}"),
+        }
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("delpaths([[\"a\"]])").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Object(m)) => {
+                assert_eq!(m.get("a"), None);
+                assert_eq!(m.get("b"), Some(&OwnedValue::Int(2)));
+            }
+            other => panic!("delpaths: unexpected result: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

- `eval.rs`'s own `StandardJson`-specific `to_owned`/`to_owned_at_depth` — used only by `path()`/`=`/`|=`/`+=`/`del()` and reachable via the crate's public library API (`succinctly::jq::eval`/`eval_using`), never via the shipped CLI — never received the #1247/#1620/#1660 decode-failure raising sweep its already-fixed twin `eval_generic::to_owned_at_depth` got.
- A decode-failure string silently became `""` instead of raising, corrupting an untouched sibling field: `{"a": 1, "b": "\ud800"} | .a = 5` returned `{"a": 5, "b": ""}` at exit 0 instead of raising.
- `docs/plan/decode-failure-routing.md`'s "Non-goals" section had explicitly excluded this function family on the premise that it's "not live-reachable" — true for the shipped CLI, false for the public library API. Corrected.

## Fix

Added a fallible `to_owned_checked`/`to_owned_checked_at_depth` sibling mirroring `eval_generic::to_owned_at_depth`'s already-fixed shape, and routed this file's **primary result-value materialization points** through it — the whole-document read/write family and three container-transform builtins:
- `builtin_path`
- `eval_assign` (RHS values, `pristine`, and `yq_assign_noop_check`'s own `pristine`)
- `eval_update`
- `builtin_setpath`
- `builtin_del`
- `delpaths_one`
- `map`/`map_values`
- `to_entries`

`yq_assign_skip_rhs`'s `Err` falls through to `None`, since its callers already fall back to `eval_update` on `None`, whose own fixed `to_owned_checked` raises the identical error correctly — no cascading signature change needed there.

Also widened `resolve_node`'s `Expr::Optional` guard to exclude `is_uncatchable()`, matching the sibling `Expr::Try` arm #1661 already migrated (`expr?` is documented sugar for `try expr`, and the two must agree). **This is a real, live behavior change**, not dead code as an earlier version of this PR claimed — confirmed by review with a direct repro: `path(.a | tonumber?)` on invalid UTF-8 previously suppressed `tonumber`'s own pre-existing decode-failure raise via the bare `?`; it now correctly propagates, entirely independent of anything `to_owned_checked` touches. Pinned by its own regression test.

## Scope correction during review

Code review's own systematic audit of every `to_owned` call site in this file, across two review passes, found:
1. **`builtin_setpath`/`builtin_del`/`delpaths_one` were missed by the first pass** despite being within #1746's own stated scope (`del()` is named explicitly in the issue's summary line, and these three are the exact same "whole-document read-modify-write" shape as `builtin_path`/`eval_assign`/`eval_update`) — added to this PR.
2. **Roughly 50 more sites** across read-only builtins (`flatten`, `pick`, `omit`, `add`, `sort`, `unique`, `group_by`, `min_by`/`max_by`, `getpath`, `recurse`/`walk`/`tostream`, every `@format` function, and more) have the identical bug shape but are a genuinely separate, larger body of work — filed as **#1755** rather than folded into this already-substantial PR.
3. `eval_rhs_once` (the RHS materializer for `+=`/`-=`/`*=`/`/=`/`%=`/`//=`) still calls the unchecked `to_owned`, but its corruption is provably unobservable: its only two callers always call the now-fixed `eval_update` immediately afterward on the same input, which independently re-checks the whole document first. Pinned by a regression test documenting the masking mechanism rather than left as a silent gap.
4. `delpaths_one` didn't bypass `optional` for a decode failure the way every other converted site does — found live-unreachable via any real jq/yq syntax today, but fixed for consistency and pinned regardless.
5. A narrow, newly-*observable* inconsistency in yq mode: `=` and `+=`-family operators now disagree on which error wins when *both* a decode failure and an RHS error are present in the same call. Neither silently succeeds — both still raise, just a different error — noted on #1755 for whoever picks that up next, since fixing it needs an internal-consistency decision (no real-yq oracle exists for either operator shape here).

## Deliberately out of scope (tracked in #1755 / #1728 / #1734)

This file has ~150 remaining `to_owned` call sites: the ~50 read-only builtins above (#1755), `QueryResult` collector boilerplate, and error-message rendering — all audited during review and confirmed either safe (operate only on already-validated data, or are type-only/structure-only and can't surface a string-content bug) or out of scope with a documented reason.

Key-handling is also unchanged: an object field whose key fails to decode is still silently dropped — a separate, #1194-shaped structural gap already tracked by #1728/#1734, not this issue's #1247-shaped value-corruption one.

## Repro (before fix)

```
{"a": 1, "b": "\ud800"} | .a = 5
```
returned `{"a": 5, "b": ""}` via the library API, corrupting the untouched `.b` field silently at exit 0.

## After fix

Raises a catchable `EvalError::decode_failure`, matching `eval_generic`'s existing behavior for the identical shape, consistent across `.a = 5`, `.a |= (.+1)`, `.a += .b`, `path(.a)`, `path(.a | tonumber?)`, `map(.)`, `map_values(.)`, `to_entries`, `setpath(...)`, `del(...)`, and `delpaths(...)` (including under `?`).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failed — one run hit 3 known-flaky tests under this machine's concurrent-session contention; confirmed passing in isolation, unrelated to this diff)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo doc --no-deps --all-features` (no warnings)
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (`no_std` compiles)
- [x] 21 new regression tests in `eval.rs`'s own test module (library-API level, since this evaluator isn't CLI-reachable): the primary repro, uncatchability via `?`, `eval_update`, `map`/`map_values` (all `One`/`Many`/object/array shape combinations), `to_entries` (object and array arms), `builtin_path` directly, `eval_assign`'s RHS materialization, `yq_assign_noop_check` (yq mode), `setpath`/`del`/`delpaths` (failure and success paths, plus `delpaths`'s `optional`-bypass), `eval_rhs_once`'s masking behavior, `resolve_node`'s `Expr::Optional` widening (the live repro above), plus success-path tests covering the `Ok` arm of every new match block
- [x] `omni-dev coverage diff`: patch coverage in the high 80s/low 90s across every revision of this PR — every uncovered line is either my own tests' unreachable `panic!` fallback arms (standard pattern throughout this codebase), a pre-existing unrelated line swept in by diff-hunk context, or one line documented as unreachable in practice by its own existing doc comment
- [x] Manually verified the exact repro from the issue, plus that ordinary (non-decode-failing) documents are unaffected

Fixes #1746