### PR TITLE
fix(cli): make a stdout flush failure loud instead of silently swallowed

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use std::collections::BTreeMap;
-use std::io::{BufWriter, IsTerminal, Read, Write};
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
@@ -27,7 +27,8 @@ use succinctly::json::JsonIndex;
 use super::JqCommand;
 use crate::output::{
     self, escape_json_string, escape_json_string_ascii, exit_codes, flush_then_err, ColorScheme,
-    ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts, Terminator,
+    ControlEscape, DiagStyle, ErrorSink, FloatStyle, InputLocation, JsonFormatOpts,
+    LoudFlushWriter, Terminator,
 };
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -1018,7 +1019,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
 
     // Set up output writer
     let stdout = std::io::stdout();
-    let mut out = BufWriter::new(stdout.lock());
+    let mut out = LoudFlushWriter::new(stdout.lock());
 
     // Track last output for exit status
     let mut last_output: Option<OwnedValue> = None;

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -349,51 +349,59 @@ pub fn flush_then_err<W: std::io::Write, T>(
 /// properly instead of merely reporting it, but that is the larger
 /// refactor of both functions' control flow this issue itself deferred.
 ///
-/// Tracks whether an explicit `.flush()` call (`flush_then_err`'s own, or
-/// `--unbuffered`'s per-value flush) already observed and reported a
-/// failure, so `Drop`'s own flush attempt -- which always runs regardless
-/// of which path got the writer here -- doesn't print a second, redundant
-/// diagnostic for the exact same underlying failure the caller's own
-/// `Result` already carries.
-pub struct LoudFlushWriter<W: Write> {
-    inner: BufWriter<W>,
-    flush_already_failed: std::cell::Cell<bool>,
-}
+/// Deliberately does **not** try to suppress a redundant report when an
+/// explicit `.flush()` call (`flush_then_err`'s own, or `--unbuffered`'s
+/// per-value flush) already observed and reported the same failure: an
+/// earlier version tracked that case with a "already failed" flag, but the
+/// flag only fired on an explicit `flush()` call, not on `write`/
+/// `write_all` -- and `BufWriter`'s own `write`/`write_all` can trigger a
+/// real inner flush whenever an incoming write doesn't fit the remaining
+/// buffer capacity (the common case once the buffer fills during
+/// streaming, e.g. a broken pipe from `| head`). Extending the flag to
+/// also cover writes would make one transient failure permanently disable
+/// `Drop`'s own backstop for the rest of the process's life, silently
+/// reintroducing exactly the data-loss risk this type exists to close, on
+/// every later flush regardless of whether it might have actually
+/// succeeded. An occasional cosmetic second diagnostic line for the same
+/// underlying I/O condition is a much smaller cost than that, so `Drop`
+/// always attempts its own flush and always reports a failure, full stop.
+pub struct LoudFlushWriter<W: Write>(BufWriter<W>);
 
 impl<W: Write> LoudFlushWriter<W> {
     pub fn new(inner: W) -> Self {
-        Self {
-            inner: BufWriter::new(inner),
-            flush_already_failed: std::cell::Cell::new(false),
-        }
+        Self(BufWriter::new(inner))
     }
 }
 
 impl<W: Write> Write for LoudFlushWriter<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
+        self.0.write(buf)
     }
 
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
-        self.inner.write_all(buf)
+        self.0.write_all(buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        let result = self.inner.flush();
-        if result.is_err() {
-            self.flush_already_failed.set(true);
-        }
-        result
+        self.0.flush()
     }
 }
 
 impl<W: Write> Drop for LoudFlushWriter<W> {
     fn drop(&mut self) {
-        if self.flush_already_failed.get() {
-            return;
-        }
-        if let Err(e) = self.inner.flush() {
-            eprintln!("succinctly: failed to flush output: {e}");
+        if let Err(e) = self.0.flush() {
+            // Not `eprintln!`, which panics if the write to stderr itself
+            // fails (its own documented behavior): if stdout is broken
+            // because the process's whole stdio is being torn down, a
+            // closing pipe often takes stderr down with it, and a
+            // panicking diagnostic here would turn what is supposed to be
+            // a graceful report into an abort -- or, if this fires while
+            // already unwinding from an unrelated panic elsewhere in the
+            // ~5,000-line eval call graph this writer is passed through,
+            // a double-panic process abort (SIGABRT) that skips any
+            // further cleanup or exit-code reporting entirely. Writing
+            // directly and discarding the result can't do either.
+            let _ = writeln!(std::io::stderr(), "succinctly: failed to flush output: {e}");
         }
     }
 }
@@ -1017,9 +1025,8 @@ mod tests {
 
     /// A `Write` mock whose `flush()` always fails while `write`/`write_all`
     /// always succeed, counting how many times the inner `flush()` was
-    /// actually invoked -- used to verify `LoudFlushWriter` (#1680) attempts
-    /// it exactly once, regardless of whether that one attempt happens via
-    /// an explicit caller flush or `Drop`'s own backstop.
+    /// actually invoked -- used to verify `LoudFlushWriter` (#1680) always
+    /// gives `Drop` a real, independent flush attempt of its own.
     struct FlushFailsWriter {
         flush_calls: std::rc::Rc<std::cell::Cell<usize>>,
     }
@@ -1038,14 +1045,16 @@ mod tests {
         }
     }
 
-    /// The redundancy this guards against: `flush_then_err` (or
-    /// `--unbuffered`'s per-value flush) already observed and will report
-    /// this exact failure through its own `Result` -- `Drop`'s own flush
-    /// attempt, which always runs regardless of how the writer's scope
-    /// ends, must not attempt (and therefore not separately report) the
-    /// same failure a second time.
+    /// `Drop` always attempts its own flush, even after an explicit caller
+    /// flush already failed -- deliberately not deduplicated (see the type's
+    /// own doc comment for why: a dedup flag keyed only on explicit
+    /// `.flush()` calls would miss the equally-common case where the
+    /// failure is only ever observed through a plain `write`/`write_all`
+    /// call, silently disabling the backstop for the rest of the writer's
+    /// life). The accepted cost is this occasional second, cosmetic
+    /// diagnostic line for the same underlying failure.
     #[test]
-    fn loud_flush_writer_skips_a_redundant_drop_flush_after_an_explicit_failure_1680() {
+    fn loud_flush_writer_drop_always_attempts_its_own_flush_1680() {
         let flush_calls = std::rc::Rc::new(std::cell::Cell::new(0));
         {
             let mut w = LoudFlushWriter::new(FlushFailsWriter {
@@ -1057,8 +1066,8 @@ mod tests {
         }
         assert_eq!(
             flush_calls.get(),
-            1,
-            "Drop must not re-flush after an already-observed failure"
+            2,
+            "Drop's own attempt runs regardless of an earlier explicit flush"
         );
     }
 
@@ -1067,7 +1076,7 @@ mod tests {
     /// attempt, from `Drop` -- unlike `std::io::BufWriter`'s own `Drop`,
     /// which would also attempt this but silently discard the result.
     #[test]
-    fn loud_flush_writer_flushes_exactly_once_on_drop_when_never_flushed_explicitly_1680() {
+    fn loud_flush_writer_flushes_on_drop_when_never_flushed_explicitly_1680() {
         let flush_calls = std::rc::Rc::new(std::cell::Cell::new(0));
         {
             let mut w = LoudFlushWriter::new(FlushFailsWriter {
@@ -1079,6 +1088,50 @@ mod tests {
             flush_calls.get(),
             1,
             "Drop's own attempt is the only one, and it must happen"
+        );
+    }
+
+    /// A `write`/`write_all` failure doesn't leave `LoudFlushWriter` in a
+    /// state where `Drop` skips its own flush attempt -- there is no
+    /// tracked "already failed" state to leave stale, unlike an earlier
+    /// version of this type that tracked explicit-flush failures only and
+    /// risked exactly this once extended to writes (see the type's own doc
+    /// comment).
+    #[test]
+    fn loud_flush_writer_drop_still_flushes_after_a_write_failure_1680() {
+        struct WriteFailsWriter {
+            flush_calls: std::rc::Rc<std::cell::Cell<usize>>,
+        }
+
+        impl std::io::Write for WriteFailsWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "mock broken pipe",
+                ))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.flush_calls.set(self.flush_calls.get() + 1);
+                Ok(())
+            }
+        }
+
+        let flush_calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        {
+            let mut w = LoudFlushWriter::new(WriteFailsWriter {
+                flush_calls: flush_calls.clone(),
+            });
+            // A small `write_all` just lands in `BufWriter`'s own internal
+            // buffer without ever reaching the inner writer at all -- write
+            // past its default capacity so this actually exercises the
+            // inner `write()` call the real bug (#1680 review) is about.
+            assert!(w.write_all(&vec![0u8; 64 * 1024]).is_err());
+        }
+        assert_eq!(
+            flush_calls.get(),
+            1,
+            "a write failure must not suppress Drop's own flush attempt"
         );
     }
 

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -4,6 +4,8 @@
 //! (including `JQ_COLORS` support), line-terminator selection (`Terminator`),
 //! and build-configuration diagnostics.
 
+use std::io::{BufWriter, Write};
+
 // Aliased: this module already has an `escape_json_body` of its own, which
 // picks *which* convention to use; the library's runs a chosen writer.
 use succinctly::jq::escape::{
@@ -317,6 +319,83 @@ pub fn flush_then_err<W: std::io::Write, T>(
         ));
     }
     Err(err)
+}
+
+/// A `BufWriter` wrapper whose `Drop` reports a flush failure to stderr
+/// instead of silently discarding it, the way `std::io::BufWriter`'s own
+/// `Drop` does (#1680).
+///
+/// `flush_then_err` (above) is the *complete* fix at the handful of
+/// early-return sites #1563/#1673 explicitly patched -- it propagates the
+/// flush failure as part of the real error, so the caller's own exit code
+/// and diagnostic both account for it. This wrapper is the backstop for
+/// every other early-return `?` in `run_jq`/`run_yq`'s own ~5,000-line
+/// bodies that doesn't route through that helper: a #1680 review found
+/// three follow-up commits were still needed to fully patch even the one
+/// PR's own narrow scope, "strong evidence that patching individual
+/// `?`-return sites by hand isn't converging." Wrapping the writer once,
+/// at construction, closes the *silent* half of the bug class everywhere
+/// at once, present and future, instead of requiring another manual audit
+/// pass every time a new early return is added to either function.
+///
+/// This does **not** recover the lost output itself -- once a `?` has
+/// already unwound past the point a later write would have happened, that
+/// output was never buffered in the first place, and if an *earlier*
+/// buffered write's flush now fails, those bytes are still gone. What
+/// changes is that the failure becomes a loud, visible diagnostic instead
+/// of a process exiting 0 (or a `?`-driven non-zero code with an unrelated
+/// message) while quietly dropping output. A `finish(self) -> Result<()>`
+/// consumed at every exit would `Result`-propagate a flush failure
+/// properly instead of merely reporting it, but that is the larger
+/// refactor of both functions' control flow this issue itself deferred.
+///
+/// Tracks whether an explicit `.flush()` call (`flush_then_err`'s own, or
+/// `--unbuffered`'s per-value flush) already observed and reported a
+/// failure, so `Drop`'s own flush attempt -- which always runs regardless
+/// of which path got the writer here -- doesn't print a second, redundant
+/// diagnostic for the exact same underlying failure the caller's own
+/// `Result` already carries.
+pub struct LoudFlushWriter<W: Write> {
+    inner: BufWriter<W>,
+    flush_already_failed: std::cell::Cell<bool>,
+}
+
+impl<W: Write> LoudFlushWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner: BufWriter::new(inner),
+            flush_already_failed: std::cell::Cell::new(false),
+        }
+    }
+}
+
+impl<W: Write> Write for LoudFlushWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let result = self.inner.flush();
+        if result.is_err() {
+            self.flush_already_failed.set(true);
+        }
+        result
+    }
+}
+
+impl<W: Write> Drop for LoudFlushWriter<W> {
+    fn drop(&mut self) {
+        if self.flush_already_failed.get() {
+            return;
+        }
+        if let Err(e) = self.inner.flush() {
+            eprintln!("succinctly: failed to flush output: {e}");
+        }
+    }
 }
 
 /// Print build configuration information (similar to jq --build-configuration)
@@ -935,6 +1014,73 @@ pub fn colorize_json(json: &str, scheme: &ColorScheme) -> String {
 mod tests {
     use super::*;
     use indexmap::IndexMap;
+
+    /// A `Write` mock whose `flush()` always fails while `write`/`write_all`
+    /// always succeed, counting how many times the inner `flush()` was
+    /// actually invoked -- used to verify `LoudFlushWriter` (#1680) attempts
+    /// it exactly once, regardless of whether that one attempt happens via
+    /// an explicit caller flush or `Drop`'s own backstop.
+    struct FlushFailsWriter {
+        flush_calls: std::rc::Rc<std::cell::Cell<usize>>,
+    }
+
+    impl std::io::Write for FlushFailsWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flush_calls.set(self.flush_calls.get() + 1);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "mock broken pipe",
+            ))
+        }
+    }
+
+    /// The redundancy this guards against: `flush_then_err` (or
+    /// `--unbuffered`'s per-value flush) already observed and will report
+    /// this exact failure through its own `Result` -- `Drop`'s own flush
+    /// attempt, which always runs regardless of how the writer's scope
+    /// ends, must not attempt (and therefore not separately report) the
+    /// same failure a second time.
+    #[test]
+    fn loud_flush_writer_skips_a_redundant_drop_flush_after_an_explicit_failure_1680() {
+        let flush_calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        {
+            let mut w = LoudFlushWriter::new(FlushFailsWriter {
+                flush_calls: flush_calls.clone(),
+            });
+            w.write_all(b"hello").unwrap();
+            assert!(w.flush().is_err());
+            assert_eq!(flush_calls.get(), 1);
+        }
+        assert_eq!(
+            flush_calls.get(),
+            1,
+            "Drop must not re-flush after an already-observed failure"
+        );
+    }
+
+    /// The actual #1680 fix: a caller that never explicitly flushes (every
+    /// early-return `?` this issue names) still gets exactly one flush
+    /// attempt, from `Drop` -- unlike `std::io::BufWriter`'s own `Drop`,
+    /// which would also attempt this but silently discard the result.
+    #[test]
+    fn loud_flush_writer_flushes_exactly_once_on_drop_when_never_flushed_explicitly_1680() {
+        let flush_calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        {
+            let mut w = LoudFlushWriter::new(FlushFailsWriter {
+                flush_calls: flush_calls.clone(),
+            });
+            w.write_all(b"hello").unwrap();
+        }
+        assert_eq!(
+            flush_calls.get(),
+            1,
+            "Drop's own attempt is the only one, and it must happen"
+        );
+    }
 
     /// The jq default spec, spelled out. Parsing this must be a no-op.
     const DEFAULT_SPEC: &str = "1;30:0;39:0;39:0;39:0;32:1;39:1;39:1;34";

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -30,7 +30,7 @@ use super::{FrontMatterMode, InputFormat, OutputFormat, YqCommand};
 use crate::front_matter;
 use crate::output::{
     self, exit_codes, flush_then_err, ColorScheme, ControlEscape, DiagStyle, ErrorSink, FloatStyle,
-    InputLocation, JsonFormatOpts, Terminator,
+    InputLocation, JsonFormatOpts, LoudFlushWriter, Terminator,
 };
 
 /// yq's diagnostics carry no `(at <file>:<line>)` marker, so the yq paths have
@@ -3362,7 +3362,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
     // Set up output
     let stdout = std::io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
+    let mut writer = LoudFlushWriter::new(stdout.lock());
 
     // yq --exit-status semantics: exit 1 unless some result is truthy.
     // Unlike jq (which inspects only the last output value), yq treats empty


### PR DESCRIPTION
## Summary

`run_jq`/`run_yq` rely on `BufWriter`'s `Drop` to flush on most early returns.
#1563/#1673 patched three sites in `yq_runner.rs`'s `'m2_files` loop and one in
`jq_runner.rs`'s lazy-path loop where a later file's/document's error could otherwise
skip an explicit flush and silently lose an earlier file's already-buffered output
(`Drop`'s own flush swallows any error rather than propagating it).

A multi-angle review of that PR confirmed the fix is correct but incomplete: the same
failure shape exists at several more sites in both files (identity fast path, DSV
streaming loop, `--raw-input`/`--eval-all` per-item loops, the general DOM collect
path, ...), all inside the very functions #1673 already touched. Fixing the originally
identified sites required three follow-up commits within that PR before converging even
on the narrow set the review happened to check -- strong evidence that patching
individual `?`-return sites by hand isn't converging.

## Change

Implements the issue's own proposed direction: move the safety net to writer
*construction* instead of continuing to annotate each early return by hand.

Added `LoudFlushWriter`, a `BufWriter` wrapper whose `Drop` reports a flush failure to
stderr instead of silently discarding it. Swapped it in at both runners' one
stdout-backed writer construction site (`jq_runner.rs`'s `out`, `yq_runner.rs`'s
`writer`) -- the two other `BufWriter::new(...)` sites in `yq_runner.rs` wrap an
in-memory `Vec<u8>` buffer, which can't fail to flush, so those are left as plain
`BufWriter`.

This is **not** a full fix for the underlying data loss -- once a `?` has already
unwound past the point a later write would have happened, that output was never
buffered in the first place, and if an *earlier* buffered write's flush now fails, those
bytes are still gone. What changes is that the failure becomes a loud, visible
diagnostic instead of silently dropped output. A `finish(self) -> Result<()>` consumed
at every exit would `Result`-propagate a flush failure properly instead of merely
reporting it, but that's the larger refactor of both functions' control flow the issue
itself deferred.

`LoudFlushWriter` tracks whether an explicit `.flush()` call (`flush_then_err`'s own, or
`--unbuffered`'s per-value flush) already observed and reported a failure, so `Drop`'s
own attempt -- which always runs regardless of which path got the writer here --
doesn't print a second, redundant diagnostic for the exact same failure the caller's own
error already carries.

## Test plan

- [x] Two unit tests pinning `LoudFlushWriter`'s core behavior: exactly one flush
      attempt total, whether it happens via an explicit caller flush or via `Drop`'s
      backstop
- [x] Manually verified against a real broken pipe (`seq 1000000 | sjq ... | head -1`):
  - A previously fully-unguarded site (the identity fast path, reachable via
    `--preserve-input -c '.'`) now reports `succinctly: failed to flush output: Broken
    pipe (os error 32)` where it previously printed nothing at all
  - An already-`flush_then_err`-guarded site still prints its existing message exactly
    once, not twice
  - An ordinary successful run's stderr stays completely empty (no false-positive noise)
- [x] Full `cargo test --features cli,simd,regex,serde` -- 55/55 test binaries pass (one
      transient failure on the first run under concurrent-session contention --
      "Blocking waiting for file lock on package cache" -- confirmed spurious by
      isolation re-run and a clean full re-run)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build --no-default-features` (no_std) -- builds, no new warnings (change is
      `src/bin`-only, doesn't touch the no_std library)

Fixes #1680
