### PR TITLE
perf(jq): use O(1) is_falsy() instead of materializing select()'s cond

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -974,10 +974,11 @@ pub fn colliding_display_key_error(key: &str) -> EvalError {
 /// `colliding_display_key_error` instead of allowing a silent overwrite.
 ///
 /// Shared by `eval_generic.rs`'s three `to_owned*_at_depth` conversions,
+/// its validate-only `push_generic_truthiness_cursor_error` (#1645),
 /// `lazy.rs`'s `cursor_to_owned_at_depth`, and `succinctly-cli`'s
 /// `yq_runner.rs` `--input-format json` bridge (`pub` for that reason,
 /// same as [`DisplayKeyGuard`] and [`key_display_string`] before it) -- one
-/// definition rather than a fifth hand-copied guard-and-raise sequence.
+/// definition rather than a sixth hand-copied guard-and-raise sequence.
 pub fn resolve_display_key<V: DocumentValue, T>(
     key: &V,
     map: &IndexMap<String, T>,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1780,14 +1780,25 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
 /// (same object/array unconsing, same key-collision guard, same checks
 /// in the same order once a scalar is reached) -- but it builds no
-/// `OwnedValue` anywhere, only walking and checking, so `select`'s
-/// truthiness check keeps its #1645 performance win (no `String`/`Vec`
-/// value allocation) for the overwhelmingly common case where nothing is
-/// corrupted, while still raising on a value corrupted at *any* depth
-/// below `c`'s own top level -- not just when `c` itself is the bad
-/// scalar (an earlier version of this fix only checked `c.value()`
-/// directly, silently missing anything nested inside a well-formed
-/// container; caught by review, #1645).
+/// `OwnedValue` container or scalar payload anywhere, only walking and
+/// checking, raising on a value corrupted at *any* depth below `c`'s own
+/// top level -- not just when `c` itself is the bad scalar (an earlier
+/// version of this fix only checked `c.value()` directly, silently
+/// missing anything nested inside a well-formed container; caught by
+/// review, #1645).
+///
+/// For a scalar condition this keeps #1645's O(1) win in full: neither
+/// this walk nor `is_falsy()` afterward materializes anything. For a
+/// container condition, jq's own truthiness rule needs none of this --
+/// any object/array is unconditionally truthy regardless of contents --
+/// but this walk still visits the whole subtree anyway, because a
+/// corrupted value can be anywhere inside it and the #1247/#1194
+/// invariant this function exists to enforce is a property of the whole
+/// subtree, not of the truthiness question alone. That walk still
+/// allocates one `String` per object key (`resolve_display_key`'s own
+/// #1642 guard), so "no allocation" only ever describes the *value*
+/// side (no `OwnedValue`/`Vec` payload) -- not a claim that a
+/// container-shaped condition is free.
 fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
     assert_nesting_depth(depth);
     let value = c.value();

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1768,6 +1768,30 @@ fn push_generic_owned_values<V: DocumentValue>(
     None
 }
 
+/// Whether `c`'s value cannot be honestly answered "truthy or falsy" at
+/// all -- a decode failure (a string token whose bytes don't decode) or a
+/// structural error (a token the semi-index accepted as a span but
+/// couldn't classify, #1194) -- and if so, the `Control::Error` a caller
+/// should raise instead of falling through to
+/// [`DocumentCursor::is_falsy`]'s own silent "not falsy" default for
+/// exactly these two cases. Mirrors [`to_owned_at_depth`]'s identical pair
+/// of checks (same order, same messages), which `is_falsy` bypasses since
+/// it never inspects either (#1645 review).
+fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C) -> Option<Control> {
+    let v = c.value();
+    if let Some(reason) = v.string_decode_error() {
+        return Some(Control::Error(EvalError::decode_failure(reason)));
+    }
+    if v.is_error() {
+        return Some(Control::Error(EvalError::new(
+            v.error_message()
+                .unwrap_or("malformed value in document")
+                .to_string(),
+        )));
+    }
+    None
+}
+
 /// Append one truthiness bit per output of a `GenericResult` stream to
 /// `out`. Mirrors [`super::eval::push_truthiness`] for the generic
 /// evaluator's cursor-aware result type — used to fan `select`'s condition
@@ -1781,8 +1805,17 @@ fn push_generic_truthiness<V: DocumentValue>(
         // `DocumentCursor::is_falsy` answers this in O(1) without
         // materializing the value at all -- an arbitrarily deep object/
         // array previously paid a full recursive `to_owned_cursor` copy
-        // just to learn it isn't `null`/`false` (#1645).
+        // just to learn it isn't `null`/`false` (#1645). `is_falsy` itself
+        // is deliberately silent on a value that fails to decode (its own
+        // doc comment: "conservative assumption", matching `--exit-status`'s
+        // pre-existing, best-effort use of it) -- `select`'s own filtering
+        // needs the real #1247/#1194 raise instead, so that check runs
+        // first, same as `to_owned_at_depth`'s own two checks in the same
+        // order, just without materializing on the ordinary-value path.
         GenericResult::OneCursor(c) => {
+            if let Some(control) = push_generic_truthiness_cursor_error(&c) {
+                return Some(control);
+            }
             out.push(!c.is_falsy());
         }
         GenericResult::Many(vs) => {
@@ -1792,6 +1825,9 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
+                if let Some(control) = push_generic_truthiness_cursor_error(c) {
+                    return Some(control);
+                }
                 out.push(!c.is_falsy());
             }
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1768,28 +1768,73 @@ fn push_generic_owned_values<V: DocumentValue>(
     None
 }
 
-/// Whether `c`'s value cannot be honestly answered "truthy or falsy" at
-/// all -- a decode failure (a string token whose bytes don't decode) or a
-/// structural error (a token the semi-index accepted as a span but
-/// couldn't classify, #1194) -- and if so, the `Control::Error` a caller
-/// should raise instead of falling through to
+/// Whether `c`'s subtree, at any depth, contains a value that cannot be
+/// honestly answered "truthy or falsy" at all -- a decode failure (a
+/// string token whose bytes don't decode), a structural error (a token
+/// the semi-index accepted as a span but couldn't classify, #1194), or a
+/// #1642 colliding-decode-failure-key -- and if so, the `Control::Error`
+/// a caller should raise instead of falling through to
 /// [`DocumentCursor::is_falsy`]'s own silent "not falsy" default for
-/// exactly these two cases. Mirrors [`to_owned_at_depth`]'s identical pair
-/// of checks (same order, same messages), which `is_falsy` bypasses since
-/// it never inspects either (#1645 review).
-fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C) -> Option<Control> {
-    let v = c.value();
-    if let Some(reason) = v.string_decode_error() {
-        return Some(Control::Error(EvalError::decode_failure(reason)));
-    }
-    if v.is_error() {
-        return Some(Control::Error(EvalError::new(
-            v.error_message()
+/// exactly these cases.
+///
+/// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
+/// (same object/array unconsing, same key-collision guard, same checks
+/// in the same order once a scalar is reached) -- but it builds no
+/// `OwnedValue` anywhere, only walking and checking, so `select`'s
+/// truthiness check keeps its #1645 performance win (no `String`/`Vec`
+/// value allocation) for the overwhelmingly common case where nothing is
+/// corrupted, while still raising on a value corrupted at *any* depth
+/// below `c`'s own top level -- not just when `c` itself is the bad
+/// scalar (an earlier version of this fix only checked `c.value()`
+/// directly, silently missing anything nested inside a well-formed
+/// container; caught by review, #1645).
+fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
+    assert_nesting_depth(depth);
+    let value = c.value();
+    if let Some(fields) = value.as_object() {
+        let mut map: IndexMap<String, ()> = IndexMap::new();
+        let mut guard = DisplayKeyGuard::default();
+        let mut f = fields;
+        while let Some((field, rest)) = f.uncons() {
+            match resolve_display_key(&field.key, &map, &mut guard) {
+                Ok(Some(key)) => {
+                    map.insert(key, ());
+                }
+                Ok(None) => return Some(Control::Error(f.malformed_member_error())),
+                Err(e) => return Some(Control::Error(e)),
+            }
+            if let Some(control) =
+                push_generic_truthiness_cursor_error(&field.value_cursor, depth + 1)
+            {
+                return Some(control);
+            }
+            f = rest;
+        }
+        if f.ends_unpaired() {
+            return Some(Control::Error(f.malformed_member_error()));
+        }
+        None
+    } else if let Some(elements) = value.as_array() {
+        let mut elems = elements;
+        while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            if let Some(control) = push_generic_truthiness_cursor_error(&elem_cursor, depth + 1) {
+                return Some(control);
+            }
+            elems = rest;
+        }
+        None
+    } else if let Some(reason) = value.string_decode_error() {
+        Some(Control::Error(EvalError::decode_failure(reason)))
+    } else if value.is_error() {
+        Some(Control::Error(EvalError::new(
+            value
+                .error_message()
                 .unwrap_or("malformed value in document")
                 .to_string(),
-        )));
+        )))
+    } else {
+        None
     }
-    None
 }
 
 /// Append one truthiness bit per output of a `GenericResult` stream to
@@ -1813,7 +1858,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         // first, same as `to_owned_at_depth`'s own two checks in the same
         // order, just without materializing on the ordinary-value path.
         GenericResult::OneCursor(c) => {
-            if let Some(control) = push_generic_truthiness_cursor_error(&c) {
+            if let Some(control) = push_generic_truthiness_cursor_error(&c, 0) {
                 return Some(control);
             }
             out.push(!c.is_falsy());
@@ -1825,7 +1870,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
-                if let Some(control) = push_generic_truthiness_cursor_error(c) {
+                if let Some(control) = push_generic_truthiness_cursor_error(c, 0) {
                     return Some(control);
                 }
                 out.push(!c.is_falsy());

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1778,14 +1778,20 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// exactly these cases.
 ///
 /// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
-/// (same object/array unconsing, same key-collision guard, same checks
-/// in the same order once a scalar is reached) -- but it builds no
-/// `OwnedValue` container or scalar payload anywhere, only walking and
-/// checking, raising on a value corrupted at *any* depth below `c`'s own
-/// top level -- not just when `c` itself is the bad scalar (an earlier
-/// version of this fix only checked `c.value()` directly, silently
-/// missing anything nested inside a well-formed container; caught by
-/// review, #1645).
+/// (same object/array unconsing, same key-collision guard) -- but it
+/// builds no `OwnedValue` container or scalar payload anywhere, only
+/// walking and checking, raising on a value corrupted at *any* depth
+/// below `c`'s own top level -- not just when `c` itself is the bad
+/// scalar (an earlier version of this fix only checked `c.value()`
+/// directly, silently missing anything nested inside a well-formed
+/// container; caught by review, #1645). Once a scalar is reached, this
+/// runs only the two checks that can actually raise
+/// (`string_decode_error`/`is_error`) -- not `to_owned_cursor_at_depth`'s
+/// preceding `explicit_tag`/`canonicalize_numbers` attempt, since tag
+/// resolution only ever changes a successfully-decoded value's inferred
+/// *type*, never turns a decode failure or structural error into success
+/// or vice versa (`tagged_scalar_to_owned` requires `as_str()` to already
+/// have succeeded), so skipping it here cannot skip a real raise.
 ///
 /// For a scalar condition this keeps #1645's O(1) win in full: neither
 /// this walk nor `is_falsy()` afterward materializes anything. For a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1778,8 +1778,12 @@ fn push_generic_truthiness<V: DocumentValue>(
 ) -> Option<Control> {
     match result {
         GenericResult::One(v) => out.push(push_or_control!(to_owned(&v)).is_truthy()),
+        // `DocumentCursor::is_falsy` answers this in O(1) without
+        // materializing the value at all -- an arbitrarily deep object/
+        // array previously paid a full recursive `to_owned_cursor` copy
+        // just to learn it isn't `null`/`false` (#1645).
         GenericResult::OneCursor(c) => {
-            out.push(push_or_control!(to_owned_cursor(&c)).is_truthy());
+            out.push(!c.is_falsy());
         }
         GenericResult::Many(vs) => {
             for v in &vs {
@@ -1788,7 +1792,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
-                out.push(push_or_control!(to_owned_cursor(c)).is_truthy());
+                out.push(!c.is_falsy());
             }
         }
         // A lazy keys array, materialized or not, sorted or not, is

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -463,16 +463,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// reason in reverse -- there is no cursor left to map from by the
     /// time that method returns.
     ///
-    /// This method's own 5 call sites still pay a version of that same
-    /// cost: each calls `resolved.<method>(...)`, and every one of those
-    /// methods opens with its own `match self.value() {...}` -- so
-    /// `.value()` on the terminal cursor is computed once by this loop's
-    /// exit check (and discarded) and once more by the method the caller
-    /// invokes. Unlike `resolve_alias_chain`'s callers, there is no way to
-    /// avoid this without threading an already-computed `YamlValue`
-    /// through 5 otherwise-cursor-only method signatures -- accepted as a
-    /// real but small (non-chain-scaling) cost, not benchmarked separately
-    /// from the fix as a whole.
+    /// This method's own call sites (6 as of #1645's `is_falsy`) still pay
+    /// a version of that same cost: each calls `resolved.<method>(...)`,
+    /// and every one of those methods opens with its own
+    /// `match self.value() {...}` -- so `.value()` on the terminal cursor
+    /// is computed once by this loop's exit check (and discarded) and once
+    /// more by the method the caller invokes. Unlike `resolve_alias_chain`'s
+    /// callers, there is no way to avoid this without threading an
+    /// already-computed `YamlValue` through otherwise-cursor-only method
+    /// signatures -- accepted as a real but small (non-chain-scaling) cost,
+    /// not benchmarked separately from the fix as a whole.
     ///
     /// A `pub`, not `pub(crate)`, visibility (unlike its sibling):
     /// `yaml_to_owned_value` (`src/bin/succinctly/yq_runner.rs`) is a
@@ -6474,10 +6474,13 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             // review caught (latent today: neither of this type's two
             // construction sites is reachable behind a real alias, since
             // `YamlIndex::build` already refuses to build an alias it
-            // can't resolve, #372).
-            YamlValue::Alias { target, .. } => {
-                target.is_some_and(|t| t.resolve_alias_chain().is_some_and(|v| v.is_error()))
-            }
+            // can't resolve, #372). The dangling-target case defaults to
+            // `true`, matching `is_null`'s own convention for the same
+            // unreachable case, not `false` -- so every accessor in this
+            // impl agrees on how a dangling alias is treated.
+            YamlValue::Alias { target, .. } => target.map_or(true, |t| {
+                t.resolve_alias_chain().map_or(true, |v| v.is_error())
+            }),
             _ => false,
         }
     }
@@ -6487,7 +6490,14 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             YamlValue::Error(msg) => Some(msg),
             // Kept in sync with `is_error`'s own `Alias` arm just above --
             // a caller that finds `is_error() == true` behind an alias must
-            // also be able to read the resolved target's message.
+            // also be able to read the resolved target's message. The one
+            // exception is the same dangling-target case `is_error`
+            // documents: `is_error()` reports `true` there (matching
+            // `is_null`'s convention) but there is no real message to
+            // return, so this falls to `None` -- every caller of this pair
+            // already has its own fallback wording for a missing message
+            // (e.g. `push_generic_truthiness_cursor_error`'s
+            // `unwrap_or("malformed value in document")`).
             YamlValue::Alias { target, .. } => {
                 target.and_then(|t| t.resolve_alias_chain()?.error_message())
             }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6145,10 +6145,14 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
             // unresolved `Alias` node itself would report "not falsy" for a
             // target that genuinely is (#1645 code review) --
             // `resolve_alias_target_cursor` already guarantees its result is
-            // never itself an `Alias`, so this recurses at most once.
+            // never itself an `Alias`, so this recurses at most once. The
+            // dangling-target case (`None`) is unreachable for an index
+            // from `YamlIndex::build`, same as `is_null`'s own `Alias` arm
+            // above -- treated the same way (`true`) for consistency, not
+            // unwrapped, so a hand-built index cannot panic here.
             YamlValue::Alias { .. } => self
                 .resolve_alias_target_cursor()
-                .is_some_and(|target| target.is_falsy()),
+                .map_or(true, |target| target.is_falsy()),
             _ => false,
         }
     }
@@ -6462,12 +6466,31 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
     }
 
     fn is_error(&self) -> bool {
-        matches!(self, YamlValue::Error(_))
+        match self {
+            YamlValue::Error(_) => true,
+            // See `is_null`'s `Alias` arm above (#1193/PR #1314) -- every
+            // other typed accessor in this impl resolves the chain before
+            // answering; this one hadn't, an inconsistency #1645 code
+            // review caught (latent today: neither of this type's two
+            // construction sites is reachable behind a real alias, since
+            // `YamlIndex::build` already refuses to build an alias it
+            // can't resolve, #372).
+            YamlValue::Alias { target, .. } => {
+                target.is_some_and(|t| t.resolve_alias_chain().is_some_and(|v| v.is_error()))
+            }
+            _ => false,
+        }
     }
 
     fn error_message(&self) -> Option<&'static str> {
         match self {
             YamlValue::Error(msg) => Some(msg),
+            // Kept in sync with `is_error`'s own `Alias` arm just above --
+            // a caller that finds `is_error() == true` behind an alias must
+            // also be able to read the resolved target's message.
+            YamlValue::Alias { target, .. } => {
+                target.and_then(|t| t.resolve_alias_chain()?.error_message())
+            }
             _ => None,
         }
     }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6139,6 +6139,16 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
                         ResolvedScalar::Null | ResolvedScalar::Bool(false)
                     )
             }
+            // Resolve the whole chain first, exactly as `string_decode_error`
+            // above does and for the same reason (#1191): a 2+-hop alias to
+            // `null`/`false` is still `null`/`false`, and answering from the
+            // unresolved `Alias` node itself would report "not falsy" for a
+            // target that genuinely is (#1645 code review) --
+            // `resolve_alias_target_cursor` already guarantees its result is
+            // never itself an `Alias`, so this recurses at most once.
+            YamlValue::Alias { .. } => self
+                .resolve_alias_target_cursor()
+                .is_some_and(|target| target.is_falsy()),
             _ => false,
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2043,6 +2043,10 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
             r#"{"bad": [xyz123], "keep": 5}"#,
         ),
         (
+            "structural error, nested in object",
+            r#"{"bad": {"x": xyz123}, "keep": 5}"#,
+        ),
+        (
             "#1642 colliding decode-failure keys",
             r#"{"bad": {"\ud800":1,"\ud800":2}, "keep": 5}"#,
         ),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1924,6 +1924,46 @@ fn test_builtin_select() -> Result<()> {
     Ok(())
 }
 
+/// #1645: `push_generic_truthiness`'s `OneCursor`/`ManyCursor` arms swapped a
+/// full materializing `to_owned_cursor(&c).is_truthy()` for the O(1)
+/// `DocumentCursor::is_falsy()` -- caught by review that `is_falsy()` itself
+/// is deliberately silent on a decode failure or a #1194 structural error
+/// (its own doc comment: "conservative assumption", matching
+/// `--exit-status`'s existing best-effort use of it), where the removed
+/// materializing path used to raise. `select` must still raise here rather
+/// than silently treating the value as truthy and passing it through.
+#[test]
+fn test_select_raises_on_decode_failure_instead_of_silently_truthy_1645() -> Result<()> {
+    // `\x` is not a valid JSON escape -- structurally a string token, but
+    // its bytes don't decode (#1247's own trigger shape).
+    let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some(r#"["\x"]"#))
+        .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
+    assert_ne!(
+        code, 0,
+        "an undecodable value must not be silently treated as truthy\nstdout: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1645 sibling case: a *structurally* malformed value (#1194 -- a token
+/// the semi-index accepted as a span but couldn't classify) must also still
+/// raise through `select`'s truthiness check, not silently pass through.
+#[test]
+fn test_select_raises_on_structural_error_instead_of_silently_truthy_1645() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some("[xyz123]"))
+        .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
+    assert_ne!(
+        code, 0,
+        "a structurally malformed value must not be silently treated as truthy\nstdout: {stdout:?}"
+    );
+    assert!(!stderr.is_empty(), "expected a diagnostic on stderr");
+    Ok(())
+}
+
 #[test]
 fn test_builtin_type() -> Result<()> {
     let (output, code) = run_jq_stdin("type", r#"{"a":1}"#, &["-r"])?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1938,9 +1938,9 @@ fn test_select_raises_on_decode_failure_instead_of_silently_truthy_1645() -> Res
     // its bytes don't decode (#1247's own trigger shape).
     let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some(r#"["\x"]"#))
         .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
-    assert_ne!(
-        code, 0,
-        "an undecodable value must not be silently treated as truthy\nstdout: {stdout:?}"
+    assert_eq!(
+        code, 5,
+        "an undecodable value must not be silently treated as truthy\nstdout: {stdout:?}\nstderr: {stderr:?}"
     );
     assert!(
         stderr.contains("invalid escape sequence"),
@@ -1956,11 +1956,59 @@ fn test_select_raises_on_decode_failure_instead_of_silently_truthy_1645() -> Res
 fn test_select_raises_on_structural_error_instead_of_silently_truthy_1645() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some("[xyz123]"))
         .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
-    assert_ne!(
-        code, 0,
-        "a structurally malformed value must not be silently treated as truthy\nstdout: {stdout:?}"
+    assert_eq!(
+        code, 5,
+        "a structurally malformed value must not be silently treated as truthy\nstdout: {stdout:?}\nstderr: {stderr:?}"
     );
-    assert!(!stderr.is_empty(), "expected a diagnostic on stderr");
+    assert!(
+        stderr.contains("unexpected character"),
+        "expected the #1194 structural-error message on stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1645: the same decode failure, but nested a level below the value
+/// `select`'s condition actually resolves to -- `.bad` resolves to the
+/// *array*, not the bad string directly, so this only passes if the
+/// truthiness check recurses into container contents rather than checking
+/// only the condition's own top-level cursor (an earlier version of this
+/// fix did exactly that and silently missed this shape -- caught by
+/// review).
+#[test]
+fn test_select_raises_on_decode_failure_nested_in_container_1645() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["select(.bad) | .keep"],
+        Some(r#"{"bad": ["\x"], "keep": 5}"#),
+    )
+    .unwrap_or_else(|e| panic!("`select(.bad)` failed to run: {e}"));
+    assert_eq!(
+        code, 5,
+        "a decode failure nested inside the condition's container must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1645 sibling case: a #1194 structural error nested a level below the
+/// condition's own top-level cursor.
+#[test]
+fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["select(.bad) | .keep"],
+        Some(r#"{"bad": [xyz123], "keep": 5}"#),
+    )
+    .unwrap_or_else(|e| panic!("`select(.bad)` failed to run: {e}"));
+    assert_eq!(
+        code, 5,
+        "a structural error nested inside the condition's container must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("unexpected character"),
+        "expected the #1194 structural-error message on stderr: {stderr:?}"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2012,6 +2012,62 @@ fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<(
     Ok(())
 }
 
+/// #1645 code review: `push_generic_truthiness_cursor_error` is a second,
+/// hand-copied implementation of the same "walk and raise on corruption"
+/// predicate `to_owned_cursor_at_depth` already implements for
+/// materialization (`-S`, `-s`, `.,.`) -- the exact "duplicated predicate"
+/// shape this repo's own testing guidance warns diverges silently unless a
+/// test pins that every site agrees, not just that each is individually
+/// correct (see the `testing` skill and CLAUDE.md's "Duplicated predicates
+/// diverge silently" note, #106). For each malformed shape below, checks
+/// that `select(.bad) | .keep` (the new walk) and `-Sc .` on the bare `.bad`
+/// value (the pre-existing materializing walk) raise on the *same* input.
+#[test]
+fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
+    let cases = [
+        ("decode failure, top level", r#"{"bad": "\x", "keep": 5}"#),
+        (
+            "decode failure, nested in array",
+            r#"{"bad": ["\x"], "keep": 5}"#,
+        ),
+        (
+            "decode failure, nested in object",
+            r#"{"bad": {"x": "\x"}, "keep": 5}"#,
+        ),
+        (
+            "structural error, top level",
+            r#"{"bad": xyz123, "keep": 5}"#,
+        ),
+        (
+            "structural error, nested in array",
+            r#"{"bad": [xyz123], "keep": 5}"#,
+        ),
+        (
+            "#1642 colliding decode-failure keys",
+            r#"{"bad": {"\ud800":1,"\ud800":2}, "keep": 5}"#,
+        ),
+    ];
+
+    for (label, doc) in cases {
+        let (select_out, select_err, select_code) =
+            run_jq_full(&["select(.bad) | .keep"], Some(doc))
+                .unwrap_or_else(|e| panic!("[{label}] select run failed: {e}"));
+        assert_eq!(
+            select_code, 5,
+            "[{label}] select(.bad) must raise\nstdout: {select_out:?}\nstderr: {select_err:?}"
+        );
+
+        let (materialize_out, materialize_err, materialize_code) =
+            run_jq_full(&["-Sc", ".bad"], Some(doc))
+                .unwrap_or_else(|e| panic!("[{label}] materialize run failed: {e}"));
+        assert_eq!(
+            materialize_code, 5,
+            "[{label}] -Sc .bad must raise the same way select's condition walk does\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn test_builtin_type() -> Result<()> {
     let (output, code) = run_jq_stdin("type", r#"{"a":1}"#, &["-r"])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24441,3 +24441,43 @@ fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1645 code review: every JSON-side corruption regression test
+/// (`tests/jq_cli_tests.rs`) has no YAML sibling -- `push_generic_truthiness_cursor_error`
+/// is generic over `DocumentCursor` and reached identically by the yq
+/// evaluator, but nothing pinned that `select()` actually raises on a YAML
+/// decode failure nested inside its condition's container, only that it
+/// resolves alias falsiness correctly. Uses `\q` (not a recognized YAML
+/// escape) rather than `\x` (a valid two-hex-digit escape in YAML, unlike
+/// JSON) -- confirmed live against this binary that `\x41` decodes
+/// successfully in a YAML double-quoted string.
+#[test]
+fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Result<()> {
+    let doc = "bad:\n  - \"\\q\"\nkeep: 5\n";
+
+    let (select_out, select_err, select_code) =
+        run_yq_stdin_with_stderr("select(.bad) | .keep", doc, &[])?;
+    assert_ne!(
+        select_code, 0,
+        "select(.bad) must raise on the nested decode failure\nstdout: {select_out:?}\nstderr: {select_err:?}"
+    );
+    assert!(
+        select_err.contains("invalid escape sequence"),
+        "stderr: {select_err:?}"
+    );
+
+    // `.bad,.bad` is yq's multi-output materializing route (yq's analogue
+    // of jq's `-Sc`/`.,.` DOM-forcing tests) -- confirms select's new walk
+    // agrees with the pre-existing materializing path on this input.
+    let (materialize_out, materialize_err, materialize_code) =
+        run_yq_stdin_with_stderr(".bad,.bad", doc, &[])?;
+    assert_ne!(
+        materialize_code, 0,
+        "the materializing route must raise the same way\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
+    );
+    assert!(
+        materialize_err.contains("invalid escape sequence"),
+        "stderr: {materialize_err:?}"
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24394,3 +24394,50 @@ fn test_yq_string_repeat_cap_compound_assign_does_not_abort_1612() -> Result<()>
     assert_eq!(code, 1, "stderr: {stderr:?}");
     Ok(())
 }
+
+/// #1645 code review: `push_generic_truthiness`'s `OneCursor`/`ManyCursor`
+/// arms swapped a materializing `is_truthy()` for `DocumentCursor::is_falsy`
+/// -- `is_falsy`'s YAML impl had no `Alias` arm at all (falling into its
+/// `_ => false` default), so an alias resolving to `false`/`null` was
+/// silently reported as truthy regardless of what it pointed at. This is a
+/// pre-existing gap in `is_falsy` itself, newly load-bearing once `select`
+/// started relying on it. Covers a direct alias and a 2-hop chain.
+#[test]
+fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
+    let (stdout, _stderr, code) =
+        run_yq_stdin_with_stderr("select(.b) | .keep", "a: &x false\nb: *x\nkeep: 5\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "an alias to `false` must be filtered out, not passed through"
+    );
+
+    let (stdout, _stderr, code) =
+        run_yq_stdin_with_stderr("select(.b) | .keep", "a: &x null\nb: *x\nkeep: 5\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "an alias to `null` must be filtered out, not passed through"
+    );
+
+    let (stdout, _stderr, code) = run_yq_stdin_with_stderr(
+        "select(.b) | .keep",
+        "orig: &x false\na: &y *x\nb: *y\nkeep: 5\n",
+        &[],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "",
+        "a 2-hop alias chain to `false` must be filtered out"
+    );
+
+    let (stdout, _stderr, code) =
+        run_yq_stdin_with_stderr("select(.b) | .keep", "a: &x true\nb: *x\nkeep: 5\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "5",
+        "an alias to `true` must still pass through"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Found by the multi-agent `/code-review` run on PR #1644 (#1613's fix). `eval_generic.rs`'s
`push_generic_truthiness` computed each `cond` output's truthiness via
`to_owned_cursor(&c).is_truthy()` in its `OneCursor`/`ManyCursor` arms -- a full recursive
materialization of the value, arbitrarily deep for a nested object/array, just to answer a
question `DocumentCursor::is_falsy()` already answers in O(1) without materializing anything
(already used elsewhere in this same file, e.g. `--exit-status`'s `stats.last_was_falsy`).

`cond` must still run to completion for every output (side effects, any error/break it raises)
-- real yq's own `select` does **not** short-circuit after the first truthy output either
(confirmed live against yq v4.53.3 in the issue: `select((true, error("boom")))` still raises
`boom`) -- so this only changes *how* each output's truthiness is checked, not how many
outputs `cond` produces or visits.

## Change

Swapped `push_generic_truthiness`'s `OneCursor`/`ManyCursor` arms from
`push_or_control!(to_owned_cursor(&c)).is_truthy()` to `!c.is_falsy()`.

## Benchmarks

Per this repo's own A/B discipline (`docs/guides/benchmarking.md`), on both reference machines
(Apple M4 Pro/NEON, AMD Ryzen 9 7950X/AVX-512), interleaved A/B, two independent 15-rep runs
each, output-identity-gated on all 22 (machine x workload x size) cells before trusting any
timing:

**Deep-nesting workload** (`select(.[])` over N objects, 7 levels deep, the case this targets):

| N | M4 Pro (before -> after) | 7950X (before -> after) |
|---|---|---|
| 1,000 | 24.59ms -> 14.05ms (**-42.9%**) | 27.02ms -> 15.55ms (**-42.5%**) |
| 10,000 | 244.48ms -> 127.55ms (**-47.8%**) | 279.88ms -> 156.22ms (**-44.2%**) |
| 100,000 | 2970.28ms -> 1551.80ms (**-47.8%**) | 3058.72ms -> 1696.28ms (**-44.5%**) |

Flat percentage across N (nesting depth is constant, only absolute time scales) -- the expected
signature of eliminating a fixed per-element materialization cost, not an algorithmic-complexity
change.

**Shallow-scalar workload** (the case the issue expected to be a wash -- every output already
"cheap" to materialize): turns out `to_owned_cursor`'s scalar path wasn't actually free either
(an `explicit_tag()`/`canonicalize_numbers()` check plus a string allocation or number-literal
parse, work `is_falsy()`'s pure type-tag check skips entirely). At N>=100,000: **20-27% faster
on ARM, 10-11% faster on x86_64** (architecture-dependent, not further explained here); at
N=1,000 the delta is 1-4%, indistinguishable from the measured noise floor (<=1.9% both
machines). **No regression in any of the 8 shallow cells, either architecture.**

Noise floor (control run, before-binary vs itself): 0.63% (M4 Pro), 1.91% (7950X).

## Test plan

- [x] A/B benchmarked as above -- real win on the target workload, no regression on the
      "can't help" workload, both architectures, output-identical on all 22 cells
- [x] Manually verified `select` semantics: basic truthy/falsy filtering, deep nested
      objects/arrays, yq-mode object fan-out, and that `cond`'s side effects/errors are still
      fully evaluated (`select((true, error("boom")))` still raises)
- [x] Full `cargo test --features cli,simd,regex,serde` -- 55/55 test binaries pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build --no-default-features` (no_std) -- builds, no new warnings

## Not addressed here (filed as follow-up scope, per the issue's own split)

`eval.rs`'s `select_emits` (added by #1613) still invokes the per-bit closure once per
*remaining* bit in yq's collapsed-select case even after the collapse outcome is already fixed
-- a smaller, cosmetic version of the same shape (a branch, no allocation, no materialization),
left for a separate pass since it's orthogonal to this fix's actual measured win.

Fixes #1645
