### PR TITLE
fix(jq): re-validate an Expr::Comma prefix's terminal check on a later escape

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21211,6 +21211,37 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         Ok(kept)
     }
 
+    /// Same terminal check as [`reject_untracked_at_terminal`], but also run
+    /// over whatever a *later* sibling's own escape stopped resolution with.
+    ///
+    /// jq validates each `Expr::Comma` sibling's path-validity the instant it
+    /// is produced, before the next sibling ever runs (confirmed live:
+    /// `path(.a | (1, error("boom")))` raises "Invalid path expression with
+    /// result 1" -- the first branch's own violation -- and never reaches
+    /// `error("boom")` at all; jq prints nothing to stdout). `resolve_node`'s
+    /// `Expr::Comma` arm cannot replicate that ordering on its own (#986
+    /// Stage 2's reasoning still holds: mid-pipe, it does not yet know
+    /// whether it is terminal), so it always resolves every sibling before
+    /// returning. When a *later* sibling's own escape is what stopped that
+    /// resolution, the branches collected before it still carry whatever an
+    /// earlier, terminal-but-untracked sibling produced -- and without this,
+    /// that branch skips the terminal check an all-`Ok` result gets, both
+    /// surfacing the later sibling's error instead of jq's real one and
+    /// leaking that untracked branch's stale path into the assembled prefix
+    /// (#1560).
+    fn reject_untracked_prefix_too<'a>(
+        result: Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, EvalEscape)>,
+        near_iterate: bool,
+    ) -> Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, EvalEscape)> {
+        match result {
+            Ok(branches) => reject_untracked_at_terminal(branches, near_iterate),
+            Err((prefix, e)) => match reject_untracked_at_terminal(prefix, near_iterate) {
+                Ok(prefix) => Err((prefix, e)),
+                terminal_violation => terminal_violation,
+            },
+        }
+    }
+
     /// Is this a bare trailing iterate — `Expr::Iterate` or
     /// `Expr::Optional(Iterate)` (`.foo[]?`) — the shape `resolve_seq`'s
     /// fan-out loop would otherwise fully enumerate one static `Index`
@@ -21277,8 +21308,7 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         // frozen `$x` snapshot, so ambient `snapshot` starts `false` here,
         // same as it does at this function's other top-level entry point
         // below (#1591).
-        return match resolve_node::<S>(expr, input, true, false)
-            .and_then(|branches| reject_untracked_at_terminal(branches, false))
+        return match reject_untracked_prefix_too(resolve_node::<S>(expr, input, true, false), false)
         {
             Ok(branches) => {
                 if short_circuit_del_root && branches.iter().any(|b| b.path.depth() == 0) {
@@ -21295,9 +21325,7 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         1 => flat.into_iter().next().expect("len checked"),
         _ => Expr::Pipe(flat),
     };
-    match resolve_node::<S>(&reduced_expr, input, true, false)
-        .and_then(|branches| reject_untracked_at_terminal(branches, true))
-    {
+    match reject_untracked_prefix_too(resolve_node::<S>(&reduced_expr, input, true, false), true) {
         Ok(branches) => Ok(assemble(branches)
             .into_iter()
             .map(|e| append_trailing(e, &trailing))
@@ -47686,6 +47714,53 @@ mod tests {
                 QueryResult::Error(e) => assert_eq!(e.message, message, "{filter}")
             );
         }
+    }
+
+    /// #1560: `resolve_dynamic_indexes` only ran its terminal
+    /// untracked-branch check (`reject_untracked_at_terminal`) on
+    /// `resolve_node`'s *Ok* result. When a later `Expr::Comma` sibling's own
+    /// escape stopped resolution first, an earlier sibling's own terminal
+    /// violation -- already sitting in the `Err` prefix -- skipped that check
+    /// entirely: `error("boom")`'s message surfaced instead of jq's real
+    /// "Invalid path expression with result 1", and the untracked branch's
+    /// stale path leaked into the assembled (would-be) prefix.
+    ///
+    /// jq evaluates each comma sibling's path-validity the instant it is
+    /// produced and never reaches a later sibling once an earlier one is
+    /// found invalid -- confirmed live against jq 1.7.1: every filter below
+    /// produces zero stdout lines, only the terminal-check error, regardless
+    /// of which side of the comma the later escape sits on.
+    #[test]
+    fn test_path_comma_terminal_check_wins_over_a_later_siblings_escape_1560() {
+        for filter in [
+            r#"path(.a | (1, error("boom")))"#,
+            r#"path((1, error("boom")))"#,
+            r#"del(.a | (1, error("boom")))"#,
+        ] {
+            query!(br#"{"a":[1,2]}"#, filter,
+                QueryResult::Error(e) => assert_eq!(
+                    e.message, "Invalid path expression with result 1", "{filter}"
+                )
+            );
+        }
+    }
+
+    /// Sibling of the test above: when the *earlier* comma branch is itself
+    /// trackable (a real navigation, not a computed value), the terminal
+    /// check has nothing to object to, and a later sibling's own escape
+    /// surfaces normally -- with whatever resolved before it still kept, per
+    /// #1560's own doc comment on `resolve_dynamic_indexes` ("never un-emit
+    /// an output already produced before a later one errors"). This is the
+    /// existing #986/#1440 behavior `reject_untracked_prefix_too` must not
+    /// disturb.
+    #[test]
+    fn test_path_comma_valid_prefix_keeps_a_later_siblings_own_error_1560() {
+        query!(br#"{"a":1,"b":2}"#, r#"path(.a, error("z"), .b)"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
+                assert_eq!(e.message, "z");
+            }
+        );
     }
 
     /// #861: `path(paths(node_filter))` checks each of `paths(node_filter)`'s

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21229,17 +21229,21 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// surfacing the later sibling's error instead of jq's real one and
     /// leaking that untracked branch's stale path into the assembled prefix
     /// (#1560).
-    fn reject_untracked_prefix_too<'a>(
-        result: Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, EvalEscape)>,
+    fn reject_untracked_prefix_too(
+        result: PathResolveResult<'_>,
         near_iterate: bool,
-    ) -> Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, EvalEscape)> {
-        match result {
-            Ok(branches) => reject_untracked_at_terminal(branches, near_iterate),
-            Err((prefix, e)) => match reject_untracked_at_terminal(prefix, near_iterate) {
-                Ok(prefix) => Err((prefix, e)),
-                terminal_violation => terminal_violation,
-            },
-        }
+    ) -> PathResolveResult<'_> {
+        let (prefix, escape) = match result {
+            Ok(branches) => (branches, None),
+            Err((prefix, e)) => (prefix, Some(e)),
+        };
+        // `?` here is the priority rule: a terminal violation found in
+        // `prefix` propagates immediately, discarding `escape` (a later
+        // sibling's own error/break/halt that never got the chance to run
+        // in real jq either) -- exactly `path_result`'s own `Some`/`None`
+        // combine once a violation-free `prefix` reaches it.
+        let checked = reject_untracked_at_terminal(prefix, near_iterate)?;
+        path_result(checked, escape)
     }
 
     /// Is this a bare trailing iterate — `Expr::Iterate` or

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10390,6 +10390,51 @@ fn test_path_try_catch_handler_halt_keeps_prefix_832() -> Result<()> {
     Ok(())
 }
 
+/// #1560: `resolve_dynamic_indexes`'s terminal untracked-branch check
+/// (`reject_untracked_at_terminal`) used to run only over `resolve_node`'s
+/// *Ok* result. When a later `Expr::Comma` sibling's own escape stopped
+/// resolution first, an earlier sibling's terminal violation — sitting right
+/// there in the `Err` prefix — skipped that check, so `error("boom")`'s
+/// message surfaced instead of jq's real "Invalid path expression with
+/// result 1", with a stale `["a"]` leaking onto stdout besides. Confirmed
+/// against jq 1.7.1: this filter prints nothing and raises the terminal
+/// check's error, never reaching `error("boom")` at all.
+#[test]
+fn test_path_comma_terminal_check_wins_over_a_later_siblings_escape_1560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a | (1, error("boom")))"#],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout, "",
+        "must not leak the untracked branch's stale path"
+    );
+    assert!(
+        stderr.contains("Invalid path expression with result 1"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("boom"), "{stderr}");
+    Ok(())
+}
+
+/// Sibling of the test above: when the *earlier* comma branch is trackable
+/// (a real navigation), the terminal check has nothing to object to, and a
+/// later sibling's own error surfaces normally with whatever resolved
+/// before it kept — the existing #986/#1440 behavior the fix above must not
+/// disturb.
+#[test]
+fn test_path_comma_valid_prefix_keeps_a_later_siblings_own_error_1560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.a, error("z"), .b)"#],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(stderr.contains(": z"), "{stderr}");
+    Ok(())
+}
+
 #[test]
 fn test_limit_n_bound_break_inside_a_path_call_reaches_an_outer_label_824() -> Result<()> {
     // `resolve_limit`'s own `n_expr` evaluation (`limit(n; f)`'s count) sits


### PR DESCRIPTION
## Summary

`resolve_dynamic_indexes` (the top-level entry point for `path()`, `del()`,
`=`, and `|=`) validates that every branch a resolved path expression
produces is "trackable" — a real navigation, not a computed value — via
`reject_untracked_at_terminal`. But it only ran that check on
`resolve_node`'s `Ok` result:

```rust
return match resolve_node::<S>(expr, input, true, false)
    .and_then(|branches| reject_untracked_at_terminal(branches, false))
{ ... }
```

When a later `Expr::Comma` sibling's own escape stops resolution first
(`resolve_node` returns `Err((prefix, e))`), `.and_then` never runs — so an
earlier sibling's own untracked-terminal violation, already sitting right
there in `prefix`, skips the check entirely. The later sibling's error
surfaces instead of jq's real "Invalid path expression" message, and the
untracked branch's stale path leaks into the assembled (would-be) prefix.

```
$ echo '{"a":[1,2]}' | jq -c 'path(.a | (1, error("boom")))'
jq: error (at <stdin>:1): Invalid path expression with result 1   # exit 5, no stdout

$ echo '{"a":[1,2]}' | succinctly-before jq -c 'path(.a | (1, error("boom")))'
jq: error (at <stdin>:1): boom                                    # wrong message
["a"]                                                              # phantom output jq never prints
```

jq validates each comma sibling's path-validity the instant it is produced,
before the next sibling ever runs — so branch 1 (`1`, untracked) is checked
and found invalid before branch 2 (`error("boom")`) is ever evaluated.

## Fix

Added `reject_untracked_prefix_too`, which runs the same terminal check on
an `Err` prefix too — giving an earlier terminal violation priority over a
later sibling's own escape, matching jq's evaluation order. Both call sites
in `resolve_dynamic_indexes` (the ordinary case and the trailing-bare-iterate
case, `near_iterate: true`/`false`) now go through it.

The existing #986 Stage 2 behavior — a *valid* prefix keeps whatever resolved
before a later real error (`path(.a, error("z"), .b)` still prints `["a"]`
then raises `"z"`) — is unaffected; the new check only intervenes when the
prefix itself contains an untracked branch.

## Verification

22-shape live differential sweep against pinned jq 1.7.1 (`/usr/bin/jq`
1.7.1), zero regressions — including the control cases this fix must not
disturb:
- `(.a, 1) | .c` (mid-pipe, non-terminal — #986 Stage 2's own case)
- `path(.a, error("x"))` / `path(.a, .b, error("z"))` / `path(.a, error("z"), .b)` (valid prefix + later real error, both orderings)
- `path((1, error("boom")) | .[])` / `path((error("boom"), 1) | .[])` (the `near_iterate: true` call site)
- `del(.a, 1)`, `(.a, 1) = 5` (the write-side callers of the same function)

## Test plan

- [x] New unit tests in `src/jq/eval.rs`: `test_path_comma_terminal_check_wins_over_a_later_siblings_escape_1560`, `test_path_comma_valid_prefix_keeps_a_later_siblings_own_error_1560`
- [x] New CLI integration tests in `tests/jq_cli_tests.rs` (same two shapes, exercised through the actual binary)
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`): all green, no regressions
- [x] Both required clippy legs clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features` (no_std) still builds

Fixes #1560