### PR TITLE
docs: add stacked-PR bisectability guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,29 @@ Per #531's timeline, a content-identical amend + force-push and a
 close/reopen did *not* revive triggering, but a real rebase (new commit
 SHAs) did — if you hit this, a rebase is a known workaround.
 
+### Keeping a stacked PR bisectable
+
+CI builds a PR's head commit and the merge queue's replay result — not each
+commit in a multi-commit PR individually. A PR that only compiles once every
+commit is applied, but not partway through the stack, merges cleanly and
+passes every check, yet leaves a broken commit sitting on `main` (#1626: an
+intermediate commit left two CLI call sites unadapted after a signature
+change; the very next commit in the same PR fixed them as an aside, so
+nothing outside that PR ever saw the gap). `git bisect` across that range
+then fails to build instead of answering, at exactly the moment a stray
+build error is most expensive — the natural reading is "the bug is here."
+
+Before pushing a stacked series, check that every commit in it builds on its
+own:
+
+```bash
+git rebase --exec 'cargo check --features cli' -i <base>
+```
+
+This is cheap (`cargo check` doesn't produce a binary) and catches the class
+of gap #1626 found before it reaches `main`, rather than leaving it for a
+future bisector to notice and `git bisect skip` past.
+
 ## Architecture Guidelines
 
 ### Memory Layout


### PR DESCRIPTION
## Summary

`c06f8ad09` on `main` doesn't compile in isolation — it made `effective_keys` fallible and left two CLI call sites unadapted, fixed as an aside by the very next commit in the same PR. CI never caught it because it only builds a PR's head commit and the merge queue's replay result, not each commit individually — so `git bisect` across that range fails to build instead of answering, at exactly the point a stray build error is most expensive.

The issue names three options: rewrite history (ruled out — public repo), add per-commit CI (costs minutes on every stacked PR), or document the habit that avoids it (`git rebase --exec 'cargo check --features cli'` before pushing a stack). Went with the issue's own recommended third option — added a new "Keeping a stacked PR bisectable" subsection to `CONTRIBUTING.md`, right after the existing "Verifying CI actually ran" section.

## Test plan

- `lychee --offline CONTRIBUTING.md`: 0 errors.
- `cargo build --features cli,simd,regex,serde`: clean (no Rust source touched).
- `cargo fmt --check`: clean.

Fixes #1626