### PR TITLE
fix(jq): eval_comma raises on decode failure in a heterogeneous comma

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1242,33 +1242,47 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     for expr in exprs {
         match eval_single::<W, S>(expr, value.clone(), optional).materialize_cursor() {
-            QueryResult::One(v) => match owned.as_mut() {
-                Some(acc) => acc.push(to_owned(&v)),
-                None => borrowed.push(v),
-            },
+            // #1790: to_owned_checked, not to_owned -- a heterogeneous
+            // comma (a navigable branch alongside an already-owned one,
+            // e.g. `[.a, 1]`) used to promote the borrowed branch's
+            // undecodable string to `""` here, silently, the moment the
+            // owned sibling forced the promotion. `push_promoted`/
+            // `promote_borrowed_checked` are the same helpers
+            // `eval_pipe`'s identical `Many`-branch promotion uses
+            // (#1755/#1843's own instance of this exact bug shape).
+            QueryResult::One(v) => {
+                if let Err(e) = push_promoted(core::iter::once(v), &mut borrowed, &mut owned) {
+                    let merged = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                    return partial(merged, Control::Error(e));
+                }
+            }
             QueryResult::OneCursor(_) => {
                 unreachable!("materialize_cursor should have converted this")
             }
-            QueryResult::Many(vs) => match owned.as_mut() {
-                Some(acc) => acc.extend(vs.iter().map(to_owned)),
-                None => borrowed.extend(vs),
-            },
-            QueryResult::Owned(v) => owned
-                .get_or_insert_with(|| {
-                    core::mem::take(&mut borrowed)
-                        .iter()
-                        .map(to_owned)
-                        .collect()
-                })
-                .push(v),
-            QueryResult::ManyOwned(vs) => owned
-                .get_or_insert_with(|| {
-                    core::mem::take(&mut borrowed)
-                        .iter()
-                        .map(to_owned)
-                        .collect()
-                })
-                .extend(vs),
+            QueryResult::Many(vs) => {
+                if let Err(e) = push_promoted(vs, &mut borrowed, &mut owned) {
+                    let merged = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                    return partial(merged, Control::Error(e));
+                }
+            }
+            QueryResult::Owned(v) => {
+                if owned.is_none() {
+                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                        Ok(acc) => owned = Some(acc),
+                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                    }
+                }
+                owned.as_mut().unwrap().push(v);
+            }
+            QueryResult::ManyOwned(vs) => {
+                if owned.is_none() {
+                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                        Ok(acc) => owned = Some(acc),
+                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                    }
+                }
+                owned.as_mut().unwrap().extend(vs);
+            }
             QueryResult::None => {}
             // A sibling that errors or breaks no longer discards the outputs
             // the earlier siblings already produced (#400): `(1,error("x"))`
@@ -13994,18 +14008,21 @@ fn splits_with_resolved_pattern<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
-/// Push one already-produced cursor result into `eval_pipe`'s `Many`-branch
-/// element loop's promotion state: still lazily borrowed if promotion
-/// hasn't started, checked-converted into `owned` if it has.
+/// Push one already-produced cursor result into a "still lazily borrowed
+/// until a sibling forces promotion to owned" accumulator's promotion
+/// state -- shared by `eval_pipe`'s `Many`-branch element loop and
+/// `eval_comma`'s own identical shape.
 ///
-/// #1755 review: an earlier version of this slice's fix left this specific
-/// promotion path on unchecked `to_owned`, silently corrupting an
+/// #1755 review: an earlier version of `eval_pipe`'s own fix left this
+/// specific promotion path on unchecked `to_owned`, silently corrupting an
 /// already-borrowed undecodable element the moment any sibling forced
 /// promotion to owned -- `.[] | (if type == "string" then . else . + 0
 /// end)` on `["\xff\xfe", 1]` returned `ManyOwned([String(""), Int(1)])`
-/// instead of raising. On failure, `owned` is left holding whatever
-/// pushed successfully before the failing element, matching the #400
-/// "keep the prefix" policy every other control arm in that loop follows.
+/// instead of raising. `eval_comma` had the identical bug shape for a
+/// heterogeneous comma (`[.a, 1]`, #1790). On failure, `owned` is left
+/// holding whatever pushed successfully before the failing element,
+/// matching the #400 "keep the prefix" policy every other control arm in
+/// both loops follows.
 fn push_promoted<'a, W: Clone + AsRef<[u64]>>(
     rs: impl IntoIterator<Item = StandardJson<'a, W>>,
     borrowed: &mut Vec<StandardJson<'a, W>>,
@@ -14026,10 +14043,11 @@ fn push_promoted<'a, W: Clone + AsRef<[u64]>>(
 }
 
 /// Promote `borrowed` into a checked `Vec<OwnedValue>`, used the moment an
-/// `Owned`/`ManyOwned` sibling in `eval_pipe`'s `Many`-branch loop forces
-/// the whole batch out of its lazy borrowed state for the first time
-/// (see [`push_promoted`]'s identical #1755 reasoning). Returns whatever
-/// converted successfully so far as the `Err` payload's own prefix.
+/// `Owned`/`ManyOwned` sibling in `eval_pipe`'s `Many`-branch loop (or
+/// `eval_comma`'s identical shape, #1790) forces the whole batch out of
+/// its lazy borrowed state for the first time (see [`push_promoted`]'s
+/// identical #1755 reasoning). Returns whatever converted successfully so
+/// far as the `Err` payload's own prefix.
 fn promote_borrowed_checked<W: Clone + AsRef<[u64]>>(
     borrowed: Vec<StandardJson<'_, W>>,
 ) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalError)> {
@@ -37148,6 +37166,61 @@ mod tests {
             QueryResult::Error(e) if e.is_decode_failure() => {
                 assert!(e.message.contains("invalid unicode escape"), "message: {}", e.message);
             }
+        );
+    }
+
+    /// #1790: a *heterogeneous* comma -- mixing a navigable branch (still
+    /// lazily borrowed as a cursor) with an already-owned one (a literal,
+    /// or any other branch that materializes eagerly) -- used to silently
+    /// corrupt the borrowed branch's undecodable string to `""` the
+    /// moment the owned sibling forced `eval_comma`'s own accumulator to
+    /// promote from borrowed to owned. A *homogeneous* comma (`[.a, .a]`,
+    /// both branches navigable) was already correct, since it never
+    /// leaves the borrowed fast path at all -- confirmed unaffected by
+    /// `test_eval_array_construction_raises_on_decode_failure_1755` above.
+    #[test]
+    fn test_eval_comma_heterogeneous_raises_on_decode_failure_1790() {
+        // Array construction (this issue's own repro): the owned literal
+        // `1` forces `eval_comma`'s promotion inside `[.a, 1]`.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[.a, 1]",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // The same shape without array construction wrapping it -- a bare
+        // top-level comma forcing the same promotion.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a, 1",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // Order matters for the #400 "keep the prefix" policy: the
+        // borrowed (bad) branch is the *first* operand above (nothing yet
+        // to keep), but here the owned branch comes first, so the
+        // already-produced `1` must survive as the `Partial` prefix once
+        // the second (borrowed, bad) operand is reached and forces the
+        // promotion to fail.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "1, .a",
+            QueryResult::Partial(vs, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+            }
+        );
+    }
+
+    /// #1790 positive control: a heterogeneous comma with valid data is
+    /// unaffected by routing through `push_promoted`/
+    /// `promote_borrowed_checked`.
+    #[test]
+    fn test_eval_comma_heterogeneous_valid_data_unaffected_1790() {
+        query!(br#"{"a":"x"}"#, "[.a, 1]",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(v, vec![OwnedValue::String("x".to_string()), OwnedValue::Int(1)]);
+            }
+        );
+        query!(br#"{"a":"x"}"#, "1, .a",
+            QueryResult::Many(_) | QueryResult::ManyOwned(_) => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1252,7 +1252,9 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // (#1755/#1843's own instance of this exact bug shape).
             QueryResult::One(v) => {
                 if let Err(e) = push_promoted(core::iter::once(v), &mut borrowed, &mut owned) {
-                    let merged = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                    // push_promoted only errors from its `Some(acc)` arm, so
+                    // `owned` is always `Some` here.
+                    let merged = owned.expect("push_promoted only errors when owned is Some");
                     return partial(merged, Control::Error(e));
                 }
             }
@@ -1261,7 +1263,7 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             QueryResult::Many(vs) => {
                 if let Err(e) = push_promoted(vs, &mut borrowed, &mut owned) {
-                    let merged = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
+                    let merged = owned.expect("push_promoted only errors when owned is Some");
                     return partial(merged, Control::Error(e));
                 }
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37224,6 +37224,35 @@ mod tests {
         );
     }
 
+    /// #1790: `push_promoted`'s `Many(vs)` call site inside `eval_comma`
+    /// (a batch of several cursor-backed outputs arriving after promotion
+    /// has already happened, the first of which is undecodable) --
+    /// `.a[]`'s own iteration produces `Many`, unlike a comma of owned
+    /// literals which materializes straight to `ManyOwned`.
+    #[test]
+    fn test_eval_comma_many_arm_raises_on_decode_failure_1790() {
+        query!(
+            b"{\"a\": [\"\xff\xfe\"]}",
+            "1, .a[]",
+            QueryResult::Partial(vs, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+            }
+        );
+    }
+
+    /// #1790: `promote_borrowed_checked`'s failure path via the
+    /// `ManyOwned` arm specifically (not `Owned`) -- a comma of two owned
+    /// literals (`(1,2)`) forces the *first* promotion of an
+    /// already-borrowed, undecodable branch.
+    #[test]
+    fn test_eval_comma_manyowned_arm_raises_on_decode_failure_1790() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a, (1,2)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
     /// #1620: a decode failure reached through this module's own dispatch
     /// (the public `succinctly::jq::eval` library API, not the CLI's
     /// `eval_generic.rs` bridge) must not be suppressed by `?` -- same rule,


### PR DESCRIPTION
Fixes #1790

## Root cause

`eval_comma`'s `QueryResult::One`/`::Many` arms promoted a cursor-backed
branch's value via unchecked `to_owned` the moment an already-owned sibling
(e.g. a literal) forced promotion to `ManyOwned` — silently substituting
`OwnedValue::String("")` for a string that fails UTF-8 decode, instead of
raising `EvalError::decode_failure`. This is the same bug shape #1755/#1843
already fixed for `eval_pipe`'s identical `Many`-branch promotion, just
reached through a different expression (`Expr::Comma` instead of `Expr::Pipe`).

A homogeneous comma (`[.a, .a]`) was already correct — both branches route
through `eval_array_construction`'s own `QueryResult::Many` arm, fixed by
#1755's PR. Only a heterogeneous comma (a navigable branch alongside an
already-owned one) hit this gap, and only via the public `succinctly::jq::eval`
library API — the CLI's `eval_generic.rs` bridge validates the whole document
upfront, so this was never a live CLI regression (confirmed live:
`succinctly jq -c '[.a, 1]'` on `{"a":"\ud800"}` already raised correctly).

## Fix

Rewrote `eval_comma`'s `One`/`Many`/`Owned`/`ManyOwned` arms to go through the
same `push_promoted`/`promote_borrowed_checked` helpers `eval_pipe` uses
(built in #1843) — reused directly, not re-duplicated a third time — so any
promotion failure raises `decode_failure` with the correct `#400` prefix
semantics (outputs already produced by earlier siblings in the comma are kept
via `QueryResult::Partial`, matching #1843's precedent).

## Verification

- Live-confirmed the repro from #1790 before and after the fix.
- New tests cover: heterogeneous comma with cursor-branch first (`[.a, 1]`,
  `.a, 1`) and last (`1, .a`), homogeneous valid-data regression check, and
  the `Many`/`ManyOwned` arms specifically (`1, .a[]`, `.a, (1,2)`).
- 100% patch coverage (46/46 new lines) via `omni-dev coverage diff`.
- Full test suite green under both `cargo test --verbose` (CI's default
  feature set) and `cargo test --features cli,simd,regex,serde` (this repo's
  full feature set), before and after rebasing onto `main`.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo build --no-default-features` clean (no_std compatibility).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo test --verbose` (default features, matches CI)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --no-default-features`
- [x] `omni-dev coverage diff` — 100% patch coverage