### PR TITLE
refactor(cli): hoist Terminator into a shared output module

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3579,7 +3579,7 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
 /// own `--unbuffered` flush has no yq-mode equivalent at this call site,
 /// so it stays local rather than folding into the shared type.
 fn write_terminator<W: Write>(out: &mut W, config: &OutputConfig) -> Result<()> {
-    Terminator::new(config.raw_output0, config.join_output).write_io(out)?;
+    Terminator::from_flags(config.raw_output0, config.join_output).write_io(out)?;
     if config.unbuffered {
         out.flush()?;
     }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -27,7 +27,7 @@ use succinctly::json::JsonIndex;
 use super::JqCommand;
 use crate::output::{
     self, escape_json_string, escape_json_string_ascii, exit_codes, flush_then_err, ColorScheme,
-    ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts,
+    ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts, Terminator,
 };
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -3573,13 +3573,13 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
     Ok(())
 }
 
-/// Write the appropriate line terminator based on config.
+/// Write the appropriate line terminator based on config. The NUL/newline/
+/// join three-way choice itself is shared with yq_runner.rs's own
+/// `terminator_from_config` via `output::Terminator` (#1711) -- jq mode's
+/// own `--unbuffered` flush has no yq-mode equivalent at this call site,
+/// so it stays local rather than folding into the shared type.
 fn write_terminator<W: Write>(out: &mut W, config: &OutputConfig) -> Result<()> {
-    if config.raw_output0 {
-        out.write_all(&[0])?; // NUL byte
-    } else if !config.join_output {
-        out.write_all(b"\n")?;
-    }
+    Terminator::new(config.raw_output0, config.join_output).write_io(out)?;
     if config.unbuffered {
         out.flush()?;
     }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -54,6 +54,56 @@ pub fn json_bytes_to_owned_value(bytes: &[u8]) -> Result<OwnedValue, EvalError> 
     generic_to_owned(&cursor.value())
 }
 
+/// Which terminator follows a written value: NUL (`-0`/`--nul-output`),
+/// a bare newline (the default), or nothing (`-j`/`--join-output`). `nul`
+/// wins over `join` in both runners' own precedence, matching real jq/yq:
+/// `-0 -j` together behaves as `-0`.
+///
+/// Shared by `jq_runner.rs` and `yq_runner.rs` (#1701, #1711) -- both
+/// binaries' own `OutputConfig` agree on this exact three-way rule but
+/// don't share a type (different field names: `raw_output0` vs
+/// `nul_output`), so each keeps a thin local `Terminator::new(nul, join)`
+/// wrapper reading its own config's fields rather than this module taking
+/// either `OutputConfig` directly.
+#[derive(Clone, Copy)]
+pub enum Terminator {
+    Nul,
+    Newline,
+    None,
+}
+
+impl Terminator {
+    pub fn new(nul: bool, join: bool) -> Self {
+        if nul {
+            Self::Nul
+        } else if !join {
+            Self::Newline
+        } else {
+            Self::None
+        }
+    }
+
+    /// Write this terminator to an `io::Write` sink.
+    pub fn write_io<W: std::io::Write>(self, writer: &mut W) -> std::io::Result<()> {
+        match self {
+            Self::Nul => writer.write_all(&[0]),
+            Self::Newline => writeln!(writer),
+            Self::None => Ok(()),
+        }
+    }
+
+    /// Write this terminator to a `core::fmt::Write` sink -- yq's M2 path's
+    /// per-result callbacks, which write into a buffered `fmt::Write`
+    /// target rather than the process's own `io::Write` sink directly.
+    pub fn write_fmt<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
+        match self {
+            Self::Nul => writer.write_char('\0'),
+            Self::Newline => writer.write_char('\n'),
+            Self::None => Ok(()),
+        }
+    }
+}
+
 /// Exit codes matching jq behavior
 pub mod exit_codes {
     pub const SUCCESS: i32 = 0;

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -1,7 +1,8 @@
 //! Output helpers shared by the jq and yq CLI runners.
 //!
 //! Exit codes, JSON string escaping, JSON pretty-printing, ANSI colorization
-//! (including `JQ_COLORS` support), and build-configuration diagnostics.
+//! (including `JQ_COLORS` support), line-terminator selection (`Terminator`),
+//! and build-configuration diagnostics.
 
 // Aliased: this module already has an `escape_json_body` of its own, which
 // picks *which* convention to use; the library's runs a chosen writer.
@@ -56,16 +57,23 @@ pub fn json_bytes_to_owned_value(bytes: &[u8]) -> Result<OwnedValue, EvalError> 
 
 /// Which terminator follows a written value: NUL (`-0`/`--nul-output`),
 /// a bare newline (the default), or nothing (`-j`/`--join-output`). `nul`
-/// wins over `join` in both runners' own precedence, matching real jq/yq:
-/// `-0 -j` together behaves as `-0`.
+/// wins over `join` in both runners' own precedence -- verified against
+/// real *jq* 1.7.1 (`--raw-output0 -j`, order-independent either way), not
+/// yq: the pinned yq oracle (Homebrew v4.53.3) has no `--join-output` flag
+/// at all (it errors "unknown flag"), so `-j` in yq mode is a documented
+/// open divergence (docs/compliance/yq/limitations.md), not a real-yq
+/// behavior this precedence matches.
 ///
 /// Shared by `jq_runner.rs` and `yq_runner.rs` (#1701, #1711) -- both
 /// binaries' own `OutputConfig` agree on this exact three-way rule but
 /// don't share a type (different field names: `raw_output0` vs
-/// `nul_output`), so each keeps a thin local `Terminator::new(nul, join)`
-/// wrapper reading its own config's fields rather than this module taking
-/// either `OutputConfig` directly.
-#[derive(Clone, Copy)]
+/// `nul_output`), so each keeps a thin local `Terminator::from_flags(nul,
+/// join)` wrapper reading its own config's fields rather than this module
+/// taking either `OutputConfig` directly. Named `from_flags` to match
+/// `env_config::ColorChoice::from_flags`'s identical "two mutually
+/// exclusive CLI bools -> precedence-resolved enum" shape, rather than
+/// introducing a second, differently-named idiom for the same pattern.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Terminator {
     Nul,
     Newline,
@@ -73,7 +81,7 @@ pub enum Terminator {
 }
 
 impl Terminator {
-    pub fn new(nul: bool, join: bool) -> Self {
+    pub fn from_flags(nul: bool, join: bool) -> Self {
         if nul {
             Self::Nul
         } else if !join {
@@ -83,18 +91,25 @@ impl Terminator {
         }
     }
 
-    /// Write this terminator to an `io::Write` sink.
+    /// Write this terminator to an `io::Write` sink. `write_all(b"\n")`
+    /// rather than `writeln!(writer)` for the newline case -- this is
+    /// jq_runner.rs's own default-output-path terminator write, not just
+    /// yq's occasional doc-separator one, so it keeps the exact zero-
+    /// formatting-overhead shape jq_runner.rs used before this hoist
+    /// rather than detouring through `fmt::Arguments` machinery on every
+    /// value.
     pub fn write_io<W: std::io::Write>(self, writer: &mut W) -> std::io::Result<()> {
         match self {
             Self::Nul => writer.write_all(&[0]),
-            Self::Newline => writeln!(writer),
+            Self::Newline => writer.write_all(b"\n"),
             Self::None => Ok(()),
         }
     }
 
-    /// Write this terminator to a `core::fmt::Write` sink -- yq's M2 path's
-    /// per-result callbacks, which write into a buffered `fmt::Write`
-    /// target rather than the process's own `io::Write` sink directly.
+    /// Write this terminator to a `core::fmt::Write` sink, for a caller
+    /// writing into a buffered `fmt::Write` target rather than the
+    /// process's own `io::Write` sink directly (yq's M2 fast path's
+    /// per-result callbacks, at the time of writing).
     pub fn write_fmt<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
         match self {
             Self::Nul => writer.write_char('\0'),
@@ -1467,5 +1482,18 @@ mod tests {
             result.is_err(),
             "format_json should panic at MAX_VALUE_TREE_DEPTH"
         );
+    }
+
+    /// Pins `Terminator::from_flags`'s precedence table by name (#1711),
+    /// mirroring `env_config::ColorChoice::from_flags`'s own
+    /// `from_flags_maps_each_flag_combination` test for the identical
+    /// "two mutually exclusive CLI bools" shape -- nul wins if both are
+    /// somehow set.
+    #[test]
+    fn terminator_from_flags_maps_each_flag_combination() {
+        assert_eq!(Terminator::from_flags(false, false), Terminator::Newline);
+        assert_eq!(Terminator::from_flags(false, true), Terminator::None);
+        assert_eq!(Terminator::from_flags(true, false), Terminator::Nul);
+        assert_eq!(Terminator::from_flags(true, true), Terminator::Nul);
     }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -30,7 +30,7 @@ use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
     self, exit_codes, flush_then_err, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle,
-    InputLocation, JsonFormatOpts,
+    InputLocation, JsonFormatOpts, Terminator,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -1983,7 +1983,7 @@ impl SplitDocState {
     fn write_separator<W: Write>(&mut self, writer: &mut W, config: &OutputConfig) -> Result<()> {
         if self.has_split_doc && config.output_format == OutputFormat::Yaml && !config.no_doc {
             if !self.is_first_output {
-                write_doc_separator_marker(writer, Terminator::from_config(config))?;
+                write_doc_separator_marker(writer, terminator_from_config(config))?;
             }
             self.is_first_output = false;
         }
@@ -1991,71 +1991,35 @@ impl SplitDocState {
     }
 }
 
-/// Which terminator (if any) follows a written value, per `-0`/`--nul-output`
-/// and `-j`/`--join-output`. NUL wins over join (`-0 -j` still separates on
-/// NUL, not nothing) -- verified against real *jq* 1.7.1
-/// (`--raw-output0 -j`, order-independent either way), not yq: the pinned
-/// yq oracle (Homebrew v4.53.3) has no `--join-output` flag at all (it
-/// errors "unknown flag"), and its own `-j` is an unrelated, deprecated
-/// alias for `--tojson`. yq-mode's `-j`/`--join-output` borrows jq's flag
-/// meaning and collides with real yq's own `-j` — a documented open
-/// divergence (docs/compliance/yq/limitations.md), not a real-yq behavior
-/// to match. A bare newline is the default when neither flag is set.
+/// [`output::Terminator`] reads its NUL/newline/join precedence off two
+/// plain `bool`s, not `OutputConfig` directly, since jq_runner.rs's own
+/// `OutputConfig` names the same flag `raw_output0` rather than
+/// `nul_output` (#1711) -- this is yq-mode's own thin wrapper reading the
+/// right fields once, so no call site here can transpose them.
 ///
-/// Split out from [`write_terminator`] (#1701) so the same three-way choice
-/// can also drive the M2 fast path's own terminator writes -- previously
-/// `stream_cursor!` hardcoded a bare newline unconditionally, ignoring both
-/// flags whenever the fast path was taken (confirmed live on unmodified
-/// `main`, same root cause and fix shape as #1699's `--no-doc` gap in the
-/// same macro).
-#[derive(Clone, Copy)]
-enum Terminator {
-    Nul,
-    Newline,
-    None,
-}
-
-impl Terminator {
-    /// Takes `&OutputConfig` (not two positional bools) so no call site can
-    /// silently transpose `nul_output`/`join_output` -- the exact risk
-    /// `stream_cursor!`'s own `$output_config:expr` consolidation (#1701
-    /// code review) was about, one level up from here.
-    fn from_config(config: &OutputConfig) -> Self {
-        if config.nul_output {
-            Self::Nul
-        } else if !config.join_output {
-            Self::Newline
-        } else {
-            Self::None
-        }
-    }
-
-    /// Write this terminator to an `io::Write` sink (the M2 path's own
-    /// `$writer`, and every DOM-path caller of `write_terminator`).
-    fn write_io<W: Write>(self, writer: &mut W) -> std::io::Result<()> {
-        match self {
-            Self::Nul => writer.write_all(&[0]),
-            Self::Newline => writeln!(writer),
-            Self::None => Ok(()),
-        }
-    }
-
-    /// Write this terminator to a `core::fmt::Write` sink -- the M2 path's
-    /// per-result callbacks passed into `stream_yaml`/`stream_json`, which
-    /// write into a buffered `fmt::Write` target rather than `$writer`
-    /// itself.
-    fn write_fmt<W: core::fmt::Write>(self, writer: &mut W) -> core::fmt::Result {
-        match self {
-            Self::Nul => writer.write_char('\0'),
-            Self::Newline => writer.write_char('\n'),
-            Self::None => Ok(()),
-        }
-    }
+/// NUL wins over join (`-0 -j` still separates on NUL, not nothing) --
+/// verified against real *jq* 1.7.1 (`--raw-output0 -j`, order-independent
+/// either way), not yq: the pinned yq oracle (Homebrew v4.53.3) has no
+/// `--join-output` flag at all (it errors "unknown flag"), and its own
+/// `-j` is an unrelated, deprecated alias for `--tojson`. yq-mode's
+/// `-j`/`--join-output` borrows jq's flag meaning and collides with real
+/// yq's own `-j` — a documented open divergence
+/// (docs/compliance/yq/limitations.md), not a real-yq behavior to match.
+/// A bare newline is the default when neither flag is set.
+///
+/// Threaded through `stream_cursor!`'s own `$output_config:expr` (#1701
+/// code review) so the same three-way choice also drives the M2 fast
+/// path's own terminator writes -- previously `stream_cursor!` hardcoded a
+/// bare newline unconditionally, ignoring both flags whenever the fast
+/// path was taken (confirmed live on unmodified `main`, same root cause
+/// and fix shape as #1699's `--no-doc` gap in the same macro).
+fn terminator_from_config(config: &OutputConfig) -> Terminator {
+    Terminator::new(config.nul_output, config.join_output)
 }
 
 /// Write the appropriate line terminator based on output config.
 fn write_terminator<W: Write>(writer: &mut W, config: &OutputConfig) -> Result<()> {
-    Terminator::from_config(config).write_io(writer)?;
+    terminator_from_config(config).write_io(writer)?;
     Ok(())
 }
 
@@ -3671,7 +3635,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // overridden per call site).
     macro_rules! stream_cursor {
         ($cursor:expr, $writer:expr, $is_yaml:expr, $doc_streamed:expr, $use_color:expr, $output_config:expr) => {{
-            let terminator = Terminator::from_config(&$output_config);
+            let terminator = terminator_from_config(&$output_config);
             if $is_yaml {
                 // M2 YAML path: YAML output streaming
                 if is_identity {
@@ -4100,7 +4064,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // (#1701 code review): the previous result's own
                 // `write_terminator` call (inside `output_value` below)
                 // might have written `\0`/nothing rather than `\n`.
-                write_doc_separator_marker(&mut writer, Terminator::from_config(&output_config))?;
+                write_doc_separator_marker(&mut writer, terminator_from_config(&output_config))?;
             }
             any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
             output_value(&mut writer, result, &CommentTree::empty(), &output_config)?;
@@ -4699,7 +4663,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             // `\n`.
                             write_doc_separator_marker(
                                 &mut buf_writer,
-                                Terminator::from_config(&output_config),
+                                terminator_from_config(&output_config),
                             )?;
                         }
                         doc_had_output = true;
@@ -4742,7 +4706,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 if any_real_output {
                     write_doc_marker_newline_guard(
                         &mut output_buffer,
-                        Terminator::from_config(&output_config),
+                        terminator_from_config(&output_config),
                     )?;
                 }
                 output_buffer.extend_from_slice(b"---");
@@ -4933,7 +4897,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // own terminator might not have been `\n`.
                     write_doc_separator_marker(
                         &mut writer,
-                        Terminator::from_config(&file_output_config),
+                        terminator_from_config(&file_output_config),
                     )?;
                 }
                 if file_output_config.output_format == OutputFormat::Yaml {
@@ -4957,7 +4921,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 if any_output_this_file {
                     write_doc_marker_newline_guard(
                         &mut writer,
-                        Terminator::from_config(&file_output_config),
+                        terminator_from_config(&file_output_config),
                     )?;
                 }
                 writer.write_all(b"---")?;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1991,21 +1991,13 @@ impl SplitDocState {
     }
 }
 
-/// [`output::Terminator`] reads its NUL/newline/join precedence off two
-/// plain `bool`s, not `OutputConfig` directly, since jq_runner.rs's own
-/// `OutputConfig` names the same flag `raw_output0` rather than
-/// `nul_output` (#1711) -- this is yq-mode's own thin wrapper reading the
-/// right fields once, so no call site here can transpose them.
-///
-/// NUL wins over join (`-0 -j` still separates on NUL, not nothing) --
-/// verified against real *jq* 1.7.1 (`--raw-output0 -j`, order-independent
-/// either way), not yq: the pinned yq oracle (Homebrew v4.53.3) has no
-/// `--join-output` flag at all (it errors "unknown flag"), and its own
-/// `-j` is an unrelated, deprecated alias for `--tojson`. yq-mode's
-/// `-j`/`--join-output` borrows jq's flag meaning and collides with real
-/// yq's own `-j` — a documented open divergence
-/// (docs/compliance/yq/limitations.md), not a real-yq behavior to match.
-/// A bare newline is the default when neither flag is set.
+/// yq-mode's own thin wrapper onto [`output::Terminator::from_flags`] --
+/// see that function's own doc for the NUL/newline/join precedence rule
+/// and its jq-vs-yq oracle verification. Exists only because
+/// jq_runner.rs's own `OutputConfig` names the same flag `raw_output0`
+/// rather than `nul_output` (#1711), so the two runners can't share one
+/// `from_config`-style call; reading both fields once here means no call
+/// site in this file can transpose them.
 ///
 /// Threaded through `stream_cursor!`'s own `$output_config:expr` (#1701
 /// code review) so the same three-way choice also drives the M2 fast
@@ -2014,7 +2006,7 @@ impl SplitDocState {
 /// path was taken (confirmed live on unmodified `main`, same root cause
 /// and fix shape as #1699's `--no-doc` gap in the same macro).
 fn terminator_from_config(config: &OutputConfig) -> Terminator {
-    Terminator::new(config.nul_output, config.join_output)
+    Terminator::from_flags(config.nul_output, config.join_output)
 }
 
 /// Write the appropriate line terminator based on output config.


### PR DESCRIPTION
## Summary

Found by `/code-review` on PR #1707 (#1701). #1701 centralized yq mode's "which
terminator follows a written value" three-way decision (NUL / newline / nothing, per
`-0`/`--join-output`) into a `Terminator` enum in `yq_runner.rs`. `jq_runner.rs` had its
own, independent `write_terminator` function reimplementing the identical logic for jq
mode, using a differently-named field (`raw_output0` vs `nul_output`) and inlining an
extra `unbuffered` flush. Neither file's copy was hoisted into a shared location.

## Change

Moved `Terminator` (the enum plus its `write_io`/`write_fmt` methods) into `output.rs`,
which both binaries already import from. Since the two `OutputConfig` structs are
different types with different field names, the shared type takes two `bool`s
(`Terminator::new(nul, join)`) rather than either `OutputConfig` directly:

- `yq_runner.rs`: removed its local `enum Terminator`/`impl Terminator` entirely; kept a
  thin `terminator_from_config(config: &OutputConfig) -> Terminator` wrapper reading
  `nul_output`/`join_output`, used at all 8 existing call sites (the DOM path's
  `write_terminator`, plus the M2 fast path's `stream_cursor!` macro and doc-separator
  writes #1701 added this type for in the first place).
- `jq_runner.rs`: `write_terminator` now delegates the NUL/newline/join decision to
  `output::Terminator::new(config.raw_output0, config.join_output).write_io(out)`,
  keeping its own `--unbuffered` flush local (no yq-mode equivalent at this call site).

Pure refactor, no behavior change intended.

## Test plan

- [x] Manually verified terminator behavior for both binaries: `jq --raw-output0`,
      `jq -j`, `jq` default; `yq -0`, `yq -j`, `yq` default; `jq --raw-output0 -j`
      (NUL wins over join, matching real jq's own order-independence) -- all byte-exact
      to pre-change output
- [x] Full `cargo test --features cli,simd,regex,serde` -- 55/55 test binaries pass,
      2950+204+... lib/integration tests, 0 failed (run under `cargo-guard.sh` after an
      earlier attempt silently stalled -- see below)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build --no-default-features` (no_std) -- builds, no new warnings
- [x] `cargo doc --no-deps` -- clean, no intra-doc-link errors
- [x] Rebased cleanly onto main after a large batch of concurrent merges landed while
      this branch sat idle; re-verified the diff is textually and semantically intact
      post-rebase, then re-ran the full build/clippy/test suite against the new base

Fixes #1711
