### PR TITLE
fix(jq): reassemble a --seq record whose bytes span a file boundary

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1822,104 +1822,115 @@ fn get_inputs(
     // Process based on input mode
     let mut values = Vec::new();
 
-    for (file_idx, raw) in raw_inputs {
-        let src = file_idx.unwrap_or(0);
-
-        if let Some(delimiter) = args.input_dsv {
-            // DSV input: each row becomes a JSON array of strings
-            let parsed = parse_dsv_input(&raw, delimiter);
-            // One row per line (approximate for embedded newlines; jq has no
-            // DSV input mode, so there is no oracle to match here). Skipped
-            // under `--slurp` (#1541): the combined array's own location
-            // comes from `slurp_eof_line` above, not from any of these
-            // per-value entries, which `get_inputs` discards wholesale when
-            // it replaces `locations` with `InputLocations::single` below.
-            if !args.slurp {
-                for line in 1..=parsed.len() {
-                    locations.push(src, line);
-                }
-            }
-            values.extend(parsed);
-        } else if args.raw_input {
-            // Raw input: each line becomes a string. Deliberately ungated by
-            // `!args.slurp` (#1541), unlike its three siblings above/below --
-            // `args.raw_input && args.slurp` can only reach this arm when
-            // `args.input_dsv` is also set (otherwise the dedicated `-R -s`
-            // early return above already handled it), and the DSV check is
-            // tried first in this `if`/`else if` chain, so it always wins:
-            // this arm is unreachable whenever `args.slurp` is true.
-            for (line_idx, line) in raw.lines().enumerate() {
-                values.push(OwnedValue::String(line.to_string()));
-                locations.push(src, line_idx + 1);
-            }
-        } else if args.seq {
-            // JSON sequence input (RFC 7464): split on RS, ignore parse failures
-            let parsed = parse_json_seq(&raw);
-            // Skipped under `--slurp` (#1541) -- see the DSV branch above.
-            if !args.slurp {
-                locations.extend_from_ends(src, &raw, &json_seq_ends(raw.as_bytes()), parsed.len());
-            }
-            values.extend(parsed);
-        } else {
-            // JSON input: validate first if --validate is set
-            if args.validate {
-                let filename = file_idx.map(|idx| files[idx].to_string_lossy().to_string());
-                validate_json_input(raw.as_bytes(), filename.as_deref())?;
-            }
-            // Parse as JSON stream
-            let parsed = match parse_json_stream(&raw) {
-                Ok(p) => p,
-                Err(e) => return Ok(Err(e)),
-            };
-            // Skipped under `--slurp` (#1541) -- see the DSV branch above.
-            // `find_json_values` exists here only to feed
-            // `locations.extend_from_ends`, so slurp mode skips that scan
-            // entirely rather than running it and discarding the result.
-            // Side effect: the divergence check below (`find_json_values`
-            // disagreeing with `parse_json_stream`/`serde_json`) no longer
-            // runs under `--slurp` either -- if the two validators were ever
-            // to disagree on some input, non-slurp mode would still raise
-            // the internal error below, but slurp mode would now silently
-            // proceed. Accepted: the comment above already treats that
-            // divergence as unreachable through this crate's public CLI
-            // surface, so this only narrows *where* an already-believed-dead
-            // safety net runs, not what output a real input can produce.
-            if !args.slurp {
-                // `parse_json_stream` (above) already validated this exact
-                // input successfully via `serde_json`, which is strictly
-                // pickier than `find_json_values`'s own lenient heuristic
-                // scan (RFC 8259 plus #1094's leading-zero tolerance, vs.
-                // `find_json_values`'s RFC 8259 plus leading-zero *and*
-                // leading-dot tolerance, #1171) -- so `find_json_values`
-                // should never fail here in practice; unreachable through
-                // this crate's own public CLI surface, not exercised by a
-                // test for that reason (matching this codebase's established
-                // convention for exhaustive-but-dead defensive arms, e.g.
-                // #1064). Surfaced as an internal error rather than silently
-                // reusing a stale/wrong offset list if the two validators
-                // ever do diverge.
-                let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
-                    Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
-                    Err(offset) => {
-                        return Ok(Err(anyhow::anyhow!(
-                            "internal error: find_json_values failed at byte {offset} \
-                             after parse_json_stream already validated this input"
-                        )));
-                    }
-                };
-                locations.extend_from_ends(src, &raw, &ends, parsed.len());
-            }
-            values.extend(parsed);
-        }
-
-        // Scoped to `!args.slurp` (#1541): under slurp, `locations` is left
-        // empty by design (the branches above skip their pushes), so this
-        // invariant no longer holds there and isn't meaningful to check --
-        // the real slurp-mode invariant is `InputLocations::single`'s own
-        // unconditional single push, asserted independently by `run_jq`'s
-        // `debug_assert_eq!(inputs.len(), locations.per_value().len())`.
+    // `--seq` (RFC 7464, #1571): a record's bytes can genuinely span a file
+    // boundary -- real jq's own reader treats every file as one continuous
+    // byte stream for parsing purposes (unrelated to whether `-s` is also
+    // passed: `-s` only changes what happens to the *values* afterward, not
+    // how records are delimited), so this handles the whole file list at
+    // once via [`build_seq_values`] rather than per file inside the loop
+    // below. The other three modes keep the per-file loop unchanged: DSV
+    // and raw-input are line-oriented (no multi-byte record to split across
+    // a boundary), and plain JSON's `find_json_values`/`parse_json_stream`
+    // never had a record delimiter to lose in the first place -- multiple
+    // JSON files are just independent value streams concatenated in the
+    // output, with no boundary-spanning-record concept to get wrong.
+    if args.seq && !args.raw_input && args.input_dsv.is_none() {
+        values = build_seq_values(&raw_inputs, &mut locations, args.slurp);
         if !args.slurp {
             debug_assert_eq!(locations.len(), values.len(), "one location per value");
+        }
+    } else {
+        for (file_idx, raw) in raw_inputs {
+            let src = file_idx.unwrap_or(0);
+
+            if let Some(delimiter) = args.input_dsv {
+                // DSV input: each row becomes a JSON array of strings
+                let parsed = parse_dsv_input(&raw, delimiter);
+                // One row per line (approximate for embedded newlines; jq has no
+                // DSV input mode, so there is no oracle to match here). Skipped
+                // under `--slurp` (#1541): the combined array's own location
+                // comes from `slurp_eof_line` above, not from any of these
+                // per-value entries, which `get_inputs` discards wholesale when
+                // it replaces `locations` with `InputLocations::single` below.
+                if !args.slurp {
+                    for line in 1..=parsed.len() {
+                        locations.push(src, line);
+                    }
+                }
+                values.extend(parsed);
+            } else if args.raw_input {
+                // Raw input: each line becomes a string. Deliberately ungated by
+                // `!args.slurp` (#1541), unlike its three siblings above/below --
+                // `args.raw_input && args.slurp` can only reach this arm when
+                // `args.input_dsv` is also set (otherwise the dedicated `-R -s`
+                // early return above already handled it), and the DSV check is
+                // tried first in this `if`/`else if` chain, so it always wins:
+                // this arm is unreachable whenever `args.slurp` is true.
+                for (line_idx, line) in raw.lines().enumerate() {
+                    values.push(OwnedValue::String(line.to_string()));
+                    locations.push(src, line_idx + 1);
+                }
+            } else {
+                // JSON input: validate first if --validate is set
+                if args.validate {
+                    let filename = file_idx.map(|idx| files[idx].to_string_lossy().to_string());
+                    validate_json_input(raw.as_bytes(), filename.as_deref())?;
+                }
+                // Parse as JSON stream
+                let parsed = match parse_json_stream(&raw) {
+                    Ok(p) => p,
+                    Err(e) => return Ok(Err(e)),
+                };
+                // Skipped under `--slurp` (#1541) -- see the DSV branch above.
+                // `find_json_values` exists here only to feed
+                // `locations.extend_from_ends`, so slurp mode skips that scan
+                // entirely rather than running it and discarding the result.
+                // Side effect: the divergence check below (`find_json_values`
+                // disagreeing with `parse_json_stream`/`serde_json`) no longer
+                // runs under `--slurp` either -- if the two validators were ever
+                // to disagree on some input, non-slurp mode would still raise
+                // the internal error below, but slurp mode would now silently
+                // proceed. Accepted: the comment above already treats that
+                // divergence as unreachable through this crate's public CLI
+                // surface, so this only narrows *where* an already-believed-dead
+                // safety net runs, not what output a real input can produce.
+                if !args.slurp {
+                    // `parse_json_stream` (above) already validated this exact
+                    // input successfully via `serde_json`, which is strictly
+                    // pickier than `find_json_values`'s own lenient heuristic
+                    // scan (RFC 8259 plus #1094's leading-zero tolerance, vs.
+                    // `find_json_values`'s RFC 8259 plus leading-zero *and*
+                    // leading-dot tolerance, #1171) -- so `find_json_values`
+                    // should never fail here in practice; unreachable through
+                    // this crate's own public CLI surface, not exercised by a
+                    // test for that reason (matching this codebase's established
+                    // convention for exhaustive-but-dead defensive arms, e.g.
+                    // #1064). Surfaced as an internal error rather than silently
+                    // reusing a stale/wrong offset list if the two validators
+                    // ever do diverge.
+                    let ends: Vec<usize> = match find_json_values(raw.as_bytes()) {
+                        Ok(values) => values.into_iter().map(|(_, end)| end).collect(),
+                        Err(offset) => {
+                            return Ok(Err(anyhow::anyhow!(
+                                "internal error: find_json_values failed at byte {offset} \
+                                 after parse_json_stream already validated this input"
+                            )));
+                        }
+                    };
+                    locations.extend_from_ends(src, &raw, &ends, parsed.len());
+                }
+                values.extend(parsed);
+            }
+
+            // Scoped to `!args.slurp` (#1541): under slurp, `locations` is left
+            // empty by design (the branches above skip their pushes), so this
+            // invariant no longer holds there and isn't meaningful to check --
+            // the real slurp-mode invariant is `InputLocations::single`'s own
+            // unconditional single push, asserted independently by `run_jq`'s
+            // `debug_assert_eq!(inputs.len(), locations.per_value().len())`.
+            if !args.slurp {
+                debug_assert_eq!(locations.len(), values.len(), "one location per value");
+            }
         }
     }
 
@@ -2868,6 +2879,82 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
 /// failure mode -- but only for content that's actually malformed, not for
 /// a shape jq itself accepts) was a real, jq-observable divergence, not a
 /// spelling nit.
+/// Build the values (and, when `!slurp`, one `(source, line)` location per
+/// value) for `--seq` input across the whole file list at once (#1571).
+///
+/// Concatenates every file's raw content, in order, into one string and
+/// runs the ordinary [`parse_json_seq`] over it exactly once -- matching
+/// real jq's own `-s` reader, which treats the entire multi-file input as
+/// one continuous RFC 7464 byte stream and doesn't stop scanning a record
+/// at a file boundary. This is what makes `seq_trailing_record_is_dropped`'s
+/// own ambiguous-bare-number-at-EOF check (inside [`parse_json_seq`]) come
+/// out correct too: run against the *true* full stream, it can only ever
+/// see genuine end-of-input, never a false EOF at some earlier file's own
+/// end -- no separate per-file special-casing needed for that interaction.
+///
+/// `!slurp` locations still need each value's own *file* and *file-local*
+/// line, not the byte offset's raw position in the throwaway `combined`
+/// string, so [`json_seq_ends`] runs once against `combined` and each
+/// resulting end offset is mapped back to whichever file's own byte range
+/// contains it (a boundary-spanning record is attributed to the file its
+/// *end* falls in -- matching #1568's own precedent for the stream's
+/// trailing record, which uses the same rule). One [`LineCounter`] per file,
+/// created only when an end offset first crosses into that file's range:
+/// `ends` is non-decreasing (`json_seq_ends` is a single left-to-right
+/// scan) and files are laid out in `combined` in file order, so this walks
+/// forward through `raw_inputs` at most once, never backtracking.
+fn build_seq_values(
+    raw_inputs: &[(Option<usize>, String)],
+    locations: &mut InputLocations,
+    slurp: bool,
+) -> Vec<OwnedValue> {
+    let mut combined = String::new();
+    let mut file_ends: Vec<usize> = Vec::with_capacity(raw_inputs.len());
+    for (_, raw) in raw_inputs {
+        combined.push_str(raw);
+        file_ends.push(combined.len());
+    }
+
+    let values = parse_json_seq(&combined);
+
+    if !slurp {
+        let ends = json_seq_ends(combined.as_bytes());
+        if ends.len() == values.len() {
+            let mut file_idx = 0;
+            let mut file_start = 0usize;
+            let mut counter = LineCounter::new(
+                raw_inputs
+                    .first()
+                    .map_or(&[][..], |(_, raw)| raw.as_bytes()),
+            );
+            for &end in &ends {
+                while file_idx + 1 < file_ends.len() && end > file_ends[file_idx] {
+                    file_start = file_ends[file_idx];
+                    file_idx += 1;
+                    counter = LineCounter::new(raw_inputs[file_idx].1.as_bytes());
+                }
+                let src = raw_inputs[file_idx].0.unwrap_or(0);
+                let line = counter.advance_to(end.saturating_sub(file_start));
+                locations.push(src, line);
+            }
+        } else {
+            // Counts disagree (a malformed/dropped record somewhere) --
+            // fall back the same way `extend_from_ends` does per-file: the
+            // last content line of the last file involved, for every
+            // value. Matches that helper's own established tolerance for
+            // imprecision here rather than inventing a new rule.
+            let (src, line) = raw_inputs
+                .last()
+                .map_or((0, 1), |(idx, raw)| (idx.unwrap_or(0), content_lines(raw)));
+            for _ in 0..values.len() {
+                locations.push(src, line);
+            }
+        }
+    }
+
+    values
+}
+
 fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
     let mut values = Vec::new();
 
@@ -5258,6 +5345,59 @@ mod tests {
         let values = parse_json_seq("\x1E1e400\n");
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].to_json(), "1E+400");
+    }
+
+    /// #1571: a record's opening RS byte and closing bytes can live in
+    /// different files -- `parse_json_seq` running once per file in
+    /// isolation drops both independently-malformed halves. `build_seq_values`
+    /// treats the whole file list as one continuous byte stream instead,
+    /// matching real jq's own `-s`/`--seq` reader.
+    #[test]
+    fn test_build_seq_values_reassembles_across_file_boundary_1571() {
+        let raw_inputs = vec![
+            (Some(0), "\x1E1\n\x1E{\"a\":\"unterminated ".to_string()),
+            (Some(1), "str\"}\n".to_string()),
+        ];
+        let mut locations =
+            InputLocations::new(vec![Some("f1".to_string()), Some("f2".to_string())]);
+        let values = build_seq_values(&raw_inputs, &mut locations, false);
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].to_json(), "1");
+        assert_eq!(values[1].to_json(), "{\"a\":\"unterminated str\"}");
+        assert_eq!(locations.len(), 2, "one location per value, non-slurp");
+    }
+
+    /// A record spanning three files, not just two.
+    #[test]
+    fn test_build_seq_values_reassembles_across_three_files_1571() {
+        let raw_inputs = vec![
+            (Some(0), "\x1E1\n\x1E{\"a\":\"unter".to_string()),
+            (Some(1), "minated ".to_string()),
+            (Some(2), "str\"}\n\x1E9\n".to_string()),
+        ];
+        let mut locations = InputLocations::new(vec![
+            Some("f1".to_string()),
+            Some("f2".to_string()),
+            Some("f3".to_string()),
+        ]);
+        let values = build_seq_values(&raw_inputs, &mut locations, false);
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0].to_json(), "1");
+        assert_eq!(values[1].to_json(), "{\"a\":\"unterminated str\"}");
+        assert_eq!(values[2].to_json(), "9");
+    }
+
+    /// Control: a record genuinely malformed on its own, not at a file
+    /// boundary, must still be dropped -- reassembly must not paper over
+    /// real malformation just because multiple files are involved.
+    #[test]
+    fn test_build_seq_values_still_drops_genuinely_malformed_record_1571() {
+        let raw_inputs = vec![(Some(0), "\x1E1\n\x1E{invalid\n\x1E3\n".to_string())];
+        let mut locations = InputLocations::new(vec![Some("f1".to_string())]);
+        let values = build_seq_values(&raw_inputs, &mut locations, false);
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].to_json(), "1");
+        assert_eq!(values[1].to_json(), "3");
     }
 
     /// #1192: `standard_json_to_jq_value` now surfaces a genuinely

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1828,12 +1828,18 @@ fn get_inputs(
     // passed: `-s` only changes what happens to the *values* afterward, not
     // how records are delimited), so this handles the whole file list at
     // once via [`build_seq_values`] rather than per file inside the loop
-    // below. The other three modes keep the per-file loop unchanged: DSV
-    // and raw-input are line-oriented (no multi-byte record to split across
-    // a boundary), and plain JSON's `find_json_values`/`parse_json_stream`
-    // never had a record delimiter to lose in the first place -- multiple
-    // JSON files are just independent value streams concatenated in the
-    // output, with no boundary-spanning-record concept to get wrong.
+    // below. The other three modes keep the per-file loop unchanged for now:
+    // plain JSON's `find_json_values`/`parse_json_stream` never had a
+    // record delimiter to lose in the first place (multiple JSON files are
+    // just independent value streams concatenated in the output, with no
+    // boundary-spanning-record concept to get wrong), and DSV rows are
+    // line-oriented and unverified either way. Raw-input (`-R`) is NOT
+    // actually safe from this class of bug -- confirmed live against
+    // pinned jq 1.7.1 that `-R`'s reader joins a file's own unterminated
+    // trailing line with the next file's first line the same way `--seq`
+    // joins a boundary-split record, which succinctly's own per-file
+    // `raw.lines()` loop below does not (#1809, filed rather than fixed
+    // here to keep this PR scoped to `--seq`).
     if args.seq && !args.raw_input && args.input_dsv.is_none() {
         values = build_seq_values(&raw_inputs, &mut locations, args.slurp);
         if !args.slurp {
@@ -1961,31 +1967,6 @@ fn content_lines(raw: &str) -> usize {
     raw.lines().count().max(1)
 }
 
-/// Exclusive end offsets of the RS-delimited records in a `--seq` stream.
-///
-/// Trailing whitespace is trimmed so the line lands on the record itself rather
-/// than on the separator that follows it, matching jq.
-fn json_seq_ends(raw: &[u8]) -> Vec<usize> {
-    const RS: u8 = 0x1e;
-    let starts: Vec<usize> = raw
-        .iter()
-        .enumerate()
-        .filter(|(_, &b)| b == RS)
-        .map(|(i, _)| i)
-        .collect();
-
-    (0..starts.len())
-        .map(|i| {
-            // A record runs up to the next separator, or to end of input.
-            let mut end = starts.get(i + 1).copied().unwrap_or(raw.len());
-            while end > 0 && raw[end - 1].is_ascii_whitespace() {
-                end -= 1;
-            }
-            end
-        })
-        .collect()
-}
-
 /// Sentinel `per_value` line meaning "no real position" (#1542 -- a
 /// `--seq` trailing record real jq itself never resolves). Never a real
 /// line number: every genuine line comes from an actual newline count or
@@ -2070,10 +2051,14 @@ impl InputLocations {
     /// disagree — modes that skip unparsable records can produce fewer values
     /// than the scan found offsets, and a wrong line is worse than a vague one.
     ///
-    /// `ends` is already non-decreasing (both of this crate's own callers --
-    /// `find_json_values`/`json_seq_ends` -- are single left-to-right scans),
-    /// so one shared `LineCounter` keeps this whole loop O(n) rather than the
-    /// O(n^2) a per-value `line_at` rescan from byte 0 produced (#1213).
+    /// `ends` is already non-decreasing (this crate's own caller,
+    /// `find_json_values`, is a single left-to-right scan), so one shared
+    /// `LineCounter` keeps this whole loop O(n) rather than the O(n^2) a
+    /// per-value `line_at` rescan from byte 0 produced (#1213). `--seq`'s
+    /// own per-value locations no longer go through this helper at all
+    /// (#1808): a boundary-spanning record's own file can't be recovered
+    /// from an isolated `raw`, so `build_seq_values`/`parse_json_seq_with_ends`
+    /// track offsets across the whole multi-file stream directly instead.
     fn extend_from_ends(&mut self, src: usize, raw: &str, ends: &[usize], values: usize) {
         if ends.len() == values {
             let mut line_counter = LineCounter::new(raw.as_bytes());
@@ -2280,8 +2265,8 @@ fn read_file_bytes(path: &Path) -> Result<Vec<u8>> {
 /// remembering how far the previous call already counted.
 ///
 /// `advance_to` must be called with non-decreasing `end` values -- the same
-/// order [`find_json_values`]/`json_seq_ends` already produce their offsets
-/// in, since both are themselves single left-to-right scans.
+/// order [`find_json_values`]/[`parse_json_seq_with_ends`] already produce
+/// their offsets in, since both are themselves single left-to-right scans.
 struct LineCounter<'a> {
     bytes: &'a [u8],
     pos: usize,
@@ -2883,26 +2868,28 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
 /// value) for `--seq` input across the whole file list at once (#1571).
 ///
 /// Concatenates every file's raw content, in order, into one string and
-/// runs the ordinary [`parse_json_seq`] over it exactly once -- matching
-/// real jq's own `-s` reader, which treats the entire multi-file input as
-/// one continuous RFC 7464 byte stream and doesn't stop scanning a record
-/// at a file boundary. This is what makes `seq_trailing_record_is_dropped`'s
-/// own ambiguous-bare-number-at-EOF check (inside [`parse_json_seq`]) come
-/// out correct too: run against the *true* full stream, it can only ever
-/// see genuine end-of-input, never a false EOF at some earlier file's own
-/// end -- no separate per-file special-casing needed for that interaction.
+/// runs [`parse_json_seq_with_ends`] over it exactly once -- matching real
+/// jq's own `-s` reader, which treats the entire multi-file input as one
+/// continuous RFC 7464 byte stream and doesn't stop scanning a record at a
+/// file boundary. This is what makes `seq_trailing_record_is_dropped`'s own
+/// ambiguous-bare-number-at-EOF check come out correct too: run against the
+/// *true* full stream, it can only ever see genuine end-of-input, never a
+/// false EOF at some earlier file's own end -- no separate per-file
+/// special-casing needed for that interaction.
 ///
 /// `!slurp` locations still need each value's own *file* and *file-local*
 /// line, not the byte offset's raw position in the throwaway `combined`
-/// string, so [`json_seq_ends`] runs once against `combined` and each
-/// resulting end offset is mapped back to whichever file's own byte range
-/// contains it (a boundary-spanning record is attributed to the file its
-/// *end* falls in -- matching #1568's own precedent for the stream's
-/// trailing record, which uses the same rule). One [`LineCounter`] per file,
-/// created only when an end offset first crosses into that file's range:
-/// `ends` is non-decreasing (`json_seq_ends` is a single left-to-right
-/// scan) and files are laid out in `combined` in file order, so this walks
-/// forward through `raw_inputs` at most once, never backtracking.
+/// string, so each value's own end offset (computed by
+/// `parse_json_seq_with_ends` in the same pass as the value itself -- never
+/// a separately-scanned list to fall out of sync with) is mapped back to
+/// whichever file's own byte range contains it via `partition_point`, since
+/// both `file_ends` and each value's own `end` are non-decreasing (a
+/// boundary-spanning record is attributed to the file its *end* falls in --
+/// matching #1568's own precedent for the stream's trailing record, which
+/// uses the same rule). `current` caches the one `LineCounter` in use,
+/// replaced only when `partition_point` reports a new file index -- since
+/// `end` values are non-decreasing, that index is too, so this never
+/// backtracks to a file already passed.
 fn build_seq_values(
     raw_inputs: &[(Option<usize>, String)],
     locations: &mut InputLocations,
@@ -2915,48 +2902,70 @@ fn build_seq_values(
         file_ends.push(combined.len());
     }
 
-    let values = parse_json_seq(&combined);
+    let parsed = parse_json_seq_with_ends(&combined);
 
     if !slurp {
-        let ends = json_seq_ends(combined.as_bytes());
-        if ends.len() == values.len() {
-            let mut file_idx = 0;
-            let mut file_start = 0usize;
-            let mut counter = LineCounter::new(
-                raw_inputs
-                    .first()
-                    .map_or(&[][..], |(_, raw)| raw.as_bytes()),
-            );
-            for &end in &ends {
-                while file_idx + 1 < file_ends.len() && end > file_ends[file_idx] {
-                    file_start = file_ends[file_idx];
-                    file_idx += 1;
-                    counter = LineCounter::new(raw_inputs[file_idx].1.as_bytes());
-                }
-                let src = raw_inputs[file_idx].0.unwrap_or(0);
-                let line = counter.advance_to(end.saturating_sub(file_start));
-                locations.push(src, line);
+        let mut current: Option<(usize, LineCounter<'_>)> = None;
+        for &(_, end) in &parsed {
+            let file_idx = file_ends
+                .partition_point(|&fe| fe < end)
+                .min(file_ends.len().saturating_sub(1));
+            if current.as_ref().map(|(idx, _)| *idx) != Some(file_idx) {
+                current = Some((
+                    file_idx,
+                    LineCounter::new(raw_inputs[file_idx].1.as_bytes()),
+                ));
             }
-        } else {
-            // Counts disagree (a malformed/dropped record somewhere) --
-            // fall back the same way `extend_from_ends` does per-file: the
-            // last content line of the last file involved, for every
-            // value. Matches that helper's own established tolerance for
-            // imprecision here rather than inventing a new rule.
-            let (src, line) = raw_inputs
-                .last()
-                .map_or((0, 1), |(idx, raw)| (idx.unwrap_or(0), content_lines(raw)));
-            for _ in 0..values.len() {
-                locations.push(src, line);
-            }
+            let file_start = if file_idx == 0 {
+                0
+            } else {
+                file_ends[file_idx - 1]
+            };
+            let src = raw_inputs[file_idx].0.unwrap_or(0);
+            let line = current
+                .as_mut()
+                .expect("just set above")
+                .1
+                .advance_to(end.saturating_sub(file_start));
+            locations.push(src, line);
         }
     }
 
-    values
+    parsed.into_iter().map(|(v, _)| v).collect()
 }
 
-fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
-    let mut values = Vec::new();
+/// Parse `--seq` content into values paired with each surviving segment's
+/// own trimmed end byte offset, both computed in the same pass so they can
+/// never fall out of sync (#1808 code review, following #1571's own
+/// cross-file fix: an earlier version scanned end offsets separately via a
+/// now-removed `json_seq_ends` helper and reconciled the two lists by comparing lengths
+/// afterward -- when a record anywhere in a multi-file stream was
+/// genuinely malformed, that reconciliation's "counts disagree" fallback
+/// attributed *every* value across the *whole* stream to the last file's
+/// last line, not just the dropped record's own, silently misreporting the
+/// filename in an error message for records that had nothing to do with
+/// the drop). [`build_seq_values`] is this function's only remaining
+/// caller; a `parse_json_seq(s) -> Vec<OwnedValue>` values-only wrapper
+/// existed here too until its own last caller (this function's own
+/// predecessor) was replaced -- removed rather than kept unused, per its
+/// own three unit tests now calling this function directly instead.
+fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
+    let bytes = s.as_bytes();
+    const RS: u8 = 0x1e;
+
+    // Byte offset where each `s.split('\x1E')` segment begins: 0, then one
+    // past each RS byte -- enumerates the identical segments, in the
+    // identical order, `s.split('\x1E')` always has (segment 0, anything
+    // before the very first RS byte and ordinarily empty, included).
+    let mut segment_starts = vec![0usize];
+    segment_starts.extend(
+        bytes
+            .iter()
+            .enumerate()
+            .filter(|(_, &b)| b == RS)
+            .map(|(i, _)| i + 1),
+    );
+    let last_idx = segment_starts.len() - 1;
 
     // The stream's own trailing record, when real jq's incremental reader
     // never resolves it (malformed, or an ambiguous bare number at true
@@ -2964,18 +2973,32 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
     // from the *output* too, not just from the error-location computation
     // (#1542): `printf '\x1e1\n\x1e2' | jq --seq -s '.'` gives `[1]` on
     // real jq, not `[1,2]`, even though "2" alone is perfectly valid JSON.
-    // Computed once, up front, and checked only against the split's last
-    // element below -- the already-malformed case is caught either way
-    // (this check, or `seq_record_parses` failing on its own a few lines
-    // down), but the ambiguous-number case parses just fine on its own and
-    // needs this explicit exclusion to be dropped at all.
+    // Computed once, up front, and checked only against the last segment
+    // below -- the already-malformed case is caught either way (this
+    // check, or `seq_record_parses` failing on its own a few lines down),
+    // but the ambiguous-number case parses just fine on its own and needs
+    // this explicit exclusion to be dropped at all.
     let drop_trailing = seq_trailing_record_is_dropped(s);
-    let segments: Vec<&str> = s.split('\x1E').collect();
-    let last_idx = segments.len().saturating_sub(1);
 
-    // Split on RS character (0x1E)
-    for (i, segment) in segments.into_iter().enumerate() {
-        let segment = segment.trim();
+    let mut results = Vec::new();
+    for (i, &start) in segment_starts.iter().enumerate() {
+        let raw_end = segment_starts
+            .get(i + 1)
+            .map_or(bytes.len(), |&next| next - 1);
+
+        // Trailing-whitespace-only trim for the *reported* end offset, so a
+        // value's line lands on the record itself, not the separator/
+        // whitespace after it -- matches `json_seq_ends`'s own rule. Can't
+        // walk past `start`: the byte immediately before it is either the
+        // string start or an RS byte, and neither is whitespace.
+        let mut end = raw_end;
+        while end > start && bytes[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+
+        // Full (both-sides) trim to decide parse-eligibility -- matches
+        // the original per-segment `segment.trim()` check exactly.
+        let segment = s[start..raw_end].trim();
         if segment.is_empty() {
             continue;
         }
@@ -2990,17 +3013,17 @@ fn parse_json_seq(s: &str) -> Vec<OwnedValue> {
             // is the same answer for a segment that parses but won't decode
             // (#1247).
             if let Ok(v) = crate::output::json_bytes_to_owned_value(segment.as_bytes()) {
-                values.push(v);
+                results.push((v, end));
             }
         }
         // Genuine parse failures are silently ignored per RFC 7464
     }
 
-    values
+    results
 }
 
 /// Whether a trimmed, non-empty `--seq` record segment parses as JSON --
-/// [`parse_json_seq`]'s own per-segment success check, factored out so
+/// [`parse_json_seq_with_ends`]'s own per-segment success check, factored out so
 /// [`seq_trailing_record_is_dropped`] can ask the identical question about
 /// one specific segment without duplicating the leading-zero retry logic.
 fn seq_record_parses(segment: &str) -> bool {
@@ -3022,8 +3045,8 @@ fn seq_record_parses(segment: &str) -> bool {
 ///
 /// - **Genuinely malformed/truncated** -- [`seq_record_parses`] fails on it
 ///   (an unterminated string/object, e.g.), matching
-///   [`parse_json_seq`]'s own silent-drop rule (RFC 7464's recommended
-///   failure mode, #1243).
+///   [`parse_json_seq_with_ends`]'s own silent-drop rule (RFC 7464's
+///   recommended failure mode, #1243).
 /// - **A bare number with nothing at all after it before EOF** -- valid
 ///   JSON on its own, but jq's streaming number scanner can't rule out more
 ///   digits still arriving without seeing a terminating byte (whitespace,
@@ -5319,7 +5342,10 @@ mod tests {
     /// of accepting it the way real jq does.
     #[test]
     fn test_parse_json_seq_tolerates_leading_zero_1243() {
-        let values = parse_json_seq("\x1E007e5\n");
+        let values: Vec<OwnedValue> = parse_json_seq_with_ends("\x1E007e5\n")
+            .into_iter()
+            .map(|(v, _)| v)
+            .collect();
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].to_json(), "7E+5");
     }
@@ -5329,7 +5355,10 @@ mod tests {
     /// leading-zero retry.
     #[test]
     fn test_parse_json_seq_still_drops_genuine_malformed_record_1243() {
-        let values = parse_json_seq("\x1E{invalid\n\x1E5\n");
+        let values: Vec<OwnedValue> = parse_json_seq_with_ends("\x1E{invalid\n\x1E5\n")
+            .into_iter()
+            .map(|(v, _)| v)
+            .collect();
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].to_json(), "5");
     }
@@ -5342,7 +5371,10 @@ mod tests {
     /// primary document input already produces for it.
     #[test]
     fn test_parse_json_seq_accepts_magnitude_overflowing_number_1267() {
-        let values = parse_json_seq("\x1E1e400\n");
+        let values: Vec<OwnedValue> = parse_json_seq_with_ends("\x1E1e400\n")
+            .into_iter()
+            .map(|(v, _)| v)
+            .collect();
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].to_json(), "1E+400");
     }
@@ -5365,6 +5397,50 @@ mod tests {
         assert_eq!(values[0].to_json(), "1");
         assert_eq!(values[1].to_json(), "{\"a\":\"unterminated str\"}");
         assert_eq!(locations.len(), 2, "one location per value, non-slurp");
+        // `1` lives entirely in f1, on its own line 1 (matches real jq
+        // 1.7.1's own `input_line_number` for this exact byte layout,
+        // verified live); the reassembled record's own *end* falls in f2,
+        // so it's attributed there -- matching #1568's own file-
+        // attribution rule for a boundary-spanning record. Not just a
+        // location count -- the actual file and line each value reports
+        // (#1808 code review: a prior version only checked
+        // `locations.len()`, missing that both values were silently
+        // misattributed to the *last* file whenever a mismatch fired
+        // anywhere in the whole stream).
+        assert_eq!(locations.get(0).file.as_deref(), Some("f1"));
+        assert_eq!(locations.get(0).line, Some(1));
+        assert_eq!(locations.get(1).file.as_deref(), Some("f2"));
+        assert_eq!(locations.get(1).line, Some(1));
+    }
+
+    /// #1808 code review: a malformed record anywhere in the multi-file
+    /// stream must not degrade *other* files' own precise locations --
+    /// only the earlier design (reconciling two separately-scanned
+    /// end/value lists by comparing counts) had this failure mode, and it
+    /// applied to the *whole* stream on any single drop, not just the
+    /// offending file. `f1` has a real value followed by a malformed
+    /// record; `f2`'s own value must still resolve to `f2`'s own line, not
+    /// silently fall back to `f1`'s.
+    #[test]
+    fn test_build_seq_values_malformed_record_does_not_misattribute_other_files_1808() {
+        let raw_inputs = vec![
+            (Some(0), "\x1E1\n\x1E{bad\n".to_string()),
+            (Some(1), "\x1E2\n".to_string()),
+        ];
+        let mut locations =
+            InputLocations::new(vec![Some("f1".to_string()), Some("f2".to_string())]);
+        let values = build_seq_values(&raw_inputs, &mut locations, false);
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].to_json(), "1");
+        assert_eq!(values[1].to_json(), "2");
+        assert_eq!(locations.get(0).file.as_deref(), Some("f1"));
+        assert_eq!(locations.get(0).line, Some(1));
+        assert_eq!(
+            locations.get(1).file.as_deref(),
+            Some("f2"),
+            "f2's own value must not be misattributed to f1 just because f1 dropped a record"
+        );
+        assert_eq!(locations.get(1).line, Some(1));
     }
 
     /// A record spanning three files, not just two.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20784,6 +20784,43 @@ fn test_jq_seq_value_reassembled_across_file_boundary_1571() -> Result<()> {
     Ok(())
 }
 
+/// #1808 code review on #1571's own fix: an earlier version computed
+/// `--seq`'s per-value locations by scanning end offsets separately from
+/// parsing values, then reconciling the two lists by comparing counts --
+/// when a record anywhere in the multi-file stream was genuinely
+/// malformed, that reconciliation misattributed *every* value across the
+/// *whole* stream to the last file, not just the dropped record's own.
+/// This pins the correct, precise per-file attribution instead: a
+/// malformed record in one file must not corrupt error locations for a
+/// well-formed value living in a *different* file. Every expectation here
+/// is jq 1.7.1's own live output.
+#[test]
+fn test_jq_seq_malformed_record_does_not_misattribute_other_files_error_location_1808() -> Result<()>
+{
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "if . == 1 then error(\"boom\") else . end"],
+        &["\x1e1\n\x1e{bad\n", "\x1e2\n"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): boom", paths[0])),
+        "the error on value `1` must report its own file (paths[0]), not paths[1]: {stderr}"
+    );
+
+    let (_, stderr, code, paths) = run_jq_over_files(
+        &["--seq", "-c", "if . == 2 then error(\"boom\") else . end"],
+        &["\x1e1\n\x1e{bad\n", "\x1e2\n"],
+    )?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): boom", paths[1])),
+        "the error on value `2` (which lives in the second file) must report \
+         its own file, not silently fall back to the first: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20727,6 +20727,63 @@ fn test_jq_seq_slurp_truncated_record_across_file_boundary_1550() -> Result<()> 
     Ok(())
 }
 
+/// #1571: #1550/#1568 fixed only the *error-location* half of a `--seq`
+/// record spanning a file boundary -- the *value* itself, produced by
+/// `parse_json_seq` running once per file in isolation, was still silently
+/// dropped: each half is independently malformed JSON, so both are dropped
+/// per RFC 7464's own recommended failure mode, even though the whole
+/// record read as one continuous byte stream (real jq's own `-s`/`--seq`
+/// reader's actual model) is perfectly well-formed. Every expectation here
+/// is jq 1.7.1's own live output.
+#[test]
+fn test_jq_seq_value_reassembled_across_file_boundary_1571() -> Result<()> {
+    // The issue's own repro: an unterminated string split across two files.
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", "."],
+        &["\x1e1\n\x1e{\"a\":\"unterminated ", "str\"}\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\x1e[1,{\"a\":\"unterminated str\"}]\n");
+
+    // Same shape, non-slurp: both records still stream out separately.
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "."],
+        &["\x1e1\n\x1e{\"a\":\"unterminated ", "str\"}\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\x1e1\n\x1e{\"a\":\"unterminated str\"}\n");
+
+    // A record spanning three files, not just two -- the fix must not be
+    // narrowly hard-coded to a single boundary.
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", "."],
+        &["\x1e1\n\x1e{\"a\":\"unter", "minated ", "str\"}\n\x1e9\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\x1e[1,{\"a\":\"unterminated str\"},9]\n");
+
+    // A bare number ambiguous only because its own file ends right after it
+    // (#1542's own trigger) is disambiguated by the next file's content,
+    // exactly as it already was for the error-location-only case #1550
+    // fixed -- but here checking the *value* itself isn't dropped either.
+    let (stdout, stderr, code, _paths) =
+        run_jq_over_files(&["--seq", "-c", "-s", "."], &["\x1e1\n\x1e2", "\n\x1e3\n"])?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\x1e[1,2,3]\n");
+
+    // Control: a record that's genuinely malformed on its own, NOT at a
+    // file boundary, must still be dropped -- reassembly must not paper
+    // over real malformation just because multiple files are involved.
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["--seq", "-c", "-s", "."],
+        &["\x1e1\n\x1e{invalid\n\x1e3\n", "\x1e4\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\x1e[1,3,4]\n");
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///


### PR DESCRIPTION
## Summary

`get_inputs` calls `parse_json_seq` once per file, treating each file's
content in complete isolation. A record whose opening RS byte is in one
file and whose closing bytes are in the next is never reassembled: each
half is independently invalid JSON, so both are silently dropped per RFC
7464's "ignore malformed records" rule — even though the whole record,
read as one continuous byte stream (which is what real jq's own `-s`
reader actually does), is perfectly well-formed.

```console
$ jq --seq -c -s '.' v1 v2
[1,{"a":"unterminated str"}]

$ succinctly-before jq --seq -c -s '.' v1 v2
[1]
```

Found during `/code-review` of PR #1568 (#1550's fix for this same
boundary's *error-location* marker only — that fix doesn't touch what
values get parsed, per its own scope).

## Fix

Extracted `--seq` handling out of the main per-file loop into a new
`build_seq_values`, which concatenates every file's raw content in file
order into one string and runs the existing `parse_json_seq` **once**
over the combined result — matching real jq's actual model directly
(multiple `--seq` files are one continuous RFC 7464 byte stream to its
reader, regardless of whether `-s` is also passed) instead of
special-casing a narrower "two adjacent files" reassembly.

This also resolves a subtler pre-existing correctness question for free:
`parse_json_seq`'s own `seq_trailing_record_is_dropped` check (the
ambiguous-bare-number-at-true-EOF exclusion) previously ran once per file,
treating each file's own tail as if it were the true end of the whole
input — wrong whenever a later file exists. Run against the real combined
stream instead, it can only ever see genuine end-of-input.

Non-slurp mode's per-value `(source, line)` locations are recovered by
mapping each record's end offset in the combined string back to whichever
file's own byte range contains it, and computing the line via a fresh
per-file `LineCounter` — a boundary-spanning record is attributed to the
file its *end* falls in, matching #1568's own precedent for the stream's
trailing record.

The other three input modes (DSV, raw-input, plain JSON) are unaffected —
none has a multi-byte record delimiter that can be split across a file
boundary in the first place.

## Verification

9-shape differential sweep against pinned jq 1.7.1 (`/usr/bin/jq`), zero
regressions:

- The issue's own 2-file repro, slurp and non-slurp
- A record spanning 3 files (not just 2 — confirms the fix isn't narrowly
  hard-coded to one boundary)
- A bare number ambiguous only at its own file's end, disambiguated by the
  next file's content (the subtler correctness question above)
- Genuinely malformed content *not* at a boundary still drops (control —
  reassembly must not paper over real malformation)
- `input_line_number` for a boundary-spanning record
- Plain single-file `--seq` (regression check vs. old per-file behavior)

## Test plan

- [x] New unit tests in `src/bin/succinctly/jq_runner.rs`:
      `test_build_seq_values_reassembles_across_file_boundary_1571`,
      `test_build_seq_values_reassembles_across_three_files_1571`,
      `test_build_seq_values_still_drops_genuinely_malformed_record_1571`
- [x] New CLI integration test in `tests/jq_cli_tests.rs`:
      `test_jq_seq_value_reassembled_across_file_boundary_1571` (5 shapes,
      exact byte-for-byte jq 1.7.1 output)
- [x] Full test suite (`cargo test --features cli,simd,regex,serde`): all
      green, no regressions
- [x] Both required clippy legs clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features` (no_std) still builds

Fixes #1571