### PR TITLE
refactor(yq): consolidate the -I0/-I1 YAML indent clamp into IndentSpec::for_yaml

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -234,20 +234,23 @@ impl OutputConfig {
         }
     }
 
-    /// `-I0`/`-I1` both clamp to width 2 for YAML output (#1486, #1575):
-    /// real yq's YAML output at `-I1` is byte-identical to its own `-I2`
-    /// output at every level, mirroring the fast-path streamer's identical
-    /// clamp on `yaml_indent_spaces` below; `-I0` reuses the same clamp
-    /// rather than modeling real yq's own irregular `-I0`-behaves-like-`-I4`
-    /// quirk (see `compute_indent_str`'s own comment on the clamp). JSON has
-    /// no such quirk (verified live: `-I1 -o=json` genuinely indents 1
-    /// space per level in real yq, and `-I0 -o=json` means compact/flow,
-    /// handled separately by `OutputConfig::compact`) -- `indent_str` is
-    /// shared by both formats' DOM emitters (see its use in the JSON branch
-    /// of `output_value`), so the clamp only applies when `output_value`
-    /// will actually take the YAML branch, i.e. `effective_output_format ==
-    /// Yaml` exactly -- matching that dispatch's own condition, not its
-    /// complement.
+    /// The YAML clamp itself -- `-I0`/`-I1` both landing on width 2 -- is
+    /// `IndentSpec::for_yaml`'s rule (#1486, #1575, #1685; shared with the
+    /// M2 streaming fast path's own indent setup below, previously an
+    /// independently hand-encoded copy of the identical formula). `indent_str`
+    /// is shared by both formats' DOM emitters (see its use in the JSON
+    /// branch of `output_value`), so the clamp only applies when
+    /// `output_value` will actually take the YAML branch, i.e.
+    /// `effective_output_format == Yaml` exactly -- matching that dispatch's
+    /// own condition, not its complement. JSON has no such clamp (verified
+    /// live: `-I1 -o=json` genuinely indents 1 space per level in real yq,
+    /// and `-I0 -o=json` means compact/flow, handled separately by
+    /// `OutputConfig::compact`).
+    ///
+    /// `--tab` is handled once here rather than delegated to
+    /// `IndentSpec::for_yaml`: unlike the clamp, a single tab character
+    /// applies to *both* output formats identically, so it belongs at this
+    /// shared entry point, not inside the YAML-specific constructor.
     ///
     /// Takes the caller's *effective* format rather than reading
     /// `args.output_format` directly: `Self::from_args` passes
@@ -262,23 +265,10 @@ impl OutputConfig {
         if args.tab {
             return "\t".to_string();
         }
-        let width = args.indent as usize;
         let width = if effective_output_format == OutputFormat::Yaml {
-            // This clamp used to run only for a nonzero `args.indent`; an
-            // early return above it short-circuited `-I0` straight to an
-            // empty string instead. YAML's significant whitespace then read
-            // a nested container's fields back as siblings of their parent
-            // key, silently losing the whole value on read-back (#1575).
-            // `0.max(2)` already lands on the same width-2 convention the M2
-            // streaming fast path uses for its own `-I0`
-            // (`yaml_indent_spaces` below), so letting `-I0` reach this
-            // clamp like every other width is the whole fix. JSON is
-            // unaffected either way: `-I0` there means compact/flow, and
-            // `OutputConfig::compact` already forces JSON's own indent to
-            // `""` independently of this string.
-            width.max(2)
+            IndentSpec::for_yaml(args.indent, false).width
         } else {
-            width
+            args.indent as usize
         };
         " ".repeat(width)
     }
@@ -3610,35 +3600,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && args.front_matter.is_none()
         && context.named.is_empty();
 
-    // Indent width/unit for the fast path's streamers. `--tab` always means
-    // exactly one tab per level, ignoring `-I`'s numeric value — matching
-    // `OutputConfig::indent_str`'s DOM-path behavior above. YAML's `-I0` is
-    // otherwise a special case: real `yq` treats it as "use the library
-    // default" (4 spaces), and succinctly's existing (pre-#442) compact-YAML
-    // fast path hardcodes 2 regardless of `-I` — preserved as-is here since
-    // reconciling that mismatch is a separate, out-of-scope issue. `-I1`
-    // clamps to 2 (#1486): real yq's YAML output at `-I1` is byte-identical
-    // to its own `-I2` output at every level (mappings, sequences, and
-    // compact/anchor-deferred sequence items alike, verified live against
-    // v4.53.3) — every other value (`-I2` and above) threads through
-    // directly, matching what the DOM path already produces (verified
-    // against `-I1` through `-I6`). JSON has no such quirk: `-I0` means
-    // compact/flow and `-I1` genuinely means a literal 1-space step, for
-    // both real yq and succinctly today (verified live: `-I1 -o=json`
-    // indents 1/2/3 spaces per level in real yq, not clamped).
+    // Indent width/unit for the fast path's streamers. YAML's clamp
+    // (`-I0`/`-I1` both landing on width 2, `--tab` always one tab per
+    // level) is `IndentSpec::for_yaml`'s rule -- shared with
+    // `OutputConfig::compute_indent_str`'s DOM-path equivalent above,
+    // previously an independently hand-encoded copy of the identical
+    // formula (#1685). JSON has no such clamp: `-I0` means compact/flow and
+    // `-I1` genuinely means a literal 1-space step, for both real yq and
+    // succinctly today (verified live: `-I1 -o=json` indents 1/2/3 spaces
+    // per level in real yq, not clamped) -- `--tab` still means one tab per
+    // level regardless of format, so `json_indent` threads `args.tab`
+    // through its own `unit` the same way `yaml_indent`'s does.
     let indent_unit: char = if args.tab { '\t' } else { ' ' };
-    let yaml_indent_spaces: usize = if args.tab {
-        1
-    } else if args.indent == 0 {
-        2
-    } else {
-        (args.indent as usize).max(2)
-    };
+    let yaml_indent = IndentSpec::for_yaml(args.indent, args.tab);
     let json_indent_spaces: usize = if args.tab { 1 } else { args.indent as usize };
-    let yaml_indent = IndentSpec {
-        width: yaml_indent_spaces,
-        unit: indent_unit,
-    };
     let json_indent = IndentSpec {
         width: json_indent_spaces,
         unit: indent_unit,
@@ -4418,7 +4393,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             cursors.iter().copied(),
                             out,
                             0,
-                            yaml_indent_spaces,
+                            yaml_indent.width,
                             indent_unit,
                             sort_keys,
                         )

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -20,10 +20,7 @@ use super::error::EvalError;
 /// `width` is the number of `unit` characters written per nesting level;
 /// `width == 0` means compact/flow style (no newlines, no indentation).
 /// `unit` is `' '` for ordinary space-indented output and `'\t'` for
-/// `--tab` — mirroring `OutputConfig::indent_str` in
-/// `src/bin/succinctly/yq_runner.rs`, which the `OwnedValue` DOM path
-/// already builds this way (`if args.tab { "\t" } else { "
-/// ".repeat(args.indent) }`).
+/// `--tab`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndentSpec {
     /// Number of `unit` characters per indentation level.
@@ -44,10 +41,80 @@ impl IndentSpec {
         Self { width, unit: ' ' }
     }
 
+    /// The `-I`/`--tab` CLI flags' shared YAML-output rule (#1486, #1575,
+    /// #1685): `--tab` means exactly one tab per level regardless of
+    /// `indent`'s value; otherwise `-I0`/`-I1` both clamp to width 2 --
+    /// real yq's YAML output at `-I1` is byte-identical to its own `-I2`
+    /// output at every level (live-verified against v4.53.3), and `-I0`
+    /// reuses that same clamp rather than modeling real yq's own irregular
+    /// `-I0`-behaves-like-`-I4` quirk (out of scope, see
+    /// `docs/compliance/yq/limitations.md`). `-I2` and above thread through
+    /// unchanged.
+    ///
+    /// Takes primitive `indent`/`tab` rather than a whole CLI-args struct:
+    /// this is a library-crate (`src/jq/`) type, and the parsed args live in
+    /// the `succinctly-cli` binary crate (`src/bin/succinctly/yq_runner.rs`),
+    /// which cannot be depended on here. Shared by that binary's own
+    /// `OutputConfig::compute_indent_str` (DOM output path) and its M2
+    /// streaming fast path's indent setup -- previously two independently
+    /// hand-encoded copies of this exact rule (#1685), the third recurrence
+    /// of the same duplication in that file's history.
+    ///
+    /// JSON has no such clamp (`-I1 -o=json` genuinely indents 1 space per
+    /// level in real yq, and `-I0 -o=json` means compact/flow, handled
+    /// separately) -- this constructor is YAML-specific, not a general
+    /// `-I`-flag-to-`IndentSpec` conversion.
+    pub fn for_yaml(indent: u8, tab: bool) -> Self {
+        if tab {
+            return Self {
+                width: 1,
+                unit: '\t',
+            };
+        }
+        Self::spaces((indent as usize).max(2))
+    }
+
     /// Whether this spec requests compact/flow-style output (no newlines).
     #[inline]
     pub fn is_compact(&self) -> bool {
         self.width == 0
+    }
+}
+
+#[cfg(test)]
+mod indent_spec_tests {
+    use super::IndentSpec;
+
+    /// #1685: `-I0`/`-I1` both clamp to width 2, `-I2` and above thread
+    /// through unchanged -- the rule the DOM path's `compute_indent_str`
+    /// and the M2 fast path's indent setup previously hand-encoded twice.
+    #[test]
+    fn for_yaml_clamps_zero_and_one_to_two_1685() {
+        for indent in [0u8, 1, 2] {
+            assert_eq!(
+                IndentSpec::for_yaml(indent, false),
+                IndentSpec::spaces(2),
+                "indent={indent}"
+            );
+        }
+        assert_eq!(IndentSpec::for_yaml(4, false), IndentSpec::spaces(4));
+        assert_eq!(IndentSpec::for_yaml(6, false), IndentSpec::spaces(6));
+    }
+
+    /// `--tab` means exactly one tab per level regardless of `-I`'s value,
+    /// including the values that would otherwise clamp.
+    #[test]
+    fn for_yaml_tab_ignores_indent_value_1685() {
+        for indent in [0u8, 1, 2, 4] {
+            assert_eq!(
+                IndentSpec::for_yaml(indent, true),
+                IndentSpec {
+                    width: 1,
+                    unit: '\t'
+                },
+                "indent={indent}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
`OutputConfig::compute_indent_str` (DOM output path) and the M2 streaming fast path's `yaml_indent_spaces`/`indent_unit` setup independently hand-encoded the identical rule: YAML `-I0`/`-I1` both clamp to width 2 (#1486, #1575), `--tab` means one tab per level. Two structurally different expressions of the same formula (`width.max(2)` vs. an `if args.indent == 0 {2} else {...}` chain, the latter provably containing dead code since `0usize.max(2) == 2`) — the third recurrence of this exact duplication pattern in this file's history, per the issue.

Factored both into `IndentSpec::for_yaml(indent: u8, tab: bool) -> Self` in `src/jq/document.rs` (a primitive-args constructor, not `IndentSpec::for_yaml(args: &YqCommand)`, since `document.rs` is the library crate and `YqCommand` lives in the `succinctly-cli` binary crate). Both call sites in `yq_runner.rs` now call it instead of hand-rolling the clamp.

## Test plan
- New unit tests `for_yaml_clamps_zero_and_one_to_two_1685`/`for_yaml_tab_ignores_indent_value_1685` pin the pure logic.
- Manually verified every `-I` value (0/1/2/4) and `--tab` produce identical output on both the M2 fast path (identity query) and the DOM path (forced via a transform) — no behavior change.
- Full test suite (`cargo test --features cli,simd,regex,serde --no-fail-fast`): 55/55 binaries pass, 0 failures (includes the existing `-I`-flag golden tests, unchanged).
- `cargo clippy --all-targets --all-features -- -D warnings` and CI's second (non-all-features) clippy leg: clean.
- `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --no-deps --all-features`: clean.

Closes #1685