### PR TITLE
refactor(jq): consolidate combinations/cartesian_product's mixed-radix loop

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31120,40 +31120,71 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if results.try_reserve_exact(total).is_err() {
         return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     }
-    let mut indices: Vec<usize> = vec![0; n];
+
+    mixed_radix_combinations(
+        n,
+        &mut results,
+        |_| base_array.len(),
+        |_, idx| base_array[idx].clone(),
+    );
+
+    QueryResult::ManyOwned(results)
+}
+
+/// The mixed-radix counting walk shared by [`cartesian_product`] and
+/// `builtin_combinations_n` (#1721): both build every combination of `width`
+/// positions by treating `indices` as a mixed-radix counter and carrying
+/// into the next position once the current one wraps, differing only in
+/// whether a position's own length is looked up per-position (independent
+/// arrays) or is one constant repeated `width` times (`combinations(n)`'s
+/// single array raised to itself). `len_at`/`value_at` abstract over that
+/// one difference; everything else -- the counter, the carry propagation,
+/// the termination check -- was previously hand-duplicated in both
+/// callers, ~30 lines apart, and had to be kept in sync by eye.
+///
+/// `results` must already be reserved for the caller's own already-guarded
+/// total capacity -- this only walks and pushes, it never sizes or grows
+/// the backing allocation itself, so it carries none of either caller's
+/// crash-prevention guards and must not be called before them.
+fn mixed_radix_combinations(
+    width: usize,
+    results: &mut Vec<OwnedValue>,
+    len_at: impl Fn(usize) -> usize,
+    value_at: impl Fn(usize, usize) -> OwnedValue,
+) {
+    let mut indices = vec![0usize; width];
 
     loop {
-        let combination: Vec<OwnedValue> =
-            indices.iter().map(|&idx| base_array[idx].clone()).collect();
+        let combination: Vec<OwnedValue> = (0..width).map(|i| value_at(i, indices[i])).collect();
         results.push(OwnedValue::Array(combination));
 
-        // Increment indices (like counting in mixed radix), same as
-        // cartesian_product's own loop below.
+        // Increment indices (like counting in mixed radix).
         let mut carry = true;
-        for idx in indices.iter_mut().rev() {
+        for i in (0..width).rev() {
             if carry {
-                *idx += 1;
-                if *idx >= base_array.len() {
-                    *idx = 0;
+                indices[i] += 1;
+                if indices[i] >= len_at(i) {
+                    indices[i] = 0;
                 } else {
                     carry = false;
                 }
             }
         }
+
+        // If we carried all the way through, we're done.
         if carry {
             break;
         }
     }
-    QueryResult::ManyOwned(results)
 }
 
 /// Compute the Cartesian product of a list of arrays.
 ///
 /// The result has one entry per combination -- `arrays.iter().map(Vec::len)`'s
-/// product -- so that product is exactly what [`try_reserve_product`] guards
-/// before the loop below grows `results` one push at a time: without this,
-/// `results` grows via ordinary `Vec` doubling with no upfront size check at
-/// all, the identical missed guard #1612/#1634 already closed for other
+/// product -- so that product is exactly what the guard below checks before
+/// the walk grows `results` one push at a time: without this, `results`
+/// grows via ordinary `Vec` doubling with no upfront size check at all, the
+/// identical missed guard #1612/#1634 already closed for other
 /// generator-controlled cross products (#1669).
 fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, EvalError> {
     if arrays.is_empty() {
@@ -31162,12 +31193,11 @@ fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, Eval
 
     // Guard the row width (arrays.len()) against the heaviest type that
     // recurs at that length -- OwnedValue, not usize -- before building
-    // anything: `lens`/`indices` below are also arrays.len() elements
-    // long, but of the smaller `usize`, so this subsumes their own
-    // allocation cost. Independent of `results`' own length-*product*
-    // guard just below: many length-1 factor arrays keep that product tiny
-    // while the row width (arrays.len() itself) stays unbounded (#1669
-    // review).
+    // anything: `lens` below is also arrays.len() elements long, but of
+    // the smaller `usize`, so this subsumes its own allocation cost.
+    // Independent of `results`' own length-*product* guard just below:
+    // many length-1 factor arrays keep that product tiny while the row
+    // width (arrays.len() itself) stays unbounded (#1669 review).
     if Vec::<OwnedValue>::new()
         .try_reserve_exact(arrays.len())
         .is_err()
@@ -31176,38 +31206,41 @@ fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, Eval
     }
 
     let lens: Vec<usize> = arrays.iter().map(Vec::len).collect();
-    let mut results = try_reserve_product(&lens)?;
-    let mut indices = vec![0usize; arrays.len()];
-
-    loop {
-        // Build current combination
-        let combination: Vec<OwnedValue> = indices
-            .iter()
-            .enumerate()
-            .map(|(i, &idx)| arrays[i][idx].clone())
-            .collect();
-        results.push(OwnedValue::Array(combination));
-
-        // Increment indices (like counting in mixed radix)
-        let mut carry = true;
-        for i in (0..arrays.len()).rev() {
-            if carry {
-                indices[i] += 1;
-                if indices[i] >= arrays[i].len() {
-                    indices[i] = 0;
-                } else {
-                    carry = false;
-                }
-            }
-        }
-
-        // If we carried all the way through, we're done
-        if carry {
-            break;
-        }
+    // Not `try_reserve_product`, despite computing the identical guarded
+    // product: that helper's own message names ".[$keys]"-style computed
+    // indexing, which describes none of this builtin's own call sites
+    // (#1721) -- `combinations` never indexes anything.
+    let mut len: usize = 1;
+    for &l in &lens {
+        let Some(next) = len.checked_mul(l) else {
+            return Err(cannot_allocate_cartesian_product(&lens));
+        };
+        len = next;
+    }
+    let mut results = Vec::new();
+    if results.try_reserve_exact(len).is_err() {
+        return Err(cannot_allocate_cartesian_product(&lens));
     }
 
+    mixed_radix_combinations(
+        arrays.len(),
+        &mut results,
+        |i| arrays[i].len(),
+        |i, idx| arrays[i][idx].clone(),
+    );
+
     Ok(results)
+}
+
+fn cannot_allocate_cartesian_product(lens: &[usize]) -> EvalError {
+    let product = lens
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(" * ");
+    EvalError::new(format!(
+        "Cannot allocate {product} elements for combinations"
+    ))
 }
 
 /// Builtin: builtins - list all builtin function names

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13831,31 +13831,56 @@ pub(crate) fn index_one_owned(
 /// reach comparable scale in principle; that variant wasn't pursued
 /// further within this issue's scope.
 pub(crate) fn try_reserve_product<T>(factors: &[usize]) -> Result<Vec<T>, EvalError> {
+    try_reserve_product_labeled(factors, cannot_reserve_cross_product)
+}
+
+/// [`try_reserve_product`], but with the caller's own `EvalError` message
+/// instead of `cannot_reserve_cross_product`'s "computed-index expansion"
+/// wording -- shared with [`cartesian_product`], whose own call sites
+/// (`combinations`) never index anything, so that message would mislead
+/// there (#1721).
+fn try_reserve_product_labeled<T>(
+    factors: &[usize],
+    err: impl Fn(&[usize]) -> EvalError,
+) -> Result<Vec<T>, EvalError> {
     if factors.contains(&0) {
         return Ok(Vec::new());
     }
-    let mut len: usize = 1;
-    for &f in factors {
-        let Some(next) = len.checked_mul(f) else {
-            return Err(cannot_reserve_cross_product(factors));
-        };
-        len = next;
-    }
+    let Some(len) = checked_product(factors) else {
+        return Err(err(factors));
+    };
     let mut out = Vec::new();
     if out.try_reserve_exact(len).is_err() {
-        return Err(cannot_reserve_cross_product(factors));
+        return Err(err(factors));
     }
     Ok(out)
 }
 
-fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
-    let product = factors
+/// The checked product `factors` guards against overflowing, shared by
+/// [`try_reserve_product_labeled`]'s two error paths (an overflowing
+/// product, or a product that doesn't overflow but still can't be
+/// reserved) so both raise the same way from the same computation.
+fn checked_product(factors: &[usize]) -> Option<usize> {
+    factors
+        .iter()
+        .try_fold(1usize, |acc, &f| acc.checked_mul(f))
+}
+
+/// Renders `factors` as `"a * b * c"` for an allocation-refusal message --
+/// shared by [`cannot_reserve_cross_product`]/[`cannot_allocate_cartesian_product`],
+/// which differ only in the sentence this product is embedded in.
+fn format_product(factors: &[usize]) -> String {
+    factors
         .iter()
         .map(usize::to_string)
         .collect::<Vec<_>>()
-        .join(" * ");
+        .join(" * ")
+}
+
+fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
     EvalError::new(format!(
-        "Cannot allocate {product} elements for a computed-index expansion"
+        "Cannot allocate {} elements for a computed-index expansion",
+        format_product(factors)
     ))
 }
 
@@ -31106,10 +31131,10 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     //    rows there are -- `checked_combinations_len`'s own `base <= 1`
     //    short-circuit makes the row count permanently 1 regardless of n,
     //    so that guard alone never bounds this. `OwnedValue` is a larger
-    //    type than `indices`' own `usize`, so a `Vec<OwnedValue>`-sized
-    //    probe for this exact `n` subsumes `indices`' own allocation (a
-    //    smaller request for the same length) rather than needing a
-    //    second, separate guard for it.
+    //    type than the `usize` counter `mixed_radix_combinations` builds
+    //    internally, so a `Vec<OwnedValue>`-sized probe for this exact `n`
+    //    subsumes that counter's own allocation (a smaller request for the
+    //    same length) rather than needing a second, separate guard for it.
     let Some(total) = checked_combinations_len(base_array.len(), n) else {
         return QueryResult::Error(cannot_allocate_combinations(base_array.len(), n));
     };
@@ -31145,7 +31170,14 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `results` must already be reserved for the caller's own already-guarded
 /// total capacity -- this only walks and pushes, it never sizes or grows
 /// the backing allocation itself, so it carries none of either caller's
-/// crash-prevention guards and must not be called before them.
+/// crash-prevention guards and must not be called before them. Both
+/// callers also guarantee `len_at(i) >= 1` for every `i` in `0..width`
+/// before calling in (an empty position would make `value_at(i, 0)`
+/// index out of bounds on the very first row, before any carry/bounds
+/// check runs) -- `builtin_combinations_n` via its own `n == 0`/
+/// `base_array.is_empty()` checks, `cartesian_product` via its own
+/// `arrays.is_empty()`/per-element emptiness checks.
+#[inline]
 fn mixed_radix_combinations(
     width: usize,
     results: &mut Vec<OwnedValue>,
@@ -31206,40 +31238,32 @@ fn cartesian_product(arrays: &[Vec<OwnedValue>]) -> Result<Vec<OwnedValue>, Eval
     }
 
     let lens: Vec<usize> = arrays.iter().map(Vec::len).collect();
-    // Not `try_reserve_product`, despite computing the identical guarded
-    // product: that helper's own message names ".[$keys]"-style computed
-    // indexing, which describes none of this builtin's own call sites
-    // (#1721) -- `combinations` never indexes anything.
-    let mut len: usize = 1;
-    for &l in &lens {
-        let Some(next) = len.checked_mul(l) else {
-            return Err(cannot_allocate_cartesian_product(&lens));
-        };
-        len = next;
-    }
-    let mut results = Vec::new();
-    if results.try_reserve_exact(len).is_err() {
-        return Err(cannot_allocate_cartesian_product(&lens));
-    }
+    // `try_reserve_product_labeled`, not the plain `try_reserve_product`
+    // every other cross-product call site uses: that one's own message
+    // names ".[$keys]"-style computed indexing, which describes none of
+    // this builtin's own call sites (#1721) -- `combinations` never
+    // indexes anything.
+    let mut results = try_reserve_product_labeled(&lens, cannot_allocate_cartesian_product)?;
 
     mixed_radix_combinations(
         arrays.len(),
         &mut results,
-        |i| arrays[i].len(),
+        |i| lens[i],
         |i, idx| arrays[i][idx].clone(),
     );
 
     Ok(results)
 }
 
+/// Distinct from [`cannot_allocate_combinations`]/[`cannot_allocate_combinations_count`]
+/// (`combinations(n)`'s own guards): this one backs bare `combinations`
+/// (`cartesian_product`), whose factors are independent arrays' lengths
+/// rather than one base raised to a power, so it names the product
+/// directly instead of `base^n`.
 fn cannot_allocate_cartesian_product(lens: &[usize]) -> EvalError {
-    let product = lens
-        .iter()
-        .map(usize::to_string)
-        .collect::<Vec<_>>()
-        .join(" * ");
     EvalError::new(format!(
-        "Cannot allocate {product} elements for combinations"
+        "Cannot allocate {} elements for combinations",
+        format_product(lens)
     ))
 }
 


### PR DESCRIPTION
## Summary

Found by `/code-review` on PR #1716 (#1669's combinations allocation-crash fix). This
PR addresses items 1 and 3 of that review:

### 1. Two near-identical mixed-radix counting loops

`builtin_combinations_n`'s loop (indexing one shared `base_array` by a constant radix)
and `cartesian_product`'s loop (indexing `arrays[i]` by a per-position radix)
implemented the same carry-propagation algorithm ~30 lines apart, differing only in
whether the per-digit length is constant or looked up per-array. PR #1716's own doc
comment on the new loop ("same as `cartesian_product`'s own loop below") acknowledged
the duplication rather than eliminating it.

Extracted the shared walk into `mixed_radix_combinations(width, results, len_at,
value_at)`, taking closures for the one difference. Each caller keeps its own
already-reviewed allocation guards completely unchanged, in their original order --
the shared function only walks and pushes into an already-reserved `Vec`, it never
sizes or grows the backing allocation itself. This was a deliberate design choice to
minimize risk: the guard logic in both callers is the crash-prevention code #1669
carefully ordered cheapest-check-first, and this PR doesn't touch it at all.

### 3. Misleading reused error message

`cartesian_product`'s length-product overflow (backing bare `combinations`) was
reusing `try_reserve_product`'s "Cannot allocate ... elements for a computed-index
expansion" wording, which describes `.[$keys]`-style computed indexing -- bare
`combinations` never indexes anything. Gave it a dedicated
`cannot_allocate_cartesian_product` message ("Cannot allocate ... elements for
combinations", matching the other two combinations-family messages) instead of
touching `try_reserve_product` itself, which is used correctly by 8+ other call sites
across `eval.rs`/`eval_generic.rs`.

### Not addressed here (filed separately)

Item 2 from the same review -- a shared `try_reserve_sized`-style helper unifying all
4 independent "guard-then-reserve" copies (#1017/#1612/#1634/#1669) -- needs its own
dedicated pass: it touches more call sites across more of this crash-prevention code
than a loop-dedup PR should bundle, and deserves review focused specifically on
allocation-guard correctness rather than sharing space with an unrelated loop
refactor.

## Test plan

- [x] Manually verified: `combinations(n)` basic output, bare `combinations` output,
      `combinations(0)` (`[[]]`), empty-base/empty-inner-array no-output cases -- all
      unchanged
- [x] Manually verified all three allocation-guard crash paths still reject cleanly
      (exit 5, no abort): huge `n` count, huge `base^n`, huge bare-`combinations`
      product -- the last now reporting the corrected message
      (`Cannot allocate 10 * 10 * ... elements for combinations`)
- [x] Full `cargo test --features cli,simd,regex,serde` -- 55/55 test binaries pass,
      including every existing `_1669`/`_1720`/`_1279`/`_1408` crash-regression test
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build --no-default-features` (no_std) -- builds, no new warnings

Fixes #1721
