### PR TITLE
refactor(jq): collapse the triplicated materialized! macro into one helper

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3461,30 +3461,47 @@ fn evaluate_input(
     // "defense-in-depth" there). Kept as `Result` rather than `.unwrap()` so
     // a real failure, if this invariant is ever violated, surfaces as a
     // normal `EvalError` instead of a panic.
-    macro_rules! materialized {
-        ($e:expr) => {
-            match $e {
-                Ok(v) => v,
-                Err(e) => {
-                    sink.report(DiagStyle::Jq, &e, &at.resolve());
-                    return Ok(vec![]);
-                }
-            }
-        };
-    }
-
     // Convert result to Vec<OwnedValue>
     match result {
-        GenericResult::One(v) => Ok(vec![materialized!(generic_to_owned(&v))]),
-        GenericResult::OneCursor(c) => Ok(vec![materialized!(generic_to_owned(&c.value()))]),
-        GenericResult::Many(vs) => Ok(materialized!(vs
-            .iter()
-            .map(generic_to_owned)
-            .collect::<core::result::Result<Vec<_>, _>>())),
-        GenericResult::ManyCursor(cs) => Ok(materialized!(cs
-            .iter()
-            .map(|c| generic_to_owned(&c.value()))
-            .collect::<core::result::Result<Vec<_>, _>>())),
+        GenericResult::One(v) => {
+            let Some(v) = sink.materialize(DiagStyle::Jq, generic_to_owned(&v), &at.resolve())
+            else {
+                return Ok(vec![]);
+            };
+            Ok(vec![v])
+        }
+        GenericResult::OneCursor(c) => {
+            let Some(v) =
+                sink.materialize(DiagStyle::Jq, generic_to_owned(&c.value()), &at.resolve())
+            else {
+                return Ok(vec![]);
+            };
+            Ok(vec![v])
+        }
+        GenericResult::Many(vs) => {
+            let Some(vs) = sink.materialize(
+                DiagStyle::Jq,
+                vs.iter()
+                    .map(generic_to_owned)
+                    .collect::<core::result::Result<Vec<_>, _>>(),
+                &at.resolve(),
+            ) else {
+                return Ok(vec![]);
+            };
+            Ok(vs)
+        }
+        GenericResult::ManyCursor(cs) => {
+            let Some(vs) = sink.materialize(
+                DiagStyle::Jq,
+                cs.iter()
+                    .map(|c| generic_to_owned(&c.value()))
+                    .collect::<core::result::Result<Vec<_>, _>>(),
+                &at.resolve(),
+            ) else {
+                return Ok(vec![]);
+            };
+            Ok(vs)
+        }
         // Fallback: materialize. This runner boundary never sees a
         // fast-pathed `keys`/`keys_unsorted | length`/`.[]`/`.[n]`/`first`/
         // `last` — those are fully resolved inside the evaluator's `Pipe`
@@ -3496,7 +3513,13 @@ fn evaluate_input(
             sorted,
             collapse,
         } => {
-            let mut keys = materialized!(effective_keys(&fields, collapse));
+            let Some(mut keys) = sink.materialize(
+                DiagStyle::Jq,
+                effective_keys(&fields, collapse),
+                &at.resolve(),
+            ) else {
+                return Ok(vec![]);
+            };
             if sorted {
                 keys.sort();
             }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -233,6 +233,28 @@ impl ErrorSink {
         self.emit(style, &err.message, err.payload_is_not_a_string(), at);
     }
 
+    /// Unwrap `result`, or report it as an uncaught error and return `None`
+    /// -- one shared definition for a report-and-bail step previously
+    /// copy-pasted as three independent `macro_rules! materialized` blocks,
+    /// one per materialization call site (#1822). Callers pair this with
+    /// `let Some(v) = sink.materialize(...) else { return <empty>; };`,
+    /// since each call site's own "no results" shape (`vec![]`,
+    /// `Ok(vec![])`, ...) differs and can't be baked in here.
+    pub fn materialize<T>(
+        &mut self,
+        style: DiagStyle,
+        result: core::result::Result<T, EvalError>,
+        at: &InputLocation,
+    ) -> Option<T> {
+        match result {
+            Ok(v) => Some(v),
+            Err(e) => {
+                self.report(style, &e, at);
+                None
+            }
+        }
+    }
+
     /// Records a `halt`/`halt_error` request with its exit code (#791).
     ///
     /// Unlike `report`/`report_break`, this is not a diagnostic: no message

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -972,24 +972,34 @@ fn query_result_to_owned_values(
     // (search "defense-in-depth" there). Kept as `Result` rather than
     // `.unwrap()` so a real failure, if this invariant is ever violated,
     // surfaces as a normal `EvalError` instead of a panic.
-    macro_rules! materialized {
-        ($e:expr) => {
-            match $e {
-                Ok(v) => v,
-                Err(e) => {
-                    sink.report(DiagStyle::Yq, &e, &no_location());
-                    return Vec::new();
-                }
-            }
-        };
-    }
     match result {
-        QueryResult::One(v) => vec![materialized!(generic_to_owned(&v))],
-        QueryResult::OneCursor(c) => vec![materialized!(generic_to_owned(&c.value()))],
-        QueryResult::Many(vs) => materialized!(vs
-            .iter()
-            .map(generic_to_owned)
-            .collect::<core::result::Result<Vec<_>, _>>()),
+        QueryResult::One(v) => {
+            let Some(v) = sink.materialize(DiagStyle::Yq, generic_to_owned(&v), &no_location())
+            else {
+                return Vec::new();
+            };
+            vec![v]
+        }
+        QueryResult::OneCursor(c) => {
+            let Some(v) =
+                sink.materialize(DiagStyle::Yq, generic_to_owned(&c.value()), &no_location())
+            else {
+                return Vec::new();
+            };
+            vec![v]
+        }
+        QueryResult::Many(vs) => {
+            let Some(vs) = sink.materialize(
+                DiagStyle::Yq,
+                vs.iter()
+                    .map(generic_to_owned)
+                    .collect::<core::result::Result<Vec<_>, _>>(),
+                &no_location(),
+            ) else {
+                return Vec::new();
+            };
+            vs
+        }
         QueryResult::None => vec![],
         QueryResult::Error(e) => {
             sink.report(DiagStyle::Yq, &e, &no_location());
@@ -1595,23 +1605,16 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // A decode failure anywhere in this function is an uncaught error like
     // any other (#1247): report it and yield no documents, exactly as the
     // `GenericResult::Error` arm below does.
-    macro_rules! materialized {
-        ($e:expr) => {
-            match $e {
-                Ok(v) => v,
-                Err(e) => {
-                    sink.report(DiagStyle::Yq, &e, &no_location());
-                    return Ok(Vec::new());
-                }
-            }
-        };
-    }
-
     let has_aliases = cursor.index().has_aliases();
     let alias_sync_ctx = match (is_alias_sensitive_assign(expr) && has_aliases)
         .then(|| generic_to_owned(&cursor.value()))
     {
-        Some(pristine) => Some((materialized!(pristine), collect_alias_groups(cursor))),
+        Some(pristine) => {
+            let Some(pristine) = sink.materialize(DiagStyle::Yq, pristine, &no_location()) else {
+                return Ok(Vec::new());
+            };
+            Some((pristine, collect_alias_groups(cursor)))
+        }
         None => None,
     };
 
@@ -1625,7 +1628,12 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     let presentation_sync_ctx = match (need_comments && is_alias_sensitive_assign(expr))
         .then(|| to_owned_with_comments(&cursor.value(), Some(&cursor)))
     {
-        Some(snapshot) => Some(materialized!(snapshot)),
+        Some(snapshot) => {
+            let Some(snapshot) = sink.materialize(DiagStyle::Yq, snapshot, &no_location()) else {
+                return Ok(Vec::new());
+            };
+            Some(snapshot)
+        }
         None => None,
     };
 
@@ -1665,20 +1673,44 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // arms are defensive/unreachable here today, kept for exhaustiveness
     // over the shared `GenericResult` enum.
     let mut docs = match result {
-        GenericResult::One(v) => Ok(vec![no_comments(materialized!(generic_to_owned(&v)))]),
-        GenericResult::OneCursor(c) => Ok(vec![materialized!(owned_with_comments(&c))]),
-        GenericResult::Many(vs) => Ok(materialized!(vs
-            .iter()
-            .map(generic_to_owned)
-            .collect::<core::result::Result<Vec<_>, _>>())
-        .into_iter()
-        .map(&no_comments)
-        .collect()),
-        GenericResult::ManyCursor(cs) => Ok(materialized!(cs
-            .iter()
-            .map(owned_with_comments)
-            .collect::<core::result::Result<Vec<_>, _>>(
-        ))),
+        GenericResult::One(v) => {
+            let Some(v) = sink.materialize(DiagStyle::Yq, generic_to_owned(&v), &no_location())
+            else {
+                return Ok(Vec::new());
+            };
+            Ok(vec![no_comments(v)])
+        }
+        GenericResult::OneCursor(c) => {
+            let Some(v) = sink.materialize(DiagStyle::Yq, owned_with_comments(&c), &no_location())
+            else {
+                return Ok(Vec::new());
+            };
+            Ok(vec![v])
+        }
+        GenericResult::Many(vs) => {
+            let Some(vs) = sink.materialize(
+                DiagStyle::Yq,
+                vs.iter()
+                    .map(generic_to_owned)
+                    .collect::<core::result::Result<Vec<_>, _>>(),
+                &no_location(),
+            ) else {
+                return Ok(Vec::new());
+            };
+            Ok(vs.into_iter().map(&no_comments).collect())
+        }
+        GenericResult::ManyCursor(cs) => {
+            let Some(vs) = sink.materialize(
+                DiagStyle::Yq,
+                cs.iter()
+                    .map(owned_with_comments)
+                    .collect::<core::result::Result<Vec<_>, _>>(),
+                &no_location(),
+            ) else {
+                return Ok(Vec::new());
+            };
+            Ok(vs)
+        }
         // This is the DOM/slow path (`evaluate_yaml_direct_filtered`'s
         // fallback), reached only when `can_use_m2_streaming` rejects the
         // expression or a flag (`--sort-keys`, color, `--tab`, `--slurp`,
@@ -1701,7 +1733,13 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
             sorted,
             collapse,
         } => {
-            let mut keys = materialized!(effective_keys(&fields, collapse));
+            let Some(mut keys) = sink.materialize(
+                DiagStyle::Yq,
+                effective_keys(&fields, collapse),
+                &no_location(),
+            ) else {
+                return Ok(Vec::new());
+            };
             if sorted {
                 keys.sort();
             }


### PR DESCRIPTION
## Summary
- The bail-and-report macro that turns a materialization `Result` into a diagnostic plus an early return was defined three independent times (`query_result_to_owned_values` and `evaluate_yaml_cursor` in `yq_runner.rs`, `evaluate_input` in `jq_runner.rs`) — byte-identical in shape, differing only in `DiagStyle`/location expression/empty-return shape.
- Replaced with one `ErrorSink::materialize(style, result, at) -> Option<T>` method in `output.rs` (next to the existing shared `json_bytes_to_owned_value`), used at each of the 15 individual call sites via `let Some(v) = sink.materialize(...) else { return <empty>; };`.
- No behavioral change: diagnostics, exit codes, and empty-result shapes are identical before/after — the three local `macro_rules! materialized` blocks are gone, one definition remains.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, including the existing #1247/#1391 decode-failure tests unchanged
- [x] Live spot-check: yq/jq `LazyKeys` path, basic filters, `--eval-all` (the three touched functions' distinct code paths)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Fixes #1822