### PR TITLE
perf(yaml): reserve scratch-buffer capacity in stream_yaml_string_to_json

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3981,7 +3981,11 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
                 // `String` can, so transcode into a scratch buffer and commit
                 // only once it succeeds (#1247). Only this branch pays the
                 // allocation: the fast path above decodes before it writes.
-                let mut committed = String::new();
+                // `bytes.len()` is a tight lower bound on the transcoded
+                // length (escapes shrink; JSON escaping can grow it a
+                // little), so reserving it up front avoids the realloc
+                // chain `String::new()` would pay for (#1622).
+                let mut committed = String::with_capacity(bytes.len() + 2);
                 stream_transcode_double_quoted_to_json(&mut committed, bytes)?;
                 out.write_str(&committed)
                     .map_err(|_| YamlStringError::InvalidUtf8)?;
@@ -3997,8 +4001,8 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
                 stream_json_string(out, s).map_err(|_| YamlStringError::InvalidUtf8)?;
             } else {
                 // Same commit-on-success rollback as the double-quoted arm
-                // above (#1247).
-                let mut committed = String::new();
+                // above (#1247), with the same capacity hint (#1622).
+                let mut committed = String::with_capacity(bytes.len() + 2);
                 stream_transcode_single_quoted_to_json(&mut committed, bytes)?;
                 out.write_str(&committed)
                     .map_err(|_| YamlStringError::InvalidUtf8)?;


### PR DESCRIPTION
## Summary

Fixes #1622. The commit-on-success scratch buffer #1247 added to `stream_yaml_string_to_json`'s streaming double- and single-quoted arms started at `String::new()`, forcing a realloc chain on every scalar taking the slow branch. That branch fires on any double-quoted scalar with a backslash or line span, and any single-quoted scalar with an embedded `''` or line span — routine on real Kubernetes manifests, CI configs, and log-bearing YAML, not just malformed input.

`bytes.len()` is a tight lower bound on the transcoded length (escapes shrink; JSON escaping can grow it a little), so `String::with_capacity(bytes.len() + 2)` turns the realloc chain into one allocation for the common case, matching the issue's own suggested fix exactly.

## Verification

- Full test suite: 1028/1028 in `jq_cli_tests` + full workspace suite green (one `signal 9` flake in `test_range_bound_fanout_prefix_then_raises_1556` reproduced as machine contention, not a regression — passes in isolation and on full re-run).
- Both clippy legs (`--all-features` and `cli,simd,regex,serde`) clean, `cargo fmt --check` clean.
- Pure allocation-strategy change — no behavioral difference, byte-identical output.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`

Closes #1622