### PR TITLE
test(ci): run bench-runner-gated tests in CI, fix a cargo-run clobber hazard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,17 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
+      # `tests/orchestrate_cli_tests.rs` is `#![cfg(feature = "bench-runner")]`
+      # and was never previously built or run by any `cargo test` step here
+      # (#1705) -- run in its own step, isolated from the `cli`-only tests
+      # above (whose `cargo run`-spawned CLI subprocesses would otherwise
+      # re-link the shared `target/debug/succinctly` binary with a narrower
+      # feature set, dropping the `bench` subcommand out from under this
+      # test target if it ran afterward in the same invocation).
+      - name: Run bench-runner-gated tests
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --features cli,bench-runner --test orchestrate_cli_tests
+
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
@@ -245,6 +256,10 @@ jobs:
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
         run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+
+      - name: Run bench-runner-gated tests
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --features cli,bench-runner --test orchestrate_cli_tests
 
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
@@ -344,6 +359,10 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
 
+      - name: Run bench-runner-gated tests
+        if: needs.gate.outputs.code == 'true'
+        run: cargo test --features cli,bench-runner --test orchestrate_cli_tests
+
       - name: Run tests
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose
@@ -405,6 +424,9 @@ jobs:
 
       - name: Run cli-gated tests
         run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+
+      - name: Run bench-runner-gated tests
+        run: cargo test --features cli,bench-runner --test orchestrate_cli_tests
 
       - name: Run tests
         run: cargo test --verbose

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -26,7 +26,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, MAX_CARGO_RETRIES};
+use cargo_run_exit::{cargo_run_features, classify_cargo_run_exit, MAX_CARGO_RETRIES};
 
 /// Run `succinctly <args>` with `stdin` piped in, returning captured stdout.
 ///
@@ -36,7 +36,14 @@ use cargo_run_exit::{classify_cargo_run_exit, MAX_CARGO_RETRIES};
 fn run(args: &[&str], stdin: &str) -> Result<String> {
     for attempt in 0..MAX_CARGO_RETRIES {
         let mut cmd = Command::new("cargo")
-            .args(["run", "--features", "cli", "--bin", "succinctly", "--"])
+            .args([
+                "run",
+                "--features",
+                cargo_run_features(),
+                "--bin",
+                "succinctly",
+                "--",
+            ])
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -9,13 +9,22 @@ use std::time::Duration;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
+use cargo_run_exit::{
+    cargo_run_features, classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES,
+};
 
 /// Helper to run a CLI command and capture its output
 fn run_cli(args: &[&str]) -> Result<String> {
     for attempt in 0..MAX_CARGO_RETRIES {
         let output = Command::new("cargo")
-            .args(["run", "--features", "cli", "--bin", "succinctly", "--"])
+            .args([
+                "run",
+                "--features",
+                cargo_run_features(),
+                "--bin",
+                "succinctly",
+                "--",
+            ])
             .args(args)
             .output()?;
 

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -26,8 +26,10 @@ use anyhow::Result;
 mod exit_status;
 
 /// The `--features` value a `cargo run`-spawned CLI subprocess should build
-/// with -- always `cli` (needed for the binary itself), plus `bench-runner`
-/// whenever the enclosing `cargo test` invocation also requested it.
+/// with -- always `cli` (needed for the binary itself), or just
+/// `bench-runner` whenever the enclosing `cargo test` invocation also
+/// requested it (`Cargo.toml`'s `bench-runner = ["cli", ...]` already pulls
+/// `cli` in, so naming both would be redundant).
 ///
 /// A hardcoded `"cli"` at each call site used to clobber a shared
 /// `target/debug/succinctly` binary another test target in the same run
@@ -43,7 +45,7 @@ mod exit_status;
 /// out from under a sibling test target.
 pub fn cargo_run_features() -> &'static str {
     if cfg!(feature = "bench-runner") {
-        "cli,bench-runner"
+        "bench-runner"
     } else {
         "cli"
     }

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -1,9 +1,10 @@
 //! Shared exit-code classification for `cargo run`-spawned CLI test helpers.
 //!
 //! Included by `tests/jq_cli_tests.rs`, `tests/cli_golden_tests.rs`,
-//! `tests/cli_characterization_tests.rs` and `tests/deep_nesting_valid_tests.rs`
-//! via `#[path = ...] mod`, per the `tests/common/` convention `json_oracle.rs`
-//! established. #1516 fixed the signal-death misdiagnosis
+//! `tests/cli_characterization_tests.rs`, `tests/deep_nesting_valid_tests.rs`
+//! and `tests/json_validate_tests.rs` via `#[path = ...] mod`, per the
+//! `tests/common/` convention `json_oracle.rs` established. #1516 fixed the
+//! signal-death misdiagnosis
 //! (`.code().unwrap_or(-1)` silently coercing a killed child to a fake exit
 //! code) in `jq_cli_tests.rs` alone; its own `/code-review` found the
 //! identical pattern hand-rolled in three more files (#1546). Sharing one
@@ -23,6 +24,30 @@ use anyhow::Result;
 
 #[path = "../../src/bin/succinctly/exit_status.rs"]
 mod exit_status;
+
+/// The `--features` value a `cargo run`-spawned CLI subprocess should build
+/// with -- always `cli` (needed for the binary itself), plus `bench-runner`
+/// whenever the enclosing `cargo test` invocation also requested it.
+///
+/// A hardcoded `"cli"` at each call site used to clobber a shared
+/// `target/debug/succinctly` binary another test target in the same run
+/// depends on (#1705): `cargo run --features cli` rebuilds and relinks that
+/// exact path with a narrower feature set than the outer `cargo test
+/// --features cli,...,bench-runner` invocation that compiled *this* test
+/// binary, silently dropping the `bench` subcommand out from under
+/// `tests/orchestrate_cli_tests.rs`'s own `env!("CARGO_BIN_EXE_succinctly")`
+/// if that test target happens to run afterward in the same `cargo test`
+/// process. `cfg!(feature = "bench-runner")` reads whether *this* compiled
+/// test binary was built with it, which is exactly the feature set the
+/// inner `cargo run` needs to match to avoid re-linking the shared binary
+/// out from under a sibling test target.
+pub fn cargo_run_features() -> &'static str {
+    if cfg!(feature = "bench-runner") {
+        "cli,bench-runner"
+    } else {
+        "cli"
+    }
+}
 
 /// Maximum retries for a `cargo run` command that fails with exit code 101,
 /// or whose child is killed by a signal (`ExitStatus::code()` returns `None`

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -22,7 +22,7 @@ use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, MAX_CARGO_RETRIES};
+use cargo_run_exit::{cargo_run_features, classify_cargo_run_exit, MAX_CARGO_RETRIES};
 
 /// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
 /// yet comfortably under the ~128-level DoS cap proposed in #151/#152.
@@ -32,7 +32,14 @@ const VALID_DEPTH: usize = 100;
 fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
     for attempt in 0..MAX_CARGO_RETRIES {
         let mut cmd = Command::new("cargo")
-            .args(["run", "--features", "cli", "--bin", "succinctly", "--"])
+            .args([
+                "run",
+                "--features",
+                cargo_run_features(),
+                "--bin",
+                "succinctly",
+                "--",
+            ])
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12,7 +12,9 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
+use cargo_run_exit::{
+    cargo_run_features, classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES,
+};
 
 /// Maximum retries for spawning the pre-built binary directly.
 ///
@@ -136,7 +138,7 @@ fn run_jq_stdin_streams(
                 "run",
                 "--quiet",
                 "--features",
-                "cli",
+                cargo_run_features(),
                 "--bin",
                 "succinctly",
                 "--",
@@ -233,7 +235,7 @@ fn run_jq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(St
                 "run",
                 "--quiet",
                 "--features",
-                "cli",
+                cargo_run_features(),
                 "--bin",
                 "succinctly",
                 "--",
@@ -266,7 +268,7 @@ fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
                 "run",
                 "--quiet",
                 "--features",
-                "cli",
+                cargo_run_features(),
                 "--bin",
                 "succinctly",
                 "--",
@@ -408,7 +410,7 @@ fn test_unary_minus() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -437,7 +439,7 @@ fn test_unary_minus_expression() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -466,7 +468,7 @@ fn test_double_negation() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -561,7 +563,7 @@ fn test_slurp_with_raw_input_multiple_files() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -1298,7 +1300,7 @@ fn test_from_file() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -1534,7 +1536,7 @@ fn test_multiple_file_inputs() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -1606,7 +1608,7 @@ fn test_builtin_first_on_non_array_errors() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -1651,7 +1653,7 @@ fn jq_stderr(filter: &str, input: &str, extra_args: &[&str]) -> Result<String> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -1872,7 +1874,7 @@ fn test_contains_type_mismatch_errors() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -2239,7 +2241,7 @@ fn test_default_identity_filter() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -2267,7 +2269,7 @@ fn test_jq_help() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3338,7 +3340,7 @@ fn test_args_positional() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3363,7 +3365,7 @@ fn test_jsonargs_positional() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3389,7 +3391,7 @@ fn test_args_named() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3419,7 +3421,7 @@ fn test_args_combined() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3454,7 +3456,7 @@ fn test_no_color_env_var() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3490,7 +3492,7 @@ fn test_jq_colors_env_var() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3519,7 +3521,7 @@ fn test_color_output_overrides_no_color() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3548,7 +3550,7 @@ fn test_monochrome_overrides_jq_colors() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3578,7 +3580,7 @@ fn test_jq_colors_invalid_spec_warns_and_uses_defaults() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3626,7 +3628,7 @@ fn test_build_configuration_flag() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3662,7 +3664,7 @@ fn test_include_directive() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3699,7 +3701,7 @@ fn test_import_directive() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3731,7 +3733,7 @@ fn test_library_path_option() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3761,7 +3763,7 @@ fn test_jq_library_path_env() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3792,7 +3794,7 @@ fn test_module_not_found_error() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3821,7 +3823,7 @@ fn test_namespaced_call_parse() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3856,7 +3858,7 @@ fn test_home_jq_file_autoload() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3900,7 +3902,7 @@ fn test_home_jq_dir_search_path() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -3936,7 +3938,7 @@ fn test_import_with_namespace() -> Result<()> {
         .args([
             "run",
             "--features",
-            "cli",
+            cargo_run_features(),
             "--bin",
             "succinctly",
             "--",
@@ -4057,7 +4059,7 @@ fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Resul
                 "run",
                 "--quiet",
                 "--features",
-                "cli",
+                cargo_run_features(),
                 "--bin",
                 "succinctly",
                 "--",

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -12,7 +12,9 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, exit_code_or_signal_death, MAX_CARGO_RETRIES};
+use cargo_run_exit::{
+    cargo_run_features, classify_cargo_run_exit, exit_code_or_signal_death, MAX_CARGO_RETRIES,
+};
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -380,7 +382,7 @@ fn run_json_validate_via_cargo(files: &[&std::path::Path]) -> Result<i32> {
             .args([
                 "run",
                 "--features",
-                "cli",
+                cargo_run_features(),
                 "--bin",
                 "succinctly",
                 "--",


### PR DESCRIPTION
## Summary

While verifying #1696 (PR #1703), running the local test suite with `--features cli,simd,regex,serde,bench-runner` together surfaced two related gaps:

**1. `orchestrate_cli_tests.rs` (and other `bench-runner`-gated integration tests) never execute in CI at all.** `.github/workflows/ci.yml`'s `cargo test` steps never pass `--features bench-runner` (only in the three `cargo clippy` invocations, never a `cargo test` one). `tests/orchestrate_cli_tests.rs` is `#![cfg(feature = "bench-runner")]`, so it silently never compiles, let alone runs, in CI.

**2. When it *is* run, a `cargo run` clobber hazard breaks it.** `tests/jq_cli_tests.rs` (and `cli_golden_tests.rs`, `cli_characterization_tests.rs`, `deep_nesting_valid_tests.rs`, `json_validate_tests.rs`) invoke `Command::new("cargo").args(["run", "--quiet", "--features", "cli", ...])` directly as part of their own test bodies -- a narrower feature set than the outer `cargo test --features cli,simd,regex,serde,bench-runner` invocation. Since `jq_cli_tests.rs` runs alphabetically before `orchestrate_cli_tests.rs`, its `cargo run --features cli` subprocess rebuilds and relinks the shared `target/debug/succinctly` binary with the narrower set, clobbering the `bench` subcommand out from under `orchestrate_cli_tests.rs`'s own `env!("CARGO_BIN_EXE_succinctly")`.

## Fix

- Added a dedicated "Run bench-runner-gated tests" step (`cargo test --features cli,bench-runner --test orchestrate_cli_tests`) to all four Test jobs (x86_64, ARM64, macOS ARM64, beta/nightly matrix) -- scoped narrowly to just that one test target, matching the issue's own suggested direction, rather than a broad wildcard that would also pull in unrelated snapshot tests this repo has never run under `bench-runner`.
- Added `cargo_run_features()` to the shared `tests/common/cargo_run_exit.rs` module (already included by all 5 affected files): `cfg!(feature = "bench-runner")` reads whether the *current* compiled test binary needs it, so the inner `cargo run` always matches what compiled the outer `cargo test` invocation. Replaced the ~38 hardcoded `"--features", "cli"` call sites across the 5 files with it.

## Not included

The issue's own "related, minor" bonus item (`.omni-dev/scopes.yaml`'s `bench` scope `file_patterns` not covering `src/bin/succinctly/bench_runner/**`) was explicitly deferred by the issue itself ("not fixed here since it's a one-line docs/config change orthogonal to the two gaps above") -- left out of this PR to stay on scope.

## Test plan

- Reproduced the original clobber bug locally (`cargo test --features cli,simd,regex,serde,bench-runner` on unmodified `main`: `orchestrate_cli_tests.rs` fails with `error: unrecognized subcommand 'bench'`), then confirmed the fix resolves it (same command post-fix: 0 failures, no clobber error).
- Verified the exact CI-scoped invocation (`cargo test --features cli,bench-runner --test orchestrate_cli_tests`) passes cleanly: 5/5 tests pass.
- Full local `cargo test --features cli,simd,regex,serde` (CI's normal, non-bench-runner invocation): 0 failures -- confirms the fix doesn't change behavior for the common case.
- `cargo test --features cli,simd,regex,serde,bench-runner --tests` (whole suite compiles with the new feature): clean.
- `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD/x86 feature-set leg: both clean.
- `cargo doc --no-deps --all-features`, `cargo fmt --check`, `cargo build --no-default-features` (no_std): all clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` on the modified `ci.yml`: valid.
- No coverage delta: this PR touches only `tests/*.rs` and CI YAML, neither in `cargo llvm-cov`'s scanned scope.

Fixes #1705
