### PR TITLE
fix(jq): keys_unsorted demand-aware sink raises on a malformed key it pulls

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1214,6 +1214,46 @@ Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../
 [`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
 (the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).
 
+## A truncating consumer of `keys_unsorted[]` skips a malformed member it never needed
+
+Sibling of the `map(f)` divergence directly above, for the same underlying reason: a
+[#1194](https://github.com/rust-works/succinctly/issues/1194) malformed object member
+(a non-string key, or an unpaired trailing member with no value) is detected by walking
+the object, and a demand-aware consumer that stops pulling early never walks past its own
+stopping point.
+
+[#1629](https://github.com/rust-works/succinctly/issues/1629) made every `keys_unsorted`
+arm that already walks the whole object regardless (`keys_unsorted[]`, `| last`, a
+*negative* `[n]`) raise on a malformed member, riding that walk for free.
+[#1770](https://github.com/rust-works/succinctly/issues/1770) extended the same check to
+`first(keys_unsorted[])`/`limit(n; keys_unsorted[])` for a malformed key the sink *actually
+pulls* — `DistinctKeyCursors::next` already decodes every key it yields to hash it, so
+checking it there costs nothing extra:
+
+```
+$ echo '{123: 1, "b": 2}' | succinctly jq -c 'first(keys_unsorted[])'      # error, exit 5
+$ echo '{"a":1, 123:2}'   | succinctly jq -c 'limit(2; keys_unsorted[])'   # "a", then error, exit 5
+```
+
+What neither fix reaches: a malformed member sitting *after* whatever the consumer
+actually pulled. Detecting an unpaired tail specifically requires reaching exhaustion
+(there is no per-key signal for "the object ends improperly" the way there is for "this
+key isn't a string") — which a truncating consumer may never do by design:
+
+```
+$ echo '{"a":1,123:2}' | succinctly jq -c 'first(keys_unsorted[])'   # "a", exit 0
+$ echo '{"a":1,"b"}'   | succinctly jq -c 'first(keys_unsorted[])'   # "a", exit 0
+$ echo '{"a":1,123:2}' | succinctly jq -c 'keys_unsorted[]'          # error, exit 5 (unaffected -- always exhausts)
+```
+
+Deliberate, for the same reason the `map(f)` divergence above is: restoring the check here
+would mean walking past the point the demand-aware sink stopped, defeating the reason
+`each_lazy_keys_iterate_sink` (`src/jq/eval_generic.rs`) exists rather than routing through
+the already-checked, always-walks `fold_lazy_keys_stage`. Pinned by
+[`test_jq_keys_unsorted_demand_aware_raises_on_pulled_malformed_key_1770`](../../../tests/jq_cli_tests.rs)
+and
+[`test_jq_keys_unsorted_demand_aware_still_known_gap_past_what_it_pulled_1770`](../../../tests/jq_cli_tests.rs).
+
 ## `limit`'s own `n` argument is not demand-aware when it is itself a generator
 
 Real jq passes `limit($n; f)`'s `$n` through the same backtracking arg-passing convention

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3535,6 +3535,22 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// scalar resolve, not a cheap re-read), measurable as a ~5% regression on
 /// a query that walks every key and matches none. Carrying the value
 /// through instead removes that redundancy without changing output.
+/// **Deliberate divergence, sibling of `each_lazy_seq_iterate_sink`'s own
+/// (#725/#1565): a malformed key past whatever the consumer actually pulls
+/// is never detected.** #1629 taught the non-demand-aware `keys_unsorted`
+/// arms (`fold_lazy_keys_stage`) to raise on a #1194 malformed member by
+/// walking the whole object -- correct there because those arms already pay
+/// for a full walk regardless. This function exists specifically so
+/// `first(keys_unsorted[])`/`limit(n; keys_unsorted[])` do NOT pay for a
+/// full walk, so an unconditional whole-object check would defeat the
+/// point. What it *can* do for free: `DistinctKeyCursors::next` already
+/// decodes every key it yields (to hash it), so a key the consumer actually
+/// pulls is checked below at no extra cost -- but a malformed key, or an
+/// unpaired tail, sitting *after* the last element the consumer pulled is
+/// never reached, the same way `each_lazy_seq_iterate_sink`'s doc comment
+/// above describes for a `map(f)` failure past what `first` needed. Pinned
+/// by the `..._1770` tests below; recorded in
+/// `docs/compliance/jq/limitations.md`.
 fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     fields: &V::Fields,
     sorted: bool,
@@ -3545,8 +3561,13 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 ) -> Flow {
     if !sorted {
         return drive_pipe_elements_generic::<S, V>(
-            DistinctKeyCursors::new(fields, collapse)
-                .map(|(value, cursor)| Ok(GenericItem::OneCursorValue(cursor, value))),
+            DistinctKeyCursors::new(fields, collapse).map(|(value, cursor)| {
+                if key_is_malformed(&value) {
+                    Err(Control::Error(fields.malformed_member_error()))
+                } else {
+                    Ok(GenericItem::OneCursorValue(cursor, value))
+                }
+            }),
             rest,
             optional,
             sink,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16946,6 +16946,77 @@ fn test_jq_keys_unsorted_positional_early_exit_arms_still_known_gap_1629() -> Re
     Ok(())
 }
 
+/// #1770: `first(keys_unsorted[])`/`limit(n; keys_unsorted[])` raise on a
+/// malformed key the demand-aware sink actually pulls -- `each_lazy_keys_iterate_sink`'s
+/// `!sorted` arm now checks `key_is_malformed` on each key `DistinctKeyCursors::next`
+/// already decodes, matching bare `keys_unsorted[]` for this shape. Sibling of #1629,
+/// which fixed the non-demand-aware `fold_lazy_keys_stage` arms; this covers the
+/// demand-aware path #1629 didn't touch.
+#[test]
+fn test_jq_keys_unsorted_demand_aware_raises_on_pulled_malformed_key_1770() -> Result<()> {
+    let input = r#"{123: 1, "b": 2}"#;
+    for filter in ["first(keys_unsorted[])", "limit(1; keys_unsorted[])"] {
+        let (out, _stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "{filter} on {input}: out: {out:?}");
+        assert!(out.trim().is_empty(), "{filter} on {input}: out: {out:?}");
+    }
+
+    // Not just the first pulled element: a malformed key pulled *second*
+    // (well-formed "a" first, non-string 123 second) still raises once
+    // `limit` actually reaches it -- "a" survives as a partial output ahead
+    // of the error, same as bare `keys_unsorted[]`'s own partial-prefix
+    // behavior.
+    let (out, _stderr, code) = run_jq_full(
+        &["-c", "limit(2; keys_unsorted[])"],
+        Some(r#"{"a":1, 123:2}"#),
+    )?;
+    assert_eq!(code, 5, "out: {out:?}");
+    assert_eq!(out.trim(), "\"a\"");
+
+    // A well-formed object still answers normally -- the fix must not make
+    // every demand-aware pull pay for a check it never fails.
+    let input = r#"{"a":1,"b":2,"c":3}"#;
+    let (out, _stderr, code) = run_jq_full(&["-c", "first(keys_unsorted[])"], Some(input))?;
+    assert_eq!((out.trim(), code), ("\"a\"", 0));
+    let (out, _stderr, code) = run_jq_full(&["-c", "limit(2; keys_unsorted[])"], Some(input))?;
+    assert_eq!((out, code), ("\"a\"\n\"b\"\n".to_string(), 0));
+
+    Ok(())
+}
+
+/// #1770: deliberately still a known gap -- a malformed key (or an unpaired
+/// tail) sitting *after* whatever the consumer actually pulled is never
+/// detected, since finding it would require walking past the point the
+/// demand-aware sink stopped, defeating the reason it exists (#1514/#1599).
+/// Sibling of `each_lazy_seq_iterate_sink`'s own #725/#1565 divergence.
+/// Pinned as a known, documented divergence
+/// (`docs/compliance/jq/limitations.md`) -- if this starts raising, that is
+/// a deliberate future fix, not a regression, and this test should be
+/// updated alongside it.
+#[test]
+fn test_jq_keys_unsorted_demand_aware_still_known_gap_past_what_it_pulled_1770() -> Result<()> {
+    // Malformed key past the one element `first` pulls.
+    let (out, _stderr, code) =
+        run_jq_full(&["-c", "first(keys_unsorted[])"], Some(r#"{"a":1,123:2}"#))?;
+    assert_eq!((out.trim(), code), ("\"a\"", 0));
+
+    // An unpaired tail past what `first` pulls (two spellings: a truncated
+    // member with no value at all, and one with neither `:` nor value).
+    for input in [r#"{"a":1,"b"}"#, r#"{"a":1, invalid}"#] {
+        let (out, _stderr, code) = run_jq_full(&["-c", "first(keys_unsorted[])"], Some(input))?;
+        assert_eq!((out.trim(), code), ("\"a\"", 0), "input {input}");
+    }
+
+    // Bare iteration over the identical documents still raises (unaffected
+    // by this gap -- it always reaches exhaustion).
+    for input in [r#"{"a":1,123:2}"#, r#"{"a":1,"b"}"#, r#"{"a":1, invalid}"#] {
+        let (out, _stderr, code) = run_jq_full(&["-c", "keys_unsorted[]"], Some(input))?;
+        assert_eq!(code, 5, "input {input}: out: {out:?}");
+    }
+
+    Ok(())
+}
+
 /// #1194: a malformed member raises whether or not the run takes the lazy
 /// path.
 ///


### PR DESCRIPTION
## Summary

Fixes #1770. #1629 fixed `keys_unsorted[]`/`keys_unsorted | last`/`keys_unsorted[-n]` to raise on a #1194 malformed object member (non-string key, or unpaired trailing member) — but only in `fold_lazy_keys_stage`'s non-demand-aware arms. `Expr::Iterate` has a second, separate evaluator path for early-terminating consumers (`first(...)`, `limit(n; ...)`): `fold_pipe_stages_sink` special-cases it before ever reaching `fold_lazy_keys_stage`, routing instead through `each_lazy_keys_iterate_sink`, which streamed `DistinctKeyCursors`'s raw keys with no check at all.

```bash
$ echo '{123: 1, "b": 2}' | sjq -c 'keys_unsorted[]'         # exit 5 -- correct (#1629)
$ echo '{123: 1, "b": 2}' | sjq -c 'first(keys_unsorted[])'  # 123, exit 0 -- wrong (fixed here)
```

## Fix

`DistinctKeyCursors::next` already decodes every key it yields (to hash it), so checking `key_is_malformed` on each pulled key in `each_lazy_keys_iterate_sink`'s `!sorted` arm costs nothing extra — a malformed key becomes `Err(Control::Error(...))` instead of `Ok(GenericItem::OneCursorValue(...))`, which `drive_pipe_elements_generic` already knows how to propagate.

**Deliberately still a gap, and documented as such** (not fixed here): a malformed key or unpaired tail sitting *after* whatever the consumer actually pulled is never detected — finding it needs exhaustion, which a truncating consumer may by design never reach, and forcing it would defeat the entire reason this demand-aware path exists (#1514/#1599). Mirrors the precedent `each_lazy_seq_iterate_sink`'s own #725/#1565 divergence already established for the analogous `map(f)` question. Recorded in [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md#a-truncating-consumer-of-keys_unsorted-skips-a-malformed-member-it-never-needed).

## Verification

- 2 new regression tests: the fixed case (malformed key pulled first, and pulled second via `limit(2;...)`, confirming the check isn't just-the-first-element), and the documented known-gap case (malformed key/unpaired tail past what `first` pulls, two spellings, confirmed bare `keys_unsorted[]` still raises on the identical documents).
- Full test suite green, both clippy legs clean, `cargo fmt --check` clean, `cargo doc` clean, `--no-default-features` builds clean.
- Live-verified all repro shapes against the built binary.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features`

Closes #1770