### PR TITLE
fix(jq): resolve key/parent/file_index through single-pattern AsPattern

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -810,6 +810,16 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // This is the single most common trigger for this whole bug class:
         // `.a.b | . as $x | parent(1)` previously silently stubbed to `{}`.
         Expr::As { expr, body, .. } => needs_path_context(expr) || needs_path_context(body),
+        // `. as PATTERN | body` (#1765): same reasoning as `Expr::As` above,
+        // for destructuring `as`. Deliberately not gated on `patterns.len()`
+        // here -- unlike the dedicated evaluation arm below (which only
+        // handles the single-pattern case), this is just the routing
+        // question "does the whole pipe need path-context evaluation at
+        // all," and a `?//`-chain with a path-context builtin inside still
+        // needs `true` here so the surrounding pipe routes correctly, even
+        // though the chain itself then falls through to the generic
+        // fallback (its pre-existing, unchanged stub behavior) once inside.
+        Expr::AsPattern { expr, body, .. } => needs_path_context(expr) || needs_path_context(body),
         _ => false,
     }
 }
@@ -26242,6 +26252,96 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             let mut stopped = None;
             for bound_val in bound_values {
                 let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
+                let body_result = eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(&substituted_body),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
+                    stopped = Some(stop);
+                    break;
+                }
+            }
+
+            let combined = stopped.unwrap_or_else(|| match bound_control {
+                Some(control) => partial(all_results, control),
+                None => owned_vec_to_result(all_results),
+            });
+            continue_rest_with_context::<W, S>(
+                combined,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        // `. as PATTERN | body` (#1765, item 1 of #1663's own remaining-gaps
+        // list): the single-pattern case only -- mirrors the `Expr::As` arm
+        // above exactly (neither `expr` nor `body` navigates away from the
+        // caller's own position), substituting the pattern's destructured
+        // bindings into `body` instead of one bound variable.
+        //
+        // `patterns.len() == 1` deliberately excludes a `?//`-chain
+        // (`. as PATTERN1 ?// PATTERN2 | body`): its retry-on-failure
+        // semantics (`try_pattern_alternatives`'s decode-failure/break/halt
+        // classification, carried-prefix-across-alternatives bookkeeping)
+        // are real complexity this fix doesn't attempt to replicate here, per
+        // the issue's own scoping. A `?//`-chain with a `key`/`parent`/
+        // `file_index` inside it still falls through to the generic fallback
+        // below -- its pre-existing (already broken, unchanged) stub
+        // behavior, not a regression.
+        Expr::AsPattern {
+            expr,
+            patterns,
+            body,
+        } if patterns.len() == 1 && (needs_path_context(expr) || needs_path_context(body)) => {
+            let bound_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(expr),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
+                Ok(pair) => pair,
+                Err(Flow::Exhausted) => return QueryResult::None,
+                Err(Flow::Escaped(Control::Error(e))) => return QueryResult::Error(e),
+                Err(Flow::Escaped(Control::Break(label))) => return QueryResult::Break(label),
+                Err(Flow::Escaped(Control::Halt(code))) => return QueryResult::Halt(code),
+                Err(Flow::Stopped { .. }) => unreachable!(
+                    "materialize_bound_values only ever produces Exhausted/Escaped, \
+                     never Stopped (that variant is sink-driven laziness this eager \
+                     evaluator never uses)"
+                ),
+            };
+
+            let mut all_results: Vec<OwnedValue> = Vec::new();
+            let mut stopped = None;
+            for bound_val in bound_values {
+                // `invert = false`: the duplicate-binding dedup rule
+                // `extract_pattern_bindings` inverts only applies to a real
+                // `?//`-chain (`patterns.len() > 1`, excluded above) -- see
+                // that function's own doc comment for the live-verified
+                // evidence this mirrors.
+                let bindings = match extract_pattern_bindings(&patterns[0], &bound_val, false) {
+                    Ok(b) => b,
+                    // `accumulate_path_context_step` on `QueryResult::Error`
+                    // always yields `Some` (never asks to keep iterating),
+                    // so this always stops the loop -- reused here rather
+                    // than duplicating its exact `partial(..., Control::
+                    // Error(e))` wrapping by hand.
+                    Err(e) => {
+                        stopped =
+                            accumulate_path_context_step(&mut all_results, QueryResult::Error(e));
+                        break;
+                    }
+                };
+                let substituted_body = substitute_vars(body, as_var_refs(&bindings));
                 let body_result = eval_pipe_with_path_context_internal::<W, S>(
                     core::slice::from_ref(&substituted_body),
                     value,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -811,15 +811,24 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // `.a.b | . as $x | parent(1)` previously silently stubbed to `{}`.
         Expr::As { expr, body, .. } => needs_path_context(expr) || needs_path_context(body),
         // `. as PATTERN | body` (#1765): same reasoning as `Expr::As` above,
-        // for destructuring `as`. Deliberately not gated on `patterns.len()`
-        // here -- unlike the dedicated evaluation arm below (which only
-        // handles the single-pattern case), this is just the routing
-        // question "does the whole pipe need path-context evaluation at
-        // all," and a `?//`-chain with a path-context builtin inside still
-        // needs `true` here so the surrounding pipe routes correctly, even
-        // though the chain itself then falls through to the generic
-        // fallback (its pre-existing, unchanged stub behavior) once inside.
-        Expr::AsPattern { expr, body, .. } => needs_path_context(expr) || needs_path_context(body),
+        // for destructuring `as` -- but gated to the single-pattern case,
+        // matching the dedicated evaluation arm below exactly (code review:
+        // an earlier version answered `true` here for a `?//`-chain too,
+        // since that's "just" the routing question. It wasn't free: the
+        // dedicated eval arm still only handles `patterns.len() == 1`, so a
+        // `?//`-chain routed into path-context evaluation on this arm's say-
+        // so just fell through to the generic fallback there anyway --
+        // paying `eval_pipe_with_path_context_internal`'s full eager-
+        // materialization cost, and losing whatever lazy/demand-driven
+        // interleaving the caller's own cheaper path would otherwise give
+        // it, for byte-identical output. Same reasoning `Expr::Object`'s own
+        // doc comment above gives for staying out of this function
+        // entirely despite having the identical #1332 known-gap status).
+        Expr::AsPattern {
+            expr,
+            patterns,
+            body,
+        } => patterns.len() == 1 && (needs_path_context(expr) || needs_path_context(body)),
         _ => false,
     }
 }
@@ -25251,6 +25260,97 @@ fn eval_boolean_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     )
 }
 
+/// Shared "bind `expr`'s outputs, then per bound value derive a substituted
+/// `body` and evaluate that too" skeleton for `Expr::As`/`Expr::AsPattern`'s
+/// path-context arms (#1765 code review). Both arms bind `expr` through this
+/// same path-context evaluator identically -- neither `expr` nor `body`
+/// navigates away from the caller's own position, so `key`/`parent`/
+/// `file_index` inside either sees the caller's ambient position unchanged
+/// -- and only differ in how one bound value becomes a substituted `body`
+/// (one bound variable vs. a pattern's destructured bindings), which
+/// `substitute` supplies. Previously two byte-for-byte-identical ~65-line
+/// blocks around that one differing step -- exactly the kind of duplicated
+/// skeleton this file's own established practice avoids (`materialize_bound_values`/
+/// `accumulate_path_context_step`, cited by the `Expr::As` arm's own comment,
+/// were extracted for the identical reason: past copies of this exact
+/// unpacking and accumulate-or-stop shape drifted out of sync, e.g. #1457/
+/// #1660 correcting `try_pattern_alternatives` independently of its sibling
+/// `each_pattern_alternatives`).
+///
+/// `optional` is *not* forced to `false` for either bind or body evaluation:
+/// `eval_as`'s own doc comment establishes that `as` (and, identically,
+/// destructuring `as`) is deliberately non-atomic under `?` --
+/// `(1,2,error("x")) as $v | $v + 10` keeps `11`, `12` as a real prefix,
+/// unlike `[...]`'s atomicity -- so it's passed straight through to both
+/// evaluations here, exactly as `eval_as`/`eval_as_pattern` do.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors eval_pipe_with_path_context_internal's
+                                     // own parameter set (this function is a thin wrapper around
+                                     // it), plus `rest` and `substitute` -- both call sites are the
+                                     // only ones, so a bundling struct would just move these fields
+                                     // one level out rather than reduce the real parameter count.
+fn eval_bind_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    rest: &[Expr],
+    optional: bool,
+    mut substitute: impl FnMut(&OwnedValue) -> Result<Expr, EvalError>,
+) -> QueryResult<'a, W> {
+    let bound_result = eval_pipe_with_path_context_internal::<W, S>(
+        core::slice::from_ref(expr),
+        value,
+        root,
+        file_origin,
+        current_path,
+        optional,
+    );
+    let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
+        Ok(pair) => pair,
+        Err(Flow::Exhausted) => return QueryResult::None,
+        Err(Flow::Escaped(Control::Error(e))) => return QueryResult::Error(e),
+        Err(Flow::Escaped(Control::Break(label))) => return QueryResult::Break(label),
+        Err(Flow::Escaped(Control::Halt(code))) => return QueryResult::Halt(code),
+        Err(Flow::Stopped { .. }) => unreachable!(
+            "materialize_bound_values only ever produces Exhausted/Escaped, \
+             never Stopped (that variant is sink-driven laziness this eager \
+             evaluator never uses)"
+        ),
+    };
+
+    let mut all_results: Vec<OwnedValue> = Vec::new();
+    let mut stopped = None;
+    for bound_val in bound_values {
+        // `accumulate_path_context_step` on `QueryResult::Error` always
+        // yields `Some` (never asks to keep iterating), so a `substitute`
+        // failure (e.g. a pattern-match failure) always stops the loop here
+        // too -- reused rather than duplicating its exact `partial(...,
+        // Control::Error(e))` wrapping by hand.
+        let body_result = match substitute(&bound_val) {
+            Ok(substituted_body) => eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(&substituted_body),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            ),
+            Err(e) => QueryResult::Error(e),
+        };
+        if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
+            stopped = Some(stop);
+            break;
+        }
+    }
+
+    let combined = stopped.unwrap_or_else(|| match bound_control {
+        Some(control) => partial(all_results, control),
+        None => owned_vec_to_result(all_results),
+    });
+    continue_rest_with_context::<W, S>(combined, rest, root, file_origin, current_path, optional)
+}
+
 /// Internal helper that also tracks the root value for parent navigation,
 /// and (for `--eval-all`, #715) an optional origin-file-index side table
 /// keyed by top-level array position, resolving `file_index`/`fileIndex`/`fi`.
@@ -26220,63 +26320,24 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // prefix, unlike `[...]`'s atomicity -- so it's passed straight
             // through to both evaluations, exactly as `eval_as` does.
             //
-            // #1663 code review: uses `materialize_bound_values` (shared
-            // with `each_as`/`each_as_pattern`, #1462) and
-            // `accumulate_path_context_step` (shared with every other
-            // fan-out loop in this function, #715 follow-up) rather than
-            // hand-rolling a 5th/7th copy of either -- both were built
-            // specifically because past copies of this exact unpacking and
-            // accumulate-or-stop shape drifted out of sync with each other.
-            let bound_result = eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(expr),
+            // #1765 code review: shares `eval_bind_with_path_context` with
+            // the `Expr::AsPattern` arm below -- both bind `expr` the same
+            // way and only differ in how one bound value becomes a
+            // substituted `body`, which used to be two hand-copied ~85-line
+            // arms around that one differing step (exactly the kind of
+            // "past copies of this exact shape drifted apart" #1663's own
+            // comment here already warned about for the pieces it *did*
+            // dedupe, e.g. #1457/#1660 correcting `try_pattern_alternatives`
+            // independently of its sibling `each_pattern_alternatives`).
+            eval_bind_with_path_context::<W, S>(
+                expr,
                 value,
                 root,
                 file_origin,
                 current_path,
-                optional,
-            );
-            let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
-                Ok(pair) => pair,
-                Err(Flow::Exhausted) => return QueryResult::None,
-                Err(Flow::Escaped(Control::Error(e))) => return QueryResult::Error(e),
-                Err(Flow::Escaped(Control::Break(label))) => return QueryResult::Break(label),
-                Err(Flow::Escaped(Control::Halt(code))) => return QueryResult::Halt(code),
-                Err(Flow::Stopped { .. }) => unreachable!(
-                    "materialize_bound_values only ever produces Exhausted/Escaped, \
-                     never Stopped (that variant is sink-driven laziness this eager \
-                     evaluator never uses)"
-                ),
-            };
-
-            let mut all_results: Vec<OwnedValue> = Vec::new();
-            let mut stopped = None;
-            for bound_val in bound_values {
-                let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
-                let body_result = eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(&substituted_body),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                );
-                if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
-                    stopped = Some(stop);
-                    break;
-                }
-            }
-
-            let combined = stopped.unwrap_or_else(|| match bound_control {
-                Some(control) => partial(all_results, control),
-                None => owned_vec_to_result(all_results),
-            });
-            continue_rest_with_context::<W, S>(
-                combined,
                 rest,
-                root,
-                file_origin,
-                current_path,
                 optional,
+                |bound_val| Ok(substitute_bound_var(expr, body, var, bound_val)),
             )
         }
         // `. as PATTERN | body` (#1765, item 1 of #1663's own remaining-gaps
@@ -26293,80 +26354,32 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // the issue's own scoping. A `?//`-chain with a `key`/`parent`/
         // `file_index` inside it still falls through to the generic fallback
         // below -- its pre-existing (already broken, unchanged) stub
-        // behavior, not a regression.
+        // behavior, not a regression. `needs_path_context`'s own
+        // `Expr::AsPattern` arm carries the identical `patterns.len() == 1`
+        // gate, so a `?//`-chain doesn't even route into this eager
+        // evaluator on this arm's account in the first place.
         Expr::AsPattern {
             expr,
             patterns,
             body,
         } if patterns.len() == 1 && (needs_path_context(expr) || needs_path_context(body)) => {
-            let bound_result = eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(expr),
+            eval_bind_with_path_context::<W, S>(
+                expr,
                 value,
                 root,
                 file_origin,
                 current_path,
-                optional,
-            );
-            let (bound_values, bound_control) = match materialize_bound_values(bound_result) {
-                Ok(pair) => pair,
-                Err(Flow::Exhausted) => return QueryResult::None,
-                Err(Flow::Escaped(Control::Error(e))) => return QueryResult::Error(e),
-                Err(Flow::Escaped(Control::Break(label))) => return QueryResult::Break(label),
-                Err(Flow::Escaped(Control::Halt(code))) => return QueryResult::Halt(code),
-                Err(Flow::Stopped { .. }) => unreachable!(
-                    "materialize_bound_values only ever produces Exhausted/Escaped, \
-                     never Stopped (that variant is sink-driven laziness this eager \
-                     evaluator never uses)"
-                ),
-            };
-
-            let mut all_results: Vec<OwnedValue> = Vec::new();
-            let mut stopped = None;
-            for bound_val in bound_values {
-                // `invert = false`: the duplicate-binding dedup rule
-                // `extract_pattern_bindings` inverts only applies to a real
-                // `?//`-chain (`patterns.len() > 1`, excluded above) -- see
-                // that function's own doc comment for the live-verified
-                // evidence this mirrors.
-                let bindings = match extract_pattern_bindings(&patterns[0], &bound_val, false) {
-                    Ok(b) => b,
-                    // `accumulate_path_context_step` on `QueryResult::Error`
-                    // always yields `Some` (never asks to keep iterating),
-                    // so this always stops the loop -- reused here rather
-                    // than duplicating its exact `partial(..., Control::
-                    // Error(e))` wrapping by hand.
-                    Err(e) => {
-                        stopped =
-                            accumulate_path_context_step(&mut all_results, QueryResult::Error(e));
-                        break;
-                    }
-                };
-                let substituted_body = substitute_vars(body, as_var_refs(&bindings));
-                let body_result = eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(&substituted_body),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                );
-                if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
-                    stopped = Some(stop);
-                    break;
-                }
-            }
-
-            let combined = stopped.unwrap_or_else(|| match bound_control {
-                Some(control) => partial(all_results, control),
-                None => owned_vec_to_result(all_results),
-            });
-            continue_rest_with_context::<W, S>(
-                combined,
                 rest,
-                root,
-                file_origin,
-                current_path,
                 optional,
+                |bound_val| {
+                    // `invert = false`: the duplicate-binding dedup rule
+                    // `extract_pattern_bindings` inverts only applies to a
+                    // real `?//`-chain (`patterns.len() > 1`, excluded
+                    // above) -- see that function's own doc comment for the
+                    // live-verified evidence this mirrors.
+                    let bindings = extract_pattern_bindings(&patterns[0], bound_val, false)?;
+                    Ok(substitute_vars(body, as_var_refs(&bindings)))
+                },
             )
         }
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6759,31 +6759,34 @@ fn test_as_path_context_builtin_body_loop_arms_1663() -> Result<()> {
     Ok(())
 }
 
-/// Documents four deliberate, narrow gaps #1663 leaves open rather than
-/// silently missing: `needs_path_context` still has no arm for
-/// `Expr::AsPattern` (destructuring `as`), `Expr::Reduce`, `Expr::Foreach`,
-/// or `Expr::Limit`, so a path-context builtin inside any of these four
-/// still falls through to the generic fallback and stubs to its zero
-/// default, exactly as before this fix. `Expr::Object` has the identical
-/// gap but is tracked separately as #1332 (already true before #1663, per
-/// the `Array` arm's own doc comment). Only `Expr::As` -- the single most
-/// consequential shape per #1663's own filing (the ordinary
-/// `EXPR as $v | body` idiom) -- was fixed here; the remaining four have
-/// no real-yq oracle to verify a fix against (yq's lexer rejects
-/// destructuring `as`, `reduce`, `foreach`, and `limit` outright) and
-/// `Reduce`/`Foreach` in particular raise a real semantic question (what
-/// should `key` mean while evaluating the fold's own accumulator, which
-/// has no document position?) that #1663's own investigation didn't
-/// settle. Filed as a follow-up rather than guessed at here. Pinned so a
-/// future regression or accidental fix is visible either way, matching
-/// #1306's identical "known gap" precedent
-/// (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
+/// Documents three deliberate, narrow gaps #1663 leaves open rather than
+/// silently missing: `needs_path_context` still has no dedicated evaluation
+/// arm for `Expr::Reduce`, `Expr::Foreach`, or `Expr::Limit`, so a
+/// path-context builtin inside any of these three still falls through to the
+/// generic fallback and stubs to its zero default, exactly as before this
+/// fix. `Expr::Object` has the identical gap but is tracked separately as
+/// #1332 (already true before #1663, per the `Array` arm's own doc comment).
+///
+/// `Expr::As` (#1663) and the single-pattern case of `Expr::AsPattern`
+/// (#1765) -- the two most consequential shapes, since they're the ordinary
+/// `EXPR as $v | body` / `EXPR as PATTERN | body` idioms -- are both fixed;
+/// see `test_as_pattern_single_pattern_path_context_resolves_1765` for that
+/// coverage. A `?//`-chained `AsPattern` (2+ alternatives) is intentionally
+/// still a known gap alongside the three below -- its retry-on-failure
+/// semantics are real complexity #1765 didn't attempt to replicate, per that
+/// issue's own scoping.
+///
+/// None of the remaining four shapes (reduce/foreach/limit, plus `?//`) have
+/// a real-yq oracle to verify a fix against (yq's lexer rejects destructuring
+/// `as`, `reduce`, `foreach`, and `limit` outright), and `Reduce`/`Foreach`
+/// in particular raise a real semantic question (what should `key` mean
+/// while evaluating the fold's own accumulator, which has no document
+/// position?) that #1663's own investigation didn't settle. Filed as a
+/// follow-up rather than guessed at here. Pinned so a future regression or
+/// accidental fix is visible either way, matching #1306's identical "known
+/// gap" precedent (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
 #[test]
-fn test_as_pattern_reduce_foreach_limit_path_context_still_known_gaps_1663() -> Result<()> {
-    let (stdout, _, code) = run_jq_full(&["-c", ".a | . as [$x] | key"], Some(r#"{"a":[1]}"#))?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "null");
-
+fn test_reduce_foreach_limit_path_context_still_known_gaps_1663() -> Result<()> {
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | reduce .[] as $x (key; .)"],
         Some(r#"{"a":[1,2]}"#),
@@ -6801,6 +6804,39 @@ fn test_as_pattern_reduce_foreach_limit_path_context_still_known_gaps_1663() -> 
     let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(1; key)]"], Some(r#"{"a":1}"#))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "[null]");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | . as [$x] ?// {b:$x} | key"],
+        Some(r#"{"a":[1]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    Ok(())
+}
+
+/// #1765: `Expr::AsPattern`'s single-pattern case (no `?//` alternatives)
+/// now resolves `key`/`parent`/`file_index` against the caller's own ambient
+/// position, mirroring #1663's `Expr::As` fix -- both array and object
+/// destructuring, and a nested `parent(n)` reaching past the bound position
+/// back toward the document root.
+#[test]
+fn test_as_pattern_single_pattern_path_context_resolves_1765() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | . as [$x] | key"], Some(r#"{"a":[1]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | . as {b: $x} | key"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | . as {b: $x} | $x, parent(1)"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1\n{\"a\":{\"b\":1}}");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6841,6 +6841,39 @@ fn test_as_pattern_single_pattern_path_context_resolves_1765() -> Result<()> {
     Ok(())
 }
 
+/// #1765 code review: an earlier version of this fix's `needs_path_context`
+/// arm answered `true` for a `?//`-chained `AsPattern` too, not just the
+/// single-pattern case the dedicated eval arm actually handles. That routed
+/// a `?//`-chain into the eager path-context evaluator whenever it sat
+/// inside `Arithmetic`/`Compare`/a non-terminal `Pipe` position, where its
+/// generic fallback (`eval_owned_expr_full`) collapses a multi-output
+/// `Many`/`Partial` result into a single `OwnedValue::Array` instead of
+/// streaming it -- silently changing both output count and value shape for
+/// something never even the (broken) `key`/`parent` stub was meant to
+/// affect. Confirmed live against pre-#1765 `main`: both filters below give
+/// two separate `"null"`/`"0"` outputs there, not one collapsed
+/// `"[null,null]"` or a type error. `needs_path_context`'s `AsPattern` arm
+/// now carries the identical `patterns.len() == 1` gate the eval arm does,
+/// closing this before it ever shipped.
+#[test]
+fn test_as_pattern_qmark_slash_slash_chain_does_not_collapse_cardinality_1765() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "(.a[] as {x:$v} ?// [$v] | key) | tostring"],
+        Some(r#"{"a":[{"x":1},{"x":2}]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"null\"\n\"null\"\n");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "(.a[] as {x:$v} ?// [$v] | key) + 0 | tostring"],
+        Some(r#"{"a":[{"x":1},{"x":2}]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"0\"\n\"0\"\n");
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::Array` arm (#1302), so `[key]` --
 /// semantically equivalent to `(key,key)`'s single-branch case, just
 /// array-wrapped instead of comma-joined -- silently lost path context and


### PR DESCRIPTION
## Summary

#1663 fixed `needs_path_context`'s missing `Expr::As` arm (the ordinary
`EXPR as $v | body` idiom), the single most consequential shape in that
issue's filing. Four other shapes it named remain unfixed, still silently
stubbing `key`/`parent(n)`/`file_index` to their zero defaults — tracked as
#1765. This PR takes the first of those four, per the issue's own suggested
value/cost ordering: `Expr::AsPattern`'s single-pattern case (no `?//`),
which mirrors #1663's fix most directly.

```
$ echo '{"a":[1]}' | succinctly jq -c '.a | . as [$x] | key'
null                                             # before: should be "a"
$ echo '{"a":[1]}' | succinctly-fixed jq -c '.a | . as [$x] | key'
"a"                                              # after
```

## Fix

Adds a dedicated `Expr::AsPattern` arm to `eval_pipe_with_path_context_internal`,
structurally identical to the existing `Expr::As` arm just above it: bind
`expr`'s outputs through the path-context evaluator, extract each pattern's
bindings via `extract_pattern_bindings(&patterns[0], &bound_val, false)`
(`invert: false`, matching the single-pattern/non-`?//` contract that
function's own doc comment establishes), substitute into `body` via the
existing `substitute_vars`, and evaluate each substituted body through the
same path-context evaluator — so `key`/`parent`/`file_index` inside `body`
see the caller's own ambient position, unchanged.

`needs_path_context`'s own `Expr::AsPattern` arm mirrors `Expr::As`'s too,
without a pattern-count gate — that's just the routing question ("does the
whole pipe need path-context evaluation at all"), so a `?//`-chain still
routes into path-context evaluation when needed, then correctly falls
through to the generic (pre-existing, unchanged, stub) fallback once inside,
rather than hitting the new dedicated arm.

## Scope: deliberately not `Reduce`/`Foreach`/`Limit`/`?//`

Per the issue's own scoping note — a `?//`-chain's retry-on-failure
semantics (`try_pattern_alternatives`'s decode-failure/break/halt
classification, carried-prefix-across-alternatives bookkeeping) are real
complexity this PR doesn't attempt to replicate. Confirmed live this isn't a
regression, just unchanged:

```
$ echo '{"a":[1]}' | succinctly-fixed jq -c '.a | . as [$x] ?// {b:$x} | key'
null   # same as before this PR -- falls through to the generic fallback
```

`Reduce`/`Foreach`/`Limit` (items 2-4 of the issue's own ordering) are left
as documented known gaps for follow-up — `Reduce`/`Foreach` raise a real
semantic question the issue itself flags (what does `key` mean while
evaluating the fold's own accumulator, which has no document position?)
that isn't settled yet.

The issue (#1765) is intentionally left open, narrowed to those three
remaining shapes, rather than closed by this PR.

## Verification

No jq/yq oracle exists for any of this — `key`/`parent`/`file_index` are
succinctly extensions, and yq's own lexer rejects destructuring `as`
outright (confirmed live against v4.53.3) — so this pins internal
consistency with the already-fixed `Expr::As` sibling, not oracle
compliance. Manually verified array destructuring, object destructuring,
and `parent(n)` reaching back through a bound position to the document
root, plus confirmed the `?//` and Reduce/Foreach/Limit cases are
unchanged.

## Test plan

- [x] Updated the existing #1663 known-gaps test
      (`test_as_pattern_reduce_foreach_limit_path_context_still_known_gaps_1663`
      → `test_reduce_foreach_limit_path_context_still_known_gaps_1663`) to
      drop the now-fixed single-pattern `AsPattern` case and add the `?//`
      case explicitly (previously only implied)
- [x] New test `test_as_pattern_single_pattern_path_context_resolves_1765`
      covering array destructuring, object destructuring, and `parent(n)`
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`): all
      green, no regressions
- [x] Both required clippy legs clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features` (no_std) still builds

Refs #1765