### PR TITLE
fix(yq): reject a NUL-output result whose value contains a NUL byte

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -121,28 +121,72 @@ impl<W: Write> ColorSink<'_, W> {
     }
 }
 
-/// Streams through `render` directly when `use_color` is false. When true,
-/// renders into a buffer instead (still via the duplicate-key-safe cursor
-/// streamer passed in as `render`), then runs the buffer through `colorize`
-/// before writing the colorized result (#748).
+/// Streams through `render` directly when neither buffering condition below
+/// applies. Buffers into a single in-memory string first when `use_color`
+/// (so `colorize` can re-lex the whole rendered result, #748) or when
+/// `terminator` is [`Terminator::Nul`] (so the buffer can be scanned for an
+/// embedded NUL byte before any of it reaches `writer`, #1709) -- YAML's raw
+/// scalar rendering can contain a literal NUL from the source document,
+/// unlike JSON output, which always escapes one as the six-character
+/// sequence backslash-u-0-0-0-0; pass `Terminator::None` at a JSON call
+/// site to skip this check, since it can never apply there and buffering
+/// the whole result for nothing would be pure cost.
 fn stream_maybe_colored<W: Write, T>(
     writer: &mut W,
     use_color: bool,
+    terminator: Terminator,
     colorize: impl FnOnce(&str, &[usize]) -> String,
     render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, core::fmt::Error>,
 ) -> anyhow::Result<T> {
-    if use_color {
+    if use_color || matches!(terminator, Terminator::Nul) {
         let mut sink = ColorSink::Buffered(String::new(), Vec::new());
         let value = render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))?;
         let ColorSink::Buffered(buf, boundaries) = sink else {
             unreachable!("stream_maybe_colored always constructs ColorSink::Buffered here")
         };
-        write!(writer, "{}", colorize(&buf, &boundaries))?;
+        // Real yq refuses this rather than emit an ambiguous NUL-delimited
+        // stream (#1709) -- `buf` never contains the terminator's own NUL
+        // byte itself (boundaries are tracked out-of-band, #1708), so any
+        // NUL found here came from the rendered content.
+        if matches!(terminator, Terminator::Nul) && buf.contains('\0') {
+            anyhow::bail!(
+                "can't serialise value because it contains NUL char and you are using NUL separated output"
+            );
+        }
+        let out = if use_color {
+            colorize(&buf, &boundaries)
+        } else {
+            insert_terminators_at_boundaries(&buf, terminator, &boundaries)
+        };
+        write!(writer, "{out}")?;
         Ok(value)
     } else {
         let mut sink = ColorSink::Direct(FmtWriter(writer));
         render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))
     }
+}
+
+/// Splices `terminator` into `text` at each recorded boundary offset,
+/// without any coloring -- the non-colored counterpart to `colorize_yaml`'s
+/// own boundary handling, needed because [`stream_maybe_colored`] now also
+/// buffers (for the #1709 NUL check) when `use_color` is false.
+fn insert_terminators_at_boundaries(
+    text: &str,
+    terminator: Terminator,
+    boundaries: &[usize],
+) -> String {
+    if boundaries.is_empty() {
+        return text.to_string();
+    }
+    let mut result = String::with_capacity(text.len() + boundaries.len() * 2);
+    let mut last = 0;
+    for &pos in boundaries {
+        result.push_str(&text[last..pos]);
+        let _ = terminator.write_fmt(&mut result);
+        last = pos;
+    }
+    result.push_str(&text[last..]);
+    result
 }
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -3697,9 +3741,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     )?;
                     // No boundary recorded here -- the terminator is written
                     // directly to `$writer` below, outside this buffer (#1708).
+                    // `terminator` is still passed through so a NUL-output
+                    // result with an embedded NUL byte is caught (#1709).
                     stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
                         |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                         |out| $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys),
                     )?;
@@ -3738,6 +3785,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
                         |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
                             result.stream_yaml(out, yaml_indent, sort_keys, |w| {
@@ -3752,9 +3800,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // M2 path: JSON output streaming
                 if is_identity {
                     // P9 path: stream directly without evaluation
+                    // `Terminator::None` here (not the real `terminator`):
+                    // JSON output always escapes a NUL, so the #1709 check
+                    // can never fire for it, and buffering the whole result
+                    // to run it anyway would be pure cost.
                     stream_maybe_colored(
                         $writer,
                         $use_color,
+                        Terminator::None,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| $cursor.stream_json(out, json_indent, sort_keys),
                     )?;
@@ -3767,9 +3820,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 } else {
                     // M2 path: evaluate and stream results
                     let result = eval_with_cursor_using::<YqSemantics, _>(&program.expr, $cursor);
+                    // `Terminator::None` (#1709): JSON output always escapes
+                    // a NUL, so the check can never fire here.
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        Terminator::None,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| {
                             result.stream_json(out, json_indent, sort_keys, |w| {
@@ -3842,17 +3898,24 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             if can_yaml_fast_path {
                                 // No boundary recorded here --
                                 // `write_terminator` below writes directly,
-                                // outside this buffer (#1708).
+                                // outside this buffer (#1708). Still passed
+                                // through so a NUL-output result with an
+                                // embedded NUL byte is caught (#1709).
                                 stream_maybe_colored(
                                     &mut writer,
                                     output_config.use_color,
+                                    Terminator::from_config(&output_config),
                                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                                     |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
                                 )?;
                             } else {
+                                // `Terminator::None` (#1709): JSON output
+                                // always escapes a NUL, so the check can
+                                // never fire here.
                                 stream_maybe_colored(
                                     &mut writer,
                                     output_config.use_color,
+                                    Terminator::None,
                                     |s, _boundaries| {
                                         output::colorize_json(s, &ColorScheme::default())
                                     },
@@ -3971,9 +4034,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     // No boundary recorded here --
                                     // `write_terminator` below writes
                                     // directly, outside this buffer (#1708).
+                                    // Still passed through so a NUL-output
+                                    // result with an embedded NUL byte is
+                                    // caught (#1709).
                                     stream_maybe_colored(
                                         &mut writer,
                                         output_config.use_color,
+                                        Terminator::from_config(&output_config),
                                         |s, boundaries| {
                                             colorize_yaml(s, Terminator::None, boundaries)
                                         },
@@ -3982,9 +4049,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         },
                                     )?;
                                 } else {
+                                    // `Terminator::None` (#1709): JSON
+                                    // output always escapes a NUL, so the
+                                    // check can never fire here.
                                     stream_maybe_colored(
                                         &mut writer,
                                         output_config.use_color,
+                                        Terminator::None,
                                         |s, _boundaries| {
                                             output::colorize_json(s, &ColorScheme::default())
                                         },
@@ -4391,9 +4462,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `stream_json_sequence` are both generic over `core::fmt::Write`,
             // so each slots into `stream_maybe_colored` unmodified.
             if output_config.output_format == OutputFormat::Json {
+                // `Terminator::None` (#1709): JSON output always escapes a
+                // NUL, so the check can never fire here.
                 stream_maybe_colored(
                     &mut writer,
                     output_config.use_color,
+                    Terminator::None,
                     |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                     |out| {
                         stream_json_sequence(
@@ -4408,10 +4482,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 )?;
             } else {
                 // No boundary recorded here -- `write_terminator` below
-                // writes directly, outside this buffer (#1708).
+                // writes directly, outside this buffer (#1708). Still
+                // passed through so a NUL-output result with an embedded
+                // NUL byte is caught (#1709).
                 stream_maybe_colored(
                     &mut writer,
                     output_config.use_color,
+                    Terminator::from_config(&output_config),
                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                     |out| {
                         stream_yaml_sequence(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3686,6 +3686,87 @@ fn test_nul_output_eval_all_does_not_corrupt_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1709: real yq (pinned v4.53.3) refuses `-0`/`--nul-output` when a
+/// scalar's own value contains an embedded NUL character -- succinctly used
+/// to silently emit it inline, making the record boundary ambiguous to any
+/// NUL-delimited consumer (e.g. `xargs -0`). Live-verified against the
+/// oracle: `printf 'a: "hello\x00world"\n' | yq -0 '.a'` exits 1 with
+/// `Error: can't serialise value because it contains NUL char and you are
+/// using NUL separated output`.
+#[test]
+fn test_nul_output_rejects_embedded_nul_in_value_1709() -> Result<()> {
+    let input = "a: \"hello\\x00world\"\n";
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a", input, &["-0"])?;
+    assert_ne!(code, 0, "expected a failure, stderr: {stderr}");
+    assert!(
+        stderr.contains("contains NUL char"),
+        "expected the NUL-content error, got: {stderr}"
+    );
+    Ok(())
+}
+
+/// Same value, but the default newline terminator has no such ambiguity --
+/// real yq accepts it there (live-verified: exits 0, emits the raw NUL
+/// byte). The #1709 check is specifically `-0`-mode-only.
+#[test]
+fn test_default_terminator_accepts_embedded_nul_in_value_1709() -> Result<()> {
+    let input = "a: \"hello\\x00world\"\n";
+    let (output, code) = run_yq_stdin(".a", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "hello\0world\n");
+    Ok(())
+}
+
+/// JSON output escapes a NUL rather than emitting it raw, so
+/// there's no ambiguity for `-0` to guard against -- real yq accepts this
+/// (live-verified: exits 0, prints the escaped form), unlike the same
+/// value under YAML output above.
+#[test]
+fn test_nul_output_json_accepts_embedded_nul_in_value_1709() -> Result<()> {
+    let input = "a: \"hello\\x00world\"\n";
+    let (output, code) = run_yq_stdin(".a", input, &["-0", "-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "\"hello\\u0000world\"\0");
+    Ok(())
+}
+
+/// The #1709 check must also fire on the colored path, which already
+/// buffered per-result (#748) before this fix added buffering for the
+/// non-colored `-0` case too.
+#[test]
+fn test_nul_output_color_rejects_embedded_nul_in_value_1709() -> Result<()> {
+    let input = "a: \"hello\\x00world\"\n";
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a", input, &["-C", "-0"])?;
+    assert_ne!(code, 0, "expected a failure, stderr: {stderr}");
+    assert!(
+        stderr.contains("contains NUL char"),
+        "expected the NUL-content error, got: {stderr}"
+    );
+    Ok(())
+}
+
+/// The identity path (no evaluation) re-emits a scalar's source spelling
+/// verbatim rather than decoding it, so an escaped `\x00` stays the four
+/// printable characters backslash-x-0-0, never becoming a raw NUL byte --
+/// the #1709 check correctly does not fire here. Real yq agrees
+/// (live-verified: exits 0, re-emits the same escape -- normalized to
+/// `\0`, a cosmetic difference unrelated to this issue).
+#[test]
+fn test_nul_output_identity_accepts_embedded_nul_escape_1709() -> Result<()> {
+    let input = "a: \"hello\\x00world\"\n";
+    let (output, code) = run_yq_stdin(".", input, &["-0"])?;
+    assert_eq!(code, 0);
+    // Exactly one NUL byte total: the `-0` terminator itself. The escaped
+    // `\x00`/`\0` in the re-emitted scalar stays literal, printable
+    // characters, never decoding into a second, embedded NUL.
+    assert_eq!(
+        output.matches('\0').count(),
+        1,
+        "expected exactly one NUL byte (the terminator), got: {output:?}"
+    );
+    Ok(())
+}
+
 /// Same fix, `--inplace` on the DOM path (#1701 code review round 2).
 #[test]
 fn test_join_output_inplace_dom_path_does_not_corrupt_1701() -> Result<()> {


### PR DESCRIPTION
## Summary

Found by `/code-review` on PR #1707 (#1701). Real yq (pinned Homebrew v4.53.3) refuses `-0`/`--nul-output` output when a scalar's own value contains an embedded NUL character; succinctly silently emitted it inline, making the record boundary ambiguous to any NUL-delimited consumer (e.g. `xargs -0`).

Repro (verified against the pinned oracle): a YAML document with a scalar containing a NUL escape (hex 00) under `-0` -- real yq exits 1 with "can't serialise value because it contains NUL char and you are using NUL separated output"; succinctly used to exit 0, emitting the raw byte inline (indistinguishable from two records).

**Scope**: YAML output only. JSON output always escapes a NUL as a six-character sequence rather than emitting it raw, so there's no ambiguity there -- live-verified against the oracle that real yq accepts the same value under `-o=json` (exit 0). The identity path (`.`, no evaluation) also needed no change: it re-emits a scalar's source spelling verbatim rather than decoding it, so an escaped NUL stays printable characters, never becoming a raw NUL byte -- real yq agrees there too.

**Mechanism**: `stream_maybe_colored` now also buffers (not just for `--color`) whenever the real terminator is `Nul`, so the fully-rendered result can be scanned for an embedded NUL before any of it reaches the writer -- reusing the same buffering machinery #1708 built for coloring, extended to a second reason to need it. JSON call sites pass `Terminator::None` to skip the check entirely (it can never apply there, and buffering for nothing would be pure cost). `insert_terminators_at_boundaries` is the new non-colored counterpart to `colorize_yaml`'s own boundary handling, needed now that the non-colored path can also buffer.

## Test plan

- 5 new regression tests in `tests/yq_cli_tests.rs`, each verified against the pinned oracle first: rejects an embedded NUL under `-0` (evaluated path), accepts it under the default newline terminator, accepts it under `-o=json`, rejects it under `-C -0` (colored path), and confirms the identity path emits exactly one NUL byte total (the terminator itself, not a second embedded one).
- Full local `cargo test --features cli,simd,regex,serde`: 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD/x86 feature-set leg: both clean.
- `cargo doc --no-deps --all-features`, `cargo fmt --check`, `cargo build --no-default-features` (no_std): all clean.
- Patch coverage: 87.88% (29/33 new lines). The 4 uncovered lines are pre-existing defensive-fallback `stream_maybe_colored` call sites (documented "rarely if ever reached") that only changed by gaining one more argument; not new logic.

Fixes #1709
