### PR TITLE
fix(jq): --raw-input applies #1717's UTF-8 fixup per line, not whole-buffer

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1721,7 +1721,29 @@ fn get_inputs(
                     let filename = file_idx.map(|idx| files[idx].to_string_lossy().to_string());
                     validate_json_input(e.as_bytes(), filename.as_deref())?;
                 }
-                succinctly::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
+                if args.raw_input && !args.slurp {
+                    // #1742: real jq's non-slurp `-R` applies this
+                    // end-of-buffer-relative fixup (#1717) per *line*, not
+                    // once over the whole document -- splitting the raw
+                    // bytes on `b'\n'` first, before substituting, is safe
+                    // even amid invalid UTF-8: `\n` (0x0A) can never appear
+                    // as a multi-byte sequence's own continuation byte, so
+                    // this never risks splitting one mid-sequence. Joining
+                    // back on `"\n"` reproduces the original byte layout
+                    // exactly (including a trailing newline, which
+                    // `split`'s own trailing-empty-segment already accounts
+                    // for) -- `raw.lines()` further down re-splits this
+                    // same way, so it sees corrected content at unchanged
+                    // line boundaries. Slurp mode (`-s`) keeps whole-buffer
+                    // substitution below, matching real jq there too.
+                    e.into_bytes()
+                        .split(|&b| b == b'\n')
+                        .map(succinctly::text::utf8::substitute_invalid_utf8_jq_style)
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                } else {
+                    succinctly::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
+                }
             }
         };
         raw_inputs.push((file_idx, raw));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23492,6 +23492,77 @@ fn test_utf8_wide_sequence_collapses_raw_input_1617() -> Result<()> {
     Ok(())
 }
 
+/// #1742: non-slurp `-R` applies #1717's end-of-buffer-relative substitution
+/// fixup per *line*, not once over the whole document -- `get_inputs`
+/// substitutes the whole raw buffer up front, but real jq's own non-slurp
+/// `-R` reader is per-line for this exact quirk. Live-verified against
+/// pinned jq 1.7.1: a malformed multi-byte sequence at a line's own end,
+/// not just the whole file's end, must drop its extra trailing byte.
+#[test]
+fn test_raw_input_utf8_substitution_is_per_line_not_whole_buffer_1742() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a\xe1\x41\nsecond\nthird\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "\"a\u{fffd}\"\n\"second\"\n\"third\"\n");
+    Ok(())
+}
+
+/// #1742: the single-line case (no trailing content after the malformed
+/// sequence besides the final newline) is the same bug at its simplest --
+/// still per-line, not "whole buffer happens to equal one line".
+#[test]
+fn test_raw_input_utf8_substitution_single_line_1742() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a\xe1\x41\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"a\u{fffd}\"");
+    Ok(())
+}
+
+/// #1742: a malformed sequence in a *later* line (not just the first) is
+/// independently corrected at that line's own end -- confirms the fix
+/// applies to every line, not just the buffer's overall last line.
+#[test]
+fn test_raw_input_utf8_substitution_multiple_malformed_lines_1742() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a\xe1\x41\nb\xe1\x42\nthird\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "\"a\u{fffd}\"\n\"b\u{fffd}\"\n\"third\"\n");
+    Ok(())
+}
+
+/// #1742: `-R -s` (slurp) keeps whole-buffer substitution, matching real jq
+/// there too -- the fix must not touch this mode. Regression guard against
+/// the per-line change accidentally reaching the slurp branch.
+#[test]
+fn test_raw_input_slurp_still_whole_buffer_substitution_1742() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a\xe1\x41\nsecond\nthird\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-s", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"a\u{fffd}A\\nsecond\\nthird\\n\"");
+    Ok(())
+}
+
 /// #1247 guard: the substitution pass must leave valid multi-byte content
 /// byte-for-byte alone -- it runs on every document, so a false positive
 /// would corrupt ordinary files.


### PR DESCRIPTION
## Summary

Fixes #1742. `get_inputs`'s `--raw-input` handling substituted invalid UTF-8 over the whole raw document buffer, then split into lines afterwards. Real jq's non-slurp `-R` is per-line for #1717's end-of-buffer-relative substitution quirk — confirmed live against pinned jq 1.7.1.

```bash
$ printf 'a\xe1\x41\nsecond\nthird\n' | jq -R -c '.'
"a�"
"second"
"third"
$ printf 'a\xe1\x41\nsecond\nthird\n' | succinctly jq -R -c '.'   # before this PR
"a�A"
"second"
"third"
```

## Fix

For non-slurp `--raw-input`, split the raw bytes on `b'\n'` *before* substituting, then substitute each line's own bytes and rejoin on `"\n"`. Splitting on `\n` is safe even amid invalid UTF-8 — `0x0A` can never appear as a multi-byte sequence's own continuation byte — and rejoining reproduces the original byte layout exactly (including a trailing newline), so the existing `raw.lines()` split further down sees corrected content at unchanged line boundaries. Slurp mode (`-s`) keeps whole-buffer substitution unchanged, matching real jq there too. The JSON-mode (non-raw-input) path is untouched — same code, same pre-existing (out-of-scope, separately tracked) divergence as before.

## Verification

- 5 new regression tests: multi-line, single-line, multiple malformed lines, slurp-mode non-regression, plus the existing `test_utf8_wide_sequence_collapses_raw_input_1617` still passes.
- Live-verified against `/usr/bin/jq` (1.7.1 pin) for every repro shape above plus an additional multi-bad-line case.
- Full test suite green (one unrelated `test_short_circuit_side_effect_shapes_already_match_jq_820` flake, reproduced as machine contention — passes in isolation and on full re-run).
- Both clippy legs clean, `cargo fmt --check` clean, `cargo doc` clean, `--no-default-features` builds clean.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features`

Closes #1742