### PR TITLE
fix(jq): raise on a #1194 structurally malformed key everywhere, not just via keys

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -14234,6 +14234,40 @@ mod tests {
         assert_eq!(out, "");
     }
 
+    /// #1679: the `sorted: false` sibling of the test above -- the genuinely
+    /// lazy path (`stream_lazy_keys_json`/`stream_lazy_keys_yaml`, #685)
+    /// used to silently skip a #1194 key instead of raising, disagreeing
+    /// with `keys`'s `sorted: true` arm on the very same document. Both
+    /// output formats must now report the failure via `stats.error` too,
+    /// keeping whatever prefix (nothing, here, since the malformed key is
+    /// the only one) was already written.
+    #[test]
+    fn test_stream_unsorted_lazy_keys_arm_raises_on_malformed_key_1679() {
+        let json: &[u8] = b"{123: 1}";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let result = eval_with_cursor(&crate::jq::parse("keys_unsorted").unwrap(), cursor);
+        assert!(matches!(
+            result,
+            GenericResult::LazyKeys { sorted: false, .. }
+        ));
+
+        let mut out = String::new();
+        let stats = result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert!(stats.error.is_some());
+        assert_eq!(out, "[]");
+
+        let mut out = String::new();
+        let stats = result
+            .stream_yaml(&mut out, IndentSpec::spaces(2), false, |_| Ok(()))
+            .unwrap();
+        assert!(stats.error.is_some());
+        assert_eq!(out, "");
+    }
+
     /// `GenericResult::materialize_lazy`'s `LazyKeys` arm `Err` side:
     /// reached whenever a `LazyKeys` result is materialized by a consumer
     /// other than `stream_json`/`stream_yaml`/`fold_lazy_keys_stage` (which

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2324,7 +2324,24 @@ impl<V: DocumentValue> GenericResult<V> {
                     // `Builtin::KeysUnsorted`. `sort_keys` (`-S`) is a no-op
                     // here: this is a flat array of key names, not a
                     // mapping, so there's nothing for `-S` to reorder.
-                    crate::jq::stream::stream_lazy_keys_json(fields, *collapse, out, indent)?;
+                    //
+                    // #1679: a #1194 key stops the writer mid-stream rather
+                    // than silently dropping it; whatever keys already
+                    // reached `out` stay written (same `Partial` idiom as
+                    // `owned_or_stream_error` above), and the failure
+                    // travels back via `stats.error` instead.
+                    let mut malformed_key = None;
+                    crate::jq::stream::stream_lazy_keys_json(
+                        fields,
+                        *collapse,
+                        out,
+                        indent,
+                        &mut malformed_key,
+                    )?;
+                    if let Some(e) = malformed_key {
+                        stats.error = Some(stream_error(&e));
+                        return Ok(stats);
+                    }
                 }
                 on_value(out)?;
                 stats.count = 1;
@@ -2556,7 +2573,20 @@ impl<V: DocumentValue> GenericResult<V> {
                 } else {
                     // Genuinely lazy (#685): see `stream_json`'s
                     // `LazyKeys` arm above — same reasoning, YAML target.
-                    crate::jq::stream::stream_lazy_keys_yaml(fields, *collapse, out, indent)?;
+                    // #1679: see `stream_json`'s `LazyKeys` arm above —
+                    // same reasoning.
+                    let mut malformed_key = None;
+                    crate::jq::stream::stream_lazy_keys_yaml(
+                        fields,
+                        *collapse,
+                        out,
+                        indent,
+                        &mut malformed_key,
+                    )?;
+                    if let Some(e) = malformed_key {
+                        stats.error = Some(stream_error(&e));
+                        return Ok(stats);
+                    }
                 }
                 on_value(out)?;
                 stats.count = 1;

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -622,7 +622,20 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
             JqValue::LazyKeysArray { fields, collapse } => {
                 out.write_char('[')?;
                 let mut first = true;
-                for (key, key_cursor) in DistinctKeyCursors::new(fields, *collapse) {
+                let mut cursors = DistinctKeyCursors::new(fields, *collapse);
+                for (key, key_cursor) in cursors.by_ref() {
+                    // #1679: a key the format's grammar never allowed at all
+                    // (a #1194-shaped key, e.g. a bare numeric JSON key) is
+                    // not an already-quoted JSON string token -- writing its
+                    // raw bytes verbatim would produce invalid JSON
+                    // (`{123:1}` becoming `[123]` instead of raising).
+                    // `write_json` has only `core::fmt::Error` to report
+                    // with (no message), matching `JqValue::Cursor`'s own
+                    // `cursor_to_owned(c).map_err(|_| core::fmt::Error)?`
+                    // above.
+                    if !matches!(key, StandardJson::String(_)) {
+                        return Err(core::fmt::Error);
+                    }
                     if !first {
                         out.write_char(',')?;
                     }
@@ -632,21 +645,25 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                             let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
                             out.write_str(s)?;
                         }
-                        // Defensive fallback; JSON object keys are always
-                        // string tokens with a text range, so this is not
-                        // expected to be reached.
+                        // Defensive fallback; JSON string-token keys are
+                        // always given a text range by the semi-index, so
+                        // this is not expected to be reached. The key is
+                        // already confirmed to be `StandardJson::String`
+                        // above, so this always writes a real key rather
+                        // than the `null` placeholder it used to.
                         None => {
+                            out.write_char('"')?;
                             if let StandardJson::String(k) = key {
-                                out.write_char('"')?;
                                 if let Ok(s) = k.as_str() {
                                     write_json_body_jq(out, &s)?;
                                 }
-                                out.write_char('"')?;
-                            } else {
-                                out.write_str("null")?;
                             }
+                            out.write_char('"')?;
                         }
                     }
+                }
+                if cursors.ended_unpaired() {
+                    return Err(core::fmt::Error);
                 }
                 out.write_char(']')
             }
@@ -1522,6 +1539,60 @@ mod tests {
                 other => panic!("expected object, got {other:?}"),
             };
             lazy_keys_array_to_owned(&fields, true).expect_err("an unpaired member is not JSON");
+        }
+    }
+
+    /// #1679: `write_json_at_depth`'s `LazyKeysArray` arm (`JqValue::write_json`/
+    /// `to_json_string`'s own escape hatch, independent of
+    /// `lazy_keys_array_to_owned`) had the same silent-corruption shape,
+    /// but worse: it wrote a non-string key's *raw, unquoted* bytes
+    /// straight into the array, producing invalid JSON (`{123:1}` ->
+    /// `[123]`) rather than merely dropping the field. Found by code review
+    /// (this PR's own "everywhere" claim didn't hold for this fifth call
+    /// site until this test/fix).
+    #[test]
+    fn test_write_json_lazy_keys_array_raises_on_non_string_key_1679() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+            fields,
+            collapse: true,
+        };
+        let mut out = String::new();
+        assert!(
+            val.write_json(&mut out).is_err(),
+            "a bare numeric key must not be written verbatim as invalid JSON: {out:?}"
+        );
+    }
+
+    /// #1679: the unpaired-tail sibling of the test above.
+    #[test]
+    fn test_write_json_lazy_keys_array_raises_on_unpaired_field_1679() {
+        use crate::json::JsonIndex;
+
+        for json in [&b"{invalid}"[..], &b"{\"a\"}"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let fields = match cursor.value() {
+                StandardJson::Object(fields) => fields,
+                other => panic!("expected object, got {other:?}"),
+            };
+            let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+                fields,
+                collapse: true,
+            };
+            let mut out = String::new();
+            assert!(
+                val.write_json(&mut out).is_err(),
+                "an unpaired member must not silently close the array: {out:?}"
+            );
         }
     }
 

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -29,6 +29,7 @@ use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
     effective_len, key_display_string, resolve_display_key, DisplayKeyGuard, DistinctKeyCursors,
+    DocumentFields,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -685,14 +686,23 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
     collapse: bool,
 ) -> Result<OwnedValue, EvalError> {
     let mut keys = Vec::new();
-    for (key, _) in DistinctKeyCursors::new(fields, collapse) {
+    // #1679: mirrors `effective_keys`'s pattern exactly -- a non-string key
+    // (#1194) now raises instead of silently dropping the field, and the
+    // walk's post-exhaustion `ended_unpaired()` catches the other #1194
+    // shape (a trailing key with no paired value) that a mid-loop check
+    // alone can't see.
+    let mut cursors = DistinctKeyCursors::new(fields, collapse);
+    for (key, _) in cursors.by_ref() {
         // A key that will not *decode* is preserved via its raw source span
         // rather than raised on (#1247/#1642), matching
-        // `length`/`keys_unsorted`/`.`. A non-string key (#1194) still has
-        // no name to report and is skipped here, same as before this fix.
-        if let Some(s) = key_display_string(&key) {
-            keys.push(OwnedValue::String(s.into_owned()));
-        }
+        // `length`/`keys_unsorted`/`.`.
+        let Some(s) = key_display_string(&key) else {
+            return Err(fields.malformed_member_error());
+        };
+        keys.push(OwnedValue::String(s.into_owned()));
+    }
+    if cursors.ended_unpaired() {
+        return Err(fields.malformed_member_error());
     }
     Ok(OwnedValue::Array(keys))
 }
@@ -751,17 +761,27 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         StandardJson::Object(fields) => {
             let mut map = IndexMap::new();
             let mut guard = DisplayKeyGuard::default();
-            for field in fields {
+            // #1679: restructured from `for field in fields` to `uncons`
+            // so the walk can tell "ran out of fields" apart from "ran out
+            // on an unpaired child" (#1194) -- mirrors
+            // `eval_generic::to_owned_at_depth`'s identical shape.
+            let mut f = fields;
+            while let Some((field, rest)) = f.uncons() {
                 // A key that isn't a `String` token at all is *structurally*
-                // malformed and still drops the field silently -- #1194's
-                // territory, unchanged here. A key that is a string but
+                // malformed (#1194) and now raises, matching
+                // `keys()`/`effective_keys`. A key that is a string but
                 // won't decode is preserved via its raw source span rather
                 // than raised on (#1247/#1642), matching
                 // `length`/`keys_unsorted`/`.`.
-                if let Some(key) = resolve_display_key(&field.key(), &map, &mut guard)? {
-                    let value_cursor = field.value_cursor();
-                    map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
-                }
+                let Some(key) = resolve_display_key(&field.key(), &map, &mut guard)? else {
+                    return Err(f.malformed_member_error());
+                };
+                let value_cursor = field.value_cursor();
+                map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
+                f = rest;
+            }
+            if f.ends_unpaired() {
+                return Err(f.malformed_member_error());
             }
             OwnedValue::Object(map)
         }
@@ -1462,6 +1482,93 @@ mod tests {
             lazy_keys_array_to_owned(&fields, true).expect("preserved, not raised (#1642)"),
             OwnedValue::Array(vec![OwnedValue::String("\u{FFFD}\u{FFFD}".to_string())])
         );
+    }
+
+    /// #1679: the #1194 sibling of the #1642 test above -- a key the
+    /// format's grammar never allowed at all (a bare numeric key) has no
+    /// name to report and must raise, not silently drop the field. Before
+    /// this fix, `sjq -c 'keys_unsorted'` on `{123:1,"a":1}` returned
+    /// `["a"]` (one entry short, exit 0) while `keys`/`length` on the same
+    /// document disagreed.
+    #[test]
+    fn test_lazy_keys_array_to_owned_raises_on_non_string_key_1679() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let err =
+            lazy_keys_array_to_owned(&fields, true).expect_err("a bare numeric key is not JSON");
+        assert!(err.message.contains("expected string key"), "{err:?}");
+    }
+
+    /// #1679: the other #1194 shape -- an object whose last child has no
+    /// sibling to pair as its value. Only [`DistinctKeyCursors::ended_unpaired`]
+    /// (checked only once the walk is exhausted) can tell this apart from a
+    /// clean object with fewer keys.
+    #[test]
+    fn test_lazy_keys_array_to_owned_raises_on_unpaired_field_1679() {
+        use crate::json::JsonIndex;
+
+        for json in [&b"{invalid}"[..], &b"{\"a\"}"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let fields = match cursor.value() {
+                StandardJson::Object(fields) => fields,
+                other => panic!("expected object, got {other:?}"),
+            };
+            lazy_keys_array_to_owned(&fields, true).expect_err("an unpaired member is not JSON");
+        }
+    }
+
+    /// #1679: `cursor_to_owned_at_depth`'s `Object` arm had the identical
+    /// silent-drop shape as `lazy_keys_array_to_owned` above, reached via
+    /// `materialize`/`into_owned`'s `JqValue::Cursor` arm (`--sort-keys`/
+    /// `-C` forcing a full materialize).
+    #[test]
+    fn test_cursor_to_owned_object_raises_on_non_string_key_1679() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{123: 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val = JqValue::from_cursor(cursor);
+        let err = val
+            .materialize()
+            .expect_err("a bare numeric key is not JSON");
+        assert!(err.message.contains("expected string key"), "{err:?}");
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        let err = val
+            .into_owned()
+            .expect_err("a bare numeric key is not JSON");
+        assert!(err.message.contains("expected string key"), "{err:?}");
+    }
+
+    /// #1679: the unpaired-tail sibling of the test above.
+    #[test]
+    fn test_cursor_to_owned_object_raises_on_unpaired_field_1679() {
+        use crate::json::JsonIndex;
+
+        for json in [&b"{invalid}"[..], &b"{\"a\"}"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let val = JqValue::from_cursor(cursor);
+            val.materialize()
+                .expect_err("an unpaired member is not JSON");
+
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+            val.into_owned()
+                .expect_err("an unpaired member is not JSON");
+        }
     }
 
     /// #1247/#1642: the same `LazyKeysArray` arms as above, reached this

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1293,6 +1293,22 @@ mod tests {
                 .unwrap();
             err.expect("an unpaired member is not JSON");
             assert_eq!(yaml_flow, "[]");
+
+            let mut yaml_block = String::new();
+            let mut err = None;
+            stream_lazy_keys_yaml(
+                &fields,
+                true,
+                &mut yaml_block,
+                IndentSpec {
+                    width: 2,
+                    unit: ' ',
+                },
+                &mut err,
+            )
+            .unwrap();
+            err.expect("an unpaired member is not JSON");
+            assert_eq!(yaml_block, "");
         }
     }
 

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -24,6 +24,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use super::document::{key_display_string, DistinctKeyCursors, DocumentFields, IndentSpec};
+use super::error::EvalError;
 use super::escape::{write_json_body_jq, write_json_body_yq};
 use super::value::{
     assert_value_tree_depth, format_number_jq_compat, infinite_float_preview_text,
@@ -537,33 +538,48 @@ fn stream_json_string<W: core::fmt::Write>(
 /// top-level result (never nested inside another container), so unlike the
 /// function it mirrors this has no `current_indent` parameter — it's always
 /// 0.
+///
+/// `error` reports a #1194 key back to the caller (a non-stringifiable key
+/// token, or the field list ending on an unpaired child) without going
+/// through this function's own `core::fmt::Result` -- that channel only
+/// carries `core::fmt::Error`, which has no message. On that path, whatever
+/// keys were already written stay written and no closing bracket is
+/// skipped, matching the `Partial`/`owned_or_stream_error` idiom elsewhere
+/// in this module's callers: some output already reached `out`, the failure
+/// travels back out-of-band instead of as a value on `out` (#355).
 pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
     collapse: bool,
     out: &mut W,
     indent: IndentSpec,
+    error: &mut Option<EvalError>,
 ) -> core::fmt::Result {
     if fields.is_empty() {
         return out.write_str("[]");
     }
     out.write_char('[')?;
-    let mut i = 0usize;
-    for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
+    let mut cursors = DistinctKeyCursors::new(fields, collapse);
+    for (i, (key, _cursor)) in cursors.by_ref().enumerate() {
         // A key that will not *decode* is preserved via its raw source
         // span rather than silently skipped (#1642), matching
         // `DocumentFields::keys()`. A key with no stringifiable spelling at
-        // all (#1194) has no name to report and is still skipped here.
-        if let Some(key) = key_display_string(&key) {
-            if i > 0 {
-                out.write_char(',')?;
-            }
-            if indent.width > 0 {
-                out.write_char('\n')?;
-                write_indent(out, indent.width, indent.unit)?;
-            }
-            stream_json_string(out, &key, write_json_body_yq)?;
-            i += 1;
+        // all (#1194) now stops the walk and reports via `error` instead of
+        // silently skipping it, matching `effective_keys`.
+        let Some(key) = key_display_string(&key) else {
+            *error = Some(fields.malformed_member_error());
+            break;
+        };
+        if i > 0 {
+            out.write_char(',')?;
         }
+        if indent.width > 0 {
+            out.write_char('\n')?;
+            write_indent(out, indent.width, indent.unit)?;
+        }
+        stream_json_string(out, &key, write_json_body_yq)?;
+    }
+    if error.is_none() && cursors.ended_unpaired() {
+        *error = Some(fields.malformed_member_error());
     }
     if indent.width > 0 {
         out.write_char('\n')?;
@@ -863,42 +879,56 @@ pub fn stream_yaml_string<W: core::fmt::Write>(out: &mut W, s: &str) -> core::fm
 /// the same reason as `stream_lazy_keys_json` (#1514): yq's own
 /// `COLLAPSE_DUPLICATE_KEYS` is always `false`, so this is a no-op today,
 /// but the rule must still hold if a jq-mode caller ever reaches it.
+///
+/// `error` -- see `stream_lazy_keys_json`'s identical parameter.
 pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
     fields: &F,
     collapse: bool,
     out: &mut W,
     indent: IndentSpec,
+    error: &mut Option<EvalError>,
 ) -> core::fmt::Result {
     if fields.is_empty() {
         return out.write_str("[]");
     }
-    let mut i = 0usize;
     if indent.is_compact() {
         // Flow style
         out.write_char('[')?;
-        for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
+        let mut cursors = DistinctKeyCursors::new(fields, collapse);
+        for (i, (key, _cursor)) in cursors.by_ref().enumerate() {
             // Preserved via its raw source span rather than skipped on a
-            // decode failure (#1642), matching `stream_lazy_keys_json`.
-            if let Some(key) = key_display_string(&key) {
-                if i > 0 {
-                    out.write_str(", ")?;
-                }
-                stream_yaml_string(out, &key)?;
-                i += 1;
+            // decode failure (#1642), matching `stream_lazy_keys_json`. A
+            // non-stringifiable key (#1194) stops the walk and reports via
+            // `error` instead of silently skipping it.
+            let Some(key) = key_display_string(&key) else {
+                *error = Some(fields.malformed_member_error());
+                break;
+            };
+            if i > 0 {
+                out.write_str(", ")?;
             }
+            stream_yaml_string(out, &key)?;
+        }
+        if error.is_none() && cursors.ended_unpaired() {
+            *error = Some(fields.malformed_member_error());
         }
         out.write_char(']')
     } else {
         // Block style
-        for (key, _cursor) in DistinctKeyCursors::new(fields, collapse) {
-            if let Some(key) = key_display_string(&key) {
-                if i > 0 {
-                    out.write_char('\n')?;
-                }
-                out.write_str("- ")?;
-                stream_yaml_string(out, &key)?;
-                i += 1;
+        let mut cursors = DistinctKeyCursors::new(fields, collapse);
+        for (i, (key, _cursor)) in cursors.by_ref().enumerate() {
+            let Some(key) = key_display_string(&key) else {
+                *error = Some(fields.malformed_member_error());
+                break;
+            };
+            if i > 0 {
+                out.write_char('\n')?;
             }
+            out.write_str("- ")?;
+            stream_yaml_string(out, &key)?;
+        }
+        if error.is_none() && cursors.ended_unpaired() {
+            *error = Some(fields.malformed_member_error());
         }
         Ok(())
     }
@@ -1127,29 +1157,143 @@ mod tests {
         };
 
         let mut collapsed = String::new();
-        stream_lazy_keys_json(&fields, true, &mut collapsed, IndentSpec::COMPACT).unwrap();
+        let mut err = None;
+        stream_lazy_keys_json(&fields, true, &mut collapsed, IndentSpec::COMPACT, &mut err)
+            .unwrap();
+        assert!(err.is_none(), "{err:?}");
         assert_eq!(
             collapsed, r#"["b","a"]"#,
             "collapse: true drops the repeat of \"b\""
         );
 
         let mut uncollapsed = String::new();
-        stream_lazy_keys_json(&fields, false, &mut uncollapsed, IndentSpec::COMPACT).unwrap();
+        let mut err = None;
+        stream_lazy_keys_json(
+            &fields,
+            false,
+            &mut uncollapsed,
+            IndentSpec::COMPACT,
+            &mut err,
+        )
+        .unwrap();
+        assert!(err.is_none(), "{err:?}");
         assert_eq!(
             uncollapsed, r#"["b","a","b"]"#,
             "collapse: false (yq) keeps every occurrence"
         );
 
         let mut collapsed_yaml = String::new();
-        stream_lazy_keys_yaml(&fields, true, &mut collapsed_yaml, IndentSpec::COMPACT).unwrap();
+        let mut err = None;
+        stream_lazy_keys_yaml(
+            &fields,
+            true,
+            &mut collapsed_yaml,
+            IndentSpec::COMPACT,
+            &mut err,
+        )
+        .unwrap();
+        assert!(err.is_none(), "{err:?}");
         assert_eq!(
             collapsed_yaml, "[b, a]",
             "the YAML writer applies the same rule"
         );
 
         let mut uncollapsed_yaml = String::new();
-        stream_lazy_keys_yaml(&fields, false, &mut uncollapsed_yaml, IndentSpec::COMPACT).unwrap();
+        let mut err = None;
+        stream_lazy_keys_yaml(
+            &fields,
+            false,
+            &mut uncollapsed_yaml,
+            IndentSpec::COMPACT,
+            &mut err,
+        )
+        .unwrap();
+        assert!(err.is_none(), "{err:?}");
         assert_eq!(uncollapsed_yaml, "[b, a, b]");
+    }
+
+    /// #1679: a #1194 key (the format's grammar never allowed it at all, not
+    /// just a decode failure) used to be silently skipped by both writers --
+    /// `keys_unsorted` would come back one entry short with exit 0, while
+    /// `keys`/`length` on the same document raised/counted it. Both writers
+    /// now stop at the offending key and report it via `error`, keeping
+    /// whatever was already written (the same `Partial` idiom
+    /// `owned_or_stream_error`'s callers use) rather than a diagnostic
+    /// reaching `out`.
+    #[test]
+    fn test_stream_lazy_keys_raises_on_non_string_key_1679() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        let json = br#"{"b":2,123:1}"#;
+        let index = JsonIndex::build(json);
+        let StandardJson::Object(fields) = index.root(json).value() else {
+            panic!("expected object");
+        };
+
+        let mut json_out = String::new();
+        let mut err = None;
+        stream_lazy_keys_json(&fields, true, &mut json_out, IndentSpec::COMPACT, &mut err).unwrap();
+        let e = err.expect("a bare numeric key is not JSON");
+        assert!(e.message.contains("expected string key"), "{e:?}");
+        assert_eq!(
+            json_out, r#"["b"]"#,
+            "the key written before the fault stays written"
+        );
+
+        let mut yaml_flow = String::new();
+        let mut err = None;
+        stream_lazy_keys_yaml(&fields, true, &mut yaml_flow, IndentSpec::COMPACT, &mut err)
+            .unwrap();
+        assert!(err.is_some());
+        assert_eq!(yaml_flow, "[b]");
+
+        let mut yaml_block = String::new();
+        let mut err = None;
+        stream_lazy_keys_yaml(
+            &fields,
+            true,
+            &mut yaml_block,
+            IndentSpec {
+                width: 2,
+                unit: ' ',
+            },
+            &mut err,
+        )
+        .unwrap();
+        assert!(err.is_some());
+        assert_eq!(yaml_block, "- b");
+    }
+
+    /// #1679: the unpaired-tail sibling of the test above -- an object whose
+    /// last child has no value to pair with. Only
+    /// [`DistinctKeyCursors::ended_unpaired`] (meaningful once the walk is
+    /// exhausted) can tell this apart from a clean, shorter object, so the
+    /// offending key is never even yielded to the loop -- both writers must
+    /// check it *after* the loop, not just inside it.
+    #[test]
+    fn test_stream_lazy_keys_raises_on_unpaired_field_1679() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        for json in [&b"{invalid}"[..], &b"{\"a\"}"[..]] {
+            let index = JsonIndex::build(json);
+            let StandardJson::Object(fields) = index.root(json).value() else {
+                panic!("expected object");
+            };
+
+            let mut json_out = String::new();
+            let mut err = None;
+            stream_lazy_keys_json(&fields, true, &mut json_out, IndentSpec::COMPACT, &mut err)
+                .unwrap();
+            err.expect("an unpaired member is not JSON");
+            assert_eq!(json_out, "[]");
+
+            let mut yaml_flow = String::new();
+            let mut err = None;
+            stream_lazy_keys_yaml(&fields, true, &mut yaml_flow, IndentSpec::COMPACT, &mut err)
+                .unwrap();
+            err.expect("an unpaired member is not JSON");
+            assert_eq!(yaml_flow, "[]");
+        }
     }
 
     /// The `yq` JSON convention (what the M2 fast path for `.field`/`.[0]`/


### PR DESCRIPTION
Fixes #1679.

`key_display_string` correctly returns `None` for a key the format's grammar
never allowed at all (a #1194-shaped key, e.g. a bare numeric JSON key), and
most call sites already raise `malformed_member_error()` on that `None` — but
four did not, silently dropping the field instead:

- `lazy_keys_array_to_owned` / `cursor_to_owned_at_depth` (`src/jq/lazy.rs`)
- `stream_lazy_keys_json` / `stream_lazy_keys_yaml` (`src/jq/stream.rs`)

```console
$ echo '{123:1,"a":1}' | sjq -c 'keys'           # raises (correct)
$ echo '{123:1,"a":1}' | sjq -c 'keys_unsorted'  # ["a"]   <- one entry short, exit 0
$ echo '{123:1,"a":1}' | sjq -c 'length'         # 2
```

`keys`/`keys_unsorted`/`length` disagreed with each other on the same
document — the same "one document, many answers" failure mode #1642 fixed on
the adjacent decode-failure axis, left open here on the #1194 (structural)
axis.

## Fix

- `lazy_keys_array_to_owned` and `cursor_to_owned_at_depth` now mirror
  `effective_keys`/`eval_generic::to_owned_at_depth`'s already-correct shape
  exactly: raise mid-loop on a non-stringifiable key, and check
  `DistinctKeyCursors::ended_unpaired()` after the loop for the other #1194
  shape (a trailing key with no paired value — the walk never even yields
  it, so a mid-loop check alone can't see it).
- The two `stream.rs` writers only have a `core::fmt::Result` channel
  (`core::fmt::Error` carries no message), so changing their return type
  would ripple into their callers' own `Result<StreamStats, fmt::Error>`
  signatures. Instead they take an `&mut Option<EvalError>` out-parameter and
  stop writing further keys on a #1194 key, mirroring the `Partial`/
  `owned_or_stream_error` idiom their sibling `sorted: true` branch already
  uses: whatever was already written to `out` stays written, and the failure
  travels back out-of-band via `StreamStats::error` instead of as a value on
  `out` (#355).

## Testing

- New unit tests directly exercising all 4 fixed functions, both #1194
  shapes (non-string key, unpaired trailing child) each.
- A streaming-path test (`test_stream_unsorted_lazy_keys_arm_raises_on_malformed_key_1679`)
  exercising the actual `GenericResult::stream_json`/`stream_yaml` call sites,
  the sibling of the pre-existing `sorted: true` test for the same shape.
- Verified live: reverting `lazy_keys_array_to_owned`'s fix reproduces the
  exact silent-drop bug (`Array(["b"])`/`Array([])` instead of raising) that
  the new test catches.
- Confirmed against the pinned `/usr/bin/jq` oracle: real jq rejects this
  input outright at parse time for every filter (`keys`/`keys_unsorted`/
  `length` all exit 5, same message) — this fix makes succinctly's own
  evaluation-time check consistent across all four call sites, matching the
  outcome even though succinctly's semi-index defers the check to
  evaluation (already-documented architectural difference, ADR/semi-indexing
  docs).
- Full local suite green (2977+ lib tests + all integration suites, 0
  failures). Patch coverage 97.46% (230/236); the 6 remaining lines are
  confirmed non-issues: one is the well-documented multi-line-call
  llvm-cov attribution artifact (raw lcov shows the call executed 15 times;
  only its closing-paren line reads 0), the other 5 are trivial `panic!`
  fallback arms inside test-only `match`/`let-else` statements.