### PR TITLE
fix(jq): to_owned_checked_at_depth raises on an undecodable object key

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -620,13 +620,20 @@ fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
             for field in *fields {
-                // Get the key as a string
+                // A structurally non-string key (#1194) stays silently
+                // skipped here, matching #1642's established
+                // preserve-not-raise convention for that axis -- only a
+                // *string* key that fails to *decode* raises, mirroring
+                // the value arm just above.
                 if let StandardJson::String(key_str_val) = field.key() {
-                    if let Ok(cow) = key_str_val.as_str() {
-                        map.insert(
-                            cow.into_owned(),
-                            to_owned_checked_at_depth(&field.value(), depth + 1)?,
-                        );
+                    match key_str_val.as_str() {
+                        Ok(cow) => {
+                            map.insert(
+                                cow.into_owned(),
+                                to_owned_checked_at_depth(&field.value(), depth + 1)?,
+                            );
+                        }
+                        Err(e) => return Err(EvalError::decode_failure(e.message())),
                     }
                 }
             }
@@ -58689,6 +58696,34 @@ mod tests {
             other => {
                 panic!("expected the decode failure to bypass `optional` uncaught, got: {other:?}")
             }
+        }
+    }
+
+    /// #1734: `to_owned_checked_at_depth`'s `Object` arm guarded a field's
+    /// *value* against decode failure (the string-value arm just above)
+    /// but not its *key* -- an undecodable key was silently dropped from
+    /// the materialized map instead of raising, unlike every other
+    /// #1620/#1247 decode-failure site. Live-reachable via `sort` alone
+    /// (`builtin_sort` was already migrated to `to_owned_checked` by
+    /// #1755's own prior work): confirmed via the library API that
+    /// `[{<undecodable key>: 1}] | sort` used to return
+    /// `Owned(Array([Object({})]))` -- the whole field silently vanished,
+    /// no error -- rather than raising like the sibling string-value case
+    /// already did.
+    #[test]
+    fn eval_rs_to_owned_checked_object_key_decode_failure_raises_1734() {
+        let json: &[u8] = br#"[{"\ud800":1}]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("sort").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "expected a decode-failure error, got: {e:?}"
+            ),
+            other => panic!(
+                "expected the undecodable object key to raise instead of being silently dropped, got: {other:?}"
+            ),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -631,7 +631,17 @@ fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
             let mut guard = DisplayKeyGuard::default();
-            for field in *fields {
+            // `uncons`/`rest`, not `for field in *fields`: a `for` loop
+            // consumes the `Iterator` impl, whose `next()` reports `None`
+            // both on genuine exhaustion *and* on a trailing unpaired
+            // member (#1194, e.g. `{"a":1,"b"}`) -- the two are
+            // indistinguishable through that protocol, so a `for` loop
+            // has no way to ask `ends_unpaired` afterward (it needs the
+            // list state a walk *finished* on, not the one it started
+            // from). Mirrors `eval_generic::to_owned_at_depth`'s own walk
+            // shape for exactly this reason.
+            let mut f = *fields;
+            while let Some((field, rest)) = f.uncons() {
                 let key_val = field.key();
                 // `resolve_display_key` covers both key axes in one call
                 // (#1734): `Ok(None)` is a structurally non-string key
@@ -644,9 +654,13 @@ fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
                 // an ordinary key and a decode-failure key preserved via
                 // its lossily-decoded raw source span.
                 let Some(key) = resolve_display_key(&key_val, &map, &mut guard)? else {
-                    return Err(fields.malformed_member_error());
+                    return Err(f.malformed_member_error());
                 };
                 map.insert(key, to_owned_checked_at_depth(&field.value(), depth + 1)?);
+                f = rest;
+            }
+            if f.ends_unpaired() {
+                return Err(f.malformed_member_error());
             }
             OwnedValue::Object(map)
         }
@@ -58792,6 +58806,29 @@ mod tests {
             ),
             other => panic!(
                 "expected the colliding fallback keys to raise instead of one silently overwriting the other, got: {other:?}"
+            ),
+        }
+    }
+
+    /// #1734 second review pass: a `for field in *fields` loop consumes
+    /// `JsonFields`'s `Iterator` impl to exhaustion, which cannot
+    /// distinguish genuine exhaustion from a trailing *unpaired* member
+    /// (#1194, e.g. `{"a":1,"b"}` -- a key with no value) -- both report
+    /// `None`. The fix walks `uncons`/`rest` instead (matching
+    /// `eval_generic::to_owned_at_depth`'s own shape) so `ends_unpaired`
+    /// can be asked of the list state a walk *finished* on, catching this
+    /// exactly where the earlier `for`-loop version silently dropped the
+    /// dangling key instead of raising.
+    #[test]
+    fn eval_rs_to_owned_checked_trailing_unpaired_member_raises_1734() {
+        let json: &[u8] = br#"[{"a":1,"b"}]"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("sort").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(_) => {}
+            other => panic!(
+                "expected the trailing unpaired member to raise instead of being silently dropped, got: {other:?}"
             ),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37,7 +37,9 @@ use core::cell::Cell;
 
 use indexmap::{IndexMap, IndexSet};
 
-use super::document::{effective_fields, effective_len};
+use super::document::{
+    effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
+};
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
 
@@ -589,9 +591,18 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
 /// at every one of them in a single change. Left as a documented gap for a
 /// follow-up rather than attempted here (#1746's own comment thread).
 ///
-/// Key handling is intentionally unchanged from [`to_owned`]: an object
-/// field whose key fails to decode is still silently dropped (a distinct,
-/// #1194-shaped structural gap, not this function's #1247-shaped one).
+/// A field's key is resolved through [`resolve_display_key`] (#1734), the
+/// same shared sequence `eval_generic::to_owned_at_depth` uses: a key that
+/// fails to *decode* is preserved via its lossily-decoded raw source span
+/// rather than dropped or raised on (#1642 relaxed #1247's original raise
+/// here specifically, to match `length`/`keys_unsorted`/`.`), a key that
+/// does not *stringify* at all raises (#1194's distinct structural axis),
+/// and two decode-failure keys whose fallback spellings collide also raise
+/// rather than silently overwriting one another in `map` (#1642's own
+/// `DisplayKeyGuard`). Was hand-rolled here as silent-drop-on-either-axis
+/// before this fix, `StandardJson`'s own
+/// [`DocumentValue`](super::document::DocumentValue) impl making the shared
+/// helper directly usable.
 fn to_owned_checked<W: Clone + AsRef<[u64]>>(
     value: &StandardJson<'_, W>,
 ) -> Result<OwnedValue, EvalError> {
@@ -619,23 +630,23 @@ fn to_owned_checked_at_depth<W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
+            let mut guard = DisplayKeyGuard::default();
             for field in *fields {
-                // A structurally non-string key (#1194) stays silently
-                // skipped here, matching #1642's established
-                // preserve-not-raise convention for that axis -- only a
-                // *string* key that fails to *decode* raises, mirroring
-                // the value arm just above.
-                if let StandardJson::String(key_str_val) = field.key() {
-                    match key_str_val.as_str() {
-                        Ok(cow) => {
-                            map.insert(
-                                cow.into_owned(),
-                                to_owned_checked_at_depth(&field.value(), depth + 1)?,
-                            );
-                        }
-                        Err(e) => return Err(EvalError::decode_failure(e.message())),
-                    }
-                }
+                let key_val = field.key();
+                // `resolve_display_key` covers both key axes in one call
+                // (#1734): `Ok(None)` is a structurally non-string key
+                // (#1194) and raises here, matching
+                // `eval_generic::to_owned_at_depth`'s own handling of the
+                // identical case; `Err` is a collision between two
+                // decode-failure fallback spellings, which also raises
+                // rather than silently overwriting an entry in `map`
+                // (#1642's `DisplayKeyGuard`); `Ok(Some(key))` covers both
+                // an ordinary key and a decode-failure key preserved via
+                // its lossily-decoded raw source span.
+                let Some(key) = resolve_display_key(&key_val, &map, &mut guard)? else {
+                    return Err(fields.malformed_member_error());
+                };
+                map.insert(key, to_owned_checked_at_depth(&field.value(), depth + 1)?);
             }
             OwnedValue::Object(map)
         }
@@ -58699,30 +58710,88 @@ mod tests {
         }
     }
 
-    /// #1734: `to_owned_checked_at_depth`'s `Object` arm guarded a field's
-    /// *value* against decode failure (the string-value arm just above)
-    /// but not its *key* -- an undecodable key was silently dropped from
-    /// the materialized map instead of raising, unlike every other
-    /// #1620/#1247 decode-failure site. Live-reachable via `sort` alone
-    /// (`builtin_sort` was already migrated to `to_owned_checked` by
-    /// #1755's own prior work): confirmed via the library API that
-    /// `[{<undecodable key>: 1}] | sort` used to return
-    /// `Owned(Array([Object({})]))` -- the whole field silently vanished,
-    /// no error -- rather than raising like the sibling string-value case
-    /// already did.
+    /// #1734: `to_owned_checked_at_depth`'s `Object` arm dropped an
+    /// undecodable key's whole field from the materialized map instead of
+    /// preserving it -- live-reachable via `sort` alone (`builtin_sort`
+    /// was already migrated to `to_owned_checked` by #1755's own prior
+    /// work): confirmed via the library API that `[{<undecodable key>:
+    /// 1}] | sort` used to return `Owned(Array([Object({})]))`, silently
+    /// losing the field.
+    ///
+    /// The fix is preserve-via-lossy-decode, *not* raise: `eval_generic.rs`'s
+    /// sibling `to_owned` established (#1642, `key_display_string_kind`)
+    /// that an undecodable *key* is preserved through its raw source span,
+    /// matching `length`/`keys_unsorted`/`.` -- #1247 originally raised
+    /// here too, and #1642 deliberately relaxed that. Only an undecodable
+    /// *value* still raises (the arm just above this one, unchanged).
     #[test]
-    fn eval_rs_to_owned_checked_object_key_decode_failure_raises_1734() {
-        let json: &[u8] = br#"[{"\ud800":1}]"#;
+    fn eval_rs_to_owned_checked_object_key_decode_failure_preserved_1734() {
+        let json: &[u8] = b"[{\"\xff\xfe\": 1}]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("sort").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Owned(OwnedValue::Array(items)) => {
+                assert_eq!(items.len(), 1, "expected the field to survive: {items:?}");
+                match &items[0] {
+                    OwnedValue::Object(map) => {
+                        assert_eq!(
+                            map.get("\u{FFFD}\u{FFFD}"),
+                            Some(&OwnedValue::from_number_literal("1")),
+                            "expected the undecodable key preserved as its lossy-decoded \
+                             source span, matching eval_generic.rs's own #1642 convention, \
+                             got: {map:?}"
+                        );
+                    }
+                    other => panic!("expected an object, got: {other:?}"),
+                }
+            }
+            other => panic!(
+                "expected the field to survive with a lossy-decoded key, not raise or drop, got: {other:?}"
+            ),
+        }
+    }
+
+    /// #1734, the other key axis `resolve_display_key` covers in the same
+    /// call: a *structurally* non-string key (#1194 -- JSON's grammar
+    /// never allows a bare number as a key, e.g. `{123: 1}`) must raise,
+    /// not silently drop the field, matching
+    /// `eval_generic::to_owned_at_depth`'s own handling of the identical
+    /// case. Distinct from the *decode-failure* axis above: this key is a
+    /// valid JSON token, just not a string at all.
+    #[test]
+    fn eval_rs_to_owned_checked_structural_key_raises_1734() {
+        let json: &[u8] = b"[{123:1}]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = parse("sort").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
+            QueryResult::Error(_) => {}
+            other => panic!(
+                "expected the structurally non-string key to raise instead of being silently dropped, got: {other:?}"
+            ),
+        }
+    }
+
+    /// #1734: two different decode-failure keys in the same object whose
+    /// lossy-decoded fallback spellings collide must raise, not let the
+    /// second silently overwrite the first in `map` -- `resolve_display_key`'s
+    /// `DisplayKeyGuard` (#1642) exists specifically for this, and this
+    /// fix is the first thing to give `to_owned_checked_at_depth` a guard
+    /// instance to actually engage it with.
+    #[test]
+    fn eval_rs_to_owned_checked_object_key_collision_raises_1734() {
+        let json: &[u8] = b"[{\"\xff\xfe\": 1, \"\xff\xff\": 2}]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let expr = parse("sort").unwrap();
         match eval::<Vec<u64>, JqSemantics>(&expr, cursor) {
             QueryResult::Error(e) => assert!(
-                e.is_decode_failure(),
-                "expected a decode-failure error, got: {e:?}"
+                e.message.contains("ambiguous"),
+                "expected a colliding-key error, got: {e:?}"
             ),
             other => panic!(
-                "expected the undecodable object key to raise instead of being silently dropped, got: {other:?}"
+                "expected the colliding fallback keys to raise instead of one silently overwriting the other, got: {other:?}"
             ),
         }
     }


### PR DESCRIPTION
## Summary

`to_owned_checked_at_depth` (`src/jq/eval.rs`) silently dropped an object field whose key failed to *decode* from the materialized map, instead of preserving it -- the same "still swallows a decode failure" bug class the `checked`/ variant exists to close.

The fix routes through `document.rs`'s shared `resolve_display_key`/`DisplayKeyGuard` mechanism -- `StandardJson` already implements `DocumentValue`, so the same mechanism `eval_generic.rs`'s three `to_owned*_at_depth` conversions and `lazy.rs`'s `cursor_to_owned_at_depth` already share is directly usable here, closing all four cases in one call:

- A key that fails to **decode** is **preserved** via its lossily-decoded raw source span (#1642's established convention, matching `length`/`keys_unsorted`/`.`) -- not raised on, not dropped.
- A key that is **structurally non-string** (#1194, JSON's grammar never allows it, e.g. `{123: 1}`) **raises** -- matching `eval_generic::to_owned_at_depth`'s own handling of the identical case.
- Two decode-failure keys whose lossy fallback spellings **collide** also **raise**, via `DisplayKeyGuard`, rather than one silently overwriting the other.
- A **trailing unpaired member** (#1194, e.g. `{"a":1,"b"}` -- a key with no value) **raises** -- this needed switching the iteration from `for field in *fields` to the `uncons`/`rest` walk `eval_generic::to_owned_at_depth` already uses, since a `for` loop consumes the `Iterator` impl to exhaustion and loses the signal `ends_unpaired` needs (genuine exhaustion and a trailing unpaired member both report `None` from `next()`).

All four live-verified via the library API, each matching the real CLI's own `eval_generic.rs`-routed behavior on the identical input.

## Revision history

Two review-driven corrections landed on top of the original submission:

1. **First pass**: the initial fix made a decode-failure key *raise* instead of preserving it -- inverting #1642's established convention (confirmed against `eval_generic.rs`'s own `test_to_owned_preserves_object_key_decode_failure_1642` and live CLI behavior). It also left the structural-key axis (#1194) unfixed. Both closed by routing through the shared `resolve_display_key` mechanism instead of hand-rolling either axis.
2. **Second pass**: a `for field in *fields` loop (kept from the original hand-rolled version) can never reach an `ends_unpaired` check, since the signal it needs is consumed by the time a `for` loop's body could ask for it -- not a missing line, the wrong iteration primitive. Fixed by switching to the `uncons`/`rest` walk shape, which also incidentally corrected `malformed_member_error()` being called on the un-advanced outer `fields` binding rather than the walk's current position (accidentally correct before this fix only because `JsonCursor::text()` returns the whole document regardless of cursor position -- not a documented invariant this code should have depended on).

Two further findings from the second pass are **pre-existing bugs in separate code**, unrelated to and predating this PR (reproduced identically against unmodified `main`), filed as follow-ups rather than fixed here:
- `eval_generic.rs`'s `Expr::Try` handling (`owned_or_err!` in the wildcard fallback arm of `eval_single`) has no catchability check at all, so `try`/`catch` doesn't contain a decode-failure/collision error the way `?` does -- this PR widens where that pre-existing gap is reachable (every one of `to_owned_checked`'s ~40 call sites can now raise the error class), but doesn't cause it.
- `colliding_display_key_error` is built via `EvalError::decode_failure`, whose doc comment says it must never be caught by `try`/`catch`/`?` -- but `is_decode_failure()`'s message-matching doesn't recognize its "is ambiguous" text, so it's actually an ordinary catchable error today, contrary to that documented contract.

Reachability is unaffected by any of the above: `jq_runner.rs` never calls `eval.rs`'s `eval()` at all, and `yq_runner.rs`'s only call site re-serializes an already-materialized `OwnedValue` (keys already valid) before rebuilding the cursor -- so this fix has no observable effect on either shipped CLI tool today, only on direct library API use, same as every other #1746/#1755 site already fixed this way.

## Test plan

- 4 regression tests in `src/jq/eval.rs`'s own test module: decode-failure key preserved, structural key raises, colliding fallback keys raise, trailing unpaired member raises.
- Full local `cargo test --features cli,simd,regex,serde`: 0 failures (confirmed via explicit `echo "exit: $?"` after two separate transient runs hit unrelated flaky `cargo run`-spawning integration tests under heavy concurrent load on this shared machine -- each confirmed passing individually and in a clean full-suite re-run).
- `cargo clippy --all-targets --all-features -- -D warnings` and the SIMD/x86 feature-set leg: both clean.
- `cargo doc --no-deps --all-features` (including the new intra-doc link to `DocumentValue`), `cargo fmt --check`, `cargo build --no-default-features` (no_std): all clean.
- Patch coverage: 90.74% (49/54 new lines) -- all 5 uncovered lines are the 4 new tests' own unreachable-on-success `panic!` arms, the same pattern every other test in this cluster has.

Fixes #1734