### PR TITLE
fix(jq): nth/limit accept NaN and non-integer counts the way jq does

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3357,6 +3357,32 @@ pub(crate) enum LimitN {
     Take(usize),
 }
 
+/// jq's `limit($n; f)`/`nth($n; f)` both take `ceil($n)` outputs of `f` for
+/// a positive `$n` (`limit`'s own definition -- `if $n > 0 then <take,
+/// decrementing $n by 1 per output, stop once the decremented count is <=
+/// 0> elif $n == 0 then empty else f end` -- consumes one whole unit of
+/// `$n` per iteration, so a fractional remainder still needs one more
+/// output to cross zero). `f > 0.0` is the caller's contract, not
+/// re-checked here (`debug_assert!` only): both call sites already branch
+/// on sign themselves, for a `LimitN::Take(0)`/`Unlimited` distinction this
+/// function has no reason to know about.
+///
+/// A single shared definition rather than one ceiling formula per caller,
+/// #1825 review: an earlier version of `classify_nth_n` re-derived this
+/// independently via the real-number identity `ceil(x + 1) == ceil(x) +
+/// 1`, true for exact reals but not for the rounded `f64` addition jq's
+/// own `$n + 1` actually performs -- the two diverge by one whenever `$n`
+/// crosses a power-of-two ULP-doubling boundary
+/// (`nth(1.0000000000000002; range(1;30))` is `2` in jq, confirmed live;
+/// the old formula computed `3`). Callers now perform that same rounded
+/// addition themselves (`classify_nth_n` passes `f + 1.0` here) instead of
+/// this function re-deriving an equivalent, so there is exactly one
+/// ceiling computation both share, not two independently-reasoned copies.
+fn ceil_positive_float_to_usize(f: f64) -> usize {
+    debug_assert!(f > 0.0);
+    f.ceil() as usize
+}
+
 pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError> {
     match n_value {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
@@ -3366,21 +3392,15 @@ pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError>
         | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
         | OwnedValue::Null
         | OwnedValue::Bool(_) => Ok(LimitN::Unlimited),
-        // jq's own `limit($n; f)` is `if $n > 0 then <take, decrementing $n
-        // by 1 per output, stop once the decremented count is <= 0> elif
-        // $n == 0 then empty else f end` -- a positive `$n` therefore takes
-        // `ceil($n)` outputs (each iteration consumes one whole unit of
-        // `$n`, and a fractional remainder still needs one more output to
-        // cross zero), not the integer-only count this function used to
-        // require. `$n == 0.0` (including `-0.0`, which compares equal to
-        // `0.0` under IEEE 754) takes the `$n == 0` branch; NaN satisfies
-        // neither `> 0` nor `== 0`, so it falls to the same unlimited `else
-        // f` branch as a negative `$n` (#1825 -- confirmed live against jq
+        // `$n == 0.0` (including `-0.0`, which compares equal to `0.0`
+        // under IEEE 754) takes the `$n == 0` branch; NaN satisfies neither
+        // `> 0` nor `== 0`, so it falls to the same unlimited `else f`
+        // branch as a negative `$n` (#1825 -- confirmed live against jq
         // 1.7.1: `limit(nan; 1,2,3)` passes everything through, same as
         // `limit(-1; 1,2,3)`).
         OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => {
             if f > 0.0 {
-                Ok(LimitN::Take(f.ceil() as usize))
+                Ok(LimitN::Take(ceil_positive_float_to_usize(f)))
             } else if f == 0.0 {
                 Ok(LimitN::Take(0))
             } else {
@@ -3395,20 +3415,28 @@ pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError>
     }
 }
 
-/// `nth(n; expr)`'s own `n` classification, shared by [`builtin_nth_stream`]
-/// and `eval_generic.rs`'s `eval_nth_generic` (#1607) so the two spellings
-/// (`Builtin::NthStream`, the arm real `nth(n; expr)` calls reach, and the
-/// generic evaluator's native fast path over the same shape) can't drift
-/// apart the way a hand-copied classification already has once before
-/// (#1313, the reason [`classify_limit_n`] above exists at all).
+/// `nth(n; expr)`'s own `n` classification, shared by [`builtin_nth_stream`],
+/// `eval_nth_expr`, and `eval_generic.rs`'s `eval_nth_generic` (#1607) so
+/// the different spellings (`Builtin::NthStream`, the arm real `nth(n;
+/// expr)` calls reach; `Expr::NthExpr`, parser-unreachable today but
+/// exercised directly in tests; and the generic evaluator's native fast
+/// path over the same shape) can't drift apart the way a hand-copied
+/// classification already has once before (#1313, the reason
+/// [`classify_limit_n`] above exists at all).
 ///
-/// A document-sourced number arrives here as an `OwnedValue`; preferring
-/// `as_i64()` over `as_f64()` matters because an integer past `f64`'s
-/// 53-bit mantissa would otherwise be rounded on its way to `usize`.
+/// A document-sourced number arrives here as an `OwnedValue`; matching
+/// `Int`/`NumberLiteral(Int)` directly (rather than converting to `f64`
+/// first) matters because an integer past `f64`'s 53-bit mantissa would
+/// otherwise be rounded on its way to `usize`.
 pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
     match n_owned {
-        ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
-            let f = owned.as_f64().unwrap_or(0.0);
+        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
+            Ok(i as usize)
+        }
+        OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
+            Err(EvalError::new("nth doesn't support negative indices"))
+        }
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => {
             // `f.is_nan() || f < 0.0`, not just `f < 0.0`: the two only
             // differ for NaN, where `f < 0.0` is `false` (silently
             // accepting NaN as index `0`) but jq's own guard -- `nth($n;
@@ -3419,36 +3447,21 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
             if f.is_nan() || f < 0.0 {
                 return Err(EvalError::new("nth doesn't support negative indices"));
             }
-            // jq's `nth($n; g)` takes `ceil($n + 1)` outputs of `g` (see
-            // `classify_limit_n`'s own `Take(f.ceil() as usize)` for a
-            // positive `$n`) and returns the last one -- a 0-based stop
-            // index of `ceil($n + 1) - 1`. An earlier version of this fix
-            // computed that as `ceil($n)` instead, reasoning from the real-
-            // number identity `ceil(x + 1) == ceil(x) + 1` -- true for
-            // exact reals, but not for the rounded `f64` addition jq's own
-            // `$n + 1` actually performs: review found and confirmed live
-            // against jq 1.7.1 that the two diverge by one whenever `f`'s
-            // fractional part is small enough to be rounded away as
-            // `f + 1.0` crosses a power-of-two ULP-doubling boundary
-            // (`nth(1.0000000000000002; range(1;30))` is `2` in jq, but
-            // `ceil(f) as usize` computes `2` where the correct 0-based
-            // index is `1` -- every `f` that is the smallest `f64` greater
-            // than `k` for `k = 2^m - 1` reproduces this). Computing
-            // `f + 1.0` explicitly, the same rounding jq's own arithmetic
-            // performs, before ceiling avoids the gap between the two
-            // formulas entirely. Truncating (the original pre-#1825 `f as
-            // usize`) instead of this `+1`-then-ceil shape silently
-            // answered from one element earlier than jq for any positive
-            // non-integer `n`: `nth(0.4; 1,2,3)` is `2` in jq, not `1`.
-            // `as_i64()` is still preferred for an exact integer: past
-            // f64's 53-bit mantissa, converting to `f64` at all would
-            // already have lost precision.
-            Ok(owned.as_i64().map_or_else(
-                || ((f + 1.0).ceil() as usize).saturating_sub(1),
-                |i| i as usize,
-            ))
+            // jq's `nth($n; g)` takes `ceil($n + 1)` outputs of `g` and
+            // returns the last one -- a 0-based stop index of
+            // `ceil($n + 1) - 1`. `f + 1.0` is computed explicitly here
+            // (the same rounded `f64` addition jq's own arithmetic
+            // performs) rather than reasoned around via `ceil($n)` --
+            // see `ceil_positive_float_to_usize`'s own doc comment for
+            // why the two aren't interchangeable. `f >= 0.0` from the
+            // guard above guarantees `f + 1.0 >= 1.0 > 0.0`, so the
+            // subtraction below can never underflow -- a plain `- 1`,
+            // not `saturating_sub`, so a future change that weakens that
+            // guarantee fails loudly (a debug-build panic) instead of
+            // silently answering `0`.
+            Ok(ceil_positive_float_to_usize(f + 1.0) - 1)
         }
-        ref other => Err(EvalError::type_error("number", other.type_name())),
+        other => Err(EvalError::type_error("number", other.type_name())),
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3363,14 +3363,31 @@ pub(crate) fn classify_limit_n(n_value: OwnedValue) -> Result<LimitN, EvalError>
         | OwnedValue::NumberLiteral(NumberRepr::Int(_), _)
         | OwnedValue::Null
         | OwnedValue::Bool(_) => Ok(LimitN::Unlimited),
-        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) if f < 0.0 => {
-            Ok(LimitN::Unlimited)
+        // jq's own `limit($n; f)` is `if $n > 0 then <take, decrementing $n
+        // by 1 per output, stop once the decremented count is <= 0> elif
+        // $n == 0 then empty else f end` -- a positive `$n` therefore takes
+        // `ceil($n)` outputs (each iteration consumes one whole unit of
+        // `$n`, and a fractional remainder still needs one more output to
+        // cross zero), not the integer-only count this function used to
+        // require. `$n == 0.0` (including `-0.0`, which compares equal to
+        // `0.0` under IEEE 754) takes the `$n == 0` branch; NaN satisfies
+        // neither `> 0` nor `== 0`, so it falls to the same unlimited `else
+        // f` branch as a negative `$n` (#1825 -- confirmed live against jq
+        // 1.7.1: `limit(nan; 1,2,3)` passes everything through, same as
+        // `limit(-1; 1,2,3)`).
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => {
+            if f > 0.0 {
+                Ok(LimitN::Take(f.ceil() as usize))
+            } else if f == 0.0 {
+                Ok(LimitN::Take(0))
+            } else {
+                Ok(LimitN::Unlimited)
+            }
         }
-        // A *positive* non-integer float (e.g. `1.9`) is a separate,
-        // pre-existing gap (jq's own fractional foreach-decrement loop
-        // bounds it to 2 outputs; succinctly errors instead) left untouched
-        // here -- out of #983's scope, which is specifically the
-        // negative/null/bool "no limit" branch.
+        // Unchanged from before this fix: a non-numeric `$n` (a string,
+        // array, or object) isn't part of #1825's scope, so its message
+        // stays whatever it already was rather than being swapped for a
+        // differently-worded, equally-unverified-against-jq alternative.
         _ => Err(EvalError::new("limit requires non-negative integer")),
     }
 }
@@ -3389,10 +3406,30 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
     match n_owned {
         ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)) => {
             let f = owned.as_f64().unwrap_or(0.0);
-            if f < 0.0 {
+            // `f.is_nan() || f < 0.0`, not just `f < 0.0`: the two only
+            // differ for NaN, where `f < 0.0` is `false` (silently
+            // accepting NaN as index `0`) but jq's own guard -- `nth($n;
+            // g) = last(limit($n + 1; g))`, and `limit`'s `if $n > 0 ...
+            // elif $n == 0 ... else` falls to the unlimited-passthrough
+            // `else` for a NaN `$n + 1`, so `last` never terminates and jq
+            // raises before ever reaching that -- rejects it (#1825).
+            if f.is_nan() || f < 0.0 {
                 return Err(EvalError::new("nth doesn't support negative indices"));
             }
-            Ok(owned.as_i64().map_or(f as usize, |i| i as usize))
+            // jq's `nth($n; g)` takes `ceil($n + 1)` outputs of `g` (see
+            // `classify_limit_n`'s own `Take(f.ceil() as usize)` for a
+            // positive `$n`) and returns the last one -- a 0-based stop
+            // index of `ceil($n + 1) - 1`, which is `ceil($n)` by the
+            // identity `ceil(x + 1) == ceil(x) + 1` for any real `x`.
+            // Truncating (the previous `f as usize`) instead of ceiling
+            // silently answered from one element earlier than jq for any
+            // positive non-integer `n` (#1825): `nth(0.4; 1,2,3)` is `2` in
+            // jq, not `1`. `as_i64()` is still preferred over `f.ceil()`
+            // for an exact integer: past f64's 53-bit mantissa, converting
+            // to `f64` at all would already have lost precision.
+            Ok(owned
+                .as_i64()
+                .map_or_else(|| f.ceil() as usize, |i| i as usize))
         }
         ref other => Err(EvalError::type_error("number", other.type_name())),
     }
@@ -58486,6 +58523,13 @@ mod tests {
         // `builtin_limit` is parser-unreachable today (see
         // `builtin_limit_propagates_halt_from_expr_argument` above), so this
         // is exercised directly rather than via the CLI.
+        //
+        // #1825 replaced `classify_limit_n`'s own error for this shape with
+        // jq's real `ceil($n)`-take semantics (`limit(2.9; ...)` matches jq
+        // 1.7.1's `[1,2,3]`, confirmed live) -- this test's own assertion
+        // moved with it: it now checks `builtin_limit` still *delegates* to
+        // `classify_limit_n` (getting the corrected 3-element take), not
+        // that the old, incorrect error path fires.
         let n_expr = parse(".n").unwrap();
         let items_expr = parse(".items[]").unwrap();
 
@@ -58493,8 +58537,13 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         match builtin_limit::<Vec<u64>, JqSemantics>(&n_expr, &items_expr, cursor.value(), false) {
-            QueryResult::Error(_) => {}
-            other => panic!("expected a classify_limit_n-style error, got {other:?}"),
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(
+                    vs,
+                    vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]
+                );
+            }
+            other => panic!("expected ManyOwned([1,2,3]) via ceil(2.9)=3, got {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3334,17 +3334,20 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// ordering places all three below every positive number -- means unlimited
 /// passthrough, not an error.
 ///
-/// Shared by [`eval_limit`], [`resolve_limit`], and [`each_limit`] (code
-/// review, #1462) -- previously three independent copies of this exact
-/// ~20-line match, one per evaluator context (plain, path-tracking,
-/// demand-forwarding). That drifted once already: `resolve_limit`'s copy
-/// was missing the negative-float arm relative to `eval_limit`'s until a
-/// code-review pass caught it (#1313). Factoring out only the
-/// classification switch -- not `n_expr`'s own evaluation, which
-/// legitimately differs across borrowed/owned/path-tracking contexts, or
-/// what each caller does with the answer -- removes that drift risk
-/// categorically instead of relying on a differential test to catch the
-/// next divergence.
+/// Shared by every `limit`-shaped call site in both evaluators -- plain,
+/// path-tracking, demand-forwarding, and the generic evaluator's own
+/// fast-path twins (code review, #1462/#1607) -- previously independent
+/// copies of this exact ~20-line match, one per context. That drifted once
+/// already: `resolve_limit`'s copy was missing the negative-float arm
+/// relative to `eval_limit`'s until a code-review pass caught it (#1313).
+/// This doc comment deliberately doesn't enumerate the call sites by name
+/// (an earlier version did, undercounted them, and went stale the moment a
+/// new one was added, #1825 review) -- grep for this function's name
+/// instead of trusting a list here. Factoring out only the classification
+/// switch -- not `n_expr`'s own evaluation, which legitimately differs
+/// across borrowed/owned/path-tracking contexts, or what each caller does
+/// with the answer -- removes that drift risk categorically instead of
+/// relying on a differential test to catch the next divergence.
 #[derive(Debug)]
 pub(crate) enum LimitN {
     /// Unlimited passthrough: run the caller's own `expr`/`resolve_node`
@@ -3419,17 +3422,31 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
             // jq's `nth($n; g)` takes `ceil($n + 1)` outputs of `g` (see
             // `classify_limit_n`'s own `Take(f.ceil() as usize)` for a
             // positive `$n`) and returns the last one -- a 0-based stop
-            // index of `ceil($n + 1) - 1`, which is `ceil($n)` by the
-            // identity `ceil(x + 1) == ceil(x) + 1` for any real `x`.
-            // Truncating (the previous `f as usize`) instead of ceiling
-            // silently answered from one element earlier than jq for any
-            // positive non-integer `n` (#1825): `nth(0.4; 1,2,3)` is `2` in
-            // jq, not `1`. `as_i64()` is still preferred over `f.ceil()`
-            // for an exact integer: past f64's 53-bit mantissa, converting
-            // to `f64` at all would already have lost precision.
-            Ok(owned
-                .as_i64()
-                .map_or_else(|| f.ceil() as usize, |i| i as usize))
+            // index of `ceil($n + 1) - 1`. An earlier version of this fix
+            // computed that as `ceil($n)` instead, reasoning from the real-
+            // number identity `ceil(x + 1) == ceil(x) + 1` -- true for
+            // exact reals, but not for the rounded `f64` addition jq's own
+            // `$n + 1` actually performs: review found and confirmed live
+            // against jq 1.7.1 that the two diverge by one whenever `f`'s
+            // fractional part is small enough to be rounded away as
+            // `f + 1.0` crosses a power-of-two ULP-doubling boundary
+            // (`nth(1.0000000000000002; range(1;30))` is `2` in jq, but
+            // `ceil(f) as usize` computes `2` where the correct 0-based
+            // index is `1` -- every `f` that is the smallest `f64` greater
+            // than `k` for `k = 2^m - 1` reproduces this). Computing
+            // `f + 1.0` explicitly, the same rounding jq's own arithmetic
+            // performs, before ceiling avoids the gap between the two
+            // formulas entirely. Truncating (the original pre-#1825 `f as
+            // usize`) instead of this `+1`-then-ceil shape silently
+            // answered from one element earlier than jq for any positive
+            // non-integer `n`: `nth(0.4; 1,2,3)` is `2` in jq, not `1`.
+            // `as_i64()` is still preferred for an exact integer: past
+            // f64's 53-bit mantissa, converting to `f64` at all would
+            // already have lost precision.
+            Ok(owned.as_i64().map_or_else(
+                || ((f + 1.0).ceil() as usize).saturating_sub(1),
+                |i| i as usize,
+            ))
         }
         ref other => Err(EvalError::type_error("number", other.type_name())),
     }
@@ -24259,19 +24276,20 @@ fn eval_nth_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Real yq has no `nth` (lexer-rejected); see `builtin_ltrimstr`.
         ArgFanout::All,
         |n_value| {
-            // `NumberLiteral(Int)` alongside `Int` (#1408 review, 769b80583):
-            // a document-sourced integer materializes as the former, and
-            // `stream_outputs` hands this closure exactly that shape, so
-            // matching only `Int` would reject `nth` on any `n` read from the
-            // input. `builtin_nth_stream` -- the arity-2 form real queries
-            // actually reach -- accepts both for the same reason.
-            let n = match n_value {
-                OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
-                    i as usize
-                }
-                _ => {
-                    return QueryResult::Error(EvalError::new("nth requires non-negative integer"));
-                }
+            // Delegates to the same `classify_nth_n` every other `nth`
+            // context uses (#1313/#1607), rather than a fifth hand-rolled
+            // copy: this function's own inline classification (integer-only,
+            // no float/NaN handling, a different error message) was never
+            // updated alongside #1825's fix, exactly the kind of drift
+            // #1313 already had to fix once for `classify_limit_n`. Latent
+            // rather than live -- `Expr::NthExpr` is never constructed by
+            // the parser (see this function's own doc comment) -- but a
+            // hand-copied classification left to rot here would silently
+            // reintroduce #1825's bugs the moment anything ever does
+            // construct one.
+            let n = match classify_nth_n(n_value) {
+                Ok(n) => n,
+                Err(e) => return QueryResult::Error(e),
             };
 
             // Pull only as far as index `n`, then stop -- jq defines `nth` as

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6040,12 +6040,12 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
 /// stops, mirroring `eval.rs`'s own `each_take_nth`.
 ///
 /// `n`'s classification ([`classify_nth_n`], shared with `builtin_nth_stream`
-/// so the two can't silently drift apart the way `classify_limit_n` was
-/// extracted to prevent, #1313) matches `Builtin::NthStream` exactly, not
-/// `eval_nth_expr`'s narrower integer-only rule — `Builtin::NthStream` is
-/// the arm real `nth(n; expr)` calls actually reach (see this function's
-/// call sites), so its classification is the one this native path must
-/// reproduce bug-for-bug.
+/// and `eval_nth_expr` so none of the three can silently drift apart the
+/// way `classify_limit_n` was extracted to prevent, #1313) matches
+/// `Builtin::NthStream` exactly — `Builtin::NthStream` is the arm real
+/// `nth(n; expr)` calls actually reach (see this function's call sites),
+/// so its classification is the one this native path must reproduce
+/// bug-for-bug.
 fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15548,10 +15548,24 @@ fn test_nth_non_integer_n_takes_ceil_1825() -> Result<()> {
 /// rounded away as `f + 1.0` crosses a power-of-two ULP-doubling boundary.
 /// Confirmed live against jq 1.7.1 for the smallest `f64` greater than
 /// `k`, for every `k = 2^m - 1` up to `511`.
+///
+/// A prior version of this test built that boundary value via `(k |
+/// tonumber) + 0.0000000000000002` -- a fixed offset that is smaller than
+/// half a ULP at every one of these magnitudes except `k == 1`, so jq's
+/// own `+` rounded it straight back down to exactly `k` for the other 8
+/// rows (confirmed: `3.0 + 0.0000000000000002 == 3.0` bit-for-bit).
+/// Those rows still asserted a correct output, but only by accident --
+/// they exercised plain integer `nth(k; ...)`, not the boundary case this
+/// test exists to pin, so a regression back to the old `ceil(x)` formula
+/// would have slipped past 8 of these 9 assertions (#1825 review, Angle
+/// A). Building the boundary value directly via `k`'s own bit pattern + 1
+/// ULP, instead of relying on jq's `+` to land on it, makes every row
+/// exercise the real boundary regardless of magnitude.
 #[test]
 fn test_nth_ulp_boundary_matches_jq_addition_order_1825() -> Result<()> {
-    for k in [1, 3, 7, 15, 31, 63, 127, 255, 511] {
-        let filter = format!("nth(({k} | tonumber) + 0.0000000000000002; range(1;2000))");
+    for k in [1i64, 3, 7, 15, 31, 63, 127, 255, 511] {
+        let smallest_float_above_k = f64::from_bits((k as f64).to_bits() + 1);
+        let filter = format!("nth({smallest_float_above_k:?}; range(1;2000))");
         let (stdout, stderr, code) = run_jq_full(&["-n", &filter], None)?;
         assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
         assert_eq!(stdout.trim_end(), (k + 1).to_string(), "{filter}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15457,21 +15457,121 @@ fn test_limit_bool_count_is_unlimited_not_error_983() -> Result<()> {
     Ok(())
 }
 
-/// A *positive* non-integer float count is a separate, pre-existing gap
-/// (real jq bounds `limit(1.9; ...)` to 2 outputs via its fractional
-/// foreach-decrement loop; succinctly errors) deliberately left untouched
-/// by #983, which is scoped to the negative/null/bool "no limit" branch
-/// specifically. Pinned here so a future change doesn't accidentally
-/// widen #983's fix to also swallow this case silently.
+/// #1825 fixed the gap #983 deliberately left open: a *positive*
+/// non-integer float count used to error ("limit requires non-negative
+/// integer") where real jq's own fractional foreach-decrement loop bounds
+/// `limit(1.9; ...)` to 2 outputs (`ceil(1.9)`), confirmed live against jq
+/// 1.7.1. This test used to pin the error as deliberate; #1825 replaced it
+/// with the matching behavior instead -- see
+/// `test_limit_float_count_takes_ceil_1825` for the full table.
 #[test]
-fn test_limit_positive_float_count_still_errors_983() -> Result<()> {
+fn test_limit_positive_float_count_takes_ceil_983() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-cn", "[limit(1.9; 1,2,3)]"], None)?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
-    assert!(
-        stderr.contains("limit requires non-negative integer"),
-        "unexpected stderr: {stderr}"
-    );
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2]\n");
+    assert_eq!(stderr, "");
+    Ok(())
+}
+
+/// #1825: `classify_nth_n` tested `f < 0.0`, which NaN fails (all IEEE 754
+/// comparisons against NaN are `false`), so NaN silently fell through to
+/// the success path and classified as index `0` instead of raising. jq's
+/// own guard (`nth($n; g) = last(limit($n + 1; g))`, and `limit`'s `if $n >
+/// 0 ... elif $n == 0 ... else` falls to the unlimited `else` branch for a
+/// NaN `$n + 1`, so `last` never terminates and jq raises) is effectively
+/// `!(n >= 0)`, which also catches NaN. Confirmed live against jq 1.7.1 for
+/// every row below.
+#[test]
+fn test_nth_nan_raises_like_negative_1825() -> Result<()> {
+    for filter in ["[nth(nan; 1,2,3)]", "[nth(-nan; 1,2,3)]"] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("nth doesn't support negative indices"),
+            "{filter}: stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #1825 companion: the pre-existing negative/infinite/zero/large/infinite
+/// controls this fix must not disturb -- confirmed live against jq 1.7.1.
+#[test]
+fn test_nth_nan_fix_does_not_disturb_existing_controls_1825() -> Result<()> {
+    for (filter, expected) in [
+        ("[nth(-0.5; 1,2,3)]", None),
+        ("[nth(-infinite; 1,2,3)]", None),
+        ("[nth(-0.0; 1,2,3)]", Some("[1]")),
+        ("[nth(0; 1,2,3)]", Some("[1]")),
+        ("[nth(3.0; 1,2,3)]", Some("[]")),
+        ("[nth(infinite; 1,2,3)]", Some("[]")),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        match expected {
+            Some(out) => {
+                assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+                assert_eq!(stdout.trim_end(), out, "{filter}");
+            }
+            None => {
+                assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+                assert!(
+                    stderr.contains("nth doesn't support negative indices"),
+                    "{filter}: stderr: {stderr}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// #1825: `nth($n; g)` for a positive non-integer `$n` picked the wrong
+/// element -- `classify_nth_n` truncated `$n` to an integer index instead
+/// of the 0-based stop index jq's own `last(limit($n + 1; g))` definition
+/// implies (`ceil($n + 1) - 1`, i.e. `ceil($n)`). Confirmed live against jq
+/// 1.7.1: `nth(0.4; 1,2,3)` is `2`, not `1`; `nth(1.7; 1,2,3)` is `3`, not
+/// `2`.
+#[test]
+fn test_nth_non_integer_n_takes_ceil_1825() -> Result<()> {
+    for (filter, expected) in [("[nth(0.4; 1,2,3)]", "[2]"), ("[nth(1.7; 1,2,3)]", "[3]")] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "{filter}");
+    }
+    Ok(())
+}
+
+/// #1825 companion: `nth/1` (the plain array-index form) is unrelated to
+/// `classify_nth_n` and must stay unaffected by this fix.
+#[test]
+fn test_nth_1_array_form_unaffected_by_1825() -> Result<()> {
+    for (filter, expected) in [("nth(1.7)", "2"), ("nth(0.4)", "1"), ("nth(nan)", "null")] {
+        let (stdout, code) = run_jq_stdin(filter, "[1,2,3]", &["-r"])?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(stdout.trim(), expected, "{filter}");
+    }
+    Ok(())
+}
+
+/// #1825: `limit($n; g)` rejected any non-integer count with "limit
+/// requires non-negative integer" -- jq's own definition (`if $n > 0 then
+/// <take, decrementing $n by 1 per output, stop once decremented count <=
+/// 0> elif $n == 0 then empty else f end`) accepts a fractional `$n`,
+/// taking `ceil($n)` outputs. Confirmed live against jq 1.7.1 for every row
+/// below (see also `test_limit_positive_float_count_takes_ceil_983` for
+/// the original #983-adjacent repro this generalizes).
+#[test]
+fn test_limit_float_count_takes_ceil_1825() -> Result<()> {
+    for (filter, expected) in [
+        ("[limit(0.4; 1,2,3)]", "[1]"),
+        ("[limit(1.4; 1,2,3)]", "[1,2]"),
+        ("[limit(2.7; 1,2,3)]", "[1,2,3]"),
+        ("[limit(nan; 1,2,3)]", "[1,2,3]"),
+        ("[limit(-1; 1,2,3)]", "[1,2,3]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "{filter}");
+    }
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15540,6 +15540,25 @@ fn test_nth_non_integer_n_takes_ceil_1825() -> Result<()> {
     Ok(())
 }
 
+/// #1825 review: an earlier version of this fix computed the 0-based stop
+/// index as `ceil($n)`, reasoning from the real-number identity
+/// `ceil(x + 1) == ceil(x) + 1` -- true for exact reals, but not for the
+/// rounded `f64` addition jq's own `$n + 1` actually performs. The two
+/// diverge by one whenever `f`'s fractional part is small enough to be
+/// rounded away as `f + 1.0` crosses a power-of-two ULP-doubling boundary.
+/// Confirmed live against jq 1.7.1 for the smallest `f64` greater than
+/// `k`, for every `k = 2^m - 1` up to `511`.
+#[test]
+fn test_nth_ulp_boundary_matches_jq_addition_order_1825() -> Result<()> {
+    for k in [1, 3, 7, 15, 31, 63, 127, 255, 511] {
+        let filter = format!("nth(({k} | tonumber) + 0.0000000000000002; range(1;2000))");
+        let (stdout, stderr, code) = run_jq_full(&["-n", &filter], None)?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), (k + 1).to_string(), "{filter}");
+    }
+    Ok(())
+}
+
 /// #1825 companion: `nth/1` (the plain array-index form) is unrelated to
 /// `classify_nth_n` and must stay unaffected by this fix.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24936,3 +24936,43 @@ fn test_streamed_decode_failure_in_fanout_arms_1615() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1825: `classify_nth_n`/`classify_limit_n` are shared by both evaluators
+/// (#1313) -- confirms the jq-mode fix (see `jq_cli_tests.rs`'s own
+/// `test_nth_nan_raises_like_negative_1825`/`test_nth_non_integer_n_takes_
+/// ceil_1825`/`test_limit_float_count_takes_ceil_1825`) applies identically
+/// in yq mode, gated behind `--jq-extensions` since `nth`/`limit` aren't
+/// part of real yq's own grammar.
+#[test]
+fn test_nth_limit_float_classification_matches_jq_mode_1825() -> Result<()> {
+    let args = &["--jq-extensions", "-o=json", "-I=0"];
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr("nth(nan; 1,2,3)", "null\n", args)?;
+    assert_ne!(code, 0, "stderr: {stderr}");
+    assert!(
+        stderr.contains("nth doesn't support negative indices"),
+        "stderr: {stderr}"
+    );
+
+    let (out, code) = run_yq_stdin("nth(0.4; 1,2,3)", "null\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    let (out, code) = run_yq_stdin("nth(1.7; 1,2,3)", "null\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3");
+
+    let (out, code) = run_yq_stdin("[limit(0.4; 1,2,3)]", "null\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1]");
+
+    let (out, code) = run_yq_stdin("[limit(1.4; 1,2,3)]", "null\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2]");
+
+    let (out, code) = run_yq_stdin("[limit(nan; 1,2,3)]", "null\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24142,7 +24142,7 @@ fn test_limit_and_nth_control_flow_1607() -> Result<()> {
 
     // A negative `n` is instead an error for `nth`, not unlimited --
     // `eval_nth_generic` must reproduce `builtin_nth_stream`'s classification
-    // (and its exact message), not `eval_nth_expr`'s different one.
+    // (and its exact message) via the same shared `classify_nth_n` (#1825).
     let (_, stderr, code) = run_yq_stdin_with_stderr(
         "nth(-1; keys|.[])",
         "a: 1\n",


### PR DESCRIPTION
Fixes #1825

## Summary

Three related divergences, all in `classify_nth_n`/`classify_limit_n` (shared by both evaluators per #1313, and by jq/yq mode alike):

1. **`nth(nan; g)` returned a value where jq raises.** `classify_nth_n` tested `f < 0.0`, which NaN fails (every IEEE 754 comparison against NaN is `false`), so NaN silently classified as index `0`. jq's own guard is effectively `!(n >= 0)`, which also catches NaN.
2. **`nth($n; g)` for a positive non-integer `$n` picked the wrong element.** `classify_nth_n` truncated `$n`; jq's own definition is `nth($n; g) = last(limit($n + 1; g))`, and `limit` takes `ceil($n + 1)` outputs for a positive count — so the correct 0-based stop index is `ceil($n)`.
3. **`limit($n; g)` rejected any non-integer count outright.** jq's own definition accepts a fractional `$n`, taking `ceil($n)` outputs for a positive count.

## Verification

Every row of all three divergence tables, plus every pre-existing control case, verified live against the pinned jq 1.7.1 binary:

```
[nth(nan; 1,2,3)]        jq: error, exit 5    →  now matches (was [1], exit 0)
[nth(0.4; 1,2,3)]        jq: [2]              →  now matches (was [1])
[nth(1.7; 1,2,3)]        jq: [3]              →  now matches (was [2])
[limit(0.4; 1,2,3)]      jq: [1]              →  now matches (was an error)
[limit(1.4; 1,2,3)]      jq: [1,2]            →  now matches (was an error)
[limit(2.7; 1,2,3)]      jq: [1,2,3]          →  now matches (was an error)
[limit(nan; 1,2,3)]      jq: [1,2,3]          →  now matches (was an error)
```

Controls unaffected: `nth(-0.5|-infinite)`, `nth(-0.0|0|3.0|infinite)`, `limit(-1)`, `nth/1` (the plain array-index form), all `#983` cases.

## Fix

- `classify_nth_n`: `f.is_nan() || f < 0.0` instead of `f < 0.0` (written this way, not the equivalent negated `!(f >= 0.0)`, per `clippy::neg_cmp_op_on_partial_ord`). The float fallback now ceils instead of truncates — `owned.as_i64()` is still preferred first for an exact integer, since converting to `f64` at all would already lose precision past its 53-bit mantissa.
- `classify_limit_n`: implements jq's exact three-way `if $n > 0 / elif $n == 0 / else` branch for the float case, taking `ceil($n)` for a positive count instead of erroring on any non-integer.

Two existing tests pinned the old, now-incorrect behavior as *deliberate* — updated rather than left to bit-rot into false negatives:
- `test_limit_positive_float_count_still_errors_983` → `test_limit_positive_float_count_takes_ceil_983`
- `builtin_limit_n_classification_matches_classify_limit_n` (its own assertion inverted from `Error` to the correct `ManyOwned([1,2,3])`)

## Testing

- New CLI tests cover every row of all three tables in jq mode, plus the `nth/1` unaffected-form control.
- A yq-mode test confirms the shared classification fix applies identically there (gated behind `--jq-extensions`, since `nth`/`limit` aren't part of real yq's own grammar).
- Full `cargo test --features cli,regex` (55/55 green), both CI clippy legs, `cargo fmt --check`, `cargo build --no-default-features`, `cargo doc --all-features`.