### PR TITLE
fix(jq): plug decode-failure corruption in the format-function family

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -42310,6 +42310,41 @@ mod tests {
         );
     }
 
+    /// #1755: `eval_format`'s `to_owned_checked` runs *before* any
+    /// format-specific type/shape check, so a decode failure now preempts
+    /// an error that would have fired regardless of the string's content
+    /// (`@csv` on an object always errors; yq's `@uri`/`@base64`/`@html`
+    /// always reject a container) -- matching the established rule that a
+    /// decode failure is never suppressed, here extended to "never
+    /// outranked by an unrelated type error" (`scalar_decode_failure`'s
+    /// own doc comment states the same precedence for the sort family).
+    /// Pinned in both modes since `format_owned`'s yq-specific container
+    /// rejection (`stringify_for_format`) is the one dispatch arm that
+    /// could plausibly have raced with this ordering.
+    #[test]
+    fn test_format_decode_failure_outranks_shape_error_1755() {
+        // jq: `{"a": ...} | @csv` always errors -- @csv never accepts an
+        // object, content aside. With a decode failure inside it, that
+        // decode failure now fires first, not the "not both arrays" shape
+        // error.
+        query!(
+            &b"{\"a\": \"\xff\xfe\"}"[..],
+            "@csv",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+
+        // yq: `[...] | @uri` on a container always errors (yq rejects
+        // encoding a !!seq as URI outright, real-yq-verified per #1096's
+        // own divergence note) -- with a decode failure inside it, that
+        // decode failure now fires first, not yq's container-rejection
+        // type error.
+        yq_query!(
+            &b"[\"\xff\xfe\"]"[..],
+            "@uri",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
     // =========================================================================
     // Phase 6: Type Conversion Builtins
     // =========================================================================

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8891,7 +8891,15 @@ fn eval_format<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    match format_owned::<S>(format_type, &to_owned(&value), optional) {
+    // #1755: to_owned_checked, not to_owned -- an undecodable string must
+    // raise, not silently format `""` (or a container holding `""` for a
+    // nested field). Every `@format` function shares this single
+    // materialization point via `format_owned`.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return e.into(),
+    };
+    match format_owned::<S>(format_type, &owned, optional) {
         Ok(s) => QueryResult::Owned(OwnedValue::String(s)),
         Err(e) => e.into(),
     }
@@ -42255,6 +42263,50 @@ mod tests {
             QueryResult::Owned(OwnedValue::String(s)) => {
                 assert_eq!(s, "-.inf");
             }
+        );
+    }
+
+    /// #1755: `eval_format` -- the single materialization point every
+    /// `@format` function shares -- used unchecked `to_owned`, so an
+    /// undecodable string silently formatted as if it were `""` instead of
+    /// raising. Covers a representative format from each of `format_owned`'s
+    /// dispatch arms: a plain stringifier (`@text`), a serializer (`@json`),
+    /// a byte-transform (`@base64`), a percent-encoder (`@uri`), and a
+    /// row-formatter (`@csv`) -- both on the malformed value directly and
+    /// nested inside a container, since `@json`/`@csv`/etc. recurse into
+    /// containers via `to_owned_checked`'s own (already-fixed) recursion.
+    #[test]
+    fn test_format_raises_on_decode_failure_1755() {
+        for expr in ["@text", "@json", "@base64", "@uri", "@csv", "@sh", "@html"] {
+            query!(
+                &b"[1, \"\xff\xfe\"]"[..],
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(
+                        e.message.contains("invalid UTF-8"),
+                        "expr={expr} message: {}",
+                        e.message
+                    );
+                }
+            );
+        }
+    }
+
+    /// #1755 positive control: valid data through each of `eval_format`'s
+    /// dispatch arms is unaffected by routing through `to_owned_checked`.
+    #[test]
+    fn test_format_valid_data_unaffected_1755() {
+        query!(br#""hi""#, "@text",
+            QueryResult::Owned(OwnedValue::String(s)) => { assert_eq!(s, "hi"); }
+        );
+        query!(br"[1,2]", "@json",
+            QueryResult::Owned(OwnedValue::String(s)) => { assert_eq!(s, "[1,2]"); }
+        );
+        query!(br#""hi""#, "@base64",
+            QueryResult::Owned(OwnedValue::String(s)) => { assert_eq!(s, "aGk="); }
+        );
+        query!(br#""hi""#, "@uri",
+            QueryResult::Owned(OwnedValue::String(s)) => { assert_eq!(s, "hi"); }
         );
     }
 


### PR DESCRIPTION
## Summary

Part of #1755 -- this slice covers the format-function family
(`eval_format`) only; #1755 stays open, tracking the remaining sites
(recurse/walk/tostream, indirect comparison-key sites, and the misc
"direct" bucket).

`eval_format` is the single materialization point every `@format`
function (`@json`, `@csv`, `@tsv`, `@dsv`, `@base64`, `@base64d`, `@html`,
`@sh`, `@uri`, `@urid`, `@yaml`, `@props`, `@text`) shares via
`format_owned` -- it still called plain `to_owned`, so an undecodable
string silently formatted as `""` (or a container holding `""` for a
nested field) instead of raising `EvalError::decode_failure`. Converted to
`to_owned_checked` (established by #1746/#1754/#1794), propagating the
error through `QueryResult::Error` via the existing
`From<EvalError> for QueryResult` conversion.

Because every format function shares this one conversion point, fixing
`eval_format` closes the vulnerability for the entire family in one
surgical change, rather than needing a per-format-function fix.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli,regex --no-fail-fast` (full suite, 0 failures)
- [x] `cargo build --no-default-features` (no_std)
- [x] New regression tests: `test_format_raises_on_decode_failure_1755`
      (loops over `@text`/`@json`/`@base64`/`@uri`/`@csv`/`@sh`/`@html`),
      `test_format_valid_data_unaffected_1755` -- verified the first test
      actually depends on the fix (temporarily reverted, confirmed it fails
      with the exact silent-corruption output `[1,""]` the issue describes,
      restored)
- [x] Patch coverage: 100% (23/23 new lines)