### PR TITLE
fix(jq): route builtin_keys through the shared display-key policy

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -824,19 +824,41 @@ positional fast paths (`.[0]`, `first`, `last`, `.[n]`, tracked separately as #1
 `keys_unsorted`'s streaming truncation (a partial array can reach stdout beside the exit 5,
 for the same "cannot rewind a byte-at-a-time writer" reason).
 
-**Mostly not covered: `succinctly::jq::eval`'s own separate evaluator.** `src/jq/eval.rs`
-defines a second, independent `pub fn eval` — the function `succinctly::jq::eval` actually
-re-exports, and the one used in `src/jq/mod.rs`'s own module-doc example — with its own
-unchecked `to_owned`/`effective_len`/`effective_fields`. `Builtin::Keys` (`keys`/
-`keys_unsorted`) is the one exception, fixed by #1829/#1835 to delegate to
-`DocumentFields::keys()` (the same shared walk `eval_generic.rs` uses) instead of a
-narrower hand-rolled copy, which gives it both this check and #1194's protection as a side
-effect. Every other builtin in this file has neither check: a library caller who follows the
-documented `eval()` example and evaluates straight off a fresh cursor gets no protection from
-either class outside `keys`/`keys_unsorted`. The CLI itself never reaches this path except
-through the reindex bridge, which only ever feeds it an already-validated `OwnedValue`, so
-`sjq`/`syq` are unaffected. The remaining call sites are tracked as a follow-up (#1829) rather
-than folded into #1677, which scoped itself to `eval_generic.rs`.
+**Partly covered: `succinctly::jq::eval`'s own separate evaluator.** `src/jq/eval.rs` defines
+a second, independent `pub fn eval` — the function `succinctly::jq::eval` actually re-exports,
+and the one used in `src/jq/mod.rs`'s own module-doc example — with its own separate, unchecked
+`to_owned`/`effective_len`/`effective_fields`. Two different checks are in play, and their
+coverage differs:
+
+- **The #1194/#1642 decode-failure and structural-key policy** already reaches most of this
+  file's materializing builtins via `to_owned_checked`/`to_owned_checked_at_depth` (`in(xs)`,
+  `ltrimstr`/`rtrimstr`, the sort family, `min`/`max`/`unique`/`group_by`, `add`, `join`,
+  `flatten`, and every assignment RHS, among others) — not the wholesale gap the previous
+  revision of this paragraph implied.
+- **The #1677 malformed-`,`/`:`-delimiter check is the narrower gap.**
+  `to_owned_checked_at_depth` itself never calls `key_delimiter_ok`/`value_delimiter_ok`, so
+  every builtin routed through it still misses this one check. `Builtin::Keys` (`keys`/
+  `keys_unsorted`) is the sole exception, fixed by #1829/#1835 to delegate to `effective_keys`
+  (`document.rs`) — the same `DistinctKeyCursors` walk `eval_generic.rs`'s own `keys_unsorted`
+  writer is built on, not a narrower hand-rolled copy — which gives it #1677 protection
+  alongside #1194/#1642's.
+
+A library caller who follows the documented `eval()` example and evaluates straight off a
+fresh cursor gets #1677 protection only from `keys`/`keys_unsorted`; every other builtin in
+this file, checked or not on the decode-failure/#1194 axis, still misses it. The CLI itself
+never reaches this path except through the reindex bridge, which only ever feeds it an
+already-validated `OwnedValue`, so `sjq`/`syq` are unaffected. The remaining #1677 call sites
+are tracked as a follow-up (#1829) rather than folded into #1677 itself, which scoped itself to
+`eval_generic.rs`.
+
+Fixing `keys`/`keys_unsorted` alone creates a transitional inconsistency worth naming rather
+than leaving implicit: `to_entries` (and `with_entries`/`map_values`, which route through it)
+still silently drops a decode-failure or #1194-malformed key, so `keys_unsorted | length` and
+`to_entries | length` can now disagree with *each other* on the same document, where before
+#1829/#1835 both silently dropped the same key and so happened to agree. Not a new bug in
+either builtin -- `to_entries`'s own gap predates this fix and is #1829's own next-listed
+slice -- but the two builtins' agreement was accidental, not a guarantee, and this fix is the
+first thing to make that visible.
 
 ## Refusing an allocation jq does not survive
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -824,15 +824,19 @@ positional fast paths (`.[0]`, `first`, `last`, `.[n]`, tracked separately as #1
 `keys_unsorted`'s streaming truncation (a partial array can reach stdout beside the exit 5,
 for the same "cannot rewind a byte-at-a-time writer" reason).
 
-**Not covered at all: `succinctly::jq::eval`'s own separate evaluator.** `src/jq/eval.rs`
+**Mostly not covered: `succinctly::jq::eval`'s own separate evaluator.** `src/jq/eval.rs`
 defines a second, independent `pub fn eval` — the function `succinctly::jq::eval` actually
 re-exports, and the one used in `src/jq/mod.rs`'s own module-doc example — with its own
-unchecked `to_owned`/`effective_len`/`effective_fields`/`Builtin::Keys`. It has neither this
-check nor #1194's: a library caller who follows that documented example and evaluates
-straight off a fresh cursor gets no protection from either class. The CLI itself never reaches
-this path except through the reindex bridge, which only ever feeds it an already-validated
-`OwnedValue`, so `sjq`/`syq` are unaffected. Tracked as a follow-up rather than folded into
-#1677, which scoped itself to `eval_generic.rs`.
+unchecked `to_owned`/`effective_len`/`effective_fields`. `Builtin::Keys` (`keys`/
+`keys_unsorted`) is the one exception, fixed by #1829/#1835 to delegate to
+`DocumentFields::keys()` (the same shared walk `eval_generic.rs` uses) instead of a
+narrower hand-rolled copy, which gives it both this check and #1194's protection as a side
+effect. Every other builtin in this file has neither check: a library caller who follows the
+documented `eval()` example and evaluates straight off a fresh cursor gets no protection from
+either class outside `keys`/`keys_unsorted`. The CLI itself never reaches this path except
+through the reindex bridge, which only ever feeds it an already-validated `OwnedValue`, so
+`sjq`/`syq` are unaffected. The remaining call sites are tracked as a follow-up (#1829) rather
+than folded into #1677, which scoped itself to `eval_generic.rs`.
 
 ## Refusing an allocation jq does not survive
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38,8 +38,7 @@ use core::cell::Cell;
 use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
-    effective_fields, effective_len, key_display_string, resolve_display_key, DisplayKeyGuard,
-    DocumentFields,
+    effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
 };
 // Only consumed by `yaml_value_to_owned_checked`, which is itself
 // `#[cfg(feature = "std")]`-gated (`load()`'s YAML path) -- gated
@@ -5986,38 +5985,24 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Object(fields) => {
-            let mut keys: Vec<String> = Vec::new();
-            // `uncons`/`rest`, not `for field in fields`: a `for` loop
-            // consumes the `Iterator` impl, whose `next()` reports `None`
-            // both on genuine exhaustion *and* on a trailing unpaired
-            // member (#1194, e.g. `{"a":1,"b"}`) -- indistinguishable
-            // through that protocol, so only a walk that can inspect the
-            // list state it *finished* on can ask `ends_unpaired`
-            // afterward. Mirrors `to_owned_checked_at_depth`'s own shape
-            // (#1734).
-            let mut f = fields;
-            while let Some((field, rest)) = f.uncons() {
-                let key_val = field.key();
-                // #1829: preserve a decode-failure key via its raw source
-                // span (#1642), matching `to_owned_checked`/`path()`/
-                // `tojson`'s policy -- this used to silently skip both a
-                // decode-failure key and a structurally non-string one
-                // (#1194), disagreeing with those and with `length`, which
-                // counts every field regardless. Plain `key_display_string`,
-                // not `resolve_display_key`: `keys` builds a `Vec`, not a
-                // map, so two decode-failure keys sharing the same fallback
-                // spelling are simply two list entries, not the ambiguous
-                // overwrite `DisplayKeyGuard` exists to prevent for a real
-                // `IndexMap`.
-                let Some(key) = key_display_string(&key_val) else {
-                    return QueryResult::Error(f.malformed_member_error());
-                };
-                keys.push(key.into_owned());
-                f = rest;
-            }
-            if f.ends_unpaired() {
-                return QueryResult::Error(f.malformed_member_error());
-            }
+            // #1829: delegates to `DocumentFields::keys()` (`document.rs`,
+            // already implemented for `JsonFields`) rather than a fourth
+            // hand-rolled copy of the same uncons/key_display_string/
+            // ends_unpaired walk (`document.rs`'s own default, this file's
+            // `to_owned_checked_at_depth`, and an earlier draft of this very
+            // function). Closes two gaps this function used to have on its
+            // own: a decode-failure key is now preserved via its raw source
+            // span (#1642, matching `to_owned_checked`/`path()`/`tojson`'s
+            // policy, not silently dropped), a #1194 structurally malformed
+            // key now raises, and -- as a consequence of reusing the shared
+            // walk rather than re-deriving a narrower one -- a malformed
+            // `,`/`:` delimiter (#1677) now raises too, closing a gap that
+            // `to_owned_checked_at_depth` still has (out of scope for this
+            // fix to touch there; noted, not silently left stale).
+            let mut keys = match DocumentFields::keys(&fields) {
+                Ok(keys) => keys,
+                Err(e) => return QueryResult::Error(e),
+            };
             if sorted {
                 keys.sort();
             }
@@ -41136,6 +41121,30 @@ mod tests {
             QueryResult::Error(e) => {
                 assert!(!e.is_decode_failure(), "message: {}", e.message);
             }
+        );
+        query!(doc, "keys",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829 review: delegating to `DocumentFields::keys()` (`document.rs`)
+    /// rather than hand-rolling a narrower walk closes a third axis this
+    /// function never explicitly set out to fix -- a malformed `,`/`:`
+    /// delimiter (#1677). JSON's semi-index treats the two as interchangeable
+    /// gap bytes, so a missing colon leaves an even sibling count and
+    /// `ends_unpaired()` alone can't see it; only `key_delimiter_ok`/
+    /// `value_delimiter_ok` (both inside `DocumentFields::keys()`) can. Real
+    /// jq rejects this document outright at parse time; succinctly's own
+    /// CLI path (`eval_generic.rs`) already raises here too
+    /// (`test_nonreserializing_builtins_raise_on_missing_delimiter_1677`) --
+    /// this pins the library `eval()` entry point catching up to it for
+    /// `keys`/`keys_unsorted` specifically.
+    #[test]
+    fn test_builtin_keys_raises_on_malformed_delimiter_1677() {
+        let doc: &[u8] = br#"{"a" 1, "b": 2}"#;
+
+        query!(doc, "keys_unsorted",
+            QueryResult::Error(_) => {}
         );
         query!(doc, "keys",
             QueryResult::Error(_) => {}

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38,7 +38,8 @@ use core::cell::Cell;
 use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
-    effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
+    effective_fields, effective_len, key_display_string, resolve_display_key, DisplayKeyGuard,
+    DocumentFields,
 };
 // Only consumed by `yaml_value_to_owned_checked`, which is itself
 // `#[cfg(feature = "std")]`-gated (`load()`'s YAML path) -- gated
@@ -5986,12 +5987,36 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
     match value {
         StandardJson::Object(fields) => {
             let mut keys: Vec<String> = Vec::new();
-            for field in fields {
-                if let StandardJson::String(k) = field.key() {
-                    if let Ok(cow) = k.as_str() {
-                        keys.push(cow.into_owned());
-                    }
-                }
+            // `uncons`/`rest`, not `for field in fields`: a `for` loop
+            // consumes the `Iterator` impl, whose `next()` reports `None`
+            // both on genuine exhaustion *and* on a trailing unpaired
+            // member (#1194, e.g. `{"a":1,"b"}`) -- indistinguishable
+            // through that protocol, so only a walk that can inspect the
+            // list state it *finished* on can ask `ends_unpaired`
+            // afterward. Mirrors `to_owned_checked_at_depth`'s own shape
+            // (#1734).
+            let mut f = fields;
+            while let Some((field, rest)) = f.uncons() {
+                let key_val = field.key();
+                // #1829: preserve a decode-failure key via its raw source
+                // span (#1642), matching `to_owned_checked`/`path()`/
+                // `tojson`'s policy -- this used to silently skip both a
+                // decode-failure key and a structurally non-string one
+                // (#1194), disagreeing with those and with `length`, which
+                // counts every field regardless. Plain `key_display_string`,
+                // not `resolve_display_key`: `keys` builds a `Vec`, not a
+                // map, so two decode-failure keys sharing the same fallback
+                // spelling are simply two list entries, not the ambiguous
+                // overwrite `DisplayKeyGuard` exists to prevent for a real
+                // `IndexMap`.
+                let Some(key) = key_display_string(&key_val) else {
+                    return QueryResult::Error(f.malformed_member_error());
+                };
+                keys.push(key.into_owned());
+                f = rest;
+            }
+            if f.ends_unpaired() {
+                return QueryResult::Error(f.malformed_member_error());
             }
             if sorted {
                 keys.sort();
@@ -41076,6 +41101,44 @@ mod tests {
                 assert_eq!(arr.len(), 2);
                 // Note: Order depends on how JSON was parsed
             }
+        );
+    }
+
+    /// #1829: `keys`/`keys_unsorted` used to silently drop a decode-failure
+    /// key, disagreeing with `length` (which counts every field regardless)
+    /// and with `path(.[])`/`tojson` (which already preserve it via its raw
+    /// source span, #1642/#1734). Both builtins must now agree: the key is
+    /// present, at its raw-source-span spelling.
+    #[test]
+    fn test_builtin_keys_preserves_decode_failure_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+
+        query!(doc, "length",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(doc, "keys_unsorted",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 2)
+        );
+        query!(doc, "keys",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 2)
+        );
+    }
+
+    /// #1829's other axis: a structurally non-string/unpaired key (#1194,
+    /// `{"a":1,"b"}`) must raise for `keys`/`keys_unsorted` too, matching
+    /// `path(.[])`/`tojson` -- previously silently dropped instead (`["a"]`
+    /// rather than an error).
+    #[test]
+    fn test_builtin_keys_raises_on_structurally_malformed_key_1829() {
+        let doc: &[u8] = br#"{"a":1,"b"}"#;
+
+        query!(doc, "keys_unsorted",
+            QueryResult::Error(e) => {
+                assert!(!e.is_decode_failure(), "message: {}", e.message);
+            }
+        );
+        query!(doc, "keys",
+            QueryResult::Error(_) => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38,7 +38,8 @@ use core::cell::Cell;
 use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
-    effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
+    effective_fields, effective_keys, effective_len, resolve_display_key, DisplayKeyGuard,
+    DocumentFields,
 };
 // Only consumed by `yaml_value_to_owned_checked`, which is itself
 // `#[cfg(feature = "std")]`-gated (`load()`'s YAML path) -- gated
@@ -5985,10 +5986,10 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Object(fields) => {
-            // #1829: delegates to `DocumentFields::keys()` (`document.rs`,
-            // already implemented for `JsonFields`) rather than a fourth
-            // hand-rolled copy of the same uncons/key_display_string/
-            // ends_unpaired walk (`document.rs`'s own default, this file's
+            // #1829: delegates to `effective_keys` (`document.rs`) rather
+            // than a fourth hand-rolled copy of the uncons/
+            // key_display_string/ends_unpaired walk (`document.rs`'s own
+            // `DocumentFields::keys()` default, this file's
             // `to_owned_checked_at_depth`, and an earlier draft of this very
             // function). Closes two gaps this function used to have on its
             // own: a decode-failure key is now preserved via its raw source
@@ -5999,7 +6000,25 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
             // `,`/`:` delimiter (#1677) now raises too, closing a gap that
             // `to_owned_checked_at_depth` still has (out of scope for this
             // fix to touch there; noted, not silently left stale).
-            let mut keys = match DocumentFields::keys(&fields) {
+            //
+            // Not `DocumentFields::keys()` (that trait method's own
+            // default): code review found it walks via `uncons`, which
+            // materializes every field's *value* -- the same #1514 cost
+            // this function has no use for and `eval_generic.rs`'s own
+            // `keys_unsorted` writer specifically avoids via
+            // `DistinctKeyCursors`/`uncons_key`. `effective_keys` is that
+            // same cheap path, exposed as a free function for exactly this
+            // kind of caller. `collapse: false` matches this function's own
+            // prior behaviour on both sides of this fix (never collapsed a
+            // duplicate key, in either mode) -- `builtin_keys` has no
+            // `S: EvalSemantics` parameter to derive a mode-correct
+            // `S::COLLAPSE_DUPLICATE_KEYS` from, and real jq *does* collapse
+            // (confirmed live: `{"a":1,"a":2} | keys_unsorted` is `["a"]`).
+            // That divergence predates this fix on both the old hand-rolled
+            // walk and `DocumentFields::keys()` alike, so it isn't
+            // reintroduced or newly widened here -- tracked separately
+            // rather than folded into this fix's own narrower scope.
+            let mut keys = match effective_keys(&fields, false) {
                 Ok(keys) => keys,
                 Err(e) => return QueryResult::Error(e),
             };
@@ -41101,11 +41120,31 @@ mod tests {
         query!(doc, "length",
             QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
         );
+        // The fallback spelling itself is pinned, not just the count: a
+        // regression that replaced the decode-failure key with `""`, a
+        // placeholder, or an accidental duplicate of `"a"` would still pass
+        // a length-2 check alone.
         query!(doc, "keys_unsorted",
-            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 2)
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::String("\u{FFFD}\u{FFFD}".to_string()),
+                        OwnedValue::String("a".to_string()),
+                    ]
+                );
+            }
         );
         query!(doc, "keys",
-            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 2)
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("\u{FFFD}\u{FFFD}".to_string()),
+                    ]
+                );
+            }
         );
     }
 
@@ -41133,9 +41172,9 @@ mod tests {
     /// delimiter (#1677). JSON's semi-index treats the two as interchangeable
     /// gap bytes, so a missing colon leaves an even sibling count and
     /// `ends_unpaired()` alone can't see it; only `key_delimiter_ok`/
-    /// `value_delimiter_ok` (both inside `DocumentFields::keys()`) can. Real
-    /// jq rejects this document outright at parse time; succinctly's own
-    /// CLI path (`eval_generic.rs`) already raises here too
+    /// `value_delimiter_ok` (both inside `effective_keys`) can. Real jq
+    /// rejects this document outright at parse time; succinctly's own CLI
+    /// path (`eval_generic.rs`) already raises here too
     /// (`test_nonreserializing_builtins_raise_on_missing_delimiter_1677`) --
     /// this pins the library `eval()` entry point catching up to it for
     /// `keys`/`keys_unsorted` specifically.
@@ -41149,6 +41188,23 @@ mod tests {
         query!(doc, "keys",
             QueryResult::Error(_) => {}
         );
+    }
+
+    /// Code review, #1829/#1835: the object arm's new error paths (#1194,
+    /// #1677) return `QueryResult::Error` directly, with no `optional`
+    /// check of their own -- unlike this same function's scalar/array
+    /// `_ if optional => QueryResult::None` fallthrough. Not a gap: `keys?`/
+    /// `keys_unsorted?` always parses to `Expr::Optional`, whose own
+    /// `eval_try` unconditionally catches an ordinary `QueryResult::Error`
+    /// (mirrors `builtin_length`'s identical scalar-arm shape, already
+    /// established elsewhere in this file). Pinned here since neither
+    /// prior #1829 test exercises `?` at all.
+    #[test]
+    fn test_builtin_keys_optional_suppresses_malformed_key_errors_1829() {
+        for expr in ["keys?", "keys_unsorted?"] {
+            query!(br#"{"a":1,"b"}"#, expr, QueryResult::None => {});
+            query!(br#"{"a" 1, "b": 2}"#, expr, QueryResult::None => {});
+        }
     }
 
     #[test]


### PR DESCRIPTION
Part of #1829.

## Problem

`eval.rs`'s own `builtin_keys` (backing `keys`/`keys_unsorted` via the library API's `eval()` entry point — the path `succinctly::jq::{eval, parse}` uses, distinct from the CLI's `eval_generic.rs`) silently skipped both:

- a decode-failure key (invalid UTF-8, an invalid escape/`\u` codepoint)
- a #1194 structurally non-string or trailing-unpaired key (`{"a":1,"b"}`)

This disagreed with `length` (counts every field regardless) and with `path(.[])`/`tojson` (which already preserve a decode-failure key via its raw source span and raise on a structural one, per #1642/#1734).

## What changed

`builtin_keys`'s Object arm now delegates to `effective_keys(&fields, false)` (`document.rs`) — the same `DistinctKeyCursors` walk `eval_generic.rs`'s own `keys_unsorted` streaming writer is built on — instead of a hand-rolled walk. This gives it, at the cheap `uncons_key`-based path's cost (no per-field value materialization, #1514):

- decode-failure key preservation via raw source span (#1642)
- #1194 structural-key raise
- #1677 malformed `,`/`:` delimiter raise, as a side effect of reusing the shared walk

`collapse: false` matches this function's own prior behavior on both sides of this fix (never collapsed a duplicate key in either mode) — `builtin_keys` has no `S: EvalSemantics` parameter to derive a mode-correct collapse flag from, and real jq *does* collapse duplicate keys. That's a real, separate, pre-existing divergence this fix doesn't touch — tracked separately rather than folded in here.

## Scope note

This issue's acceptance criteria lists 7 builtins (`keys`, `keys_unsorted`, `paths`, `to_entries`, `with_entries`, `map_values`, `leaf_paths`). This PR covers `keys`/`keys_unsorted` only. Leaving #1829 open for the remaining slices, matching #1755's own established incremental-slicing pattern. Review also surfaced `pick`/`omit` as carrying the same silent-drop shape, not originally in #1829's list — noted for a future slice.

## Review history

Three rounds of independent multi-agent code review:

1. **First pass**: the initial hand-rolled fix worked but duplicated `document.rs`'s own `DocumentFields::keys()` walk and was missing the #1677 delimiter check that method already has. Fixed by delegating to `DocumentFields::keys()` directly, closing #1677 as a side effect; also updated a now-stale `limitations.md` entry naming `Builtin::Keys` as fully unchecked.
2. **Second pass**: found `DocumentFields::keys()` itself walks via `uncons()` (materializing every field's value) and — per its own doc comment — had no production caller before this fix; the real CLI streaming path avoids exactly this cost via `DistinctKeyCursors`/`uncons_key`. Fixed by switching to `effective_keys`, the free-function form of that same cheap walk. Also strengthened a test that only checked array length (not the actual fallback spelling), added `keys?`/`keys_unsorted?` optional-suppression coverage, and rewrote `limitations.md`'s coverage paragraph, which had overclaimed "every other builtin has neither check" (most already get #1642/#1194 protection via `to_owned_checked_at_depth`; only #1677 was genuinely exclusive to `keys`/`keys_unsorted`).
3. **Third pass**: confirmed the `effective_keys` switch and independently re-derived the same finding from pass 2, corroborating it.

## Testing

- `test_builtin_keys_preserves_decode_failure_key_1829`: pins the exact fallback spelling for `keys`/`keys_unsorted`, not just array length.
- `test_builtin_keys_raises_on_structurally_malformed_key_1829`: `{"a":1,"b"}` raises instead of silently returning `["a"]`.
- `test_builtin_keys_raises_on_malformed_delimiter_1677`: `{"a" 1, "b": 2}` raises, mirroring `eval_generic.rs`'s own #1677 coverage for the library `eval()` entry point.
- `test_builtin_keys_optional_suppresses_malformed_key_errors_1829`: `keys?`/`keys_unsorted?` correctly suppress both error axes via the outer `Expr::Optional` catch.
- Full local suite green: 2992 lib tests, 1064 jq CLI tests, 1263 yq CLI tests, yq golden conformance, cli_golden_tests, evaluator parity — 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second clippy leg both clean. `cargo fmt --check`, `cargo build --no-default-features` (no_std), `cargo doc --no-deps --all-features` all clean.