### PR TITLE
fix(yq): exclude raw_output from M2 JSON fast-path eligibility

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3515,8 +3515,25 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // `can_slurp_fast_path`'s JSON arm) per /code-review on #1693's own PR:
     // `can_slurp_fast_path` originally diverged from this exact predicate
     // because #1577 copied it by hand instead of sharing it.
-    let can_stream_json_output_style =
-        !args.ascii_output && (output_config.compact || can_stream_pretty_or_colored);
+    // `!output_config.raw_output` (#1715): none of the M2 JSON streamers
+    // consult `raw_output` at all, so `-r`/`-0`/`--join-output` (which all
+    // set it, see `OutputConfig::from_args`) fail to strip JSON string
+    // quoting on this path -- unlike the DOM path's `output_value`, whose
+    // `if config.raw_output { if let OwnedValue::String(s) = value ... }`
+    // arm handles it correctly. Excluded from fast-path eligibility here
+    // rather than fixed inside the streamers themselves: the real fix needs
+    // `GenericResult::stream_json`/`YamlCursor::stream_json` to special-case
+    // a lone string value the same way, which is nontrivial for the
+    // multi-result evaluated case (`stream_json` owns the whole per-value
+    // streaming+separator logic internally) -- this is the low-risk
+    // direction the issue itself names, giving up the fast path's
+    // performance advantage only for this one flag combination rather than
+    // risk a wrong fix to the streamers. Same reasoning YAML never needed:
+    // YAML's own scalar rendering is already unquoted by default (`-r`-like
+    // even without `-r`), so `can_yaml_fast_path` never had this gap.
+    let can_stream_json_output_style = !args.ascii_output
+        && !output_config.raw_output
+        && (output_config.compact || can_stream_pretty_or_colored);
     let can_json_fast_path = is_m2_streamable
         && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3441,6 +3441,52 @@ fn test_join_output_multidoc_does_not_corrupt_documents_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1715: the M2 fast path's JSON streaming never consulted `raw_output`,
+/// so `-r` failed to strip JSON string quoting -- unlike the DOM path's
+/// `output_value`, which handles it correctly. Confirmed live to still
+/// print `"hello"` (quoted) on unmodified `main`. Fixed by excluding
+/// `raw_output` from JSON fast-path eligibility (`can_stream_json_output_style`)
+/// rather than teaching the M2 streamers the special case, so this falls
+/// back to the already-correct DOM path.
+#[test]
+fn test_raw_output_json_identity_strips_quotes_1715() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "\"hello\"\n", &["-o", "json", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "hello\n");
+
+    // Baseline: without -r, the M2 fast path still quotes normally.
+    let (output, code) = run_yq_stdin(".", "\"hello\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "\"hello\"\n");
+
+    Ok(())
+}
+
+/// Same fix, evaluated (multi-result) path -- each iterated string must be
+/// unquoted, not just a bare identity scalar.
+#[test]
+fn test_raw_output_json_evaluated_strips_quotes_1715() -> Result<()> {
+    let (output, code) = run_yq_stdin(".[]", "[\"hello\", \"world\"]\n", &["-o", "json", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "hello\nworld\n");
+    Ok(())
+}
+
+/// `--join-output` also sets `raw_output` (`OutputConfig::from_args`) and
+/// suppresses the terminator entirely -- verified against the pinned jq
+/// 1.7.1 oracle (`echo '["hello","world"]' | jq -j '.[]'` -> `helloworld`).
+#[test]
+fn test_join_output_json_strips_quotes_1715() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".[]",
+        "[\"hello\", \"world\"]\n",
+        &["-o", "json", "--join-output"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "helloworld");
+    Ok(())
+}
+
 /// #1708: `-0`/`--join-output` combined with `-C` (color) on the M2 fast
 /// path's evaluated (non-identity) branch embedded the terminator byte
 /// *inside* the ANSI color span, before the trailing reset code --

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3472,6 +3472,35 @@ fn test_raw_output_json_evaluated_strips_quotes_1715() -> Result<()> {
     Ok(())
 }
 
+/// #1715 review: `--inplace` gates the identical bug independently via
+/// `can_inplace_json_fast_path`, which shares `can_stream_json_output_style`
+/// with the stdout gates above -- same one-line fix, but a distinct code
+/// path (its own `stream_cursor!` call site) that no test here exercised.
+/// Confirmed live on the pre-fix commit: `-o json -r -i` wrote the literal
+/// quoted `"hello"` back to disk instead of `hello`.
+#[test]
+fn test_raw_output_json_inplace_strips_quotes_1715() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "\"hello\"")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-o")
+        .arg("json")
+        .arg("-r")
+        .arg("-i")
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(output.status.success());
+    let rewritten = std::fs::read(input_file.path())?;
+    assert_eq!(rewritten, b"hello\n");
+
+    Ok(())
+}
+
 /// `--join-output` also sets `raw_output` (`OutputConfig::from_args`) and
 /// suppresses the terminator entirely -- verified against the pinned jq
 /// 1.7.1 oracle (`echo '["hello","world"]' | jq -j '.[]'` -> `helloworld`).


### PR DESCRIPTION
## Summary
The M2 fast path's JSON streaming (`stream_cursor!`'s JSON arm, both the identity and evaluated branches in `yq_runner.rs`) never consulted `OutputConfig::raw_output`, so `-r`/`--raw-output` (and, since #1701, anything that implies it: `-0`/`--nul-output`, `--join-output`) failed to strip JSON string quoting — unlike the DOM path's `output_value`, which handles it correctly.

```console
$ printf '"hello"\n' | succinctly yq -o json -r '.'
"hello"          # should be: hello
```

Fixed by excluding `raw_output` from `can_stream_json_output_style` — the local already shared by all three JSON fast-path gates (`can_json_fast_path`, `can_inplace_json_fast_path`, `can_slurp_fast_path`'s JSON arm), the same mechanism the repo already uses for `--ascii-output`'s exclusion — falling back to the already-correct DOM path for this one flag combination, rather than teaching the M2 streamers the special case inline. The issue itself names this as the low-risk direction: the real fix (`stream_json` special-casing a lone string value) is nontrivial for the multi-result evaluated case, since that function owns the whole per-value streaming+separator logic internally.

YAML never had this gap: YAML's own scalar rendering is already unquoted by default (`-r`-like even without `-r`), so `can_yaml_fast_path` needed no equivalent exclusion.

## Test plan
- Verified all three repro shapes from the issue against the pinned yq/jq oracles: bare `-r` (identity and evaluated/iterated), `--join-output` (matches `jq -j` exactly), `-0`/`--nul-output`.
- Verified the DOM-forced path (already correct), the normal M2 path without `-r` (still quoted, unaffected), and YAML raw output (unaffected) all still behave correctly.
- New tests `test_raw_output_json_identity_strips_quotes_1715`, `test_raw_output_json_evaluated_strips_quotes_1715`, `test_join_output_json_strips_quotes_1715`.
- Full test suite (`cargo test --features cli,simd,regex,serde --no-fail-fast`): 55/55 binaries pass, 0 failures — no golden-test regressions.
- `cargo clippy --all-targets --all-features -- -D warnings` and CI's second (non-all-features) clippy leg: clean.
- `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --no-deps --all-features`: clean.

Closes #1715