### PR TITLE
fix(jq): plug decode-failure corruption in the misc-bucket family

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6626,15 +6626,14 @@ fn builtin_any<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
+    let owned_bool = |r: Result<bool, EvalError>| {
+        r.map_or_else(QueryResult::Error, |b| {
+            QueryResult::Owned(OwnedValue::Bool(b))
+        })
+    };
     match value {
-        StandardJson::Array(elements) => match any_all_over(elements, true) {
-            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
-            Err(e) => QueryResult::Error(e),
-        },
-        StandardJson::Object(fields) => match any_all_over(fields.map(|f| f.value()), true) {
-            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
-            Err(e) => QueryResult::Error(e),
-        },
+        StandardJson::Array(elements) => owned_bool(any_all_over(elements, true)),
+        StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), true)),
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
@@ -6647,15 +6646,14 @@ fn builtin_all<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
+    let owned_bool = |r: Result<bool, EvalError>| {
+        r.map_or_else(QueryResult::Error, |b| {
+            QueryResult::Owned(OwnedValue::Bool(b))
+        })
+    };
     match value {
-        StandardJson::Array(elements) => match any_all_over(elements, false) {
-            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
-            Err(e) => QueryResult::Error(e),
-        },
-        StandardJson::Object(fields) => match any_all_over(fields.map(|f| f.value()), false) {
-            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
-            Err(e) => QueryResult::Error(e),
-        },
+        StandardJson::Array(elements) => owned_bool(any_all_over(elements, false)),
+        StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), false)),
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
@@ -6701,25 +6699,38 @@ fn any_all_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     target_truthy: bool,
 ) -> QueryResult<'a, W> {
-    // #1755: to_owned_checked, not to_owned -- an undecodable element must
-    // raise, not silently become "" and get probed as if it were the real
-    // value.
-    let elements: Vec<OwnedValue> = match value {
-        StandardJson::Array(elements) => match elements.map(|e| to_owned_checked(&e)).collect() {
+    match value {
+        StandardJson::Array(elements) => any_all_f_over::<W, S>(cond, elements, target_truthy),
+        StandardJson::Object(fields) => {
+            any_all_f_over::<W, S>(cond, fields.map(|f| f.value()), target_truthy)
+        }
+        _ if optional => QueryResult::None,
+        _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+    }
+}
+
+/// Shared element loop for [`any_all_f`]'s `Array`/`Object` arms.
+///
+/// #1755 review: an earlier version of this fix `to_owned_checked`-collected
+/// every element into a `Vec` upfront, before `cond` ever ran -- so a
+/// decode failure past the deciding element aborted a call that should
+/// have short-circuited before reaching it. Oracle-verified:
+/// `[1, <bad-string>] | any(.==1)` is `true` in real jq, which never needs
+/// to decode the second element. Each element is now converted right
+/// before its own `cond` probe instead, exactly restoring the pre-#1755
+/// loop's short-circuit timing while still raising on the element that
+/// actually gets reached.
+fn any_all_f_over<'a, W: Clone + AsRef<[u64]> + 'a, S: EvalSemantics>(
+    cond: &Expr,
+    elements: impl Iterator<Item = StandardJson<'a, W>>,
+    target_truthy: bool,
+) -> QueryResult<'a, W> {
+    for cursor_elem in elements {
+        let elem = match to_owned_checked(&cursor_elem) {
             Ok(v) => v,
             Err(e) => return QueryResult::Error(e),
-        },
-        StandardJson::Object(fields) => {
-            match fields.map(|f| to_owned_checked(&f.value())).collect() {
-                Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
-            }
-        }
-        _ if optional => return QueryResult::None,
-        _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
-    };
-    for elem in &elements {
-        match any_all_probe_element::<S>(cond, elem, target_truthy) {
+        };
+        match any_all_probe_element::<S>(cond, &elem, target_truthy) {
             Ok(true) => return QueryResult::Owned(OwnedValue::Bool(target_truthy)),
             Ok(false) => {}
             Err(control) => return control_to_result(control),
@@ -13916,6 +13927,55 @@ fn splits_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
+/// Push one already-produced cursor result into `eval_pipe`'s `Many`-branch
+/// element loop's promotion state: still lazily borrowed if promotion
+/// hasn't started, checked-converted into `owned` if it has.
+///
+/// #1755 review: an earlier version of this slice's fix left this specific
+/// promotion path on unchecked `to_owned`, silently corrupting an
+/// already-borrowed undecodable element the moment any sibling forced
+/// promotion to owned -- `.[] | (if type == "string" then . else . + 0
+/// end)` on `["\xff\xfe", 1]` returned `ManyOwned([String(""), Int(1)])`
+/// instead of raising. On failure, `owned` is left holding whatever
+/// pushed successfully before the failing element, matching the #400
+/// "keep the prefix" policy every other control arm in that loop follows.
+fn push_promoted<'a, W: Clone + AsRef<[u64]>>(
+    rs: impl IntoIterator<Item = StandardJson<'a, W>>,
+    borrowed: &mut Vec<StandardJson<'a, W>>,
+    owned: &mut Option<Vec<OwnedValue>>,
+) -> Result<(), EvalError> {
+    match owned {
+        Some(acc) => {
+            for r in rs {
+                acc.push(to_owned_checked(&r)?);
+            }
+            Ok(())
+        }
+        None => {
+            borrowed.extend(rs);
+            Ok(())
+        }
+    }
+}
+
+/// Promote `borrowed` into a checked `Vec<OwnedValue>`, used the moment an
+/// `Owned`/`ManyOwned` sibling in `eval_pipe`'s `Many`-branch loop forces
+/// the whole batch out of its lazy borrowed state for the first time
+/// (see [`push_promoted`]'s identical #1755 reasoning). Returns whatever
+/// converted successfully so far as the `Err` payload's own prefix.
+fn promote_borrowed_checked<W: Clone + AsRef<[u64]>>(
+    borrowed: Vec<StandardJson<'_, W>>,
+) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalError)> {
+    let mut acc = vec_with_capacity(borrowed.len());
+    for b in &borrowed {
+        match to_owned_checked(b) {
+            Ok(v) => acc.push(v),
+            Err(e) => return Err((acc, e)),
+        }
+    }
+    Ok(acc)
+}
+
 /// Evaluate a pipe (chain) of expressions.
 fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     exprs: &[Expr],
@@ -13960,31 +14020,39 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let mut owned: Option<Vec<OwnedValue>> = None;
             for v in values {
                 match eval_pipe::<W, S>(rest, v, optional).materialize_cursor() {
-                    QueryResult::One(r) => match owned.as_mut() {
-                        Some(acc) => acc.push(to_owned(&r)),
-                        None => borrowed.push(r),
-                    },
+                    QueryResult::One(r) => {
+                        if let Err(e) =
+                            push_promoted(core::iter::once(r), &mut borrowed, &mut owned)
+                        {
+                            let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                            return partial(prefix, Control::Error(e));
+                        }
+                    }
                     QueryResult::OneCursor(_) => unreachable!(),
-                    QueryResult::Many(rs) => match owned.as_mut() {
-                        Some(acc) => acc.extend(rs.iter().map(to_owned)),
-                        None => borrowed.extend(rs),
-                    },
-                    QueryResult::Owned(r) => owned
-                        .get_or_insert_with(|| {
-                            core::mem::take(&mut borrowed)
-                                .iter()
-                                .map(to_owned)
-                                .collect()
-                        })
-                        .push(r),
-                    QueryResult::ManyOwned(rs) => owned
-                        .get_or_insert_with(|| {
-                            core::mem::take(&mut borrowed)
-                                .iter()
-                                .map(to_owned)
-                                .collect()
-                        })
-                        .extend(rs),
+                    QueryResult::Many(rs) => {
+                        if let Err(e) = push_promoted(rs, &mut borrowed, &mut owned) {
+                            let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                            return partial(prefix, Control::Error(e));
+                        }
+                    }
+                    QueryResult::Owned(r) => {
+                        if owned.is_none() {
+                            match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                                Ok(acc) => owned = Some(acc),
+                                Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                            }
+                        }
+                        owned.as_mut().unwrap().push(r);
+                    }
+                    QueryResult::ManyOwned(rs) => {
+                        if owned.is_none() {
+                            match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                                Ok(acc) => owned = Some(acc),
+                                Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                            }
+                        }
+                        owned.as_mut().unwrap().extend(rs);
+                    }
                     QueryResult::None => {}
                     // A downstream error/break no longer discards outputs
                     // already piped through from earlier elements (#400).
@@ -15718,10 +15786,9 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // stream (`(1,2) | select(false)`, `(empty, empty)`) -- all
         // correctly arrive as the `None` arm above instead, confirming the
         // invariant holds for every reachable path today.
-        QueryResult::Many(vs) => match vs.first() {
-            Some(v) => to_owned_checked(v).map_err(QueryResult::Error),
-            None => Ok(OwnedValue::Null),
-        },
+        QueryResult::Many(vs) => vs.first().map_or(Ok(OwnedValue::Null), |v| {
+            to_owned_checked(v).map_err(QueryResult::Error)
+        }),
         QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().unwrap_or(OwnedValue::Null)),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
         QueryResult::Break(label) => Err(QueryResult::Break(label)),
@@ -33701,21 +33768,15 @@ fn builtin_transpose<W: Clone + AsRef<[u64]>>(
     let mut inner_arrays: Vec<Vec<OwnedValue>> = Vec::new();
     for item in elements {
         match item {
-            StandardJson::Array(inner) => {
-                let row = match inner.map(|v| to_owned_checked(&v)).collect() {
-                    Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
-                };
-                inner_arrays.push(row);
-            }
-            _ => {
-                // Non-array elements are treated as single-element arrays
-                let owned = match to_owned_checked(&item) {
-                    Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
-                };
-                inner_arrays.push(vec![owned]);
-            }
+            StandardJson::Array(inner) => match inner.map(|v| to_owned_checked(&v)).collect() {
+                Ok(row) => inner_arrays.push(row),
+                Err(e) => return QueryResult::Error(e),
+            },
+            // Non-array elements are treated as single-element arrays
+            _ => match to_owned_checked(&item) {
+                Ok(owned) => inner_arrays.push(vec![owned]),
+                Err(e) => return QueryResult::Error(e),
+            },
         }
     }
 
@@ -37461,6 +37522,66 @@ mod tests {
             QueryResult::Error(e) if e.is_decode_failure() => {}
             other => panic!("unexpected result: {other:?}"),
         }
+    }
+
+    /// #1755 code review: an earlier version of `any_all_f`'s own fix
+    /// eagerly `to_owned_checked`-collected every element into a `Vec`
+    /// before `cond` ever probed any of them, so a decode failure past
+    /// the deciding element aborted a call that should have
+    /// short-circuited before reaching it. Oracle-verified: `[1,
+    /// <bad-string>] | any(.==1)` is `true` in real jq, which never needs
+    /// to decode the second element.
+    #[test]
+    fn test_any_all_f_short_circuits_before_a_later_decode_failure_1755() {
+        query!(
+            &b"[1, \"\xff\xfe\"]"[..],
+            "any(.==1)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(
+            &b"[1, \"\xff\xfe\"]"[..],
+            "all(.==2)",
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+        );
+        // The sibling case: no earlier element decides the answer, so the
+        // walk genuinely reaches the bad element and must still raise.
+        query!(
+            &b"[\"\xff\xfe\", 1]"[..],
+            "any(.==99)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
+    /// #1755 code review: `eval_pipe`'s `Many`-branch element loop
+    /// promotes its whole batch from lazily-borrowed cursors to an owned
+    /// `Vec` the moment any sibling forces an owned result -- an earlier
+    /// version of this slice's fix left that promotion step on unchecked
+    /// `to_owned`, so `.[] | (if type == "string" then . else . + 0 end)`
+    /// on `["\xff\xfe", 1]` silently returned `ManyOwned([String(""),
+    /// Int(1)])` instead of raising.
+    #[test]
+    fn test_eval_pipe_promotion_raises_on_decode_failure_1755() {
+        query!(
+            &b"[\"\xff\xfe\", 1]"[..],
+            ".[] | (if type == \"string\" then . else . + 0 end)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // The `ManyOwned` promotion path (a multi-output owned sibling,
+        // not a single `Owned` one).
+        query!(
+            &b"[\"\xff\xfe\", 1]"[..],
+            ".[] | (if type == \"string\" then . else (.+0, .+1) end)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // Positive control: unaffected on valid data, both promotion
+        // shapes.
+        query!(
+            &b"[\"a\", 1]"[..],
+            "[.[] | (if type == \"string\" then . else . + 0 end)]",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::String("a".to_string()), OwnedValue::Int(1)]);
+            }
+        );
     }
 
     /// #1755 positive control: valid data through each of the misc

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -981,7 +981,14 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // re-deriving key/value-pair iteration against the cursor's own
             // field type.
             StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-                let OwnedValue::Object(map) = to_owned(&value) else {
+                // #1755: to_owned_checked, not to_owned -- an undecodable
+                // field value must raise, not silently become "" and get
+                // sliced as if it were the real value.
+                let owned = match to_owned_checked(&value) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                let OwnedValue::Object(map) = owned else {
                     unreachable!("StandardJson::Object always materializes to OwnedValue::Object")
                 };
                 QueryResult::Owned(slice_object_as_yq_children(&map, *start, *end))
@@ -6599,13 +6606,15 @@ fn builtin_add<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn any_all_over<'a, W: Clone + AsRef<[u64]> + 'a>(
     elements: impl Iterator<Item = StandardJson<'a, W>>,
     target_truthy: bool,
-) -> bool {
+) -> Result<bool, EvalError> {
+    // #1755: to_owned_checked, not to_owned -- an undecodable element must
+    // raise, not silently become "" (truthy) and decide the answer.
     for elem in elements {
-        if to_owned(&elem).is_truthy() == target_truthy {
-            return target_truthy;
+        if to_owned_checked(&elem)?.is_truthy() == target_truthy {
+            return Ok(target_truthy);
         }
     }
-    !target_truthy
+    Ok(!target_truthy)
 }
 
 /// Builtin: any
@@ -6618,13 +6627,14 @@ fn builtin_any<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
-        StandardJson::Array(elements) => {
-            QueryResult::Owned(OwnedValue::Bool(any_all_over(elements, true)))
-        }
-        StandardJson::Object(fields) => QueryResult::Owned(OwnedValue::Bool(any_all_over(
-            fields.map(|f| f.value()),
-            true,
-        ))),
+        StandardJson::Array(elements) => match any_all_over(elements, true) {
+            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
+            Err(e) => QueryResult::Error(e),
+        },
+        StandardJson::Object(fields) => match any_all_over(fields.map(|f| f.value()), true) {
+            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
+            Err(e) => QueryResult::Error(e),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
@@ -6638,13 +6648,14 @@ fn builtin_all<W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
-        StandardJson::Array(elements) => {
-            QueryResult::Owned(OwnedValue::Bool(any_all_over(elements, false)))
-        }
-        StandardJson::Object(fields) => QueryResult::Owned(OwnedValue::Bool(any_all_over(
-            fields.map(|f| f.value()),
-            false,
-        ))),
+        StandardJson::Array(elements) => match any_all_over(elements, false) {
+            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
+            Err(e) => QueryResult::Error(e),
+        },
+        StandardJson::Object(fields) => match any_all_over(fields.map(|f| f.value()), false) {
+            Ok(b) => QueryResult::Owned(OwnedValue::Bool(b)),
+            Err(e) => QueryResult::Error(e),
+        },
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_iterate(&to_owned(&value))),
     }
@@ -6690,9 +6701,20 @@ fn any_all_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     target_truthy: bool,
 ) -> QueryResult<'a, W> {
+    // #1755: to_owned_checked, not to_owned -- an undecodable element must
+    // raise, not silently become "" and get probed as if it were the real
+    // value.
     let elements: Vec<OwnedValue> = match value {
-        StandardJson::Array(elements) => elements.map(|e| to_owned(&e)).collect(),
-        StandardJson::Object(fields) => fields.map(|f| to_owned(&f.value())).collect(),
+        StandardJson::Array(elements) => match elements.map(|e| to_owned_checked(&e)).collect() {
+            Ok(v) => v,
+            Err(e) => return QueryResult::Error(e),
+        },
+        StandardJson::Object(fields) => {
+            match fields.map(|f| to_owned_checked(&f.value())).collect() {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            }
+        }
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
     };
@@ -6752,7 +6774,16 @@ fn any_all_gen_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // decided the answer yet. Confirmed against jq 1.7.1:
     // `all(2, (5|stderr); .==2)` writes `5` there too, and is pinned by
     // `test_short_circuit_side_effect_shapes_already_match_jq_820`.
-    let owned = to_owned(&value);
+    //
+    // #1755: to_owned_checked, not to_owned -- an undecodable root value
+    // must raise, not silently become "" and get fed to `gen` as if it
+    // were the real value. Unconditional regardless of `optional`: that
+    // flag governs `gen`'s own generator errors below, never a decode
+    // failure at this entry point.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     let mut matched = false;
     // `cond`'s own escape is not `gen`'s, so it travels out-of-band rather
@@ -8716,13 +8747,28 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         let index = crate::json::JsonIndex::build(&entry_json);
         let cursor = index.root(&entry_json);
 
+        // #1755: to_owned_checked, not to_owned -- an undecodable output
+        // of `f` must raise, not silently become "" and get folded into
+        // the object as if it were the real value. Not reachable via any
+        // query today: `entry_json` comes from `owned_to_json_bytes`,
+        // which serializes into a Rust `String` (always valid UTF-8 by
+        // the type system) before ever building the cursor `f` evaluates
+        // against, so `v` can never carry an undecodable string here --
+        // fixed anyway for the same structural-consistency reason as
+        // `eval_rhs_once`'s masked fix.
         match eval_single::<Vec<u64>, S>(f, cursor.value(), optional).materialize_cursor() {
-            QueryResult::One(v) => transformed.push(to_owned(&v)),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => transformed.push(v),
+                Err(e) => return QueryResult::Error(e),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
             QueryResult::Owned(v) => transformed.push(v),
             QueryResult::Many(vs) => {
                 for v in vs {
-                    transformed.push(to_owned(&v));
+                    match to_owned_checked(&v) {
+                        Ok(v) => transformed.push(v),
+                        Err(e) => return QueryResult::Error(e),
+                    }
                 }
             }
             QueryResult::ManyOwned(vs) => transformed.extend(vs),
@@ -11326,7 +11372,12 @@ fn builtin_upper_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    let current = to_owned(&value);
+    // #1755: to_owned_checked, not to_owned -- an undecodable input must
+    // raise, not silently seed the fold with "" in its place.
+    let current = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     match eval_owned_multi::<S>(&Expr::Iterate, &current) {
         Ok(rows) => build_upper_index::<W, S>(rows, idx_expr),
         Err(e) => e.into(),
@@ -11342,7 +11393,11 @@ fn builtin_upper_index_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    let current = to_owned(&value);
+    // #1755: see `builtin_upper_index`'s identical reasoning.
+    let current = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     match eval_owned_multi::<S>(stream, &current) {
         Ok(rows) => build_upper_index::<W, S>(rows, idx_expr),
         Err(e) => e.into(),
@@ -11505,7 +11560,14 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     };
 
-    let mut current = to_owned(value);
+    // #1755: to_owned_checked, not to_owned -- an undecodable root value
+    // must raise, not silently become "" and get walked as if it were the
+    // real value. Unconditional regardless of `optional`: that flag only
+    // governs the path-shape check above, never a decode failure.
+    let mut current = match to_owned_checked(value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     for segment in path {
         match (&current, &segment) {
@@ -13862,7 +13924,12 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Check if any expression in the pipe needs path context (PathNoArg, Parent)
     if exprs.iter().any(needs_path_context) {
-        let owned = to_owned(&value);
+        // #1755: to_owned_checked, not to_owned -- an undecodable input
+        // must raise, not silently become "" for the path-context walk.
+        let owned = match to_owned_checked(&value) {
+            Ok(v) => v,
+            Err(e) => return QueryResult::Error(e),
+        };
         return eval_pipe_with_path_context::<W, S>(exprs, &owned, &[], optional);
     }
 
@@ -15616,7 +15683,16 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> Result<OwnedValue, QueryResult<'a, W>> {
     match eval_single::<W, S>(expr, value, optional).materialize_cursor() {
-        QueryResult::One(v) => Ok(to_owned(&v)),
+        // #1755: to_owned_checked, not to_owned -- an undecodable RHS
+        // value must raise, not silently become "" and get spliced into
+        // the update filter. Both callers (`eval_compound_assign`/
+        // `eval_alternative_assign`) immediately re-materialize the
+        // *whole* document via `eval_update`'s own already-fixed
+        // `to_owned_checked`, which happens to catch a bad RHS value
+        // today since it's necessarily part of that same document --
+        // fixed here too so correctness doesn't rest on that coincidence
+        // surviving a future refactor of either caller.
+        QueryResult::One(v) => to_owned_checked(&v).map_err(QueryResult::Error),
         QueryResult::Owned(v) => Ok(v),
         // #1313: a genuinely zero-output RHS (`.a += empty`) makes the
         // *whole* compound/alternative assignment produce zero output in
@@ -15642,7 +15718,10 @@ fn eval_rhs_once<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // stream (`(1,2) | select(false)`, `(empty, empty)`) -- all
         // correctly arrive as the `None` arm above instead, confirming the
         // invariant holds for every reachable path today.
-        QueryResult::Many(vs) => Ok(vs.first().map_or(OwnedValue::Null, to_owned)),
+        QueryResult::Many(vs) => match vs.first() {
+            Some(v) => to_owned_checked(v).map_err(QueryResult::Error),
+            None => Ok(OwnedValue::Null),
+        },
         QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().unwrap_or(OwnedValue::Null)),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
         QueryResult::Break(label) => Err(QueryResult::Break(label)),
@@ -31506,7 +31585,13 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // Parse as JSON
                 let index = crate::json::JsonIndex::build(&file_bytes);
                 let cursor = index.root(&file_bytes);
-                QueryResult::Owned(to_owned(&cursor.value()))
+                // #1755: to_owned_checked, not to_owned -- an undecodable
+                // value in the loaded file must raise, not silently
+                // become "".
+                match to_owned_checked(&cursor.value()) {
+                    Ok(v) => QueryResult::Owned(v),
+                    Err(e) => QueryResult::Error(e),
+                }
             } else {
                 // Parse as YAML (default)
                 match crate::yaml::YamlIndex::build(&file_bytes) {
@@ -31693,7 +31778,14 @@ fn builtin_combinations<W: Clone + AsRef<[u64]>>(
             for elem in *elements {
                 match elem {
                     StandardJson::Array(inner) => {
-                        let inner_values: Vec<OwnedValue> = inner.map(|v| to_owned(&v)).collect();
+                        // #1755: to_owned_checked, not to_owned -- an
+                        // undecodable element must raise, not silently
+                        // become "" and take part in the product.
+                        let inner_values: Vec<OwnedValue> =
+                            match inner.map(|v| to_owned_checked(&v)).collect() {
+                                Ok(v) => v,
+                                Err(e) => return QueryResult::Error(e),
+                            };
                         arrays.push(inner_values);
                     }
                     _ if optional => return QueryResult::None,
@@ -31799,8 +31891,15 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 
     // Input must be an array
-    let base_array = match &value {
-        StandardJson::Array(elements) => (*elements).map(|v| to_owned(&v)).collect::<Vec<_>>(),
+    // #1755: to_owned_checked, not to_owned -- an undecodable element must
+    // raise, not silently become "" and take part in the product.
+    let base_array: Vec<OwnedValue> = match &value {
+        StandardJson::Array(elements) => {
+            match (*elements).map(|v| to_owned_checked(&v)).collect() {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            }
+        }
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::type_error("array", type_name(&value))),
     };
@@ -33167,7 +33266,12 @@ fn builtin_debug<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
-    let owned = to_owned(&value);
+    // #1755: to_owned_checked, not to_owned -- an undecodable value must
+    // raise, not silently print/pass through "" in its place.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     write_debug_line::<S>(&owned);
     QueryResult::Owned(owned)
 }
@@ -33208,7 +33312,11 @@ fn builtin_debug_msg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    let owned = to_owned(&value);
+    // #1755: see `builtin_debug`'s identical reasoning.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     let flow = eval_each_owned::<S>(msg, &owned, false, &mut |msg_value| {
         write_debug_line::<S>(&msg_value);
         Demand::Continue
@@ -33278,7 +33386,12 @@ fn builtin_stderr<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
-    let owned = to_owned(&value);
+    // #1755: to_owned_checked, not to_owned -- an undecodable value must
+    // raise, not silently print/pass through "" in its place.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     match &owned {
         OwnedValue::String(s) => write_stderr(s),
         other => write_stderr(&owned_value_to_json::<S>(other)),
@@ -33360,7 +33473,13 @@ fn builtin_halt_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         None => S::DEFAULT_HALT_ERROR_CODE,
     };
 
-    let owned = to_owned(&value);
+    // #1755: to_owned_checked, not to_owned -- an undecodable value must
+    // raise a normal, catchable error rather than halting the process with
+    // a corrupted "" message in its place.
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) => return QueryResult::Error(e),
+    };
     match &owned {
         OwnedValue::Null => {}
         OwnedValue::String(s) => write_stderr(s),
@@ -33577,15 +33696,25 @@ fn builtin_transpose<W: Clone + AsRef<[u64]>>(
     };
 
     // Collect all inner arrays
+    // #1755: to_owned_checked, not to_owned -- an undecodable element must
+    // raise, not silently become "" and take part in the transpose.
     let mut inner_arrays: Vec<Vec<OwnedValue>> = Vec::new();
     for item in elements {
         match item {
             StandardJson::Array(inner) => {
-                inner_arrays.push(inner.map(|v| to_owned(&v)).collect());
+                let row = match inner.map(|v| to_owned_checked(&v)).collect() {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                inner_arrays.push(row);
             }
             _ => {
                 // Non-array elements are treated as single-element arrays
-                inner_arrays.push(vec![to_owned(&item)]);
+                let owned = match to_owned_checked(&item) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                inner_arrays.push(vec![owned]);
             }
         }
     }
@@ -34120,7 +34249,14 @@ fn builtin_shuffle<W: Clone + AsRef<[u64]>>(
 
     match value {
         StandardJson::Array(elements) => {
-            let mut items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // element must raise, not silently become "" and get shuffled
+            // in as if it were the real value.
+            let mut items: Vec<OwnedValue> = match elements.map(|e| to_owned_checked(&e)).collect()
+            {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
             // Use a seeded RNG for reproducibility in tests if needed,
             // but seed from system entropy for actual randomness
             let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
@@ -34159,7 +34295,13 @@ fn builtin_pivot<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let items: Vec<OwnedValue> = elements.map(|e| to_owned(&e)).collect();
+            // #1755: to_owned_checked, not to_owned -- an undecodable
+            // element must raise, not silently become "" and get pivoted
+            // in as if it were the real value.
+            let items: Vec<OwnedValue> = match elements.map(|e| to_owned_checked(&e)).collect() {
+                Ok(v) => v,
+                Err(e) => return QueryResult::Error(e),
+            };
 
             if items.is_empty() {
                 // Empty array pivots to empty array
@@ -37265,6 +37407,150 @@ mod tests {
         query!(br"[1]", "[tostream]",
             QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 2); }
         );
+    }
+
+    /// #1755: the "misc bucket" slice -- `INDEX`/`INDEX(stream;...)`,
+    /// `getpath`, `any`/`all` (bare and `(cond)`/`(gen;cond)` forms),
+    /// `eval_pipe`'s path-context entry, `combinations`/`combinations(n)`,
+    /// `debug`/`debug(msg)`/`stderr`/`halt_error`, `transpose`, `shuffle`,
+    /// and `pivot` all convert their starting value (or an element of it)
+    /// via a single `to_owned` call -- an undecodable value must raise
+    /// there, not silently become `""` and feed the rest of the builtin as
+    /// if it were the real value.
+    #[test]
+    fn test_misc_bucket_raises_on_decode_failure_1755() {
+        for (json, expr) in [
+            (&b"[\"\xff\xfe\"]"[..], "INDEX(.)"),
+            (&b"[\"\xff\xfe\"]"[..], "INDEX(.[]; .)"),
+            (&b"\"\xff\xfe\""[..], "getpath([])"),
+            (&b"[\"\xff\xfe\"]"[..], "any"),
+            (&b"[\"\xff\xfe\"]"[..], "all"),
+            (&b"[\"\xff\xfe\"]"[..], "any(.>0)"),
+            (&b"[\"\xff\xfe\"]"[..], "all(.>0)"),
+            (&b"[\"\xff\xfe\"]"[..], "any(.[]; true)"),
+            (&b"[\"\xff\xfe\"]"[..], "all(.[]; true)"),
+            (&b"[\"\xff\xfe\"]"[..], ".[] | key"),
+            (&b"[[\"\xff\xfe\"]]"[..], "combinations"),
+            (&b"[\"\xff\xfe\"]"[..], "combinations(2)"),
+            (&b"\"\xff\xfe\""[..], "debug"),
+            (&b"\"\xff\xfe\""[..], "debug(1)"),
+            (&b"\"\xff\xfe\""[..], "stderr"),
+            (&b"\"\xff\xfe\""[..], "halt_error"),
+            (&b"[[\"\xff\xfe\"]]"[..], "transpose"),
+            (&b"[\"\xff\xfe\"]"[..], "transpose"),
+            (&b"[\"\xff\xfe\"]"[..], "shuffle"),
+            (&b"[[\"\xff\xfe\"]]"[..], "pivot"),
+        ] {
+            query!(
+                json,
+                expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {}
+            );
+        }
+
+        // `eval_single`'s yq-mode object slice arm is gated on
+        // `S::TAG == EvalTag::Yq`, so `yq_query!`'s error pattern (which
+        // panics with `unexpected result` on anything but the exact given
+        // pattern) can't express "any decode-failure error" as directly as
+        // a manual `match` -- written out below instead.
+        let json_bytes: &[u8] = b"{\"a\": \"\xff\xfe\"}";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let expr = parse_with_mode_and_extensions(".[0:1]", ParserMode::Yq, true).unwrap();
+        match eval::<Vec<u64>, YqSemantics>(&expr, cursor) {
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1755 positive control: valid data through each of the misc
+    /// bucket's dispatch points is unaffected by routing through
+    /// `to_owned_checked`.
+    #[test]
+    fn test_misc_bucket_valid_data_unaffected_1755() {
+        query!(br#"[{"a":1},{"a":2}]"#, "INDEX(.a)",
+            QueryResult::Owned(OwnedValue::Object(m)) => { assert_eq!(m.len(), 2); }
+        );
+        query!(br#"[{"a":1},{"a":2}]"#, "INDEX(.[]; .a)",
+            QueryResult::Owned(OwnedValue::Object(m)) => { assert_eq!(m.len(), 2); }
+        );
+        query!(br#"{"a":{"b":1}}"#, "getpath([\"a\",\"b\"])",
+            QueryResult::One(_) | QueryResult::Owned(_) => {}
+        );
+        query!(br"[1,2]", "any",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[0,false]", "all",
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+        );
+        query!(br"[1,2]", "any(.>1)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1,2]", "all(.>0)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1,2]", "any(.[]; .>1)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1,2]", "all(.[]; .>0)",
+            QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+        query!(br"[1,2]", "[.[] | key]",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::Int(0), OwnedValue::Int(1)]);
+            }
+        );
+        query!(br"[[1,2],[3,4]]", "combinations",
+            QueryResult::ManyOwned(v) => { assert_eq!(v.len(), 4); }
+        );
+        query!(br"[1,2]", "combinations(2)",
+            QueryResult::ManyOwned(v) => { assert_eq!(v.len(), 4); }
+        );
+        query!(br"1", "debug",
+            QueryResult::Owned(v) => { assert!(v.is_truthy()); }
+        );
+        query!(br"1", "debug(2)",
+            QueryResult::Owned(v) => { assert!(v.is_truthy()); }
+        );
+        query!(br"1", "stderr",
+            QueryResult::Owned(v) => { assert!(v.is_truthy()); }
+        );
+        query!(br"[[1,2],[3,4]]", "transpose",
+            QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 2); }
+        );
+        query!(br"[1,2,3]", "shuffle",
+            QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 3); }
+        );
+        query!(br"[[1,2],[3,4]]", "pivot",
+            QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 2); }
+        );
+        yq_query!(
+            br#"{"a": 1, "b": 2}"#,
+            ".[0:1]",
+            QueryResult::Owned(_) => {}
+        );
+    }
+
+    /// #1755: `eval_rhs_once`'s own fix, pinned directly against the
+    /// private function rather than through `+=`/etc, since both real
+    /// callers (`eval_compound_assign`/`eval_alternative_assign`)
+    /// immediately re-materialize the whole document via `eval_update`'s
+    /// own already-fixed `to_owned_checked` right after, masking this
+    /// fix at the integration level whenever the RHS value comes from the
+    /// same document (the only way it *can* come from a `StandardJson`
+    /// cursor at all). This test is what actually exercises the fixed
+    /// line -- a `+=`-based integration test would only prove
+    /// `eval_update`'s pre-existing fix, not this one.
+    #[test]
+    fn test_eval_rhs_once_raises_on_decode_failure_1755() {
+        let json_bytes: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let expr = parse(".").unwrap();
+        match eval_rhs_once::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
+            Err(QueryResult::Error(e)) => assert!(e.is_decode_failure(), "{e:?}"),
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     /// the 18-site `builtin_tonumber`-shaped fix directly: before it, this
@@ -56149,6 +56435,29 @@ mod tests {
                     }
                 },
             );
+        }
+
+        /// #1755: `builtin_load`'s JSON branch had the same silent-`""`
+        /// shape as the rest of this file's `to_owned` sites -- an
+        /// undecodable value in the loaded file must raise, not silently
+        /// substitute `""`. Uses raw bytes (not `with_temp_file`'s `&str`
+        /// helper, which can't hold invalid UTF-8) written directly to a
+        /// temp path.
+        #[test]
+        fn test_load_json_file_raises_on_decode_failure_1755() {
+            let path = "/tmp/succinctly_test_load_decode_failure_1755.json";
+            fs::write(path, b"{\"a\": \"\xff\xfe\"}").unwrap();
+            let json_bytes: &[u8] = b"null";
+            let index = JsonIndex::build(json_bytes);
+            let cursor = index.root(json_bytes);
+            let query = format!(r#"load("{path}")"#);
+            let expr = parse(&query).unwrap();
+            let result = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
+            let _ = fs::remove_file(path);
+            match result {
+                QueryResult::Error(e) => assert!(e.is_decode_failure(), "{e:?}"),
+                other => panic!("unexpected result: {other:?}"),
+            }
         }
 
         #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37621,6 +37621,16 @@ mod tests {
                 );
             }
         );
+        // `push_promoted`'s `Many(rs)` call site (not `One`): a batch of
+        // several cursor-backed outputs arrives after promotion has
+        // already happened, and the first one is undecodable.
+        query!(
+            &b"[1, [\"\xff\xfe\", \"b\"]]"[..],
+            ".[] | (if type == \"number\" then .+0 else .[] end)",
+            QueryResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(prefix, vec![OwnedValue::Int(1)]);
+            }
+        );
     }
 
     /// #1755 positive control: valid data through each of the misc

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37499,7 +37499,10 @@ mod tests {
             (&b"\"\xff\xfe\""[..], "halt_error"),
             (&b"[[\"\xff\xfe\"]]"[..], "transpose"),
             (&b"[\"\xff\xfe\"]"[..], "transpose"),
-            (&b"[\"\xff\xfe\"]"[..], "shuffle"),
+            // `shuffle` needs the `cli` feature (a `cfg(not(feature =
+            // "cli"))` stub errors with an unrelated message otherwise,
+            // and CI's default `Test` job runs `cargo test` with no
+            // features) -- covered separately below.
             (&b"[[\"\xff\xfe\"]]"[..], "pivot"),
         ] {
             query!(
@@ -37688,9 +37691,9 @@ mod tests {
         query!(br"[[1,2],[3,4]]", "transpose",
             QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 2); }
         );
-        query!(br"[1,2,3]", "shuffle",
-            QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 3); }
-        );
+        // `shuffle`'s own decode-failure/valid-data coverage lives in
+        // `test_shuffle_raises_on_decode_failure_1755` below (`cli`-gated
+        // -- see that test's own comment for why).
         query!(br"[[1,2],[3,4]]", "pivot",
             QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 2); }
         );
@@ -56401,6 +56404,26 @@ mod tests {
         // shuffle can be used in a pipeline
         query!(br"[3, 1, 2]", "shuffle | length",
             QueryResult::Owned(OwnedValue::Int(3)) => {}
+        );
+    }
+
+    /// #1755: `builtin_shuffle`'s own decode-failure/valid-data coverage,
+    /// split out of `test_misc_bucket_raises_on_decode_failure_1755`/
+    /// `test_misc_bucket_valid_data_unaffected_1755` and `cli`-gated like
+    /// every other `shuffle` test in this module -- the `cfg(not(feature
+    /// = "cli"))` stub errors with an unrelated "requires the 'cli'
+    /// feature" message, and CI's default `Test` job runs `cargo test`
+    /// with no explicit features.
+    #[test]
+    #[cfg(feature = "cli")]
+    fn test_shuffle_raises_on_decode_failure_1755() {
+        query!(
+            &b"[\"\xff\xfe\"]"[..],
+            "shuffle",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        query!(br"[1,2,3]", "shuffle",
+            QueryResult::Owned(OwnedValue::Array(v)) => { assert_eq!(v.len(), 3); }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37582,6 +37582,45 @@ mod tests {
                 assert_eq!(v, vec![OwnedValue::String("a".to_string()), OwnedValue::Int(1)]);
             }
         );
+        // `push_promoted`'s own `Some(acc)` branch: a `One` result arrives
+        // *after* promotion has already happened (a prior sibling forced
+        // `owned` to `Some`), so the undecodable third element is checked
+        // there, not in `promote_borrowed_checked`. `Partial` (not a bare
+        // `Error`) because two valid outputs already reached the caller
+        // before the third element's failure -- matching #400's "keep
+        // what already piped through" policy.
+        query!(
+            &b"[1, 2, \"\xff\xfe\"]"[..],
+            ".[] | (if . == 1 then (.+10, .+20) elif . == 2 then . else . end)",
+            QueryResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(
+                    prefix,
+                    vec![
+                        OwnedValue::Int(11),
+                        OwnedValue::Int(21),
+                        OwnedValue::NumberLiteral(NumberRepr::Int(2), "2".into()),
+                    ]
+                );
+            }
+        );
+        // Positive control for the same shape: valid data reaches both
+        // `promote_borrowed_checked`'s `Ok` arm (owned = Some(acc)) and
+        // the subsequent `ManyOwned`/`push_promoted` extends.
+        query!(
+            &b"[1, 2, 3]"[..],
+            ".[] | (if . == 1 then (.+10, .+20) elif . == 2 then . else . end)",
+            QueryResult::ManyOwned(v) => {
+                assert_eq!(
+                    v,
+                    vec![
+                        OwnedValue::Int(11),
+                        OwnedValue::Int(21),
+                        OwnedValue::NumberLiteral(NumberRepr::Int(2), "2".into()),
+                        OwnedValue::NumberLiteral(NumberRepr::Int(3), "3".into()),
+                    ]
+                );
+            }
+        );
     }
 
     /// #1755 positive control: valid data through each of the misc

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37551,6 +37551,18 @@ mod tests {
             Err(QueryResult::Error(e)) => assert!(e.is_decode_failure(), "{e:?}"),
             other => panic!("unexpected result: {other:?}"),
         }
+
+        // The `QueryResult::Many(vs)` arm (not `One`, above): `.[]` on an
+        // array materializes straight to `Many` (`Expr::Iterate`'s own
+        // arm), so its first cursor can carry an undecodable string too.
+        let json_bytes: &[u8] = b"[\"\xff\xfe\", 2]";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let expr = parse(".[]").unwrap();
+        match eval_rhs_once::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
+            Err(QueryResult::Error(e)) => assert!(e.is_decode_failure(), "{e:?}"),
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     /// the 18-site `builtin_tonumber`-shaped fix directly: before it, this


### PR DESCRIPTION
Part of #1755. Follow-up scope filed as #1820.

Fixes the last 13 named functions from #1755's own tracking scope, converting
their `to_owned`/`to_owned_at_depth` entry-point conversions to the fallible
`to_owned_checked`, with the error propagated as `QueryResult::Error` before
any generator loop starts:

- `builtin_upper_index` / `builtin_upper_index_stream` (`INDEX`)
- `getpath_one_path`
- `eval_single`'s yq-mode object slice arm
- `any_all_over` / `any_all_f` / `any_all_gen_cond` (`any`/`all`, bare and
  `(cond)`/`(gen;cond)` forms)
- `eval_pipe`'s path-context entry
- `builtin_load`'s JSON branch
- `builtin_combinations` / `builtin_combinations_n`
- `builtin_debug` / `builtin_debug_msg` / `builtin_stderr` /
  `builtin_halt_error` (the last found incidentally, same file region, same
  shape)
- `builtin_transpose`
- `builtin_shuffle`
- `builtin_pivot`
- `builtin_with_entries`
- `eval_rhs_once` (the "masked hygiene fix" — currently unobservable through
  either real caller, since both immediately re-materialize the whole
  document via `eval_update`'s own already-fixed `to_owned_checked` right
  after; fixed anyway so correctness doesn't rest on that coincidence)

None of these route through `finish_fork`, so there's no `optional`-suppression
interaction to work around (unlike the recurse/walk/tostream slice, #1806).

`builtin_with_entries`'s fix site is structurally unreachable via any query
today: `entry_json` is built via `owned_to_json_bytes`, which serializes into
a Rust `String` (always valid UTF-8 by the type system) before the cursor `f`
evaluates against is ever built — documented at the call site rather than
forced into a test.

## Broader audit finding

While implementing this slice, auditing every remaining `to_owned(&value)`
call in `eval.rs` found ~20 more genuine same-shape sites beyond this slice's
own named scope (e.g. `builtin_paths`/`builtin_leaf_paths`/
`builtin_truncate_stream`, structurally identical to the recurse/walk/tostream
family), plus a ~47-site unaudited pool in generic `QueryResult`-collector
plumbing. Filed as #1820 rather than folded in here, to keep this PR
reviewable at a similar size to the five prior #1755 slices.

## Testing

- `test_misc_bucket_raises_on_decode_failure_1755` covers all 12 reachable
  sites (19 expressions, plus a manual yq-mode check for the object slice
  arm).
- `test_misc_bucket_valid_data_unaffected_1755` is the positive control.
- `builtin_load` gets a dedicated test (raw-byte file I/O, since the
  existing `with_temp_file` helper's `&str` signature can't hold invalid
  UTF-8).
- `eval_rhs_once` gets a dedicated test calling the private function
  directly (both its `One` and `Many` result arms) — a `+=`-based
  integration test would only prove `eval_update`'s pre-existing fix, not
  this one.
- Verified live: reverting `any_all_over`'s fix reproduces the exact
  silent-corruption bug (`any` on `["\xff\xfe"]` returns `true` instead of
  raising).
- Full local suite green (2988 lib tests + all integration suites). One
  CLI-suite flake (`test_preserve_input_duplicate_keys_are_output_only_1385`,
  unrelated to this `eval.rs`-only diff) confirmed transient via isolated
  rerun and a clean full-suite rerun.
- Patch coverage 92.93% (184/198). Remaining gaps: 6 confirmed llvm-cov
  attribution artifacts (multi-line match-arm/macro-invocation lines
  showing 0 hits despite the exact same test asserting the value they
  construct — verified via raw lcov `DA:` counts), the 3-line
  `with_entries` fix documented above as genuinely unreachable, and the
  rest are trivial `panic!`/`other =>` fallback arms inside the new
  tests' own `match` statements.