### PR TITLE
fix(jq): plug decode-failure corruption in the sort/unique/group_by family

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -35816,6 +35816,71 @@ mod tests {
         }
     }
 
+    /// #1755 positive control: the sort family's normal (no decode
+    /// failure) behavior is unaffected by routing through
+    /// `to_owned_checked` instead of `to_owned` -- exercised directly via
+    /// this module's own library-API dispatch (not the CLI, which never
+    /// reaches these functions at all, only `eval_generic.rs`'s sibling
+    /// implementation) since that's the only reachable path for them.
+    #[test]
+    fn test_sort_family_valid_data_unaffected_1755() {
+        query!(
+            br"[2, 1, 3]",
+            "sort",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]);
+            }
+        );
+        query!(
+            br"[2, 1, 1]",
+            "unique",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+        query!(
+            br"[2, 1, 3]",
+            "min",
+            QueryResult::Owned(v) => { assert_eq!(v, OwnedValue::Int(1)); }
+        );
+        query!(
+            br"[2, 1, 3]",
+            "max",
+            QueryResult::Owned(v) => { assert_eq!(v, OwnedValue::Int(3)); }
+        );
+        query!(
+            br#"[{"a":2},{"a":1}]"#,
+            "sort_by(.a)",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v.len(), 2);
+            }
+        );
+        query!(
+            br#"[{"a":1},{"a":1}]"#,
+            "group_by(.a)",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v.len(), 1);
+            }
+        );
+        query!(
+            br#"[{"a":1},{"a":1}]"#,
+            "unique_by(.a)",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v.len(), 1);
+            }
+        );
+        query!(
+            br#"[{"a":2},{"a":1}]"#,
+            "min_by(.a)",
+            QueryResult::Owned(OwnedValue::Object(_)) => {}
+        );
+        query!(
+            br#"[{"a":2},{"a":1}]"#,
+            "max_by(.a)",
+            QueryResult::Owned(OwnedValue::Object(_)) => {}
+        );
+    }
+
     /// #1755: `eval_array_construction` (backs literal `[...]` array
     /// construction's homogeneous-comma case, and every `min_by`/
     /// `max_by`/`sort_by`/`group_by`/`unique_by` key computation via jq's

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1216,10 +1216,26 @@ fn eval_array_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Collect all outputs from the inner expression into an array
     let result = eval_single::<W, S>(inner, value, optional);
 
+    // #1755: to_owned_checked, not to_owned -- an undecodable string among
+    // the constructed elements must raise, not silently become "". Not
+    // named in #1755's own site audit (this helper backs both literal `[
+    // ...]` construction, Expr::Array below, and every `min_by`/`max_by`/
+    // `sort_by`/`group_by`/`unique_by` key computation -- `[f]`, jq's own
+    // desugaring), found while fixing this file's sort-family siblings:
+    // their own fix alone left this shared helper's key computation
+    // unguarded, so a decode failure on a *non-winning* comparison element
+    // was silently swallowed entirely rather than merely corrupting the
+    // eventual output value.
     let items: Vec<OwnedValue> = match result.materialize_cursor() {
-        QueryResult::One(v) => vec![to_owned(&v)],
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(v) => vec![v],
+            Err(e) => return QueryResult::Error(e),
+        },
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::Many(vs) => match vs.iter().map(to_owned_checked).collect::<Result<_, _>>() {
+            Ok(items) => items,
+            Err(e) => return QueryResult::Error(e),
+        },
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => vec![],
@@ -6689,7 +6705,14 @@ fn builtin_min<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string element must raise, not silently sort in as "".
+            let items: Result<Vec<OwnedValue>, EvalError> =
+                elements.map(|e| to_owned_checked(&e)).collect();
+            let items = match items {
+                Ok(items) => items,
+                Err(e) => return QueryResult::Error(e),
+            };
             if items.is_empty() {
                 return QueryResult::Owned(OwnedValue::Null);
             }
@@ -6712,7 +6735,14 @@ fn builtin_max<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string element must raise, not silently sort in as "".
+            let items: Result<Vec<OwnedValue>, EvalError> =
+                elements.map(|e| to_owned_checked(&e)).collect();
+            let items = match items {
+                Ok(items) => items,
+                Err(e) => return QueryResult::Error(e),
+            };
             if items.is_empty() {
                 return QueryResult::Owned(OwnedValue::Null);
             }
@@ -6821,11 +6851,16 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
             }
 
-            let min = keyed
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string result must raise, not silently return "".
+            let (_, v) = keyed
                 .into_iter()
                 .min_by(|(a, _), (b, _)| compare_values(a, b))
-                .map(|(_, v)| to_owned(&v))
                 .unwrap();
+            let min = match to_owned_checked(&v) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
             QueryResult::Owned(min)
         }
         // #929: see `object_pair_type_error` -- confirmed live:
@@ -6873,11 +6908,16 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
             }
 
-            let max = keyed
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string result must raise, not silently return "".
+            let (_, v) = keyed
                 .into_iter()
                 .max_by(|(a, _), (b, _)| compare_values(a, b))
-                .map(|(_, v)| to_owned(&v))
                 .unwrap();
+            let max = match to_owned_checked(&v) {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
             QueryResult::Owned(max)
         }
         // #929: same operand-pairing as min_by's own Object arm above --
@@ -7821,7 +7861,13 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
-                keyed.push((key, to_owned(&item)));
+                // #1755: to_owned_checked, not to_owned -- an undecodable
+                // string element must raise, not silently sort in as "".
+                let owned_item = match to_owned_checked(&item) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                keyed.push((key, owned_item));
             }
 
             // Sort by key
@@ -7883,7 +7929,14 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string element must raise, not silently sort in as "".
+            let items: Result<Vec<OwnedValue>, EvalError> =
+                elements.map(|e| to_owned_checked(&e)).collect();
+            let mut items = match items {
+                Ok(items) => items,
+                Err(e) => return QueryResult::Error(e),
+            };
 
             // Sort first (jq's unique returns sorted unique values)
             items.sort_by(compare_values);
@@ -7938,7 +7991,13 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
-                keyed.push((key, to_owned(&item)));
+                // #1755: to_owned_checked, not to_owned -- an undecodable
+                // string element must raise, not silently sort in as "".
+                let owned_item = match to_owned_checked(&item) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                keyed.push((key, owned_item));
             }
 
             // Sort by key
@@ -7975,7 +8034,14 @@ fn builtin_sort<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // string element must raise, not silently sort in as "".
+            let items: Result<Vec<OwnedValue>, EvalError> =
+                elements.map(|e| to_owned_checked(&e)).collect();
+            let mut items = match items {
+                Ok(items) => items,
+                Err(e) => return QueryResult::Error(e),
+            };
             items.sort_by(compare_values);
             QueryResult::Owned(OwnedValue::Array(items))
         }
@@ -8009,7 +8075,13 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
-                keyed.push((key, to_owned(&item)));
+                // #1755: to_owned_checked, not to_owned -- an undecodable
+                // string element must raise, not silently sort in as "".
+                let owned_item = match to_owned_checked(&item) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                keyed.push((key, owned_item));
             }
 
             // Sort by key
@@ -35701,6 +35773,85 @@ mod tests {
                 other => panic!("unexpected result: {:?}", other),
             }
         }};
+    }
+
+    /// #1755: the sort/unique/group_by/min/max family of builtins
+    /// (`eval.rs`'s own `to_owned`-based materialization, reachable only
+    /// through the public `succinctly::jq::eval` library API, not the
+    /// CLI's `eval_generic.rs` bridge, same as #1746's original finding)
+    /// silently substituted an empty string for an undecodable element
+    /// instead of raising. Covers both "the corrupted element itself
+    /// wins the comparison" (the direct #1746-shaped bug) and "the
+    /// corrupted element loses the comparison" (only exercisable once
+    /// the sort key is content-comparable against something that isn't
+    /// automatically smaller/larger by type alone, e.g. two strings) --
+    /// `min`/`max`/`min_by`/`max_by` need a same-type comparison to
+    /// actually touch the corrupted element's own key.
+    #[test]
+    fn test_sort_family_raises_on_decode_failure_1755() {
+        for expr in [
+            "sort",
+            "unique",
+            "min",
+            "max",
+            "sort_by(.)",
+            "group_by(.)",
+            "unique_by(.)",
+            "min_by(.)",
+            "max_by(.)",
+        ] {
+            for json in [&b"[1, \"\xff\xfe\"]"[..], &b"[\"b\", \"\xff\xfe\"]"[..]] {
+                query!(
+                    json,
+                    expr,
+                    QueryResult::Error(e) if e.is_decode_failure() => {
+                        assert!(
+                            e.message.contains("invalid UTF-8"),
+                            "expr={expr} json={json:?} message: {}",
+                            e.message
+                        );
+                    }
+                );
+            }
+        }
+    }
+
+    /// #1755: `eval_array_construction` (backs literal `[...]` array
+    /// construction's homogeneous-comma case, and every `min_by`/
+    /// `max_by`/`sort_by`/`group_by`/`unique_by` key computation via jq's
+    /// own `[f]` desugaring) shared the same unguarded `to_owned` bug,
+    /// found while fixing this file's sort-family siblings above --
+    /// their own fix alone left this shared helper's key computation
+    /// unguarded, so a decode failure on a *non-winning* comparison
+    /// element was silently swallowed entirely (no error at all) rather
+    /// than merely corrupting the eventual output value. Not named in
+    /// #1755's own site audit.
+    #[test]
+    fn test_eval_array_construction_raises_on_decode_failure_1755() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[.a]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[.a, .a]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        // A multi-key sort/comparison actually exercises this shared
+        // helper's own Many-output arm (unlike the single-key `sort_by(.)`
+        // case above, which only ever produces one output per key).
+        query!(
+            br#"[{"a": "\ud83d", "b":1}, {"a":2, "b":2}]"#,
+            "sort_by(.a, .b)",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid unicode escape"), "message: {}", e.message);
+            }
+        );
     }
 
     /// #1620: a decode failure reached through this module's own dispatch

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -627,6 +627,30 @@ fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
     })
 }
 
+/// If `value` is an undecodable string, returns its decode-failure error.
+///
+/// Used ahead of the sort family's own "wrong type for this builtin"
+/// fallback arms (`min`/`max`/`min_by`/`max_by`/`group_by`/`unique`/
+/// `unique_by`/`sort`/`sort_by`'s scalar-input case): those arms used to
+/// decide `optional`-suppression vs. a type-error message straight off
+/// `value` without ever checking whether `value` itself was decodable,
+/// so a decode failure on a non-array/non-object scalar was either
+/// silently swallowed by `?` (violating the established #1247/#1620 rule
+/// that a decode failure is never suppressed) or misreported as an
+/// ordinary, catchable type-mismatch error instead of `decode_failure`
+/// (#1755). Call this first and propagate its `Some` unconditionally,
+/// before consulting `optional` at all.
+fn scalar_decode_failure<W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'_, W>,
+) -> Option<EvalError> {
+    if let StandardJson::String(s) = value {
+        if let Err(e) = s.as_str() {
+            return Some(EvalError::decode_failure(e.message()));
+        }
+    }
+    None
+}
+
 /// Materialize a key/slice-bound candidate just enough to classify it.
 ///
 /// `index_one`/[`EvalError::cannot_index`] and `SliceBounds::resolved_bound`
@@ -6720,11 +6744,21 @@ fn builtin_min<W: Clone + AsRef<[u64]>>(
             let min = items.into_iter().min_by(compare_values).unwrap();
             QueryResult::Owned(min)
         }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::pair_cannot_be_iterated(
-            &to_owned(&value),
-            &to_owned(&value),
-        )),
+        // #1755: a decode failure on the scalar itself must raise
+        // unconditionally, never be suppressed by `optional`/`?` (the
+        // #1247/#1620 rule) or misreported as an ordinary type error.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::pair_cannot_be_iterated(
+                &to_owned(&value),
+                &to_owned(&value),
+            ))
+        }
     }
 }
 
@@ -6750,11 +6784,19 @@ fn builtin_max<W: Clone + AsRef<[u64]>>(
             let max = items.into_iter().max_by(compare_values).unwrap();
             QueryResult::Owned(max)
         }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::pair_cannot_be_iterated(
-            &to_owned(&value),
-            &to_owned(&value),
-        )),
+        // #1755: same reasoning as builtin_min's own scalar arm above.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::pair_cannot_be_iterated(
+                &to_owned(&value),
+                &to_owned(&value),
+            ))
+        }
     }
 }
 
@@ -6818,7 +6860,13 @@ fn object_pair_type_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if optional {
         QueryResult::None
     } else {
-        let original = to_owned(&StandardJson::Object(fields));
+        // #1755: to_owned_checked, not to_owned -- a field the key filter
+        // `f` never touches can still be undecodable, and must raise
+        // rather than silently drop out of this error message's operand.
+        let original = match to_owned_checked(&StandardJson::Object(fields)) {
+            Ok(v) => v,
+            Err(e) => return QueryResult::Error(e),
+        };
         QueryResult::Error(error_ctor(&original, &OwnedValue::Array(computed)))
     }
 }
@@ -6869,13 +6917,24 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_iterated)
         }
-        _ if optional => QueryResult::None,
         // #929: real jq defines min_by(f) via `.[0] as $x | reduce ...` --
         // the eventual failure is the same "Cannot iterate over" a bare
         // `.[]`/`length` on a non-array/non-object gets, not a bespoke
         // "expected array" wording. Confirmed live: `5 | min_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        //
+        // #1755: but a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -6927,11 +6986,21 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_iterated)
         }
-        _ if optional => QueryResult::None,
         // #929: same wording as min_by's own scalar arm above -- confirmed
         // live: `5 | max_by(.)` raises "Cannot iterate over number (5)" in
         // jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        //
+        // #1755: same decode-failure precedence as min_by's own scalar arm
+        // above.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -7914,11 +7983,22 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
-        _ if optional => QueryResult::None,
         // #995: same "Cannot iterate over" wording min_by/max_by/unique_by's
         // own scalar arm uses -- confirmed live: `5 | group_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        //
+        // #1755: but a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -7961,8 +8041,18 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             optional,
             EvalError::pair_cannot_be_sorted,
         ),
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        // #1755: a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -8019,11 +8109,22 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
-        _ if optional => QueryResult::None,
         // #929: same "Cannot iterate over" wording min_by/max_by's own
         // scalar arm uses -- confirmed live: `5 | unique_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        //
+        // #1755: but a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -8045,8 +8146,18 @@ fn builtin_sort<W: Clone + AsRef<[u64]>>(
             items.sort_by(compare_values);
             QueryResult::Owned(OwnedValue::Array(items))
         }
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::cannot_be_sorted(&to_owned(&value))),
+        // #1755: a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_be_sorted(&to_owned(&value)))
+        }
     }
 }
 
@@ -8099,11 +8210,22 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
-        _ if optional => QueryResult::None,
         // #995: same "Cannot iterate over" wording min_by/max_by/unique_by/
         // group_by's own scalar arm uses -- confirmed live: `5 | sort_by(.)`
         // raises "Cannot iterate over number (5)" in jq 1.7.1.
-        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+        //
+        // #1755: but a decode failure on the scalar itself must raise
+        // unconditionally, checked ahead of `optional` -- see
+        // `scalar_decode_failure`.
+        _ => {
+            if let Some(e) = scalar_decode_failure(&value) {
+                return QueryResult::Error(e);
+            }
+            if optional {
+                return QueryResult::None;
+            }
+            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+        }
     }
 }
 
@@ -35912,6 +36034,117 @@ mod tests {
                     assert!(
                         e.message.contains("invalid UTF-8"),
                         "expr={expr} json={json:?} message: {}",
+                        e.message
+                    );
+                }
+            );
+        }
+    }
+
+    /// #1755: the sort family's scalar-input fallback arm (a non-array,
+    /// non-object value) used to decide `optional`-suppression vs. a type
+    /// error purely off the input's *type*, never checking whether the
+    /// scalar itself was even decodable -- so an undecodable string here
+    /// was either silently swallowed by `?` (violating the established
+    /// #1247/#1620 rule that a decode failure is never suppressed) or
+    /// misreported as an ordinary, catchable type error. `scalar_decode_failure`
+    /// now runs first, unconditionally, in every one of these arms.
+    #[test]
+    fn test_sort_family_scalar_decode_failure_unsuppressed_by_optional_1755() {
+        let json = &b"\"\xff\xfe\""[..];
+        for expr in [
+            "sort",
+            "sort?",
+            "min",
+            "min?",
+            "max",
+            "max?",
+            "unique",
+            "unique?",
+            "sort_by(.)",
+            "sort_by(.)?",
+            "group_by(.)",
+            "group_by(.)?",
+            "unique_by(.)",
+            "unique_by(.)?",
+            "min_by(.)",
+            "min_by(.)?",
+            "max_by(.)",
+            "max_by(.)?",
+        ] {
+            query!(
+                json,
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(
+                        e.message.contains("invalid UTF-8"),
+                        "expr={expr} message: {}",
+                        e.message
+                    );
+                }
+            );
+        }
+    }
+
+    /// #1755 positive control: a *valid* scalar's existing optional-vs-error
+    /// behavior on the sort family's fallback arm is unchanged by adding
+    /// the `scalar_decode_failure` check ahead of it.
+    #[test]
+    fn test_sort_family_scalar_optional_behavior_unaffected_1755() {
+        for expr in [
+            "sort?",
+            "min?",
+            "max?",
+            "unique?",
+            "sort_by(.)?",
+            "group_by(.)?",
+            "unique_by(.)?",
+            "min_by(.)?",
+            "max_by(.)?",
+        ] {
+            query!(br"5", expr, QueryResult::None => {});
+        }
+        for expr in [
+            "sort",
+            "min",
+            "max",
+            "unique",
+            "sort_by(.)",
+            "group_by(.)",
+            "unique_by(.)",
+            "min_by(.)",
+            "max_by(.)",
+        ] {
+            query!(br"5", expr, QueryResult::Error(e) => {
+                assert!(!e.is_decode_failure(), "expr={expr} wrongly classified as decode failure: {}", e.message);
+            });
+        }
+    }
+
+    /// #1755: `object_pair_type_error` (the shared `StandardJson::Object`
+    /// arm for `min_by`/`max_by`/`group_by`/`unique_by`/`sort_by`) builds
+    /// its type-error operand from the *whole* input object, not just the
+    /// fields the key filter actually touches -- so a malformed field
+    /// outside the key filter's reach (`.y` here, with the filter reading
+    /// only `.x`) used to be silently dropped by unchecked `to_owned`
+    /// instead of raising.
+    #[test]
+    fn test_by_variants_object_input_raises_on_untouched_field_decode_failure_1755() {
+        let json = &b"{\"a\":{\"x\":1,\"y\":\"\xff\xfe\"}}"[..];
+        for expr in [
+            "min_by(.x)",
+            "max_by(.x)",
+            "group_by(.x)",
+            "unique_by(.x)",
+            "sort_by(.x)",
+        ] {
+            query!(
+                json,
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(
+                        e.message.contains("invalid UTF-8"),
+                        "expr={expr} message: {}",
                         e.message
                     );
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -35881,6 +35881,44 @@ mod tests {
         );
     }
 
+    /// #1755: the `_by` variants convert twice per item -- once for the
+    /// key filter's own output (`eval_array_construction`), once for the
+    /// item itself (whole-value `to_owned_checked`). A key filter that
+    /// avoids the malformed field (`.a` on `{"a":1,"b":"\xff\xfe"}`)
+    /// decodes fine, so this only reaches the *second* conversion's own
+    /// `Err` arm -- distinct coverage from
+    /// `test_sort_family_raises_on_decode_failure_1755` above, whose `.`
+    /// key filter always fails at the *first* conversion instead (the
+    /// whole item IS the key there), never reaching the second.
+    #[test]
+    fn test_by_variants_raise_on_item_decode_failure_after_valid_key_1755() {
+        for (json, expr) in [
+            (&b"[{\"a\":1,\"b\":\"\xff\xfe\"}]"[..], "sort_by(.a)"),
+            (&b"[{\"a\":1,\"b\":\"\xff\xfe\"}]"[..], "group_by(.a)"),
+            (&b"[{\"a\":1,\"b\":\"\xff\xfe\"}]"[..], "unique_by(.a)"),
+            (
+                &b"[{\"a\":1,\"b\":\"\xff\xfe\"},{\"a\":2,\"b\":\"ok\"}]"[..],
+                "min_by(.a)",
+            ),
+            (
+                &b"[{\"a\":1,\"b\":\"ok\"},{\"a\":2,\"b\":\"\xff\xfe\"}]"[..],
+                "max_by(.a)",
+            ),
+        ] {
+            query!(
+                json,
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(
+                        e.message.contains("invalid UTF-8"),
+                        "expr={expr} json={json:?} message: {}",
+                        e.message
+                    );
+                }
+            );
+        }
+    }
+
     /// #1755: `eval_array_construction` (backs literal `[...]` array
     /// construction's homogeneous-comma case, and every `min_by`/
     /// `max_by`/`sort_by`/`group_by`/`unique_by` key computation via jq's


### PR DESCRIPTION
## Summary

Part of #1755 -- this slice covers the sort/unique/group_by/min/max family
only; #1755 stays open, tracking the remaining ~40 sites (format functions,
recurse/walk/tostream, indirect comparison-key sites).

- `builtin_sort`, `builtin_sort_by`, `builtin_group_by`, `builtin_unique`,
  `builtin_unique_by`, `builtin_min`, `builtin_max`, `builtin_min_by`,
  `builtin_max_by`: converted from the silent `to_owned` to the fallible
  `to_owned_checked` (established by #1746/#1754) so an undecodable string
  element raises `EvalError::decode_failure` instead of silently
  substituting `""` and corrupting the sort/group/uniqueness result.
- `eval_array_construction` (backs literal `[...]` array construction and
  every `_by` builtin's own `[f]` key computation): found during testing to
  share the same unguarded `to_owned` bug -- not named in #1755's own site
  audit. Fixed the same way.
- Filed #1790 as a follow-up for a narrower, distinct gap found while
  testing this: a *heterogeneous* comma inside a literal array
  (`[.a, 1]`, mixing a navigable field with a literal) still silently
  corrupts, traced to `Expr::Comma`'s own handling upstream of
  `eval_array_construction`, not this function.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli,regex --no-fail-fast` (full suite, 0 failures)
- [x] `cargo build --no-default-features` (no_std)
- [x] New regression tests: `test_sort_family_raises_on_decode_failure_1755`,
      `test_sort_family_valid_data_unaffected_1755`,
      `test_by_variants_raise_on_item_decode_failure_after_valid_key_1755`,
      `test_eval_array_construction_raises_on_decode_failure_1755` -- each
      verified to actually depend on the fix (temporarily reverted the fix,
      confirmed the new tests fail, restored)
- [x] Patch coverage: 100% (147/147 new lines)

## Update (post code-review)

`/code-review` found two real, live-verified gaps in the same functions this
PR touches: the scalar/object fallback arms of `min`/`max`/`min_by`/
`max_by`/`group_by`/`unique`/`unique_by`/`sort`/`sort_by` still swallowed a
decode failure via `?` (`"\ud83d" | sort?` returned `None` instead of
raising) or misreported it as an ordinary type error instead of
`decode_failure`. Added `scalar_decode_failure()`, checked unconditionally
ahead of `optional` in every one of those arms (and in
`object_pair_type_error`'s Object-input arm), matching the established
#1247/#1620 rule that a decode failure is never suppressed by `try`/`catch`/
`?`. New regression tests confirmed to fail with the fix reverted.

Patch coverage is 96.68% (291/301), not 100%: the remaining 10 lines are
single-statement `if optional { return QueryResult::None; }` / early-return
branches that are demonstrably exercised (proven by the revert test above
actually failing without them) but that `llvm-cov` attributes 0 hits to --
the same kind of line-coverage misattribution on trivial branch bodies
already documented elsewhere in this file for guarded match arms. Coverage
is a non-required CI job (`ci.yml`'s "Non-required jobs (bench, coverage,
perf-guard)" comment), so this doesn't block the merge queue.
