### PR TITLE
docs(jq,yq): fix ADR-0018 rule 4's stale three-conditions count

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -5,7 +5,7 @@
 This page records how closely succinctly's evaluator reproduces jq's *error messages*,
 measured against the pinned `jq` binary rather than asserted. It is one of the two pages
 [ADR-0018](../../adrs/adr-0018.md) obliges: that record makes jq-fidelity the rule for jq
-mode, permits divergence only under three named conditions, and requires every divergence to
+mode, permits divergence only under four named conditions, and requires every divergence to
 be written down — so **this page is the enumeration of exceptions to ADR-0018** for jq mode,
 as [yq Limitations](../yq/limitations.md) is for yq mode. Since
 [#158](https://github.com/rust-works/succinctly/issues/158) bound the raised value as
@@ -1309,7 +1309,7 @@ abort-on-parse-error for every ordinary evaluation error, not just a decode fail
 [#1247](https://github.com/rust-works/succinctly/issues/1247)'s own design doc
 ([`docs/plan/decode-failure-routing.md`](../../plan/decode-failure-routing.md), Stage 4)
 calls succinctly's behaviour "the more useful of the two" and treats it as settled — but
-none of ADR-0018's three permitted conditions actually cover it (the output is readable,
+none of ADR-0018's four permitted conditions actually cover it (the output is readable,
 nothing is corrupted or discarded, and the process does not die either way), so per rule 4
 it is recorded here as a still-open policy question, matching
 [yq Limitations](../yq/limitations.md)'s "Merge-flag `+` and `d` combined" precedent for a

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -6,7 +6,7 @@ This page records where `succinctly yq` behaves differently from `mikefarah/yq`,
 It is the yq-mode counterpart to
 [jq Error Message Conformance](../jq/limitations.md), and it exists because
 [ADR-0018](../../adrs/adr-0018.md) requires it: that record makes yq-fidelity the rule for
-yq mode, permits divergence only under three named conditions, and obliges every divergence
+yq mode, permits divergence only under four named conditions, and obliges every divergence
 to be written down. **This page is the enumeration of exceptions to ADR-0018.** A divergence
 that is not recorded here is not a decision — it is a bug nobody has found yet.
 
@@ -42,7 +42,7 @@ manifest to close this hole is worth its own issue.
 ## Deliberate divergences (ADR-0018 rule 4)
 
 These are the cases where succinctly knowingly does not match real yq. Each is measured
-against the three permitted conditions — including the one below that fails them, which is
+against the four permitted conditions — including the one below that fails them, which is
 labelled as such rather than grandfathered.
 
 ### Anchor soundness: never emit YAML we cannot read back — rule 4(a)
@@ -158,7 +158,7 @@ $ succinctly yq -o=json -I=0 '.a *=+d .b | .a' arr.yaml # [1,2,3,4]
 
 This was accepted as a "documented simplification" of behaviour that is surprising and
 untested upstream. Under ADR-0018 rule 4 that is **not** a valid justification — the output
-is readable, no data is corrupted and no process dies, so none of the three conditions
+is readable, no data is corrupted and no process dies, so none of the four conditions
 applies. It is recorded here as a divergence to be either fixed or re-justified, not as a
 settled decision. The plain (non-combined) flags all match real yq:
 

--- a/docs/plan/jq-duplicate-key-collapse.md
+++ b/docs/plan/jq-duplicate-key-collapse.md
@@ -44,7 +44,7 @@ same document, and `map_values(.)` — a no-op transform — changes the key cou
 document cannot both have two keys and three. This is why "record it as a semi-indexing
 divergence" is not available: it would mean documenting a contradiction. ADR-0018 rule 4 closes
 the door from the other side — "our architecture makes it awkward" is explicitly not one of the
-three admissible divergence justifications.
+four admissible divergence justifications.
 
 This producer is the root of seven symptom issues patched one consumer at a time: #443, #442,
 #478, #1251, #1170 on the jq side; #1342/#1343/#1344 on the yq side.
@@ -289,7 +289,7 @@ repetition, so drift cancels, median of the per-repetition ratios) gave:
 
 Call it **4-6% on jq-mode streaming output over object-heavy JSON, and free on `length`**.
 
-**This misses the ≤2% target.** It is shipped anyway: ADR-0018 rule 4 admits three grounds for
+**This misses the ≤2% target.** It is shipped anyway: ADR-0018 rule 4 admits four grounds for
 diverging from the reference and performance is not among them, so the choice was never
 "collapse or stay fast" but "how cheaply can the collapse be made". `length` is free because
 the evaluator already walked the field list; the residue is entirely the printer's, which is


### PR DESCRIPTION
## Summary

ADR-0018 was amended (#1501) to add a fourth carve-out to rule 4, condition (d) ("the
reference's semantics have no expressible equivalent in any dependency that clears the
project's portability bar"). The ADR itself now correctly says "four named conditions,"
but the two compliance pages that summarize rule 4 for readers
(`docs/compliance/jq/limitations.md`, `docs/compliance/yq/limitations.md`) were never
updated to match — they still said "three" at all 5 sites, contradicting their own
governing ADR.

One of the two `jq/limitations.md` citations had also drifted from line 1173 (the issue's
own citation) to line 1312 by the time this was picked up — expected churn in this
fast-moving repo, re-found by grepping the actual stale-text phrase rather than trusting
the stale line numbers.

Swept both files afterward for any other place implicitly assuming only three conditions
exist (per the issue's own suggestion); found none — every other "three" mention in
either file is unrelated (gate predicates, string-search builtins, benchmark reps, etc).

Neither file contains an enumerated (a)/(b)/(c) list of the conditions themselves — only
count references — so there was no list to extend with condition (d), just the 5 count
mentions to correct.

Closes #1730.

## Test plan

- [x] `cargo build --features cli` (docs-only change; sanity build to confirm nothing else
      touched)
- [x] Grepped both files for every remaining "three ... condition" occurrence post-fix —
      none found
- [x] Grepped both files for every "four ... condition" occurrence post-fix — all 5
      expected sites present