### PR TITLE
fix(yq): split(re; flags) ignores every argument once arity exceeds 1

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -415,14 +415,31 @@ $ echo '"aaa"' | yq            'sub("A";"X";"i")'   # "aaa" (flags never read, n
 $ echo '"aaa"' | succinctly yq 'sub("A";"X";"i")'   # "aaa" (matches)
 ```
 
-`split`'s 2-arg `split(re; flags)` form has an unrelated, still-unresolved mystery of its
-own ([#1439](https://github.com/rust-works/succinctly/issues/1439)) — it doesn't do a regex
-split at all:
+### 2-argument `split(re; flags)` — resolved, real yq ignores every argument once arity exceeds 1
+
+`split`'s 2-arg `split(re; flags)` form had an unrelated mystery of its own, now resolved
+by [#1439](https://github.com/rust-works/succinctly/issues/1439): the same fixed-AST-slot
+shape as `sub` above, not a designed feature. Real yq's `split` ignores every argument once
+arity exceeds 1 and behaves exactly as `split("")` — splitting the input into individual
+Unicode characters, not a regex split, and not jq's `split/2`. Confirmed live: an
+`error(...)` placed in either the pattern or the flags argument never fires, and neither a
+present nor absent literal pattern changes the output at all:
 
 ```bash
 $ echo '"a1b2c"' | yq            -o=json 'split("[0-9]";"g")'   # ["a","1","b","2","c"]
-$ echo '"a1b2c"' | succinctly yq -o=json 'split("[0-9]";"g")'   # ["a","b","c"] -- jq-modeled regex split
+$ echo '"a1b2c"' | succinctly yq -o=json 'split("[0-9]";"g")'   # ["a","1","b","2","c"] (matches)
+$ echo '"a,b,c"' | yq            -o=json 'split(",";"g")'       # ["a",",","b",",","c"] -- pattern is present, still irrelevant
+$ echo '"a,b,c"' | succinctly yq -o=json 'split(",";"g")'       # ["a",",","b",",","c"] (matches)
 ```
+
+Per [ADR-0018](../../adrs/adr-0018.md) rule 3, succinctly reproduces this bug-for-bug rather
+than performing an actual regex split; arity 3+ is accepted and discarded (parser leniency),
+matching `sub`'s own arity 4+ handling above. The 1-arg `split(s)` form is unaffected — its
+own argument really is evaluated and used (`split(error("boom"))` still raises, confirmed
+live) — and `succinctly jq`'s `split/2` keeps its real jq-modeled regex-split behavior
+unchanged in jq mode. Non-string-input error wording (`array (...) cannot be matched, as it
+is not a string` vs. real yq's `cannot split !!seq, can only split strings`) is a separate,
+pre-existing gap unrelated to arity, not addressed here.
 
 ### Global regex zero-width-match iteration — resolved, real yq uses Go's `regexp`
 
@@ -551,7 +568,7 @@ which was true only before #1534.
   `inside` at all to verify it against — see the fan-out table above). Confirmed by
   `test_yq_contains_scalar_vs_scalar_kind_mismatch_answers_false_1649` and its siblings.
 
-### Regex flag grammar — `test`/`match`/`capture` fixed, `split` still open
+### Regex flag grammar — `test`/`match`/`capture` fixed
 
 **Fixed by [#1426](https://github.com/rust-works/succinctly/issues/1426):** real yq doesn't
 use jq's flag grammar at all for `test`/`match`/`capture` — only `g` is a real flag; every
@@ -574,9 +591,10 @@ Deliberately **not** extended to:
 - `sub` — moot rather than unverified now that #1122 resolved its mystery: 3-arg `sub`
   never evaluates its `flags` argument at all, so there is no flags *grammar* to check in
   the first place, valid or garbage.
-- `split` — its own mystery (#1439, above) is still genuinely unresolved; applying this
-  rule there without first understanding its actual argument semantics would be a new,
-  unverified guess.
+- `split` — moot rather than unverified now that #1439 resolved its mystery (above):
+  2-arg `split(re; flags)` never evaluates its `flags` argument (or its pattern) at all
+  once arity reaches 2, so there is no flags *grammar* to check in the first place,
+  valid or garbage — the same reasoning as `sub` immediately above.
 - `gsub`/`scan`/`splits` (not real yq builtins at all, per #1436 — flag validation is moot
   for a call real yq would reject before ever reaching it).
 - The array-unpack form (`test(["abc","i"])`, no explicit flags argument) — real yq's own
@@ -611,12 +629,14 @@ $ echo '"a1X5c"' | succinctly yq 'test(1.5)'      # was: Error: number (1.5) is 
 
 `Null`/`Bool`/`Int`/`Float`/`NumberLiteral` now coerce (`owned_to_string`-equivalent)
 before the existing type-check runs; jq mode is unaffected (real jq 1.7.1 keeps
-strict typing here too, matching ADR-0018 rule 2). `split(re;flags)`'s own output
-still diverges from real yq for an unrelated, already-tracked reason regardless of
-this fix (below: "3-argument `sub`" section's sibling gap, tracked as
-[#1439](https://github.com/rust-works/succinctly/issues/1439) — succinctly performs
-a real regex split, real yq's own `split` doesn't remove the matched delimiter at
-all) — this fix only closes the pattern-type gap, not #1439's separate one.
+strict typing here too, matching ADR-0018 rule 2). This coercion applied to
+2-arg `split(re;flags)`'s pattern too at the time — moot as of #1439 (above): once
+arity reaches 2, yq mode never evaluates the pattern at all (it dispatches to the
+same `split("")` behavior as every other arity-2+ call, regardless of what the
+pattern argument is), so there is no pattern *value* left for this coercion to
+apply to in yq mode any more, the same way #1439 also mooted the flags-grammar
+question for `split` above. jq mode's own `split/2` is unaffected either way — it
+never went through this coercion (strict typing, matching real jq).
 
 Deliberately **not** extended to a container (`Array`/`Object`) pattern — this fix's
 own live probes showed real yq doesn't simply error there either, but its exact

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13889,6 +13889,18 @@ fn builtin_split_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // Real yq's `split(re; flags[, ...])` ignores every argument once arity
+    // exceeds 1 and behaves exactly as `split("")` -- the same fixed-AST-
+    // slot-past-arity-1 upstream Go bug shape already documented for
+    // `sub(re; s; flags)` (#1122), confirmed live against yq v4.53.3
+    // (#1439). Dispatched *before* either argument is evaluated, not just
+    // ignored after: `split(error("boom");"y")` doesn't raise in real yq
+    // (confirmed live), so `re_expr`/`flags_expr` must never be touched
+    // here, matching how `sub`'s own yq-mode arm never evaluates its
+    // `replacement`/`flags` either.
+    if S::TAG == EvalTag::Yq {
+        return yq_split_ignores_arguments::<W>(&value, optional);
+    }
     fanout_regex_pattern_with_collected_flags::<W, S>(
         re_expr,
         flags_expr,
@@ -13899,6 +13911,36 @@ fn builtin_split_regex<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             split_regex_resolved::<W>(pattern, global_flags, &value, optional)
         },
     )
+}
+
+/// Real yq's `split(re; flags[, ...extra arity-3+ args])`: never a regex
+/// split at all (#1439) -- see `builtin_split_regex`'s own doc comment for
+/// why this is dispatched to before `re_expr`/`flags_expr` are ever
+/// evaluated. Shares `split_regex_resolved`'s "read the input string,
+/// raising the same wording it already does for a decode failure or a
+/// non-string input" step (that error wording's own mismatch against real
+/// yq's `cannot split !!seq, can only split strings` is a separate,
+/// pre-existing, explicitly out-of-scope gap per #1439's own issue body,
+/// unrelated to arity) rather than `builtin_split`'s -- the two already
+/// diverge on this wording and #1439 doesn't unify them.
+#[cfg(feature = "regex")]
+fn yq_split_ignores_arguments<'a, W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    let input = match value {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(cow) => cow,
+            Err(e) => return QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
+        _ if optional => return QueryResult::None,
+        _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(value))),
+    };
+    let parts: Vec<OwnedValue> = input
+        .chars()
+        .map(|c| OwnedValue::String(c.to_string()))
+        .collect();
+    QueryResult::Owned(OwnedValue::Array(parts))
 }
 
 /// `split(re; flags)`'s work once the pattern and every flags value are

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7486,9 +7486,7 @@ fn builtin_split<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     // jq: split("") returns each character as a separate element
                     // Rust's split("") includes empty strings at boundaries, so special-case it
                     let parts: Vec<OwnedValue> = if sep.is_empty() {
-                        cow.chars()
-                            .map(|c| OwnedValue::String(c.to_string()))
-                            .collect()
+                        split_into_individual_chars(&cow)
                     } else {
                         cow.split(&sep)
                             .map(|p| OwnedValue::String(p.to_string()))
@@ -13936,11 +13934,22 @@ fn yq_split_ignores_arguments<'a, W: Clone + AsRef<[u64]>>(
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::cannot_be_matched(&to_owned(value))),
     };
-    let parts: Vec<OwnedValue> = input
-        .chars()
+    QueryResult::Owned(OwnedValue::Array(split_into_individual_chars(&input)))
+}
+
+/// One `OwnedValue::String` per Unicode character of `s` -- `split("")`'s
+/// own behavior, shared by [`builtin_split`]'s empty-separator case and
+/// [`yq_split_ignores_arguments`] (#1439), whose entire arity-2+ result
+/// *is* this: real yq's `split(re; flags)` doesn't merely fall back to it
+/// on some edge case, it always equals it once arity exceeds 1. The two
+/// callers' surrounding error handling for a non-string/undecodable input
+/// intentionally differs (`builtin_split` vs. `split_regex_resolved`'s own
+/// wording, #1439's own issue body: not unified here), so only this pure
+/// splitting step is factored out, not the input-extraction around it.
+fn split_into_individual_chars(s: &str) -> Vec<OwnedValue> {
+    s.chars()
         .map(|c| OwnedValue::String(c.to_string()))
-        .collect();
-    QueryResult::Owned(OwnedValue::Array(parts))
+        .collect()
 }
 
 /// `split(re; flags)`'s work once the pattern and every flags value are

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2606,6 +2606,24 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
+                // yq mode accepts (and ignores) any further `; expr`
+                // arguments at arity 3+, the same fixed-slot-past-arity-1
+                // parser leniency already established for `sub` above
+                // (#1122) -- confirmed live against yq v4.53.3: `split("x";
+                // "y"; "z")` parses and behaves identically to arity 2
+                // (#1439). Parsed and discarded here, not evaluated at all:
+                // `builtin_split_regex`'s yq-mode arm never evaluates `s`/
+                // `flags` either, so a discarded 3rd+ argument is
+                // consistent with that same "every argument past arity 1 is
+                // a dead AST slot" rule, not a separate carve-out for it.
+                if self.mode == ParserMode::Yq {
+                    while self.peek() == Some(';') {
+                        self.next();
+                        self.skip_ws();
+                        self.parse_expr()?;
+                        self.skip_ws();
+                    }
+                }
                 self.expect(')')?;
                 return Ok(Some(Builtin::SplitRegex(Box::new(s), Box::new(flags))));
             }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -285,6 +285,30 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Consumes and discards any further `; expr` arguments past the
+    /// arity real yq's evaluator actually reads, in yq mode only -- shared
+    /// by `sub(re; s; flags[, ...])` (#1122) and `split(re; flags[, ...])`
+    /// (#1439), the two builtins confirmed live against yq v4.53.3 to have
+    /// this same fixed-AST-slot-past-arity-N upstream Go bug shape. Each
+    /// caller parses its own required arguments first and calls this only
+    /// once positioned at the (possibly absent) first extra `;`; the
+    /// parsed-and-discarded expressions are never evaluated, matching how
+    /// neither builtin's yq-mode evaluator arm reads past its own last
+    /// used argument either. A no-op in jq mode, and a no-op if there is
+    /// no further `;` to consume -- callers don't need their own mode
+    /// check before calling this.
+    fn parse_yq_arity_leniency_tail(&mut self) -> Result<(), ParseError> {
+        if self.mode == ParserMode::Yq {
+            while self.peek() == Some(';') {
+                self.next();
+                self.skip_ws();
+                self.parse_expr()?;
+                self.skip_ws();
+            }
+        }
+        Ok(())
+    }
+
     /// Check if current position matches a keyword (followed by non-ident char).
     fn matches_keyword(&self, keyword: &str) -> bool {
         if !self.input[self.pos..].starts_with(keyword) {
@@ -2607,23 +2631,13 @@ impl<'a> Parser<'a> {
                 let flags = self.parse_expr()?;
                 self.skip_ws();
                 // yq mode accepts (and ignores) any further `; expr`
-                // arguments at arity 3+, the same fixed-slot-past-arity-1
-                // parser leniency already established for `sub` above
-                // (#1122) -- confirmed live against yq v4.53.3: `split("x";
-                // "y"; "z")` parses and behaves identically to arity 2
-                // (#1439). Parsed and discarded here, not evaluated at all:
-                // `builtin_split_regex`'s yq-mode arm never evaluates `s`/
-                // `flags` either, so a discarded 3rd+ argument is
-                // consistent with that same "every argument past arity 1 is
-                // a dead AST slot" rule, not a separate carve-out for it.
-                if self.mode == ParserMode::Yq {
-                    while self.peek() == Some(';') {
-                        self.next();
-                        self.skip_ws();
-                        self.parse_expr()?;
-                        self.skip_ws();
-                    }
-                }
+                // arguments at arity 3+ -- confirmed live against yq
+                // v4.53.3: `split("x"; "y"; "z")` parses and behaves
+                // identically to arity 2 (#1439). See
+                // `parse_yq_arity_leniency_tail`'s own doc comment for why
+                // this is shared with `sub` below rather than a second
+                // hand-copied loop.
+                self.parse_yq_arity_leniency_tail()?;
                 self.expect(')')?;
                 return Ok(Some(Builtin::SplitRegex(Box::new(s), Box::new(flags))));
             }
@@ -2689,19 +2703,10 @@ impl<'a> Parser<'a> {
                 // arguments -- confirmed live against yq v4.53.3: arity 4+
                 // parses and behaves identically to arity 3 (#1122), unlike
                 // jq, where `sub/4` is a hard "not defined" compile error.
-                // Parsed and discarded here, not evaluated at all --
-                // `yq_sub_arity3_empty_replace` already never reads
-                // `replacement`/`flags` either, so a discarded 4th+ argument
-                // is consistent with that same "ignored past the first"
-                // rule, not a separate carve-out for it.
-                if self.mode == ParserMode::Yq {
-                    while self.peek() == Some(';') {
-                        self.next();
-                        self.skip_ws();
-                        self.parse_expr()?;
-                        self.skip_ws();
-                    }
-                }
+                // See `parse_yq_arity_leniency_tail`'s own doc comment for
+                // why this is shared with `split` above rather than a
+                // second hand-copied loop (#1439 review).
+                self.parse_yq_arity_leniency_tail()?;
                 self.expect(')')?;
                 return Ok(Some(Builtin::SubFlags(
                     Box::new(re),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21917,20 +21917,20 @@ fn test_yq_regex_pattern_coercion_container_known_gap_1443() -> Result<()> {
     Ok(())
 }
 
-/// #1443: `split(re; flags)` -- a real yq builtin, unlike `gsub`/`scan`/
-/// `splits` which share this same helper but are succinctly's own
-/// extensions -- also coerces a numeric pattern instead of erroring.
-/// Asserts only that it no longer errors, not the exact output shape:
-/// `split`'s own output already diverges from real yq for an unrelated,
-/// already-tracked reason (#1439 -- succinctly does a real regex split,
-/// real yq's own `split(re;flags)` doesn't remove the matched delimiter
-/// at all), live-verified independently of this fix
-/// (`split("[0-9]";"g")` on `"a1b2c"` is `["a","1","b","2","c"]` in real
-/// yq, `["a","b","c"]` in succinctly, both before and after this change).
+/// #1443's own pattern-coercion fix is now moot for `split` specifically
+/// (superseded by #1439, not just "still not erroring"): once arity
+/// reaches 2, yq mode never evaluates the pattern at all, so a numeric
+/// pattern was never actually "coerced" here in the first place -- it's
+/// simply ignored, the same as any other pattern would be. This test used
+/// to assert only `code == 0` (not the exact output), since #1439 hadn't
+/// resolved `split`'s output shape yet at the time; now that it has, this
+/// checks the real, oracle-matched output too.
 #[test]
 fn test_yq_split_regex_pattern_coerces_1443() -> Result<()> {
     let (out, code) = run_yq_stdin("split(1;\"g\")", "a1c", &["-o", "json"])?;
     assert_eq!(code, 0, "out={out}");
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!(["a", "1", "c"]));
     Ok(())
 }
 
@@ -22194,15 +22194,137 @@ fn test_yq_scan_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
     Ok(())
 }
 
-/// `split(re;flags)` *is* a real yq builtin, but has its own separate,
-/// unresolved algorithm mismatch (#1439) -- #1255 deliberately doesn't
-/// touch it. Guards `builtin_split_regex`'s hardcoded `JqSemantics` call.
+/// `split(re;flags)`'s hardcoded `JqSemantics` zero-width-match call
+/// (#1255) is guarded here in **jq mode**, not yq: #1439 resolved yq
+/// mode's own separate mystery by finding it never reaches
+/// `split_regex_resolved`/`global_captures` at all once arity reaches 2
+/// (it dispatches to a plain char-split, ignoring the pattern
+/// completely) -- so `run_yq_stdin` on this exact filter no longer
+/// exercises the code this test exists to pin, and jq mode is now the
+/// only spelling that does. `run_jq_stdin`, not `run_yq_stdin`, is
+/// therefore the fix, not a substitution of convenience.
 #[test]
-fn test_yq_split_regex_keeps_jq_style_zero_width_1255() -> Result<()> {
-    let (output, code) = run_yq_stdin(r#"split("a*"; "g")"#, "\"bab\"\n", &["-o", "json"])?;
+fn test_jq_split_regex_keeps_zero_width_1255() -> Result<()> {
+    let (output, _stderr, code) =
+        run_jq_stdin_with_stderr(r#"split("a*"; "g")"#, "\"bab\"\n", &["-c"])?;
     assert_eq!(code, 0, "output: {output:?}");
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v, serde_json::json!(["", "b", "", "b", ""]));
+    Ok(())
+}
+
+/// #1439: real yq's `split(re; flags)` ignores every argument once arity
+/// exceeds 1 and behaves exactly as `split("")` -- splitting into
+/// individual Unicode characters, not a regex split. This is the yq-mode
+/// counterpart the test above no longer covers: the same `"a*"` pattern
+/// that means "zero-width match, keep splitting" in jq mode is inert
+/// here, and the full input's own characters are what's produced instead.
+#[test]
+fn test_yq_split_regex_ignores_pattern_and_flags_1439() -> Result<()> {
+    let (output, code) = run_yq_stdin(r#"split("a*"; "g")"#, "\"bab\"\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    let v: serde_json::Value = serde_json::from_str(&output)?;
+    assert_eq!(v, serde_json::json!(["b", "a", "b"]));
+    Ok(())
+}
+
+/// #1439's full oracle-verified probe table (issue body), condensed into
+/// one table-driven test: a present, absent, or matching-but-irrelevant
+/// pattern all produce the identical char-split output, including a
+/// multi-byte (rune, not byte) input.
+#[test]
+fn test_yq_split_regex_probe_table_1439() -> Result<()> {
+    for (filter, input, expected) in [
+        (
+            r#"split("[0-9]";"g")"#,
+            "\"a1b2c\"",
+            serde_json::json!(["a", "1", "b", "2", "c"]),
+        ),
+        (
+            r#"split("[0-9]";"x")"#,
+            "\"a1b2c\"",
+            serde_json::json!(["a", "1", "b", "2", "c"]),
+        ),
+        (
+            r#"split("[0-9]";"")"#,
+            "\"a1b2c\"",
+            serde_json::json!(["a", "1", "b", "2", "c"]),
+        ),
+        (
+            r#"split("XX";"g")"#,
+            "\"aXXbXXc\"",
+            serde_json::json!(["a", "X", "X", "b", "X", "X", "c"]),
+        ),
+        (
+            r#"split(",";"g")"#,
+            "\"a,b,c\"",
+            serde_json::json!(["a", ",", "b", ",", "c"]),
+        ),
+        (
+            r#"split("Z";"g")"#,
+            "\"abc\"",
+            serde_json::json!(["a", "b", "c"]),
+        ),
+        (r#"split("x";"y")"#, "\"\"", serde_json::json!([])),
+        (
+            r#"split("x";"y")"#,
+            "\"aé日b\"",
+            serde_json::json!(["a", "é", "日", "b"]),
+        ),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter} on {input}: out={out}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, expected, "{filter} on {input}");
+    }
+    Ok(())
+}
+
+/// #1439: neither argument is evaluated once arity reaches 2 -- not just
+/// "the result doesn't reflect them," but genuinely never touched, so an
+/// `error(...)` in either position never fires. The arity-1 form is the
+/// contrast case: its one argument really is evaluated and used.
+#[test]
+fn test_yq_split_regex_arguments_never_evaluated_1439() -> Result<()> {
+    for filter in [
+        r#"split(error("boom1");"y")"#,
+        r#"split("x";error("boom2"))"#,
+    ] {
+        let (out, code) = run_yq_stdin(filter, "\"abc\"", &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}: out={out}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, serde_json::json!(["a", "b", "c"]), "{filter}");
+    }
+    // Contrast: the 1-arg form's own argument really is evaluated.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(r#"split(error("boom"))"#, "\"abc\"\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("boom"), "stderr={stderr}");
+    Ok(())
+}
+
+/// #1439: arity 3+ is accepted (parser leniency) and every extra argument
+/// is discarded without evaluation, matching `sub`'s own arity 4+
+/// handling (#1122) -- confirmed live against yq v4.53.3.
+#[test]
+fn test_yq_split_regex_arity_three_plus_accepted_1439() -> Result<()> {
+    for filter in [r#"split("x";"y";"z")"#, "split(1;2)"] {
+        let (out, code) = run_yq_stdin(filter, "\"abc\"", &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}: out={out}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, serde_json::json!(["a", "b", "c"]), "{filter}");
+    }
+    Ok(())
+}
+
+/// #1439 negative control: `succinctly jq`'s own `split/2` keeps its real
+/// jq-modeled regex-split behavior unchanged -- this fix is yq-mode only.
+#[test]
+fn test_jq_split_regex_unaffected_by_1439() -> Result<()> {
+    let (out, _stderr, code) =
+        run_jq_stdin_with_stderr(r#"split("[0-9]";"g")"#, "\"a1b2c\"", &["-c"])?;
+    assert_eq!(code, 0, "out={out}");
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!(["a", "b", "c"]));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Real yq's `split(re; flags)` ignores every argument once arity exceeds 1 and always behaves as `split("")` — one element per Unicode character, not a regex split. Same upstream Go bug shape already documented for `sub(re; s; flags)` (#1122): the argument is read from a fixed AST slot that's empty at higher arities, not a designed feature.

Confirmed live against yq v4.53.3 across the issue's full probe table: a present-but-irrelevant literal pattern, `error(...)` never firing in either argument position (genuinely unevaluated, not just unused), arity 3+ accepted and discarded the same way `sub`'s arity 4+ already is, and the 1-arg `split(s)` form staying unaffected (its own argument really is evaluated).

## Implementation

- `builtin_split_regex` dispatches on `S::TAG == EvalTag::Yq` *before* either argument is evaluated — `fanout_regex_pattern_with_collected_flags` is never called in yq mode once arity reaches 2, matching "neither argument evaluated" exactly rather than "evaluated but ignored."
- Parser accepts (and discards, unevaluated) arity 3+ in yq mode only, mirroring `sub`'s existing precedent.
- `succinctly jq`'s own `split/2` is unchanged.
- `docs/compliance/yq/limitations.md`: resolved the existing "split — still open" stub, and updated the adjacent flag-grammar and #1443 pattern-coercion notes that pointed at this as an open question.

## Tests

Two pre-existing tests pinned the old (real-regex-split) output as intentional — updated now that #1439 resolves what they called an unresolved question:
- `test_yq_split_regex_pattern_coerces_1443` — was asserting only `code == 0`; now checks the real output too.
- `test_yq_split_regex_keeps_jq_style_zero_width_1255` → renamed `test_jq_split_regex_keeps_zero_width_1255`, converted to jq mode — yq mode no longer reaches the code this test exists to guard (`split_regex_resolved`/`global_captures`), so jq mode is now the only spelling that does.

Added 5 new tests: the full probe table, "neither argument evaluated," "arity 3+ accepted," a yq-mode zero-width-pattern-is-inert case, and a jq-mode negative control.

## Verification

Full `jq_cli_tests`/`yq_cli_tests` suites (1079 + 1276 tests), both CI clippy legs, `--no-default-features` (no_std) build, and `cargo doc --all-features` all green.

Fixes #1439