### PR TITLE
fix(jq): raise #1194 on keys_unsorted's walked positional arms

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -621,20 +621,32 @@ is the opt-in form for callers who want it (exit 3, its own separately-pinned co
 `--slurp`, `--sort-keys`, `--ascii-output`, and any filter shape that costs the value its cursor
 (a comma, an `if`) — because #1247 made the `to_owned`/`cursor_to_owned` family fallible and
 this check rides along with it. Bare `.[]` and the identity printer raise now too (#1641, below).
-One route remains, and it never walks the whole object, so it is not in a position to find the
-malformed member at all:
+
+This is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `[n]`, `first`, `last` — where
+`#1514` and `#1599` deliberately took the whole-object probe *off* the arms that don't otherwise
+need it. #1629 restored the check on every arm that already pays for a walk regardless (`[]`,
+`last`, and a *negative* `[n]`, which has to know the object's length to normalize against) —
+free, since the check rides the walk rather than adding one:
 
 ```
-$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'     # 123 then "b", exit 0
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'      # exit 5 now (was: 123 then "b", exit 0)
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted | last' # exit 5 now (was: "b",           exit 0)
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[-1]'    # exit 5 now (was: "b",           exit 0)
 ```
 
-This is `keys_unsorted`'s **positional** fast paths — `[]`, `[0]`, `[n]`, `first`, `last`.
-`#1514` and `#1599` deliberately took the whole-object probe *off* these arms: `first` and `[0]`
-answer from one `uncons_key` because collapsing keeps every key at its first position, so the
-answer holds whatever the rest of the object turns out to be. Restoring a #1194 check means
-restoring exactly the walk those two issues removed, which is why it is tracked separately
-(#1629) rather than fixed here. `keys_unsorted | length` is *not* in this set — it reaches
-`effective_len`, which walks, and so carries the check for free.
+**Still not fixed, and deliberately so: `first`, `[0]`, and a *positive* `[n]`.** These three
+answer from one `uncons_key`/a short early-exit walk (collapsing keeps every key at its first
+position, so a small positive index never needs to look past it) — restoring the check here means
+restoring exactly the walk #1514/#1599 removed, on the one arm shape built to avoid it entirely:
+
+```
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[0]'      # 123, exit 0 -- unfixed
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted | first' # 123, exit 0 -- unfixed
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[1]'      # "b",  exit 0 -- unfixed
+```
+
+`keys_unsorted | length` is not in this set at all — it reaches `effective_len`, which walks, and
+so has carried the check for free since #1628.
 
 Bare `keys_unsorted` — no stage after it — does raise, but only part-way through: it streams,
 and finds a non-string key once its `[` is already out, so a **truncated** array can reach

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -634,16 +634,35 @@ $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted | last' # exit 5 now (was: "b"
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[-1]'    # exit 5 now (was: "b",           exit 0)
 ```
 
-**Still not fixed, and deliberately so: `first`, `[0]`, and a *positive* `[n]`.** These three
-answer from one `uncons_key`/a short early-exit walk (collapsing keeps every key at its first
-position, so a small positive index never needs to look past it) — restoring the check here means
-restoring exactly the walk #1514/#1599 removed, on the one arm shape built to avoid it entirely:
+**Still not fixed: `first`, `[0]`, and a *positive* `[n]`.** These three answer from one
+`uncons_key`/a short early-exit walk (collapsing keeps every key at its first position, so a small
+positive index never needs to look past it) — restoring the check here means restoring exactly the
+walk #1514/#1599 removed, on the one arm shape built to avoid it entirely. #1629 left this part of
+#1514/#1599's original tradeoff as it found it rather than widening its own scope to relitigate it:
 
 ```
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[0]'      # 123, exit 0 -- unfixed
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted | first' # 123, exit 0 -- unfixed
 $ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[1]'      # "b",  exit 0 -- unfixed
 ```
+
+**Also not fixed: any of the four raising arms above, once wrapped in an early-exit demand
+combinator** (`first(keys_unsorted[])`, `limit(1; keys_unsorted[])`). `fold_pipe_stages_sink`
+routes `Expr::Iterate` through a separate demand-driven `each_lazy_keys_iterate_sink`, not
+`fold_lazy_keys_stage`'s arm #1629 fixed, and that sink still streams the raw, unchecked
+`DistinctKeyCursors` iterator directly:
+
+```
+$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'              # exit 5 (fixed above)
+$ echo '{123: 1, "b": 2}' | sjq -c 'first(keys_unsorted[])'       # 123, exit 0 -- unfixed
+```
+
+Found during #1629's own review. Unlike the early-exit arms above, this isn't obviously the same
+tradeoff: whether an early-exit *consumer* should pay to validate object shape it may never finish
+reading is a real, separate design question — the same one #725/#1565 already answered "no" to for
+a `map(f)` error under `first` (`docs/compliance/jq/limitations.md`, `each_lazy_seq_iterate_sink`'s
+own doc comment) — so resolving it here, one way or the other, is left to its own issue (#1770)
+rather than folded into #1629's own scope.
 
 `keys_unsorted | length` is not in this set at all — it reaches `effective_len`, which walks, and
 so has carried the check for free since #1628.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3181,18 +3181,33 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // #1629: unlike `First`/`.[0]` above, this arm already walks the
         // whole object regardless (there is no way to find "the last
         // field" without reaching the end), so the #1194 check rides along
-        // for free -- same helper as the negative-index arm above. An
-        // earlier version of this arm hand-rolled the walk separately per
-        // branch and missed the check entirely on the collapsed one
-        // (`collapsed_fields_if` returning `Some`, i.e. jq mode with a
-        // genuine duplicate key) -- caught by code review before merge.
+        // for free. Tracks only the running last cursor rather than calling
+        // `distinct_key_cursors_checked` -- unlike the negative-index arm
+        // above, this one never needs random access into the collected
+        // list, so collecting one would be a pure O(n)-space cost for an
+        // O(1)-space answer (review caught this on the first version of
+        // this fix, which called that helper here too). An earlier version
+        // still hand-rolled the walk separately per branch and missed the
+        // check entirely on the collapsed one (`collapsed_fields_if`
+        // returning `Some`, i.e. jq mode with a genuine duplicate key) --
+        // also caught by code review before merge. `DistinctKeyCursors`
+        // itself already handles collapse=true/false, so there is no
+        // branch left to miss.
         Expr::Builtin(Builtin::Last) if !sorted => {
-            match distinct_key_cursors_checked::<V>(&fields, collapse) {
-                Ok(cursors) => match cursors.into_iter().next_back() {
-                    Some(cursor) => GenericResult::OneCursor(cursor),
-                    None => GenericResult::Owned(OwnedValue::Null),
-                },
-                Err(err) => GenericResult::Error(err),
+            let mut cursors = DistinctKeyCursors::new(&fields, collapse);
+            let mut last_cursor = None;
+            for (key, cursor) in cursors.by_ref() {
+                if key_is_malformed(&key) {
+                    return GenericResult::Error(fields.malformed_member_error());
+                }
+                last_cursor = Some(cursor);
+            }
+            if cursors.ended_unpaired() {
+                return GenericResult::Error(fields.malformed_member_error());
+            }
+            match last_cursor {
+                Some(c) => GenericResult::OneCursor(c),
+                None => GenericResult::Owned(OwnedValue::Null),
             }
         }
         // Slice 1 (#724): stay lazy instead of falling

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -828,16 +828,34 @@ fn materialize_lazy_keys<V: DocumentValue>(
 }
 
 /// An object's key cursors in document order, with a repeated key dropped
-/// after its first occurrence when the mode collapses (#1514).
+/// after its first occurrence when the mode collapses (#1514), refusing an
+/// object whose members the format's grammar never allowed (#1194, #1629).
 ///
 /// Materializes what [`DistinctKeyCursors`] streams. `.[]` over a key array
 /// has to hand back every cursor at once, but the dedup still happens during
 /// the single walk that collects them -- where before, the caller ran a
 /// whole separate `document::census` and then walked again to build this.
-fn distinct_key_cursors<V: DocumentValue>(fields: &V::Fields, collapse: bool) -> Vec<V::Cursor> {
-    DistinctKeyCursors::new(fields, collapse)
-        .map(|(_, cursor)| cursor)
-        .collect()
+/// The #1194 check rides along in that same walk, the same way
+/// [`effective_keys`] already checks during its own single
+/// [`DistinctKeyCursors`] walk -- one pass, not a second one bolted on top,
+/// which on a wide object would double the walk this arm already pays for
+/// (the exact mistake #1678's own perf-guard catch was about).
+fn distinct_key_cursors_checked<V: DocumentValue>(
+    fields: &V::Fields,
+    collapse: bool,
+) -> Result<Vec<V::Cursor>, EvalError> {
+    let mut out = Vec::new();
+    let mut cursors = DistinctKeyCursors::new(fields, collapse);
+    for (key, cursor) in cursors.by_ref() {
+        if key_is_malformed(&key) {
+            return Err(fields.malformed_member_error());
+        }
+        out.push(cursor);
+    }
+    if cursors.ended_unpaired() {
+        return Err(fields.malformed_member_error());
+    }
+    Ok(out)
 }
 
 /// Materialize a `GenericResult::LazyIndexRange` fallback: build the
@@ -3056,14 +3074,15 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // the `if !sorted` guard on a new arm here without
         // re-deriving why document order would still be a
         // correct answer.
-        Expr::Iterate if !sorted => {
-            let cursors = distinct_key_cursors::<V>(&fields, collapse);
-            if cursors.is_empty() {
-                GenericResult::None
-            } else {
-                GenericResult::ManyCursor(cursors)
-            }
-        }
+        // #1629: unlike `first`/`.[0]` below, this arm already walks the
+        // whole object to collect every cursor, so the #1194 check
+        // (`distinct_key_cursors_checked`) rides along for free -- same
+        // reasoning as `Builtin::Length`'s arm above.
+        Expr::Iterate if !sorted => match distinct_key_cursors_checked::<V>(&fields, collapse) {
+            Ok(cursors) if cursors.is_empty() => GenericResult::None,
+            Ok(cursors) => GenericResult::ManyCursor(cursors),
+            Err(err) => GenericResult::Error(err),
+        },
         // `.[0]` is `first` by another spelling, so it takes
         // the `Builtin::First` arm's reasoning below rather
         // than the general positional one: collapsing keeps a
@@ -3080,58 +3099,59 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 None => GenericResult::Owned(OwnedValue::Null),
             }
         }
+        // #1629: a negative index always has to walk the whole object
+        // anyway (to normalize against its length), so the #1194 check
+        // (`effective_fields_checked`, in place of the unchecked
+        // `collapsed_fields_if`/`fields.len()` pair) rides along for free
+        // -- same reasoning as `Expr::Iterate` above. This mirrors real
+        // jq's own rule: it can't even *parse* an object with a malformed
+        // member, so every access into it raises, not just the ones that
+        // happen to touch the bad member (verified live against pinned jq
+        // 1.7.1: `{"a":1,"b":2,123:3} | keys_unsorted[0]` raises the same
+        // parse error as `keys_unsorted[2]` would).
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted && *idx < 0 => {
+            match effective_fields_checked(&fields, collapse) {
+                Ok(eff) => {
+                    let target = usize::try_from(eff.len() as i64 + idx).ok();
+                    match target.and_then(|t| eff.into_iter().nth(t)) {
+                        Some(field) => GenericResult::OneCursor(field.key_cursor),
+                        None => GenericResult::Owned(OwnedValue::Null),
+                    }
+                }
+                Err(err) => GenericResult::Error(err),
+            }
+        }
+        // A *positive* index, unlike the negative arm above, does not
+        // otherwise need to know the whole object -- it walks only as far
+        // as the target position (or, when collapsed, the free probe
+        // `collapsed_fields_if` already runs). Adding the #1194 check here
+        // would mean walking the rest of the object purely to validate it,
+        // undoing exactly the early-exit #1514/#1599 built. Left
+        // unchecked, same as `Builtin::First`/`.[0]` below -- see #1629's
+        // own accounting of this tradeoff (its "Option 1") and
+        // `docs/compliance/jq/limitations.md`.
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
-            // Positional: a collapsed object has fewer
-            // members, so `.[n]` lands elsewhere. This is one
-            // of the two arms that still has to know the
-            // whole answer before it can pick an element.
-            //
-            // Negative indices need the length to normalize
-            // against, same as `Expr::Index`'s array arm
-            // above; positive indices skip straight to the
-            // walk. Out-of-bounds is `null`, never an error
-            // (#307), matching that same arm.
             let collapsed = collapsed_fields_if(&fields, collapse);
             if let Some(eff) = collapsed {
-                let target = if *idx < 0 {
-                    usize::try_from(eff.len() as i64 + idx).ok()
-                } else {
-                    Some(*idx as usize)
-                };
-                match target.and_then(|t| eff.into_iter().nth(t)) {
+                match eff.into_iter().nth(*idx as usize) {
                     Some(field) => GenericResult::OneCursor(field.key_cursor),
                     None => GenericResult::Owned(OwnedValue::Null),
                 }
             } else {
-                let target = if *idx < 0 {
-                    let len = fields.len();
-                    let normalized = len as i64 + idx;
-                    if normalized < 0 {
-                        None
-                    } else {
-                        Some(normalized as usize)
+                let target = *idx as usize;
+                let mut current = fields;
+                let mut found = None;
+                let mut i = 0usize;
+                while let Some((field, rest)) = current.uncons() {
+                    if i == target {
+                        found = Some(field.key_cursor);
+                        break;
                     }
-                } else {
-                    Some(*idx as usize)
-                };
-                match target {
-                    Some(target) => {
-                        let mut current = fields;
-                        let mut found = None;
-                        let mut i = 0usize;
-                        while let Some((field, rest)) = current.uncons() {
-                            if i == target {
-                                found = Some(field.key_cursor);
-                                break;
-                            }
-                            current = rest;
-                            i += 1;
-                        }
-                        match found {
-                            Some(c) => GenericResult::OneCursor(c),
-                            None => GenericResult::Owned(OwnedValue::Null),
-                        }
-                    }
+                    current = rest;
+                    i += 1;
+                }
+                match found {
+                    Some(c) => GenericResult::OneCursor(c),
                     None => GenericResult::Owned(OwnedValue::Null),
                 }
             }
@@ -3139,6 +3159,12 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // No probe: collapsing keeps every key at its *first*
         // position, and the first field is nobody's repeat, so
         // it survives whatever the rest of the object does.
+        //
+        // #1629: deliberately still unchecked, same reasoning as the
+        // positive-index arm above -- this is the one arm that exists to
+        // be genuinely O(1) (#1514/#1599), and a #1194 check would cost
+        // strictly more than the answer itself. See
+        // `docs/compliance/jq/limitations.md`.
         Expr::Builtin(Builtin::First) if !sorted => match fields.uncons() {
             Some((field, _)) => GenericResult::OneCursor(field.key_cursor),
             None => GenericResult::Owned(OwnedValue::Null),
@@ -3146,6 +3172,11 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // The other positional arm: the last field *is*
         // droppable — if its key repeats an earlier one it
         // collapses away and some other field ends up last.
+        //
+        // #1629: unlike `First`/`.[0]` above, *both* branches here already
+        // walk the whole object (there is no way to find "the last field"
+        // without reaching the end), so the #1194 check rides along for
+        // free either way.
         Expr::Builtin(Builtin::Last) if !sorted => {
             let collapsed = collapsed_fields_if(&fields, collapse);
             if let Some(eff) = collapsed {
@@ -3157,8 +3188,14 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 let mut current = fields;
                 let mut last_cursor = None;
                 while let Some((field, rest)) = current.uncons() {
+                    if key_is_malformed(&field.key) {
+                        return GenericResult::Error(current.malformed_member_error());
+                    }
                     last_cursor = Some(field.key_cursor);
                     current = rest;
+                }
+                if current.ends_unpaired() {
+                    return GenericResult::Error(current.malformed_member_error());
                 }
                 match last_cursor {
                     Some(c) => GenericResult::OneCursor(c),
@@ -3441,9 +3478,10 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// Neither is needed here. "First occurrence wins" is an *online* rule, so
 /// the dedup rides along with the walk instead of preceding it -- exactly
 /// what `fold_lazy_keys_stage`'s own `Expr::Iterate` arm switched to in
-/// #1514, via the `distinct_key_cursors` wrapper. That arm has to hand back
-/// every cursor at once to build a `ManyCursor`, so it collects; this one
-/// drives elements one at a time and can consume the iterator directly.
+/// #1514, via the `distinct_key_cursors_checked` wrapper. That arm has to
+/// hand back every cursor at once to build a `ManyCursor`, so it collects;
+/// this one drives elements one at a time and can consume the iterator
+/// directly.
 ///
 /// **The early exit is not unconditional.** It holds until a repeated key
 /// is *reached*: at that point `DistinctKeyCursors` calls

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -839,7 +839,10 @@ fn materialize_lazy_keys<V: DocumentValue>(
 /// [`effective_keys`] already checks during its own single
 /// [`DistinctKeyCursors`] walk -- one pass, not a second one bolted on top,
 /// which on a wide object would double the walk this arm already pays for
-/// (the exact mistake #1678's own perf-guard catch was about).
+/// (the exact mistake PR #1768's own perf-guard catch was about, earlier
+/// this same session -- a different check, `string_decode_error`, but the
+/// identical shape of mistake: a validation pass added ahead of an
+/// already-cheap path instead of folded into it).
 fn distinct_key_cursors_checked<V: DocumentValue>(
     fields: &V::Fields,
     collapse: bool,
@@ -3101,20 +3104,22 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         }
         // #1629: a negative index always has to walk the whole object
         // anyway (to normalize against its length), so the #1194 check
-        // (`effective_fields_checked`, in place of the unchecked
-        // `collapsed_fields_if`/`fields.len()` pair) rides along for free
-        // -- same reasoning as `Expr::Iterate` above. This mirrors real
-        // jq's own rule: it can't even *parse* an object with a malformed
-        // member, so every access into it raises, not just the ones that
-        // happen to touch the bad member (verified live against pinned jq
-        // 1.7.1: `{"a":1,"b":2,123:3} | keys_unsorted[0]` raises the same
-        // parse error as `keys_unsorted[2]` would).
+        // rides along for free -- same reasoning as `Expr::Iterate` above,
+        // and indeed the same helper: `distinct_key_cursors_checked` needs
+        // no value decoding (unlike `effective_fields_checked`, an earlier
+        // version of this arm's choice -- this arm only ever reads a
+        // cursor, never a field's value). This mirrors real jq's own rule:
+        // it can't even *parse* an object with a malformed member, so every
+        // access into it raises, not just the ones that happen to touch the
+        // bad member (verified live against pinned jq 1.7.1:
+        // `{"a":1,"b":2,123:3} | keys_unsorted[0]` raises the same parse
+        // error as `keys_unsorted[2]` would).
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted && *idx < 0 => {
-            match effective_fields_checked(&fields, collapse) {
-                Ok(eff) => {
-                    let target = usize::try_from(eff.len() as i64 + idx).ok();
-                    match target.and_then(|t| eff.into_iter().nth(t)) {
-                        Some(field) => GenericResult::OneCursor(field.key_cursor),
+            match distinct_key_cursors_checked::<V>(&fields, collapse) {
+                Ok(cursors) => {
+                    let target = usize::try_from(cursors.len() as i64 + idx).ok();
+                    match target.and_then(|t| cursors.into_iter().nth(t)) {
+                        Some(cursor) => GenericResult::OneCursor(cursor),
                         None => GenericResult::Owned(OwnedValue::Null),
                     }
                 }
@@ -3173,34 +3178,21 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // droppable — if its key repeats an earlier one it
         // collapses away and some other field ends up last.
         //
-        // #1629: unlike `First`/`.[0]` above, *both* branches here already
-        // walk the whole object (there is no way to find "the last field"
-        // without reaching the end), so the #1194 check rides along for
-        // free either way.
+        // #1629: unlike `First`/`.[0]` above, this arm already walks the
+        // whole object regardless (there is no way to find "the last
+        // field" without reaching the end), so the #1194 check rides along
+        // for free -- same helper as the negative-index arm above. An
+        // earlier version of this arm hand-rolled the walk separately per
+        // branch and missed the check entirely on the collapsed one
+        // (`collapsed_fields_if` returning `Some`, i.e. jq mode with a
+        // genuine duplicate key) -- caught by code review before merge.
         Expr::Builtin(Builtin::Last) if !sorted => {
-            let collapsed = collapsed_fields_if(&fields, collapse);
-            if let Some(eff) = collapsed {
-                match eff.into_iter().next_back() {
-                    Some(field) => GenericResult::OneCursor(field.key_cursor),
+            match distinct_key_cursors_checked::<V>(&fields, collapse) {
+                Ok(cursors) => match cursors.into_iter().next_back() {
+                    Some(cursor) => GenericResult::OneCursor(cursor),
                     None => GenericResult::Owned(OwnedValue::Null),
-                }
-            } else {
-                let mut current = fields;
-                let mut last_cursor = None;
-                while let Some((field, rest)) = current.uncons() {
-                    if key_is_malformed(&field.key) {
-                        return GenericResult::Error(current.malformed_member_error());
-                    }
-                    last_cursor = Some(field.key_cursor);
-                    current = rest;
-                }
-                if current.ends_unpaired() {
-                    return GenericResult::Error(current.malformed_member_error());
-                }
-                match last_cursor {
-                    Some(c) => GenericResult::OneCursor(c),
-                    None => GenericResult::Owned(OwnedValue::Null),
-                }
+                },
+                Err(err) => GenericResult::Error(err),
             }
         }
         // Slice 1 (#724): stay lazy instead of falling

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16861,6 +16861,68 @@ fn test_jq_keys_unsorted_on_malformed_object_errors_1194() -> Result<()> {
     Ok(())
 }
 
+/// #1629: `keys_unsorted`'s **positional** fast paths -- `[]`, `[n]`,
+/// `first`, `last` -- still answered from a malformed object, disagreeing
+/// with `keys_unsorted`/`keys_unsorted | length` (already fixed above) on
+/// the very same document. Fixed on every arm that already pays for a full
+/// walk regardless (`[]`, `last`, and a *negative* `[n]`, which needs the
+/// object's length to normalize against): the #1194 check now rides that
+/// walk for free, matching real jq (verified live against pinned jq 1.7.1),
+/// which refuses to even parse a document with a non-string key -- so every
+/// access into it raises, not just the ones that touch the bad member.
+#[test]
+fn test_jq_keys_unsorted_positional_walked_arms_raise_1629() -> Result<()> {
+    for input in [r#"{123: 1, "b": 2}"#, r#"{"a":1, invalid}"#] {
+        for filter in [
+            "keys_unsorted[]",
+            "keys_unsorted | last",
+            "keys_unsorted[-1]",
+        ] {
+            let (out, _stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+            assert_eq!(code, 5, "{filter} on {input}: out: {out:?}");
+            assert!(out.trim().is_empty(), "{filter} on {input}: out: {out:?}");
+        }
+    }
+
+    // A well-formed object still answers normally on all three -- the fix
+    // must not make every keys_unsorted positional access pay for a check
+    // it never fails.
+    let input = r#"{"a":1,"b":2,"c":3}"#;
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[]"], Some(input))?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out, "\"a\"\n\"b\"\n\"c\"\n");
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted | last"], Some(input))?;
+    assert_eq!((out.trim(), code), ("\"c\"", 0));
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[-1]"], Some(input))?;
+    assert_eq!((out.trim(), code), ("\"c\"", 0));
+
+    Ok(())
+}
+
+/// #1629: `first`, `.[0]`, and a *positive* `.[n]` are the one shape left
+/// unfixed -- deliberately. They exist specifically to answer in O(1) (or a
+/// short early-exit walk) without looking at the rest of the object
+/// (#1514/#1599); restoring the #1194 check here would restore exactly the
+/// walk those two issues removed. Pinned as a known, documented divergence
+/// (`docs/compliance/jq/limitations.md`) rather than left to silently drift
+/// -- if one of these three starts raising, that is a deliberate future
+/// fix, not a regression, and this test should be updated alongside it.
+#[test]
+fn test_jq_keys_unsorted_positional_early_exit_arms_still_known_gap_1629() -> Result<()> {
+    let input = r#"{123: 1, "b": 2}"#;
+
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[0]"], Some(input))?;
+    assert_eq!((out.trim(), code), ("123", 0));
+
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted | first"], Some(input))?;
+    assert_eq!((out.trim(), code), ("123", 0));
+
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[1]"], Some(input))?;
+    assert_eq!((out.trim(), code), ("\"b\"", 0));
+
+    Ok(())
+}
+
 /// #1194: a malformed member raises whether or not the run takes the lazy
 /// path.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16896,6 +16896,29 @@ fn test_jq_keys_unsorted_positional_walked_arms_raise_1629() -> Result<()> {
     let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[-1]"], Some(input))?;
     assert_eq!((out.trim(), code), ("\"c\"", 0));
 
+    // A genuine duplicate key ("a" repeats), combined with a malformed
+    // member, must still raise on `last`/`[-1]` -- an earlier version of
+    // this fix hand-rolled `Last`'s two branches separately and only
+    // checked the uncollapsed one, missing exactly this shape: jq mode
+    // with a real duplicate routes through `collapsed_fields_if`'s `Some`
+    // branch, which materialized via `all_fields()`/`collapse_repeated`
+    // without ever checking `key_is_malformed`/`ends_unpaired`. Caught by
+    // code review before merge; verified live that a genuine duplicate
+    // alone still answers normally (the second assertion below).
+    let malformed_with_duplicate = r#"{"a":1,"a":2,"b"}"#;
+    for filter in [
+        "keys_unsorted | last",
+        "keys_unsorted[-1]",
+        "keys_unsorted[]",
+    ] {
+        let (out, _stderr, code) = run_jq_full(&["-c", filter], Some(malformed_with_duplicate))?;
+        assert_eq!(code, 5, "{filter}: out: {out:?}");
+        assert!(out.trim().is_empty(), "{filter}: out: {out:?}");
+    }
+    let duplicate_only = r#"{"a":1,"a":2,"b":3}"#;
+    let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted | last"], Some(duplicate_only))?;
+    assert_eq!((out.trim(), code), ("\"b\"", 0));
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
`keys_unsorted`'s positional fast paths (`[]`, `[n]`, `first`, `last`) still answered from a malformed object, disagreeing with `keys_unsorted`/`keys_unsorted | length` (already fixed by #1628) on the same document — the exact "two answers for one document" split #1385's postmortem named, one pipe stage further along.

Fixed on every arm that already pays for a full walk of the object regardless of what it's looking for:
- `keys_unsorted[]` (`Expr::Iterate`) — already collects every cursor to build the array.
- `keys_unsorted | last` (`Builtin::Last`) — has to reach the true end either way; there's no way to find "the last field" without walking there.
- `keys_unsorted[-n]` (negative `Index`) — already needs the object's full length to normalize a negative index against.

In all three cases the #1194 check now rides that walk instead of adding a second one — verified with a local wide-object (200K keys) timing sanity check, and CI's own Perf Regression Guard is the authority here (see the `docs/guides/benchmarking.md` discipline this repo already follows, and #1678 earlier this session for why that guard matters).

**Deliberately left unfixed:** `first`, `[0]`, and a *positive* `[n]`. These exist specifically to answer in O(1) (or a short early-exit walk) without looking at the rest of the object — #1514 and #1599's whole point. Restoring the check here means restoring exactly the walk those two issues removed, on the one arm shape built to avoid it. This matches the issue's own "Option 1" (cheapest, accept the asymmetry) rather than the untested "Option 2" (an O(1) `ends_unpaired` via new BP-tree primitives) — investigating that turned out to require either walking anyway or new, unproven succinct-tree machinery well beyond this issue's scope.

Verified live against pinned jq 1.7.1: it refuses to even *parse* a document with a non-string key, so **every** access into it raises — not just the ones that happen to touch the bad member — confirming the fixed arms' new behavior and documenting the residual gap in `docs/compliance/jq/limitations.md` per ADR-0018.

## Test plan
- New tests `test_jq_keys_unsorted_positional_walked_arms_raise_1629` (fixed arms raise on both fault shapes — non-string key, unpaired tail — and still answer normally on a well-formed object) and `test_jq_keys_unsorted_positional_early_exit_arms_still_known_gap_1629` (pins the deliberately-unfixed arms so a future change to them is a conscious decision, not silent drift).
- Full test suite (`cargo test --features cli,simd,regex,serde --no-fail-fast`): 55/55 binaries pass, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and CI's second (non-all-features) clippy leg: clean.
- `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --no-deps --all-features`: clean.
- Manually verified all repro shapes from #1629 and the pinned jq oracle, both before and after.

Closes #1629