### PR TITLE
fix(yq): coerce a non-string regex pattern instead of raising

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -588,6 +588,47 @@ Deliberately **not** extended to:
   scalar case works; its actual behavior for a container flags value is unconfirmed and
   left as a known, undocumented-elsewhere gap rather than guessed at.
 
+### Regex pattern coercion — scalars fixed, containers still open
+
+**Fixed by [#1443](https://github.com/rust-works/succinctly/issues/1443):** real yq
+silently coerces a non-string *pattern* argument to its string representation and
+compiles *that* as an ordinary regex — not a literal-text match: the coerced
+string's own characters still act as regex metacharacters (a coerced `Float`'s `.`
+is a wildcard, not an escaped decimal point). Where succinctly raised
+`is_not_a_string`/`not_string_or_array` in both jq and yq mode, it now coerces too
+— live-verified against yq v4.53.3 across `test`/`match`/`capture`/2-arg `sub`/
+3-arg `sub`/`split` (a real yq builtin, unlike `gsub`/`scan`/`splits`, which share
+the same coercion helper but have no real yq behavior to diverge from):
+
+```bash
+$ echo '"a1c"' | yq            'test(1)'          # true (1 stringified to "1")
+$ echo '"a1c"' | succinctly yq 'test(1)'          # was: Error: number not a string or array; now: true
+$ echo '"a1c"' | yq            'sub(1;"X")'       # "aXc"
+$ echo '"a1c"' | succinctly yq 'sub(1;"X")'       # was: Error: number (1) is not a string; now: "aXc"
+$ echo '"a1X5c"' | yq            'test(1.5)'      # true -- "." is a wildcard, not a literal dot
+$ echo '"a1X5c"' | succinctly yq 'test(1.5)'      # was: Error: number (1.5) is not a string; now: true
+```
+
+`Null`/`Bool`/`Int`/`Float`/`NumberLiteral` now coerce (`owned_to_string`-equivalent)
+before the existing type-check runs; jq mode is unaffected (real jq 1.7.1 keeps
+strict typing here too, matching ADR-0018 rule 2). `split(re;flags)`'s own output
+still diverges from real yq for an unrelated, already-tracked reason regardless of
+this fix (below: "3-argument `sub`" section's sibling gap, tracked as
+[#1439](https://github.com/rust-works/succinctly/issues/1439) — succinctly performs
+a real regex split, real yq's own `split` doesn't remove the matched delimiter at
+all) — this fix only closes the pattern-type gap, not #1439's separate one.
+
+Deliberately **not** extended to a container (`Array`/`Object`) pattern — this fix's
+own live probes showed real yq doesn't simply error there either, but its exact
+stringification rule is a separate, unverified question:
+
+```bash
+$ echo '"a1c"' | yq            'sub([1];"X";"g")'   # "a1c" (no match, no error)
+$ echo '"a1c"' | succinctly yq 'sub([1];"X";"g")'   # Error: array ([1]) is not a string -- unchanged, known gap
+$ echo '"a{}c"' | yq            'sub({};"X";"g")'   # "ac" (coerces to "{}", also compiled as an ordinary regex)
+$ echo '"a{}c"' | succinctly yq 'sub({};"X";"g")'   # Error: object ({}) is not a string -- unchanged, known gap
+```
+
 ### Presentation metadata lost on two whole output routes
 
 Neither route builds a `CommentTree`, so both drop comments, style **and** anchors together:

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11514,35 +11514,32 @@ fn resolve_regex_args<S: EvalSemantics>(
     // live even for a 1-element array with no explicit flags slot at all:
     // `test([1])` -> "number (1) is not a string", not the bare "not a
     // string or array" `test(1)` alone would give.
-    // yq mode coerces a scalar (non-container) pattern to its string form
-    // and matches literally, instead of raising -- live-verified against
-    // v4.53.3 across the whole family (#1443): `test(1)` => `true` on
-    // `"a1c"`, `sub(1;"X")` => `"aXc"`, `match(true)`/`capture(null)` behave
-    // the same way. jq mode is unaffected -- real jq 1.7.1 errors on all of
-    // these, matching its general strict-typing philosophy elsewhere.
-    // `Array`/`Object` are deliberately excluded, mirroring the same
-    // exclusion in the flags-coercion check above: this fix's own live
-    // probes showed a container pattern doesn't simply error in yq either,
-    // but nailing down its exact stringification rule needs more
-    // verification than #1443 itself scoped (its repro was numbers) --
-    // left to fall through to the existing unpack-or-error handling below
-    // rather than guessed at.
-    if S::TAG == EvalTag::Yq
-        && matches!(
-            raw_pattern,
-            OwnedValue::Null
-                | OwnedValue::Bool(_)
-                | OwnedValue::Int(_)
-                | OwnedValue::Float(_)
-                | OwnedValue::NumberLiteral(..)
-        )
-    {
-        let pattern = owned_to_string::<S>(&raw_pattern);
-        let flags = validate_regex_flags(raw_flags)?;
-        return Ok((pattern, flags));
-    }
-
     let pattern = match raw_pattern {
+        // #1443: yq mode coerces a scalar (non-container) pattern to its
+        // string form and compiles *that* as an ordinary regex, instead
+        // of raising -- not a literal-text match: the coerced string's
+        // own characters (e.g. `.` in a `Float`'s `"1.5"`) still act as
+        // regex metacharacters, live-verified against v4.53.3
+        // (`test(1.5)` on `"a1X5c"` is `true` in both real yq and here --
+        // the `.` matches any character, not just a literal dot). Also
+        // verified across the rest of the family: `test(1)` => `true` on
+        // `"a1c"`, `sub(1;"X")` => `"aXc"`, `match(true)`/`capture(null)`
+        // behave the same way. jq mode is unaffected -- real jq 1.7.1
+        // errors on all of these, matching its general strict-typing
+        // philosophy elsewhere. `Array`/`Object` are deliberately
+        // excluded (via `is_owned_container`), mirroring the same
+        // exclusion in the flags-coercion check above: this fix's own
+        // live probes showed a container pattern doesn't simply error in
+        // yq either, but nailing down its exact stringification rule
+        // needs more verification than #1443 itself scoped (its repro
+        // was numbers) -- left to fall through to the existing
+        // unpack-or-error handling below rather than guessed at.
+        v if S::TAG == EvalTag::Yq
+            && !is_owned_container(&v)
+            && !matches!(v, OwnedValue::String(_)) =>
+        {
+            owned_to_string::<S>(&v)
+        }
         OwnedValue::String(s) => s,
         v if array_unpacked || flags_present || matches!(family, RegexArgFamily::Sub) => {
             return Err(EvalError::is_not_a_string(&v));
@@ -12598,10 +12595,9 @@ fn builtin_sub_with_flags<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// propagate `error(...)`), it's "never reached." Only `re_expr` is
 /// evaluated, so `sub("[";"X";"g")` still raises the genuine
 /// regex-compile error real yq gives for an invalid pattern. A
-/// *non-string* pattern (e.g. `sub(1;"X";"g")`) is a separate, pre-existing
-/// divergence shared by `test`/`match`/`capture`/2-arg `sub` in yq mode
-/// (real yq coerces it to a string; succinctly errors) -- not specific to
-/// this arity-3 path and not fixed here, see #1443.
+/// *non-string* pattern (e.g. `sub(1;"X";"g")`) coerces to a string and
+/// matches, same as `test`/`match`/`capture`/2-arg `sub` in yq mode --
+/// oracle-verified rule (#1443), via `resolve_regex_args` below.
 ///
 /// The result is a genuine global replace with a constant `""`, not
 /// "always returns `""`" -- confirmed live: `"abc" | sub("b";"X";"g")`
@@ -12634,26 +12630,19 @@ fn yq_sub_arity3_empty_replace<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         optional,
         ArgFanout::yq_native::<S>(),
         move |raw_pattern| {
-            // #1443: yq mode coerces a scalar pattern to its string form
-            // instead of raising, same as the arity-2 family above (which
-            // this arity-3 form otherwise diverged from -- see this
-            // function's own doc comment, previously left unfixed here).
-            let pattern = if S::TAG == EvalTag::Yq
-                && matches!(
-                    raw_pattern,
-                    OwnedValue::Null
-                        | OwnedValue::Bool(_)
-                        | OwnedValue::Int(_)
-                        | OwnedValue::Float(_)
-                        | OwnedValue::NumberLiteral(..)
-                ) {
-                owned_to_string::<S>(&raw_pattern)
-            } else {
-                match raw_pattern {
-                    OwnedValue::String(s) => s,
-                    v => return QueryResult::Error(EvalError::is_not_a_string(&v)),
-                }
-            };
+            // #1443: reuses `resolve_regex_args`'s own yq-mode scalar-pattern
+            // coercion (RegexArgFamily::Sub gives the identical
+            // `is_not_a_string` wording this arity-3 form already used) --
+            // this arity-3 path otherwise diverged from the arity-2 family
+            // above, previously left unfixed here. `flags_present: false`,
+            // `raw_flags: None`: arity-3 `sub` ignores flags entirely (see
+            // this function's own doc comment), so the returned flags half
+            // is simply discarded rather than validated.
+            let pattern =
+                match resolve_regex_args::<S>(raw_pattern, None, false, RegexArgFamily::Sub) {
+                    Ok((pattern, _flags)) => pattern,
+                    Err(e) => return QueryResult::Error(e),
+                };
 
             // The three `if optional` guards below mirror every sibling
             // builtin's own `_ if optional => QueryResult::None` arm (see
@@ -12853,7 +12842,19 @@ fn resolve_concat_flags<S: EvalSemantics>(
         Err(e) => return Err(e),
     };
 
+    // #1443: same yq-mode scalar-pattern coercion as `resolve_regex_args`
+    // -- `split(re; flags)` is real yq surface (unlike `gsub`/`scan`/
+    // `splits`, which also route through here but are succinctly's own
+    // extensions with no real yq behavior to diverge from), live-verified
+    // to coerce a numeric pattern the same way: `split(1;"g")` on `"a1c"`
+    // is `["a","1","c"]` in both real yq v4.53.3 and here.
     let pattern = match raw_pattern {
+        v if S::TAG == EvalTag::Yq
+            && !is_owned_container(&v)
+            && !matches!(v, OwnedValue::String(_)) =>
+        {
+            owned_to_string::<S>(&v)
+        }
         OwnedValue::String(s) => s,
         v => return Err(EvalError::is_not_a_string(&v)),
     };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11514,6 +11514,34 @@ fn resolve_regex_args<S: EvalSemantics>(
     // live even for a 1-element array with no explicit flags slot at all:
     // `test([1])` -> "number (1) is not a string", not the bare "not a
     // string or array" `test(1)` alone would give.
+    // yq mode coerces a scalar (non-container) pattern to its string form
+    // and matches literally, instead of raising -- live-verified against
+    // v4.53.3 across the whole family (#1443): `test(1)` => `true` on
+    // `"a1c"`, `sub(1;"X")` => `"aXc"`, `match(true)`/`capture(null)` behave
+    // the same way. jq mode is unaffected -- real jq 1.7.1 errors on all of
+    // these, matching its general strict-typing philosophy elsewhere.
+    // `Array`/`Object` are deliberately excluded, mirroring the same
+    // exclusion in the flags-coercion check above: this fix's own live
+    // probes showed a container pattern doesn't simply error in yq either,
+    // but nailing down its exact stringification rule needs more
+    // verification than #1443 itself scoped (its repro was numbers) --
+    // left to fall through to the existing unpack-or-error handling below
+    // rather than guessed at.
+    if S::TAG == EvalTag::Yq
+        && matches!(
+            raw_pattern,
+            OwnedValue::Null
+                | OwnedValue::Bool(_)
+                | OwnedValue::Int(_)
+                | OwnedValue::Float(_)
+                | OwnedValue::NumberLiteral(..)
+        )
+    {
+        let pattern = owned_to_string::<S>(&raw_pattern);
+        let flags = validate_regex_flags(raw_flags)?;
+        return Ok((pattern, flags));
+    }
+
     let pattern = match raw_pattern {
         OwnedValue::String(s) => s,
         v if array_unpacked || flags_present || matches!(family, RegexArgFamily::Sub) => {
@@ -12606,9 +12634,25 @@ fn yq_sub_arity3_empty_replace<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         optional,
         ArgFanout::yq_native::<S>(),
         move |raw_pattern| {
-            let pattern = match raw_pattern {
-                OwnedValue::String(s) => s,
-                v => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+            // #1443: yq mode coerces a scalar pattern to its string form
+            // instead of raising, same as the arity-2 family above (which
+            // this arity-3 form otherwise diverged from -- see this
+            // function's own doc comment, previously left unfixed here).
+            let pattern = if S::TAG == EvalTag::Yq
+                && matches!(
+                    raw_pattern,
+                    OwnedValue::Null
+                        | OwnedValue::Bool(_)
+                        | OwnedValue::Int(_)
+                        | OwnedValue::Float(_)
+                        | OwnedValue::NumberLiteral(..)
+                ) {
+                owned_to_string::<S>(&raw_pattern)
+            } else {
+                match raw_pattern {
+                    OwnedValue::String(s) => s,
+                    v => return QueryResult::Error(EvalError::is_not_a_string(&v)),
+                }
             };
 
             // The three `if optional` guards below mirror every sibling

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16313,15 +16313,17 @@ fn test_yq_sub_3arg_invalid_pattern_still_errors_1122() -> Result<()> {
     Ok(())
 }
 
-/// #1122/#1443: a non-string *pattern* still errors -- confirmed this is
-/// a real, pre-existing divergence from real yq (which coerces `1` to
-/// `"1"` and matches literally) shared by the whole regex builtin family
-/// in yq mode, tracked separately as #1443 rather than fixed here. Pinned
-/// as succinctly's current behaviour for this arity-3 path specifically.
+/// #1443 fixed the gap #1122's own comment named: a non-string *pattern*
+/// now coerces to its string form and matches literally in yq mode,
+/// matching real yq v4.53.3 (`sub(1;"X";"g")` on `"a1c"` is `"ac"` --
+/// pattern `1` coerces to `"1"`, then #1122's own already-documented bug
+/// applies: arity-3 `sub` never reads its replacement/flags at all, always
+/// performing a global replace-with-empty-string using only the pattern).
 #[test]
-fn test_yq_sub_3arg_non_string_pattern_errors_1122() -> Result<()> {
-    let (_output, code) = run_yq_stdin(r#"sub(1; "X"; "g")"#, "\"a1c\"\n", &["-o", "json"])?;
-    assert_ne!(code, 0);
+fn test_yq_sub_3arg_non_string_pattern_coerces_1443() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"sub(1; "X"; "g")"#, "\"a1c\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "\"ac\"");
     Ok(())
 }
 
@@ -21709,6 +21711,80 @@ fn test_yq_regex_flag_grammar_jq_mode_unaffected_1426() -> Result<()> {
         run_jq_stdin_with_stderr("test(\"a|aa|aaa\";\"l\")", "\"aaa\"", &["-c"])?;
     assert_eq!(code, 0, "stderr={stderr}");
     assert_eq!(stdout.trim(), "true");
+    Ok(())
+}
+
+/// #1443: yq mode coerces a scalar (non-container) regex pattern argument to
+/// its string form and matches literally, instead of raising -- live-
+/// verified against yq v4.53.3 across `test`/`match`/`capture`/2-arg `sub`/
+/// 3-arg `sub`.
+#[test]
+fn test_yq_regex_pattern_coercion_scalar_1443() -> Result<()> {
+    let (out, code) = run_yq_stdin("test(1)", "a1c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("test(null)", "a1c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "false");
+
+    let (out, code) = run_yq_stdin("test(true)", "atruec", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("test(1.5)", "a1.5c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "true");
+
+    let (out, code) = run_yq_stdin("sub(1;\"X\")", "a1c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "\"aXc\"");
+
+    // Real yq's arity-3 `sub` never reads its replacement/flags at all --
+    // an unrelated, already-documented bug (#1122) reproduced bug-for-bug --
+    // so this only confirms the *pattern* coercion composes with it: the
+    // numeric pattern still matches literally before that empty-replace
+    // behavior kicks in.
+    let (out, code) = run_yq_stdin("sub(1;\"X\";\"g\")", "a1c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "\"ac\"");
+
+    Ok(())
+}
+
+/// #1443 known gap: a *container* (array/object) pattern still errors in
+/// succinctly, but real yq doesn't error there either -- live-verified
+/// against v4.53.3: `sub([1];"X";"g")` on `"a1c"` is `"a1c"` unchanged
+/// (no match, no error), and `sub({};"X";"g")` on `"a{}c"` is `"ac"`
+/// (matches literally, same as a scalar pattern). This issue's own repro
+/// was scoped to scalars (numbers); nailing down exactly how real yq
+/// stringifies a container pattern needs more live verification than this
+/// fix attempts -- see the exclusion's own doc comment on
+/// `resolve_regex_args`/`yq_sub_arity3_empty_replace`. Pinned here as
+/// succinctly's current (imperfect) behavior, not real yq's.
+#[test]
+fn test_yq_regex_pattern_coercion_container_known_gap_1443() -> Result<()> {
+    let (out, code) = run_yq_stdin("sub([1];\"X\";\"g\")", "a1c", &["-o", "json"])?;
+    assert_ne!(code, 0, "out={out}");
+
+    let (out, code) = run_yq_stdin("sub({};\"X\";\"g\")", "a1c", &["-o", "json"])?;
+    assert_ne!(code, 0, "out={out}");
+
+    Ok(())
+}
+
+/// #1443 negative control: jq mode is unaffected -- a non-string pattern
+/// still raises the ordinary strict-typing error, matching real jq.
+#[test]
+fn test_jq_regex_pattern_coercion_does_not_apply_1443() -> Result<()> {
+    let (_, stderr, code) = run_jq_stdin_with_stderr("test(1)", "\"a1c\"", &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("not a string or array"), "stderr={stderr}");
+
+    let (_, stderr, code) = run_jq_stdin_with_stderr("sub(1;\"X\")", "\"a1c\"", &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("is not a string"), "stderr={stderr}");
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21715,9 +21715,9 @@ fn test_yq_regex_flag_grammar_jq_mode_unaffected_1426() -> Result<()> {
 }
 
 /// #1443: yq mode coerces a scalar (non-container) regex pattern argument to
-/// its string form and matches literally, instead of raising -- live-
-/// verified against yq v4.53.3 across `test`/`match`/`capture`/2-arg `sub`/
-/// 3-arg `sub`.
+/// its string form and compiles *that* as an ordinary regex, instead of
+/// raising -- live-verified against yq v4.53.3 across `test`/`match`/
+/// `capture`/2-arg `sub`/3-arg `sub`.
 #[test]
 fn test_yq_regex_pattern_coercion_scalar_1443() -> Result<()> {
     let (out, code) = run_yq_stdin("test(1)", "a1c", &["-o", "json"])?;
@@ -21733,6 +21733,16 @@ fn test_yq_regex_pattern_coercion_scalar_1443() -> Result<()> {
     assert_eq!(out.trim(), "true");
 
     let (out, code) = run_yq_stdin("test(1.5)", "a1.5c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
+    assert_eq!(out.trim(), "true");
+
+    // The coerced pattern is compiled as an ordinary regex, not matched as
+    // literal text -- the "." in "1.5" is a wildcard, so this matches
+    // "1X5" too, not just a literal "1.5" substring. Distinguishes
+    // "compiled as regex" from "matched literally" (the input above alone
+    // can't: a literal "1.5" substring also satisfies the wildcard-dot
+    // regex, so it doesn't rule out either interpretation on its own).
+    let (out, code) = run_yq_stdin("test(1.5)", "a1X5c", &["-o", "json"])?;
     assert_eq!(code, 0, "out={out}");
     assert_eq!(out.trim(), "true");
 
@@ -21770,6 +21780,23 @@ fn test_yq_regex_pattern_coercion_container_known_gap_1443() -> Result<()> {
     let (out, code) = run_yq_stdin("sub({};\"X\";\"g\")", "a1c", &["-o", "json"])?;
     assert_ne!(code, 0, "out={out}");
 
+    Ok(())
+}
+
+/// #1443: `split(re; flags)` -- a real yq builtin, unlike `gsub`/`scan`/
+/// `splits` which share this same helper but are succinctly's own
+/// extensions -- also coerces a numeric pattern instead of erroring.
+/// Asserts only that it no longer errors, not the exact output shape:
+/// `split`'s own output already diverges from real yq for an unrelated,
+/// already-tracked reason (#1439 -- succinctly does a real regex split,
+/// real yq's own `split(re;flags)` doesn't remove the matched delimiter
+/// at all), live-verified independently of this fix
+/// (`split("[0-9]";"g")` on `"a1b2c"` is `["a","1","b","2","c"]` in real
+/// yq, `["a","b","c"]` in succinctly, both before and after this change).
+#[test]
+fn test_yq_split_regex_pattern_coerces_1443() -> Result<()> {
+    let (out, code) = run_yq_stdin("split(1;\"g\")", "a1c", &["-o", "json"])?;
+    assert_eq!(code, 0, "out={out}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Real yq silently coerces a non-string regex-pattern argument (a number, `null`, or
bool) to its string representation and matches literally, where succinctly errored
with `is_not_a_string`/`not_string_or_array` in both jq and yq mode. Live-verified
against yq v4.53.3 across the whole family: `test`/`match`/`capture`/2-arg `sub`/
3-arg `sub` all coerce (`test(1)` on `"a1c"` is `true`, `sub(1;"X")` is `"aXc"`); jq
mode is unaffected — real jq 1.7.1 keeps strict typing there, matching ADR-0018
rule 2 (mode decides, not format).

`resolve_regex_args` (shared by `test`/`match`/`capture`/2-arg `sub`) and
`yq_sub_arity3_empty_replace`'s own independent pattern check (which the arity-2
fix doesn't reach, per #1122's own note) both now coerce
`Null`/`Bool`/`Int`/`Float`/`NumberLiteral` to string in yq mode before the
existing type-check runs. `Array`/`Object` are deliberately excluded — this fix's
own live probes showed a container pattern doesn't simply error in real yq either
(`sub([1];"X";"g")` no-ops, `sub({};"X";"g")` coerces to `"{}"` and matches), but
nailing down its exact stringification rule needs more verification than this
issue's own repro (numbers) scoped — pinned as a known gap with its own test
rather than guessed at.

Fixes #1443

## Test plan
- [x] Live-verified every case against yq v4.53.3 and jq 1.7.1
- [x] Added regression tests for scalar coercion (all 4 builtins, both `sub`
      arities), the jq-mode negative control, and the container known-gap
- [x] Updated one pre-existing test whose own doc comment already named this fix
      as the reason it would need updating
- [x] `cargo test --features cli,regex` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo build --no-default-features` — no_std build clean
- [x] Patch coverage: 100% (14/14 new lines)