### PR TITLE
fix(jq): make key_hash_of check string_decode_error for YAML too

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -721,13 +721,29 @@ fn ascii_key_hash(key: &[u8]) -> Option<u64> {
     ascii.then_some(hash)
 }
 
-/// The hash a field's key compares under, or `None` when the key does not
-/// stringify at all (a YAML alias or complex key, or a JSON escape that
-/// will not decode).
+/// The hash a field's key compares under, or `None` when the key has no
+/// reliable identity: a JSON escape that will not decode, or -- since
+/// #1678 -- a YAML scalar key with the same problem.
 ///
-/// Prefers the raw span (see [`ascii_key_hash`]) and falls back to the
-/// decoded key, which is what every exact resolution downstream uses.
+/// Must check [`DocumentValue::string_decode_error`] first, not
+/// [`key_string`](DocumentValue::key_string): YAML's `key_string()`
+/// override never returns `None` at all (#222 -- a complex or undecodable
+/// key stringifies to `""` rather than being dropped), so a YAML
+/// decode-failure key would otherwise hash its `""` fallback like a real
+/// key and silently collapse with any other undecodable key in the same
+/// object under `collapse: true` (#1385's "never a duplicate" rule exists
+/// precisely to prevent that). JSON's two checks are redundant with each
+/// other (both resolve via `as_str`), so this changes nothing there --
+/// same mirroring [`key_display_string_kind`] already does for the
+/// display-string case.
+///
+/// Otherwise prefers the raw span (see [`ascii_key_hash`]) and falls back
+/// to the decoded key, which is what every exact resolution downstream
+/// uses.
 fn key_hash_of<V: DocumentValue>(key: &V) -> Option<u64> {
+    if key.string_decode_error().is_some() {
+        return None;
+    }
     if let Some(raw) = key.key_raw_unescaped() {
         if let Some(hash) = ascii_key_hash(raw) {
             return Some(hash);
@@ -1916,7 +1932,8 @@ mod checked_len_tests {
 #[cfg(test)]
 mod key_display_string_tests {
     use super::{
-        effective_keys, key_display_string, key_is_malformed, DocumentFields, DocumentValue,
+        effective_keys, effective_len_checked, key_display_string, key_is_malformed,
+        DocumentFields, DocumentValue,
     };
     use crate::json::JsonIndex;
 
@@ -1993,6 +2010,29 @@ mod key_display_string_tests {
             effective_keys(&fields, false).expect("well formed"),
             vec!["a".to_string(), "a".to_string(), "b".to_string()]
         );
+    }
+
+    /// YAML counterpart of [`effective_keys_never_collapses_colliding_decode_failures_1642`]
+    /// -- #1678. Unlike JSON, `YamlValue::key_string()` never returns `None`
+    /// at all (#222), so before `key_hash_of` learned to check
+    /// `string_decode_error()` first, two different undecodable YAML keys
+    /// hashed the same `""` fallback and silently collapsed into one,
+    /// violating #1385's "never a duplicate" rule on this format too.
+    #[test]
+    fn effective_keys_never_collapses_colliding_yaml_decode_failures_1678() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"\"a\\qb\": 1\n\"a\\zc\": 2\n";
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let cursor = index.root(yaml);
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let fields = mapping_cursor.value().as_object().expect("a mapping");
+
+        assert_eq!(effective_len_checked(&fields, true).ok(), Some(2));
+        let keys = effective_keys(&fields, true).expect("no genuine #1194 fault");
+        assert_eq!(keys, vec![String::new(), String::new()]);
     }
 
     /// `DocumentFields::keys()`'s per-field raise for a key the format's

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -725,29 +725,35 @@ fn ascii_key_hash(key: &[u8]) -> Option<u64> {
 /// reliable identity: a JSON escape that will not decode, or -- since
 /// #1678 -- a YAML scalar key with the same problem.
 ///
-/// Must check [`DocumentValue::string_decode_error`] first, not
-/// [`key_string`](DocumentValue::key_string): YAML's `key_string()`
+/// Tries the raw span first (see [`ascii_key_hash`]) -- the #1514 fast path
+/// that skips decoding entirely for the common escape-free ASCII key, which
+/// [`DocumentValue::string_decode_error`] cannot answer for cheaply: its
+/// only implementation (`StandardJson`) resolves through the same full
+/// `as_str()` decode `key_string()` does, so checking it *before* the raw
+/// span would pay that decode on every key regardless of whether the fast
+/// path could have answered for free -- confirmed by CI's perf guard on
+/// `wide_keys_unsorted` (+10-12%) when this was tried in that order.
+///
+/// Once off that fast path (an escape, non-ASCII bytes, or no raw span at
+/// all -- YAML never has one), checks `string_decode_error` before falling
+/// to [`key_string`](DocumentValue::key_string): YAML's `key_string()`
 /// override never returns `None` at all (#222 -- a complex or undecodable
 /// key stringifies to `""` rather than being dropped), so a YAML
 /// decode-failure key would otherwise hash its `""` fallback like a real
 /// key and silently collapse with any other undecodable key in the same
 /// object under `collapse: true` (#1385's "never a duplicate" rule exists
-/// precisely to prevent that). JSON's two checks are redundant with each
-/// other (both resolve via `as_str`), so this changes nothing there --
-/// same mirroring [`key_display_string_kind`] already does for the
-/// display-string case.
-///
-/// Otherwise prefers the raw span (see [`ascii_key_hash`]) and falls back
-/// to the decoded key, which is what every exact resolution downstream
-/// uses.
+/// precisely to prevent that) -- the same ordering
+/// [`key_display_string_kind`] already uses for the display-string case.
+/// A no-op for JSON off the fast path: its two checks are redundant with
+/// each other (both resolve via `as_str`), just no longer free to reach.
 fn key_hash_of<V: DocumentValue>(key: &V) -> Option<u64> {
-    if key.string_decode_error().is_some() {
-        return None;
-    }
     if let Some(raw) = key.key_raw_unescaped() {
         if let Some(hash) = ascii_key_hash(raw) {
             return Some(hash);
         }
+    }
+    if key.string_decode_error().is_some() {
+        return None;
     }
     key.key_string().map(|key| key_hash(key.as_bytes()))
 }


### PR DESCRIPTION
## Summary
`key_hash_of` (`src/jq/document.rs`) decided a key's hash identity from `key_raw_unescaped()`/`key_string()`, with `None` meaning "no reliable identity, never a duplicate" (the mechanism #1385 relies on to keep a decode-failure key from silently colliding with another one).

For JSON that's correct: `key_string()` returns `None` exactly on a decode failure. For YAML it isn't: `YamlValue::key_string()` never returns `None` at all (#222 — a key with no scalar form, including a decode failure, stringifies to `Some("")` rather than being dropped). So `key_hash_of` for YAML always produced a real hash, even for an undecodable key, and two *distinct* decode-failure keys collapsed into one under `collapse: true`.

Fixed by checking `string_decode_error()` first, mirroring the ordering `key_display_string_kind` (#1642) already uses for the analogous display-string problem. No behavior change for JSON (its `string_decode_error()`/`key_string()` checks are already redundant with each other).

## Scope note
Per the issue: not reachable via the shipped `syq` CLI (yq mode never sets `collapse: true`), but a real, tested behavior on the library's public `eval_using::<JqSemantics, _>` surface over a `YamlValue`.

## Test plan
- New test `effective_keys_never_collapses_colliding_yaml_decode_failures_1678` — two distinct invalid-escape YAML keys (`"a\qb"`, `"a\zc"`) now report `effective_len_checked(&fields, true) == Ok(2)` and `effective_keys` returns two separate entries instead of collapsing to one.
- Full test suite (`cargo test --features cli,simd,regex,serde --no-fail-fast`): 55/55 binaries pass, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second (non-all-features) clippy leg: clean.
- `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --no-deps --all-features`: clean.

Closes #1678