### PR TITLE
fix(jq): -R joins a line across a file boundary, matching --seq's #1571 fix

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2954,40 +2954,16 @@ fn build_seq_values(
     locations: &mut InputLocations,
     slurp: bool,
 ) -> Vec<OwnedValue> {
-    let mut combined = String::new();
-    let mut file_ends: Vec<usize> = Vec::with_capacity(raw_inputs.len());
-    for (_, raw) in raw_inputs {
-        combined.push_str(raw);
-        file_ends.push(combined.len());
-    }
-
+    let (combined, file_ends) = concat_with_file_ends(raw_inputs);
     let parsed = parse_json_seq_with_ends(&combined);
 
     if !slurp {
-        let mut current: Option<(usize, LineCounter<'_>)> = None;
-        for &(_, end) in &parsed {
-            let file_idx = file_ends
-                .partition_point(|&fe| fe < end)
-                .min(file_ends.len().saturating_sub(1));
-            if current.as_ref().map(|(idx, _)| *idx) != Some(file_idx) {
-                current = Some((
-                    file_idx,
-                    LineCounter::new(raw_inputs[file_idx].1.as_bytes()),
-                ));
-            }
-            let file_start = if file_idx == 0 {
-                0
-            } else {
-                file_ends[file_idx - 1]
-            };
-            let src = raw_inputs[file_idx].0.unwrap_or(0);
-            let line = current
-                .as_mut()
-                .expect("just set above")
-                .1
-                .advance_to(end.saturating_sub(file_start));
-            locations.push(src, line);
-        }
+        remap_ends_to_locations(
+            parsed.iter().map(|&(_, end)| end),
+            raw_inputs,
+            &file_ends,
+            locations,
+        );
     }
 
     parsed.into_iter().map(|(v, _)| v).collect()
@@ -2996,26 +2972,32 @@ fn build_seq_values(
 /// Build the values and one `(source, line)` location per value for
 /// raw-input (`-R`) mode across the whole file list at once (#1809).
 ///
-/// Mirrors [`build_seq_values`]'s concatenate-then-remap pattern: real jq's
-/// `-R` reader treats multiple files as one continuous byte stream for
-/// line-splitting too -- confirmed live against jq 1.7.1 that a file's own
-/// unterminated trailing line joins with the next file's first line, the
-/// same way `--seq` joins a boundary-split record. This can't reuse
-/// `build_seq_values` directly (RS-delimited/JSON-shaped, not
-/// newline-shaped), but reuses its exact
-/// `file_ends`/`partition_point`/[`LineCounter`] remap loop.
+/// Mirrors [`build_seq_values`]'s concatenate-then-remap pattern (sharing
+/// its [`concat_with_file_ends`]/[`remap_ends_to_locations`] helpers
+/// directly): real jq's `-R` reader treats multiple files as one
+/// continuous byte stream for line-splitting too -- confirmed live against
+/// jq 1.7.1 that a file's own unterminated trailing line joins with the
+/// next file's first line, the same way `--seq` joins a boundary-split
+/// record. This can't reuse `parse_json_seq_with_ends` itself
+/// (RS-delimited/JSON-shaped, not newline-shaped), so it does its own `\n`
+/// scan to find each line's byte range instead.
 ///
-/// Splits on `\n` matching [`str::lines`]'s own rules (a trailing `\r` is
-/// stripped from each line's content; a trailing `\n` does not open an
-/// extra empty final line) rather than calling `str::lines()` itself, since
-/// that discards the byte offsets this needs for the remap. Attributing
-/// each line's *end* offset to a file via `LineCounter::advance_to` also
-/// fixes a real jq 1.7.1 line-number quirk single-file `-R` already had
-/// wrong: a final line with no trailing `\n` reports the *previous*
-/// completed line's number, not one past it (confirmed live: `printf
-/// 'abc\ndef' | jq -R -c '., input_line_number'` reports `1` for both
-/// lines, not `1` then `2`) -- no test previously covered this, since every
-/// existing `-R` fixture's lines were all `\n`-terminated.
+/// Splits on `\n` matching [`str::lines`]'s own rule that a trailing `\n`
+/// does not open an extra empty final line, but -- unlike `str::lines()`
+/// -- keeps a trailing `\r` as part of each line's content rather than
+/// stripping it: real jq's `-R` reader never strips `\r` either (confirmed
+/// live: `printf 'abc\r\n' | jq -R -c '.'` => `"abc\r"`, not `"abc"`). This
+/// needs its own scan rather than calling `str::lines()` regardless, since
+/// that discards the byte offsets this needs for the remap.
+///
+/// Attributing each line's *end* offset to a file via
+/// `remap_ends_to_locations` also fixes a real jq 1.7.1 line-number quirk
+/// single-file `-R` already had wrong: a final line with no trailing `\n`
+/// reports the *previous* completed line's number, not one past it
+/// (confirmed live: `printf 'abc\ndef' | jq -R -c '., input_line_number'`
+/// reports `1` for both lines, not `1` then `2`) -- no test previously
+/// covered this, since every existing `-R` fixture's lines were all
+/// `\n`-terminated.
 ///
 /// Never called under `--slurp`: `-R -s` without `--input-dsv` returns
 /// early above this point, and `-R -s --input-dsv` takes the per-file DSV
@@ -3026,12 +3008,7 @@ fn build_raw_input_values(
     raw_inputs: &[(Option<usize>, String)],
     locations: &mut InputLocations,
 ) -> Vec<OwnedValue> {
-    let mut combined = String::new();
-    let mut file_ends: Vec<usize> = Vec::with_capacity(raw_inputs.len());
-    for (_, raw) in raw_inputs {
-        combined.push_str(raw);
-        file_ends.push(combined.len());
-    }
+    let (combined, file_ends) = concat_with_file_ends(raw_inputs);
 
     // ((content start, content end), line's own attribution-end offset --
     // the `\n`'s own position, or `combined.len()` for a final unterminated
@@ -3049,14 +3026,73 @@ fn build_raw_input_values(
         lines.push(((start, bytes.len()), bytes.len()));
     }
 
-    let mut values = Vec::with_capacity(lines.len());
-    let mut current: Option<(usize, LineCounter<'_>)> = None;
-    for ((content_start, content_end), end) in lines {
-        let content_raw = &combined[content_start..content_end];
-        let content = content_raw.strip_suffix('\r').unwrap_or(content_raw);
+    remap_ends_to_locations(
+        lines.iter().map(|&(_, end)| end),
+        raw_inputs,
+        &file_ends,
+        locations,
+    );
 
+    lines
+        .into_iter()
+        .map(|((content_start, content_end), _)| {
+            OwnedValue::String(combined[content_start..content_end].to_string())
+        })
+        .collect()
+}
+
+/// Concatenate every file's raw content, in order, into one string,
+/// recording each file's own cumulative end offset in the result -- shared
+/// by [`build_seq_values`] and [`build_raw_input_values`], both of which
+/// treat the whole multi-file input as one continuous byte stream for
+/// their own purposes (RFC 7464 records / newline-delimited lines).
+fn concat_with_file_ends(raw_inputs: &[(Option<usize>, String)]) -> (String, Vec<usize>) {
+    let mut combined = String::new();
+    let mut file_ends: Vec<usize> = Vec::with_capacity(raw_inputs.len());
+    for (_, raw) in raw_inputs {
+        combined.push_str(raw);
+        file_ends.push(combined.len());
+    }
+    (combined, file_ends)
+}
+
+/// Map each `end` offset in `ends` (non-decreasing, an exclusive position
+/// within the `combined` stream `file_ends` was built from -- see
+/// [`concat_with_file_ends`]) to its owning file and file-local line
+/// number, pushing one `(source, line)` location per `end` onto
+/// `locations` in the same order. Shared by [`build_seq_values`] and
+/// [`build_raw_input_values`].
+///
+/// A value/line ending *exactly* at a file boundary is attributed to the
+/// file *starting* there, not the file ending there: `partition_point`'s
+/// `fe <= end` predicate (not `fe < end`) is what makes that call, since
+/// `file_ends[i]` is both file `i`'s own exclusive end and file `i+1`'s
+/// start offset -- an `end` equal to that offset means the byte the
+/// record/line's own trailing delimiter occupies is the *first* byte of
+/// file `i+1`, not the last byte of file `i`. Getting this wrong (an
+/// earlier version of both callers used `fe < end`) misattributes the
+/// line/record to the wrong file entirely whenever a file's sole content is
+/// the delimiter that terminates the *previous* file's unterminated
+/// trailing content -- confirmed live against jq 1.7.1 in exactly that
+/// degenerate case (three files `"abc"`, `"\n"`, `"def\n"`): both the
+/// reported line number and the `error(...)` location moved to the correct
+/// (second) file once fixed, matching jq exactly; before the fix both
+/// pointed at the first file instead.
+///
+/// `current` caches the one [`LineCounter`] in use, replaced only when
+/// `partition_point` reports a new file index -- since `end` values are
+/// non-decreasing, that index is too, so this never backtracks to a file
+/// already passed.
+fn remap_ends_to_locations(
+    ends: impl Iterator<Item = usize>,
+    raw_inputs: &[(Option<usize>, String)],
+    file_ends: &[usize],
+    locations: &mut InputLocations,
+) {
+    let mut current: Option<(usize, LineCounter<'_>)> = None;
+    for end in ends {
         let file_idx = file_ends
-            .partition_point(|&fe| fe < end)
+            .partition_point(|&fe| fe <= end)
             .min(file_ends.len().saturating_sub(1));
         if current.as_ref().map(|(idx, _)| *idx) != Some(file_idx) {
             current = Some((
@@ -3076,10 +3112,7 @@ fn build_raw_input_values(
             .1
             .advance_to(end.saturating_sub(file_start));
         locations.push(src, line);
-        values.push(OwnedValue::String(content.to_string()));
     }
-
-    values
 }
 
 /// Parse `--seq` content into values paired with each surviving segment's

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1890,29 +1890,32 @@ fn get_inputs(
     // Process based on input mode
     let mut values = Vec::new();
 
-    // `--seq` (RFC 7464, #1571): a record's bytes can genuinely span a file
-    // boundary -- real jq's own reader treats every file as one continuous
-    // byte stream for parsing purposes (unrelated to whether `-s` is also
-    // passed: `-s` only changes what happens to the *values* afterward, not
-    // how records are delimited), so this handles the whole file list at
-    // once via [`build_seq_values`] rather than per file inside the loop
-    // below. The other three modes keep the per-file loop unchanged for now:
-    // plain JSON's `find_json_values`/`parse_json_stream` never had a
-    // record delimiter to lose in the first place (multiple JSON files are
-    // just independent value streams concatenated in the output, with no
-    // boundary-spanning-record concept to get wrong), and DSV rows are
-    // line-oriented and unverified either way. Raw-input (`-R`) is NOT
-    // actually safe from this class of bug -- confirmed live against
-    // pinned jq 1.7.1 that `-R`'s reader joins a file's own unterminated
-    // trailing line with the next file's first line the same way `--seq`
-    // joins a boundary-split record, which succinctly's own per-file
-    // `raw.lines()` loop below does not (#1809, filed rather than fixed
-    // here to keep this PR scoped to `--seq`).
+    // `--seq` (RFC 7464, #1571) and raw-input (`-R`, #1809): both can
+    // genuinely join content across a file boundary -- real jq's own
+    // reader treats every file as one continuous byte stream for parsing
+    // purposes (unrelated to whether `-s` is also passed: `-s` only
+    // changes what happens to the *values* afterward, not how records/lines
+    // are delimited) -- so both handle the whole file list at once via
+    // [`build_seq_values`]/[`build_raw_input_values`] rather than per file
+    // inside the loop below. Plain JSON keeps the per-file loop unchanged:
+    // `find_json_values`/`parse_json_stream` never had a record delimiter
+    // to lose in the first place (multiple JSON files are just independent
+    // value streams concatenated in the output, with no
+    // boundary-spanning-value concept to get wrong). DSV rows are
+    // line-oriented and unverified either way (no jq DSV oracle to check
+    // against), so they also keep the per-file loop -- including when
+    // combined with `-R` (`args.raw_input && args.input_dsv.is_some()`),
+    // which the DSV branch inside the loop already takes over first.
     if args.seq && !args.raw_input && args.input_dsv.is_none() {
         values = build_seq_values(&raw_inputs, &mut locations, args.slurp);
         if !args.slurp {
             debug_assert_eq!(locations.len(), values.len(), "one location per value");
         }
+    } else if args.raw_input && args.input_dsv.is_none() {
+        // Never reached with `args.slurp`: `-R -s` without `--input-dsv`
+        // already returned early above this point.
+        values = build_raw_input_values(&raw_inputs, &mut locations);
+        debug_assert_eq!(locations.len(), values.len(), "one location per value");
     } else {
         for (file_idx, raw) in raw_inputs {
             let src = file_idx.unwrap_or(0);
@@ -1932,18 +1935,6 @@ fn get_inputs(
                     }
                 }
                 values.extend(parsed);
-            } else if args.raw_input {
-                // Raw input: each line becomes a string. Deliberately ungated by
-                // `!args.slurp` (#1541), unlike its three siblings above/below --
-                // `args.raw_input && args.slurp` can only reach this arm when
-                // `args.input_dsv` is also set (otherwise the dedicated `-R -s`
-                // early return above already handled it), and the DSV check is
-                // tried first in this `if`/`else if` chain, so it always wins:
-                // this arm is unreachable whenever `args.slurp` is true.
-                for (line_idx, line) in raw.lines().enumerate() {
-                    values.push(OwnedValue::String(line.to_string()));
-                    locations.push(src, line_idx + 1);
-                }
             } else {
                 // JSON input: validate first if --validate is set
                 if args.validate {
@@ -3000,6 +2991,95 @@ fn build_seq_values(
     }
 
     parsed.into_iter().map(|(v, _)| v).collect()
+}
+
+/// Build the values and one `(source, line)` location per value for
+/// raw-input (`-R`) mode across the whole file list at once (#1809).
+///
+/// Mirrors [`build_seq_values`]'s concatenate-then-remap pattern: real jq's
+/// `-R` reader treats multiple files as one continuous byte stream for
+/// line-splitting too -- confirmed live against jq 1.7.1 that a file's own
+/// unterminated trailing line joins with the next file's first line, the
+/// same way `--seq` joins a boundary-split record. This can't reuse
+/// `build_seq_values` directly (RS-delimited/JSON-shaped, not
+/// newline-shaped), but reuses its exact
+/// `file_ends`/`partition_point`/[`LineCounter`] remap loop.
+///
+/// Splits on `\n` matching [`str::lines`]'s own rules (a trailing `\r` is
+/// stripped from each line's content; a trailing `\n` does not open an
+/// extra empty final line) rather than calling `str::lines()` itself, since
+/// that discards the byte offsets this needs for the remap. Attributing
+/// each line's *end* offset to a file via `LineCounter::advance_to` also
+/// fixes a real jq 1.7.1 line-number quirk single-file `-R` already had
+/// wrong: a final line with no trailing `\n` reports the *previous*
+/// completed line's number, not one past it (confirmed live: `printf
+/// 'abc\ndef' | jq -R -c '., input_line_number'` reports `1` for both
+/// lines, not `1` then `2`) -- no test previously covered this, since every
+/// existing `-R` fixture's lines were all `\n`-terminated.
+///
+/// Never called under `--slurp`: `-R -s` without `--input-dsv` returns
+/// early above this point, and `-R -s --input-dsv` takes the per-file DSV
+/// branch instead (DSV is checked first in that loop's `if`/`else`), so
+/// `args.raw_input && args.input_dsv.is_none()` -- this function's own
+/// call-site guard -- can only be reached with `slurp == false`.
+fn build_raw_input_values(
+    raw_inputs: &[(Option<usize>, String)],
+    locations: &mut InputLocations,
+) -> Vec<OwnedValue> {
+    let mut combined = String::new();
+    let mut file_ends: Vec<usize> = Vec::with_capacity(raw_inputs.len());
+    for (_, raw) in raw_inputs {
+        combined.push_str(raw);
+        file_ends.push(combined.len());
+    }
+
+    // ((content start, content end), line's own attribution-end offset --
+    // the `\n`'s own position, or `combined.len()` for a final unterminated
+    // line).
+    let mut lines: Vec<((usize, usize), usize)> = Vec::new();
+    let bytes = combined.as_bytes();
+    let mut start = 0usize;
+    for (idx, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            lines.push(((start, idx), idx));
+            start = idx + 1;
+        }
+    }
+    if start < bytes.len() {
+        lines.push(((start, bytes.len()), bytes.len()));
+    }
+
+    let mut values = Vec::with_capacity(lines.len());
+    let mut current: Option<(usize, LineCounter<'_>)> = None;
+    for ((content_start, content_end), end) in lines {
+        let content_raw = &combined[content_start..content_end];
+        let content = content_raw.strip_suffix('\r').unwrap_or(content_raw);
+
+        let file_idx = file_ends
+            .partition_point(|&fe| fe < end)
+            .min(file_ends.len().saturating_sub(1));
+        if current.as_ref().map(|(idx, _)| *idx) != Some(file_idx) {
+            current = Some((
+                file_idx,
+                LineCounter::new(raw_inputs[file_idx].1.as_bytes()),
+            ));
+        }
+        let file_start = if file_idx == 0 {
+            0
+        } else {
+            file_ends[file_idx - 1]
+        };
+        let src = raw_inputs[file_idx].0.unwrap_or(0);
+        let line = current
+            .as_mut()
+            .expect("just set above")
+            .1
+            .advance_to(end.saturating_sub(file_start));
+        locations.push(src, line);
+        values.push(OwnedValue::String(content.to_string()));
+    }
+
+    values
 }
 
 /// Parse `--seq` content into values paired with each surviving segment's

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21168,6 +21168,70 @@ fn test_jq_seq_malformed_record_does_not_misattribute_other_files_error_location
     Ok(())
 }
 
+/// #1809: `-R` (raw-input) has the same cross-file-boundary bug `--seq` had
+/// (#1571) -- real jq's `-R` reader treats multiple files as one
+/// continuous byte stream for line-splitting, so a file's own unterminated
+/// trailing line joins with the next file's first line. Every expectation
+/// here is jq 1.7.1's own live output for this exact repro.
+#[test]
+fn test_jq_raw_input_line_joined_across_file_boundary_1809() -> Result<()> {
+    // The issue's own repro: file 1 has no trailing newline.
+    let (stdout, stderr, code, _paths) =
+        run_jq_over_files(&["-R", "-c", "."], &["abc", "def\nghi\n"])?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abcdef\"\n\"ghi\"\n");
+
+    // A line spanning three files, not just two.
+    let (stdout, stderr, code, _paths) =
+        run_jq_over_files(&["-R", "-c", "."], &["ab", "cd", "ef\ngh\n"])?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abcdef\"\n\"gh\"\n");
+
+    // Control: every file ends in `\n` -- no join, one line per file,
+    // matching the pre-existing (already-correct) behavior.
+    let (stdout, stderr, code, _paths) =
+        run_jq_over_files(&["-R", "-c", "."], &["abc\n", "def\n"])?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abc\"\n\"def\"\n");
+
+    Ok(())
+}
+
+/// #1809: `input_line_number` for a joined line reports the file it
+/// actually lands in, at that file's own local line count -- not the first
+/// file's count, and not a global cross-file count. Pinned against jq
+/// 1.7.1's own live output.
+#[test]
+fn test_jq_raw_input_line_number_after_cross_file_join_1809() -> Result<()> {
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["-R", "-c", "., input_line_number"],
+        &["abc", "def\nghi\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abcdef\"\n1\n\"ghi\"\n2\n");
+
+    Ok(())
+}
+
+/// #1809: the joined line's error location follows the same rule as its
+/// value/line-number attribution -- the file the line's own terminating
+/// `\n` lives in, not the file the join started in. Pinned against jq
+/// 1.7.1's own live output.
+#[test]
+fn test_jq_raw_input_error_location_after_cross_file_join_1809() -> Result<()> {
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["-R", "-c", "error(\"x\")"], &["abc", "def\nghi\n"])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[1])),
+        "the joined line `abcdef` must report the SECOND file (where its \
+         own trailing newline lives), not the first: {stderr}"
+    );
+    assert!(!stderr.contains(&paths[0]), "{stderr}");
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21232,6 +21232,69 @@ fn test_jq_raw_input_error_location_after_cross_file_join_1809() -> Result<()> {
     Ok(())
 }
 
+/// #1809 code review: a line ending *exactly* at a file boundary -- a file
+/// whose entire content is the single `\n` that terminates the *previous*
+/// file's unterminated trailing text -- must attribute to that middle
+/// file, not the first one. An earlier version of the fix used a
+/// `partition_point` predicate (`fe < end`) that got this one degenerate
+/// case backwards even though every other boundary case (including the
+/// non-degenerate cross-file joins above) happened to come out right.
+/// Every expectation here is jq 1.7.1's own live output.
+#[test]
+fn test_jq_raw_input_line_number_and_error_location_at_exact_file_boundary_1809() -> Result<()> {
+    let (stdout, stderr, code, _paths) = run_jq_over_files(
+        &["-R", "-c", "., input_line_number"],
+        &["abc", "\n", "def\n"],
+    )?;
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abc\"\n1\n\"def\"\n1\n");
+
+    let (_, stderr, code, paths) =
+        run_jq_over_files(&["-R", "-c", "error(\"x\")"], &["abc", "\n", "def\n"])?;
+    assert_eq!(code, 5, "{stderr}");
+    assert!(
+        stderr.contains(&format!("(at {}:1): x", paths[1])),
+        "the joined line `abc` must report the MIDDLE file (whose only \
+         content is the `\\n` terminating it), not the first: {stderr}"
+    );
+    assert!(!stderr.contains(&paths[0]), "{stderr}");
+
+    Ok(())
+}
+
+/// #1809 code review: real jq's `-R` reader never strips a trailing `\r`
+/// from a line -- it splits only on `\n`, keeping `\r` as literal content.
+/// Pinned against jq 1.7.1's own live output.
+#[test]
+fn test_jq_raw_input_preserves_trailing_cr_1809() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", "."], Some("abc\r\ndef\r\n")).expect("raw-input CRLF repro runs");
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abc\\r\"\n\"def\\r\"\n");
+
+    Ok(())
+}
+
+/// #1809 code review: a single, non-multi-file `-R` input with an
+/// unterminated trailing line -- the line-number quirk the fix's own doc
+/// comment claims to have corrected, isolated from any cross-file join.
+/// Pinned against jq 1.7.1's own live output.
+#[test]
+fn test_jq_raw_input_line_number_unterminated_single_file_1809() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-R", "-c", "., input_line_number"], Some("abc\ndef"))
+            .expect("raw-input single-file repro runs");
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abc\"\n1\n\"def\"\n1\n");
+
+    let (stdout, stderr, code) = run_jq_full(&["-R", "-c", "., input_line_number"], Some("abc"))
+        .expect("raw-input single unterminated line repro runs");
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout, "\"abc\"\n0\n");
+
+    Ok(())
+}
+
 /// #1088: `path()` reports a numeric component as the key *was*, not as the
 /// index it resolves to.
 ///


### PR DESCRIPTION
## Summary
- Real jq's `-R` (raw-input) reader treats multiple input files as one continuous byte stream for line-splitting, so a file's own unterminated trailing line joins with the next file's first line — confirmed live against `/usr/bin/jq` 1.7.1. succinctly's `-R` handling split each file into lines independently instead (`raw.lines().enumerate()` per file), producing an extra spurious line at every unterminated file boundary.
- Adds `build_raw_input_values`, mirroring `build_seq_values`'s (#1571/PR #1808) concatenate-then-remap pattern: concatenate every file's raw bytes, split into lines once across the whole combined stream, then remap each line's end offset back to its owning file and file-local line number via the same `LineCounter`/`partition_point` approach — reused verbatim, not reimplemented.
- The dead per-file `raw_input` arm inside the loop is removed; the new dispatch branch (`args.raw_input && args.input_dsv.is_none()`) intercepts every case that arm used to handle, since the `-R -s` early return already covers the one remaining combination.
- Side effect (not scope creep — same code path, correct-by-construction): a final unterminated line's `input_line_number`/error-location attribution is now also correct in the *single-file* case, matching real jq exactly (a final line with no trailing `\n` reports the *previous* completed line's number, confirmed live: `printf 'abc\ndef' | jq -R -c '., input_line_number'` reports `1` for both lines). No prior test covered this since every existing `-R` fixture was fully `\n`-terminated.

## Test plan
- [x] Live-verified the issue's own repro, a 3-file join, `input_line_number`, and error-location attribution all match `/usr/bin/jq` 1.7.1 exactly
- [x] `-R -s` (early-return path) and `-R --input-dsv` (still per-file) confirmed unaffected
- [x] New tests: `test_jq_raw_input_line_joined_across_file_boundary_1809`, `test_jq_raw_input_line_number_after_cross_file_join_1809`, `test_jq_raw_input_error_location_after_cross_file_join_1809`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, no regressions
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Fixes #1809