### PR TITLE
perf(jq): rindex(pattern) on an array avoids collecting into a Vec

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10752,22 +10752,23 @@ fn search_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Owned(OwnedValue::Null)
             }
             // Unlike `First`, this has to walk the whole array before it
-            // knows the answer. Carried over verbatim from the pre-merge
-            // `rindex_with_pattern` (#1538 is a pure consolidation, not a
-            // perf change): collects into a `Vec` and walks it in reverse,
-            // which costs an O(n) allocation + element clones a plain
-            // forward pass with a running "last match" accumulator would
-            // avoid -- `DocumentElements`'s cursor being forward-only rules
-            // out `DoubleEndedIterator::rev` directly, but does not require
-            // collecting first. Left as-is here; tracked as a follow-up.
+            // knows the answer. `DocumentElements`'s cursor being
+            // forward-only rules out `DoubleEndedIterator::rev` directly,
+            // but a plain forward pass with a running "last match"
+            // accumulator answers the same question without the O(n)
+            // collect-into-Vec + element clones the pre-#1773 version paid
+            // for just to walk backwards (#1773).
             SearchOccurrence::Last => {
-                let items: Vec<_> = (*elements).collect();
-                for (i, elem) in items.iter().enumerate().rev() {
-                    if owned_value_eq::<S>(&to_owned(elem), pattern) {
-                        return QueryResult::Owned(OwnedValue::Int(i as i64));
+                let mut last = None;
+                for (i, elem) in (*elements).enumerate() {
+                    if owned_value_eq::<S>(&to_owned(&elem), pattern) {
+                        last = Some(i);
                     }
                 }
-                QueryResult::Owned(OwnedValue::Null)
+                match last {
+                    Some(i) => QueryResult::Owned(OwnedValue::Int(i as i64)),
+                    None => QueryResult::Owned(OwnedValue::Null),
+                }
             }
         },
         _ => unsearchable_input(value, pattern, optional),


### PR DESCRIPTION
## Summary

Fixes #1773. `search_pattern`'s `SearchOccurrence::Last` array branch (backing `rindex(pattern)` on an array) collected every element into a `Vec<OwnedValue>` before walking it in reverse, purely to answer "which position was the last match" — an O(n) allocation plus a per-element clone. A plain forward pass with a running "last match" accumulator answers the same question in O(1) extra space, exactly as sketched in the issue.

`DocumentElements`'s cursor is forward-only so `DoubleEndedIterator::rev()` isn't directly available — this avoids needing it rather than working around its absence.

## Verification

- Spot-checked against `/usr/bin/jq` (1.7.1 pin) for multi-match, no-match, and empty-array cases.
- Existing `test_rindex_array` (`[1, 2, 3, 1, 2] | rindex(2)` expects index `4`) already exercises the multi-match case and would catch a first-vs-last regression — passed unchanged, no new test needed for this pure algorithmic equivalence.
- Full test suite green, both clippy legs clean, `cargo fmt --check` clean, `cargo doc` clean, `--no-default-features` builds clean.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features`

Closes #1773