### PR TITLE
refactor(yaml): drop write_deferred_prefix's always-None key_comment param

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1803,18 +1803,36 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         let value = field.value_cursor();
                         if is_yaml_cursor_container(&value) && value.style() != "flow" {
                             // The key's own trailing comment (#765), then
-                            // the anchor/tag -- both via the same helper
-                            // #1077/#1113's scalar/absent branch uses, so
-                            // this branch stops hand-writing (and dropping)
-                            // the tag, and stops mis-placing the anchor
-                            // after the comment instead of on its own line
-                            // (#1132).
-                            write_deferred_prefix(
-                                out,
-                                field.key_cursor().line_comment_raw(),
-                                value.anchor(),
-                                value.explicit_tag(),
-                            )?;
+                            // the anchor/tag: with no comment, both go on
+                            // this line via the shared `write_anchor_tag`
+                            // helper #1077/#1113's scalar/absent branch
+                            // also uses; with one, it's written first, then
+                            // the anchor/tag move to their own line at
+                            // column 0 -- this branch stops hand-writing
+                            // (and dropping) the tag, and stops mis-placing
+                            // the anchor after the comment instead of on
+                            // its own line (#1132). Inline rather than
+                            // through the shared helper (#1828): this is
+                            // the only one of its four original callers
+                            // that ever had a comment to place.
+                            if let Some(comment) = field.key_cursor().line_comment_raw() {
+                                write_line_comment(out, Some(comment))?;
+                                if value.anchor().is_some() || value.explicit_tag().is_some() {
+                                    out.write_char('\n')?;
+                                    if let Some(anchor) = value.anchor() {
+                                        out.write_char('&')?;
+                                        out.write_str(anchor)?;
+                                        if value.explicit_tag().is_some() {
+                                            out.write_char(' ')?;
+                                        }
+                                    }
+                                    if let Some(tag) = value.explicit_tag() {
+                                        out.write_str(tag)?;
+                                    }
+                                }
+                            } else {
+                                write_anchor_tag(out, value.anchor(), value.explicit_tag())?;
+                            }
                             out.write_char('\n')?;
                             let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
                             out.write_str(&child_indent)?;
@@ -1945,7 +1963,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             let tag = cursor.explicit_tag();
                             if anchor.is_some() || tag.is_some() {
                                 out.write_char('-')?;
-                                write_deferred_prefix(out, None, anchor, tag)?;
+                                write_anchor_tag(out, anchor, tag)?;
                                 out.write_char('\n')?;
                                 // Same "compact" rule as the non-anchored `else`
                                 // arm below: the value's own content aligns
@@ -6718,38 +6736,30 @@ fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool 
     }
 }
 
-/// Writes a mapping key's own trailing comment (if any), then an anchor
-/// and/or explicit tag -- the part of a deferred value's rendering shared
-/// by the scalar/absent-value branch (`write_deferred_value`) and the
-/// container-value branch of `stream_yaml_value`'s block-style loop
+/// Writes a value's anchor and/or explicit tag on the current line, with a
+/// leading space when either is present -- the part of a deferred value's
+/// rendering shared by the scalar/absent-value branch (`write_deferred_value`)
+/// and the container-value branch of `stream_yaml_value`'s block-style loop
 /// (#1132; previously duplicated by hand in the latter, which dropped the
 /// tag entirely and mis-placed the anchor after a key comment).
 ///
-/// Two orderings, both verified against yq v4.53.3:
-/// - No key comment: ` &anchor` then ` !!tag` on the *current* line (the
-///   line the key's own `:` is on) -- #1077's original rule, unchanged.
-/// - Key comment present: the comment is written first, then a newline,
-///   then the anchor/tag on their own line -- at *absolute column 0*, not
-///   the key's own indent, confirmed even when the key itself is nested
-///   (`parent:\n  k: # c\n&anc\n    a: 1` is real yq's own output, not
-///   `parent:\n  k: # c\n  &anc\n    a: 1`).
+/// Verified against yq v4.53.3: ` &anchor` then ` !!tag` on the *current*
+/// line (the line the key's own `:` is on) -- #1077's original rule.
 ///
-/// `write_deferred_value` always passes `None` for `key_comment`: its own
-/// comment handling lives at its call site, unchanged from #1077/#1113, so
-/// this extraction can't regress it (verified: passing `None` reproduces
-/// that function's prior inline logic byte-for-byte).
-fn write_deferred_prefix<Out: core::fmt::Write>(
+/// A mapping key's own trailing comment (#1132) is a different ordering --
+/// comment, then a newline, then the anchor/tag on their own line at
+/// *absolute column 0* (not the key's own indent, confirmed even when the
+/// key itself is nested) -- handled inline at `stream_yaml_value`'s own
+/// call site instead, the only one of this function's four original
+/// callers that ever had a comment to place (#1828): baking that shape in
+/// here meant three call sites always passed `None` for it, each carrying
+/// a comment in this function's own doc explaining why.
+fn write_anchor_tag<Out: core::fmt::Write>(
     out: &mut Out,
-    key_comment: Option<&str>,
     anchor: Option<&str>,
     tag: Option<&str>,
 ) -> core::fmt::Result {
-    if let Some(comment) = key_comment {
-        write_line_comment(out, Some(comment))?;
-        if anchor.is_some() || tag.is_some() {
-            out.write_char('\n')?;
-        }
-    } else if anchor.is_some() || tag.is_some() {
+    if anchor.is_some() || tag.is_some() {
         out.write_char(' ')?;
     }
     if let Some(anchor) = anchor {
@@ -6791,9 +6801,9 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     let absent = is_deferred_value_absent(value);
     let anchor = value.anchor();
     let tag = if absent { value.explicit_tag() } else { None };
-    write_deferred_prefix(out, None, anchor, tag)?;
+    write_anchor_tag(out, anchor, tag)?;
     if !absent {
-        // Neither `write_deferred_prefix` nor the anchor/tag it may have
+        // Neither `write_anchor_tag` nor the anchor/tag it may have
         // just written know a value follows -- exactly one separator space
         // always belongs here regardless of whether anchor/tag were
         // present (`: value` or `: &anchor value`), matching the original,
@@ -7073,7 +7083,7 @@ where
 /// Mirrors the `Sequence` block/flow-style rendering in `stream_yaml_value`
 /// (same container-vs-scalar branching, same empty-sequence `"[]"`
 /// shortcut, same `#785` compact-form handling, same anchor/tag handling
-/// via `write_deferred_prefix`/`write_deferred_value`, and per-item
+/// via `write_anchor_tag`/`write_deferred_value`, and per-item
 /// trailing-comment write) so multi-document slurped output matches
 /// single-document M2 streaming byte-for-byte, including #1077's
 /// deferred-and-absent-value handling: an earlier draft of this comment
@@ -7142,7 +7152,7 @@ where
                 let tag = cursor.explicit_tag();
                 if anchor.is_some() || tag.is_some() {
                     out.write_char('-')?;
-                    write_deferred_prefix(out, None, anchor, tag)?;
+                    write_anchor_tag(out, anchor, tag)?;
                     out.write_char('\n')?;
                     // Same "compact" rule as the non-anchored `else` arm
                     // below: the value's own content aligns under the `- `
@@ -7177,7 +7187,7 @@ where
                 // still-unfixed copy of the #1132 anchor-only pattern --
                 // hand-writing the anchor and never checking
                 // `explicit_tag()`, unlike its container-branch sibling
-                // just above (fixed via `write_deferred_prefix`) and
+                // just above (fixed via `write_anchor_tag`) and
                 // `stream_yaml_value`'s own equivalent Sequence-loop scalar
                 // branch (fixed via `write_deferred_value`). It also drops
                 // the tag on a genuinely deferred-and-absent top-level

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12565,7 +12565,7 @@ fn test_explicit_key_comment_keeps_anchor_and_tag_on_deferred_absent_value_1113(
 // anchor and never consult `value.explicit_tag()`, and unconditionally
 // appended the anchor onto the same line as a floated key comment instead of
 // giving it its own line. Both are now routed through the same
-// `write_deferred_prefix` helper #1077/#1113's branch already used (via
+// `write_anchor_tag` helper #1077/#1113's branch already used (via
 // `write_deferred_value`), extracted so both branches share one ordering
 // rule instead of hand-writing it twice. All four shapes below are pinned
 // against the live real `yq` binary (v4.53.3).
@@ -12614,7 +12614,7 @@ fn test_container_anchor_and_tag_move_to_own_line_after_key_comment_1132() -> Re
     Ok(())
 }
 
-/// Regression guard: the `write_deferred_prefix` extraction must leave the
+/// Regression guard: the `write_anchor_tag` extraction must leave the
 /// scalar/absent-value branch's own #1113 behavior byte-for-byte unchanged.
 #[test]
 fn test_scalar_absent_value_anchor_tag_comment_unchanged_after_1132_extraction() -> Result<()> {
@@ -12762,7 +12762,7 @@ fn test_flow_anchor_keeps_tag_on_empty_container_1115() -> Result<()> {
 }
 
 /// `--slurp`'s container branch (already routed through
-/// `write_deferred_prefix` alongside #1132's fix above) is unaffected by
+/// `write_anchor_tag` alongside #1132's fix above) is unaffected by
 /// the scalar-branch fix below -- an anchored container item renders
 /// identically to before.
 #[test]


### PR DESCRIPTION
## Summary
- `write_deferred_prefix`'s `key_comment: Option<&str>` parameter was only ever populated at one of its four call sites (`stream_yaml_value`'s Mapping-field branch); the other three always passed `None`, and the function's own doc comment had to explain that `None` reproduces pre-extraction behavior — a sign the parameter belonged at the one call site that needs it, not in the shared signature.
- Narrowed to `write_anchor_tag(out, anchor, tag)` — just the shared "leading space, then `&anchor`, then tag" logic all four callers actually use.
- Inlined the comment-then-newline ordering (comment first, then anchor/tag on their own line at absolute column 0) at the one call site that needs it, preserving both of that site's own branches (comment present vs absent) exactly.
- Fixed 3 stale doc-comment references elsewhere in the file that named the old function.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, including yq golden fixtures and #1444's own anchor/tag-carrying fixtures
- [x] Live spot-check: key-comment + container-anchor (column-0 placement), no-comment anchor, no-comment tag — all byte-identical against the pre-change binary
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Fixes #1828