### PR TITLE
fix(yq): yq-locate warns instead of silently disagreeing on bad UTF-8

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -786,9 +786,12 @@ succinctly yq-locate config.yaml --offset 42 --format json
 
 Unlike `succinctly yq`/`yq --validate`/`at_offset`, which all reject a YAML document
 containing invalid UTF-8 at the input boundary, `yq-locate` deliberately keeps answering on
-one: warns to stderr and continues, rather than refusing outright. Asking "what's at byte
-N" of a file a parser just rejected is the normal case for a diagnostic tool, not an edge
-case (#1627).
+one: warns to stderr and continues, rather than refusing outright, for the byte in question
+(#1627). Asking "what's at byte N" of a file a parser just rejected is the normal case for
+a diagnostic tool, not an edge case. This doesn't cover every invalid byte in the document,
+though: if the byte falls inside a *mapping key* on the path to the requested offset, the
+path expression still can't be built at all (a separate, pre-existing limitation in how
+`yq-locate` renders keys, not fixed by #1627) and the command still fails — see #1759.
 
 ---
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -784,6 +784,12 @@ succinctly yq-locate config.yaml --offset 42 --format json
 # Output: {"expression":".users[0].name","type":"string","start":38,"end":52}
 ```
 
+Unlike `succinctly yq`/`yq --validate`/`at_offset`, which all reject a YAML document
+containing invalid UTF-8 at the input boundary, `yq-locate` deliberately keeps answering on
+one: warns to stderr and continues, rather than refusing outright. Asking "what's at byte
+N" of a file a parser just rejected is the normal case for a diagnostic tool, not an edge
+case (#1627).
+
 ---
 
 ## Environment Variables

--- a/src/bin/succinctly/yq_locate.rs
+++ b/src/bin/succinctly/yq_locate.rs
@@ -48,6 +48,17 @@ pub fn run_yq_locate(args: YqLocateArgs) -> Result<i32> {
     let text = std::fs::read(&args.file)
         .with_context(|| format!("Failed to read file: {}", args.file.display()))?;
 
+    // Unlike `yq`/`yq --validate`/`at_offset` (which all reject invalid UTF-8
+    // at the input boundary, #1391/#1242), `yq-locate` keeps answering on an
+    // encoding-invalid document instead of refusing outright (#1627): asking
+    // "what's at byte N" of a file a parser just rejected is the normal case
+    // for a diagnostic tool, not an edge case, so the tool stays useful right
+    // where it's needed most. A stderr warning stops the silent
+    // self-disagreement with the rest of the yq surface without losing that.
+    if let Err(err) = succinctly::text::utf8::validate_utf8(&text) {
+        eprintln!("Warning: input is not valid UTF-8: {err}");
+    }
+
     // Determine the byte offset
     let offset = match (args.offset, args.line, args.column) {
         (Some(off), None, None) => off,

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -148,3 +148,29 @@ fn yq_locate_warns_but_still_answers_on_invalid_utf8() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1759 (found reviewing #1627/PR #1758): the warn-and-keep-answering fix
+/// only covers an invalid byte inside a *value* -- one inside a *mapping
+/// key* on the path to the requested offset still fails outright, since
+/// `path_to_bp` can't build a path expression without decoding every
+/// ancestor key. Pinning this as the current, documented behavior (not the
+/// desired end state -- see #1759) rather than leaving it unasserted.
+#[test]
+fn yq_locate_still_fails_when_invalid_utf8_is_in_an_ancestor_key() -> Result<()> {
+    let mut fixture = tempfile::NamedTempFile::new().expect("create temp fixture");
+    std::io::Write::write_all(&mut fixture, b"a: 1\n\"b\xe4c\": 2\n").expect("write fixture");
+    let path = fixture.path().to_str().expect("utf8 path");
+
+    let (_, stderr, code) = run(&["yq-locate", path, "--offset", "7"])?;
+
+    assert_ne!(code, 0, "expected a failure, got: {stderr}");
+    assert!(
+        stderr.contains("not valid UTF-8"),
+        "expected a UTF-8 warning on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Could not locate position"),
+        "expected a locate failure on stderr, got: {stderr}"
+    );
+    Ok(())
+}

--- a/tests/locate_cli_tests.rs
+++ b/tests/locate_cli_tests.rs
@@ -126,3 +126,25 @@ fn jq_locate_leading_dot_number_byte_range_is_exact() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1627: `yq`/`yq --validate`/`at_offset` all reject an encoding-invalid
+/// document at the input boundary (#1391/#1242), but `yq-locate` -- a
+/// diagnostic tool for "what's at byte N", most useful on exactly the file a
+/// parser just rejected -- deliberately keeps answering instead, warning to
+/// stderr rather than silently disagreeing with the rest of the yq surface.
+#[test]
+fn yq_locate_warns_but_still_answers_on_invalid_utf8() -> Result<()> {
+    let mut fixture = tempfile::NamedTempFile::new().expect("create temp fixture");
+    std::io::Write::write_all(&mut fixture, b"a: 1\nb: \"x\xe4y\"\n").expect("write fixture");
+    let path = fixture.path().to_str().expect("utf8 path");
+
+    let (stdout, stderr, code) = run(&["yq-locate", path, "--offset", "9"])?;
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, ".[0].b");
+    assert!(
+        stderr.contains("not valid UTF-8"),
+        "expected a UTF-8 warning on stderr, got: {stderr}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `succinctly yq`, `yq --validate`, and `at_offset` all reject a YAML document containing invalid UTF-8 at the input boundary (#1391/#1242) — but `yq-locate` (`src/bin/succinctly/yq_locate.rs`) has its own input path that never called `yaml_validate_guard`, so it silently accepted the same document and answered normally. The same navigation feature disagreed with itself depending on which front door was used: `succinctly yq 'at_offset(9)'` rejects a malformed document, `succinctly yq-locate --offset 9` on the identical file answers as if nothing were wrong.
- This is explicitly framed in the issue as a design decision with three options (leave it and document it; make `yq-locate` reject too; warn and keep answering) rather than an obvious bug — there's no oracle to settle it, since `yq-locate` is a succinctly-only extension with no real-yq equivalent. Went with the issue's own recommended option: **warn to stderr, keep answering, exit 0**. `yq-locate` is a diagnostic tool, and asking "what's at byte N" of a file a parser just rejected is the normal case for it, not an edge case — refusing outright would remove the tool exactly when it's most useful. This stops the silent self-disagreement without losing that.

## Test plan

- New regression test `yq_locate_warns_but_still_answers_on_invalid_utf8` in `tests/locate_cli_tests.rs`: confirms exit 0, the correct expression is still returned, and a UTF-8 warning appears on stderr.
- Full local `cargo test --features cli,simd,regex,serde`: 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD/x86 feature-set leg: both clean.
- `cargo doc --no-deps --all-features`, `cargo fmt --check`, `cargo build --no-default-features` (no_std): all clean.
- Patch coverage: 100% (3/3 new lines).
- Documented the deliberate divergence in `docs/guides/cli.md`'s `yq-locate` section.

Fixes #1627