### PR TITLE
fix(jq): make colliding_display_key_error actually uncatchable

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,8 +9,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    colliding_display_key_error, effective_keys, resolve_display_key, DisplayKeyGuard,
-    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    effective_keys, resolve_display_key, DisplayKeyGuard, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec,
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
@@ -358,7 +358,10 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
                 let (key, is_fallback) = field.key().key_string_kind();
                 let key = key.into_owned();
                 if !guard.check(&map, &key, is_fallback) {
-                    return Err(anyhow::anyhow!("{}", colliding_display_key_error(&key)));
+                    return Err(anyhow::anyhow!(
+                        "{}",
+                        EvalError::colliding_display_key(&key)
+                    ));
                 }
                 let value = yaml_to_owned_value(field.value_cursor())?;
                 map.insert(key, value);

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1097,32 +1097,16 @@ impl DisplayKeyGuard {
     }
 }
 
-/// The error for two keys that collide only because a decode-failure key's
-/// display fallback (#1642) matches another key's spelling.
-///
-/// #1385 forbids treating them as the same key, but a display-keyed map has
-/// no way to hold both, so this is what `to_owned`/`materialize` raise
-/// instead of silently dropping one of them -- see [`DisplayKeyGuard`].
-///
-/// `pub`, not `pub(crate)`: `succinctly-cli`'s `yq_runner.rs`
-/// (`yaml_to_owned_value`, #1749) reuses this directly rather than
-/// hand-writing a second, wording-drift-prone copy of the same message --
-/// same reasoning [`DisplayKeyGuard::check`] itself is `pub` for. The
-/// wording says "object key", which still reads correctly for a YAML
-/// mapping key (a YAML document *is* the object/mapping distinction JSON
-/// doesn't have, but "object" is the neutral term this message already
-/// uses for JSON's own object keys).
-pub fn colliding_display_key_error(key: &str) -> EvalError {
-    EvalError::colliding_display_key(key)
-}
-
 /// The full display-key resolution sequence a `to_owned`-shaped materializer
 /// needs for one field, in one call.
 ///
 /// Gets the display spelling (`None` when the key does not stringify at all
 /// -- #1194's territory, the caller's own job to handle), guards it against
 /// a colliding decode-failure fallback (#1642), and raises
-/// `colliding_display_key_error` instead of allowing a silent overwrite.
+/// [`EvalError::colliding_display_key`] instead of allowing a silent
+/// overwrite -- #1385 forbids treating two colliding keys as the same one,
+/// but a display-keyed map has no way to hold both, so this is what
+/// `to_owned`/`materialize` raise instead of silently dropping one of them.
 ///
 /// Shared by `eval_generic.rs`'s three `to_owned*_at_depth` conversions,
 /// its validate-only `push_generic_truthiness_cursor_error` (#1645),
@@ -1140,7 +1124,7 @@ pub fn resolve_display_key<V: DocumentValue, T>(
     };
     let key = key.into_owned();
     if !guard.check(map, &key, is_fallback) {
-        return Err(colliding_display_key_error(&key));
+        return Err(EvalError::colliding_display_key(&key));
     }
     Ok(Some(key))
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1113,10 +1113,7 @@ impl DisplayKeyGuard {
 /// doesn't have, but "object" is the neutral term this message already
 /// uses for JSON's own object keys).
 pub fn colliding_display_key_error(key: &str) -> EvalError {
-    EvalError::decode_failure(alloc::format!(
-        "object key \"{key}\" is ambiguous: an undecodable key's display form \
-         collides with another key of the same name and cannot be represented"
-    ))
+    EvalError::colliding_display_key(key)
 }
 
 /// The full display-key resolution sequence a `to_owned`-shaped materializer

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -968,15 +968,26 @@ impl EvalError {
     /// `object key "<key>" is ambiguous: ...` (#1642) — a #1620-class
     /// decode failure in its own right: two distinct undecodable keys
     /// whose display fallback collides, so keeping the second silently
-    /// overwrites the first. [`Self::is_decode_failure`] recognizes the
-    /// fixed suffix this constructor always appends, the same way
-    /// [`Self::invalid_path_expression`] and its own `is_*` check share a
-    /// prefix constant, so the two can never independently drift out of
-    /// sync (confirmed live before this fix, #1813: this previously built
-    /// its message ad hoc via `format!` at its one call site in
-    /// `document.rs`, and `is_decode_failure`'s fixed literal list didn't
-    /// include it — `try sort catch .` and `sort?` both wrongly treated
-    /// this as an ordinary catchable error).
+    /// overwrites the first (#1385 forbids treating them as the same key,
+    /// but a display-keyed map has no way to hold both). This is what
+    /// `to_owned`/`materialize` raise instead, via
+    /// [`super::document::resolve_display_key`]/[`super::document::DisplayKeyGuard`].
+    /// [`Self::is_decode_failure`] recognizes the fixed suffix this
+    /// constructor always appends, the same way [`Self::invalid_path_expression`]
+    /// and its own `is_*` check share a prefix constant, so the two can
+    /// never independently drift out of sync (confirmed live before this
+    /// fix, #1813: this previously built its message ad hoc via `format!`
+    /// at its one call site in `document.rs`, and `is_decode_failure`'s
+    /// fixed literal list didn't include it — `try sort catch .` and
+    /// `sort?` both wrongly treated this as an ordinary catchable error).
+    ///
+    /// Called directly (not via a `document.rs`-local wrapper, #1813
+    /// review) from three sites across two crates: `document.rs`'s own
+    /// `resolve_display_key`, `eval.rs`'s `yaml_value_to_owned_checked`
+    /// (`load()`'s YAML path), and `succinctly-cli`'s `yq_runner.rs`
+    /// (`yaml_to_owned_value`, #1749) — `EvalError` is already `pub` from
+    /// `jq::mod`, so a re-exporting wrapper added an extra hop without
+    /// adding any encapsulation.
     pub fn colliding_display_key(key: &str) -> Self {
         Self::new(format!(
             "object key \"{key}\" is ambiguous{}",

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -965,6 +965,28 @@ impl EvalError {
         Self::new(reason)
     }
 
+    /// `object key "<key>" is ambiguous: ...` (#1642) — a #1620-class
+    /// decode failure in its own right: two distinct undecodable keys
+    /// whose display fallback collides, so keeping the second silently
+    /// overwrites the first. [`Self::is_decode_failure`] recognizes the
+    /// fixed suffix this constructor always appends, the same way
+    /// [`Self::invalid_path_expression`] and its own `is_*` check share a
+    /// prefix constant, so the two can never independently drift out of
+    /// sync (confirmed live before this fix, #1813: this previously built
+    /// its message ad hoc via `format!` at its one call site in
+    /// `document.rs`, and `is_decode_failure`'s fixed literal list didn't
+    /// include it — `try sort catch .` and `sort?` both wrongly treated
+    /// this as an ordinary catchable error).
+    pub fn colliding_display_key(key: &str) -> Self {
+        Self::new(format!(
+            "object key \"{key}\" is ambiguous{}",
+            Self::COLLIDING_DISPLAY_KEY_SUFFIX
+        ))
+    }
+
+    const COLLIDING_DISPLAY_KEY_SUFFIX: &'static str = ": an undecodable key's display form \
+         collides with another key of the same name and cannot be represented";
+
     /// Whether this is a [`Self::decode_failure`] — see #1620/#1660. Every
     /// `?`/`try`/`catch` boundary consults this so a decode failure passes
     /// through unmatched instead of being suppressed, the same way
@@ -1004,7 +1026,7 @@ impl EvalError {
                 | "invalid escape sequence in string"
                 | "invalid unicode escape sequence"
                 | "invalid escape sequence"
-        )
+        ) || self.message.ends_with(Self::COLLIDING_DISPLAY_KEY_SUFFIX)
     }
 
     /// Whether this error class is *always* uncatchable, with no positional

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40,12 +40,6 @@ use indexmap::{IndexMap, IndexSet};
 use super::document::{
     effective_fields, effective_len, resolve_display_key, DisplayKeyGuard, DocumentFields,
 };
-// Only consumed by `yaml_value_to_owned_checked`, which is itself
-// `#[cfg(feature = "std")]`-gated (`load()`'s YAML path) -- gated
-// separately from the block above so a `--no-default-features` build
-// doesn't warn on an unused import.
-#[cfg(feature = "std")]
-use super::document::colliding_display_key_error;
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
 
@@ -31632,7 +31626,7 @@ fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
                             Err(_) => (String::new(), true),
                         };
                         if !guard.check(&map, &key, is_fallback) {
-                            return Err(colliding_display_key_error(&key));
+                            return Err(EvalError::colliding_display_key(&key));
                         }
                         key
                     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2991,6 +2991,64 @@ fn test_materializing_route_raises_on_colliding_decode_failure_keys_1642() -> Re
     Ok(())
 }
 
+/// #1813: `colliding_display_key_error` (#1642) is built via
+/// `EvalError::decode_failure`, whose contract says the result "must never
+/// be suppressed by `?` or caught by `try`/`catch`" -- but `is_decode_failure`
+/// classified purely by matching `message` against a fixed literal list that
+/// didn't include this error's dynamic ("object key \"<key>\" is
+/// ambiguous: ...") text, so both `?` and `try`/`catch` treated it as an
+/// ordinary catchable error. Confirmed live before this fix: `sort?`
+/// silently produced no output at exit 0, and `try sort catch .` returned
+/// the message as a caught value instead of letting it escape.
+#[test]
+fn test_colliding_display_key_error_is_uncatchable_1813() -> Result<()> {
+    let dup_doc = r#"[{"\ud800":1,"\ud800":2}]"#;
+
+    let (out, err, code) = run_jq_full(&["sort?"], Some(dup_doc))?;
+    assert_ne!(
+        code, 0,
+        "`?` must not silently suppress a colliding-key error, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    let (out, err, code) = run_jq_full(&["try sort catch ."], Some(dup_doc))?;
+    assert_ne!(
+        code, 0,
+        "try/catch must not catch a colliding-key error, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    // `delpaths(...)?` specifically, called out by the issue: #1746 review
+    // added an `is_uncatchable()`-gated suppression bypass there.
+    let dup_obj = r#"{"\ud800":1,"\ud800":2}"#;
+    let (out, err, code) = run_jq_full(&["delpaths([[\"a\"]])?"], Some(dup_obj))?;
+    assert_ne!(
+        code, 0,
+        "delpaths(...)? must not silently suppress a colliding-key error, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    Ok(())
+}
+
+/// #1813 companion: a user's own `error(...)` call, even with the exact
+/// fixed suffix text `is_decode_failure` now also matches on, must stay
+/// ordinarily catchable -- the same `self.value.is_some()` guard #1660
+/// already established for the other decode-failure message literals
+/// covers this new one too, since `error(v)` is the only constructor that
+/// ever sets `value`.
+#[test]
+fn test_user_error_matching_colliding_key_suffix_stays_catchable_1813() -> Result<()> {
+    let filter = r#"try error("object key \"x\" is ambiguous: an undecodable key's display form collides with another key of the same name and cannot be represented") catch ("caught: " + .)"#;
+    let (out, err, code) = run_jq_full(&[filter], Some("null"))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert_eq!(
+        out.trim(),
+        "\"caught: object key \\\"x\\\" is ambiguous: an undecodable key's display form collides with another key of the same name and cannot be represented\""
+    );
+    Ok(())
+}
+
 /// #1642 follow-up: `-e`/`--exit-status` forces `JqValue::materialize()` on
 /// every result before `jq_runner.rs`'s own guarded `print_json` path ever
 /// runs (see `cursor_to_owned`'s doc comment in `src/jq/lazy.rs`) -- a

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19013,6 +19013,30 @@ fn test_load_yaml_two_undecodable_keys_collide_1801() -> Result<()> {
     Ok(())
 }
 
+/// #1813 review: the sibling test above only checks the raw, uncaught
+/// route -- `yaml_value_to_owned_checked` (`load()`'s YAML path,
+/// `eval.rs`) is a third call site for `EvalError::colliding_display_key`
+/// besides the two already covered directly by #1813's own tests, and
+/// nothing pinned that `try`/`catch` around `load()` itself still can't
+/// suppress it.
+#[test]
+fn test_load_yaml_colliding_keys_not_caught_by_try_catch_1813() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"\"b\xe1\x41c\": 1\n\"d\xe1\x41e\": 2\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let expr = format!("try load({path:?}) catch .");
+    let (out, err, code) = run_jq_full(&["-cn", &expr], None)?;
+    assert_ne!(
+        code, 0,
+        "try/catch must not catch a colliding-key error from load(), out: {out:?}"
+    );
+    assert!(err.contains("is ambiguous"), "err={err}");
+
+    Ok(())
+}
+
 /// #1801: a multi-document YAML file raises as soon as any one document
 /// contains an undecodable string, not just the last/first.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24594,3 +24594,30 @@ fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Resul
     );
     Ok(())
 }
+
+/// #1813: `colliding_display_key_error`'s uncatchability fix lives in
+/// shared `src/jq/error.rs`/`document.rs` code, reached identically by
+/// both evaluators -- confirms the fix applies to yq mode too, not just
+/// jq's own CLI tests. Uses `\q` (an invalid YAML escape, not raw invalid
+/// UTF-8 bytes) since a genuinely invalid UTF-8 byte sequence is rejected
+/// by YAML's own parser before the evaluator ever sees it, unlike JSON.
+#[test]
+fn test_colliding_display_key_error_is_uncatchable_yq_1813() -> Result<()> {
+    let doc = "\"b\\qc\": 1\n\"b\\qc\": 2\n";
+
+    let (out, err, code) = run_yq_stdin_with_stderr("sort?", doc, &[])?;
+    assert_ne!(
+        code, 0,
+        "`?` must not silently suppress a colliding-key error, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    let (out, err, code) = run_yq_stdin_with_stderr("try sort catch .", doc, &[])?;
+    assert_ne!(
+        code, 0,
+        "try/catch must not catch a colliding-key error, out: {out:?}"
+    );
+    assert!(err.contains("ambiguous"), "stderr: {err}");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1813

## Summary

`colliding_display_key_error` (#1642) is built via `EvalError::decode_failure`, whose contract says the result "must never be suppressed by `?` or caught by `try`/`catch`" (#1620). But `is_decode_failure()` classifies purely by matching `message` against a fixed literal list, and this error's dynamic `object key "<key>" is ambiguous: ...` text matched none of them — so `?` and `try`/`catch` both treated it as an ordinary catchable error.

## Repro (confirmed live before this fix)

```console
$ printf '[{"\z": 1, "\z": 2}]' | succinctly jq 'sort?'
$ echo $?
0
```

Silent — a real corruption signal (two undecodable keys colliding under the same display fallback) vanishes with no diagnostic at all, exactly the failure class #1620/#1642 exist to close.

## Fix

Followed this codebase's own established precedent rather than the dedicated-field alternative the issue names: a boolean field on `EvalError` was tried once already for `is_decode_failure()` itself and reverted, because the extra width propagated into `QueryResult`/`Control`'s recursive-materializer call frames and turned a controlled panic into a genuine stack overflow during unwind (#1021 — documented on `is_decode_failure()`'s own doc comment).

Extended the same zero-size-cost message-matching technique instead:
- Added `EvalError::colliding_display_key(key)`, co-locating the message's construction with a private fixed-suffix constant, the same way `invalid_path_expression` already does with its own prefix constant.
- `is_decode_failure()` now also matches that suffix.
- `document.rs`'s `colliding_display_key_error` delegates to the new constructor instead of hand-building the message via `format!`.

The existing `self.value.is_some()` guard (#1660 — true only for `error(v)`) already covers the obvious false-positive: a user's own `error("...")` call using text that happens to end with the same fixed suffix stays ordinarily catchable — confirmed by a new test.

## Testing

- New tests cover `sort?`, `try sort catch .`, and `delpaths(...)?` (the specific case #1746's review already gated on `is_uncatchable()`) all correctly letting this error escape uncaught.
- A companion test confirms a user's own `error(...)` call with the exact matching suffix text stays catchable (no new false positive).
- Verified against **both** evaluators — `error.rs`/`document.rs` are shared code, and a yq-mode test (using an invalid escape rather than invalid UTF-8 bytes, since YAML's own parser rejects the latter before the evaluator sees it) confirms the fix applies there too.
- All pre-existing `#1642`/`#1620`/`#1660`/`#1746` tests still pass unchanged.
- Full `cargo test --features cli,regex` (69/69 suites green), both CI clippy legs, `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --all-features`.