### PR TITLE
fix(yq): place color reset before terminator in evaluated YAML output

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -102,6 +102,20 @@ impl<W: Write> ColorSink<'_, W> {
             boundaries.push(buf.len());
         }
     }
+
+    /// Writes a streamed result's terminator through whichever mode `self`
+    /// is in: records a boundary for `colorize_yaml` to place later when
+    /// `Buffered`, or writes it immediately when `Direct` -- so a caller
+    /// never needs its own `use_color` check to pick between the two, only
+    /// `ColorSink`'s own variant (which already reflects it).
+    fn write_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
+        if matches!(self, ColorSink::Buffered(..)) {
+            self.record_boundary();
+            Ok(())
+        } else {
+            terminator.write_fmt(self)
+        }
+    }
 }
 
 /// Streams through `render` directly when `use_color` is false. When true,
@@ -2841,24 +2855,37 @@ fn compact_item_opens_with_key(rest_of_line: &str) -> bool {
 /// (the identity/DOM paths, which write their terminator directly outside
 /// any buffer) passes an empty slice, and `yaml` is colorized exactly as
 /// before.
+// `close_and_terminate!`'s state resets are dead in its post-loop drain call
+// (nothing reads `at_key_start`/`escape_next` after the function returns,
+// and only the drain's *last* iteration's `trailing_reset_needed` write
+// matters) but live in its main-loop call -- sharing one macro definition
+// between both call sites is worth the otherwise-harmless dead stores.
+#[allow(unused_assignments)]
 fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> String {
-    let mut result = String::with_capacity(yaml.len() * 2 + boundaries.len() * 4);
+    let mut result = String::with_capacity(yaml.len() * 2 + boundaries.len() * 5);
     let mut in_string = false;
     let mut escape_next = false;
     let mut at_key_start = true;
     let mut in_key = false;
     let mut boundary_idx = 0;
     let mut byte_pos = 0usize;
+    // Whether the unconditional trailing reset below is still needed.
+    // `close_and_terminate!` (a boundary was just closed) clears it; any
+    // subsequently pushed content sets it again. Stays `true` throughout
+    // when `boundaries` is empty (the identity/DOM callers), so behaves
+    // exactly as before this mechanism existed for them.
+    let mut trailing_reset_needed = true;
 
-    let mut chars = yaml.chars();
-    while let Some(c) = chars.next() {
-        while boundary_idx < boundaries.len() && boundaries[boundary_idx] <= byte_pos {
-            // One recorded boundary per streamed result, so this correctly
-            // places every terminator in a multi-result stream, not just
-            // the last one -- and closes both spans a boundary can land
-            // inside (a still-open key *or* string color), not just
-            // `in_key`, so a leftover open span from one result can never
-            // bleed its missing reset into the next.
+    // One recorded boundary per streamed result, so this correctly places
+    // every terminator in a multi-result stream, not just the last one --
+    // and closes both spans a boundary can land inside (a still-open key
+    // *or* string color), not just `in_key`, so a leftover open span from
+    // one result can never bleed its missing reset into the next. A single
+    // definition (rather than duplicating this at both call sites below)
+    // keeps the in-loop and post-loop drains from drifting apart on a
+    // future edit.
+    macro_rules! close_and_terminate {
+        () => {
             if in_key || in_string {
                 result.push_str("\x1b[0m");
                 in_key = false;
@@ -2867,8 +2894,20 @@ fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> St
             let _ = terminator.write_fmt(&mut result);
             at_key_start = true;
             escape_next = false;
+            trailing_reset_needed = false;
+        };
+    }
+
+    let mut chars = yaml.chars();
+    while let Some(c) = chars.next() {
+        while boundary_idx < boundaries.len() && boundaries[boundary_idx] <= byte_pos {
+            close_and_terminate!();
             boundary_idx += 1;
         }
+        // Real content follows -- if a boundary just fired above, its
+        // terminator is no longer the buffer's final byte, so the trailing
+        // safety-net reset is needed again.
+        trailing_reset_needed = true;
 
         if escape_next {
             result.push(c);
@@ -2945,15 +2984,17 @@ fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> St
     while boundary_idx < boundaries.len() {
         // A boundary at (or past) the very end of `yaml` -- e.g. the last
         // streamed result's terminator, with no further content after it.
-        if in_key || in_string {
-            result.push_str("\x1b[0m");
-            in_key = false;
-            in_string = false;
-        }
-        let _ = terminator.write_fmt(&mut result);
+        close_and_terminate!();
         boundary_idx += 1;
     }
-    result.push_str("\x1b[0m");
+    // Skipped when the buffer's last write was already a boundary's own
+    // terminator (the ordinary case for every M2 evaluated-color result) --
+    // otherwise this would place a redundant reset *after* that terminator,
+    // the same "reset must precede terminator" defect #1708 was filed for,
+    // just relocated to the tail of the buffer instead of the middle.
+    if trailing_reset_needed {
+        result.push_str("\x1b[0m");
+    }
     result
 }
 
@@ -3691,12 +3732,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
                             result.stream_yaml(out, yaml_indent, sort_keys, |w| {
-                                if $use_color {
-                                    w.record_boundary();
-                                    Ok(())
-                                } else {
-                                    terminator.write_fmt(w)
-                                }
+                                w.write_terminator(terminator)
                             })
                         },
                     )?;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -107,8 +107,11 @@ impl<W: Write> ColorSink<'_, W> {
     /// is in: records a boundary for `colorize_yaml` to place later when
     /// `Buffered`, or writes it immediately when `Direct` -- so a caller
     /// never needs its own `use_color` check to pick between the two, only
-    /// `ColorSink`'s own variant (which already reflects it).
-    fn write_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
+    /// `ColorSink`'s own variant (which already reflects it). Named
+    /// distinctly from the free [`write_terminator`] function (which writes
+    /// to the real `$writer`/`OutputConfig` outside any `ColorSink` at all)
+    /// to keep the two apart when searching this file.
+    fn write_result_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
         if matches!(self, ColorSink::Buffered(..)) {
             self.record_boundary();
             Ok(())
@@ -2855,12 +2858,18 @@ fn compact_item_opens_with_key(rest_of_line: &str) -> bool {
 /// (the identity/DOM paths, which write their terminator directly outside
 /// any buffer) passes an empty slice, and `yaml` is colorized exactly as
 /// before.
-// `close_and_terminate!`'s state resets are dead in its post-loop drain call
-// (nothing reads `at_key_start`/`escape_next` after the function returns,
-// and only the drain's *last* iteration's `trailing_reset_needed` write
-// matters) but live in its main-loop call -- sharing one macro definition
-// between both call sites is worth the otherwise-harmless dead stores.
-#[allow(unused_assignments)]
+// A per-statement `#[allow]` on a `close_and_terminate!()` invocation below
+// doesn't reach the assignments the macro expands to (rustc: "will be
+// ignored, since it's applied to the macro invocation"), so this covers the
+// whole function instead.
+#[allow(unused_assignments)] // STYLE-0004: close_and_terminate!'s state
+                             // resets serve its two call sites asymmetrically -- `at_key_start`/
+                             // `escape_next` are read by the main loop below but dead at the trailing
+                             // drain (nothing reads them after this function returns), while
+                             // `trailing_reset_needed` is read by the final check below but dead inside
+                             // the main loop (unconditionally overwritten by the very next line there).
+                             // Sharing one macro between both sites, rather than hand-duplicating this
+                             // close/terminate logic, is worth the resulting dead stores.
 fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> String {
     let mut result = String::with_capacity(yaml.len() * 2 + boundaries.len() * 5);
     let mut in_string = false;
@@ -3732,7 +3741,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
                             result.stream_yaml(out, yaml_indent, sort_keys, |w| {
-                                w.write_terminator(terminator)
+                                w.write_result_terminator(terminator)
                             })
                         },
                     )?;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -73,15 +73,33 @@ impl<W: Write> core::fmt::Write for FmtWriter<W> {
 /// existing coloring code without teaching the streamers anything about
 /// ANSI codes (#748).
 enum ColorSink<'a, W: Write> {
-    Buffered(String),
+    Buffered(String, Vec<usize>),
     Direct(FmtWriter<&'a mut W>),
 }
 
 impl<W: Write> core::fmt::Write for ColorSink<'_, W> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         match self {
-            ColorSink::Buffered(buf) => buf.write_str(s),
+            ColorSink::Buffered(buf, _) => buf.write_str(s),
             ColorSink::Direct(w) => w.write_str(s),
+        }
+    }
+}
+
+impl<W: Write> ColorSink<'_, W> {
+    /// Records a streamed result's boundary as a byte offset into the
+    /// buffer, instead of writing a real terminator character into it
+    /// (#1708). `colorize_yaml` re-lexes the whole buffer once, at the end,
+    /// and inserts the real terminator at each recorded offset, closing
+    /// whatever color span is still open there first -- which an in-band
+    /// marker character can't do safely, since this crate's own writers can
+    /// and do emit any raw byte (including a chosen marker's own value)
+    /// when the source YAML/JSON explicitly encodes one. A no-op in
+    /// `Direct` mode, whose caller writes its terminator immediately
+    /// instead (see `stream_cursor!`).
+    fn record_boundary(&mut self) {
+        if let ColorSink::Buffered(buf, boundaries) = self {
+            boundaries.push(buf.len());
         }
     }
 }
@@ -93,16 +111,16 @@ impl<W: Write> core::fmt::Write for ColorSink<'_, W> {
 fn stream_maybe_colored<W: Write, T>(
     writer: &mut W,
     use_color: bool,
-    colorize: impl FnOnce(&str) -> String,
+    colorize: impl FnOnce(&str, &[usize]) -> String,
     render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, core::fmt::Error>,
 ) -> anyhow::Result<T> {
     if use_color {
-        let mut sink = ColorSink::Buffered(String::new());
+        let mut sink = ColorSink::Buffered(String::new(), Vec::new());
         let value = render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))?;
-        let ColorSink::Buffered(buf) = sink else {
+        let ColorSink::Buffered(buf, boundaries) = sink else {
             unreachable!("stream_maybe_colored always constructs ColorSink::Buffered here")
         };
-        write!(writer, "{}", colorize(&buf))?;
+        write!(writer, "{}", colorize(&buf, &boundaries))?;
         Ok(value)
     } else {
         let mut sink = ColorSink::Direct(FmtWriter(writer));
@@ -2026,32 +2044,6 @@ impl Terminator {
             Self::None => Ok(()),
         }
     }
-
-    /// A marker character `colorize_yaml` recognizes and substitutes for
-    /// the real terminator, closing any color span still open at that exact
-    /// position first (#1708). Distinct from either real terminator value
-    /// (`\0`, `\n`) so a colored NUL-output result can't be confused with
-    /// this marker; a C0 control character no valid, correctly-escaped
-    /// YAML/JSON string scalar can contain raw (real ones are written as
-    /// `\0`/`\uXXXX` escapes by this crate's own writers), so it can't
-    /// collide with ordinary rendered content either.
-    const SENTINEL: char = '\u{1}';
-
-    /// Writes [`Self::SENTINEL`] instead of the real terminator, for the
-    /// evaluated-and-colored M2 path only (#1708) -- `colorize_yaml`
-    /// recognizes the marker and substitutes the real terminator itself,
-    /// correctly placed relative to whatever color span is open at that
-    /// point in the buffer. Every other caller (the identity path's direct
-    /// `write_io`, and the non-colored evaluated path, neither of which
-    /// buffers through a re-lexing colorizer) keeps using [`Self::write_fmt`]
-    /// unchanged.
-    fn write_sentinel<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
-        if matches!(self, Self::None) {
-            Ok(())
-        } else {
-            writer.write_char(Self::SENTINEL)
-        }
-    }
 }
 
 /// Write the appropriate line terminator based on output config.
@@ -2157,9 +2149,9 @@ fn output_value<W: Write>(
             body
         };
         if config.use_color {
-            // No sentinel appears here -- `write_terminator` below writes
+            // No boundary recorded here -- `write_terminator` below writes
             // directly to `writer`, outside this buffer (#1708).
-            write!(writer, "{}", colorize_yaml(&output, Terminator::None))?;
+            write!(writer, "{}", colorize_yaml(&output, Terminator::None, &[]))?;
         } else {
             write!(writer, "{output}")?;
         }
@@ -2835,45 +2827,64 @@ fn compact_item_opens_with_key(rest_of_line: &str) -> bool {
 
 /// Colorize YAML output (basic ANSI colors).
 ///
-/// `terminator` is only consulted at a [`Terminator::SENTINEL`] marker
-/// (#1708) -- everywhere else in `yaml` is colorized exactly as before.
-fn colorize_yaml(yaml: &str, terminator: Terminator) -> String {
-    let mut result = String::with_capacity(yaml.len() * 2);
+/// `boundaries` are byte offsets into `yaml`, recorded by
+/// [`ColorSink::record_boundary`] instead of writing a real terminator
+/// character into the buffer (#1708): at each one, this closes whatever
+/// color span is still open at that exact position first, then writes the
+/// real terminator -- rather than leaving it for the unconditional trailing
+/// reset below to close, which is what put the terminator *inside* the
+/// color span in the first place. Driving this off recorded positions
+/// rather than an in-band marker character avoids having to pick a marker
+/// guaranteed absent from real content -- this crate's own writers can and
+/// do emit any raw byte, including a chosen marker's own value, when the
+/// source YAML/JSON explicitly encodes one. A caller with nothing to mark
+/// (the identity/DOM paths, which write their terminator directly outside
+/// any buffer) passes an empty slice, and `yaml` is colorized exactly as
+/// before.
+fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> String {
+    let mut result = String::with_capacity(yaml.len() * 2 + boundaries.len() * 4);
     let mut in_string = false;
     let mut escape_next = false;
     let mut at_key_start = true;
     let mut in_key = false;
+    let mut boundary_idx = 0;
+    let mut byte_pos = 0usize;
 
     let mut chars = yaml.chars();
     while let Some(c) = chars.next() {
+        while boundary_idx < boundaries.len() && boundaries[boundary_idx] <= byte_pos {
+            // One recorded boundary per streamed result, so this correctly
+            // places every terminator in a multi-result stream, not just
+            // the last one -- and closes both spans a boundary can land
+            // inside (a still-open key *or* string color), not just
+            // `in_key`, so a leftover open span from one result can never
+            // bleed its missing reset into the next.
+            if in_key || in_string {
+                result.push_str("\x1b[0m");
+                in_key = false;
+                in_string = false;
+            }
+            let _ = terminator.write_fmt(&mut result);
+            at_key_start = true;
+            escape_next = false;
+            boundary_idx += 1;
+        }
+
         if escape_next {
             result.push(c);
             escape_next = false;
+            byte_pos += c.len_utf8();
             continue;
         }
 
         if c == '\\' && (in_string || in_key) {
             result.push(c);
             escape_next = true;
+            byte_pos += c.len_utf8();
             continue;
         }
 
         match c {
-            Terminator::SENTINEL => {
-                // Close whatever span is open at this exact position before
-                // writing the real terminator, rather than leaving it for
-                // the unconditional trailing reset below to close -- which
-                // is what put the terminator *inside* the color span in the
-                // first place (#1708). One marker per streamed result, so
-                // this also correctly places every terminator in a
-                // multi-result stream, not just the last one.
-                if in_key {
-                    result.push_str("\x1b[0m");
-                    in_key = false;
-                }
-                let _ = terminator.write_fmt(&mut result);
-                at_key_start = true;
-            }
             '"' | '\'' => {
                 if in_string {
                     result.push(c);
@@ -2929,6 +2940,18 @@ fn colorize_yaml(yaml: &str, terminator: Terminator) -> String {
                 }
             }
         }
+        byte_pos += c.len_utf8();
+    }
+    while boundary_idx < boundaries.len() {
+        // A boundary at (or past) the very end of `yaml` -- e.g. the last
+        // streamed result's terminator, with no further content after it.
+        if in_key || in_string {
+            result.push_str("\x1b[0m");
+            in_key = false;
+            in_string = false;
+        }
+        let _ = terminator.write_fmt(&mut result);
+        boundary_idx += 1;
     }
     result.push_str("\x1b[0m");
     result
@@ -3622,12 +3645,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $output_config.no_doc,
                         terminator,
                     )?;
-                    // No sentinel here -- the terminator is written directly
-                    // to `$writer` below, outside this buffer (#1708).
+                    // No boundary recorded here -- the terminator is written
+                    // directly to `$writer` below, outside this buffer (#1708).
                     stream_maybe_colored(
                         $writer,
                         $use_color,
-                        |s| colorize_yaml(s, Terminator::None),
+                        |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                         |out| $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys),
                     )?;
                     terminator.write_io($writer)?;
@@ -3655,20 +3678,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // #1708: the per-result terminator write runs *inside*
                     // this buffered render callback, so a real terminator
                     // byte here would become part of what gets colorized --
-                    // write the sentinel marker instead when colorizing, so
-                    // `colorize_yaml` can place the real terminator itself,
-                    // correctly relative to whatever color span is open at
-                    // each result boundary. The non-colored path (`$writer`
-                    // written directly, no buffering) is unaffected and
-                    // still writes the real terminator either way.
+                    // record the result's boundary instead when colorizing,
+                    // so `colorize_yaml` can place the real terminator
+                    // itself afterward, correctly relative to whatever
+                    // color span is open at each result boundary. The
+                    // non-colored path (`$writer` written directly, no
+                    // buffering) is unaffected and still writes the real
+                    // terminator either way.
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
-                        |s| colorize_yaml(s, terminator),
+                        |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
                             result.stream_yaml(out, yaml_indent, sort_keys, |w| {
                                 if $use_color {
-                                    terminator.write_sentinel(w)
+                                    w.record_boundary();
+                                    Ok(())
                                 } else {
                                     terminator.write_fmt(w)
                                 }
@@ -3685,7 +3710,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     stream_maybe_colored(
                         $writer,
                         $use_color,
-                        |s| output::colorize_json(s, &ColorScheme::default()),
+                        |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| $cursor.stream_json(out, json_indent, sort_keys),
                     )?;
                     terminator.write_io($writer)?;
@@ -3700,7 +3725,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
-                        |s| output::colorize_json(s, &ColorScheme::default()),
+                        |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| {
                             result.stream_json(out, json_indent, sort_keys, |w| {
                                 terminator.write_fmt(w)
@@ -3770,20 +3795,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         if is_identity {
                             // P9 path for identity on single doc
                             if can_yaml_fast_path {
-                                // No sentinel here -- `write_terminator`
-                                // below writes directly, outside this
-                                // buffer (#1708).
+                                // No boundary recorded here --
+                                // `write_terminator` below writes directly,
+                                // outside this buffer (#1708).
                                 stream_maybe_colored(
                                     &mut writer,
                                     output_config.use_color,
-                                    |s| colorize_yaml(s, Terminator::None),
+                                    |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                                     |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
                                 )?;
                             } else {
                                 stream_maybe_colored(
                                     &mut writer,
                                     output_config.use_color,
-                                    |s| output::colorize_json(s, &ColorScheme::default()),
+                                    |s, _boundaries| {
+                                        output::colorize_json(s, &ColorScheme::default())
+                                    },
                                     |out| root.stream_json_document(out, json_indent, sort_keys),
                                 )?;
                             }
@@ -3896,13 +3923,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if is_identity {
                                 // P9 path for identity on single doc
                                 if can_yaml_fast_path {
-                                    // No sentinel here -- `write_terminator`
-                                    // below writes directly, outside this
-                                    // buffer (#1708).
+                                    // No boundary recorded here --
+                                    // `write_terminator` below writes
+                                    // directly, outside this buffer (#1708).
                                     stream_maybe_colored(
                                         &mut writer,
                                         output_config.use_color,
-                                        |s| colorize_yaml(s, Terminator::None),
+                                        |s, boundaries| {
+                                            colorize_yaml(s, Terminator::None, boundaries)
+                                        },
                                         |out| {
                                             root.stream_yaml_document(out, yaml_indent, sort_keys)
                                         },
@@ -3911,7 +3940,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     stream_maybe_colored(
                                         &mut writer,
                                         output_config.use_color,
-                                        |s| output::colorize_json(s, &ColorScheme::default()),
+                                        |s, _boundaries| {
+                                            output::colorize_json(s, &ColorScheme::default())
+                                        },
                                         |out| {
                                             root.stream_json_document(out, json_indent, sort_keys)
                                         },
@@ -4318,7 +4349,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 stream_maybe_colored(
                     &mut writer,
                     output_config.use_color,
-                    |s| output::colorize_json(s, &ColorScheme::default()),
+                    |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                     |out| {
                         stream_json_sequence(
                             cursors.iter().copied(),
@@ -4331,12 +4362,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     },
                 )?;
             } else {
-                // No sentinel here -- `write_terminator` below writes
-                // directly, outside this buffer (#1708).
+                // No boundary recorded here -- `write_terminator` below
+                // writes directly, outside this buffer (#1708).
                 stream_maybe_colored(
                     &mut writer,
                     output_config.use_color,
-                    |s| colorize_yaml(s, Terminator::None),
+                    |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                     |out| {
                         stream_yaml_sequence(
                             cursors.iter().copied(),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2026,6 +2026,32 @@ impl Terminator {
             Self::None => Ok(()),
         }
     }
+
+    /// A marker character `colorize_yaml` recognizes and substitutes for
+    /// the real terminator, closing any color span still open at that exact
+    /// position first (#1708). Distinct from either real terminator value
+    /// (`\0`, `\n`) so a colored NUL-output result can't be confused with
+    /// this marker; a C0 control character no valid, correctly-escaped
+    /// YAML/JSON string scalar can contain raw (real ones are written as
+    /// `\0`/`\uXXXX` escapes by this crate's own writers), so it can't
+    /// collide with ordinary rendered content either.
+    const SENTINEL: char = '\u{1}';
+
+    /// Writes [`Self::SENTINEL`] instead of the real terminator, for the
+    /// evaluated-and-colored M2 path only (#1708) -- `colorize_yaml`
+    /// recognizes the marker and substitutes the real terminator itself,
+    /// correctly placed relative to whatever color span is open at that
+    /// point in the buffer. Every other caller (the identity path's direct
+    /// `write_io`, and the non-colored evaluated path, neither of which
+    /// buffers through a re-lexing colorizer) keeps using [`Self::write_fmt`]
+    /// unchanged.
+    fn write_sentinel<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
+        if matches!(self, Self::None) {
+            Ok(())
+        } else {
+            writer.write_char(Self::SENTINEL)
+        }
+    }
 }
 
 /// Write the appropriate line terminator based on output config.
@@ -2131,7 +2157,9 @@ fn output_value<W: Write>(
             body
         };
         if config.use_color {
-            write!(writer, "{}", colorize_yaml(&output))?;
+            // No sentinel appears here -- `write_terminator` below writes
+            // directly to `writer`, outside this buffer (#1708).
+            write!(writer, "{}", colorize_yaml(&output, Terminator::None))?;
         } else {
             write!(writer, "{output}")?;
         }
@@ -2806,7 +2834,10 @@ fn compact_item_opens_with_key(rest_of_line: &str) -> bool {
 }
 
 /// Colorize YAML output (basic ANSI colors).
-fn colorize_yaml(yaml: &str) -> String {
+///
+/// `terminator` is only consulted at a [`Terminator::SENTINEL`] marker
+/// (#1708) -- everywhere else in `yaml` is colorized exactly as before.
+fn colorize_yaml(yaml: &str, terminator: Terminator) -> String {
     let mut result = String::with_capacity(yaml.len() * 2);
     let mut in_string = false;
     let mut escape_next = false;
@@ -2828,6 +2859,21 @@ fn colorize_yaml(yaml: &str) -> String {
         }
 
         match c {
+            Terminator::SENTINEL => {
+                // Close whatever span is open at this exact position before
+                // writing the real terminator, rather than leaving it for
+                // the unconditional trailing reset below to close -- which
+                // is what put the terminator *inside* the color span in the
+                // first place (#1708). One marker per streamed result, so
+                // this also correctly places every terminator in a
+                // multi-result stream, not just the last one.
+                if in_key {
+                    result.push_str("\x1b[0m");
+                    in_key = false;
+                }
+                let _ = terminator.write_fmt(&mut result);
+                at_key_start = true;
+            }
             '"' | '\'' => {
                 if in_string {
                     result.push(c);
@@ -3576,9 +3622,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $output_config.no_doc,
                         terminator,
                     )?;
-                    stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
-                        $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys)
-                    })?;
+                    // No sentinel here -- the terminator is written directly
+                    // to `$writer` below, outside this buffer (#1708).
+                    stream_maybe_colored(
+                        $writer,
+                        $use_color,
+                        |s| colorize_yaml(s, Terminator::None),
+                        |out| $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys),
+                    )?;
                     terminator.write_io($writer)?;
                     // Streaming skips evaluation, so inspect the document
                     // value directly to keep `-e` falsy tracking (#178).
@@ -3601,9 +3652,29 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $output_config.no_doc,
                         terminator,
                     )?;
-                    let stats = stream_maybe_colored($writer, $use_color, colorize_yaml, |out| {
-                        result.stream_yaml(out, yaml_indent, sort_keys, |w| terminator.write_fmt(w))
-                    })?;
+                    // #1708: the per-result terminator write runs *inside*
+                    // this buffered render callback, so a real terminator
+                    // byte here would become part of what gets colorized --
+                    // write the sentinel marker instead when colorizing, so
+                    // `colorize_yaml` can place the real terminator itself,
+                    // correctly relative to whatever color span is open at
+                    // each result boundary. The non-colored path (`$writer`
+                    // written directly, no buffering) is unaffected and
+                    // still writes the real terminator either way.
+                    let stats = stream_maybe_colored(
+                        $writer,
+                        $use_color,
+                        |s| colorize_yaml(s, terminator),
+                        |out| {
+                            result.stream_yaml(out, yaml_indent, sort_keys, |w| {
+                                if $use_color {
+                                    terminator.write_sentinel(w)
+                                } else {
+                                    terminator.write_fmt(w)
+                                }
+                            })
+                        },
+                    )?;
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
                 }
@@ -3699,10 +3770,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         if is_identity {
                             // P9 path for identity on single doc
                             if can_yaml_fast_path {
+                                // No sentinel here -- `write_terminator`
+                                // below writes directly, outside this
+                                // buffer (#1708).
                                 stream_maybe_colored(
                                     &mut writer,
                                     output_config.use_color,
-                                    colorize_yaml,
+                                    |s| colorize_yaml(s, Terminator::None),
                                     |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
                                 )?;
                             } else {
@@ -3822,10 +3896,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if is_identity {
                                 // P9 path for identity on single doc
                                 if can_yaml_fast_path {
+                                    // No sentinel here -- `write_terminator`
+                                    // below writes directly, outside this
+                                    // buffer (#1708).
                                     stream_maybe_colored(
                                         &mut writer,
                                         output_config.use_color,
-                                        colorize_yaml,
+                                        |s| colorize_yaml(s, Terminator::None),
                                         |out| {
                                             root.stream_yaml_document(out, yaml_indent, sort_keys)
                                         },
@@ -4254,16 +4331,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     },
                 )?;
             } else {
-                stream_maybe_colored(&mut writer, output_config.use_color, colorize_yaml, |out| {
-                    stream_yaml_sequence(
-                        cursors.iter().copied(),
-                        out,
-                        0,
-                        yaml_indent_spaces,
-                        indent_unit,
-                        sort_keys,
-                    )
-                })?;
+                // No sentinel here -- `write_terminator` below writes
+                // directly, outside this buffer (#1708).
+                stream_maybe_colored(
+                    &mut writer,
+                    output_config.use_color,
+                    |s| colorize_yaml(s, Terminator::None),
+                    |out| {
+                        stream_yaml_sequence(
+                            cursors.iter().copied(),
+                            out,
+                            0,
+                            yaml_indent_spaces,
+                            indent_unit,
+                            sort_keys,
+                        )
+                    },
+                )?;
             }
             // #1701: this fast path streams straight to `&mut writer`
             // (like `stream_cursor!`'s own identity branch), so it needs

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3583,6 +3583,24 @@ fn test_color_terminator_ordering_survives_embedded_control_char_in_value_1708()
     Ok(())
 }
 
+/// #1708 second review pass: `colorize_yaml`'s unconditional trailing reset
+/// used to fire even when the boundary-drain loop just above it had already
+/// closed every span and written the real terminator -- placing a redundant
+/// reset *after* the terminator instead of nothing at all, relocating (not
+/// fixing) the "reset must precede terminator" defect to the tail of the
+/// buffer. The terminator must be the actual last byte of output.
+#[test]
+fn test_color_terminator_ordering_terminator_is_final_byte_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: 1\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.as_bytes().last(),
+        Some(&0u8),
+        "the NUL terminator must be the final byte, got: {output:?}"
+    );
+    Ok(())
+}
+
 /// Same fix, `-0`/`--nul-output` (#1701 code review). Unlike `--join-output`
 /// above, `-0`'s own glued-`---` case was confirmed byte-identical to real
 /// yq's own multi-doc `-0` output -- but real yq can't reparse that output
@@ -6925,9 +6943,14 @@ fn test_color_output_survives_iteration_with_duplicate_keys() -> Result<()> {
 
     let (output, code) = run_yq_stdin(".[]", yaml, &["-C"])?;
     assert_eq!(code, 0);
+    // No trailing `\x1b[0m` after the last result's own newline terminator
+    // (#1708 second review pass): that extra reset used to fire even when
+    // every result's own boundary-close had already emitted one, which is
+    // the same "reset after terminator" defect this issue was filed for,
+    // just for the default newline terminator instead of `-0`'s NUL.
     assert_eq!(
         output,
-        "\u{1b}[36ma\u{1b}[0m: 1\n\u{1b}[36ma\u{1b}[0m: 2\n\u{1b}[36mb\u{1b}[0m: 3\n\u{1b}[0m"
+        "\u{1b}[36ma\u{1b}[0m: 1\n\u{1b}[36ma\u{1b}[0m: 2\n\u{1b}[36mb\u{1b}[0m: 3\n"
     );
 
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3528,6 +3528,61 @@ fn test_color_terminator_ordering_multi_result_1708() -> Result<()> {
     Ok(())
 }
 
+/// #1708 code review: a value whose text contains a literal, unescaped
+/// quote character (an apostrophe inside an already-double-quoted string,
+/// e.g. "it's here") desyncs `colorize_yaml`'s naive quote-toggle tracking
+/// -- without closing *every* open span (not just an open key) at each
+/// result boundary, that desync left a later result's terminator with no
+/// preceding reset at all, the exact bug this issue was filed for.
+#[test]
+fn test_color_terminator_ordering_survives_unbalanced_quote_in_value_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a[]", "a: [\"it's here\", \"second\"]\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    let terminator_positions: Vec<usize> = output.match_indices('\0').map(|(i, _)| i).collect();
+    assert_eq!(
+        terminator_positions.len(),
+        2,
+        "expected two NUL terminators, got: {output:?}"
+    );
+    let mut search_from = 0;
+    for &term_pos in &terminator_positions {
+        let reset_pos = output[search_from..term_pos]
+            .rfind("\x1b[0m")
+            .map(|p| p + search_from);
+        assert!(
+            reset_pos.is_some_and(|p| p < term_pos),
+            "expected a reset code immediately before terminator at {term_pos}, got: {output:?}"
+        );
+        search_from = term_pos + 1;
+    }
+    Ok(())
+}
+
+/// #1708 code review: a value containing a literal `\u{1}` byte -- the
+/// original fix's own marker character -- must not be misread as a
+/// terminator boundary and split one result into two. Recording boundaries
+/// out-of-band (`ColorSink::record_boundary`) rather than via an in-band
+/// marker character removes this collision entirely, regardless of what
+/// byte value the source data happens to contain.
+#[test]
+fn test_color_terminator_ordering_survives_embedded_control_char_in_value_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: \"x\x01y\"\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    let terminator_positions: Vec<usize> = output.match_indices('\0').map(|(i, _)| i).collect();
+    assert_eq!(
+        terminator_positions.len(),
+        1,
+        "a single result must produce exactly one NUL terminator, got: {output:?}"
+    );
+    let term_pos = terminator_positions[0];
+    let reset_pos = output[..term_pos].rfind("\x1b[0m");
+    assert!(
+        reset_pos.is_some_and(|p| p < term_pos),
+        "expected a reset code before the terminator, got: {output:?}"
+    );
+    Ok(())
+}
+
 /// Same fix, `-0`/`--nul-output` (#1701 code review). Unlike `--join-output`
 /// above, `-0`'s own glued-`---` case was confirmed byte-identical to real
 /// yq's own multi-doc `-0` output -- but real yq can't reparse that output

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3441,6 +3441,93 @@ fn test_join_output_multidoc_does_not_corrupt_documents_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1708: `-0`/`--join-output` combined with `-C` (color) on the M2 fast
+/// path's evaluated (non-identity) branch embedded the terminator byte
+/// *inside* the ANSI color span, before the trailing reset code --
+/// `colorize_yaml`'s per-token spans weren't self-closing, so the
+/// terminator (baked into the same buffer that gets colorized as a whole)
+/// ended up sandwiched before the function's one unconditional trailing
+/// reset. The reset must come before the terminator, matching the identity
+/// branch and the DOM path, both already correct.
+#[test]
+fn test_color_terminator_ordering_evaluated_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: 1\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    let reset_pos = output.find("\x1b[0m").expect("expected a reset code");
+    let terminator_pos = output.find('\0').expect("expected a NUL terminator");
+    assert!(
+        reset_pos < terminator_pos,
+        "reset must precede the terminator, got: {output:?}"
+    );
+    Ok(())
+}
+
+/// #1708: the identity branch already placed the terminator correctly --
+/// pinned here as a regression guard, since this fix's own sentinel-marker
+/// mechanism is only wired into the evaluated branch's terminator write.
+#[test]
+fn test_color_terminator_ordering_identity_unaffected_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: 1\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    let reset_pos = output.rfind("\x1b[0m").expect("expected a reset code");
+    let terminator_pos = output.find('\0').expect("expected a NUL terminator");
+    assert!(
+        reset_pos < terminator_pos,
+        "reset must precede the terminator, got: {output:?}"
+    );
+    Ok(())
+}
+
+/// #1708: `-o=json` never had this bug -- `colorize_json`'s per-token spans
+/// already self-close immediately, unlike `colorize_yaml`'s. Pinned as a
+/// regression guard for the (deliberately unmodified) JSON output path.
+#[test]
+fn test_color_terminator_ordering_json_output_unaffected_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: 1\n", &["-o=json", "-C", "-0"])?;
+    assert_eq!(code, 0);
+    let reset_pos = output.find("\x1b[0m").expect("expected a reset code");
+    let terminator_pos = output.find('\0').expect("expected a NUL terminator");
+    assert!(
+        reset_pos < terminator_pos,
+        "reset must precede the terminator, got: {output:?}"
+    );
+    Ok(())
+}
+
+/// #1708: a multi-result evaluated stream must place *every* terminator
+/// correctly, not just the last one -- each result's own color span must
+/// close before its own terminator, not leak into the next result's span
+/// (or get caught by the one trailing reset at the very end of the whole
+/// buffer). This shape was never even attempted by #1701's own terminator
+/// centralization (see this issue's "Why not fixed in #1701's own PR").
+#[test]
+fn test_color_terminator_ordering_multi_result_1708() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a[]", "a: [1, 2]\n", &["-C", "-0"])?;
+    assert_eq!(code, 0);
+    let terminator_positions: Vec<usize> = output.match_indices('\0').map(|(i, _)| i).collect();
+    assert_eq!(
+        terminator_positions.len(),
+        2,
+        "expected two NUL terminators, got: {output:?}"
+    );
+    // Every reset code that precedes a given terminator must actually be
+    // the one guarding *that* terminator's own result -- checked here by
+    // confirming a reset immediately precedes each terminator with no
+    // other terminator in between.
+    let mut search_from = 0;
+    for &term_pos in &terminator_positions {
+        let reset_pos = output[search_from..term_pos]
+            .rfind("\x1b[0m")
+            .map(|p| p + search_from);
+        assert!(
+            reset_pos.is_some_and(|p| p < term_pos),
+            "expected a reset code immediately before terminator at {term_pos}, got: {output:?}"
+        );
+        search_from = term_pos + 1;
+    }
+    Ok(())
+}
+
 /// Same fix, `-0`/`--nul-output` (#1701 code review). Unlike `--join-output`
 /// above, `-0`'s own glued-`---` case was confirmed byte-identical to real
 /// yq's own multi-doc `-0` output -- but real yq can't reparse that output


### PR DESCRIPTION
## Summary

- `colorize_yaml` re-lexes a buffered render and relies on one trailing, unconditional reset code (`\x1b[0m`) to close whatever color span is still open at the end. The M2 evaluated-and-colored streaming path (`stream_cursor!` macro) writes the terminator (NUL or newline) *directly to the real writer*, outside that buffer, after the colorized text has already been flushed — so under `-C -0`/`-C` a still-open color span's reset code could land *after* the terminator instead of before it (e.g. `\x1b[36m1\x00\x1b[0m` instead of `\x1b[36m1\x1b[0m\x00`).
- `colorize_json` does **not** have this bug — verified live (hex-dump comparison) that its token-by-token design already self-closes each span locally, so it needed no change.
- **Fix (revised after code review — see below):** `ColorSink::record_boundary()` records each streamed result's boundary as a byte offset into the buffer (a side `Vec<usize>`), instead of writing any terminator-related byte into the text. `colorize_yaml` takes those offsets directly and, at each one, closes whatever color span is open *there* before writing the real terminator — rather than leaving it for the single trailing reset to close.

### Revision history

The first version of this PR used an in-band sentinel character (`'\u{1}'`) written into the buffer in place of the real terminator, which `colorize_yaml` then recognized and substituted. Code review found two live bugs in that approach:

1. **Sentinel collision**: this crate's own YAML parser passes a literal `U+0001` byte straight through from a double-quoted scalar (`a: "x\x01y"`) — colliding with the marker and splitting one result into two NUL-terminated records.
2. **Incomplete span-closing at the marker**: the sentinel handler only closed an open *key* span, not an open *string* span, so a value with an unescaped apostrophe (e.g. `"it's here"`) desynced `colorize_yaml`'s naive quote-toggle tracking across the boundary — reproducing the exact terminator-before-reset bug on the *next* result in the same buffer.

Both are fixed by dropping the in-band marker entirely in favor of out-of-band boundary tracking, which removes the collision (no byte value needs to be reserved) and closes *every* open span (key or string) at each boundary, isolating each result's coloring from the next regardless of what state the lexer is left in.

## Test plan

- 6 regression tests in `tests/yq_cli_tests.rs`: reset-before-terminator ordering for the evaluated M2 path, identity path unaffected, JSON output path unaffected, correct per-result ordering with multiple `-0`-terminated results, survival of an unbalanced quote/apostrophe in a streamed value (review finding #2), and survival of a literal embedded control-char byte matching the original marker (review finding #1).
- Full local `cargo test --features cli,simd,regex,serde`: 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD/x86 feature-set leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): both clean.
- `cargo doc --no-deps --all-features`, `cargo fmt --check`, `cargo build --no-default-features` (no_std): all clean.
- Patch coverage: 84.72% (61/72 new lines). Every uncovered line is a pre-existing `colorize_yaml`/`colorize_json` call site in a defensive-fallback code path explicitly documented as "rarely if ever reached" (the root cursor always reports its virtual document sequence, so the `_ =>` single-document fallback arms are dead in practice) — the drop from the first version's 89.19% is purely line-count inflation from `rustfmt` wrapping those same call sites' closures across more lines now that they take an extra parameter, not new untested logic. The actual fix logic (`ColorSink::record_boundary`, the boundary-emit loops in `colorize_yaml`) is fully exercised by the 6 tests above.

Fixes #1708