### PR TITLE
fix(yq): gate 21 more jq-only builtins behind --jq-extensions

### DIFF
--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -388,6 +388,16 @@ surface (#1512):
 | `pow(base; exp)`                                     | Exponentiation                                |
 | `bsearch(target)`                                    | Binary search index in a sorted array         |
 | `strftime(fmt)`, `strptime(fmt)`                     | Broken-down-time formatting / parsing (#1650) |
+| `add`                                                | Sum of an array/stream (#1714)                |
+| `min_by(f)`, `max_by(f)`                             | Extremum by a key function (#1714)            |
+| `implode`                                            | Codepoint array to string (#1714)             |
+| `INDEX(idx_expr)`, `INDEX(stream; idx_expr)`         | Build an object keyed by an index expr (#1714)|
+| `walk(f)`                                            | Recursively transform every node (#1714)      |
+| `floor`, `ceil`, `round`, `sqrt`, `fabs`             | Basic math functions (#1714)                  |
+| `log`, `log2`, `log10`                               | Logarithms (#1714)                            |
+| `exp`, `exp2`, `exp10`                               | Exponentials (#1714)                          |
+| `sinh`, `cosh`, `tanh`                               | Hyperbolic trig functions (#1714)             |
+| `atan2(y; x)`                                        | Two-argument arctangent (#1714)               |
 
 ```bash
 echo '{}' | succinctly yq 'paths'

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2405,6 +2405,7 @@ impl<'a> Parser<'a> {
         // Reduction functions (no arguments)
         // Note: If followed by '(', these should be parsed as user-defined function calls
         if self.matches_keyword("add") && !self.peek_after_keyword_is_paren("add") {
+            self.reject_unless_jq_extensions("add")?;
             self.consume_keyword("add");
             return Ok(Some(Builtin::Add));
         }
@@ -2454,6 +2455,7 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("min_by") {
             // Check min_by before min
+            self.reject_unless_jq_extensions("min_by")?;
             self.consume_keyword("min_by");
             self.skip_ws();
             self.expect('(')?;
@@ -2469,6 +2471,7 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("max_by") {
             // Check max_by before max
+            self.reject_unless_jq_extensions("max_by")?;
             self.consume_keyword("max_by");
             self.skip_ws();
             self.expect('(')?;
@@ -2878,6 +2881,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Explode));
         }
         if self.matches_keyword("implode") {
+            self.reject_unless_jq_extensions("implode")?;
             self.consume_keyword("implode");
             return Ok(Some(Builtin::Implode));
         }
@@ -2936,6 +2940,7 @@ impl<'a> Parser<'a> {
         // INDEX(idx_expr) - build an object keyed by idx_expr from `.[]`
         // INDEX(stream; idx_expr) - build an object keyed by idx_expr from stream
         if self.matches_keyword("INDEX") {
+            self.reject_unless_jq_extensions("INDEX")?;
             self.consume_keyword("INDEX");
             self.skip_ws();
             self.expect('(')?;
@@ -3029,6 +3034,7 @@ impl<'a> Parser<'a> {
 
         // walk(f)
         if self.matches_keyword("walk") {
+            self.reject_unless_jq_extensions("walk")?;
             self.consume_keyword("walk");
             self.skip_ws();
             self.expect('(')?;
@@ -3147,48 +3153,59 @@ impl<'a> Parser<'a> {
 
         // Phase 10: Math Functions
         if self.matches_keyword("floor") {
+            self.reject_unless_jq_extensions("floor")?;
             self.consume_keyword("floor");
             return Ok(Some(Builtin::Floor));
         }
         if self.matches_keyword("ceil") {
+            self.reject_unless_jq_extensions("ceil")?;
             self.consume_keyword("ceil");
             return Ok(Some(Builtin::Ceil));
         }
         if self.matches_keyword("round") {
+            self.reject_unless_jq_extensions("round")?;
             self.consume_keyword("round");
             return Ok(Some(Builtin::Round));
         }
         if self.matches_keyword("sqrt") {
+            self.reject_unless_jq_extensions("sqrt")?;
             self.consume_keyword("sqrt");
             return Ok(Some(Builtin::Sqrt));
         }
         if self.matches_keyword("fabs") {
+            self.reject_unless_jq_extensions("fabs")?;
             self.consume_keyword("fabs");
             return Ok(Some(Builtin::Fabs));
         }
         // Logarithmic - check log10 and log2 before log
         if self.matches_keyword("log10") {
+            self.reject_unless_jq_extensions("log10")?;
             self.consume_keyword("log10");
             return Ok(Some(Builtin::Log10));
         }
         if self.matches_keyword("log2") {
+            self.reject_unless_jq_extensions("log2")?;
             self.consume_keyword("log2");
             return Ok(Some(Builtin::Log2));
         }
         if self.matches_keyword("log") {
+            self.reject_unless_jq_extensions("log")?;
             self.consume_keyword("log");
             return Ok(Some(Builtin::Log));
         }
         // Exponential - check exp10 and exp2 before exp
         if self.matches_keyword("exp10") {
+            self.reject_unless_jq_extensions("exp10")?;
             self.consume_keyword("exp10");
             return Ok(Some(Builtin::Exp10));
         }
         if self.matches_keyword("exp2") {
+            self.reject_unless_jq_extensions("exp2")?;
             self.consume_keyword("exp2");
             return Ok(Some(Builtin::Exp2));
         }
         if self.matches_keyword("exp") {
+            self.reject_unless_jq_extensions("exp")?;
             self.consume_keyword("exp");
             return Ok(Some(Builtin::Exp));
         }
@@ -3210,14 +3227,17 @@ impl<'a> Parser<'a> {
         }
         // Trigonometric functions - check longer names first
         if self.matches_keyword("sinh") {
+            self.reject_unless_jq_extensions("sinh")?;
             self.consume_keyword("sinh");
             return Ok(Some(Builtin::Sinh));
         }
         if self.matches_keyword("cosh") {
+            self.reject_unless_jq_extensions("cosh")?;
             self.consume_keyword("cosh");
             return Ok(Some(Builtin::Cosh));
         }
         if self.matches_keyword("tanh") {
+            self.reject_unless_jq_extensions("tanh")?;
             self.consume_keyword("tanh");
             return Ok(Some(Builtin::Tanh));
         }
@@ -3235,6 +3255,7 @@ impl<'a> Parser<'a> {
         }
         // atan2(y; x) - must check before atan
         if self.matches_keyword("atan2") {
+            self.reject_unless_jq_extensions("atan2")?;
             self.consume_keyword("atan2");
             self.skip_ws();
             self.expect('(')?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1321,15 +1321,19 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
     Ok(())
 }
 
-/// #1512/#1650: `succinctly yq` rejects jq-only builtins real yq's lexer
-/// lacks by default -- a parse error mentioning `--jq-extensions`, not the
-/// CLI silently accepting broader syntax than the reference it's meant to
-/// match. Covers both `try_parse_builtin`'s ordinary gate (`paths`,
-/// `getpath`) and `limit`'s special-cased one in `parse_primary`, plus the
-/// 14 names #1650 added to close the gap `docs/compliance/yq/limitations.md`'s
+/// #1512/#1650/#1714: `succinctly yq` rejects jq-only builtins real yq's
+/// lexer lacks by default -- a parse error mentioning `--jq-extensions`, not
+/// the CLI silently accepting broader syntax than the reference it's meant
+/// to match. Covers both `try_parse_builtin`'s ordinary gate (`paths`,
+/// `getpath`) and `limit`'s special-cased one in `parse_primary`, the 14
+/// names #1650 added to close the gap `docs/compliance/yq/limitations.md`'s
 /// own fan-out table had been documenting as ungated all along (`inside`,
 /// `startswith`, `endswith`, `rtrimstr`, `index`, `rindex`, `indices`,
-/// `range`, `nth`, `combinations`, `pow`, `strftime`, `strptime`, `bsearch`).
+/// `range`, `nth`, `combinations`, `pow`, `strftime`, `strptime`,
+/// `bsearch`), and the 21 names #1714 found still ungated (`add`, `min_by`,
+/// `max_by`, `implode`, `INDEX`, `walk`, `floor`, `ceil`, `round`, `sqrt`,
+/// `fabs`, `log`, `log2`, `log10`, `exp`, `exp2`, `exp10`, `sinh`, `cosh`,
+/// `tanh`, `atan2`).
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     for filter in [
@@ -1350,6 +1354,27 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "strftime(\"%Y\")",
         "strptime(\"%Y\")",
         "bsearch(1)",
+        "add",
+        "min_by(.)",
+        "max_by(.)",
+        "implode",
+        "INDEX(.a)",
+        "walk(.)",
+        "floor",
+        "ceil",
+        "round",
+        "sqrt",
+        "fabs",
+        "log",
+        "log2",
+        "log10",
+        "exp",
+        "exp2",
+        "exp10",
+        "sinh",
+        "cosh",
+        "tanh",
+        "atan2(1;1)",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -1361,17 +1386,19 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     Ok(())
 }
 
-/// #1512/#1650: the CLI flag actually reaches the parser -- `--jq-extensions`
-/// makes the same filters succeed end to end through the real `succinctly
-/// yq` binary, not just through the parser's own unit tests.
+/// #1512/#1650/#1714: the CLI flag actually reaches the parser --
+/// `--jq-extensions` makes the same filters succeed end to end through the
+/// real `succinctly yq` binary, not just through the parser's own unit
+/// tests.
 #[test]
 fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
-    // The #1650 additions are self-contained (their own literal input via
-    // `X | f`) rather than operating on the shared `.` document below --
+    // The #1650/#1714 additions are self-contained (their own literal input
+    // via `X | f`) rather than operating on the shared `.` document below --
     // several need a specific type (`inside`/`startswith`/... need a
-    // string, `bsearch` a sorted array) that `.` (the object `{a: 1}`)
-    // doesn't satisfy, and the point here is confirming each builtin runs
-    // to completion once gated open, not exercising every input shape.
+    // string, `bsearch` a sorted array, the math functions a number) that
+    // `.` (the object `{a: 1}`) doesn't satisfy, and the point here is
+    // confirming each builtin runs to completion once gated open, not
+    // exercising every input shape.
     for filter in [
         "paths",
         "getpath([])",
@@ -1390,6 +1417,27 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
         "0 | strftime(\"%Y\")",
         "\"2020\" | strptime(\"%Y\")",
         "[1,2,3] | bsearch(2)",
+        "[1,2,3] | add",
+        "[1,2,3] | min_by(.)",
+        "[1,2,3] | max_by(.)",
+        "[97,98,99] | implode",
+        "[{\"id\":1},{\"id\":2}] | INDEX(.id)",
+        "walk(.)",
+        "1.5 | floor",
+        "1.5 | ceil",
+        "1.5 | round",
+        "4 | sqrt",
+        "(-4) | fabs",
+        "1 | log",
+        "8 | log2",
+        "100 | log10",
+        "1 | exp",
+        "1 | exp2",
+        "1 | exp10",
+        "0 | sinh",
+        "0 | cosh",
+        "0 | tanh",
+        "atan2(1;1)",
     ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
@@ -18145,9 +18193,15 @@ fn test_1119_scalar_slice_assign_noop_covers_array_and_filter_rhs() -> Result<()
 /// this array-append arm -- not a separate scope decision. Real yq has no
 /// `add`/`reduce` syntax at all, so this locks in succinctly's own
 /// consistent-with-`+` behavior rather than verifying against an oracle.
+/// `--jq-extensions` is required since #1714 closed `add`'s gate (it was
+/// unintentionally ungated before then).
 #[test]
 fn test_1119_add_builtin_inherits_array_append_consistently() -> Result<()> {
-    let (output, code) = run_yq_stdin("[[1,2],3,4] | add", "null", &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin(
+        "[[1,2],3,4] | add",
+        "null",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[1,2,3,4]");
 
@@ -18164,18 +18218,28 @@ fn test_1119_add_builtin_inherits_array_append_consistently() -> Result<()> {
 /// no `add`/`reduce` syntax at all, so this locks in succinctly's own
 /// consistent-with-`+` behavior rather than verifying against an oracle,
 /// mirroring `test_1119_add_builtin_inherits_array_append_consistently`
-/// above.
+/// above. `--jq-extensions` is required on the yq-mode calls since #1714
+/// closed `add`'s gate (it was unintentionally ungated before then).
 #[test]
 fn test_1197_add_builtin_inherits_right_null_gating_consistently() -> Result<()> {
-    let (_out, err, code) = run_yq_stdin_with_stderr("[7, null] | add", "null", &["-o=json"])?;
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("[7, null] | add", "null", &["-o=json", "--jq-extensions"])?;
     assert_eq!(code, 1, "{err}");
     assert!(err.contains("cannot be added"), "{err}");
 
-    let (output, code) = run_yq_stdin("[null, 7] | add", "null", &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin(
+        "[null, 7] | add",
+        "null",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "7");
 
-    let (output, code) = run_yq_stdin(r#"["a", null] | add"#, "null", &["-o=json", "-I=0"])?;
+    let (output, code) = run_yq_stdin(
+        r#"["a", null] | add"#,
+        "null",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#""a""#);
 


### PR DESCRIPTION
## Summary
- `add`, `min_by`, `max_by`, `implode`, `INDEX`, `walk`, `floor`, `ceil`, `round`, `sqrt`, `fabs`, `log`, `log2`, `log10`, `exp`, `exp2`, `exp10`, `sinh`, `cosh`, `tanh`, and `atan2` were parseable in `succinctly yq` with no `--jq-extensions` flag, even though real yq's lexer rejects all of them outright (confirmed live against yq v4.53.3, both bare and with-args forms where applicable).
- Applied the same one-line `self.reject_unless_jq_extensions("name")?;` gate already used for `pow` and the other previously-gated names — mechanical, no behavior change when the flag is passed.
- This is the 4th round of the same gap (#1436, #1512, #1650), so extended the existing `test_yq_default_rejects_jq_only_builtins_1512` / `test_yq_jq_extensions_flag_enables_jq_only_builtins_1512` tests and the `docs/reference/yq-language.md` gated-builtins table rather than adding new ones.
- Fixed two pre-existing tests (`test_1119_add_builtin_inherits_array_append_consistently`, `test_1197_add_builtin_inherits_right_null_gating_consistently`) that called bare `add` in yq mode relying on it being (unintentionally) ungated — they now pass `--jq-extensions`.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — 2988+ tests, all green, including new/updated gate tests
- [x] Live-verified all 21 names against `--jq-extensions` off (parse error naming the flag) and on (succeeds)
- [x] `succinctly jq` mode confirmed unaffected (no gate exists there)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Fixes #1714