### PR TITLE
fix(jq): value-mode eval_slice_bound keeps a bound generator's partial prefix

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14106,24 +14106,34 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let starts = match eval_slice_bound::<W, S>(start, value.clone(), f64::floor) {
+    // #1528: keeps each bound generator's own partial prefix instead of
+    // discarding it on escape -- see `eval_generic::eval_slice_expr`'s own
+    // (near-identical) doc comment on this exact fix for the full
+    // jq-nesting-order rationale; not repeated here.
+    let (starts, starts_escape) = match eval_slice_bound::<W, S>(start, value.clone(), f64::floor) {
         Ok(v) => v,
-        Err(Control::Error(e)) => return QueryResult::Error(e),
-        Err(Control::Break(label)) => return QueryResult::Break(label),
-        Err(Control::Halt(code)) => return QueryResult::Halt(code),
+        Err(control) => return partial(Vec::new(), control),
     };
     if starts.is_empty() {
-        return QueryResult::None;
+        return match starts_escape {
+            None => QueryResult::None,
+            Some(control) => partial(Vec::new(), control),
+        };
     }
-    let ends = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
+    let (ends, ends_escape) = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
         Ok(v) => v,
-        Err(Control::Error(e)) => return QueryResult::Error(e),
-        Err(Control::Break(label)) => return QueryResult::Break(label),
-        Err(Control::Halt(code)) => return QueryResult::Halt(code),
+        Err(control) => return partial(Vec::new(), control),
     };
+    let ends_escaped = ends_escape.is_some();
+    let bounds_escape = ends_escape.or(starts_escape);
     if ends.is_empty() {
-        return QueryResult::None;
+        return match bounds_escape {
+            None => QueryResult::None,
+            Some(control) => partial(Vec::new(), control),
+        };
     }
+    let starts_len = if ends_escaped { 1 } else { starts.len() };
+    let starts = &starts[..starts_len];
 
     let targets = eval_single::<W, S>(target, value, false).materialize_cursor();
 
@@ -14174,7 +14184,7 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     match &targets {
         Targets::Borrowed(ts) => {
-            for s in &starts {
+            for s in starts {
                 for e in &ends {
                     let slice_expr = Expr::Slice { start: *s, end: *e };
                     for t in ts {
@@ -14190,7 +14200,7 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         Targets::Owned(ts) => {
-            for s in &starts {
+            for s in starts {
                 for e in &ends {
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
@@ -14203,7 +14213,13 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
     }
-    owned_vec_to_result(out)
+    // #1528: the bound-escape info threaded through above still has to
+    // reach the final result -- a successful loop doesn't mean `start`/`end`
+    // themselves didn't escape after producing `out`'s own values.
+    match bounds_escape {
+        None => owned_vec_to_result(out),
+        Some(control) => partial(out, control),
+    }
 }
 
 /// Evaluate one slice bound (`start` or `end`) against `value`, collecting
@@ -14221,29 +14237,38 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// error — [`eval_index_expr`]'s key evaluation, which returns `QueryResult`
 /// directly, already gets this right; the narrower `Result<_, EvalError>`
 /// this shares with [`owned_bound_to_i64`] needs `Control` to keep up.
+///
+/// Keeps the bound generator's own partial prefix rather than discarding it
+/// on escape (#1528) -- see `eval_generic::eval_slice_bound`'s own doc
+/// comment for the full rationale, shared verbatim here.
 fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: StandardJson<'_, W>,
     round: fn(f64) -> f64,
-) -> Result<Vec<Option<i64>>, Control> {
+) -> Result<(Vec<Option<i64>>, Option<Control>), Control> {
     let Some(expr) = bound else {
-        return Ok(vec![None]);
+        return Ok((vec![None], None));
     };
-    let raw: Vec<OwnedValue> = match eval_single::<W, S>(expr, value, false).materialize_cursor() {
-        QueryResult::One(v) => vec![to_owned_key_shape(&v)],
-        QueryResult::Many(vs) => vs.iter().map(to_owned_key_shape).collect(),
-        QueryResult::Owned(v) => vec![v],
-        QueryResult::ManyOwned(vs) => vs,
-        QueryResult::None => return Ok(Vec::new()),
-        QueryResult::Error(e) => return Err(Control::Error(e)),
-        QueryResult::Break(label) => return Err(Control::Break(label)),
-        QueryResult::Halt(code) => return Err(Control::Halt(code)),
-        QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
-        QueryResult::Partial(_, control) => return Err(control),
-    };
-    raw.iter()
+    let (raw, escape): (Vec<OwnedValue>, Option<Control>) =
+        match eval_single::<W, S>(expr, value, false).materialize_cursor() {
+            QueryResult::One(v) => (vec![to_owned_key_shape(&v)], None),
+            QueryResult::Many(vs) => (vs.iter().map(to_owned_key_shape).collect(), None),
+            QueryResult::Owned(v) => (vec![v], None),
+            QueryResult::ManyOwned(vs) => (vs, None),
+            QueryResult::None => (Vec::new(), None),
+            QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
+            QueryResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
+            QueryResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
+            QueryResult::OneCursor(_) => {
+                unreachable!("materialize_cursor should have converted this")
+            }
+            QueryResult::Partial(vs, control) => (vs, Some(control)),
+        };
+    let converted = raw
+        .iter()
         .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((converted, escape))
 }
 
 /// Classify a resolved bound value the way jq's slice descriptor does
@@ -51044,10 +51069,21 @@ mod tests {
             (b"[1,2,3]", "label $out | .[(break $out):(2+0)]", Ok("")),
             (b"[1,2,3]", "label $out | .[(0+0):(break $out)]", Ok("")),
             // A bound whose stream breaks (or errors) after already
-            // producing values: same conservative trade-off as the target
-            // case above, applied to the bound stream instead.
-            (b"[1,2,3]", "label $out | .[(1,2,break $out):(2+0)]", Ok("")),
-            (b"[1,2,3]", r#".[(1,2,error("boom")):(2+0)]"#, Err("boom")),
+            // producing values: unlike the target case above, the bound
+            // stream's own partial prefix is kept, not discarded (#1528) --
+            // confirmed against jq 1.7.1: both cases print `[2]` then `[]`
+            // (from `$s=1`/`$s=2` against the fixed end bound `2`) before the
+            // break/error fires on `$s`'s third candidate. `outcome()`'s own
+            // `Err` arm only matches a zero-prefix `QueryResult::Error`, so a
+            // `Partial` terminating in an error is asserted here as `Ok` of
+            // its already-collected prefix, same as the break case --
+            // this test harness doesn't itself assert the trailing error.
+            (
+                b"[1,2,3]",
+                "label $out | .[(1,2,break $out):(2+0)]",
+                Ok("[2] []"),
+            ),
+            (b"[1,2,3]", r#".[(1,2,error("boom")):(2+0)]"#, Ok("[2] []")),
         ]);
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6249,24 +6249,55 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
 ) -> GenericResult<V> {
     // Bounds first: an empty start or end stream must not evaluate the
     // target at all.
-    let starts = match eval_slice_bound::<S, V>(start, value.clone(), cursor, f64::floor) {
-        Ok(v) => v,
-        Err(Control::Error(e)) => return GenericResult::Error(e),
-        Err(Control::Break(label)) => return GenericResult::Break(label),
-        Err(Control::Halt(code)) => return GenericResult::Halt(code),
-    };
+    //
+    // #1528: keeps each bound generator's own partial prefix instead of
+    // discarding it on escape (same fix #1517 applied to the path-mode
+    // resolver, re-derived here for value mode). jq compiles `E[S:T]` as
+    // `S as $s | T as $t | E | .[$s:$t]` -- `T` (end) is nested inside `S`
+    // (start)'s own iteration and re-run fresh for every `$s`, so a `T`
+    // escape fires before `S` ever gets a chance to expose its own
+    // (confirmed against jq 1.7.1: `.[(0,1):error("b")]` on `[10,20,30]`
+    // prints nothing before raising `b`). `ends_escape` therefore wins over
+    // `starts_escape` for what ultimately propagates, and `starts` truncates
+    // to its own first value whenever `ends` escaped -- `start`'s second
+    // value would only ever be tried after `end`'s *own* re-run for it
+    // completes, which never happens once `end` has already escaped once.
+    // `end` itself is computed once here (not re-run per `s`), which is
+    // still correct: it depends only on `value`, not `s`, so its own
+    // (prefix, escape) pair is identical on every notional re-run.
+    //
+    // Not addressed here (pre-existing, separate from this fix): `target`'s
+    // own `Partial` arm below still discards its prefix outright rather than
+    // threading it through with the same truncation `target_escape` would
+    // need against `ends`, mirroring `resolve_slice_expr`'s own 3-way rule
+    // -- unreachable in practice today, since that arm already returns
+    // before the loop below can run at all.
+    let (starts, starts_escape) =
+        match eval_slice_bound::<S, V>(start, value.clone(), cursor, f64::floor) {
+            Ok(v) => v,
+            Err(control) => return partial_generic(Vec::new(), control),
+        };
     if starts.is_empty() {
-        return GenericResult::None;
+        return match starts_escape {
+            None => GenericResult::None,
+            Some(control) => partial_generic(Vec::new(), control),
+        };
     }
-    let ends = match eval_slice_bound::<S, V>(end, value.clone(), cursor, f64::ceil) {
+    let (ends, ends_escape) = match eval_slice_bound::<S, V>(end, value.clone(), cursor, f64::ceil)
+    {
         Ok(v) => v,
-        Err(Control::Error(e)) => return GenericResult::Error(e),
-        Err(Control::Break(label)) => return GenericResult::Break(label),
-        Err(Control::Halt(code)) => return GenericResult::Halt(code),
+        Err(control) => return partial_generic(Vec::new(), control),
     };
+    let ends_escaped = ends_escape.is_some();
+    let bounds_escape = ends_escape.or(starts_escape);
     if ends.is_empty() {
-        return GenericResult::None;
+        return match bounds_escape {
+            None => GenericResult::None,
+            Some(control) => partial_generic(Vec::new(), control),
+        };
     }
+    let starts_len = if ends_escaped { 1 } else { starts.len() };
+    let starts = &starts[..starts_len];
 
     // Borrowed and owned targets are kept apart so the common (borrowed) case
     // never materializes the document — mirrors `eval_index_expr`.
@@ -6331,7 +6362,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     ]));
     match &targets {
         Targets::Borrowed(ts) => {
-            for s in &starts {
+            for s in starts {
                 for e in &ends {
                     for t in ts {
                         match slice_one_generic::<S, V>(t.clone(), *s, *e, optional) {
@@ -6345,7 +6376,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             }
         }
         Targets::Owned(ts) => {
-            for s in &starts {
+            for s in starts {
                 for e in &ends {
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
@@ -6358,9 +6389,15 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             }
         }
     }
-    // #1048: a zero-result collapse here (every (start, end) pair
-    // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
-    owned_vec_to_generic_result(out)
+    // #1528: the bound-escape info threaded through above still has to
+    // reach the final result -- a successful loop doesn't mean `start`/`end`
+    // themselves didn't escape after producing `out`'s own values.
+    match bounds_escape {
+        // #1048: a zero-result collapse here (every (start, end) pair
+        // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
+        None => owned_vec_to_generic_result(out),
+        Some(control) => partial_generic(out, control),
+    }
 }
 
 /// Evaluate one slice bound (`start` or `end`) against `value`/`cursor`.
@@ -6368,44 +6405,63 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
 /// a fractional dynamic bound still widens the slice the way a literal one
 /// does — see `eval::eval_slice_bound`. A missing bound (`None`) is a single
 /// `None` ("open on this side"), not an empty stream.
+///
+/// Keeps the bound generator's own partial prefix rather than discarding it
+/// on escape (#1528, mirroring #1517's identical fix for the path-mode
+/// resolver): the `Ok` tuple's second element is the escape (if any) that
+/// ended the stream, with `raw`/the converted `Vec` still holding whatever
+/// came before it. `Err` is reserved for a genuine type failure converting an
+/// already-resolved value (`owned_bound_to_i64` rejecting a non-numeric
+/// bound) -- same residual gap #1517's own doc comment leaves open: this
+/// still discards any prefix converted cleanly before that one bad value,
+/// a different failure shape from a generator's own escape that needs its
+/// own priority-ordering pass to fix, not a quick addition here.
 fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
     bound: &Option<Box<Expr>>,
     value: V,
     cursor: Option<V::Cursor>,
     round: fn(f64) -> f64,
-) -> Result<Vec<Option<i64>>, Control> {
+) -> Result<(Vec<Option<i64>>, Option<Control>), Control> {
     let Some(expr) = bound else {
-        return Ok(vec![None]);
+        return Ok((vec![None], None));
     };
-    let raw = match eval_single::<S, V>(expr, value, false, cursor) {
-        GenericResult::Error(e) => return Err(Control::Error(e)),
-        GenericResult::Break(label) => return Err(Control::Break(label)),
-        // Falling into `other => other.collect_owned()` below would discard
-        // the halt into an empty bound list instead of propagating it, so a
-        // dynamic slice bound like `.[:halt_error(3)]` would silently exit 0
-        // (#791).
-        GenericResult::Halt(code) => return Err(Control::Halt(code)),
-        GenericResult::None => return Ok(Vec::new()),
-        GenericResult::Partial(_, control) => return Err(control),
-        GenericResult::One(v) => vec![to_owned_key_shape(&v).map_err(Control::Error)?],
-        GenericResult::OneCursor(c) => {
-            vec![to_owned_key_shape_cursor(&c).map_err(Control::Error)?]
-        }
-        GenericResult::Many(vs) => vs
-            .iter()
-            .map(to_owned_key_shape)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Control::Error)?,
-        GenericResult::ManyCursor(cs) => cs
-            .iter()
-            .map(to_owned_key_shape_cursor)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Control::Error)?,
-        other => other.collect_owned().map_err(Control::Error)?,
-    };
-    raw.iter()
+    let (raw, escape): (Vec<OwnedValue>, Option<Control>) =
+        match eval_single::<S, V>(expr, value, false, cursor) {
+            GenericResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
+            GenericResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
+            // Same "keep whatever prefix came before it" treatment as `Error`/
+            // `Break` -- a dynamic slice bound like `.[:halt_error(3)]` must
+            // still surface the halt (#791), it just no longer has to discard a
+            // successfully-produced prefix to do so.
+            GenericResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
+            GenericResult::None => (Vec::new(), None),
+            GenericResult::Partial(vs, control) => (vs, Some(control)),
+            GenericResult::One(v) => (vec![to_owned_key_shape(&v).map_err(Control::Error)?], None),
+            GenericResult::OneCursor(c) => (
+                vec![to_owned_key_shape_cursor(&c).map_err(Control::Error)?],
+                None,
+            ),
+            GenericResult::Many(vs) => (
+                vs.iter()
+                    .map(to_owned_key_shape)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(Control::Error)?,
+                None,
+            ),
+            GenericResult::ManyCursor(cs) => (
+                cs.iter()
+                    .map(to_owned_key_shape_cursor)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(Control::Error)?,
+                None,
+            ),
+            other => (other.collect_owned().map_err(Control::Error)?, None),
+        };
+    let converted = raw
+        .iter()
         .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((converted, escape))
 }
 
 /// Apply resolved bounds to one borrowed target. Mirrors `eval::eval_single`'s
@@ -11919,21 +11975,41 @@ mod tests {
     }
 
     #[test]
-    fn test_json_computed_slice_bounds_partial_bound_collapses_to_its_control() {
+    fn test_json_computed_slice_bounds_partial_bound_keeps_its_prefix_1528() {
         // A bound stream can itself be `Partial` (some outputs, then a
-        // control) — `eval_slice_bound` collapses that to the bare control,
-        // the same reduction a `Partial` *target* gets elsewhere (#400/#494).
+        // control) — `eval_slice_bound` keeps that prefix instead of
+        // collapsing to the bare control (#1528, mirroring #1517's identical
+        // fix for the path-mode resolver). Confirmed against jq 1.7.1:
+        // `.a[(1,2,error("x")):2]`/`.a[(1,2,break $out):2]` on
+        // `{"a":[1,2,3]}` both print `[2]` then `[]` (from `$s=1`/`$s=2`
+        // against the fixed end bound `2`) before the error/break fires on
+        // `$s`'s third candidate.
         let json = br#"{"a":[1,2,3]}"#;
         let index = JsonIndex::build(json);
 
         let expr = crate::jq::parse(r#".a[(1,2,error("x")):2]"#).unwrap();
-        assert!(eval_with_cursor(&expr, index.root(json)).is_error());
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Partial(prefix, Control::Error(e)) => {
+                assert_eq!(
+                    prefix.iter().map(OwnedValue::to_json).collect::<Vec<_>>(),
+                    vec!["[2]", "[]"]
+                );
+                assert_eq!(e.message, "x");
+            }
+            other => panic!("expected Partial(_, Error), got {other:?}"),
+        }
 
         let expr = crate::jq::parse(".a[(1,2,break $out):2]").unwrap();
-        assert!(matches!(
-            eval_with_cursor(&expr, index.root(json)),
-            GenericResult::Break(label) if label == "out"
-        ));
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Partial(prefix, Control::Break(label)) => {
+                assert_eq!(label, "out");
+                assert_eq!(
+                    prefix.iter().map(OwnedValue::to_json).collect::<Vec<_>>(),
+                    vec!["[2]", "[]"]
+                );
+            }
+            other => panic!("expected Partial(_, Break), got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -11951,6 +11951,60 @@ fn test_resolve_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1517(
     Ok(())
 }
 
+/// #1528: the value-mode sibling of #1517's own fix -- `eval_slice_bound`/
+/// `eval_slice_expr` keep a bound generator's own partial prefix instead of
+/// discarding it on escape, same technique, re-verified for read (not path)
+/// position. Live-verified against jq 1.7.1 for every shape below.
+#[test]
+fn test_eval_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1528() -> Result<()> {
+    // `start` escapes: `end` (nested inside) is fully iterated for the one
+    // `start` value that did resolve.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#".[(0,error("b")):(2,3)]"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10,20]\n[10,20,30]\n");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    // `end` escapes: `start` never gets to try a second value.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#".[(0,1):(2,error("b"))]"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10,20]\n");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    // The issue's own `first`/`limit` repro.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"limit(1; .[(0,error("b")):(2,3)])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10,20]\n");
+    assert_eq!(stderr, "");
+
+    // Reachable through an owned-pipe stage that materializes an
+    // `OwnedValue` ahead of the slice -- `eval.rs`'s own `eval_slice_bound`/
+    // `eval_slice_expr` copy, the "harder" of the two evaluators the issue
+    // names, not `eval_generic.rs`'s.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"sort | limit(1; .[(0,error("b")):(2,3)])"#],
+        Some("[30,10,20]"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10,20]\n");
+    assert_eq!(stderr, "");
+
+    // `end` escapes with *zero* prior values -- `ends_escape` still wins
+    // over `starts_escape`, matching #1517's own "innermost escape wins"
+    // rule.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#".[(0,1):error("b")]"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('b'), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #1517 Guard A (the write-side twin of #972's own Guard A, this time on
 /// the bound axis instead of the key axis): the exact boundary that would
 /// silently over-satisfy `take_path_branches` if the fix above overshot


### PR DESCRIPTION
## Summary

Fixes #1528. Sibling of #1517's identical fix for the path-mode resolver (`resolve_slice_bound`), re-derived and re-verified for value mode per the issue's own note that the two evaluators have independently diverged on this exact family of fix before.

Both `eval_generic.rs`'s and `eval.rs`'s own `eval_slice_bound` discarded a bound generator's already-produced prefix (`Partial(_, control) => Err(control)`), where real jq's `S as $s | T as $t | ...` compilation means an escaping bound stream still lets earlier `(s, t)` pairs contribute output before the escape propagates:

```bash
$ echo '[10,20,30]' | jq -c '.[(0,error("b")):(2,3)]'
[10,20]
[10,20,30]
jq: error (at <stdin>:1): b

$ echo '[10,20,30]' | succinctly jq -c '.[(0,error("b")):(2,3)]'   # before this PR
jq: error (at <stdin>:1): b
```

Also reachable through `limit`/`first` in value position, and through any owned-pipe stage (`sort`, `map`, ...) that materializes an `OwnedValue` ahead of a computed-bound slice — `eval.rs`'s own copy is what that shape reaches, distinct from `eval_generic.rs`'s (confirmed both were broken, both now fixed).

## Fix

Both `eval_slice_bound` functions now return `(Vec<Option<i64>>, Option<Control>)` instead of `Result<Vec<Option<i64>>, Control>`. `end`'s escape wins over `start`'s (end is nested inside start's iteration, so it fires first), and `start` truncates to its own pre-escape length whenever `end` escaped — mirroring `resolve_slice_expr`'s established truncation rule (#1517).

**Deliberately not addressed here** (pre-existing, separate from this fix): `target`'s own escape inside `eval_slice_expr` still discards its prefix outright rather than threading it through with target-triggered truncation of `ends` — unreachable today since that arm already returns before the loop below can run, so it's not exercised by anything this fix changes.

## Verification

- New CLI-level test covering the primary repro, `limit`/`first`, the owned-pipe-stage (`eval.rs`) shape, and the "end escapes with zero prior values" edge case — every case live-verified against `/usr/bin/jq` (1.7.1 pin) byte-for-byte.
- Two pre-existing unit tests that pinned the old discard-prefix behavior are updated to the correct, oracle-verified output (one literally named `..._collapses_to_its_control`, renamed and rewritten to assert the fix instead).
- Full test suite green (55 test binaries, 0 failures), both clippy legs clean, `cargo fmt --check` clean, `cargo doc` clean, `--no-default-features` builds clean.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features`

Closes #1528