### PR TITLE
fix(jq): route builtin_map_values through the shared display-key policy

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6470,21 +6470,35 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     match value {
         StandardJson::Object(fields) => {
+            // #1829: preserve a decode-failure key via its raw source span
+            // (#1642), and raise on a #1194 structural/unpaired key or a
+            // #1677 malformed delimiter, matching keys/keys_unsorted (#1835)
+            // and to_entries (#1848). resolve_display_key/DisplayKeyGuard,
+            // not plain key_display_string: map_values builds a real
+            // IndexMap, so two decode-failure keys sharing the same
+            // fallback spelling must raise rather than silently overwrite
+            // one another, unlike keys/to_entries's Vec output.
+            let checked = match effective_fields_checked(&fields, false) {
+                Ok(f) => f,
+                Err(e) => return QueryResult::Error(e),
+            };
             let mut result_map = IndexMap::new();
-            for field in fields {
-                // Get the key
-                let key = if let StandardJson::String(k) = field.key() {
-                    if let Ok(cow) = k.as_str() {
-                        cow.into_owned()
-                    } else {
-                        continue;
-                    }
-                } else {
-                    continue;
+            let mut guard = DisplayKeyGuard::default();
+            for field in checked {
+                // `effective_fields_checked` already refused every key
+                // `key_display_string`/`resolve_display_key` would answer
+                // `None` for (#1194), so that arm is unreachable here --
+                // kept as a real branch (not `.unwrap()`) so a future change
+                // to either function's refusal condition fails loudly
+                // instead of panicking.
+                let key = match resolve_display_key(&field.key, &result_map, &mut guard) {
+                    Ok(Some(k)) => k,
+                    Ok(None) => return QueryResult::Error(fields.malformed_member_error()),
+                    Err(e) => return QueryResult::Error(e),
                 };
 
                 // Apply f to the value
-                let field_val = field.value();
+                let field_val = field.value;
                 match eval_single::<W, S>(f, field_val, optional).materialize_cursor() {
                     QueryResult::One(v) => match to_owned_checked(&v) {
                         Ok(owned) => {
@@ -6530,9 +6544,18 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(OwnedValue::Object(result_map))
         }
         StandardJson::Array(elements) => {
-            // map_values on array applies to each element
+            // map_values on array applies to each element. #1829:
+            // collect_cursors_checked, not a bare `for elem in elements` --
+            // the same #1677 gap to_entries's array arm had (found in
+            // #1848's review): a plain iterator can't see a malformed `,`
+            // between elements.
+            let cursors = match elements.collect_cursors_checked() {
+                Ok(c) => c,
+                Err(e) => return QueryResult::Error(e),
+            };
             let mut results = Vec::new();
-            for elem in elements {
+            for cursor in cursors {
+                let elem = cursor.value();
                 match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
                     QueryResult::One(v) => match to_owned_checked(&v) {
                         Ok(owned) => results.push(owned),
@@ -42158,6 +42181,68 @@ mod tests {
                 assert_eq!(arr[2], OwnedValue::Int(4));
             }
         );
+    }
+
+    /// #1829: `map_values` used to silently drop a decode-failure or #1194
+    /// structurally malformed key, disagreeing with `length`/`keys`/
+    /// `to_entries` (fixed in #1835/#1848). `resolve_display_key`/
+    /// `DisplayKeyGuard`, not plain `key_display_string`: `map_values`
+    /// builds a real `IndexMap`, unlike `keys`/`to_entries`'s `Vec` output.
+    #[test]
+    fn test_builtin_map_values_preserves_decode_failure_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+
+        query!(doc, "length",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(doc, "map_values(.+1)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.len(), 2);
+                assert_eq!(
+                    obj.get("\u{FFFD}\u{FFFD}"),
+                    Some(&OwnedValue::Int(2))
+                );
+                assert_eq!(obj.get("a"), Some(&OwnedValue::Int(3)));
+            }
+        );
+    }
+
+    /// #1829's other axis: a structurally non-string/unpaired key (#1194,
+    /// `{"a":1,"b"}`) must raise for `map_values` too, matching
+    /// `keys`/`to_entries`/`path(.[])`/`tojson` -- previously silently
+    /// dropped instead (a 1-entry object, not an error).
+    #[test]
+    fn test_builtin_map_values_raises_on_structurally_malformed_key_1829() {
+        query!(br#"{"a":1,"b"}"#, "map_values(.+1)",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1677: a malformed `,`/`:` delimiter now raises for `map_values` too,
+    /// on both the object and array arms -- the array arm's own gap mirrors
+    /// the one `to_entries`'s array arm had before its own #1677 fix
+    /// (#1848).
+    #[test]
+    fn test_builtin_map_values_raises_on_malformed_delimiter_1677() {
+        query!(br#"{"a" 1, "b": 2}"#, "map_values(.+1)",
+            QueryResult::Error(_) => {}
+        );
+        query!(br"[1 2, 3]", "map_values(.+1)",
+            QueryResult::Error(_) => {}
+        );
+        // Positive control: a well-formed array is unaffected.
+        query!(br"[1, 2, 3]", "map_values(.+1)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert_eq!(arr.len(), 3)
+        );
+    }
+
+    /// Code review precedent from #1835/#1848/#1829: `map_values?` must
+    /// still suppress both error axes via the outer `Expr::Optional` catch.
+    #[test]
+    fn test_builtin_map_values_optional_suppresses_malformed_key_errors_1829() {
+        query!(br#"{"a":1,"b"}"#, "map_values(.+1)?", QueryResult::None => {});
+        query!(br#"{"a" 1, "b": 2}"#, "map_values(.+1)?", QueryResult::None => {});
+        query!(br"[1 2, 3]", "map_values(.+1)?", QueryResult::None => {});
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,7 +39,8 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::document::{
     effective_fields, effective_fields_checked, effective_keys, effective_len, key_display_string,
-    resolve_display_key, DisplayKeyGuard, DocumentElements, DocumentFields,
+    key_display_string_kind, resolve_display_key, DisplayKeyGuard, DocumentElements,
+    DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::map_builtin_subexprs;
@@ -6478,67 +6479,88 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // IndexMap, so two decode-failure keys sharing the same
             // fallback spelling must raise rather than silently overwrite
             // one another, unlike keys/to_entries's Vec output.
-            let checked = match effective_fields_checked(&fields, false) {
+            // `S::COLLAPSE_DUPLICATE_KEYS`, not a hardcoded `false` like
+            // keys/to_entries use: those two lack an `S: EvalSemantics`
+            // parameter entirely, but this function already has one (used
+            // for `S::TAG` above and for the `eval_single::<W, S>` call
+            // below), and real jq collapses a duplicate object key to its
+            // last occurrence *before* evaluating the filter -- walking
+            // every raw duplicate and applying `f` to each (including the
+            // one about to be discarded) can raise an error real jq never
+            // reaches (code review, #1829): `{"a":"x","a":2} |
+            // map_values(.+1)` must give `{"a":3}` like jq does, not error
+            // on `"x"+1` for a value collapse would have already dropped.
+            let checked = match effective_fields_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
                 Ok(f) => f,
                 Err(e) => return QueryResult::Error(e),
             };
-            let mut result_map = IndexMap::new();
+            let mut result_map = IndexMap::with_capacity(checked.len());
             let mut guard = DisplayKeyGuard::default();
             for field in checked {
                 // `effective_fields_checked` already refused every key
-                // `key_display_string`/`resolve_display_key` would answer
-                // `None` for (#1194), so that arm is unreachable here --
-                // kept as a real branch (not `.unwrap()`) so a future change
-                // to either function's refusal condition fails loudly
-                // instead of panicking.
-                let key = match resolve_display_key(&field.key, &result_map, &mut guard) {
-                    Ok(Some(k)) => k,
-                    Ok(None) => return QueryResult::Error(fields.malformed_member_error()),
-                    Err(e) => return QueryResult::Error(e),
+                // `key_display_string_kind` would answer `None` for
+                // (#1194), so that arm is unreachable here -- kept as a
+                // real branch (not `.unwrap()`) so a future change to
+                // either function's refusal condition fails loudly instead
+                // of panicking.
+                //
+                // `key_display_string_kind`, not `resolve_display_key`: the
+                // latter checks the `DisplayKeyGuard` collision (and
+                // registers the key in it) unconditionally, before `f` is
+                // evaluated below -- but `f` can produce no output at all
+                // (`QueryResult::None`), in which case this field's key is
+                // never actually inserted into `result_map`. Checking the
+                // guard that early raised a false-positive collision
+                // against a *later* field sharing the same #1642 fallback
+                // spelling even when the earlier field's own value never
+                // made it into the map (code review, #1829): every other
+                // `resolve_display_key` call site inserts unconditionally
+                // right after resolving, so this is the first one where
+                // that isn't true. The guard check is deferred below,
+                // immediately before the one line that actually inserts.
+                let (key, is_fallback) = match key_display_string_kind(&field.key) {
+                    Some((k, is_fallback)) => (k.into_owned(), is_fallback),
+                    None => return QueryResult::Error(fields.malformed_member_error()),
                 };
 
                 // Apply f to the value
                 let field_val = field.value;
-                match eval_single::<W, S>(f, field_val, optional).materialize_cursor() {
-                    QueryResult::One(v) => match to_owned_checked(&v) {
-                        Ok(owned) => {
-                            result_map.insert(key, owned);
-                        }
-                        Err(e) => return QueryResult::Error(e),
-                    },
-                    QueryResult::OneCursor(_) => unreachable!(),
-                    QueryResult::Owned(v) => {
-                        result_map.insert(key, v);
-                    }
-                    QueryResult::Many(vs) => {
-                        if let Some(v) = vs.first() {
-                            match to_owned_checked(v) {
-                                Ok(owned) => {
-                                    result_map.insert(key, owned);
-                                }
+                let value_to_insert =
+                    match eval_single::<W, S>(f, field_val, optional).materialize_cursor() {
+                        QueryResult::One(v) => match to_owned_checked(&v) {
+                            Ok(owned) => Some(owned),
+                            Err(e) => return QueryResult::Error(e),
+                        },
+                        QueryResult::OneCursor(_) => unreachable!(),
+                        QueryResult::Owned(v) => Some(v),
+                        QueryResult::Many(vs) => match vs.first() {
+                            Some(v) => match to_owned_checked(v) {
+                                Ok(owned) => Some(owned),
                                 Err(e) => return QueryResult::Error(e),
-                            }
+                            },
+                            None => None,
+                        },
+                        QueryResult::ManyOwned(vs) => vs.into_iter().next(),
+                        QueryResult::None => None,
+                        QueryResult::Error(e) => return QueryResult::Error(e),
+                        QueryResult::Break(label) => return QueryResult::Break(label),
+                        QueryResult::Halt(code) => return QueryResult::Halt(code),
+                        // Object construction is atomic in jq (see
+                        // `eval_object_construction`) — a `Partial` field value
+                        // just surfaces its control, same as a bare one.
+                        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
+                        QueryResult::Partial(_, Control::Break(label)) => {
+                            return QueryResult::Break(label);
                         }
-                    }
-                    QueryResult::ManyOwned(vs) => {
-                        if let Some(v) = vs.into_iter().next() {
-                            result_map.insert(key, v);
+                        QueryResult::Partial(_, Control::Halt(code)) => {
+                            return QueryResult::Halt(code);
                         }
+                    };
+                if let Some(value) = value_to_insert {
+                    if !guard.check(&result_map, &key, is_fallback) {
+                        return QueryResult::Error(EvalError::colliding_display_key(&key));
                     }
-                    QueryResult::None => {}
-                    QueryResult::Error(e) => return QueryResult::Error(e),
-                    QueryResult::Break(label) => return QueryResult::Break(label),
-                    QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // Object construction is atomic in jq (see
-                    // `eval_object_construction`) — a `Partial` field value
-                    // just surfaces its control, same as a bare one.
-                    QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
-                    QueryResult::Partial(_, Control::Break(label)) => {
-                        return QueryResult::Break(label);
-                    }
-                    QueryResult::Partial(_, Control::Halt(code)) => {
-                        return QueryResult::Halt(code);
-                    }
+                    result_map.insert(key, value);
                 }
             }
             QueryResult::Owned(OwnedValue::Object(result_map))
@@ -6553,8 +6575,14 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Ok(c) => c,
                 Err(e) => return QueryResult::Error(e),
             };
-            let mut results = Vec::new();
+            let mut results: Vec<OwnedValue> = vec_with_capacity(cursors.len());
             for cursor in cursors {
+                // `cursor.value()` re-resolves `text_position()` a second
+                // time here -- the same known, documented, not-fixed-here
+                // cost `to_entries`'s own array arm carries (its own doc
+                // comment has the full rationale): `collect_cursors_checked`
+                // already resolved each element's position once internally
+                // to run its delimiter check, then discards it.
                 let elem = cursor.value();
                 match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
                     QueryResult::One(v) => match to_owned_checked(&v) {
@@ -42243,6 +42271,63 @@ mod tests {
         query!(br#"{"a":1,"b"}"#, "map_values(.+1)?", QueryResult::None => {});
         query!(br#"{"a" 1, "b": 2}"#, "map_values(.+1)?", QueryResult::None => {});
         query!(br"[1 2, 3]", "map_values(.+1)?", QueryResult::None => {});
+    }
+
+    /// Code review, #1829: a duplicate object key must be collapsed to its
+    /// last occurrence *before* `f` runs, matching real jq -- an earlier
+    /// draft of this fix hardcoded `collapse: false` (correct for
+    /// `keys`/`to_entries`, which lack an `S: EvalSemantics` parameter to
+    /// derive a mode-correct flag from, but `map_values` has one) and so
+    /// walked every raw duplicate, applying `f` to a value real jq would
+    /// have already discarded. `"x" + 1` would raise here if the collapse
+    /// didn't happen before `f` ran; real jq (`{"a":"x","a":2} |
+    /// map_values(.+1)`, confirmed live) gives `{"a":3}`, never evaluating
+    /// `f` against `"x"` at all.
+    #[test]
+    fn test_builtin_map_values_collapses_duplicate_key_before_evaluating_f_1829() {
+        query!(br#"{"a": "x", "a": 2}"#, "map_values(.+1)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.len(), 1);
+                assert_eq!(obj.get("a"), Some(&OwnedValue::Int(3)));
+            }
+        );
+    }
+
+    /// Code review, #1829: two decode-failure keys that lossy-decode to the
+    /// identical #1642 fallback spelling must raise via `DisplayKeyGuard`
+    /// (the reason a key-resolution + collision-guard pair was chosen over
+    /// plain `key_display_string` for this function) once both survive `f`
+    /// and would genuinely land in `result_map` together.
+    #[test]
+    fn test_builtin_map_values_raises_on_colliding_fallback_keys_1829() {
+        // `\xff\xfe` and `\xff\xfd` are both 2-byte invalid UTF-8 sequences
+        // that lossy-decode to the same fallback, `"\u{FFFD}\u{FFFD}"`.
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"\xff\xfd\": 2}";
+        query!(doc, "map_values(.+1)",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("ambiguous"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// Code review, #1829: the collision guard's check must be deferred
+    /// until a field's own `f`-output is known to actually land in
+    /// `result_map` -- checking (and registering the key in the guard)
+    /// eagerly, before `f` runs, previously raised a false-positive
+    /// collision even when the earlier field's own value was filtered out
+    /// by `select` and never inserted at all. The two keys here share the
+    /// same #1642 fallback spelling as the collision test above, but only
+    /// one field's value survives `select(. > 0)`, so this must succeed
+    /// with a single entry, not raise.
+    #[test]
+    fn test_builtin_map_values_no_false_positive_collision_when_value_dropped_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"\xff\xfd\": -1}";
+        query!(doc, "map_values(select(.>0))",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.len(), 1);
+                assert_eq!(obj.get("\u{FFFD}\u{FFFD}"), Some(&OwnedValue::Int(1)));
+            }
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6518,10 +6518,10 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // right after resolving, so this is the first one where
                 // that isn't true. The guard check is deferred below,
                 // immediately before the one line that actually inserts.
-                let (key, is_fallback) = match key_display_string_kind(&field.key) {
-                    Some((k, is_fallback)) => (k.into_owned(), is_fallback),
-                    None => return QueryResult::Error(fields.malformed_member_error()),
+                let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
+                    return QueryResult::Error(fields.malformed_member_error());
                 };
+                let key = key.into_owned();
 
                 // Apply f to the value
                 let field_val = field.value;
@@ -42326,6 +42326,24 @@ mod tests {
             QueryResult::Owned(OwnedValue::Object(obj)) => {
                 assert_eq!(obj.len(), 1);
                 assert_eq!(obj.get("\u{FFFD}\u{FFFD}"), Some(&OwnedValue::Int(1)));
+            }
+        );
+    }
+
+    /// Code review, #1829: `S::COLLAPSE_DUPLICATE_KEYS` makes the
+    /// `effective_fields_checked` call mode-dependent -- jq mode collapses a
+    /// duplicate key before `f` runs (pinned above), yq mode does not, so
+    /// both occurrences reach `f` and the second's result overwrites the
+    /// first's in `result_map` (`IndexMap`'s own last-write-wins insert),
+    /// matching yq's own last-key-wins convention. Neither prior test nor
+    /// the pre-existing `map_values` coverage exercises this branch under
+    /// `YqSemantics` at all.
+    #[test]
+    fn test_builtin_map_values_yq_mode_does_not_collapse_duplicate_key_1829() {
+        yq_query!(br#"{"a": 10, "a": 2}"#, "map_values(.+1)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.len(), 1);
+                assert_eq!(obj.get("a"), Some(&OwnedValue::Int(3)));
             }
         );
     }


### PR DESCRIPTION
Part of #1829 — the \`map_values\` slice following #1835 (\`keys\`/\`keys_unsorted\`) and #1848 (\`to_entries\`).

## Problem

\`eval.rs\`'s own \`builtin_map_values\` silently skipped both a decode-failure key and a #1194 structurally non-string/unpaired key in its \`Object\` arm, and had no #1677 malformed-delimiter protection on either arm — disagreeing with \`length\`/\`keys\`/\`to_entries\` on the same document.

## What changed

- **Object arm**: routed through \`effective_fields_checked\` for the walk/#1194/#1677 checks, then key resolution + \`DisplayKeyGuard\` collision detection — **not** plain \`key_display_string\` like \`keys\`/\`to_entries\` used, since \`map_values\` builds a real \`IndexMap\`, so two decode-failure keys sharing the same fallback spelling must raise rather than silently overwrite one another.
- **Array arm**: fixed proactively in the same pass, learning from #1848's review — switched from a bare \`for elem in elements\` to \`collect_cursors_checked\`, closing the identical #1677 gap for a malformed \`,\` between elements.

## Review history

Two review rounds:

1. **First round** found two real bugs: (a) the object arm hardcoded \`collapse: false\` instead of deriving \`S::COLLAPSE_DUPLICATE_KEYS\` (map_values, unlike keys/to_entries, has \`S\` available) — real jq collapses a duplicate key before evaluating the filter, so applying \`f\` to a value real jq would have discarded could raise an error jq never reaches; (b) the collision-guard check ran *before* \`f\` was evaluated, so a field whose own \`f\`-output was \`QueryResult::None\` could still trigger a false-positive, uncatchable collision error against a later field sharing the same #1642 fallback spelling. Both live-verified and fixed — see commit \`6104ee76d\`'s own message for the exact repros.
2. **Second round** confirmed the restructured control flow is correct (a full line-by-line audit found the \`value_to_insert\` match preserves every original \`QueryResult\` variant's semantics, and the guard-check-then-insert ordering can't desync), and flagged a genuine coverage gap: the \`S::COLLAPSE_DUPLICATE_KEYS\` branch had zero test coverage under \`YqSemantics\` (yq mode doesn't collapse, so both duplicate occurrences reach \`f\` and the second's result overwrites the first). Added a dedicated yq-mode test, plus a small \`let-else\` style consistency fix.

## Scope note

Per #1829's own acceptance criteria, \`paths\`, \`with_entries\`'s own post-\`to_entries\` reassembly step, and \`leaf_paths\` still need their own audits/fixes (plus \`pick\`/\`omit\`). Leaving #1829 open for those slices.

## Testing

- \`test_builtin_map_values_preserves_decode_failure_key_1829\`: pins the exact fallback spelling and transformed value.
- \`test_builtin_map_values_raises_on_structurally_malformed_key_1829\` / \`test_builtin_map_values_raises_on_malformed_delimiter_1677\`: #1194/#1677 raise on both arms.
- \`test_builtin_map_values_optional_suppresses_malformed_key_errors_1829\`: \`map_values?\` suppresses all three shapes.
- \`test_builtin_map_values_collapses_duplicate_key_before_evaluating_f_1829\`: pins the duplicate-key-collapse fix.
- \`test_builtin_map_values_raises_on_colliding_fallback_keys_1829\`: pins the genuine-collision case (both values survive \`f\`).
- \`test_builtin_map_values_no_false_positive_collision_when_value_dropped_1829\`: pins the false-positive fix.
- \`test_builtin_map_values_yq_mode_does_not_collapse_duplicate_key_1829\`: pins yq mode's own last-key-wins duplicate handling.
- Full local suite green: 3025 lib tests, 1073 jq CLI tests, 1270 yq CLI tests, yq golden conformance, cli_golden_tests, evaluator parity — 0 failures (one unrelated \`test_valid_multibyte_document_is_untouched_1247\` SIGKILL flake under concurrent load, confirmed passes in isolation and on a single-threaded re-run).
- \`cargo clippy --all-targets --all-features -- -D warnings\` and the CI's second clippy leg both clean. \`cargo fmt --check\`, \`cargo build --no-default-features\` (no_std), \`cargo doc --no-deps --all-features\` all clean.
- Live-verified against the pinned oracle throughout.