### PR TITLE
fix(jq): route builtin_to_entries through effective_fields_checked

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -838,27 +838,27 @@ coverage differs:
 - **The #1677 malformed-`,`/`:`-delimiter check is the narrower gap.**
   `to_owned_checked_at_depth` itself never calls `key_delimiter_ok`/`value_delimiter_ok`, so
   every builtin routed through it still misses this one check. `Builtin::Keys` (`keys`/
-  `keys_unsorted`) is the sole exception, fixed by #1829/#1835 to delegate to `effective_keys`
-  (`document.rs`) — the same `DistinctKeyCursors` walk `eval_generic.rs`'s own `keys_unsorted`
-  writer is built on, not a narrower hand-rolled copy — which gives it #1677 protection
-  alongside #1194/#1642's.
+  `keys_unsorted`, #1829/#1835) and `to_entries` (#1829) are the exceptions so far: `keys`/
+  `keys_unsorted` delegate to `effective_keys` (`document.rs`) — the same `DistinctKeyCursors`
+  walk `eval_generic.rs`'s own `keys_unsorted` writer is built on — and `to_entries` to
+  `effective_fields_checked` (the value-carrying sibling of the same shared walk family), which
+  gives both #1677 protection alongside #1194/#1642's.
 
 A library caller who follows the documented `eval()` example and evaluates straight off a
-fresh cursor gets #1677 protection only from `keys`/`keys_unsorted`; every other builtin in
-this file, checked or not on the decode-failure/#1194 axis, still misses it. The CLI itself
-never reaches this path except through the reindex bridge, which only ever feeds it an
+fresh cursor gets #1677 protection only from `keys`/`keys_unsorted`/`to_entries`; every other
+builtin in this file, checked or not on the decode-failure/#1194 axis, still misses it. The CLI
+itself never reaches this path except through the reindex bridge, which only ever feeds it an
 already-validated `OwnedValue`, so `sjq`/`syq` are unaffected. The remaining #1677 call sites
-are tracked as a follow-up (#1829) rather than folded into #1677 itself, which scoped itself to
-`eval_generic.rs`.
+(`with_entries`'s own post-`to_entries` reassembly step, `map_values`, `paths`, `leaf_paths`, and
+the `pick`/`omit` pair review surfaced alongside this issue) are tracked as a follow-up (#1829)
+rather than folded into #1677 itself, which scoped itself to `eval_generic.rs`.
 
-Fixing `keys`/`keys_unsorted` alone creates a transitional inconsistency worth naming rather
-than leaving implicit: `to_entries` (and `with_entries`/`map_values`, which route through it)
-still silently drops a decode-failure or #1194-malformed key, so `keys_unsorted | length` and
-`to_entries | length` can now disagree with *each other* on the same document, where before
-#1829/#1835 both silently dropped the same key and so happened to agree. Not a new bug in
-either builtin -- `to_entries`'s own gap predates this fix and is #1829's own next-listed
-slice -- but the two builtins' agreement was accidental, not a guarantee, and this fix is the
-first thing to make that visible.
+Only `with_entries` routes through `to_entries` internally (it calls `builtin_to_entries`
+directly), so it inherits this fix's #1194/#1642/#1677 coverage for free on the decode step --
+though it still needs its own audit for whatever it does with the *reconstructed* object
+afterward before this issue can consider it closed. `map_values` is a separate, independent
+hand-rolled walk with the identical silent-`continue` shape `keys`/`to_entries` had before their
+own fixes -- unrelated to `to_entries` and not covered by this change at all.
 
 ## Refusing an allocation jq does not survive
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8593,6 +8593,20 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
             };
             let mut entries: Vec<OwnedValue> = vec_with_capacity(cursors.len());
             for (i, cursor) in cursors.into_iter().enumerate() {
+                // `cursor.value()` re-resolves `text_position()` here, which
+                // `collect_cursors_checked` already resolved once internally
+                // to run its own delimiter check and then discarded (it only
+                // hands back the bare cursor, per its doc comment's own
+                // "several callers reach each element through `to_owned_cursor`
+                // regardless" rationale for staying general-purpose rather
+                // than threading a position through). `.[]`'s own caller in
+                // `eval_generic.rs` doesn't pay this twice, since it hands
+                // cursors back lazily and only resolves once, on demand --
+                // `to_entries` is the eager case that does pay it, a known,
+                // minor (code review, #1829), not-fixed-here cost: doing so
+                // needs `collect_cursors_checked` to return resolved
+                // positions too, a shared-trait-signature change with a
+                // wider blast radius than this fix's own #1677 scope.
                 let val = match to_owned_checked(&cursor.value()) {
                     Ok(v) => v,
                     Err(e) => return QueryResult::Error(e),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,7 +39,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
     effective_fields, effective_fields_checked, effective_keys, effective_len, key_display_string,
-    resolve_display_key, DisplayKeyGuard, DocumentFields,
+    resolve_display_key, DisplayKeyGuard, DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
@@ -8579,19 +8579,30 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => {
-            let entries: Result<Vec<OwnedValue>, EvalError> = elements
-                .enumerate()
-                .map(|(i, elem)| {
-                    let mut entry = IndexMap::new();
-                    entry.insert("key".to_string(), OwnedValue::Int(i as i64));
-                    entry.insert("value".to_string(), to_owned_checked(&elem)?);
-                    Ok(OwnedValue::Object(entry))
-                })
-                .collect();
-            match entries {
-                Ok(entries) => QueryResult::Owned(OwnedValue::Array(entries)),
-                Err(e) => QueryResult::Error(e),
+            // #1829 review: `collect_cursors_checked` (`document.rs`), not
+            // a bare `enumerate()` -- the array counterpart of the Object
+            // arm's own #1677 fix below. Its own doc comment names
+            // `to_entries` on arrays as one of its two intended callers
+            // (`.[]` is the other): a malformed `,` between elements
+            // (`[1 2, 3]`) must raise here too, matching what the CLI's own
+            // `eval_generic.rs` path already enforces for `.[]`/`to_entries`
+            // on the identical input.
+            let cursors = match elements.collect_cursors_checked() {
+                Ok(c) => c,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let mut entries: Vec<OwnedValue> = vec_with_capacity(cursors.len());
+            for (i, cursor) in cursors.into_iter().enumerate() {
+                let val = match to_owned_checked(&cursor.value()) {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
+                };
+                let mut entry = IndexMap::new();
+                entry.insert("key".to_string(), OwnedValue::Int(i as i64));
+                entry.insert("value".to_string(), val);
+                entries.push(OwnedValue::Object(entry));
             }
+            QueryResult::Owned(OwnedValue::Array(entries))
         }
         StandardJson::Object(fields) => {
             // #1829: `effective_fields_checked` (`document.rs`) raises on a
@@ -43223,6 +43234,25 @@ mod tests {
     fn test_builtin_to_entries_raises_on_malformed_delimiter_1677() {
         query!(br#"{"a" 1, "b": 2}"#, "to_entries",
             QueryResult::Error(_) => {}
+        );
+    }
+
+    /// Code review, #1829: the *array* arm needed its own #1677 fix, not
+    /// just the object arm above -- `enumerate()` alone can't see a missing
+    /// `,` between elements, only `collect_cursors_checked` (`document.rs`,
+    /// whose own doc comment names `to_entries` on arrays as one of its two
+    /// intended callers) can. `[1 2, 3]` used to silently yield 3 entries
+    /// instead of raising, disagreeing with the CLI's own `eval_generic.rs`
+    /// path, which already enforces this for `.[]`/`to_entries` on the
+    /// identical input.
+    #[test]
+    fn test_builtin_to_entries_array_raises_on_malformed_delimiter_1677() {
+        query!(br"[1 2, 3]", "to_entries",
+            QueryResult::Error(_) => {}
+        );
+        // Positive control: a well-formed array is unaffected.
+        query!(br"[1, 2, 3]", "to_entries",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 3)
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38,8 +38,8 @@ use core::cell::Cell;
 use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
-    effective_fields, effective_keys, effective_len, resolve_display_key, DisplayKeyGuard,
-    DocumentFields,
+    effective_fields, effective_fields_checked, effective_keys, effective_len, key_display_string,
+    resolve_display_key, DisplayKeyGuard, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
@@ -8594,24 +8594,43 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
             }
         }
         StandardJson::Object(fields) => {
-            let mut entries: Vec<OwnedValue> = Vec::new();
-            for field in fields {
-                let key = if let StandardJson::String(k) = field.key() {
-                    if let Ok(cow) = k.as_str() {
-                        cow.into_owned()
-                    } else {
-                        continue;
-                    }
-                } else {
-                    continue;
+            // #1829: `effective_fields_checked` (`document.rs`) raises on a
+            // #1194 structurally malformed/unpaired member or a malformed
+            // `,`/`:` delimiter (#1677) instead of this arm's previous
+            // silent `continue`, matching `keys`/`keys_unsorted`'s own fix
+            // (#1835) for the identical two axes. `collapse: false` for the
+            // same reason that fix used it: this function has no
+            // `S: EvalSemantics` parameter to derive a mode-correct
+            // duplicate-key policy from (a real, separate, pre-existing gap
+            // this doesn't touch). `key_display_string`, not
+            // `resolve_display_key`: `to_entries` builds a `Vec` of
+            // `{key, value}` objects, not one map keyed by `key`, so two
+            // decode-failure keys sharing the same fallback spelling are
+            // simply two separate entries, not the ambiguous-overwrite
+            // `DisplayKeyGuard` exists to prevent for a real `IndexMap`.
+            // `key_display_string` returning `None` here is unreachable --
+            // `effective_fields_checked`'s own `key_is_malformed` check
+            // above already refuses exactly the condition that would cause
+            // it -- so the `else` arm can't observably fire; kept as a real
+            // branch (not `.unwrap()`) so a future change to either
+            // function's refusal condition fails loudly instead of
+            // panicking.
+            let checked = match effective_fields_checked(&fields, false) {
+                Ok(f) => f,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let mut entries: Vec<OwnedValue> = vec_with_capacity(checked.len());
+            for field in checked {
+                let Some(key) = key_display_string(&field.key) else {
+                    return QueryResult::Error(fields.malformed_member_error());
                 };
-                let val = match to_owned_checked(&field.value()) {
+                let val = match to_owned_checked(&field.value) {
                     Ok(val) => val,
                     Err(e) => return QueryResult::Error(e),
                 };
 
                 let mut entry = IndexMap::new();
-                entry.insert("key".to_string(), OwnedValue::String(key));
+                entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
                 entry.insert("value".to_string(), val);
                 entries.push(OwnedValue::Object(entry));
             }
@@ -43156,6 +43175,65 @@ mod tests {
         );
     }
 
+    /// #1829: `to_entries` used to silently drop a decode-failure or #1194
+    /// structurally malformed key, disagreeing with `length` (counts every
+    /// field regardless) and with `keys`/`keys_unsorted` (fixed in #1835 to
+    /// preserve/raise on the identical two axes, via the same
+    /// `effective_fields_checked`/`key_display_string` this fix now shares).
+    #[test]
+    fn test_builtin_to_entries_preserves_decode_failure_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+
+        query!(doc, "length",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(doc, "to_entries",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr.len(), 2);
+                let OwnedValue::Object(first) = &arr[0] else {
+                    panic!("entry is not an object: {:?}", arr[0]);
+                };
+                assert_eq!(
+                    first.get("key"),
+                    Some(&OwnedValue::String("\u{FFFD}\u{FFFD}".to_string()))
+                );
+                assert_eq!(first.get("value"), Some(&OwnedValue::Int(1)));
+                let OwnedValue::Object(second) = &arr[1] else {
+                    panic!("entry is not an object: {:?}", arr[1]);
+                };
+                assert_eq!(second.get("key"), Some(&OwnedValue::String("a".to_string())));
+            }
+        );
+    }
+
+    /// #1829's other axis: a structurally non-string/unpaired key (#1194,
+    /// `{"a":1,"b"}`) must raise for `to_entries` too, matching
+    /// `keys`/`keys_unsorted` and `path(.[])`/`tojson` -- previously
+    /// silently dropped instead (a 1-entry array, not an error).
+    #[test]
+    fn test_builtin_to_entries_raises_on_structurally_malformed_key_1829() {
+        query!(br#"{"a":1,"b"}"#, "to_entries",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1677, via the same shared walk `keys`/`keys_unsorted` picked up in
+    /// #1835: a malformed `,`/`:` delimiter now raises for `to_entries` too.
+    #[test]
+    fn test_builtin_to_entries_raises_on_malformed_delimiter_1677() {
+        query!(br#"{"a" 1, "b": 2}"#, "to_entries",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// Code review precedent from #1835/#1829: `to_entries?` must still
+    /// suppress both error axes via the outer `Expr::Optional` catch.
+    #[test]
+    fn test_builtin_to_entries_optional_suppresses_malformed_key_errors_1829() {
+        query!(br#"{"a":1,"b"}"#, "to_entries?", QueryResult::None => {});
+        query!(br#"{"a" 1, "b": 2}"#, "to_entries?", QueryResult::None => {});
+    }
+
     #[test]
     fn test_builtin_from_entries() {
         query!(br#"[{"key": "a", "value": 1}, {"key": "b", "value": 2}]"#, "from_entries",
@@ -43197,6 +43275,22 @@ mod tests {
                 assert_eq!(obj.get("a"), Some(&OwnedValue::Int(1)));
                 assert_eq!(obj.get("b"), Some(&OwnedValue::Int(2)));
             }
+        );
+    }
+
+    /// #1829: `with_entries` calls `builtin_to_entries` directly, so it
+    /// inherits that function's #1194/#1642/#1677 fix for free on the
+    /// decode step -- pinned here so a future refactor that stops routing
+    /// through `to_entries` doesn't silently regress it.
+    #[test]
+    fn test_builtin_with_entries_inherits_to_entries_decode_policy_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+        query!(doc, "with_entries({key: .key, value: .value})",
+            QueryResult::Owned(OwnedValue::Object(obj)) => assert_eq!(obj.len(), 2)
+        );
+
+        query!(br#"{"a":1,"b"}"#, "with_entries({key: .key, value: .value})",
+            QueryResult::Error(_) => {}
         );
     }
 


### PR DESCRIPTION
Part of #1829 — the `to_entries` slice following #1835's `keys`/`keys_unsorted` fix.

## Problem

`eval.rs`'s own `builtin_to_entries` (backing `to_entries` via the library `eval()` entry point) silently skipped both a decode-failure key and a #1194 structurally non-string/unpaired key in its `Object` arm, disagreeing with `length` and with `keys`/`keys_unsorted` (fixed in #1835). `keys_unsorted | length` and `to_entries | length` could disagree with each other on the same document — both used to silently drop the same key and so happened to agree, but only by accident.

## What changed

- **Object arm**: routed through `effective_fields_checked` (`document.rs`) — the value-carrying counterpart of `effective_keys`, whose own doc comment names `to_entries` as its intended caller — then `key_display_string` per resolved field, matching the #1642 preserve / #1194 raise / #1677 raise policy `keys`/`keys_unsorted` already got.
- **Array arm** (found missing in review): switched from a bare `enumerate()` to `collect_cursors_checked` (`document.rs`, whose own doc comment names `to_entries`-on-arrays as one of its two intended callers), closing the same #1677 gap for a malformed `,` between array elements (`[1 2, 3]` used to silently yield 3 entries instead of raising).

`collapse: false` throughout, same rationale as #1835: `builtin_to_entries` has no `S: EvalSemantics` parameter to derive a mode-correct duplicate-key policy from — a real, separate, pre-existing gap this doesn't touch.

## Bonus: `with_entries` inherits this for free

`with_entries` calls `builtin_to_entries` directly, so it picks up this fix's #1194/#1642/#1677 coverage on the decode step automatically — verified live and pinned with a new test. `map_values` is a **separate, independent** hand-rolled walk with the identical pre-fix silent-`continue` shape, unrelated to `to_entries` and **not** covered by this change.

## Scope note

Per #1829's own acceptance criteria, `paths`, `with_entries`'s own post-`to_entries` reassembly step, `map_values`, and `leaf_paths` still need their own audits/fixes (plus `pick`/`omit`, surfaced during #1835's review). Leaving #1829 open for those slices.

## Review history

Two rounds of independent multi-agent code review:

1. **First pass**: confirmed the Object arm's delegation is correct and genuinely cheap (not the dead-code/expensive-path trap `DocumentFields::keys()` turned out to be in #1835's review), but found the **Array arm** still had no #1677 protection at all. Fixed by switching to `collect_cursors_checked`.
2. **Second pass**: confirmed the array-arm fix is correct, but found `cursor.value()` re-resolves `text_position()` a second time per element (the delimiter check inside `collect_cursors_checked` already resolved it once and discarded it) — a real but minor, perf-only cost, not present in `eval_generic.rs`'s own `.[]` caller of the same shared method (which resolves lazily, only once, on demand, unlike `to_entries`'s eager materialization). A proper fix needs `collect_cursors_checked`'s own signature to carry resolved positions through, a wider change than this PR's #1677 scope — documented as a known, deliberately-deferred cost rather than fixed here.

## Testing

- `test_builtin_to_entries_preserves_decode_failure_key_1829`: pins the exact fallback spelling and value for the preserved decode-failure key, plus the ordinary sibling key.
- `test_builtin_to_entries_raises_on_structurally_malformed_key_1829` / `test_builtin_to_entries_raises_on_malformed_delimiter_1677`: both #1194 and #1677 now raise for the Object arm.
- `test_builtin_to_entries_array_raises_on_malformed_delimiter_1677`: #1677 now raises for the Array arm too, with a well-formed-array positive control.
- `test_builtin_to_entries_optional_suppresses_malformed_key_errors_1829`: `to_entries?` correctly suppresses both error axes.
- `test_builtin_with_entries_inherits_to_entries_decode_policy_1829`: confirms the free inheritance.
- Full local suite green: 3005 lib tests, 1073 jq CLI tests, 1264 yq CLI tests, yq golden conformance, cli_golden_tests, evaluator parity — 0 failures (one unrelated `test_short_circuit_side_effect_shapes_already_match_jq_820` flake under concurrent load, confirmed passes in isolation and on a lower-concurrency re-run).
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second clippy leg both clean. `cargo fmt --check`, `cargo build --no-default-features` (no_std), `cargo doc --no-deps --all-features` all clean.
- Live-verified against the pinned oracle: real jq also refuses both malformed-document shapes at parse time (exit 5), confirming this fix's overall refuse-to-process verdict matches.