### PR TITLE
refactor(yaml): collapse write_json_escape onto stream_json_escape

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2915,25 +2915,16 @@ fn write_json_string(output: &mut String, s: &str) {
 /// controls. An earlier version of this function additionally re-escaped
 /// non-ASCII characters as `\u00XX`/`\uXXXX`, which diverged from
 /// `stream_json_escape`/yq for any string reached through this non-streaming
-/// transcode path (#532).
+/// transcode path (#532) -- a divergence that already had to be corrected
+/// twice before this collapsed onto one definition (#1823), the same
+/// pattern #1638 fixed for `write_resolved_scalar_as_json`/
+/// `stream_resolved_scalar_as_json`.
 #[inline]
 fn write_json_escape(output: &mut String, ch: char) {
-    match ch {
-        '"' => output.push_str("\\\""),
-        '\\' => output.push_str("\\\\"),
-        '\n' => output.push_str("\\n"),
-        '\r' => output.push_str("\\r"),
-        '\t' => output.push_str("\\t"),
-        c if (c as u32) < 0x20 => {
-            // Control character - use \uXXXX
-            output.push_str("\\u00");
-            const HEX: &[u8; 16] = b"0123456789abcdef";
-            let b = c as u8;
-            output.push(HEX[(b >> 4) as usize] as char);
-            output.push(HEX[(b & 0xf) as usize] as char);
-        }
-        c => output.push(c),
-    }
+    // `String`'s `fmt::Write` impl forwards to `push_str`/`push` and always
+    // returns `Ok`, so there is no error to propagate -- the same reasoning
+    // `write_json_string` states for its own generic/buffered split above.
+    let _ = stream_json_escape(output, ch);
 }
 
 /// Scan a run of literal spaces/tabs starting at `i`.


### PR DESCRIPTION
## Summary
- `write_json_escape` (buffered) and `stream_json_escape` (generic streaming) in `src/yaml/light.rs` held two hand-maintained copies of the same JSON character-escape table, arm for arm identical — including the same `#532` doc comment recording a non-ASCII re-escaping bug that already had to be fixed twice.
- Both are already `#[inline]`, so unlike #1638's sibling collapse (item 1 of #965, `write_resolved_scalar_as_json`/`stream_resolved_scalar_as_json`), there's no inlining tradeoff to A/B — no benchmark needed per the issue's own reasoning.
- `write_json_escape` now delegates via `let _ = stream_json_escape(output, ch);`, the exact pattern `write_json_string`/`jq::escape::escape_json_body` already establish for this same generic/buffered split.
- All 8 call sites of `write_json_escape` are unchanged (same signature).

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, including the yq golden fixture tests (byte-identical output on the buffered transcode path)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Fixes #1823