### PR TITLE
fix(yq): raise on a decode failure in a streamed scalar instead of degrading

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -801,49 +801,41 @@ Live-verified against yq v4.53.3. Pinned as known gaps (current, not the desired
 state) by `test_yq_auto_output_mixed_format_multi_file_known_gap_1493` and
 `test_yq_auto_output_slurp_mixed_format_known_gap_1493` in `tests/yq_cli_tests.rs`.
 
-### A bad escape in a streamed scalar still degrades silently instead of raising
+### A key that will not decode is preserved as `""` rather than raising
 
-[#1247](https://github.com/rust-works/succinctly/issues/1247) routed almost every
-decode-failure materialization path through a real `EvalError` — but two streaming output
-writers were left as a deliberately-deferred gap ("Stage 6" in
-[`docs/plan/decode-failure-routing.md`](../../plan/decode-failure-routing.md)): their only
-error channel is `core::fmt::Result`, which carries no message, so a mid-stream failure
-there can only be silently absorbed or cause a bare, undiagnosed abort. Both still emit a
-substituted `null`/`""` at exit 0 for a value or key with a bad escape, live-verified
-against the same build that fixed every other #1247 site:
+Real yq rejects a document containing an undecodable scalar outright (`found unknown
+escape character`, exit 1), whatever the scalar's position. succinctly matches that for a
+**value**, on every route, and deliberately does not for a mapping **key**.
+
+For values this was once a route-dependent split — the *materializing* routes (`--arg`,
+`-P`, `to_entries`, `length`) raised via
+[#1247](https://github.com/rust-works/succinctly/issues/1247), while the *streaming*
+writers silently substituted `null`/`""` at exit 0, because their only error channel was
+`core::fmt::Result`, which carries no message. That was the design's deferred "Stage 6"
+(`docs/plan/decode-failure-routing.md`) and is **closed** by
+[#1615](https://github.com/rust-works/succinctly/issues/1615), which gave those writers a
+real error type (`StreamFailure`). Both spellings of one document now give one answer:
 
 ```console
 $ printf 'a: 1\nb: "bad \q escape"\n' | succinctly yq -o=json '.'
-{
-  "a": 1,
-  "b": null
-}
-$ printf 'a: 1\nb: "bad \q escape"\n' | yq -o=json '.'
-Error: bad file '-': yaml: while scanning a quoted scalar at line 2, column 4: line 2, column 9: found unknown escape character
-
+Error: invalid escape sequence                    # exit 1, matching yq's own rejection
 $ printf 'double: "quoted \q scalar"\n' | succinctly yq '.'
-double: ""
-$ printf '"a\qb": 1\nb: 2\n' | succinctly yq '.'
-"": 1
-b: 2
+Error: invalid escape sequence                    # exit 1
 ```
 
-The first pair (`-o=json`, `stream_json_value`/the YAML→JSON transcoders) is the case the
-design doc names. The second and third (default YAML→YAML output, no `-o` flag —
-`stream_yaml_string_value`/`write_yaml_field_key`, the single most common `yq`
-invocation) are the same gap on its YAML-target sibling, not previously recorded anywhere.
-Every *materializing* route (a `--arg`-forced DOM, a multi-result filter, `to_entries`,
-`length`) already raises correctly for a bad *value* like the one above; only these two
-purely-streamed writers do not. Fixing either needs `stream_json_value`/`stream_yaml_value`
-and their callers to carry a richer error than `fmt::Error` — the design doc's own stated
-reason Stage 6 was split out and deferred rather than attempted alongside the rest of
-#1247's landed stages.
+Whatever prefix had already been written before the failure is left on stdout rather than
+buffered and discarded — the same truncate-then-diagnose trade
+[#1641](https://github.com/rust-works/succinctly/issues/1641) and
+[#1679](https://github.com/rust-works/succinctly/issues/1679) settled for their own
+streaming sites. Buffering the whole record instead would reverse P9 (direct YAML-to-JSON
+streaming, a 2.3x win) for a malformed-input edge case, and is an explicit non-goal of the
+design doc.
 
 A bad *key* is a different story, on both routes, since [#1642](https://github.com/rust-works/succinctly/issues/1642):
 `to_entries`/`keys`/`length` all preserve it (as `""`, `YamlValue::key_string`'s existing
 convention for a mapping key with no scalar form -- issue #222) rather than raising, on
-*every* route, streamed or materialized alike -- matching the third example above
-(`"a\qb": 1` → `"": 1`) and jq mode's own analogous fix for a JSON key (see the "A key
+*every* route, streamed or materialized alike (`"a\qb": 1` → `"": 1`), and jq mode's own
+analogous fix for a JSON key (see the "A key
 that will not decode is never a duplicate" note under [jq Limitations § Duplicate object
 keys collapse, except under `--preserve-input`](../jq/limitations.md#duplicate-object-keys-collapse-except-under---preserve-input)).
 `has`/`in` agree too, for the same reason as jq mode: neither has native handling and both

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -831,6 +831,20 @@ streaming sites. Buffering the whole record instead would reverse P9 (direct YAM
 streaming, a 2.3x win) for a malformed-input edge case, and is an explicit non-goal of the
 design doc.
 
+Because that prefix can be left unterminated mid-value, a decode failure on a *streamed*
+route **stops the run** rather than continuing to the next document: the alternative welds
+the following document's `---` onto the truncated line, yielding output that re-reads as
+valid YAML with a fabricated value. Real yq rejects the whole file for these inputs too,
+so this is also the closer answer. `--inplace` leaves the file byte-identical, matching
+both real yq and succinctly's own materializing `-i` path.
+
+This does **not** narrow [#355](https://github.com/rust-works/succinctly/issues/355)'s
+divergence — that a malformed value does not cost you the good documents around it. #355
+lives on the *materializing* routes, which write nothing partial and still process every
+document (`--arg z y '.'` on the file above still prints the later documents after the
+diagnostic). An ordinary uncaught *evaluation* error continues on the streamed route too,
+for the same reason: it reaches stderr without having written anything to stdout.
+
 A bad *key* is a different story, on both routes, since [#1642](https://github.com/rust-works/succinctly/issues/1642):
 `to_entries`/`keys`/`length` all preserve it (as `""`, `YamlValue::key_string`'s existing
 convention for a mapping key with no scalar form -- issue #222) rather than raising, on

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -673,6 +673,13 @@ Four value-writer sites, not the three the issue scoped:
    common navigated shape, `yq '.b'`, still printed `""` at exit 0 while `yq -o=json '.b'`
    on the same document raised.
 
+Because the prefix can be left unterminated mid-value, a streamed decode failure stops the
+run rather than continuing to the next document (welding the next `---` onto a truncated
+line produces output that re-reads as valid YAML with a fabricated value), and `--inplace`
+leaves the file byte-identical. `StreamStats::truncated` is what separates this from an
+ordinary uncaught evaluation error, which writes nothing to `out` and so still continues
+per #355 — gating on `stats.error` instead would have silently narrowed that divergence.
+
 Mapping **keys** are excluded on purpose (`Undecodable::PreserveEmpty` in
 `yaml/light.rs`): #1642 settled that a key with no scalar form is preserved as `""` on
 every route, and `keys`/`to_entries`/`length` all report it, so raising in a streamed

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -1,6 +1,6 @@
 # Decode-failure error routing for `to_owned`/`cursor_to_owned` (#1247, #1242, #1194)
 
-**Status: partially implemented — Stages 1–5 landed, 6 outstanding.** This
+**Status: implemented — Stages 1–6 all landed.** This
 document is the deliverable for
 [#1247](https://github.com/rust-works/succinctly/issues/1247), which was tiered Tier 3
 ("needs a design decision before implementation, not a same-pattern continuation of the
@@ -466,10 +466,11 @@ all of 17–20 under this stage's "✅ landed."** Re-reading both directly:
   architecturally the same class of gap Stage 6 below is about (a `core::fmt::Write`-only
   error channel that cannot cleanly raise mid-stream) — it was miscategorized as a simple
   Stage-4 fix rather than folded into Stage 6 alongside its YAML→JSON and YAML→YAML
-  siblings. See [yq Limitations § A bad escape in a streamed scalar still degrades
-  silently](../compliance/yq/limitations.md#a-bad-escape-in-a-streamed-scalar-still-degrades-silently-instead-of-raising)
-  for the two siblings that are recorded; this third one belongs in the same bucket once
-  Stage 6 is scoped.
+  siblings. **Its string arm is now fixed with those siblings by #1615** (Stage 6 below);
+  the `StandardJson::Error(_)` arm itself still writes `null`, since that is a
+  *structural* malformation (#1194's class), not a decode failure, and answering it here
+  alone would split #1194's decision across two issues. See [yq Limitations § A key that
+  will not decode is preserved](../compliance/yq/limitations.md#a-key-that-will-not-decode-is-preserved-as--rather-than-raising).
 
 One site was reverted after being written, and later fixed for real by
 [#1641](https://github.com/rust-works/succinctly/issues/1641). `print_json`'s
@@ -494,8 +495,8 @@ see
 
 Site 20 (`json/light.rs:2098`, the JSON→YAML streaming output path) is a genuinely
 different case from this one, not covered by #1641: it is built on `core::fmt::Write`,
-which really does carry no richer error type, so it remains folded into Stage 6 below
-alongside its YAML→JSON and YAML→YAML siblings.
+which really does carry no richer error type, so it was folded into Stage 6 below
+alongside its YAML→JSON and YAML→YAML siblings, and landed there with them (#1615).
 
 Evaluation still continues past the bad value, so the good documents either side of it in
 a multi-value stream are still processed (`ErrorSink`, #355). Real jq aborts the whole run
@@ -641,15 +642,43 @@ remaining cost is non-ASCII YAML on ARM (no NEON arm for `validate_utf8`, +4.8%/
 net of control on a 45%-non-ASCII 10 MB document) — still under the ceiling, ARM-only,
 and a targeted NEON fix if it ever matters, not blocking.
 
-**Stage 6 — make the YAML streaming path loud (new, split out of Stage 2).** After
-Stages 2 and 3, `succinctly yq -o=json '.'` on a document with a bad *escape* still emits
-`{"b":null}` at exit 0: the streaming transcoder's only error channel is
-`core::fmt::Result`, which carries no message, so Stage 2 could make its output valid but
-not make it raise. Every *materializing* route (a `--arg`-forced DOM, a multi-result
-filter, `to_entries`, `length`) already raises. Closing the gap needs `stream_json_value`
-and its callers to carry a richer error than `fmt::Error` — a contained change, but its
-own one. Stage 5 removes the invalid-UTF-8 half of this case at the input boundary, so
-what Stage 6 is left with is bad escapes only.
+**Stage 6 — make the YAML streaming path loud (new, split out of Stage 2). ✅ landed**
+via [#1615](https://github.com/rust-works/succinctly/issues/1615). After Stages 2 and 3,
+`succinctly yq -o=json '.'` on a document with a bad *escape* still emitted `{"b":null}`
+at exit 0: the streaming transcoder's only error channel was `core::fmt::Result`, which
+carries no message, so Stage 2 could make its output valid but not make it raise. Every
+*materializing* route (a `--arg`-forced DOM, a multi-result filter, `to_entries`,
+`length`) already raised. Stage 5 removed the invalid-UTF-8 half at the input boundary, so
+what Stage 6 was left with is bad escapes only.
+
+The richer error this stage was waiting on is `StreamFailure`
+([src/jq/stream.rs](../../src/jq/stream.rs)) — `Fmt` for a genuine writer failure,
+`Decode(EvalError)` for a scalar that will not decode. Because `From<core::fmt::Error>`
+converts into it, every existing `?` inside the writers kept working unchanged; only the
+family's return types and its leaf substitution sites needed touching, not each of its
+recursive call sites. There is deliberately **no** `From<StreamFailure> for
+core::fmt::Error`: that impl would let a plain `?` silently re-collapse a decode failure
+into the message-less error this type exists to escape, so its absence is what makes every
+such site a compile error instead.
+
+Four value-writer sites, not the three the issue scoped:
+
+1. `stream_json_value` (`yaml/light.rs`) — YAML→JSON, the site this doc originally named;
+2. `stream_yaml_string_value` (`yaml/light.rs`) — YAML→YAML, the *default* invocation;
+3. `stream_json_as_yaml`'s string arm (`json/light.rs`) — JSON→YAML (site 20 above), whose
+   failure was a message-less `core::fmt::Error` rather than a silent substitution;
+4. `stream_yaml_as_document`'s **root-scalar shortcut** (`yaml/light.rs`) — found only by
+   testing, not by the site inventory. It deliberately bypasses 1–3 (see #996/#852) and so
+   carried its own `unwrap_or(Cow::Borrowed("\"\""))` swallow, which meant the single most
+   common navigated shape, `yq '.b'`, still printed `""` at exit 0 while `yq -o=json '.b'`
+   on the same document raised.
+
+Mapping **keys** are excluded on purpose (`Undecodable::PreserveEmpty` in
+`yaml/light.rs`): #1642 settled that a key with no scalar form is preserved as `""` on
+every route, and `keys`/`to_entries`/`length` all report it, so raising in a streamed
+identity alone would have re-opened the same one-document-many-answers split on the key
+axis. The output already written before a failure is kept rather than buffered and
+discarded, matching #1641/#1679 and the "buffering the whole record" non-goal below.
 
 ## Non-goals (explicit, to prevent scope creep)
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -16,6 +16,7 @@ use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
     to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
 };
+use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
     self, assert_value_tree_depth, nonfinite_display_string, sync_aliased_paths, Builtin,
     EvalError, Expr, NumberRepr, OwnedValue, QueryResult, YqSemantics,
@@ -125,24 +126,81 @@ impl<W: Write> ColorSink<'_, W> {
 /// renders into a buffer instead (still via the duplicate-key-safe cursor
 /// streamer passed in as `render`), then runs the buffer through `colorize`
 /// before writing the colorized result (#748).
+/// Render `render`'s output to `writer`, colorizing first if asked.
+///
+/// The nested `Result` is #1615's decode-failure channel, not redundancy: the
+/// outer `anyhow::Result` is a genuine *write* failure (the process cannot
+/// continue), while `Ok(Err(e))` is a well-formed run over a document holding
+/// a scalar that will not decode — a diagnostic for stderr and an exit code,
+/// which only the caller's [`ErrorSink`] can set. Collapsing the two would put
+/// a data error on the I/O path and lose the message, which is exactly the
+/// "bare, undiagnosed abort" that kept this gap open (see
+/// `docs/plan/decode-failure-routing.md`, Stage 6).
+///
+/// Whatever reached `out` before the failure is still written, colorized path
+/// included — the same keep-the-prefix-and-diagnose trade #1641/#1679 settled
+/// for their own streaming sites.
 fn stream_maybe_colored<W: Write, T>(
     writer: &mut W,
     use_color: bool,
     colorize: impl FnOnce(&str, &[usize]) -> String,
-    render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, core::fmt::Error>,
-) -> anyhow::Result<T> {
+    render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, StreamFailure>,
+) -> anyhow::Result<Result<T, EvalError>> {
     if use_color {
         let mut sink = ColorSink::Buffered(String::new(), Vec::new());
-        let value = render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))?;
+        let rendered = render(&mut sink);
         let ColorSink::Buffered(buf, boundaries) = sink else {
             unreachable!("stream_maybe_colored always constructs ColorSink::Buffered here")
         };
         write!(writer, "{}", colorize(&buf, &boundaries))?;
-        Ok(value)
+        match rendered {
+            Ok(value) => Ok(Ok(value)),
+            Err(StreamFailure::Decode(e)) => Ok(Err(e)),
+            Err(StreamFailure::Fmt) => Err(anyhow::anyhow!("Write error")),
+        }
     } else {
         let mut sink = ColorSink::Direct(FmtWriter(writer));
-        render(&mut sink).map_err(|_| anyhow::anyhow!("Write error"))
+        match render(&mut sink) {
+            Ok(value) => Ok(Ok(value)),
+            Err(StreamFailure::Decode(e)) => Ok(Err(e)),
+            Err(StreamFailure::Fmt) => Err(anyhow::anyhow!("Write error")),
+        }
     }
+}
+
+/// [`stream_maybe_colored`] for a render that produces no value, reporting a
+/// decode failure to `sink` instead of returning it (#1615).
+///
+/// Answers whether the render completed, so the caller can skip a trailing
+/// terminator write for output that was cut short.
+fn stream_or_report<W: Write>(
+    writer: &mut W,
+    use_color: bool,
+    sink: &mut ErrorSink,
+    colorize: impl FnOnce(&str, &[usize]) -> String,
+    render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<(), StreamFailure>,
+) -> anyhow::Result<bool> {
+    match stream_maybe_colored(writer, use_color, colorize, render)? {
+        Ok(()) => Ok(true),
+        Err(e) => {
+            report_stream_decode_failure(sink, &e);
+            Ok(false)
+        }
+    }
+}
+
+/// Route a streamed decode failure to the same [`ErrorSink`] every
+/// *materializing* route already reports through (#1615), so one document
+/// gives one answer — message and exit code — however it was rendered.
+fn report_stream_decode_failure(sink: &mut ErrorSink, err: &EvalError) {
+    sink.report_stream(
+        DiagStyle::Yq,
+        &succinctly::jq::stream::StreamError {
+            message: err.message.clone(),
+            not_a_string: false,
+        },
+        &no_location(),
+    );
 }
 
 /// Evaluation context for passing variables to the jq evaluator.
@@ -3648,17 +3706,25 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     )?;
                     // No boundary recorded here -- the terminator is written
                     // directly to `$writer` below, outside this buffer (#1708).
-                    stream_maybe_colored(
+                    let rendered = stream_maybe_colored(
                         $writer,
                         $use_color,
                         |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                         |out| $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys),
                     )?;
-                    terminator.write_io($writer)?;
-                    // Streaming skips evaluation, so inspect the document
-                    // value directly to keep `-e` falsy tracking (#178).
-                    if args.exit_status {
-                        any_truthy |= !$cursor.is_falsy();
+                    // #1615: this identity/P9 branch skips evaluation, so it
+                    // has no `StreamStats` to carry a diagnostic -- route the
+                    // decode failure to the same sink the evaluated branch
+                    // reaches via `absorb_stream_stats`.
+                    if let Err(e) = rendered {
+                        report_stream_decode_failure(&mut sink, &e);
+                    } else {
+                        terminator.write_io($writer)?;
+                        // Streaming skips evaluation, so inspect the document
+                        // value directly to keep `-e` falsy tracking (#178).
+                        if args.exit_status {
+                            any_truthy |= !$cursor.is_falsy();
+                        }
                     }
                 } else {
                     // M2 YAML path: evaluate and stream YAML results
@@ -3691,11 +3757,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $use_color,
                         |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
-                            result.stream_yaml(out, yaml_indent, sort_keys, |w| {
-                                w.write_result_terminator(terminator)
-                            })
+                            result
+                                .stream_yaml(out, yaml_indent, sort_keys, |w| {
+                                    w.write_result_terminator(terminator)
+                                })
+                                .map_err(StreamFailure::from)
                         },
                     )?;
+                    // `GenericResult::stream_yaml` reports a decode failure
+                    // through `stats.error`, not by failing, so the outer
+                    // `Result` here is only ever `Ok` (#1615).
+                    let stats = stats.unwrap_or_default();
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
                 }
@@ -3703,17 +3775,22 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // M2 path: JSON output streaming
                 if is_identity {
                     // P9 path: stream directly without evaluation
-                    stream_maybe_colored(
+                    // See the YAML identity branch above (#1615).
+                    let rendered = stream_maybe_colored(
                         $writer,
                         $use_color,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| $cursor.stream_json(out, json_indent, sort_keys),
                     )?;
-                    terminator.write_io($writer)?;
-                    // Streaming skips evaluation, so inspect the document
-                    // value directly to keep `-e` falsy tracking (#178).
-                    if args.exit_status {
-                        any_truthy |= !$cursor.is_falsy();
+                    if let Err(e) = rendered {
+                        report_stream_decode_failure(&mut sink, &e);
+                    } else {
+                        terminator.write_io($writer)?;
+                        // Streaming skips evaluation, so inspect the document
+                        // value directly to keep `-e` falsy tracking (#178).
+                        if args.exit_status {
+                            any_truthy |= !$cursor.is_falsy();
+                        }
                     }
                 } else {
                     // M2 path: evaluate and stream results
@@ -3723,11 +3800,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $use_color,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |out| {
-                            result.stream_json(out, json_indent, sort_keys, |w| {
-                                terminator.write_fmt(w)
-                            })
+                            result
+                                .stream_json(out, json_indent, sort_keys, |w| {
+                                    terminator.write_fmt(w)
+                                })
+                                .map_err(StreamFailure::from)
                         },
                     )?;
+                    // See the YAML branch above (#1615).
+                    let stats = stats.unwrap_or_default();
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
                 }
@@ -3790,31 +3871,35 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     if args.document.is_none() || args.document == Some(0) {
                         if is_identity {
                             // P9 path for identity on single doc
-                            if can_yaml_fast_path {
+                            let streamed_ok = if can_yaml_fast_path {
                                 // No boundary recorded here --
                                 // `write_terminator` below writes directly,
                                 // outside this buffer (#1708).
-                                stream_maybe_colored(
+                                stream_or_report(
                                     &mut writer,
                                     output_config.use_color,
+                                    &mut sink,
                                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                                     |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
-                                )?;
+                                )?
                             } else {
-                                stream_maybe_colored(
+                                stream_or_report(
                                     &mut writer,
                                     output_config.use_color,
+                                    &mut sink,
                                     |s, _boundaries| {
                                         output::colorize_json(s, &ColorScheme::default())
                                     },
                                     |out| root.stream_json_document(out, json_indent, sort_keys),
-                                )?;
-                            }
-                            write_terminator(&mut writer, &output_config)?;
-                            // `root` is the virtual document sequence; falsiness
-                            // lives on the actual document value (#178).
-                            if args.exit_status {
-                                any_truthy |= root.first_child().is_some_and(|c| !c.is_falsy());
+                                )?
+                            };
+                            if streamed_ok {
+                                write_terminator(&mut writer, &output_config)?;
+                                // `root` is the virtual document sequence; falsiness
+                                // lives on the actual document value (#178).
+                                if args.exit_status {
+                                    any_truthy |= root.first_child().is_some_and(|c| !c.is_falsy());
+                                }
                             }
                         } else {
                             // M2 path: need to get the actual document cursor
@@ -3918,37 +4003,43 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         if should_process {
                             if is_identity {
                                 // P9 path for identity on single doc
-                                if can_yaml_fast_path {
+                                let streamed_ok = if can_yaml_fast_path {
                                     // No boundary recorded here --
                                     // `write_terminator` below writes
                                     // directly, outside this buffer (#1708).
-                                    stream_maybe_colored(
+                                    stream_or_report(
                                         &mut writer,
                                         output_config.use_color,
+                                        &mut sink,
                                         |s, boundaries| {
                                             colorize_yaml(s, Terminator::None, boundaries)
                                         },
                                         |out| {
                                             root.stream_yaml_document(out, yaml_indent, sort_keys)
                                         },
-                                    )?;
+                                    )?
                                 } else {
-                                    stream_maybe_colored(
+                                    stream_or_report(
                                         &mut writer,
                                         output_config.use_color,
+                                        &mut sink,
                                         |s, _boundaries| {
                                             output::colorize_json(s, &ColorScheme::default())
                                         },
                                         |out| {
                                             root.stream_json_document(out, json_indent, sort_keys)
                                         },
-                                    )?;
-                                }
-                                write_terminator(&mut writer, &output_config)?;
-                                // `root` is the virtual document sequence; falsiness
-                                // lives on the actual document value (#178).
-                                if args.exit_status {
-                                    any_truthy |= root.first_child().is_some_and(|c| !c.is_falsy());
+                                    )?
+                                };
+                                if streamed_ok {
+                                    write_terminator(&mut writer, &output_config)?;
+                                    // `root` is the virtual document sequence;
+                                    // falsiness lives on the actual document
+                                    // value (#178).
+                                    if args.exit_status {
+                                        any_truthy |=
+                                            root.first_child().is_some_and(|c| !c.is_falsy());
+                                    }
                                 }
                             } else {
                                 // M2 path: need to get the actual document cursor
@@ -4341,10 +4432,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // to `-o=json` by #1577): `stream_yaml_sequence`/
             // `stream_json_sequence` are both generic over `core::fmt::Write`,
             // so each slots into `stream_maybe_colored` unmodified.
-            if output_config.output_format == OutputFormat::Json {
-                stream_maybe_colored(
+            let streamed_ok = if output_config.output_format == OutputFormat::Json {
+                stream_or_report(
                     &mut writer,
                     output_config.use_color,
+                    &mut sink,
                     |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                     |out| {
                         stream_json_sequence(
@@ -4356,13 +4448,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             sort_keys,
                         )
                     },
-                )?;
+                )?
             } else {
                 // No boundary recorded here -- `write_terminator` below
                 // writes directly, outside this buffer (#1708).
-                stream_maybe_colored(
+                stream_or_report(
                     &mut writer,
                     output_config.use_color,
+                    &mut sink,
                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                     |out| {
                         stream_yaml_sequence(
@@ -4374,16 +4467,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             sort_keys,
                         )
                     },
-                )?;
-            }
+                )?
+            };
             // #1701: this fast path streams straight to `&mut writer`
             // (like `stream_cursor!`'s own identity branch), so it needs
             // the same `Terminator`-based write instead of a hardcoded
             // `writeln!` -- confirmed live that `--slurp -0`/`--slurp
             // --join-output` still emitted a bare newline here before this
             // fix, unlike the `stream_cursor!`-based fast paths this same
-            // issue's title names.
-            write_terminator(&mut writer, &output_config)?;
+            // issue's title names. Skipped when the stream was cut short by a
+            // decode failure (#1615) -- the diagnostic is already on stderr
+            // and there is no complete result for a terminator to close.
+            if streamed_ok {
+                write_terminator(&mut writer, &output_config)?;
+            }
         } else {
             // #1493: resolve `Auto` against the uniform format of every
             // source, if they all agree (confirmed live: an all-JSON slurp

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3441,6 +3441,24 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // Uncaught evaluation errors. Evaluation continues past one, so the failure
     // is remembered here and turned into yq's exit 1 below (#355).
     let mut sink = ErrorSink::default();
+    // #1615: set when a streamed *identity* render was cut off part-way
+    // through a document by a decode failure. Only the identity/P9 branches
+    // can leave the output mid-document: they stream a container's structure
+    // directly, so `a: 1\nb: ` is already written by the time the bad scalar
+    // is reached, with no newline to close it. The *evaluated* branches
+    // cannot -- `GenericResult`'s streamers report through `StreamStats`
+    // without emitting a partial scalar, which is why an evaluated filter
+    // still continues to the next document (#355) and only this flag stops
+    // the loop. Declared here, before `stream_cursor!`, because a bare
+    // identifier inside a `macro_rules!` resolves against definition-site
+    // scope -- the same reason `sink` itself lives out here.
+    // A `Cell`, not a plain `bool`: `stream_cursor!` expands in several
+    // places where nothing downstream reads the flag (the `--inplace`
+    // single-document arm has no loop to break out of), and a plain
+    // assignment there is a dead store -- `unused_assignments` fires, which
+    // `-D warnings` turns into a CI failure. `Cell::set` is a method call, so
+    // the lint does not apply, and the flag stays one shared value.
+    let stream_truncated = core::cell::Cell::new(false);
 
     // Check if expression contains split_doc - if so, each result is a separate document
     let has_split_doc = contains_split_doc(&program.expr);
@@ -3718,6 +3736,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // reaches via `absorb_stream_stats`.
                     if let Err(e) = rendered {
                         report_stream_decode_failure(&mut sink, &e);
+                        stream_truncated.set(true);
                     } else {
                         terminator.write_io($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -3766,8 +3785,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     )?;
                     // `GenericResult::stream_yaml` reports a decode failure
                     // through `stats.error`, not by failing, so the outer
-                    // `Result` here is only ever `Ok` (#1615).
-                    let stats = stats.unwrap_or_default();
+                    // `Result` is only ever `Ok` here. Handled rather than
+                    // `unwrap_or_default()`ed anyway (#1615): defaulting would
+                    // discard the diagnostic and exit 0, re-creating the exact
+                    // silent swallow this change closes, if a future streamer
+                    // ever did return `Decode` from this arm.
+                    let stats = match stats {
+                        Ok(stats) => stats,
+                        Err(e) => {
+                            report_stream_decode_failure(&mut sink, &e);
+                            stream_truncated.set(true);
+                            Default::default()
+                        }
+                    };
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
                 }
@@ -3784,6 +3814,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     )?;
                     if let Err(e) = rendered {
                         report_stream_decode_failure(&mut sink, &e);
+                        stream_truncated.set(true);
                     } else {
                         terminator.write_io($writer)?;
                         // Streaming skips evaluation, so inspect the document
@@ -3808,7 +3839,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         },
                     )?;
                     // See the YAML branch above (#1615).
-                    let stats = stats.unwrap_or_default();
+                    let stats = match stats {
+                        Ok(stats) => stats,
+                        Err(e) => {
+                            report_stream_decode_failure(&mut sink, &e);
+                            stream_truncated.set(true);
+                            Default::default()
+                        }
+                    };
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
                 }
@@ -3854,8 +3892,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 output_config.use_color,
                                 output_config
                             );
-                            // See the matching check in the per-file loop below.
-                            if sink.halted().is_some() {
+                            // #1615: a truncated identity render has no
+                            // newline closing it, so continuing would weld the
+                            // next document's `---` onto the cut-off line --
+                            // producing output that reads back as valid YAML
+                            // with a fabricated value (`b: ---`), which is
+                            // worse than the silent `null` this change
+                            // replaces. Real yq aborts the whole run on this
+                            // input anyway.
+                            if sink.halted().is_some() || stream_truncated.get() {
                                 break;
                             }
                         }
@@ -3983,7 +4028,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 // `can_use_m2_streaming` — would keep
                                 // streaming further documents and files
                                 // instead of stopping immediately.
-                                if sink.halted().is_some() {
+                                // #1615: see the `Sequence` arm's note above.
+                                if sink.halted().is_some() || stream_truncated.get() {
                                     break 'm2_files;
                                 }
                             }
@@ -4053,7 +4099,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         output_config
                                     );
                                     // See the matching check in the `Sequence` arm above.
-                                    if sink.halted().is_some() {
+                                    // #1615 adds the truncation term.
+                                    if sink.halted().is_some() || stream_truncated.get() {
                                         break 'm2_files;
                                     }
                                 }
@@ -4547,6 +4594,26 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
 
             let mut output_buffer = Vec::new();
+            // #1615: a decode failure must leave the file byte-identical, the
+            // way the *materializing* `--inplace` path already does (`-i '.a =
+            // 5'` on an undecodable scalar raises and does not touch the file)
+            // and the way real yq does on every filter. The streamed path
+            // reports through `sink` and keeps going, so it would otherwise
+            // reach the `fs::write` below and commit a truncated buffer --
+            // strictly worse than the silent `b: ""` this whole change
+            // replaces, because it destroys the user's own data. Compared
+            // rather than a bool so *any* diagnostic raised while building
+            // this file's buffer protects it, not only the streamed ones.
+            let reports_before_file = sink.report_count();
+            // Reset per file, not just per run: `--inplace` keeps editing the
+            // remaining files after one fails, so a flag left set by an
+            // earlier file would break the *next* file's document loop on its
+            // first iteration -- committing a buffer holding only that file's
+            // first document and silently dropping the rest. (The stdout paths
+            // need no such reset: their truncation break leaves the whole run
+            // via `break 'm2_files`, and the stdin branch has no file loop at
+            // all.)
+            stream_truncated.set(false);
 
             // `--inplace` never writes ANSI to disk (#809): shadow
             // `output_config` for the rest of this file's write so the DOM
@@ -4620,6 +4687,18 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     if sink.halted().is_some() {
                                         break;
                                     }
+                                    // #1615: same reasoning as the halt break
+                                    // above. Once a document has been cut off
+                                    // mid-value there is no newline to close
+                                    // it, so continuing would weld the next
+                                    // document's `---` onto the truncated
+                                    // line. The buffer is discarded by the
+                                    // write-back guard either way; stopping
+                                    // keeps it from growing a fabricated
+                                    // value first.
+                                    if stream_truncated.get() {
+                                        break;
+                                    }
                                 }
                                 global_doc_index += 1;
                                 docs = rest;
@@ -4635,20 +4714,34 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 .map_or(true, |target| global_doc_index == target);
                             if should_process {
                                 if is_identity {
-                                    if can_inplace_yaml_fast_path {
+                                    // #1615: a bare `map_err(|_| "Write
+                                    // error")` here would collapse a `Decode`
+                                    // into exactly the message-less error
+                                    // `StreamFailure` exists to escape -- and
+                                    // would leave `sink` unmarked, so the
+                                    // write-back guard above would still
+                                    // commit the truncated buffer.
+                                    let streamed = if can_inplace_yaml_fast_path {
                                         root.stream_yaml_document(
                                             &mut FmtWriter(&mut buf_writer),
                                             yaml_indent,
                                             sort_keys,
                                         )
-                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
                                     } else {
                                         root.stream_json_document(
                                             &mut FmtWriter(&mut buf_writer),
                                             json_indent,
                                             sort_keys,
                                         )
-                                        .map_err(|_| anyhow::anyhow!("Write error"))?;
+                                    };
+                                    match streamed {
+                                        Ok(()) => {}
+                                        Err(StreamFailure::Decode(e)) => {
+                                            report_stream_decode_failure(&mut sink, &e);
+                                        }
+                                        Err(StreamFailure::Fmt) => {
+                                            anyhow::bail!("Write error")
+                                        }
                                     }
                                     write_terminator(&mut buf_writer, &output_config)?;
                                     if args.exit_status {
@@ -4842,7 +4935,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // external contract to defer to here, only this project's own
             // considered choice to err toward preserving user data whenever
             // a halt is involved.
-            if any_real_output || sink.halted().is_none() {
+            // #1615 adds the `report_count` term; see `reports_before_file`.
+            if (any_real_output || sink.halted().is_none())
+                && sink.report_count() == reports_before_file
+            {
                 std::fs::write(path, &output_buffer)
                     .with_context(|| format!("failed to write to file: {}", path.display()))?;
             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3800,6 +3800,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     };
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
+                    // #1615: an evaluated result can be a *container* holding
+                    // an undecodable scalar, in which case the cursor stream
+                    // is already part-written when it fails -- same truncation
+                    // the identity branches produce, so it needs the same
+                    // stop. Gated on `truncated`, never on `stats.error`: an
+                    // ordinary uncaught error writes nothing to `out` and must
+                    // still continue to the next document (#355).
+                    if stats.truncated {
+                        stream_truncated.set(true);
+                    }
                 }
             } else {
                 // M2 path: JSON output streaming
@@ -3849,6 +3859,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     };
                     any_truthy |= stats.any_truthy;
                     absorb_stream_stats(&mut sink, &stats);
+                    // #1615: an evaluated result can be a *container* holding
+                    // an undecodable scalar, in which case the cursor stream
+                    // is already part-written when it fails -- same truncation
+                    // the identity branches produce, so it needs the same
+                    // stop. Gated on `truncated`, never on `stats.error`: an
+                    // ordinary uncaught error writes nothing to `out` and must
+                    // still continue to the next document (#355).
+                    if stats.truncated {
+                        stream_truncated.set(true);
+                    }
                 }
             }
         }};

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -14,6 +14,7 @@ use indexmap::IndexMap;
 use std::borrow::Cow;
 
 use super::error::EvalError;
+use super::stream::{StreamFailure, StreamResult};
 
 /// Indentation configuration for cursor/lazy streaming output.
 ///
@@ -358,8 +359,8 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         _out: &mut W,
         _indent: IndentSpec,
         _sort_keys: bool,
-    ) -> core::fmt::Result {
-        Err(core::fmt::Error)
+    ) -> StreamResult {
+        Err(StreamFailure::Fmt)
     }
 
     /// Stream this cursor's value as YAML to the output.
@@ -376,8 +377,8 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         _out: &mut W,
         _indent: IndentSpec,
         _sort_keys: bool,
-    ) -> core::fmt::Result {
-        Err(core::fmt::Error)
+    ) -> StreamResult {
+        Err(StreamFailure::Fmt)
     }
 
     /// Like [`stream_yaml`](Self::stream_yaml), but also appends this
@@ -396,7 +397,7 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         out: &mut W,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         self.stream_yaml(out, indent, sort_keys)
     }
 
@@ -432,8 +433,8 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         _out: &mut W,
         _indent: IndentSpec,
         _sort_keys: bool,
-    ) -> core::fmt::Result {
-        Err(core::fmt::Error)
+    ) -> StreamResult {
+        Err(StreamFailure::Fmt)
     }
 
     /// The YAML counterpart of
@@ -444,8 +445,8 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         _out: &mut W,
         _indent: IndentSpec,
         _sort_keys: bool,
-    ) -> core::fmt::Result {
-        Err(core::fmt::Error)
+    ) -> StreamResult {
+        Err(StreamFailure::Fmt)
     }
 
     /// Check if the value at this cursor is falsy (null or false).

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2879,6 +2879,9 @@ fn absorb_stream_failure(
     match e {
         crate::jq::stream::StreamFailure::Decode(err) => {
             stats.error = Some(stream_error(&err));
+            // The cursor stream was cut off part-way through a value, unlike
+            // an ordinary evaluation error which writes nothing (#1615).
+            stats.truncated = true;
             Ok(true)
         }
         crate::jq::stream::StreamFailure::Fmt => Err(core::fmt::Error),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2332,7 +2332,10 @@ impl<V: DocumentValue> GenericResult<V> {
             }
             Self::OneCursor(c) => {
                 // Stream directly from cursor using DocumentCursor trait
-                c.stream_json(out, indent, sort_keys)?;
+                if let Err(e) = c.stream_json(out, indent, sort_keys) {
+                    absorb_stream_failure(e, &mut stats)?;
+                    return Ok(stats);
+                }
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -2436,7 +2439,12 @@ impl<V: DocumentValue> GenericResult<V> {
                 Ok(items) => {
                     let owned = match sequence_streamable_cursors(&items) {
                         Some(cursors) => {
-                            V::Cursor::stream_sequence_json(&cursors, out, indent, sort_keys)?;
+                            if let Err(e) =
+                                V::Cursor::stream_sequence_json(&cursors, out, indent, sort_keys)
+                            {
+                                absorb_stream_failure(e, &mut stats)?;
+                                return Ok(stats);
+                            }
                             true
                         }
                         None => match items
@@ -2473,8 +2481,15 @@ impl<V: DocumentValue> GenericResult<V> {
                 }
             },
             Self::ManyCursor(cs) => {
-                for c in cs {
-                    c.stream_json(out, indent, sort_keys)?;
+                for (i, c) in cs.iter().enumerate() {
+                    // `count` is how many results actually reached `out`, not
+                    // how many were asked for -- same contract as `Many`'s own
+                    // mid-stream failure above (#400/#494, #1247, #1615).
+                    if let Err(e) = c.stream_json(out, indent, sort_keys) {
+                        absorb_stream_failure(e, &mut stats)?;
+                        stats.count = i;
+                        return Ok(stats);
+                    }
                     on_value(out)?;
                     stats.last_was_falsy = c.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -2577,7 +2592,10 @@ impl<V: DocumentValue> GenericResult<V> {
                 // navigated container result keeps its own trailing comment
                 // just like the whole document does, unlike a navigated
                 // scalar (#793a).
-                c.stream_yaml_as_document(out, indent, sort_keys)?;
+                if let Err(e) = c.stream_yaml_as_document(out, indent, sort_keys) {
+                    absorb_stream_failure(e, &mut stats)?;
+                    return Ok(stats);
+                }
                 on_value(out)?;
                 stats.count = 1;
                 stats.last_was_falsy = c.is_falsy();
@@ -2601,10 +2619,15 @@ impl<V: DocumentValue> GenericResult<V> {
                 stats.count = vs.len();
             }
             Self::ManyCursor(cs) => {
-                for c in cs {
+                for (i, c) in cs.iter().enumerate() {
                     // See `OneCursor` above: each streamed result keeps its
-                    // own trailing comment if it's a container (#793a).
-                    c.stream_yaml_as_document(out, indent, sort_keys)?;
+                    // own trailing comment if it's a container (#793a). See
+                    // the JSON twin on why `count` is set to `i` here (#1615).
+                    if let Err(e) = c.stream_yaml_as_document(out, indent, sort_keys) {
+                        absorb_stream_failure(e, &mut stats)?;
+                        stats.count = i;
+                        return Ok(stats);
+                    }
                     on_value(out)?;
                     stats.last_was_falsy = c.is_falsy();
                     stats.any_truthy |= !stats.last_was_falsy;
@@ -2664,7 +2687,12 @@ impl<V: DocumentValue> GenericResult<V> {
                 Ok(items) => {
                     let owned = match sequence_streamable_cursors(&items) {
                         Some(cursors) => {
-                            V::Cursor::stream_sequence_yaml(&cursors, out, indent, sort_keys)?;
+                            if let Err(e) =
+                                V::Cursor::stream_sequence_yaml(&cursors, out, indent, sort_keys)
+                            {
+                                absorb_stream_failure(e, &mut stats)?;
+                                return Ok(stats);
+                            }
                             true
                         }
                         None => match items
@@ -2832,6 +2860,28 @@ fn owned_or_stream_error(
             stats.error = Some(stream_error(&e));
             None
         }
+    }
+}
+
+/// Route a [`StreamFailure`](crate::jq::stream::StreamFailure) from a cursor
+/// streamer into `stats`, the way #1679's `LazyKeys` arm routes a malformed
+/// key (#1615).
+///
+/// A decode failure is a *data* diagnostic: it belongs on stderr with an exit
+/// code, so it goes back through `stats.error` and whatever already reached
+/// `out` stays written (the `Partial` idiom). A genuine writer failure is not
+/// diagnosable and propagates as before. Returns `true` when the caller should
+/// stop and hand `stats` back immediately.
+fn absorb_stream_failure(
+    e: crate::jq::stream::StreamFailure,
+    stats: &mut crate::jq::stream::StreamStats,
+) -> Result<bool, core::fmt::Error> {
+    match e {
+        crate::jq::stream::StreamFailure::Decode(err) => {
+            stats.error = Some(stream_error(&err));
+            Ok(true)
+        }
+        crate::jq::stream::StreamFailure::Fmt => Err(core::fmt::Error),
     }
 }
 

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -115,6 +115,51 @@ pub struct StreamError {
     pub not_a_string: bool,
 }
 
+/// A failure raised while *streaming* a document to output.
+///
+/// The streaming writers (`YamlCursor::stream_json`/`stream_yaml`,
+/// `stream_json_as_yaml`) are built on [`core::fmt::Write`], whose only error
+/// type is [`core::fmt::Error`] — it carries no message, so before #1615 a
+/// scalar that would not decode could only be silently absorbed into a
+/// substituted `null`/`""` (the design doc's deferred "Stage 6",
+/// `docs/plan/decode-failure-routing.md`). This is that missing channel: a
+/// write failure stays a write failure, and a decode failure carries the same
+/// diagnosable [`EvalError`] every *materializing* route already raises, so
+/// both spellings of one document give one answer.
+///
+/// Every existing `?` inside those writers keeps working unchanged via the
+/// [`From<core::fmt::Error>`] impl below — that is the reason this is an
+/// error *type* rather than an out-of-band slot threaded through each of the
+/// family's recursive call sites.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamFailure {
+    /// The underlying writer failed (a real I/O error, or a full buffer).
+    Fmt,
+    /// A scalar could not be decoded (an invalid escape, invalid UTF-8).
+    ///
+    /// Uncatchable by `?`/`try`/`catch`, like every other decode failure
+    /// (#1620) — see [`EvalError::decode_failure`].
+    Decode(EvalError),
+}
+
+impl From<core::fmt::Error> for StreamFailure {
+    fn from(_: core::fmt::Error) -> Self {
+        Self::Fmt
+    }
+}
+
+// Deliberately no `From<StreamFailure> for core::fmt::Error`. That impl would
+// let a plain `?` silently collapse a decode failure back into the
+// message-less error this type exists to escape — reintroducing the exact
+// swallow #1615 closes, implicitly, at any call site that happens to sit in a
+// `core::fmt::Result` function. Without it, every such site is a compile
+// error until someone decides what the diagnostic should do, which is the
+// point.
+
+/// The result of a streaming write that can distinguish a decode failure from
+/// a writer failure. See [`StreamFailure`].
+pub type StreamResult = Result<(), StreamFailure>;
+
 impl StreamableValue for OwnedValue {
     fn stream_json<W: core::fmt::Write>(
         &self,

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -100,6 +100,20 @@ pub struct StreamStats {
     /// ordinary error-diagnostic path — otherwise the real exit code is lost
     /// and a halt is misreported as a generic failure (#791).
     pub halt: Option<i32>,
+
+    /// Whether the failure in `error` left `out` cut off mid-value (#1615).
+    ///
+    /// Distinct from `error.is_some()`, and the distinction is load-bearing:
+    /// an ordinary uncaught evaluation error writes *nothing* to `out` (see
+    /// `error`'s own note), so a caller streaming a multi-document input
+    /// should report it and carry on to the next document (#355). A decode
+    /// failure raised from inside a *cursor* stream is different -- the
+    /// container around it is already partly written, with no newline closing
+    /// it, so continuing would weld the next document's `---` onto the
+    /// truncated line and produce output that reads back as valid YAML with a
+    /// fabricated value. Only the streaming writers set this; a caller that
+    /// ignores it keeps the old, continue-past behaviour for everything else.
+    pub truncated: bool,
 }
 
 /// An uncaught evaluation error surfaced by a streaming operation.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2870,6 +2870,40 @@ mod tests {
         assert!(!out.is_empty());
     }
 
+    /// #1615 converted every arm of `stream_json_as_yaml` to `StreamResult`,
+    /// but only its string and nested-container arms had any coverage --
+    /// integers, floats, empty containers and the block-style closers were all
+    /// reformatted blind. This walks one document through every arm, in both
+    /// block and flow style, so a future edit to any of them is caught.
+    ///
+    /// The `StandardJson::Error` arm is deliberately not exercised: it still
+    /// writes `null` for a *structural* malformation (#1194's class, not a
+    /// decode failure), and reaching it needs a malformed index rather than a
+    /// document this constructor can build.
+    #[test]
+    fn test_stream_yaml_covers_every_value_arm_1615() {
+        let json = br#"{"i": 42, "neg": -7, "f": 1.5, "t": true, "fa": false,
+                        "n": null, "s": "x", "ea": [], "eo": {},
+                        "arr": [1, "two", [3], {"k": 4}],
+                        "obj": {"nested": {"deep": [5]}}}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        // Block style (indent 2) and flow style (COMPACT) take different
+        // branches for every container arm, so both are walked.
+        for indent in [IndentSpec::spaces(2), IndentSpec::COMPACT] {
+            let mut out = String::new();
+            root.stream_yaml(&mut out, indent, false)
+                .expect("a fully decodable document must stream");
+            for expected in ["42", "-7", "1.5", "true", "false", "null", "x", "[]", "{}"] {
+                assert!(
+                    out.contains(expected),
+                    "missing {expected:?} in {out:?} (indent {indent:?})"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_cursor_line_column() {
         // JsonCursor previously had no `line()`/`column()` at all — it fell

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1836,7 +1836,16 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
+use crate::jq::stream::{StreamFailure, StreamResult};
 use crate::jq::{nonfinite_display_string, EvalError, YqSemantics};
+
+/// A [`JsonError`] as the uncatchable decode failure (#1620) every
+/// *materializing* route already raises for the same scalar, so a document
+/// with a bad escape gets one answer whether it is streamed or materialized
+/// (#1615). The YAML-side twin is `yaml::light::decode_failure`.
+fn json_decode_failure(e: JsonError) -> StreamFailure {
+    StreamFailure::Decode(EvalError::decode_failure(e.message()))
+}
 
 /// Whether the child starting at `child_start` is preceded by `expected`
 /// (`,`/`:`), skipping whitespace, with nothing else in between.
@@ -2006,7 +2015,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // Compact only: echo the raw bytes verbatim, since they're already
         // valid JSON. Indented (pretty) JSON->JSON streaming isn't
         // implemented here — callers fall back to the DOM path (#442 only
@@ -2017,14 +2026,14 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         // Guard it explicitly so a future gate relaxation fails safe (falls
         // back to the DOM path) instead of silently emitting unsorted keys.
         if !indent.is_compact() || sort_keys {
-            return Err(core::fmt::Error);
+            return Err(StreamFailure::Fmt);
         }
         if let Some(bytes) = self.raw_bytes() {
             // SAFETY: JSON input is valid UTF-8 (checked during indexing)
             let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
-            out.write_str(s)
+            Ok(out.write_str(s)?)
         } else {
-            Err(core::fmt::Error)
+            Err(StreamFailure::Fmt)
         }
     }
 
@@ -2034,14 +2043,14 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // For JSON->YAML conversion, we need to format as YAML. `sort_keys`
         // (and `indent.unit`, e.g. `--tab`) aren't implemented here for the
         // same reason as `stream_json` above; guard explicitly so a future
         // caller fails safe instead of silently getting unsorted,
         // always-space-indented output.
         if sort_keys {
-            return Err(core::fmt::Error);
+            return Err(StreamFailure::Fmt);
         }
         stream_json_as_yaml(out, self.value(), 0, indent.width)
     }
@@ -2358,34 +2367,39 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
     value: StandardJson<'_, W>,
     current_indent: usize,
     indent_spaces: usize,
-) -> core::fmt::Result {
+) -> StreamResult {
     match value {
-        StandardJson::Null => out.write_str("null"),
-        StandardJson::Bool(b) => out.write_str(if b { "true" } else { "false" }),
+        StandardJson::Null => Ok(out.write_str("null")?),
+        StandardJson::Bool(b) => Ok(out.write_str(if b { "true" } else { "false" })?),
         StandardJson::Number(n) => {
             // Try integer first, then float
             if let Ok(i) = n.as_i64() {
-                write!(out, "{i}")
+                Ok(write!(out, "{i}")?)
             } else if let Ok(f) = n.as_f64() {
                 if f.is_nan() || f.is_infinite() {
-                    out.write_str(nonfinite_display_string::<YqSemantics>(f))
+                    Ok(out.write_str(nonfinite_display_string::<YqSemantics>(f))?)
                 } else {
-                    write!(out, "{f}")
+                    Ok(write!(out, "{f}")?)
                 }
             } else {
-                out.write_str("null")
+                Ok(out.write_str("null")?)
             }
         }
         StandardJson::String(s) => {
             // Decoded content, not `raw_bytes()` -- the latter includes the
             // source's surrounding quotes and escape sequences verbatim,
             // which would then get YAML-quoted a second time on top.
-            let str_val = s.as_str().map_err(|_| core::fmt::Error)?;
-            stream_json_string_as_yaml(out, &str_val)
+            // #1615: a scalar that will not decode raises a *diagnosable*
+            // decode failure here. Before, this was a bare `core::fmt::Error`
+            // -- which the CLI could only report as a generic write failure,
+            // the "bare, undiagnosed abort" the design doc named as the reason
+            // Stage 6 was deferred rather than attempted.
+            let str_val = s.as_str().map_err(json_decode_failure)?;
+            Ok(stream_json_string_as_yaml(out, &str_val)?)
         }
         StandardJson::Array(elements) => {
             if elements.is_empty() {
-                return out.write_str("[]");
+                return Ok(out.write_str("[]")?);
             }
             if indent_spaces == 0 {
                 // Flow style
@@ -2398,7 +2412,7 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                     first = false;
                     stream_json_as_yaml(out, elem, 0, 0)?;
                 }
-                out.write_char(']')
+                Ok(out.write_char(']')?)
             } else {
                 // Block style
                 let mut first = true;
@@ -2432,7 +2446,7 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
         }
         StandardJson::Object(fields) => {
             if fields.is_empty() {
-                return out.write_str("{}");
+                return Ok(out.write_str("{}")?);
             }
             if indent_spaces == 0 {
                 // Flow style
@@ -2454,7 +2468,7 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                     out.write_str(": ")?;
                     stream_json_as_yaml(out, field.value(), 0, 0)?;
                 }
-                out.write_char('}')
+                Ok(out.write_char('}')?)
             } else {
                 // Block style
                 let mut first = true;
@@ -2496,7 +2510,13 @@ fn stream_json_as_yaml<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                 Ok(())
             }
         }
-        StandardJson::Error(_) => out.write_str("null"),
+        // A *structural* malformation (#1194's class), not a decode failure:
+        // left writing `null` exactly as before. #1615 is scoped to scalars
+        // that fail to *decode*; whether this arm should raise too is the same
+        // open question #1194 tracks for every other `StandardJson::Error`
+        // site, and answering it here alone would split that decision across
+        // two issues.
+        StandardJson::Error(_) => Ok(out.write_str("null")?),
     }
 }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1296,7 +1296,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         self.stream_json_value(out, 0, indent.width, indent.unit, sort_keys)
     }
 
@@ -1312,7 +1312,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
             if let YamlValue::Sequence(elements) = self.value() {
@@ -1351,7 +1351,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // `self` is a navigated query result here (see this method's own
         // doc comment) and so can itself be an unresolved bare-`-`
         // sequence-item wrapper (e.g. `.[0]` on a document whose item 0
@@ -1410,7 +1410,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // See `stream_yaml` (#835): resolve once, reuse throughout, rather
         // than relying on each downstream read to notice a bare-dash
         // wrapper on its own.
@@ -1418,7 +1418,15 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self_.write_leading_anchor(out)?;
         let value = self_.value();
         if let YamlValue::String(s) = &value {
-            let str_val = s.as_str().unwrap_or(Cow::Borrowed("\"\""));
+            // #1615: this root-scalar shortcut bypasses `stream_yaml_value`/
+            // `stream_yaml_string_value` entirely (see this function's own doc
+            // comment), so it needs its own copy of their decode-failure
+            // check too -- otherwise the single most common navigated shape,
+            // `yq '.b'` on an undecodable scalar, keeps printing `""` at exit
+            // 0 while `yq -o=json '.b'` on the same document raises. This is a
+            // *value* position (the whole output is this scalar), so it
+            // raises; the mapping-key convention (#1642) does not apply.
+            let str_val = s.as_str().map_err(decode_failure)?;
             // #996: this root-scalar shortcut bypasses `stream_yaml_value`/
             // `stream_yaml_string_value` entirely (see this function's own
             // doc comment on why -- #852's "a scalar root drops its own
@@ -1439,7 +1447,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     resolve_plain(&str_val),
                     self_.index.canonicalize_numbers(),
                 ) {
-                    return write!(out, "{f}");
+                    return Ok(write!(out, "{f}")?);
                 }
             }
             out.write_str(&str_val)?;
@@ -1460,7 +1468,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         // Check if this is the root document array with a single document
         if self.bp_pos == 0 {
             if let YamlValue::Sequence(elements) = self.value() {
@@ -1566,9 +1574,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         unit: char,
         sort_keys: bool,
         known_not_flow: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         match self.value() {
-            YamlValue::Null => out.write_str("null"),
+            YamlValue::Null => Ok(out.write_str("null")?),
             YamlValue::String(s) => {
                 // YAML output (unlike JSON) has tag syntax, so an explicit
                 // tag is preserved verbatim rather than dropped - matching
@@ -1683,24 +1691,35 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             };
                             if let Some(explicit_indent) = explicit_indent {
                                 if !decoded.is_empty() && !has_trailing_space && !has_astral {
-                                    return stream_yaml_block_scalar(
+                                    return Ok(stream_yaml_block_scalar(
                                         out,
                                         &decoded,
                                         indent,
                                         explicit_indent,
                                         folded,
-                                    );
+                                    )?);
                                 }
                             }
                             // Disqualified, but already decoded above -
                             // avoid decoding `s` a second time inside
                             // `stream_yaml_string_value` below for exactly
                             // the same result.
-                            return stream_yaml_block_scalar_quoted(out, &decoded);
+                            return Ok(stream_yaml_block_scalar_quoted(out, &decoded)?);
                         }
                     }
                 }
-                stream_yaml_string_value(out, &s, self.index.canonicalize_numbers())
+                // #1615: value position, so an undecodable scalar raises
+                // rather than degrading to `""`. Contrast the *key* call site
+                // in `write_yaml_field_key`, which passes
+                // `Undecodable::PreserveEmpty` because a key that will not
+                // decode is deliberately kept as `""` on every route,
+                // streamed or materialized alike (#1642/#222).
+                stream_yaml_string_value(
+                    out,
+                    &s,
+                    self.index.canonicalize_numbers(),
+                    Undecodable::Raise,
+                )
             }
             YamlValue::Mapping(_) => {
                 // A bare `-` sequence-item wrapper (dash-alone-then-indented
@@ -1731,7 +1750,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // `keys()`, ...), which still goes through `from_mapping_cursor`.
                 let fields = YamlFields::raw(self.first_child());
                 if fields.is_empty() {
-                    return out.write_str("{}");
+                    return Ok(out.write_str("{}")?);
                 }
                 if indent_spaces == 0 || (!known_not_flow && self.style() == "flow") {
                     // Flow style
@@ -1759,7 +1778,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             write_flow_last_item_comment(out, comment, indent)?;
                         }
                     }
-                    out.write_char('}')
+                    Ok(out.write_char('}')?)
                 } else {
                     // Block style
                     let mut first = true;
@@ -1857,7 +1876,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
             YamlValue::Sequence(elements) => {
                 if elements.is_empty() {
-                    return out.write_str("[]");
+                    return Ok(out.write_str("[]")?);
                 }
                 // `style()` (#835) resolves through a bare `-` wrapper
                 // itself, so `self.style()` here already sees a flow-style
@@ -1879,7 +1898,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         }
                         elems = rest;
                     }
-                    out.write_char(']')
+                    Ok(out.write_char(']')?)
                 } else {
                     // Block style
                     let mut first = true;
@@ -1982,9 +2001,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // target's value — an unmodified/re-serialized document must
                 // keep `*name` verbatim, matching real yq (issue #712).
                 out.write_char('*')?;
-                out.write_str(anchor_name)
+                Ok(out.write_str(anchor_name)?)
             }
-            YamlValue::Error(_) => out.write_str("null"),
+            YamlValue::Error(_) => Ok(out.write_str("null")?),
         }
     }
 
@@ -2003,9 +2022,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         indent_spaces: usize,
         unit: char,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         match self.value() {
-            YamlValue::Null => out.write_str("null"),
+            YamlValue::Null => Ok(out.write_str("null")?),
             YamlValue::String(s) => {
                 // An explicit core-schema tag (`!!str`, `!!int`, …) forces
                 // resolution regardless of quoting style - `!!int "5"` is the
@@ -2015,41 +2034,52 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 if let Some(explicit) = self.explicit_tag() {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
-                            return stream_resolved_scalar_as_json(
+                            return Ok(stream_resolved_scalar_as_json(
                                 out,
                                 resolved,
                                 &str_val,
                                 self.index.canonicalize_numbers(),
-                            );
+                            )?);
                         }
                     }
                 }
                 // Direct transcoding optimization
+                // #1615: a scalar that will not decode raises here rather
+                // than degrading to a silent `null`, matching what every
+                // *materializing* route (`--arg`, `-P`, `to_entries`,
+                // `length`) has already done since #1247. Reported after the
+                // transcode attempt rather than before it, deliberately:
+                // pre-checking would mean decoding every string twice on the
+                // P9 streaming fast path (a 2.3x win) to serve an input shape
+                // that is almost always absent. The cost is that a partial
+                // prefix of *this* scalar may already have reached `out` --
+                // the same truncate-then-diagnose trade #1641 and #1679
+                // settled for their own streaming sites, and strictly better
+                // than the well-formed-but-wrong document it replaces.
                 match stream_yaml_string_to_json(out, &s) {
                     Ok(true) => Ok(()), // Written directly as JSON string
-                    Ok(false) => {
-                        if let Ok(str_val) = s.as_str() {
+                    Ok(false) => match s.as_str() {
+                        Ok(str_val) => {
                             if s.is_unquoted() {
                                 // Plain scalar - resolve per the core schema
-                                stream_yaml_scalar_as_json(
+                                Ok(stream_yaml_scalar_as_json(
                                     out,
                                     &str_val,
                                     self.index.canonicalize_numbers(),
-                                )
+                                )?)
                             } else {
                                 // Block scalars are always strings
-                                stream_json_string(out, &str_val)
+                                Ok(stream_json_string(out, &str_val)?)
                             }
-                        } else {
-                            out.write_str("null")
                         }
-                    }
-                    Err(_) => out.write_str("null"),
+                        Err(e) => Err(decode_failure(e)),
+                    },
+                    Err(e) => Err(decode_failure(e)),
                 }
             }
             YamlValue::Mapping(fields) => {
                 if fields.is_empty() {
-                    return out.write_str("{}");
+                    return Ok(out.write_str("{}")?);
                 }
                 out.write_char('{')?;
                 let next_indent = current_indent + indent_spaces;
@@ -2104,11 +2134,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     out.write_char('\n')?;
                     write_yaml_indent(out, current_indent, unit)?;
                 }
-                out.write_char('}')
+                Ok(out.write_char('}')?)
             }
             YamlValue::Sequence(elements) => {
                 if elements.is_empty() {
-                    return out.write_str("[]");
+                    return Ok(out.write_str("[]")?);
                 }
                 out.write_char('[')?;
                 let next_indent = current_indent + indent_spaces;
@@ -2139,7 +2169,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     out.write_char('\n')?;
                     write_yaml_indent(out, current_indent, unit)?;
                 }
-                out.write_char(']')
+                Ok(out.write_char(']')?)
             }
             YamlValue::Alias { target, .. } => {
                 // Resolve the *entire* chain first (#1193), not just this
@@ -2154,10 +2184,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         unit,
                         sort_keys,
                     ),
-                    None => out.write_str("null"),
+                    None => Ok(out.write_str("null")?),
                 }
             }
-            YamlValue::Error(_) => out.write_str("null"),
+            YamlValue::Error(_) => Ok(out.write_str("null")?),
         }
     }
 
@@ -5902,7 +5932,39 @@ use crate::jq::assert_depth;
 use crate::jq::document::{
     DocumentCursor, DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec,
 };
+use crate::jq::stream::{StreamFailure, StreamResult};
 use crate::jq::EvalError;
+
+/// A [`YamlStringError`] as the uncatchable decode failure (#1620) every
+/// *materializing* route already raises for the same scalar, so a document
+/// with a bad escape gets one answer whether it is streamed or materialized
+/// (#1615). The message is `YamlStringError`'s own, matching the wording the
+/// non-streaming paths already print.
+/// What a streaming writer does with a scalar that will not decode.
+///
+/// The two answers are both deliberate and both tested; which one applies is a
+/// property of the *position*, not of the failure:
+///
+/// - [`Self::Raise`] — a **value**. Every materializing route (`--arg`, `-P`,
+///   `to_entries`, `length`) has raised here since #1247; #1615 makes the
+///   streamed routes agree instead of emitting a silent `null`/`""`.
+/// - [`Self::PreserveEmpty`] — a **mapping key**. A key that will not decode is
+///   kept as `""` (`YamlValue::key_string`'s convention, #222) on *every*
+///   route, streamed or materialized, rather than raising or vanishing —
+///   settled by #1642, and load-bearing: `keys`/`to_entries`/`length` all
+///   report such a key, so a streamed identity that raised on it would
+///   re-open the one-document-many-answers split #1642 closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Undecodable {
+    /// Raise a decode failure (#1615). Value positions.
+    Raise,
+    /// Write `""` and continue (#1642/#222). Mapping-key positions.
+    PreserveEmpty,
+}
+
+fn decode_failure(e: YamlStringError) -> StreamFailure {
+    StreamFailure::Decode(EvalError::decode_failure(e.message()))
+}
 
 /// Caps the number of alias hops `YamlCursor::resolve_alias_chain` will
 /// follow (#1191 code review) -- the single place this rule's rationale is
@@ -6050,7 +6112,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         YamlCursor::stream_json(self, out, indent, sort_keys)
     }
 
@@ -6060,7 +6122,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         YamlCursor::stream_yaml(self, out, indent, sort_keys)
     }
 
@@ -6070,7 +6132,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         YamlCursor::stream_yaml_as_document(self, out, indent, sort_keys)
     }
 
@@ -6088,7 +6150,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         stream_json_sequence(
             resolved_sequence_cursors(cursors),
             out,
@@ -6105,7 +6167,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
         out: &mut Out,
         indent: IndentSpec,
         sort_keys: bool,
-    ) -> core::fmt::Result {
+    ) -> StreamResult {
         stream_yaml_sequence(
             resolved_sequence_cursors(cursors),
             out,
@@ -6720,7 +6782,7 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     indent_spaces: usize,
     unit: char,
     sort_keys: bool,
-) -> core::fmt::Result {
+) -> StreamResult {
     let absent = is_deferred_value_absent(value);
     let anchor = value.anchor();
     let tag = if absent { value.explicit_tag() } else { None };
@@ -6795,7 +6857,7 @@ fn compact_yaml_indent(indent: &str) -> String {
 fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
     out: &mut Out,
     field: YamlField<'_, W>,
-) -> core::fmt::Result {
+) -> StreamResult {
     let key = field.key();
     if let YamlValue::String(s) = &key {
         if let Some(tag) = field.key_cursor().explicit_tag() {
@@ -6814,9 +6876,9 @@ fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
         // provable no-op here. Hardcoding `false` documents that as an
         // invariant of the call site rather than leaving a live (if inert)
         // flag read to explain.
-        stream_yaml_string_value(out, s, false)
+        stream_yaml_string_value(out, s, false, Undecodable::PreserveEmpty)
     } else {
-        stream_yaml_nonstring_key(out, &key)
+        Ok(stream_yaml_nonstring_key(out, &key)?)
     }
 }
 
@@ -6827,7 +6889,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     value: YamlCursor<'_, W>,
     unit: char,
     sort_keys: bool,
-) -> core::fmt::Result {
+) -> StreamResult {
     if let Some(anchor) = value.anchor() {
         out.write_char('&')?;
         out.write_str(anchor)?;
@@ -6872,7 +6934,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     // position -- block value, flow/block sequence item, flow mapping key
     // -- already matches real yq's `""`), just this one synthesized case.
     if absent {
-        return out.write_str("''");
+        return Ok(out.write_str("''")?);
     }
     value.stream_yaml_value(out, "", 0, unit, sort_keys, false)
 }
@@ -6963,7 +7025,7 @@ pub fn stream_json_sequence<'a, W, I, Out>(
     indent_spaces: usize,
     unit: char,
     sort_keys: bool,
-) -> core::fmt::Result
+) -> StreamResult
 where
     W: AsRef<[u64]> + 'a,
     I: IntoIterator<Item = YamlCursor<'a, W>>,
@@ -6971,7 +7033,7 @@ where
 {
     let mut iter = cursors.into_iter().peekable();
     if iter.peek().is_none() {
-        return out.write_str("[]");
+        return Ok(out.write_str("[]")?);
     }
     out.write_char('[')?;
     let next_indent = current_indent + indent_spaces;
@@ -6991,7 +7053,7 @@ where
         out.write_char('\n')?;
         write_yaml_indent(out, current_indent, unit)?;
     }
-    out.write_char(']')
+    Ok(out.write_char(']')?)
 }
 
 /// Stream independent document cursors as a single YAML sequence (block or
@@ -7027,7 +7089,7 @@ pub fn stream_yaml_sequence<'a, W, I, Out>(
     indent_spaces: usize,
     unit: char,
     sort_keys: bool,
-) -> core::fmt::Result
+) -> StreamResult
 where
     W: AsRef<[u64]> + 'a,
     I: IntoIterator<Item = YamlCursor<'a, W>>,
@@ -7035,7 +7097,7 @@ where
 {
     let mut iter = cursors.into_iter().peekable();
     if iter.peek().is_none() {
-        return out.write_str("[]");
+        return Ok(out.write_str("[]")?);
     }
     if indent_spaces == 0 {
         // Flow style
@@ -7048,7 +7110,7 @@ where
             first = false;
             write_yaml_child_inline(out, cursor, unit, sort_keys)?;
         }
-        out.write_char(']')
+        Ok(out.write_char(']')?)
     } else {
         // Block style. `current_indent`/`unit` never vary across the loop
         // below (this function is never itself called recursively -- it's
@@ -7412,17 +7474,26 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
     out: &mut Out,
     s: &YamlString<'_>,
     canonicalize: bool,
-) -> core::fmt::Result {
-    // Try to get the string value
+    undecodable: Undecodable,
+) -> StreamResult {
+    // Try to get the string value. Decoded exactly once, whichever policy
+    // applies: the `Err` arm below is the *only* decode-failure check on this
+    // path, deliberately, so neither policy costs the P9 streaming fast path
+    // a second pass over a scalar that decodes fine.
     let str_val = match s.as_str() {
         Ok(v) => v,
-        Err(_) => return out.write_str("\"\""),
+        Err(e) => {
+            return match undecodable {
+                Undecodable::Raise => Err(decode_failure(e)),
+                Undecodable::PreserveEmpty => Ok(out.write_str("\"\"")?),
+            }
+        }
     };
 
     // For quoted strings, preserve the quoting style
     match s {
-        YamlString::DoubleQuoted { .. } => stream_yaml_double_quoted(out, &str_val),
-        YamlString::SingleQuoted { .. } => stream_yaml_single_quoted(out, &str_val),
+        YamlString::DoubleQuoted { .. } => Ok(stream_yaml_double_quoted(out, &str_val)?),
+        YamlString::SingleQuoted { .. } => Ok(stream_yaml_single_quoted(out, &str_val)?),
         YamlString::Unquoted { .. } => {
             // #996: checked before the verbatim-echo fallback below,
             // which is for genuine YAML source text only. A non-finite
@@ -7433,7 +7504,7 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
             // than fabricating a YAML-specific non-finite spelling this
             // function has never needed before.
             if let Some(f) = json_sourced_canonical_float(resolve_plain(&str_val), canonicalize) {
-                return write!(out, "{f}");
+                return Ok(write!(out, "{f}")?);
             }
             // Source plain scalar: re-emit verbatim so both the scalar type and
             // its representation survive (`1`, `true`, `1.0`, `.5`, `yes`),
@@ -7446,9 +7517,9 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
                 || str_val.bytes().any(|b| b < 0x20)
                 || starts_seq_entry(str_val.as_bytes(), 0)
             {
-                stream_yaml_double_quoted(out, &str_val)
+                Ok(stream_yaml_double_quoted(out, &str_val)?)
             } else {
-                out.write_str(&str_val)
+                Ok(out.write_str(&str_val)?)
             }
         }
         // Block scalar reached here either because `stream_yaml_value`'s
@@ -7457,7 +7528,7 @@ fn stream_yaml_string_value<Out: core::fmt::Write>(
         // needed (#836), or via `write_yaml_field_key` for an explicit-key
         // block scalar (`? |\n  key\n: value`), which never attempts block
         // style for a *key* at all - both want the same smart quoting.
-        _ => stream_yaml_block_scalar_quoted(out, &str_val),
+        _ => Ok(stream_yaml_block_scalar_quoted(out, &str_val)?),
     }
 }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2074,7 +2074,9 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         }
                         Err(e) => Err(decode_failure(e)),
                     },
-                    Err(e) => Err(decode_failure(e)),
+                    // Already a `StreamFailure`: a writer failure stays `Fmt`
+                    // rather than being reported as a decode failure (#1615).
+                    Err(e) => Err(e),
                 }
             }
             YamlValue::Mapping(fields) => {
@@ -3994,18 +3996,29 @@ fn stream_transcode_fold_line_break<Out: core::fmt::Write>(
 
 /// Stream YAML string to JSON output.
 /// Returns true if written as a quoted string, false if type detection needed.
+/// #1615: returns [`StreamFailure`], not `YamlStringError`, so a failure of
+/// the real `out` writer stays [`StreamFailure::Fmt`] instead of being
+/// laundered into a data diagnostic. Every `out.write_*` here used to
+/// `map_err(|_| YamlStringError::InvalidUtf8)`, which was harmless while both
+/// ends collapsed to `fmt::Error` -- but once a `YamlStringError` began
+/// carrying a *message* to the user, that mapping turned a broken pipe into
+/// `Error: invalid UTF-8 in string`, blaming the document for the reader
+/// hanging up. The `stream_transcode_*` calls keep mapping to `Decode`: their
+/// `out` is a local `String`, so their own write arms are unreachable and any
+/// error they return is genuinely about the scalar.
 fn stream_yaml_string_to_json<Out: core::fmt::Write>(
     out: &mut Out,
     s: &YamlString<'_>,
-) -> Result<bool, YamlStringError> {
+) -> Result<bool, StreamFailure> {
     match s {
         YamlString::DoubleQuoted { text, start } => {
             let end = YamlString::find_double_quote_end(text, *start);
             let bytes = &text[*start + 1..end - 1];
 
             if !bytes.contains(&b'\\') && !bytes.contains(&b'\n') && !bytes.contains(&b'\r') {
-                let s = core::str::from_utf8(bytes).map_err(|_| YamlStringError::InvalidUtf8)?;
-                stream_json_string(out, s).map_err(|_| YamlStringError::InvalidUtf8)?;
+                let s = core::str::from_utf8(bytes)
+                    .map_err(|_| decode_failure(YamlStringError::InvalidUtf8))?;
+                stream_json_string(out, s)?;
             } else {
                 // `Out` cannot be rewound the way `write_yaml_string_to_json`'s
                 // `String` can, so transcode into a scratch buffer and commit
@@ -4016,9 +4029,9 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
                 // little), so reserving it up front avoids the realloc
                 // chain `String::new()` would pay for (#1622).
                 let mut committed = String::with_capacity(bytes.len() + 2);
-                stream_transcode_double_quoted_to_json(&mut committed, bytes)?;
-                out.write_str(&committed)
-                    .map_err(|_| YamlStringError::InvalidUtf8)?;
+                stream_transcode_double_quoted_to_json(&mut committed, bytes)
+                    .map_err(decode_failure)?;
+                out.write_str(&committed)?;
             }
             Ok(true)
         }
@@ -4027,23 +4040,24 @@ fn stream_yaml_string_to_json<Out: core::fmt::Write>(
             let bytes = &text[*start + 1..end - 1];
 
             if !bytes.contains(&b'\'') && !bytes.contains(&b'\n') && !bytes.contains(&b'\r') {
-                let s = core::str::from_utf8(bytes).map_err(|_| YamlStringError::InvalidUtf8)?;
-                stream_json_string(out, s).map_err(|_| YamlStringError::InvalidUtf8)?;
+                let s = core::str::from_utf8(bytes)
+                    .map_err(|_| decode_failure(YamlStringError::InvalidUtf8))?;
+                stream_json_string(out, s)?;
             } else {
                 // Same commit-on-success rollback as the double-quoted arm
                 // above (#1247), with the same capacity hint (#1622).
                 let mut committed = String::with_capacity(bytes.len() + 2);
-                stream_transcode_single_quoted_to_json(&mut committed, bytes)?;
-                out.write_str(&committed)
-                    .map_err(|_| YamlStringError::InvalidUtf8)?;
+                stream_transcode_single_quoted_to_json(&mut committed, bytes)
+                    .map_err(decode_failure)?;
+                out.write_str(&committed)?;
             }
             Ok(true)
         }
         YamlString::BlockLiteral { .. } | YamlString::BlockFolded { .. } => {
             // Block scalars are always strings (yq/JSON semantics): no type
             // detection, and empty content is "" rather than null (#222)
-            let decoded = s.as_str()?;
-            stream_json_string(out, &decoded).map_err(|_| YamlStringError::InvalidUtf8)?;
+            let decoded = s.as_str().map_err(decode_failure)?;
+            stream_json_string(out, &decoded)?;
             Ok(true)
         }
         YamlString::Unquoted { .. } => Ok(false),
@@ -5935,11 +5949,6 @@ use crate::jq::document::{
 use crate::jq::stream::{StreamFailure, StreamResult};
 use crate::jq::EvalError;
 
-/// A [`YamlStringError`] as the uncatchable decode failure (#1620) every
-/// *materializing* route already raises for the same scalar, so a document
-/// with a bad escape gets one answer whether it is streamed or materialized
-/// (#1615). The message is `YamlStringError`'s own, matching the wording the
-/// non-streaming paths already print.
 /// What a streaming writer does with a scalar that will not decode.
 ///
 /// The two answers are both deliberate and both tested; which one applies is a
@@ -5962,6 +5971,11 @@ enum Undecodable {
     PreserveEmpty,
 }
 
+/// A [`YamlStringError`] as the uncatchable decode failure (#1620) every
+/// *materializing* route already raises for the same scalar, so a document
+/// with a bad escape gets one answer whether it is streamed or materialized
+/// (#1615). The message is `YamlStringError`'s own, matching the wording the
+/// non-streaming paths already print.
 fn decode_failure(e: YamlStringError) -> StreamFailure {
     StreamFailure::Decode(EvalError::decode_failure(e.message()))
 }
@@ -13198,6 +13212,51 @@ mod tests {
             .stream_yaml_document(&mut out, IndentSpec::spaces(2), false)
             .unwrap();
         assert_eq!(out, "item:\n  \"<<\": 5\n  b: 2");
+    }
+
+    /// #1615 review follow-up: a failure of the *writer* must surface as
+    /// [`StreamFailure::Fmt`], never as a decode failure.
+    ///
+    /// Every `out.write_*` inside `stream_yaml_string_to_json` used to
+    /// `map_err(|_| YamlStringError::InvalidUtf8)`. That was harmless while
+    /// both ends collapsed into a message-less `fmt::Error` -- but once #1615
+    /// gave the error a user-visible message, the same mapping turned a broken
+    /// pipe into `Error: invalid UTF-8 in string`, blaming a perfectly valid
+    /// document for the reader hanging up.
+    ///
+    /// Uses a writer that fails after a fixed prefix rather than a real pipe,
+    /// so the failure lands *inside* a quoted scalar deterministically.
+    #[test]
+    fn test_writer_failure_is_not_a_decode_failure_1615() {
+        struct FailsAfter(usize);
+        impl core::fmt::Write for FailsAfter {
+            fn write_str(&mut self, s: &str) -> core::fmt::Result {
+                if s.len() > self.0 {
+                    return Err(core::fmt::Error);
+                }
+                self.0 -= s.len();
+                Ok(())
+            }
+        }
+
+        // Every scalar decodes fine, so any `Decode` here is fabricated.
+        let yaml = b"a: \"a quoted value\"\nb: \"another \\t quoted value\"\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+
+        // Sweep the cutoff so the failure lands at many different points,
+        // including inside both the plain and the escape-bearing scalar.
+        let mut saw_fmt = false;
+        for budget in 0..40 {
+            match cursor.stream_json(&mut FailsAfter(budget), IndentSpec::COMPACT, false) {
+                Err(StreamFailure::Fmt) => saw_fmt = true,
+                Err(StreamFailure::Decode(e)) => {
+                    panic!("writer failure at budget {budget} reported as a decode failure: {e:?}")
+                }
+                Ok(()) => {}
+            }
+        }
+        assert!(saw_fmt, "the sweep must actually exercise a writer failure");
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24710,6 +24710,14 @@ fn test_streamed_value_decode_failure_raises_1615() -> Result<()> {
 fn test_streamed_key_decode_failure_still_preserved_1615() -> Result<()> {
     let input = "\"a\\qb\": 1\nb: 2\n";
     for (extra, expected) in [
+        // The default YAML target comes first: it is the most common
+        // invocation and the only one reaching `Undecodable::PreserveEmpty` in
+        // `write_yaml_field_key`. An earlier version of this test checked only
+        // the `-o json` rows below, which route through a different key arm --
+        // so the very behaviour it claimed to pin went unexercised, confirmed
+        // by that line reading zero hits in `cargo llvm-cov`.
+        (&[][..], "\"\": 1\nb: 2"),
+        (&["--arg", "z", "y"][..], "'': 1\nb: 2"),
         (&["-o", "json", "-I", "0"][..], r#"{"":1,"b":2}"#),
         (
             &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
@@ -24890,5 +24898,41 @@ fn test_inplace_truncation_flag_does_not_leak_across_files_1615() -> Result<()> 
         good_original,
         "a later, perfectly valid file must keep every document"
     );
+    Ok(())
+}
+
+/// #1615: the fan-out streaming arms raise too, not just the single-result
+/// ones.
+///
+/// `GenericResult` has four separate cursor-streaming arms that can meet an
+/// undecodable scalar -- `ManyCursor` (a filter yielding several cursors) and
+/// the `stream_sequence_*` pair (a `LazySeq` rendered straight from the source,
+/// #757) -- each in a JSON and a YAML flavour. They were converted alongside
+/// `OneCursor` but nothing exercised them, so this pins all four: without the
+/// `absorb_stream_failure` calls they would drop the diagnostic and exit 0.
+#[test]
+fn test_streamed_decode_failure_in_fanout_arms_1615() -> Result<()> {
+    let input = "- ok\n- \"bad \\q escape\"\n- also\n";
+    for (filter, extra) in [
+        (".[]", &[][..]),                           // ManyCursor, YAML target
+        (".[]", &["-o", "json", "-I", "0"][..]),    // ManyCursor, JSON target
+        ("map(.)", &[][..]),                        // stream_sequence_yaml
+        ("map(.)", &["-o", "json", "-I", "0"][..]), // stream_sequence_json
+    ] {
+        let (_, stderr, exit_code) = run_yq_split(filter, input, extra)?;
+        assert_eq!(exit_code, 1, "filter {filter:?} args {extra:?}: {stderr}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "filter {filter:?} args {extra:?}, stderr: {stderr}"
+        );
+    }
+
+    // The same shapes over a document that decodes cleanly must be untouched.
+    let clean = "- ok\n- fine\n- also\n";
+    for (filter, extra) in [(".[]", &[][..]), ("map(.)", &["-o", "json", "-I", "0"][..])] {
+        let (output, stderr, exit_code) = run_yq_split(filter, clean, extra)?;
+        assert_eq!(exit_code, 0, "filter {filter:?} args {extra:?}: {stderr}");
+        assert!(output.contains("ok"), "filter {filter:?}: {output:?}");
+    }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24722,3 +24722,130 @@ fn test_streamed_key_decode_failure_still_preserved_1615() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1615 review follow-up: `--inplace` must leave the file byte-identical when
+/// a streamed decode failure fires.
+///
+/// Making the streaming writers raise (#1615) also made them stop part-way
+/// through a document, and `-i` would otherwise commit that truncated buffer
+/// -- turning `a: 1\nb: "bad \q escape"\n` into the 8-byte fragment `a: 1\nb: `
+/// and, on a multi-document file, into `a: 1\nb: ---\nc: 3\n`: a *valid* YAML
+/// file whose `b` is a fabricated value, with the corruption invisible from
+/// the file itself. That is strictly worse than the silent `b: ""` #1615
+/// replaces, because it destroys the user's own data rather than misreporting
+/// it.
+///
+/// Not a new policy: `-i` on a *materializing* filter (`.a = 5`) already left
+/// the file untouched on the same input, and real yq v4.53.3 leaves it
+/// byte-identical on every filter (verified live -- same md5 before and after,
+/// exit 1). This makes the streamed path agree with both.
+#[test]
+fn test_inplace_leaves_file_untouched_on_decode_failure_1615() -> Result<()> {
+    for original in [
+        "a: 1\nb: \"bad \\q escape\"\n",
+        // The multi-document shape, where a committed buffer would have been
+        // valid-looking rather than obviously truncated.
+        "a: 1\nb: \"bad \\q escape\"\n---\nc: 3\n",
+    ] {
+        let mut input_file = NamedTempFile::new()?;
+        write!(input_file, "{original}")?;
+
+        let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .arg("-i")
+            .arg(".")
+            .arg(input_file.path())
+            .stdin(Stdio::null())
+            .output()?;
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "must fail rather than silently rewrite: {original:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(input_file.path())?,
+            original,
+            "file must survive byte-identical: {original:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1615 review follow-up: a streamed identity render cut off mid-document
+/// must not be followed by the next document's `---`.
+///
+/// The identity/P9 branches stream a container's structure directly, so
+/// `a: 1\nb: ` is already written by the time the bad scalar is reached, with
+/// no newline closing it. Continuing the document loop welded the separator
+/// onto that line and produced `a: 1\nb: ---\nc: 3` -- output that reads back
+/// as valid YAML with a fabricated `b`, and invalid JSON under `-o=json`.
+/// Real yq aborts the whole run on this input anyway.
+///
+/// The *evaluated* path is deliberately unaffected and still continues to the
+/// next document (#355): `GenericResult`'s streamers report through
+/// `StreamStats` without emitting a partial scalar, so nothing is left
+/// unterminated for a separator to collide with.
+#[test]
+fn test_streamed_truncation_does_not_weld_doc_separator_1615() -> Result<()> {
+    let input = "a: 1\nb: \"bad \\q escape\"\n---\nc: 3\n";
+
+    for extra in [&[][..], &["-o", "json"][..]] {
+        let (output, stderr, exit_code) = run_yq_split(".", input, extra)?;
+        assert_eq!(exit_code, 1, "args {extra:?}: {stderr}");
+        assert!(
+            !output.contains("---"),
+            "a truncated document must not be followed by a separator, \
+             args {extra:?}, output: {output:?}"
+        );
+        assert!(
+            !output.contains("c: 3") && !output.contains("\"c\""),
+            "the run must stop rather than emit later documents onto a \
+             truncated line, args {extra:?}, output: {output:?}"
+        );
+    }
+
+    // The evaluated route keeps #355's continue-past-a-bad-document behaviour,
+    // because it never leaves a document half-written.
+    let (output, _, exit_code) = run_yq_split(".b", input, &[])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        output.contains("null"),
+        "evaluated route should still reach the second document: {output:?}"
+    );
+    Ok(())
+}
+
+/// #1615 self-review: `--inplace` keeps editing the remaining files after one
+/// fails, so the truncation flag must reset per file.
+///
+/// Left set across the loop, it broke the *next* file's document loop on its
+/// first iteration -- committing a buffer holding only that file's first
+/// document and silently dropping the rest. Caught by re-reading the fix
+/// rather than by any existing test: a single-document second file hides it
+/// entirely, because the flag is checked *after* the document streams.
+#[test]
+fn test_inplace_truncation_flag_does_not_leak_across_files_1615() -> Result<()> {
+    let mut bad = NamedTempFile::new()?;
+    write!(bad, "a: 1\nb: \"bad \\q escape\"\n")?;
+    let good_original = "first: 1\n---\nsecond: 2\n---\nthird: 3\n";
+    let mut good = NamedTempFile::new()?;
+    write!(good, "{good_original}")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".")
+        .arg(bad.path())
+        .arg(good.path())
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        std::fs::read_to_string(good.path())?,
+        good_original,
+        "a later, perfectly valid file must keep every document"
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24805,13 +24805,56 @@ fn test_streamed_truncation_does_not_weld_doc_separator_1615() -> Result<()> {
         );
     }
 
-    // The evaluated route keeps #355's continue-past-a-bad-document behaviour,
-    // because it never leaves a document half-written.
+    // An *evaluated* filter truncates too whenever its result is a container
+    // holding the undecodable scalar -- the container's structure is already
+    // written by the time the scalar is reached. The first review round missed
+    // this because `.b` selects the bad scalar *directly*, so nothing is
+    // written before it fails; `.a` selects its parent and does write.
+    let nested = "a:\n  x: 1\n  y: \"bad \\q escape\"\n---\nz: 9\n";
+    for extra in [&[][..], &["-o", "json", "-I", "0"][..]] {
+        let (output, stderr, exit_code) = run_yq_split(".a", nested, extra)?;
+        assert_eq!(exit_code, 1, "args {extra:?}: {stderr}");
+        assert!(
+            !output.contains("---") && !output.contains('z'),
+            "an evaluated container render must not weld the next document \
+             onto its truncated line, args {extra:?}, output: {output:?}"
+        );
+    }
+
+    // A *streamed* decode failure stops the run uniformly, whether or not this
+    // particular result had already written a partial value. Distinguishing
+    // the two would mean counting bytes through the P9 streaming fast path (a
+    // 2.3x win) to serve a malformed-input edge case, and stopping is the
+    // closer answer anyway: real yq rejects the whole file for any of these
+    // inputs, so nothing reaches its stdout either.
     let (output, _, exit_code) = run_yq_split(".b", input, &[])?;
     assert_eq!(exit_code, 1);
     assert!(
-        output.contains("null"),
-        "evaluated route should still reach the second document: {output:?}"
+        !output.contains("null"),
+        "a streamed decode failure stops the run, matching real yq: {output:?}"
+    );
+
+    // #355 is untouched where it was designed. Its guarantee -- a bad value
+    // does not cost you the good documents around it -- lives on the
+    // *materializing* route, which writes nothing partial and still continues:
+    let (output, _, exit_code) = run_yq_split(".", input, &["--arg", "z", "y"])?;
+    assert_eq!(exit_code, 1);
+    assert!(
+        output.contains("c: 3"),
+        "the materializing route must still reach the second document: {output:?}"
+    );
+
+    // ...and an ordinary uncaught evaluation error still attempts every
+    // document on the streamed route too, because it writes nothing to stdout.
+    // That is the case `StreamStats::truncated` exists to keep separate from a
+    // decode failure: gating on `stats.error` instead would have stopped here.
+    let (_, stderr, exit_code) =
+        run_yq_split(".missing // error(\"boom\")", "a: 1\n---\nb: 2\n", &[])?;
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        stderr.matches("boom").count(),
+        2,
+        "an ordinary eval error must not stop the document loop: {stderr}"
     );
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24246,33 +24246,55 @@ fn test_undecodable_mapping_key_does_not_hide_later_fields_1247() -> Result<()> 
 /// Two routes, deliberately different at this stage of #1247's design (see
 /// `docs/plan/decode-failure-routing.md`):
 ///
-/// * the **materializing** routes raise a real error and exit non-zero --
-///   except for a bad *key* (`"a\qb": 1`), which #1642 changed to preserve
-///   instead (via its raw source span, matching YAML's existing
-///   never-drop-a-key convention for a key with no scalar form), so it
-///   stays in this list only for the bad *value* case;
-/// * the **streaming** routes still degrade to `null`/`""` -- but the
-///   document they emit is now parseable, which is what this test's first
-///   half pins. Making streaming loud too needs an error channel through
-///   `stream_json_value`'s `core::fmt::Result`, which is its own stage.
+/// Since #1615 closed that design's Stage 6, both routes now agree, and this
+/// test pins the agreement rather than the split it used to record:
+///
+/// * a bad **value** raises on *every* route, streamed or materializing --
+///   #1615 gave the streaming writers the error channel through
+///   `stream_json_value`'s `core::fmt::Result` that Stage 6 was waiting on
+///   (`StreamFailure`), so `-o=json '.'` no longer emits `{"b":null}` at
+///   exit 0;
+/// * a bad **key** (`"a\qb": 1`) is preserved as `""` on every route, also
+///   both -- #1642's never-drop-a-key convention (via its raw source span,
+///   YAML's existing answer for a key with no scalar form, #222). #1615
+///   deliberately did *not* make keys raise: `keys`/`to_entries`/`length`
+///   all report such a key, so raising here alone would re-open the
+///   one-document-many-answers split #1642 closed, on the other axis.
 #[test]
 fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
-    // `materialized`: `None` if materializing must still raise (a bad
-    // *value*); `Some(json)` if it must now succeed with `json` per result
-    // (a bad *key*, #1642).
-    for (input, streamed, materialized) in [
-        ("b: \"x\\qy\"\n", r#"{"b":null}"#, None),
-        ("\"a\\qb\": 1\n", r#"{"":1}"#, Some(r#"{"":1}"#)),
+    // `expected`: `None` if the route must raise (a bad *value*);
+    // `Some(json)` if it must succeed with `json` per result (a bad *key*,
+    // #1642). Since #1615 the streaming and materializing routes share one
+    // expectation instead of differing.
+    for (input, expected) in [
+        ("b: \"x\\qy\"\n", None),
+        ("\"a\\qb\": 1\n", Some(r#"{"":1}"#)),
     ] {
-        // Streaming: still degrades, but the emitted JSON is valid. `-P`
-        // takes this route too -- it forces pretty-printing, not the DOM.
+        let materialized = expected;
+        // Streaming. `-P` takes this route too -- it forces pretty-printing,
+        // not the DOM.
         for extra in [
             &["-o", "json", "-I", "0"][..],
             &["-o", "json", "-I", "0", "-P"][..],
         ] {
-            let (output, exit_code) = run_yq_stdin(".", input, extra)?;
-            assert_eq!(exit_code, 0, "args {extra:?}, output: {output:?}");
-            assert_eq!(output.trim(), streamed, "args {extra:?}");
+            let (output, stderr, exit_code) = run_yq_split(".", input, extra)?;
+            match expected {
+                // #1615: raises now, where this used to pin `{"b":null}` at
+                // exit 0. Whatever prefix already reached stdout may stay --
+                // the diagnostic and the exit code are the contract, the same
+                // truncate-then-diagnose trade #1641/#1679 settled.
+                None => {
+                    assert_eq!(exit_code, 1, "args {extra:?}, output: {output:?}");
+                    assert!(
+                        stderr.contains("invalid escape sequence"),
+                        "args {extra:?}, stderr: {stderr}"
+                    );
+                }
+                Some(json) => {
+                    assert_eq!(exit_code, 0, "args {extra:?}, stderr: {stderr}");
+                    assert_eq!(output.trim(), json, "args {extra:?}");
+                }
+            }
         }
 
         // Materializing: `--arg` forces the DOM path, and a multi-result
@@ -24619,5 +24641,84 @@ fn test_colliding_display_key_error_is_uncatchable_yq_1813() -> Result<()> {
     );
     assert!(err.contains("ambiguous"), "stderr: {err}");
 
+    Ok(())
+}
+
+/// #1615: the three streaming *value* writers left as "Stage 6" in
+/// `docs/plan/decode-failure-routing.md` now raise a diagnosable decode
+/// failure instead of silently substituting `null`/`""` at exit 0.
+///
+/// Their only error channel used to be `core::fmt::Result`, which carries no
+/// message -- so the design doc deferred them rather than accept a "bare,
+/// undiagnosed abort". `StreamFailure` is that missing channel. Real yq
+/// rejects each of these documents outright (`found unknown escape
+/// character`, exit 1), and every *materializing* succinctly route has raised
+/// since #1247; these are the routes that did not.
+///
+/// The three sites, all reached below:
+/// 1. `stream_json_value` -- YAML->JSON (`-o=json`), the site the doc named;
+/// 2. `stream_yaml_string_value` -- YAML->YAML, the *default* invocation and
+///    by far the most common, never previously recorded anywhere;
+/// 3. `stream_json_as_yaml`'s string arm -- JSON->YAML, whose failure was a
+///    message-less `core::fmt::Error` rather than a silent substitution.
+#[test]
+fn test_streamed_value_decode_failure_raises_1615() -> Result<()> {
+    let yaml = "a: 1\nb: \"bad \\q escape\"\n";
+
+    // Sites 1 and 2, plus the evaluated (non-identity) route through
+    // `GenericResult::stream_json`/`stream_yaml`, which reports via
+    // `StreamStats::error` rather than by failing.
+    for (filter, extra) in [
+        (".", &["-o", "json"][..]),  // site 1: YAML -> JSON, identity/P9
+        (".", &[][..]),              // site 2: YAML -> YAML, identity/P9
+        (".b", &["-o", "json"][..]), // evaluated, JSON target
+        (".b", &[][..]),             // evaluated, YAML target
+    ] {
+        let (_, stderr, exit_code) = run_yq_split(filter, yaml, extra)?;
+        assert_eq!(exit_code, 1, "filter {filter:?} args {extra:?}: {stderr}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "filter {filter:?} args {extra:?}, stderr: {stderr}"
+        );
+    }
+
+    // Site 3: JSON -> YAML. `--slurp` because a bare `-p=json` invocation is
+    // re-parsed as YAML flow syntax and never reaches the JSON streamers at
+    // all -- only `--slurp`/`--eval-all`/`--inplace` route through real JSON
+    // parsing.
+    let json = "{\"a\":1,\"b\":\"bad \\q escape\"}";
+    let (_, stderr, exit_code) = run_yq_split(".", json, &["-p", "json", "--slurp"])?;
+    assert_eq!(exit_code, 1, "JSON->YAML slurp: {stderr}");
+
+    // A valid sibling is still readable: this raises on the bad scalar, not
+    // on the whole document (`.a` never touches `b`).
+    let (output, _, exit_code) = run_yq_split(".a", yaml, &["-o", "json"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "1");
+    Ok(())
+}
+
+/// #1615 must not disturb #1642: a decode-failure *key* is preserved as `""`
+/// on every route, streamed included, rather than raising.
+///
+/// This is the one asymmetry in #1615's fix and it is deliberate -- see
+/// `Undecodable` in `src/yaml/light.rs`. `keys`/`to_entries`/`length` all
+/// report such a key, so a streamed identity that raised on it would put the
+/// same document's answers back into disagreement, which is exactly what
+/// #1642 closed.
+#[test]
+fn test_streamed_key_decode_failure_still_preserved_1615() -> Result<()> {
+    let input = "\"a\\qb\": 1\nb: 2\n";
+    for (extra, expected) in [
+        (&["-o", "json", "-I", "0"][..], r#"{"":1,"b":2}"#),
+        (
+            &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
+            r#"{"":1,"b":2}"#,
+        ),
+    ] {
+        let (output, stderr, exit_code) = run_yq_split(".", input, extra)?;
+        assert_eq!(exit_code, 0, "args {extra:?}, stderr: {stderr}");
+        assert_eq!(output.trim(), expected, "args {extra:?}");
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes the last decode-failure swallow left after #1247 — the streaming output writers, deliberately deferred as **"Stage 6"** in [`docs/plan/decode-failure-routing.md`](docs/plan/decode-failure-routing.md).

Their only error channel was `core::fmt::Result`, which carries no message, so a mid-stream failure could only be absorbed silently or cause a bare, undiagnosed abort. One document therefore gave two answers depending on how it was rendered:

| route | before | after |
|---|---|---|
| materializing (`--arg`, `-P`, `to_entries`, `length`) | raises, exit 1 | unchanged |
| streamed (`yq '.'`, `-o=json '.'`, `.b`) | `null` / `""`, **exit 0** | raises, exit 1 |

Real `yq` v4.53.3 rejects each of these documents outright (`found unknown escape character`, exit 1).

```console
$ printf 'a: 1\nb: "bad \q escape"\n' | succinctly yq -o=json '.'   # before: {"a":1,"b":null}, exit 0
Error: invalid escape sequence                                      # after:  exit 1
$ printf 'double: "quoted \q scalar"\n' | succinctly yq '.'         # before: double: "", exit 0
Error: invalid escape sequence                                      # after:  exit 1
```

## Approach

Adds `StreamFailure` (`src/jq/stream.rs`): `Fmt` for a genuine writer failure, `Decode(EvalError)` for a scalar that will not decode. Because `From<core::fmt::Error>` converts *into* it, every existing `?` inside the writers kept working unchanged — only the family's return types and its leaf substitution sites needed touching, not each recursive call site.

There is deliberately **no** `From<StreamFailure> for core::fmt::Error`. That impl would let a plain `?` silently re-collapse a decode failure back into the message-less error the type exists to escape. Its absence turns every such site into a compile error — which is what surfaced **six `GenericResult` arms that were dropping the message**; they now report through `StreamStats::error` exactly as #1679's `LazyKeys` arm does.

## Four writer sites, not the three the issue scoped

1. `stream_json_value` (`yaml/light.rs`) — YAML→JSON, the site the doc named
2. `stream_yaml_string_value` (`yaml/light.rs`) — YAML→YAML, the *default* invocation
3. `stream_json_as_yaml`'s string arm (`json/light.rs`) — JSON→YAML, whose failure was a message-less `core::fmt::Error`
4. **`stream_yaml_as_document`'s root-scalar shortcut** — found by testing, not by the site inventory. It bypasses 1–3 by design (#996/#852), so `yq '.b'` still printed `""` at exit 0 while `yq -o=json '.b'` raised.

## What happens after the failure fires

Making the writers raise also makes them stop part-way through a document, and three of the four defects found in review were about that, not about the raise itself. Two rounds of `/code-review` plus my own re-reads found **9 defects, all fixed here**:

- **`--inplace` committed the truncated buffer**, destroying the file — an 8-byte fragment for one document, and for a multi-document file a *valid-looking* `a: 1\nb: ---\nc: 3\n` whose corruption is invisible from the file itself. Strictly worse than the silent `b: ""` this PR replaces. Not a new policy: `-i` on a materializing filter already left the file untouched, and real yq leaves it byte-identical.
- **Multi-document output welded the next `---` onto the cut-off line**, producing `b: ---` — output that re-reads as valid YAML with a *fabricated* value, and invalid JSON under `-o=json`. Fixed for the identity path, then found again on the evaluated path (my note claiming it couldn't happen there was wrong: `.b` selects the bad scalar and writes nothing first, but `.a` selects its *parent container*, which does).
- **A broken pipe was reported as `invalid UTF-8 in string`** — every `out.write_*` in `stream_yaml_string_to_json` mapped to a data error, harmless while both ends were message-less but not once the message reached users.
- Plus: a truncation flag leaking across `--inplace` files (silently dropping documents from a later, valid file), a dropped `stats.count`, a lossy `unwrap_or_default()`, a message-less `map_err` on the `-i` fallback, a doc comment landing on the wrong item, and a `single_char_pattern` lint that `-D warnings` would have failed CI on.

A streamed decode failure therefore **stops the run**. Distinguishing "wrote a partial value" from "wrote nothing" would mean counting bytes through the P9 streaming fast path (a 2.3× win) to serve a malformed-input edge case, and stopping is the closer answer anyway — real yq puts nothing on stdout for any of these inputs.

**#355 is not narrowed.** Its guarantee — a malformed value does not cost you the good documents around it — lives on the *materializing* routes, which write nothing partial and still process every document. An ordinary uncaught *evaluation* error also still continues on the streamed route. Both are asserted in the tests; `StreamStats::truncated` exists precisely to keep them separate from a decode failure (gating on `stats.error` would have silently narrowed #355).

## Two deliberate exclusions

- **Mapping keys** (`Undecodable::PreserveEmpty`). #1642 settled that a key with no scalar form is preserved as `""` on *every* route, and `keys`/`to_entries`/`length` all report it — raising in a streamed identity alone would re-open the one-document-many-answers split on the key axis. #1615's original repro listed the key case, but **#1642 landed after the issue was filed** and settled it the other way; pinned by a test.
- **`StandardJson::Error(_)`** stays `null` — a *structural* malformation (#1194's class), not a decode failure. Answering it here alone would split #1194's decision across two issues.

**Not changed:** `.a` on a document whose `.b` is undecodable still exits 0 where real yq exits 1 — the pre-existing, documented lazy-discovery divergence (a bad scalar is only found when touched). Changing it would mean validating whole documents upfront, defeating semi-indexing.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 55 suites, all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all --check`, `cargo doc --no-deps`, `cargo build --no-default-features` (no_std)
- [x] Diffed against pinned `yq` v4.53.3 directly, not just goldens (including `-i` md5 before/after)
- [x] **Output identity gate**: byte-identical to the pre-change binary (output *and* exit code) across **704 yq** and **144 jq** configurations on valid documents, including `-C`, `--eval-all`, `--slurp`, `--inplace` and terminator paths
- [x] Re-ran the whole set after rebasing onto 9 new `main` commits (3 touch files this PR changes)
- [x] 6 new regression tests, one **proven to fail** against the unfixed writer-error mapping; updated `test_decode_failure_does_not_corrupt_json_output_1247`, which pinned the old split

Docs: the yq limitations entry recorded this as a live divergence and is rewritten; Stage 6 marked landed with the four sites and the key exclusion recorded.

Fixes #1615
