### PR TITLE
fix(jq): isolate the nesting-depth panic per-document instead of aborting the stream

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -956,18 +956,27 @@ equivalent guard only fires later, when a builtin with no native lazy fast path 
 `join`) or one that still has to materialize its result before printing (`map(.)`) forces
 a full `to_owned_cursor` conversion of the value it's handed — `nesting depth exceeds
 limit of 256` (also exit 5, matching jq's own exit code by coincidence of both picking the
-same conventional "filter failed" code, not by design). succinctly's own wording, since
-there is no equivalent jq sentence to copy for an evaluation-time guard jq has no
-counterpart to (its own check never gets this far). See #1793 for the fix that turned this
-from an uncaught process panic into a clean, catchable diagnostic.
+same conventional "filter failed" code, not by design — an internal architectural ceiling
+being reported through the same channel as an ordinary filter/type error, deliberately,
+so a `sort`/`join`/`map(.)` result is never distinguishable-by-exit-code from any other
+uncaught `EvalError` on this path). succinctly's own wording, since there is no equivalent
+jq sentence to copy for an evaluation-time guard jq has no counterpart to (its own check
+never gets this far). Falls under ADR-0018's "would take the host process down" exception
+— the pre-fix behavior was an uncaught panic, not merely different wording. See #1793 for
+the fix that turned this from an uncaught process panic into a clean, catchable
+diagnostic.
 
 This fix is scoped to the CLI's default (lazy) per-document dispatch, matching #1793's own
-repro — the same panic remains uncaught via a CLI flag that forces whole-batch
-materialization up front (`--slurp`, `-S`/`--sort-keys`, `-C`/`--color-output`,
-`--ascii-output`, `--slurpfile`) or via `-e`/`--exit-status`'s own separate materializer
-(`src/jq/lazy.rs`, already pinned uncaught by `test_exit_status_query_rejects_adversarial_
-nesting_998`), and `succinctly yq` has no equivalent guard on either its default or
-materializing path at all. Tracked separately, not fixed here.
+repro — the identical panic remains uncaught via any of: a CLI flag that forces
+whole-batch materialization up front (`--slurp`, `-S`/`--sort-keys`, `-C`/`--color-output`,
+`--ascii-output`, `--slurpfile`); a filter using `input`/`inputs`/`input_line_number`,
+which routes to that same materializing branch with *no flag at all* (#1818); `-e`/
+`--exit-status`'s own separate materializer (`src/jq/lazy.rs`, already pinned uncaught by
+`test_exit_status_query_rejects_adversarial_nesting_998`); and `succinctly yq`, which has
+no equivalent guard on either its default or materializing path at all (#1817). Tracked
+separately, not fixed here. Confirmed live, also pre-existing and unrelated to this fix:
+`print_json`'s own guard can flush corrupted/truncated JSON to stdout before it fires
+(#1819).
 
 ## Regex flags `l` and `n`
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -943,6 +943,32 @@ against the pinned jq 1.7.1 binary), so refusing with a catchable error is the s
 "would take the host process down" exception as the rest of this entry, not a new kind of
 divergence.
 
+## A too-deeply-nested document is caught at a different stage, with different wording
+
+Real jq refuses a document nested past 256 levels at *parse* time: `jq -c sort` on a
+260-level-deep array gives `jq: parse error: Exceeds depth limit for parsing at line 1,
+column 257` (exit 5) before evaluation ever starts, regardless of which filter is applied
+— confirmed live against the pinned 1.7.1 binary. Succinctly's semi-indexing accepts the
+same document at parse/index time (its own architectural point, #1793's own investigation
+confirmed: `succinctly jq -c length`/`.[1]` on the identical document already succeed,
+since navigating to or measuring a value doesn't require materializing it), so the
+equivalent guard only fires later, when a builtin with no native lazy fast path (`sort`,
+`join`) or one that still has to materialize its result before printing (`map(.)`) forces
+a full `to_owned_cursor` conversion of the value it's handed — `nesting depth exceeds
+limit of 256` (also exit 5, matching jq's own exit code by coincidence of both picking the
+same conventional "filter failed" code, not by design). succinctly's own wording, since
+there is no equivalent jq sentence to copy for an evaluation-time guard jq has no
+counterpart to (its own check never gets this far). See #1793 for the fix that turned this
+from an uncaught process panic into a clean, catchable diagnostic.
+
+This fix is scoped to the CLI's default (lazy) per-document dispatch, matching #1793's own
+repro — the same panic remains uncaught via a CLI flag that forces whole-batch
+materialization up front (`--slurp`, `-S`/`--sort-keys`, `-C`/`--color-output`,
+`--ascii-output`, `--slurpfile`) or via `-e`/`--exit-status`'s own separate materializer
+(`src/jq/lazy.rs`, already pinned uncaught by `test_exit_status_query_rejects_adversarial_
+nesting_998`), and `succinctly yq` has no equivalent guard on either its default or
+materializing path at all. Tracked separately, not fixed here.
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1273,6 +1273,17 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                             std::panic::resume_unwind(payload);
                         };
                         sink.report(DiagStyle::Jq, &EvalError::new(message), &at);
+                        // Mirrors the same check a few lines below, after the
+                        // ordinary per-result loop -- halt/halt_error (#791)
+                        // outranks everything else, including remaining
+                        // values/files, and this `continue` would otherwise
+                        // skip straight past that check for this iteration
+                        // (review: every other early-exit in this loop still
+                        // reaches it on the same iteration; this one didn't).
+                        if let Some(code) = sink.halted() {
+                            out.flush()?;
+                            return Ok(code);
+                        }
                         continue;
                     }
                 };
@@ -3431,10 +3442,22 @@ fn evaluate_input(
     }
 }
 
-/// If `payload` (a caught panic's payload) is `to_owned_cursor_at_depth`'s
-/// `MAX_NESTING_DEPTH` guard (#1793), returns its message; `None` for any
-/// other panic, so a caller can `resume_unwind` anything unrelated rather
-/// than silently treating an unexpected panic as this specific, known one.
+/// If `payload` (a caught panic's payload) is exactly
+/// `to_owned_cursor_at_depth`'s `MAX_NESTING_DEPTH` guard (#1793), returns
+/// its message; `None` for any other panic, so a caller can `resume_unwind`
+/// anything unrelated rather than silently treating an unexpected panic as
+/// this specific, known one.
+///
+/// An *exact* match against `assert_depth`'s own message template
+/// (`src/jq/value.rs`), not a substring check -- `assert_value_tree_depth`
+/// (`MAX_VALUE_TREE_DEPTH`, 384) shares that same template via the same
+/// underlying `assert_depth` call and produces byte-identical text apart
+/// from the number, so a substring match here would also silently catch
+/// *that* guard's panic (a different failure class, from filter-driven
+/// value growth rather than document nesting) and report it as if it were
+/// this one. Confirmed live by review: `reduce range(400) as $i (null;
+/// [.])` panics via the 384 guard and was being caught here before this
+/// fix narrowed the match.
 ///
 /// `assert!`'s formatted message (`"nesting depth exceeds limit of
 /// {MAX_NESTING_DEPTH}"`) panics with a `String` payload, not `&'static
@@ -3446,7 +3469,7 @@ fn nesting_depth_panic_message(payload: &(dyn core::any::Any + Send)) -> Option<
         .downcast_ref::<String>()
         .map(String::as_str)
         .or_else(|| payload.downcast_ref::<&str>().copied())?;
-    text.contains("nesting depth exceeds limit of")
+    (text == format!("nesting depth exceeds limit of {MAX_NESTING_DEPTH}"))
         .then(|| text.to_string())
 }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1272,6 +1272,14 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                             // not be silently absorbed as if it were #1793.
                             std::panic::resume_unwind(payload);
                         };
+                        // Reported through the same channel, and so with
+                        // the same exit code (5), as any other uncaught
+                        // EvalError on this loop -- deliberately: this is an
+                        // internal architectural ceiling, not a jq-level
+                        // type/arity error, but the alternative (keeping the
+                        // panic's own exit 101) would still be a hard,
+                        // uncontrolled process exit for what #1793 exists to
+                        // turn into an ordinary, recoverable diagnostic.
                         sink.report(DiagStyle::Jq, &EvalError::new(message), &at);
                         // Mirrors the same check a few lines below, after the
                         // ordinary per-result loop -- halt/halt_error (#791)

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1233,7 +1233,49 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // jq names the line the input value ends on, counted in the
                 // whole file rather than in this value's slice.
                 let at = InputLocation::at(filename.as_deref(), line_counter.advance_to(end));
-                let results = evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink);
+                // A builtin with no native lazy fast path (`sort`, `join`,
+                // ...) falls back to a full `to_owned_cursor` materialization
+                // of whatever value it's handed -- for a bare `sort`/`join`
+                // piped directly off `.`, that's the whole document. Unlike
+                // `#1194`-style malformed-document errors (handled a few
+                // lines below via `sink.report` + `continue`, isolating just
+                // this one document), an adversarially/accidentally deep
+                // document here used to escape as an uncaught panic instead,
+                // aborting the whole run and silently dropping every
+                // subsequent document in the stream (#1793). `catch_unwind`
+                // isolates it the same way #1194's own error already is,
+                // without touching `to_owned_cursor_at_depth`'s panic itself
+                // -- that guard's docs (`eval_generic.rs`, above
+                // `assert_nesting_depth`) explain why threading this through
+                // `EvalError` at its 58+ interior call sites was tried and
+                // reverted (#1021): only the two outermost call sites
+                // reachable from ordinary CLI usage are wrapped here, not
+                // the guard itself.
+                let results = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink)
+                })) {
+                    Ok(results) => results,
+                    Err(payload) => {
+                        // `&*payload`, not `&payload` -- `payload` is a
+                        // `Box<dyn Any + Send>`, and a bare `&payload`
+                        // coerces to `&(dyn Any + Send)` by treating the
+                        // *Box* as the concrete type under test (`Box<T>`
+                        // is itself `Any` via a blanket impl), not the value
+                        // it holds -- so every `downcast_ref` inside the
+                        // helper would silently miss regardless of the
+                        // panic's real payload type. Confirmed live: `&payload`
+                        // here made `nesting_depth_panic_message` return
+                        // `None` even for this exact panic.
+                        let Some(message) = nesting_depth_panic_message(&*payload) else {
+                            // Not the specific guard this catch exists for --
+                            // an unexpected panic must still crash loudly,
+                            // not be silently absorbed as if it were #1793.
+                            std::panic::resume_unwind(payload);
+                        };
+                        sink.report(DiagStyle::Jq, &EvalError::new(message), &at);
+                        continue;
+                    }
+                };
 
                 // Consume results to free memory after each value is written
                 for result in results {
@@ -3387,6 +3429,25 @@ fn evaluate_input(
             Ok(vs)
         }
     }
+}
+
+/// If `payload` (a caught panic's payload) is `to_owned_cursor_at_depth`'s
+/// `MAX_NESTING_DEPTH` guard (#1793), returns its message; `None` for any
+/// other panic, so a caller can `resume_unwind` anything unrelated rather
+/// than silently treating an unexpected panic as this specific, known one.
+///
+/// `assert!`'s formatted message (`"nesting depth exceeds limit of
+/// {MAX_NESTING_DEPTH}"`) panics with a `String` payload, not `&'static
+/// str` -- checked first since it's the only shape this specific guard
+/// actually produces; the `&str` check is defense-in-depth for a future
+/// caller of this same helper against an unformatted `panic!("literal")`.
+fn nesting_depth_panic_message(payload: &(dyn core::any::Any + Send)) -> Option<String> {
+    let text = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())?;
+    text.contains("nesting depth exceeds limit of")
+        .then(|| text.to_string())
 }
 
 /// Evaluate expression against raw JSON bytes, returning lazy JqValues.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16438,6 +16438,118 @@ fn test_exit_status_query_materializes_object_998() -> Result<()> {
     Ok(())
 }
 
+/// #1793: `sort`/`join`/`map(.)` have no native lazy fast path for a
+/// container-shaped condition (`sort`, `join`) or still have to materialize
+/// their `LazySeq` result before printing (`map(.)`), so each falls back to
+/// `to_owned_cursor_at_depth` -- the *same* `MAX_NESTING_DEPTH` guard
+/// `test_identity_query_rejects_adversarial_nesting_998` already covers for
+/// the identity path, but reached with no equivalent guard at this call
+/// site: an uncaught panic (exit 101) rather than a clean diagnostic. Fixed
+/// by isolating the panic with `catch_unwind` at the CLI's per-document
+/// dispatch, matching the exit code (5) and cross-file-tracer-confirmed
+/// clean-diagnostic behavior of every other uncaught-error path in this
+/// same loop (`#1194`, `#355`) -- not `-e`'s separate, still-101
+/// `cursor_to_owned` panic path (`lazy.rs`, untouched by this fix, see
+/// `test_exit_status_query_rejects_adversarial_nesting_998` above).
+#[test]
+fn test_sort_reports_clean_error_on_adversarial_nesting_1793() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "sort"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1793 sibling case: `map(.)`'s panic originates from a different call
+/// site than `sort`'s (its own lazy fast path stays lazy through
+/// evaluation; the panic instead comes from materializing its `LazySeq`
+/// result just before printing) but funnels into the same guard and must
+/// be caught the same way.
+#[test]
+fn test_map_identity_reports_clean_error_on_adversarial_nesting_1793() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "map(.)"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1793 sibling case: `join`, like `sort`, has no native lazy fast path in
+/// `eval_builtin` and falls to the same generic materializing bridge.
+#[test]
+fn test_join_reports_clean_error_on_adversarial_nesting_1793() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "join(\",\")"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the three tests above: legitimately-nested input well under
+/// the limit must still succeed, unaffected by the new `catch_unwind` guard.
+#[test]
+fn test_sort_accepts_nesting_under_limit_1793() -> Result<()> {
+    // `nested_arrays(100)` is already a complete, single-element array
+    // literal (`[[[...1...]]]`) -- sorting a 1-element array is a no-op,
+    // returning it unchanged, not wrapping it in another array.
+    let input = nested_arrays(100);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "sort"], Some(&input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}
+
+/// #1793's real-world-relevant failure mode: before this fix, one
+/// adversarially-deep document *anywhere* in a multi-document stream
+/// silently discarded every document after it too, since the uncaught
+/// panic aborted the whole process rather than just that one document --
+/// unlike `#1194`'s established "isolate this document, continue the
+/// stream" convention a few lines above this fix's own call site. Uses
+/// `map(.)` (identity via the lazy fast path) so the first and third
+/// records need no builtin-specific behavior to prove they still get
+/// processed.
+#[test]
+fn test_adversarial_nesting_does_not_abort_rest_of_stream_1793() -> Result<()> {
+    let deep = format!("[{}]", nested_arrays(500));
+    let input = format!("[1]\n{deep}\n[2]\n");
+    let (stdout, stderr, code) = run_jq_full(&["-c", "map(.)"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec!["[1]", "[2]"],
+        "the documents on either side of the adversarial one must still be processed\nstdout: {stdout:?}"
+    );
+    Ok(())
+}
+
+/// #1793 review: an unrelated panic (not the `MAX_NESTING_DEPTH` guard this
+/// fix targets) must still crash the process rather than being silently
+/// absorbed as if it were this specific, known condition. `sort` on a
+/// non-array is an ordinary jq-level type error (reported via `sink`, no
+/// panic involved) — included as a control case confirming the new
+/// `catch_unwind` wrapper doesn't change behavior for the vastly more
+/// common "no panic at all" path.
+#[test]
+fn test_sort_on_non_array_is_unaffected_by_1793_fix() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "sort"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("cannot be sorted"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #1008 (yq PR) code review: `format_number_jq_compat`'s `value == 0.0`/
 /// `value as i64` checks don't distinguish -0.0 from 0.0 (IEEE 754), so a
 /// negative-zero exponent literal silently lost its sign across all three

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16550,6 +16550,31 @@ fn test_sort_on_non_array_is_unaffected_by_1793_fix() -> Result<()> {
     Ok(())
 }
 
+/// #1793 review: `assert_value_tree_depth`'s `MAX_VALUE_TREE_DEPTH` (384)
+/// guard shares `to_owned_cursor_at_depth`'s `MAX_NESTING_DEPTH` (256)
+/// guard's exact message template via the same underlying `assert_depth`
+/// call (`src/jq/value.rs`) -- byte-identical apart from the interpolated
+/// number. An earlier version of this fix matched on that shared substring
+/// and silently swallowed this *different* guard's panic (filter-driven
+/// value growth, not document nesting) as if it were #1793's own condition.
+/// This must still crash uncaught -- absorbing it silently would mask a
+/// genuinely different failure class behind #1793's message.
+#[test]
+fn test_unrelated_value_tree_depth_panic_is_not_caught_by_1793_fix() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "reduce range(400) as $i (null; [.])"], Some("null"))
+            .unwrap_or_else(|e| panic!("run failed: {e}"));
+    assert_eq!(
+        code, 101,
+        "an unrelated MAX_VALUE_TREE_DEPTH panic must still crash uncaught, not be silently absorbed as #1793's own guard\nstdout: {stdout:?}\nstderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 384"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1008 (yq PR) code review: `format_number_jq_compat`'s `value == 0.0`/
 /// `value as i64` checks don't distinguish -0.0 from 0.0 (IEEE 754), so a
 /// negative-zero exponent literal silently lost its sign across all three


### PR DESCRIPTION
Fixes #1793

## Summary

`sort`/`join`/`map(.)` have no native lazy fast path (or, for `map(.)`, still need to materialize their `LazySeq` result before printing) and fall back to `to_owned_cursor_at_depth`'s `MAX_NESTING_DEPTH` guard — a deliberate `panic!`, not an `EvalError` (see that guard's own doc comment and #1021's history: routing this through `EvalError` was tried and reverted because it makes a stack-safety guard catchable by `try`/`catch`).

For a bare `sort`/`map(.)`/`join(",")` on `.`, an adversarially or accidentally deep document used to escape as an **uncaught panic** — not just an ugly message, but a real process abort that silently discarded every subsequent document in a multi-value stream too, unlike the `#1194`/`#355` "isolate this one document, continue the stream" convention this same CLI loop already follows for every other uncaught-error class.

## Fix

Wrapped the CLI's per-document `evaluate_bytes_lazy` call (`jq_runner.rs`) in `catch_unwind`, matching this specific panic's message and routing it through the same `sink.report()` + `continue` path `#1194` already uses. Anything that doesn't match this exact guard's message is re-raised via `resume_unwind` — an unexpected panic still crashes loudly, it's not silently absorbed as if it were this one known condition.

This only touches the CLI's outermost per-document call site, not `to_owned_cursor_at_depth`'s 58+ interior call sites or `EvalError`/`Control`'s own shape, so it doesn't reopen #1021's stack-safety regression. `-e`'s own separate panic path (`lazy.rs`'s `cursor_to_owned`) is untouched — confirmed live, `test_exit_status_query_rejects_adversarial_nesting_998` still panics at exit 101 exactly as before.

## Before / after

```
$ succinctly jq -c 'sort' huge-stream.json
thread 'main' panicked at src/jq/eval_generic.rs:267:5: nesting depth exceeds limit of 256
# process aborted, every document after the offending one silently lost
```
```
$ succinctly jq -c 'sort' huge-stream.json
jq: error (at huge-stream.json:1042): nesting depth exceeds limit of 256
# exit 5, and every other document in the stream still gets processed
```

## A footgun found along the way

`payload: Box<dyn Any + Send>` from `catch_unwind`'s `Err`, and a bare `&payload` coerces to `&(dyn Any + Send)` by treating the **Box itself** as the concrete type under test (`Box<T>` is `Any` too, via a blanket impl) rather than looking at what it holds — so `downcast_ref` inside a helper taking `&(dyn Any + Send)` silently misses regardless of the real payload type unless the Box is dereferenced first (`&*payload`). Cost me a debugging round; documented at the call site.

## Testing

- 6 new regression tests: `sort`/`map(.)`/`join(",")` each get a clean exit-5 diagnostic instead of panicking; a companion "still succeeds under the limit" test; the headline test (`test_adversarial_nesting_does_not_abort_rest_of_stream_1793`) proving sibling documents on either side of the adversarial one are still processed; a control case confirming an ordinary (non-panic) type error is unaffected.
- All 4 pre-existing `#998`/`-e` nesting tests still pass unchanged.
- YAML confirmed unaffected — its own parser enforces a lower (128), already-graceful structural limit at parse time, so it never reaches this guard.
- Full `cargo test --features cli,regex` (55/55 green), both CI clippy legs, `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --all-features`.
- Interleaved release-build A/B (this branch vs. unmodified `main`, 500K-small-document identity stream): output byte-identical, timing within noise across 4 reps — `catch_unwind`'s cost is near-zero on the non-panicking path.