### PR TITLE
fix(yq): = collapses a multi-output RHS to its last value, no fan-out

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -683,6 +683,50 @@ $ printf 'a: [1, 2]\n' | yq            -o=json '.a[].b = error("boom")'   # {"a"
 $ printf 'a: [1, 2]\n' | succinctly yq -o=json '.a[].b = error("boom")'   # Error: boom
 ```
 
+### `=`'s multi-output RHS: real yq takes only the last value, no fan-out
+
+[#1430](https://github.com/rust-works/succinctly/issues/1430) started as a narrower report
+("a self-referencing multi-path assignment prints one extra document") whose own claimed
+expected output turned out not to match live yq at all. Re-verified against v4.53.3: `=`'s
+RHS is not special to self-reference — a multi-output RHS of *any* shape collapses to its
+**last** output, applied once to every resolved path, producing exactly one document. Real
+jq's own `=`, by contrast, genuinely forks — one whole document per RHS output (#392,
+unaffected by this fix):
+
+```bash
+$ echo '{"a":[1,2]}' | yq            -o=json -I0 '.a[] = .a[] + 1'   # {"a":[3,3]}
+$ echo '{"a":[1,2]}' | succinctly yq -o=json -I0 '.a[] = .a[] + 1'   # {"a":[3,3]}  (fixed)
+
+$ echo '{"x":0}'     | yq            -o=json -I0 '.x = (10,20,30)'   # {"x":30}
+$ echo '{"x":0}'     | succinctly yq -o=json -I0 '.x = (10,20,30)'   # {"x":30}  (fixed)
+```
+
+Fixed in `eval_assign` (`src/jq/eval.rs`) by collapsing `rhs_values` to its last element
+before the fan-out loop, gated on `S::TAG == EvalTag::Yq` — the loop itself, and every other
+mode, is untouched.
+
+**Deliberately still open:** the collapse only applies when the RHS stream completes
+cleanly (`terminal.is_none()`). A RHS that *itself* errors partway through
+(`.x = (1, error("boom"), 3)`) still uses jq's pre-existing partial-fan-out behavior in yq
+mode too, which has not been verified against real yq (live-checked only that real yq
+raises the error with no document printed at all — not the shape needed to characterize
+what succinctly should do instead). Not folded into this fix, since redefining an
+unverified error-interaction shape risked a second, differently-wrong divergence rather than
+fixing one — filed as [#1779](https://github.com/rust-works/succinctly/issues/1779).
+
+**Separately, not part of this fix:** live-probing this also surfaced that real jq's own
+`+=`/`-=`/`*=`/`/=`/`%=` (unlike `|=`) genuinely fork over a multi-output RHS the same way
+`=` does (`.x += (10,20,30)` on `{"x":1}` is three documents, `{"x":11}`/`{"x":21}`/
+`{"x":31}`) — succinctly's `eval_rhs_once` (shared by all of `eval_compound_assign` and
+`eval_alternative_assign`) instead always collapses to the *first* output, a pre-existing,
+already-documented gap in that function's own doc comment (referencing #392) that predates
+and is unrelated to #1430's yq-mode scope. Real yq's own answer for these operators under a
+multi-output RHS also isn't "first" — live-verified `.x += (10,20,30)` on `{"x":1}` is
+`{"x":31}` (last value, matching `=`'s own rule above), not `{"x":11}`. Both the jq-mode
+fork gap and the yq-mode wrong-value gap are real, separate from each other and from #1430,
+and neither is fixed here — filed as
+[#1778](https://github.com/rust-works/succinctly/issues/1778).
+
 ### `-o=auto` on a genuinely mixed-format multi-source run doesn't match per-element
 
 [#1493](https://github.com/rust-works/succinctly/issues/1493) made `-o=auto` resolve

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15201,7 +15201,7 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // other multi-output combinator here uses (#400, #494), so the
     // zero-prefix case (a bare `Error`/`Break`) and the nonzero-prefix case
     // (`Partial`) share one code path below instead of two.
-    let (rhs_values, terminal): (Vec<OwnedValue>, Option<Control>) =
+    let (mut rhs_values, terminal): (Vec<OwnedValue>, Option<Control>) =
         match eval_single::<W, S>(value_expr, input.clone(), optional).materialize_cursor() {
             QueryResult::One(v) => match to_owned_checked(&v) {
                 Ok(owned) => (vec![owned], None),
@@ -15232,6 +15232,23 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Some(Control::Error(_)) if optional => QueryResult::None,
             Some(control) => partial(Vec::new(), control), // normalizes to bare Error/Break
         };
+    }
+
+    // Real yq's `=` never forks over a multi-output RHS the way jq's does
+    // (#392): it applies only the *last* output, once, to every resolved
+    // path -- confirmed live (v4.53.3): `.x = (1,2,3)` on `{"x":0}` is
+    // `{"x":3}`, one document, not three; `.a[] = .a[] + 1` on `{"a":[1,2]}`
+    // is `{"a":[3,3]}`, not two documents (#1430's own claimed expected
+    // output, `{"a":[2,3]}`, does not match live yq at all). Only collapsed
+    // on a *clean* completion (`terminal.is_none()`): a mid-stream error/
+    // break/halt keeps jq's existing partial-prefix fan-out below, since
+    // real yq's error-interaction behavior here hasn't been verified and
+    // this fix doesn't attempt to redefine it (#1430 was filed as, and this
+    // stays scoped to, the successful-completion case -- the error-
+    // interaction shape is tracked separately as #1779).
+    if S::TAG == EvalTag::Yq && terminal.is_none() && rhs_values.len() > 1 {
+        let last = rhs_values.pop().expect("len > 1 checked above");
+        rhs_values = vec![last];
     }
 
     // Resolve computed keys against the *original* document, before any
@@ -49980,6 +49997,56 @@ mod tests {
                 assert_eq!(prefix_json(&vs), ["[8,8,3,4]"]);
                 assert_eq!(e.message, "A slice of an array can only be assigned another array");
             }
+        );
+    }
+
+    #[test]
+    fn test_yq_assign_self_referencing_iterate_collapses_to_one_document_1430() {
+        // Real yq's `=` never forks over a multi-output RHS the way jq's
+        // does (#392): it applies only the *last* output, once, to every
+        // resolved path. Confirmed live (v4.53.3): `.a[] = .a[] + 1` on
+        // `{"a":[1,2]}` is `{"a":[3,3]}`, one document -- not
+        // `{"a":[2,3]}` (#1430's own originally-claimed expected output,
+        // which does not match live yq) and not two documents (succinctly's
+        // pre-fix behavior, which matched jq's fan-out instead).
+        assert_eq!(
+            outputs_yq(br#"{"a":[1,2]}"#, ".a[] = .a[] + 1"),
+            vec![r#"{"a":[3,3]}"#],
+        );
+        // Same collapse through a nested field under the self-referencing
+        // Iterate (live-verified: `{"a":[{"b":3},{"b":3}]}`, one document).
+        assert_eq!(
+            outputs_yq(br#"{"a":[{"b":1},{"b":2}]}"#, ".a[].b = .a[].b + 1"),
+            vec![r#"{"a":[{"b":3},{"b":3}]}"#],
+        );
+    }
+
+    #[test]
+    fn test_yq_assign_multi_output_rhs_takes_last_value_not_self_referencing_1430() {
+        // The collapse isn't specific to a self-referencing RHS -- any
+        // multi-output RHS collapses to its last value in yq mode.
+        // Live-verified: `.x = (10,20,30)` on `{"x":0}` is `{"x":30}`.
+        assert_eq!(
+            outputs_yq(br#"{"x":0}"#, ".x = (10,20,30)"),
+            vec![r#"{"x":30}"#],
+        );
+    }
+
+    #[test]
+    fn test_yq_assign_single_output_rhs_unaffected_1430() {
+        // The common case (`.x = 5`) never had more than one RHS output to
+        // collapse, so it's untouched by the fix.
+        assert_eq!(outputs_yq(br#"{"x":0}"#, ".x = 5"), vec![r#"{"x":5}"#]);
+    }
+
+    #[test]
+    fn test_jq_assign_multi_output_rhs_still_forks_unaffected_by_1430() {
+        // The yq-only collapse must not leak into jq mode, whose `.x =
+        // (1,2,3)` fan-out (#392) is separately tested elsewhere and stays
+        // exactly as it was.
+        assert_eq!(
+            outputs(b"{\"x\":0}", ".x = (1,2,3)"),
+            vec![r#"{"x":1}"#, r#"{"x":2}"#, r#"{"x":3}"#],
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15248,7 +15248,8 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // interaction shape is tracked separately as #1779).
     if S::TAG == EvalTag::Yq && terminal.is_none() && rhs_values.len() > 1 {
         let last = rhs_values.pop().expect("len > 1 checked above");
-        rhs_values = vec![last];
+        rhs_values.clear();
+        rhs_values.push(last);
     }
 
     // Resolve computed keys against the *original* document, before any


### PR DESCRIPTION
## Summary

Fixes #1430 — but the issue's own claimed expected output was wrong. Re-verified live against yq v4.53.3: `.a[] = .a[] + 1` on `{"a":[1,2]}` is `{"a":[3,3]}` (one document), not `{"a":[2,3]}` as the issue stated. And it's not specific to self-reference at all: **any** multi-output RHS collapses to its last value in real yq, applied once to every resolved LHS path — `.x = (10,20,30)` on `{"x":0}` is `{"x":30}`, not three documents.

Real jq's own `=`, by contrast, genuinely forks — one document per RHS output (#392) — and that stays unchanged; this fix is yq-mode only.

## Fix

`eval_assign` (`src/jq/eval.rs`): truncate `rhs_values` to its last element before the existing fan-out loop, gated on `S::TAG == EvalTag::Yq && terminal.is_none()`. Reuses the entire existing loop/error-handling/document-building path — the only change is which (and how many) RHS values feed it.

## Deliberately out of scope (both filed as follow-ups)

- **#1779**: the collapse only applies on a *clean* RHS completion. A RHS that errors partway through (`.x = (1, error("boom"), 3)`) still uses jq's pre-existing partial-fan-out shape in yq mode too — real yq's actual behavior here (live-checked: no document printed at all, just the error) hasn't been characterized enough to reimplement with confidence.
- **#1778**: live-probing this surfaced that the compound assignment operators (`+=`/`-=`/`*=`/`/=`/`%=`, via the shared `eval_rhs_once`) have their own, separate multi-output-RHS gaps in **both** modes — jq mode should fork (like `=` does) but doesn't; yq mode should take the *last* value (like `=` now does) but takes the *first*. Different function, different fix, tracked separately.

Both gaps and this fix are documented in [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md#s-multi-output-rhs-real-yq-takes-only-the-last-value-no-fan-out).

## Verification

- 4 new regression tests (`src/jq/eval.rs`): self-referencing Iterate collapse, non-self-referencing multi-output collapse, single-output-RHS unaffected, jq-mode fan-out unaffected.
- Full test suite green (one unrelated `signal 9` flake in a subprocess-spawning stderr test, reproduced as machine contention on two separate full re-runs, not a regression).
- Both clippy legs clean, `cargo fmt --check` clean, `cargo doc` clean, `--no-default-features` (no_std) builds clean.
- Verified against pinned yq v4.53.3 oracle for every case in the summary above.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features`

Closes #1430