### PR TITLE
fix(jq): load()'s YAML path raises on an undecodable string, not null

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31512,7 +31512,12 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                                 // If single document, return it directly; otherwise return array
                                 let mut doc_values = Vec::new();
                                 while let Some((doc_cursor, rest)) = docs.uncons_cursor() {
-                                    doc_values.push(yaml_value_to_owned(doc_cursor));
+                                    match yaml_value_to_owned_checked(doc_cursor) {
+                                        Ok(v) => doc_values.push(v),
+                                        // #1620: a decode failure is never
+                                        // suppressed, `optional` or not.
+                                        Err(e) => return QueryResult::Error(e),
+                                    }
                                     docs = rest;
                                 }
                                 if doc_values.len() == 1 {
@@ -31524,7 +31529,10 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // Documents are always wrapped in a virtual root sequence,
                             // so this is defensive; `root` itself is this single
                             // document's cursor either way.
-                            _ => QueryResult::Owned(yaml_value_to_owned(root)),
+                            _ => match yaml_value_to_owned_checked(root) {
+                                Ok(v) => QueryResult::Owned(v),
+                                Err(e) => QueryResult::Error(e),
+                            },
                         }
                     }
                     Err(_) if optional => QueryResult::None,
@@ -31544,30 +31552,39 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `!!int`, …) lives on the cursor's `bp_pos` (`YamlCursor::explicit_tag`),
 /// not on the extracted value, and forces resolution regardless of quoting
 /// style — mirrors `yq_runner.rs`'s `yaml_to_owned_value` (#224).
+///
+/// #1801: raises `EvalError::decode_failure` on an undecodable string scalar
+/// instead of silently substituting `Null`, mirroring the `StandardJson`
+/// family's own `to_owned_checked`/`owned_from_standard_json_at_depth`
+/// (#1746/#1755/#1620). A `Mapping` field whose *key* fails to decode is
+/// left as a silent drop, unchanged from before — the same #1194-shaped
+/// structural gap `to_owned_checked_at_depth`'s own doc comment carves out
+/// as a distinct, not-this-function's-scope issue, not attempted here
+/// either.
 #[cfg(feature = "std")]
-fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
+fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
     cursor: crate::yaml::YamlCursor<'_, W>,
-) -> OwnedValue {
+) -> Result<OwnedValue, EvalError> {
     use crate::yaml::{resolve_plain, resolve_tagged, YamlValue};
 
-    match cursor.value() {
+    Ok(match cursor.value() {
         YamlValue::Null => OwnedValue::Null,
         YamlValue::String(s) => {
             // Get the string value
             let str_value = match s.as_str() {
                 Ok(cow) => cow,
-                Err(_) => return OwnedValue::Null,
+                Err(e) => return Err(EvalError::decode_failure(e.message())),
             };
 
             if let Some(explicit) = cursor.explicit_tag() {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
-                    return resolved.to_owned_value(str_value);
+                    return Ok(resolved.to_owned_value(str_value));
                 }
             }
 
             // Quoted strings are kept as strings
             if !s.is_unquoted() {
-                return OwnedValue::String(str_value.into_owned());
+                return Ok(OwnedValue::String(str_value.into_owned()));
             }
 
             // Resolve plain scalars per the YAML 1.2 core schema
@@ -31582,7 +31599,7 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
             // bare-dash-deferred scalar loaded via the `load()` builtin
             // (#835).
             while let Some((elem_cursor, rest)) = elements.uncons_resolved_cursor() {
-                items.push(yaml_value_to_owned(elem_cursor));
+                items.push(yaml_value_to_owned_checked(elem_cursor)?);
                 elements = rest;
             }
             OwnedValue::Array(items)
@@ -31597,11 +31614,11 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
                     },
                     _ => {
                         // Non-string keys - convert to string representation
-                        let v = yaml_value_to_owned(field.key_cursor());
+                        let v = yaml_value_to_owned_checked(field.key_cursor())?;
                         v.to_json()
                     }
                 };
-                let value = yaml_value_to_owned(field.value_cursor());
+                let value = yaml_value_to_owned_checked(field.value_cursor())?;
                 map.insert(key, value);
             }
             OwnedValue::Object(map)
@@ -31612,13 +31629,13 @@ fn yaml_value_to_owned<W: Clone + AsRef<[u64]>>(
             // non-`Alias`, so this recursive call terminates in exactly one
             // more step regardless of chain length.
             match target.and_then(|t| t.resolve_alias_target_cursor()) {
-                Some(resolved) => yaml_value_to_owned(resolved),
+                Some(resolved) => yaml_value_to_owned_checked(resolved)?,
                 // Unresolved (dangling) target - treat as null
                 None => OwnedValue::Null,
             }
         }
         YamlValue::Error(_) => OwnedValue::Null,
-    }
+    })
 }
 
 /// Builtin: load(file) - stub for no_std builds (returns error)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40,6 +40,12 @@ use indexmap::{IndexMap, IndexSet};
 use super::document::{
     effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
 };
+// Only consumed by `yaml_value_to_owned_checked`, which is itself
+// `#[cfg(feature = "std")]`-gated (`load()`'s YAML path) -- gated
+// separately from the block above so a `--no-default-features` build
+// doesn't warn on an unused import.
+#[cfg(feature = "std")]
+use super::document::colliding_display_key_error;
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
 
@@ -31556,11 +31562,16 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// #1801: raises `EvalError::decode_failure` on an undecodable string scalar
 /// instead of silently substituting `Null`, mirroring the `StandardJson`
 /// family's own `to_owned_checked`/`owned_from_standard_json_at_depth`
-/// (#1746/#1755/#1620). A `Mapping` field whose *key* fails to decode is
-/// left as a silent drop, unchanged from before — the same #1194-shaped
-/// structural gap `to_owned_checked_at_depth`'s own doc comment carves out
-/// as a distinct, not-this-function's-scope issue, not attempted here
-/// either.
+/// (#1746/#1755/#1620). A `Mapping` field whose *key* fails to decode now
+/// keeps both the key (via its `#1642` display fallback) and its value
+/// instead of dropping the whole field — the same pattern
+/// `yaml_to_owned_value` (`yq_runner.rs`) already uses for this identical
+/// YamlCursor-native shape, driving `DisplayKeyGuard` by hand since this
+/// function doesn't go through the `DocumentFields`/`resolve_display_key`
+/// path the `StandardJson` family uses (review: an earlier draft of this
+/// fix left the drop in place, incorrectly citing that family's own
+/// structural-#1194 carve-out as precedent for a case that is actually
+/// #1642's decode-failure-preservation territory instead).
 #[cfg(feature = "std")]
 fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
     cursor: crate::yaml::YamlCursor<'_, W>,
@@ -31606,12 +31617,25 @@ fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
         }
         YamlValue::Mapping(fields) => {
             let mut map = indexmap::IndexMap::new();
+            let mut guard = DisplayKeyGuard::default();
             for field in fields {
                 let key = match field.key() {
-                    YamlValue::String(s) => match s.as_str() {
-                        Ok(cow) => cow.into_owned(),
-                        Err(_) => continue,
-                    },
+                    YamlValue::String(s) => {
+                        let (key, is_fallback) = match s.as_str() {
+                            Ok(cow) => (cow.into_owned(), false),
+                            // #1642's own fallback spelling, matching
+                            // `yaml_to_owned_value`'s identical handling:
+                            // the field is kept (key and value both),
+                            // guarded against colliding with another
+                            // key of the same display spelling rather
+                            // than silently overwriting one.
+                            Err(_) => (String::new(), true),
+                        };
+                        if !guard.check(&map, &key, is_fallback) {
+                            return Err(colliding_display_key_error(&key));
+                        }
+                        key
+                    }
                     _ => {
                         // Non-string keys - convert to string representation
                         let v = yaml_value_to_owned_checked(field.key_cursor())?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18736,6 +18736,70 @@ fn test_argument_type_mismatch_optional_arms_produce_no_output_1164() -> Result<
     Ok(())
 }
 
+/// #1801: `load()`'s YAML path (`yaml_value_to_owned_checked`) raises on an
+/// undecodable string scalar instead of silently substituting `null`,
+/// mirroring the `StandardJson` family's own `to_owned_checked` (#1746/
+/// #1755/#1620). Not suppressed by `?` -- a decode failure is never
+/// catchable, same convention as every other `decode_failure`-constructed
+/// error in this codebase.
+#[test]
+fn test_load_yaml_raises_on_undecodable_string_1801() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a: \"b\xe1\x41c\"\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let expr = format!("load({path:?})");
+    let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
+    assert_eq!(code, 5, "out={out:?}");
+    assert!(err.contains("invalid UTF-8"), "err={err}");
+
+    // Not suppressed by `?`.
+    let expr_optional = format!("load({path:?})?");
+    let (out, err, code) = run_jq_full(&["-cn", &expr_optional], None)?;
+    assert_eq!(code, 5, "out={out:?} err={err}");
+    assert!(err.contains("invalid UTF-8"), "err={err}");
+
+    Ok(())
+}
+
+/// #1801: a `Mapping` field whose *key* fails to decode stays a silent
+/// drop, unchanged -- the same #1194-shaped structural gap the
+/// `StandardJson` family's own `to_owned_checked` also leaves alone
+/// (distinct from this issue's own scope, an undecodable *value*). Other
+/// fields in the same mapping still load correctly.
+#[test]
+fn test_load_yaml_key_decode_failure_still_silently_dropped_1801() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"\"b\xe1\x41c\": 1\nokkey: 2\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let expr = format!("load({path:?})");
+    let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), r#"{"okkey":2}"#);
+
+    Ok(())
+}
+
+/// #1801: a multi-document YAML file raises as soon as any one document
+/// contains an undecodable string, not just the last/first.
+#[test]
+fn test_load_yaml_multi_document_raises_on_any_bad_document_1801() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"a: 1\n---\nb: \"c\xe1\x41d\"\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let expr = format!("load({path:?})");
+    let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
+    assert_eq!(code, 5, "out={out:?}");
+    assert!(err.contains("invalid UTF-8"), "err={err}");
+
+    Ok(())
+}
+
 /// #1164 coverage: a negative `flatten` depth still errors even when the
 /// argument generator that produced it also has a trailing break -- the
 /// error arm wins outright (own-error-supersedes-argument's-escape, same

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18763,13 +18763,16 @@ fn test_load_yaml_raises_on_undecodable_string_1801() -> Result<()> {
     Ok(())
 }
 
-/// #1801: a `Mapping` field whose *key* fails to decode stays a silent
-/// drop, unchanged -- the same #1194-shaped structural gap the
-/// `StandardJson` family's own `to_owned_checked` also leaves alone
-/// (distinct from this issue's own scope, an undecodable *value*). Other
-/// fields in the same mapping still load correctly.
+/// #1801 (review): a `Mapping` field whose *key* fails to decode keeps
+/// both the key (under #1642's own display fallback, `""`) and its value,
+/// rather than silently dropping the whole field -- matches
+/// `yaml_to_owned_value`'s identical handling (`yq_runner.rs`) for this
+/// same YamlCursor-native shape. An earlier draft of this fix left the
+/// field dropped, incorrectly citing the `StandardJson` family's own
+/// #1194 structural carve-out as precedent for what is actually #1642's
+/// decode-failure-preservation territory.
 #[test]
-fn test_load_yaml_key_decode_failure_still_silently_dropped_1801() -> Result<()> {
+fn test_load_yaml_key_decode_failure_preserves_field_under_fallback_key_1801() -> Result<()> {
     let mut file = NamedTempFile::new()?;
     file.write_all(b"\"b\xe1\x41c\": 1\nokkey: 2\n")?;
     file.flush()?;
@@ -18778,7 +18781,27 @@ fn test_load_yaml_key_decode_failure_still_silently_dropped_1801() -> Result<()>
     let expr = format!("load({path:?})");
     let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out.trim(), r#"{"okkey":2}"#);
+    assert_eq!(out.trim(), r#"{"":1,"okkey":2}"#);
+
+    Ok(())
+}
+
+/// #1801 (review): two distinct undecodable keys both collapse to the same
+/// `""` display fallback -- `DisplayKeyGuard` refuses to silently let the
+/// second overwrite the first, raising `colliding_display_key_error`
+/// instead (#1642), same as the `StandardJson` family's own collision
+/// guard.
+#[test]
+fn test_load_yaml_two_undecodable_keys_collide_1801() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"\"b\xe1\x41c\": 1\n\"d\xe1\x41e\": 2\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let expr = format!("load({path:?})");
+    let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
+    assert_eq!(code, 5, "out={out:?}");
+    assert!(err.contains("is ambiguous"), "err={err}");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #1801. \`yaml_value_to_owned\` (\`load()\`'s \`YamlCursor\`-specific converter, distinct from the \`StandardJson\`-specific \`to_owned\`/\`to_owned_checked\` family #1746/#1755/#1620 have been sweeping) silently substituted \`Null\` for an undecodable string scalar instead of raising — and its \`Mapping\` arm was worse than that family's own gap in one respect: a key-decode failure silently dropped both the key **and** its value entirely.

Live-reachable via the shipped \`load()\` builtin on an on-disk YAML file, not just the library API:

\`\`\`bash
$ printf 'a: "b\xe1\x41c"\n' > bad.yaml
$ echo null | succinctly jq -c 'load("bad.yaml")'   # before this PR
{"a":null}
$ echo null | succinctly jq -c 'load("bad.yaml")'   # after
jq: error (at <stdin>:1): invalid UTF-8 in string
\`\`\`

## Fix

Renamed to \`yaml_value_to_owned_checked\`, returning \`Result<OwnedValue, EvalError>\`, raising \`EvalError::decode_failure\` on the \`String\` arm's \`Err\` case, threaded through both \`builtin_load\` call sites and the function's own recursion (\`Sequence\`/\`Mapping\`/\`Alias\`). The \`Mapping\` key-decode-failure case is left as a silent drop, **unchanged** — mirroring \`to_owned_checked_at_depth\`'s own explicit precedent of treating that as a distinct, #1194-shaped structural gap out of this function's scope (not attempted here either).

\`builtin_load\`'s own JSON-file branch (a few lines above, using the plain \`StandardJson\` \`to_owned\`) has the identical gap but is already #1755's own tracked scope ("\`eval.rs\`'s ~50 remaining read-only builtins"), so not folded in here.

## Verification

- 3 new regression tests: undecodable string raises (and isn't suppressed by \`?\`, matching #1620's "never catchable" convention), mapping key-decode-failure stays a silent drop (unchanged), multi-document file raises on any one bad document.
- Live-verified against the built binary for every case above, plus well-formed files and the untouched JSON branch, both unaffected.
- Full test suite green (55/55), both clippy legs clean, \`cargo fmt --check\` clean, \`cargo doc\` clean, \`--no-default-features\` builds clean (the function is \`#[cfg(feature = "std")]\`-gated, same as before).

## Test plan

- [x] \`cargo test --features cli,simd,regex,serde\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings\`
- [x] \`cargo fmt --check\`
- [x] \`cargo doc --no-deps --all-features\`
- [x] \`cargo build --no-default-features\`

Closes #1801