### PR TITLE
fix(jq): give needs_path_context an Expr::As arm

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -763,6 +763,13 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // as a known gap rather than paying for a full
         // `expand_func_calls` just to answer this routing question.
         Expr::FuncDef { body, then, .. } => needs_path_context(body) || needs_path_context(then),
+        // `EXPR as $v | body` (#1663): neither `expr` nor `body` navigate
+        // away from the caller's own position -- `eval_as` evaluates both
+        // against the same `value` -- so a `key`/`parent`/`file_index`
+        // inside either one needs the same ambient context the caller has.
+        // This is the single most common trigger for this whole bug class:
+        // `.a.b | . as $x | parent(1)` previously silently stubbed to `{}`.
+        Expr::As { expr, body, .. } => needs_path_context(expr) || needs_path_context(body),
         _ => false,
     }
 }
@@ -25753,6 +25760,102 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     optional,
                 )
             }
+        }
+        Expr::As { expr, var, body } if needs_path_context(expr) || needs_path_context(body) => {
+            // #1663: mirrors `eval_as`'s own owned-value logic (bind
+            // `expr`'s outputs, substitute into `body` per bound value,
+            // evaluate each) but routes both `expr` and the substituted
+            // `body` through this path-context evaluator instead of
+            // `eval_single` -- neither one navigates away from `value`
+            // (both evaluate against the same position `eval_as` itself
+            // uses), so `key`/`parent`/`file_index` inside either sees the
+            // caller's own ambient position, unchanged.
+            //
+            // Unlike the `Array` arm below, `optional` is *not* forced to
+            // `false` here: `eval_as`'s own doc comment establishes that
+            // `as` is deliberately non-atomic under `?` --
+            // `(1,2,error("x")) as $v | $v + 10` keeps `11`, `12` as a real
+            // prefix, unlike `[...]`'s atomicity -- so it's passed straight
+            // through to both evaluations, exactly as `eval_as` does.
+            let bound_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(expr),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
+                match bound_result {
+                    QueryResult::Owned(v) => (vec![v], None),
+                    QueryResult::ManyOwned(vs) => (vs, None),
+                    QueryResult::None => return QueryResult::None,
+                    QueryResult::Error(e) => return QueryResult::Error(e),
+                    QueryResult::Break(label) => return QueryResult::Break(label),
+                    QueryResult::Halt(code) => return QueryResult::Halt(code),
+                    QueryResult::Partial(vs, control) => (vs, Some(control)),
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                };
+
+            let mut all_results: Vec<OwnedValue> = Vec::new();
+            let mut loop_control: Option<Control> = None;
+            for bound_val in bound_values {
+                let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
+                let body_result = eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(&substituted_body),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+                match body_result {
+                    QueryResult::Owned(v) => all_results.push(v),
+                    QueryResult::ManyOwned(vs) => all_results.extend(vs),
+                    QueryResult::None => {}
+                    QueryResult::Error(e) => {
+                        loop_control = Some(Control::Error(e));
+                        break;
+                    }
+                    QueryResult::Break(label) => {
+                        loop_control = Some(Control::Break(label));
+                        break;
+                    }
+                    QueryResult::Halt(code) => {
+                        loop_control = Some(Control::Halt(code));
+                        break;
+                    }
+                    QueryResult::Partial(vs, control) => {
+                        all_results.extend(vs);
+                        loop_control = Some(control);
+                        break;
+                    }
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                }
+            }
+
+            let combined = match loop_control.or(bound_control) {
+                Some(control) => partial(all_results, control),
+                None => owned_vec_to_result(all_results),
+            };
+            continue_rest_with_context::<W, S>(
+                combined,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {
             // Value-constructing expressions reset the path context

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25777,6 +25777,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // `(1,2,error("x")) as $v | $v + 10` keeps `11`, `12` as a real
             // prefix, unlike `[...]`'s atomicity -- so it's passed straight
             // through to both evaluations, exactly as `eval_as` does.
+            //
+            // #1663 code review: uses `materialize_bound_values` (shared
+            // with `each_as`/`each_as_pattern`, #1462) and
+            // `accumulate_path_context_step` (shared with every other
+            // fan-out loop in this function, #715 follow-up) rather than
+            // hand-rolling a 5th/7th copy of either -- both were built
+            // specifically because past copies of this exact unpacking and
+            // accumulate-or-stop shape drifted out of sync with each other.
             let bound_result = eval_pipe_with_path_context_internal::<W, S>(
                 core::slice::from_ref(expr),
                 value,
@@ -25785,25 +25793,21 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 current_path,
                 optional,
             );
-            let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
-                match bound_result {
-                    QueryResult::Owned(v) => (vec![v], None),
-                    QueryResult::ManyOwned(vs) => (vs, None),
-                    QueryResult::None => return QueryResult::None,
-                    QueryResult::Error(e) => return QueryResult::Error(e),
-                    QueryResult::Break(label) => return QueryResult::Break(label),
-                    QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    QueryResult::Partial(vs, control) => (vs, Some(control)),
-                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-                        unreachable!(
-                            "eval_pipe_with_path_context_internal only ever produces \
-                             Owned/ManyOwned/None/Error/Break/Partial"
-                        )
-                    }
-                };
+            let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
+                Ok(pair) => pair,
+                Err(Flow::Exhausted) => return QueryResult::None,
+                Err(Flow::Escaped(Control::Error(e))) => return QueryResult::Error(e),
+                Err(Flow::Escaped(Control::Break(label))) => return QueryResult::Break(label),
+                Err(Flow::Escaped(Control::Halt(code))) => return QueryResult::Halt(code),
+                Err(Flow::Stopped { .. }) => unreachable!(
+                    "materialize_bound_values only ever produces Exhausted/Escaped, \
+                     never Stopped (that variant is sink-driven laziness this eager \
+                     evaluator never uses)"
+                ),
+            };
 
             let mut all_results: Vec<OwnedValue> = Vec::new();
-            let mut loop_control: Option<Control> = None;
+            let mut stopped = None;
             for bound_val in bound_values {
                 let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
                 let body_result = eval_pipe_with_path_context_internal::<W, S>(
@@ -25814,40 +25818,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     current_path,
                     optional,
                 );
-                match body_result {
-                    QueryResult::Owned(v) => all_results.push(v),
-                    QueryResult::ManyOwned(vs) => all_results.extend(vs),
-                    QueryResult::None => {}
-                    QueryResult::Error(e) => {
-                        loop_control = Some(Control::Error(e));
-                        break;
-                    }
-                    QueryResult::Break(label) => {
-                        loop_control = Some(Control::Break(label));
-                        break;
-                    }
-                    QueryResult::Halt(code) => {
-                        loop_control = Some(Control::Halt(code));
-                        break;
-                    }
-                    QueryResult::Partial(vs, control) => {
-                        all_results.extend(vs);
-                        loop_control = Some(control);
-                        break;
-                    }
-                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-                        unreachable!(
-                            "eval_pipe_with_path_context_internal only ever produces \
-                             Owned/ManyOwned/None/Error/Break/Partial"
-                        )
-                    }
+                if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
+                    stopped = Some(stop);
+                    break;
                 }
             }
 
-            let combined = match loop_control.or(bound_control) {
+            let combined = stopped.unwrap_or_else(|| match bound_control {
                 Some(control) => partial(all_results, control),
                 None => owned_vec_to_result(all_results),
-            };
+            });
             continue_rest_with_context::<W, S>(
                 combined,
                 rest,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6683,6 +6683,79 @@ fn test_as_path_context_builtin_prefix_preserving_not_atomic_1663() -> Result<()
     assert_eq!(code, 9);
     assert_eq!(stdout.trim(), r#""a""#);
 
+    // A bare `halt_error` from the *bind* expression, with no successful
+    // output preceding it -- the bind match's own bare-`Halt` arm, sibling
+    // to the bare-`Error`/bare-`Break` cases already exercised above.
+    // `key`'s value ("a") never becomes a bound value here -- it's
+    // `halt_error`'s own input (piped straight into it), so it prints to
+    // *stderr* as `halt_error`'s own message, not stdout (confirmed live,
+    // and matching real jq's own identically-shaped behavior).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | (key | halt_error(9)) as $x | $x"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+    assert_eq!(stderr.trim(), "a");
+
+    Ok(())
+}
+
+/// #1663: exercises the *body*-loop's own match arms specifically (as
+/// opposed to the bind-expression match the previous test already covers)
+/// -- a single bound value whose *body* evaluation produces multiple
+/// outputs, zero outputs, a bare break, a bare halt, or its own
+/// prefix-plus-control `Partial`, none of which the previous test's
+/// single-output bodies reach.
+#[test]
+fn test_as_path_context_builtin_body_loop_arms_1663() -> Result<()> {
+    // Body produces more than one output for its single bound value --
+    // `ManyOwned`, not `Owned`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | . as $x | (key, key)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"a\"\n\"a\"\n");
+
+    // Body produces zero outputs for its single bound value (`select`
+    // filters it out) -- `None`, not an error.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | . as $x | select(key == \"z\")"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // A bare `break` from the *body* itself (no prior output from this
+    // body), unwinding to the enclosing label.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | (.a | . as $x | (key | break $out))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "", "break from the body must discard, not emit");
+
+    // A bare `halt_error` from the *body* itself. Same reasoning as the
+    // sibling bind-expression case above: `key`'s value ("a") is
+    // `halt_error`'s own input, printed to stderr as its message, not
+    // through the body's own normal stdout output path.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | . as $x | (key | halt_error(9))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout, "");
+    assert_eq!(stderr.trim(), "a");
+
+    // The body itself produces a real prefix before erroring -- the body
+    // loop's own `Partial(_, Control::Error(_))` arm, distinct from the
+    // bind-expression's identically-shaped arm the previous test covers.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | . as $x | (key, error(\"boom\"))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout.trim(), r#""a""#);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6518,6 +6518,220 @@ fn test_if_path_context_many_owned_continuation_stops_mid_loop_1409() -> Result<
     Ok(())
 }
 
+/// `needs_path_context` had no `Expr::As` arm (#1663), so `EXPR as $v |
+/// body` -- the ordinary jq variable-binding idiom, not some rare shape --
+/// silently lost path context whenever `key`/`parent`/`file_index`
+/// appeared in either `EXPR` or `body`. This is the single most
+/// consequential case in #1663's own filing: `.a.b | . as $x | parent(1)`
+/// returned `{}` instead of `{"b":1}`. Unlike #1302's `Array`/#1334's
+/// `StringInterpolation`, neither `expr` nor `body` navigate away from the
+/// caller's own position -- `eval_as` (the pre-existing, non-path-context
+/// evaluator) already evaluates both against the same `value` -- so `rest`
+/// after the whole `as` expression sees the *same*, unreset position too
+/// (`continue_rest_with_context`, not `continue_rest_with_fresh_root`).
+/// Verified live against real yq v4.53.3 (`key`/`parent` are succinctly
+/// extensions with no real-jq equivalent, so jq mode here pins internal
+/// consistency against yq's own oracle, not jq's).
+#[test]
+fn test_as_path_context_builtins_1663() -> Result<()> {
+    // The issue's own headline repro.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b | . as $x | parent(1)"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"b":1}"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | . as $x | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    // Multiple builtins and a deeper `parent(n)`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b.c | . as $x | [key, parent(2)]"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["c",{"b":{"c":1}}]"#);
+
+    // `rest` after the whole `as` expression sees the *unreset* position --
+    // the opposite of #1302/#1334's fresh-root behavior, and the reason
+    // this arm calls `continue_rest_with_context` rather than
+    // `continue_rest_with_fresh_root`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b | (. as $x | $x) | key"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""b""#);
+
+    // Nested `as` expressions, path context threading through both levels.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b | . as $x | . as $y | key"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""b""#);
+
+    // A plain `as` (no path-context builtin in either half) takes the
+    // original, unmodified code path and must be entirely unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a as $x | $x + 1"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+
+    Ok(())
+}
+
+/// #1663: unlike #1302's `Array` (atomic construction) or #1334's
+/// `StringInterpolation`, `as` is deliberately *non-atomic*: `eval_as`'s own
+/// doc comment establishes that `(1,2,error("x")) as $v | $v + 10` keeps
+/// `11`, `12` as a real prefix before the error, matching jq's own
+/// generator-processes-each-bound-value-as-produced semantics. Every case
+/// below is a `key`-substituted mirror of a `1`-only query already run
+/// against the pre-existing `eval_as` path, confirming the new path-context
+/// arm reproduces the exact same prefix-preserving behavior rather than
+/// accidentally becoming atomic like `Array` did.
+#[test]
+fn test_as_path_context_builtin_prefix_preserving_not_atomic_1663() -> Result<()> {
+    // Zero outputs from the bind expression -> zero outputs overall, not an
+    // error (mirrors `select`'s ordinary "no match" behavior).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | select(key == \"z\") as $x | $x"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // A bare error from the bind expression, with no successful output
+    // preceding it, propagates as a bare error -- no prefix to speak of.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | (key | error(\"boom\")) as $x | $x"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // The bind expression produces a real prefix (`key` => "a") before
+    // erroring -- the prefix survives on stdout, the error still raises.
+    // Exercises the `Partial(_, Control::Error(_))` arm of the bind match.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | (key, error(\"boom\")) as $x | $x"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout.trim(), r#""a""#);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // The error is in the *body*, not the bind expression: `key` (=> "a")
+    // still comes out for the first bound value before the second bound
+    // value's body evaluation errors and stops the loop.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            ".a | (1,2) as $x | (if $x==1 then key else error(\"boom\") end)",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout.trim(), r#""a""#);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `?` wrapping the whole `as` expression swallows the trailing error
+    // but keeps the already-produced prefix -- matching real jq's own
+    // `((1, error("x")) as $v | $v)?` => `1`, confirmed live.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | ((key, error(\"boom\")) as $x | $x)?"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    // A bare `break` out of the bind expression (no prior output) aborts
+    // the whole `as` expression and unwinds to the enclosing label -- the
+    // comma's second branch ("reached") must never run.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a | (key | break $out) as $x | $x), \"reached\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "break must discard, not emit, the as expression"
+    );
+
+    // Same, but with a real prefix already produced before the break --
+    // exercises the `Partial(_, Control::Break(_))` arm.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a | (key, break $out) as $x | $x), \"reached\")",
+        ],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    // `halt_error(n)` from the bind expression propagates its own exit
+    // code, with the already-produced prefix still on stdout.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | (key, halt_error(9)) as $x | $x"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 9);
+    assert_eq!(stdout.trim(), r#""a""#);
+
+    Ok(())
+}
+
+/// Documents four deliberate, narrow gaps #1663 leaves open rather than
+/// silently missing: `needs_path_context` still has no arm for
+/// `Expr::AsPattern` (destructuring `as`), `Expr::Reduce`, `Expr::Foreach`,
+/// or `Expr::Limit`, so a path-context builtin inside any of these four
+/// still falls through to the generic fallback and stubs to its zero
+/// default, exactly as before this fix. `Expr::Object` has the identical
+/// gap but is tracked separately as #1332 (already true before #1663, per
+/// the `Array` arm's own doc comment). Only `Expr::As` -- the single most
+/// consequential shape per #1663's own filing (the ordinary
+/// `EXPR as $v | body` idiom) -- was fixed here; the remaining four have
+/// no real-yq oracle to verify a fix against (yq's lexer rejects
+/// destructuring `as`, `reduce`, `foreach`, and `limit` outright) and
+/// `Reduce`/`Foreach` in particular raise a real semantic question (what
+/// should `key` mean while evaluating the fold's own accumulator, which
+/// has no document position?) that #1663's own investigation didn't
+/// settle. Filed as a follow-up rather than guessed at here. Pinned so a
+/// future regression or accidental fix is visible either way, matching
+/// #1306's identical "known gap" precedent
+/// (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
+#[test]
+fn test_as_pattern_reduce_foreach_limit_path_context_still_known_gaps_1663() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | . as [$x] | key"], Some(r#"{"a":[1]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | reduce .[] as $x (key; .)"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [foreach .[] as $x (key; .)]"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[null,null]");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(1; key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[null]");
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::Array` arm (#1302), so `[key]` --
 /// semantically equivalent to `(key,key)`'s single-branch case, just
 /// array-wrapped instead of comma-joined -- silently lost path context and


### PR DESCRIPTION
## Summary

`Builtin::Parent`/`Builtin::ParentN`/`Builtin::Key`/`Builtin::FileIndex` require
path-context tracking to resolve meaningfully, only available via
`eval_pipe_with_path_context_internal`, reached only when `needs_path_context`
recognizes the surrounding `Expr` shape. `needs_path_context` had no arm for
`Expr::As` (`EXPR as $v | body` — the ordinary jq variable-binding idiom, not
some rare shape), so any of these builtins used inside it fell through to
`eval_single`'s plain dispatch and silently returned a fixed, wrong fallback
(`{}` for `parent(n)`, `null` for `key`) instead of the correct value.

This is the single most consequential case in #1663's own filing:

```console
$ echo '{"a":{"b":1}}' | succinctly jq -c '.a.b | . as $x | parent(1)'
{}                    # before this fix
{"b":1}                # after — matches real yq's identical `. as $v | parent(1)`
```

(#1663's own text classified this repro as `Expr::AsPattern`, but only
*destructuring* `as` produces `AsPattern` — `. as $x | ...` is `Expr::As`,
confirmed while investigating. `AsPattern`/`Reduce`/`Foreach`/`Limit` still
have the same underlying gap and are tracked as a follow-up, #1765 —
`Expr::Object` has the identical gap but predates this issue as #1332.)

## Approach

Neither `expr` (the bind expression) nor `body` navigate away from the
caller's own position — the pre-existing `eval_as` already evaluates both
against the same `value` — so both route through
`eval_pipe_with_path_context_internal` unchanged, mirroring the existing
`FuncDef` arm.

Unlike #1302's `Array` arm or #1334's `StringInterpolation` arm, `as` is
deliberately **non-atomic** under `?` — `eval_as`'s own doc comment
establishes `(1,2,error("x")) as $v | $v + 10` keeps `11`, `12` as a real
prefix, unlike `[...]`'s atomicity — so `optional` is passed straight
through to both evaluations rather than forced to `false`, and the final
combined result goes through `continue_rest_with_context` (preserving
position), not `continue_rest_with_fresh_root`.

Verified against every control-flow shape (`None`/`Error`/`Break`/`Halt`,
both bare and prefix-preserving, for both the bind expression and the body)
against the pre-existing `eval_as` path as ground truth, and against real
`yq` v4.53.3 for every value-correctness case (`key`/`parent(n)` are
succinctly extensions with no jq equivalent, so yq mode is the actual
oracle here, not jq's own).

Closes #1663.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green — two
      separate runs each hit one unrelated `signal 9`-killed test under
      heavy concurrent-session load on this machine, both confirmed to
      pass in isolation and unrelated to this change)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] All 37 pre-existing `path_context` tests pass unchanged (no
      regression to the #1302/#1306/#1334/#1405/#1409 precedents this fix
      builds on)
- [x] Live-verified against real `yq` v4.53.3 for every value-correctness
      claim above
- [x] Regression tests: happy paths (including deep `parent(n)`, nested
      `as`, position-preserving `rest` continuation), the bind-expression's
      full non-`Owned`/`ManyOwned` match (prefix-preserving, not atomic —
      the key semantic difference from #1302/#1334), the body-loop's own
      identical match (a second, distinct set of arms), and a pinned
      "known gap" test for the four shapes this PR deliberately leaves
      unfixed (tracked as #1765)
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 96.55% patch coverage
      (56/58 new lines); the 2 remaining lines are both `unreachable!()`
      arms, matching the exact same accepted, always-uncovered pattern the
      pre-existing `Array`/`StringInterpolation` arms already have