### PR TITLE
test: spawn succinctly directly instead of via cargo run, stop orphans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
 
       # `tests/orchestrate_cli_tests.rs` is `#![cfg(feature = "bench-runner")]`
       # and was never previously built or run by any `cargo test` step here
@@ -255,7 +255,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
 
       - name: Run bench-runner-gated tests
         if: needs.gate.outputs.code == 'true'
@@ -357,7 +357,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
 
       - name: Run bench-runner-gated tests
         if: needs.gate.outputs.code == 'true'
@@ -423,7 +423,7 @@ jobs:
         run: cargo build --features cli --bin succinctly
 
       - name: Run cli-gated tests
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
 
       - name: Run bench-runner-gated tests
         run: cargo test --features cli,bench-runner --test orchestrate_cli_tests

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -20,56 +20,48 @@
 
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{cargo_run_features, classify_cargo_run_exit, MAX_CARGO_RETRIES};
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Run `succinctly <args>` with `stdin` piped in, returning captured stdout.
 ///
-/// Goes through the real binary (via `cargo run`) rather than the library so the
-/// snapshot reflects exactly what a user sees. Bails with stderr on failure so a
-/// broken query is a loud test error, not a silently-empty snapshot.
+/// Goes through the real binary directly (`CARGO_BIN_EXE_succinctly`, a
+/// compile-time path to this test binary's own already-built dependency)
+/// rather than the library, so the snapshot reflects exactly what a user
+/// sees. Used to go through a second `cargo run` subprocess instead: that
+/// orphans the real `succinctly` grandchild -- reparented to init, blocked
+/// forever on its now-unreadable stdout pipe -- the moment anything kills
+/// the outer `cargo test` process group (`cargo-guard.sh` does this by
+/// design on a detected stall, #935/#1847). No retry loop needed either:
+/// a compile-time path isn't a second cargo invocation that can hit lock
+/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
+/// path this used to need. Bails with stderr on failure so a broken query
+/// is a loud test error, not a silently-empty snapshot.
 fn run(args: &[&str], stdin: &str) -> Result<String> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let mut cmd = Command::new("cargo")
-            .args([
-                "run",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-            ])
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
 
-        if let Some(mut sin) = cmd.stdin.take() {
-            sin.write_all(stdin.as_bytes())?;
-        }
-
-        let output = cmd.wait_with_output()?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        if exit_code != 0 {
-            anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
-        }
-
-        return Ok(String::from_utf8(output.stdout)?);
+    if let Some(mut sin) = cmd.stdin.take() {
+        sin.write_all(stdin.as_bytes())?;
     }
-    unreachable!()
+
+    let output = cmd.wait_with_output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+
+    if exit_code != 0 {
+        anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -18,55 +18,52 @@
 //!
 //! Run with: cargo test --features cli --test cli_characterization_tests
 
-// #1847 review: `run` spawns `CARGO_BIN_EXE_succinctly` directly rather
-// than building it on demand via an inner `cargo run --features cli` the
-// way this file's helper used to -- that on-demand build was what let a
-// plain `cargo test` (no `--features cli`) still pass. `CARGO_BIN_EXE_
-// succinctly` only exists (and only builds the bin target at all) when
-// the *outer* invocation already has `--features cli` active, matching
-// every other CLI-invoking test file's own guard (`yq_cli_tests.rs`,
+// #1847 review: `run` spawns `succinctly_bin()` directly rather than
+// building it on demand via an inner `cargo run --features cli` the way
+// this file's helper used to -- that on-demand build was what let a plain
+// `cargo test` (no `--features cli`) still pass. `succinctly_bin()` only
+// exists (and only builds the bin target at all) when the *outer*
+// invocation already has `--features cli` active, matching every other
+// CLI-invoking test file's own guard (`yq_cli_tests.rs`,
 // `json_validate_tests.rs`, ...).
 #![cfg(feature = "cli")]
 
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
+use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 
 /// Run `succinctly <args>` with `stdin` piped in, returning captured stdout.
 ///
-/// Goes through the real binary directly (`CARGO_BIN_EXE_succinctly`, a
+/// Goes through the real binary directly (`succinctly_bin()`, a
 /// compile-time path to this test binary's own already-built dependency)
 /// rather than the library, so the snapshot reflects exactly what a user
 /// sees. Used to go through a second `cargo run` subprocess instead: that
 /// orphans the real `succinctly` grandchild -- reparented to init, blocked
 /// forever on its now-unreadable stdout pipe -- the moment anything kills
 /// the outer `cargo test` process group (`cargo-guard.sh` does this by
-/// design on a detected stall, #935/#1847). No retry loop needed either:
-/// a compile-time path isn't a second cargo invocation that can hit lock
-/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
-/// path this used to need. Bails with stderr on failure so a broken query
-/// is a loud test error, not a silently-empty snapshot.
+/// design on a detected stall, #935/#1847). Bails with stderr on failure
+/// so a broken query is a loud test error, not a silently-empty snapshot.
 fn run(args: &[&str], stdin: &str) -> Result<String> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut sin) = cmd.stdin.take() {
-        sin.write_all(stdin.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(args);
+            command
+        },
+        Some(stdin.as_bytes()),
+    )?;
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
 
+    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
+    // itself; a real exit code is therefore always present here.
+    let exit_code = output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     if exit_code != 0 {
         anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
     }

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -48,7 +48,7 @@ use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 /// design on a detected stall, #935/#1847). Bails with stderr on failure
 /// so a broken query is a loud test error, not a silently-empty snapshot.
 fn run(args: &[&str], stdin: &str) -> Result<String> {
-    let output = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.args(args);
@@ -58,12 +58,6 @@ fn run(args: &[&str], stdin: &str) -> Result<String> {
     )?;
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
-    // itself; a real exit code is therefore always present here.
-    let exit_code = output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     if exit_code != 0 {
         anyhow::bail!("`succinctly {}` failed: {stderr}", args.join(" "));
     }

--- a/tests/cli_characterization_tests.rs
+++ b/tests/cli_characterization_tests.rs
@@ -18,6 +18,16 @@
 //!
 //! Run with: cargo test --features cli --test cli_characterization_tests
 
+// #1847 review: `run` spawns `CARGO_BIN_EXE_succinctly` directly rather
+// than building it on demand via an inner `cargo run --features cli` the
+// way this file's helper used to -- that on-demand build was what let a
+// plain `cargo test` (no `--features cli`) still pass. `CARGO_BIN_EXE_
+// succinctly` only exists (and only builds the bin target at all) when
+// the *outer* invocation already has `--features cli` active, matching
+// every other CLI-invoking test file's own guard (`yq_cli_tests.rs`,
+// `json_validate_tests.rs`, ...).
+#![cfg(feature = "cli")]
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -5,44 +5,28 @@
 
 use anyhow::Result;
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{
-    cargo_run_features, classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES,
-};
+use cargo_run_exit::signal_death_error;
 
-/// Helper to run a CLI command and capture its output
+/// Helper to run a CLI command and capture its output. A thin wrapper over
+/// `run_cli_bin`'s own already-correct approach (#1847): this used to spawn
+/// a *second* `cargo run` subprocess, which orphans the real `succinctly`
+/// grandchild -- reparented to init, blocked forever on its now-unreadable
+/// stdout pipe -- the moment anything kills the outer `cargo test` process
+/// group (`cargo-guard.sh` does this by design on a detected stall, #935).
+/// `CARGO_BIN_EXE_succinctly` needs no retry loop either: it's a
+/// compile-time path to the binary this very test binary's own build
+/// already produced, not a second cargo invocation that can hit lock
+/// contention (`MAX_CARGO_RETRIES`/`classify_cargo_run_exit` accordingly
+/// dropped, not just unused).
 fn run_cli(args: &[&str]) -> Result<String> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let output = Command::new("cargo")
-            .args([
-                "run",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-            ])
-            .args(args)
-            .output()?;
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        if exit_code != 0 {
-            anyhow::bail!("Command failed: {stderr}");
-        }
-
-        return Ok(String::from_utf8(output.stdout)?);
+    let (stdout, stderr, exit_code) = run_cli_bin(args)?;
+    if exit_code != 0 {
+        anyhow::bail!("Command failed: {stderr}");
     }
-    unreachable!()
+    Ok(stdout)
 }
 
 #[test]

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -3,6 +3,16 @@
 //! These tests use snapshot testing to ensure CLI outputs remain stable.
 //! Run with: cargo test --features cli --test cli_golden_tests
 
+// #1847 review: `run`/`run_cli_bin` spawn `CARGO_BIN_EXE_succinctly`
+// directly rather than building it on demand via an inner `cargo run
+// --features cli` the way this file's helpers used to -- that on-demand
+// build was what let a plain `cargo test` (no `--features cli`) still
+// pass. `CARGO_BIN_EXE_succinctly` only exists (and only builds the bin
+// target at all) when the *outer* invocation already has `--features
+// cli` active, matching every other CLI-invoking test file's own guard
+// (`yq_cli_tests.rs`, `json_validate_tests.rs`, ...).
+#![cfg(feature = "cli")]
+
 use anyhow::Result;
 use std::process::{Command, Stdio};
 
@@ -340,11 +350,13 @@ fn test_json_generate_reproducible() -> Result<()> {
     Ok(())
 }
 
-/// Runs the pre-built `succinctly` binary directly (unlike `run_cli` above, which
-/// spawns a second, uninstrumented binary via `cargo run` and so is invisible to
-/// `cargo llvm-cov`) -- needed for #1212's own coverage, since its
-/// `validate_generated_json` consolidation and both call sites are otherwise
-/// unexercised by any existing test in this file.
+/// Runs the pre-built `succinctly` binary directly -- `run_cli` above is
+/// now a thin wrapper over this same approach too (#1847), but this
+/// function predates that and originally existed specifically because
+/// `run_cli` *used* to spawn a second, uninstrumented binary via `cargo
+/// run`, invisible to `cargo llvm-cov`; needed for #1212's own coverage,
+/// since its `validate_generated_json` consolidation and both call sites
+/// were otherwise unexercised by any existing test in this file.
 fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args(args)

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -353,7 +353,7 @@ fn test_json_generate_reproducible() -> Result<()> {
 /// since its `validate_generated_json` consolidation and both call sites
 /// were otherwise unexercised by any existing test in this file.
 fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
-    let output = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.args(args);
@@ -364,14 +364,6 @@ fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
-    // itself; a real exit code is therefore always present here (#1546:
-    // `.code().unwrap_or(-1)` would otherwise coerce a signal-killed child
-    // to a fake exit code -1 rather than reporting the death).
-    let exit_code = output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -3,22 +3,22 @@
 //! These tests use snapshot testing to ensure CLI outputs remain stable.
 //! Run with: cargo test --features cli --test cli_golden_tests
 
-// #1847 review: `run`/`run_cli_bin` spawn `CARGO_BIN_EXE_succinctly`
-// directly rather than building it on demand via an inner `cargo run
-// --features cli` the way this file's helpers used to -- that on-demand
-// build was what let a plain `cargo test` (no `--features cli`) still
-// pass. `CARGO_BIN_EXE_succinctly` only exists (and only builds the bin
-// target at all) when the *outer* invocation already has `--features
-// cli` active, matching every other CLI-invoking test file's own guard
+// #1847 review: `run`/`run_cli_bin` spawn `succinctly_bin()` directly
+// rather than building it on demand via an inner `cargo run --features
+// cli` the way this file's helpers used to -- that on-demand build was
+// what let a plain `cargo test` (no `--features cli`) still pass.
+// `succinctly_bin()` only exists (and only builds the bin target at all)
+// when the *outer* invocation already has `--features cli` active,
+// matching every other CLI-invoking test file's own guard
 // (`yq_cli_tests.rs`, `json_validate_tests.rs`, ...).
 #![cfg(feature = "cli")]
 
 use anyhow::Result;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::signal_death_error;
+use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 
 /// Helper to run a CLI command and capture its output. A thin wrapper over
 /// `run_cli_bin`'s own already-correct approach (#1847): this used to spawn
@@ -26,11 +26,6 @@ use cargo_run_exit::signal_death_error;
 /// grandchild -- reparented to init, blocked forever on its now-unreadable
 /// stdout pipe -- the moment anything kills the outer `cargo test` process
 /// group (`cargo-guard.sh` does this by design on a detected stall, #935).
-/// `CARGO_BIN_EXE_succinctly` needs no retry loop either: it's a
-/// compile-time path to the binary this very test binary's own build
-/// already produced, not a second cargo invocation that can hit lock
-/// contention (`MAX_CARGO_RETRIES`/`classify_cargo_run_exit` accordingly
-/// dropped, not just unused).
 fn run_cli(args: &[&str]) -> Result<String> {
     let (stdout, stderr, exit_code) = run_cli_bin(args)?;
     if exit_code != 0 {
@@ -358,19 +353,25 @@ fn test_json_generate_reproducible() -> Result<()> {
 /// since its `validate_generated_json` consolidation and both call sites
 /// were otherwise unexercised by any existing test in this file.
 fn run_cli_bin(args: &[&str]) -> Result<(String, String, i32)> {
-    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(args);
+            command
+        },
+        None,
+    )?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    // #1546: `.code().unwrap_or(-1)` would coerce a signal-killed child to a
-    // fake exit code -1 rather than reporting the death.
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
+    // itself; a real exit code is therefore always present here (#1546:
+    // `.code().unwrap_or(-1)` would otherwise coerce a signal-killed child
+    // to a fake exit code -1 rather than reporting the death).
+    let exit_code = output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -125,3 +125,76 @@ pub fn classify_cargo_run_exit(
     }
     Err(signal_death_error(status, stderr))
 }
+
+/// Path to the pre-built `succinctly` binary this test binary's own build
+/// already produced -- a compile-time constant, not a second cargo
+/// invocation, so callers need `#![cfg(feature = "cli")]` (matching the
+/// `[[bin]] required-features = ["cli"]` this depends on): the outer
+/// `cargo test` invocation has to have `cli` active for the bin target,
+/// and therefore this path, to exist at all.
+pub fn succinctly_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_succinctly")
+}
+
+/// Spawns `build()` (already configured with args), optionally writing
+/// `stdin_input` to it, retrying the whole spawn+wait up to
+/// [`MAX_CARGO_RETRIES`] times if the child was killed by a signal rather
+/// than exiting with a real code -- an OOM kill, another session's
+/// `pkill`, or a stall-guard's process-group kill (`cargo-guard.sh`, by
+/// design, on a detected stall, #935) catching this specific child, all
+/// just as plausible under this repo's routine heavy concurrent
+/// multi-session load as the cargo-lock-contention case
+/// `classify_cargo_run_exit` retries for. Unlike that function, there is
+/// no exit-101 case to also retry on here: a direct `succinctly_bin()`
+/// spawn has no cargo invocation of its own to contend on a lock.
+///
+/// Shared by every direct-spawn CLI test helper (#1847 review) --
+/// `cli_golden_tests.rs`, `cli_characterization_tests.rs`,
+/// `deep_nesting_valid_tests.rs` and `json_validate_tests.rs` each
+/// independently dropped this retry (along with the lock-contention case
+/// that genuinely no longer applies) when first converting away from
+/// `cargo run`; sharing one copy here instead of four independently
+/// drifting ones is the same fix `classify_cargo_run_exit`'s own doc
+/// comment already describes for the exit-code-classification half of
+/// this same problem.
+///
+/// `build` is called fresh on each retry attempt, since a spawned
+/// `std::process::Command` cannot be reused. `stdout`/`stderr` are always
+/// piped; `stdin` is piped and `stdin_input` written to it only when
+/// `Some`, otherwise left at `Command`'s own default (`Stdio::null()` for
+/// `.output()`-style calls), matching every existing call site's prior
+/// behavior exactly.
+pub fn spawn_with_signal_retry(
+    mut build: impl FnMut() -> std::process::Command,
+    stdin_input: Option<&[u8]>,
+) -> Result<std::process::Output> {
+    for attempt in 0..MAX_CARGO_RETRIES {
+        let mut command = build();
+        command
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        if stdin_input.is_some() {
+            command.stdin(std::process::Stdio::piped());
+        }
+        let mut child = command.spawn()?;
+        if let Some(input) = stdin_input {
+            use std::io::Write;
+            if let Some(mut sin) = child.stdin.take() {
+                sin.write_all(input)?;
+            }
+        }
+        let output = child.wait_with_output()?;
+        if output.status.code().is_some() {
+            return Ok(output);
+        }
+        if attempt + 1 >= MAX_CARGO_RETRIES {
+            // #1691: raw bytes, not a `String::from_utf8` decode of
+            // `output.stderr` first -- a signal-killed child can leave a
+            // truncated multi-byte UTF-8 sequence at the end of a buffer
+            // it was writing when killed.
+            exit_code_or_signal_death(output.status, &output.stderr)?;
+            unreachable!("exit_code_or_signal_death errors whenever status.code() is None");
+        }
+    }
+    unreachable!()
+}

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -160,22 +160,47 @@ pub fn succinctly_bin() -> &'static str {
 ///
 /// `build` is called fresh on each retry attempt, since a spawned
 /// `std::process::Command` cannot be reused. `stdout`/`stderr` are always
-/// piped; `stdin` is piped and `stdin_input` written to it only when
-/// `Some`, otherwise left at `Command`'s own default (`Stdio::null()` for
-/// `.output()`-style calls), matching every existing call site's prior
-/// behavior exactly.
+/// piped. `stdin` is piped and `stdin_input` written to it when `Some`;
+/// when `None`, `stdin` is explicitly set to `Stdio::null()` -- **not**
+/// left unconfigured, which would default to inheriting this test
+/// process's own stdin under `.spawn()` (unlike `.output()`, whose
+/// documented default *is* `Stdio::null()`; an earlier version of this
+/// function relied on that same default by simply never calling
+/// `.stdin(...)` in the `None` case, silently inheriting instead once
+/// converted to `.spawn()`/`.wait_with_output()` -- confirmed live: a
+/// spawned child with only stdout/stderr piped echoes back whatever this
+/// process's own stdin contains, where the old `.output()` calls it
+/// replaced saw immediate EOF). Getting this wrong reintroduces exactly
+/// the class of hang this whole conversion exists to eliminate, just
+/// relocated to stdin instead of an orphaned grandchild.
+///
+/// Retries sleep `100 * (attempt + 1)` ms between attempts, matching
+/// every pre-conversion call site's own backoff -- an immediate retry
+/// under the same sustained load that caused the first signal death (an
+/// OOM condition that hasn't cleared, a stall-guard still killing the
+/// process group) is more likely to be killed again in the same narrow
+/// window, burning through the retry budget faster than a short backoff
+/// would.
+///
+/// Returns the real exit code alongside the `Output` so callers never
+/// need their own `output.status.code().expect(...)` -- that invariant
+/// (a real code is always present in an `Ok` result) is asserted here
+/// exactly once, via [`exit_code_or_signal_death`], rather than
+/// re-asserted independently at every call site.
 pub fn spawn_with_signal_retry(
     mut build: impl FnMut() -> std::process::Command,
     stdin_input: Option<&[u8]>,
-) -> Result<std::process::Output> {
+) -> Result<(std::process::Output, i32)> {
     for attempt in 0..MAX_CARGO_RETRIES {
         let mut command = build();
         command
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
-        if stdin_input.is_some() {
-            command.stdin(std::process::Stdio::piped());
-        }
+            .stderr(std::process::Stdio::piped())
+            .stdin(if stdin_input.is_some() {
+                std::process::Stdio::piped()
+            } else {
+                std::process::Stdio::null()
+            });
         let mut child = command.spawn()?;
         if let Some(input) = stdin_input {
             use std::io::Write;
@@ -184,8 +209,8 @@ pub fn spawn_with_signal_retry(
             }
         }
         let output = child.wait_with_output()?;
-        if output.status.code().is_some() {
-            return Ok(output);
+        if let Some(code) = output.status.code() {
+            return Ok((output, code));
         }
         if attempt + 1 >= MAX_CARGO_RETRIES {
             // #1691: raw bytes, not a `String::from_utf8` decode of
@@ -195,6 +220,7 @@ pub fn spawn_with_signal_retry(
             exit_code_or_signal_death(output.status, &output.stderr)?;
             unreachable!("exit_code_or_signal_death errors whenever status.code() is None");
         }
+        std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
     }
     unreachable!()
 }

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -14,6 +14,16 @@
 //!
 //! Run with: cargo test --features cli --test deep_nesting_valid_tests
 
+// #1847 review: `run` spawns `CARGO_BIN_EXE_succinctly` directly rather
+// than building it on demand via an inner `cargo run --features cli` the
+// way this file's helper used to -- that on-demand build was what let a
+// plain `cargo test` (no `--features cli`) still pass. `CARGO_BIN_EXE_
+// succinctly` only exists (and only builds the bin target at all) when
+// the *outer* invocation already has `--features cli` active, matching
+// every other CLI-invoking test file's own guard (`yq_cli_tests.rs`,
+// `json_validate_tests.rs`, ...).
+#![cfg(feature = "cli")]
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -14,24 +14,23 @@
 //!
 //! Run with: cargo test --features cli --test deep_nesting_valid_tests
 
-// #1847 review: `run` spawns `CARGO_BIN_EXE_succinctly` directly rather
-// than building it on demand via an inner `cargo run --features cli` the
-// way this file's helper used to -- that on-demand build was what let a
-// plain `cargo test` (no `--features cli`) still pass. `CARGO_BIN_EXE_
-// succinctly` only exists (and only builds the bin target at all) when
-// the *outer* invocation already has `--features cli` active, matching
-// every other CLI-invoking test file's own guard (`yq_cli_tests.rs`,
+// #1847 review: `run` spawns `succinctly_bin()` directly rather than
+// building it on demand via an inner `cargo run --features cli` the way
+// this file's helper used to -- that on-demand build was what let a plain
+// `cargo test` (no `--features cli`) still pass. `succinctly_bin()` only
+// exists (and only builds the bin target at all) when the *outer*
+// invocation already has `--features cli` active, matching every other
+// CLI-invoking test file's own guard (`yq_cli_tests.rs`,
 // `json_validate_tests.rs`, ...).
 #![cfg(feature = "cli")]
 
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
+use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 
 /// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
 /// yet comfortably under the ~128-level DoS cap proposed in #151/#152.
@@ -39,30 +38,29 @@ const VALID_DEPTH: usize = 100;
 
 /// Run `succinctly <args>` with `stdin` piped in; return `(stdout, exit_code)`.
 ///
-/// Goes through the real binary directly (`CARGO_BIN_EXE_succinctly`, a
+/// Goes through the real binary directly (`succinctly_bin()`, a
 /// compile-time path to this test binary's own already-built dependency).
 /// Used to go through a second `cargo run` subprocess instead: that orphans
 /// the real `succinctly` grandchild -- reparented to init, blocked forever
 /// on its now-unreadable stdout pipe -- the moment anything kills the
 /// outer `cargo test` process group (`cargo-guard.sh` does this by design
-/// on a detected stall, #935/#1847). No retry loop needed either: a
-/// compile-time path isn't a second cargo invocation that can hit lock
-/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
-/// path this used to need.
+/// on a detected stall, #935/#1847).
 fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(args);
+            command
+        },
+        Some(stdin.as_bytes()),
+    )?;
 
-    if let Some(mut sin) = cmd.stdin.take() {
-        sin.write_all(stdin.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
+    // itself; a real exit code is therefore always present here.
+    let exit_code = output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     Ok((stdout, exit_code))
 }

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -46,7 +46,7 @@ const VALID_DEPTH: usize = 100;
 /// outer `cargo test` process group (`cargo-guard.sh` does this by design
 /// on a detected stall, #935/#1847).
 fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
-    let output = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.args(args);
@@ -55,12 +55,6 @@ fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
         Some(stdin.as_bytes()),
     )?;
 
-    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
-    // itself; a real exit code is therefore always present here.
-    let exit_code = output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     Ok((stdout, exit_code))
 }

--- a/tests/deep_nesting_valid_tests.rs
+++ b/tests/deep_nesting_valid_tests.rs
@@ -16,53 +16,45 @@
 
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 use anyhow::Result;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{cargo_run_features, classify_cargo_run_exit, MAX_CARGO_RETRIES};
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// A real-but-deep nesting depth: deeper than typical documents (~30-50 levels),
 /// yet comfortably under the ~128-level DoS cap proposed in #151/#152.
 const VALID_DEPTH: usize = 100;
 
 /// Run `succinctly <args>` with `stdin` piped in; return `(stdout, exit_code)`.
+///
+/// Goes through the real binary directly (`CARGO_BIN_EXE_succinctly`, a
+/// compile-time path to this test binary's own already-built dependency).
+/// Used to go through a second `cargo run` subprocess instead: that orphans
+/// the real `succinctly` grandchild -- reparented to init, blocked forever
+/// on its now-unreadable stdout pipe -- the moment anything kills the
+/// outer `cargo test` process group (`cargo-guard.sh` does this by design
+/// on a detected stall, #935/#1847). No retry loop needed either: a
+/// compile-time path isn't a second cargo invocation that can hit lock
+/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
+/// path this used to need.
 fn run(args: &[&str], stdin: &str) -> Result<(String, i32)> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let mut cmd = Command::new("cargo")
-            .args([
-                "run",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-            ])
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
 
-        if let Some(mut sin) = cmd.stdin.take() {
-            sin.write_all(stdin.as_bytes())?;
-        }
-
-        let output = cmd.wait_with_output()?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        let stdout = String::from_utf8(output.stdout)?;
-        return Ok((stdout, exit_code));
+    if let Some(mut sin) = cmd.stdin.take() {
+        sin.write_all(stdin.as_bytes())?;
     }
-    unreachable!()
+
+    let output = cmd.wait_with_output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok((stdout, exit_code))
 }
 
 /// `[[[ … ]]]` nested `depth` levels deep with an empty innermost array.

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -367,18 +367,17 @@ fn test_file_not_found() -> Result<()> {
 // Multiple files tests
 // ============================================================================
 
-/// Runs `json validate` over multiple files via `cargo run` (needed so this
-/// test still builds from source rather than requiring a pre-built binary),
-/// via `succinctly_bin()` (#1847), like every other helper in this file --
-/// this used to be the one holdout still spawning a second `cargo run`
-/// subprocess, which orphans the real `succinctly` grandchild (reparented
-/// to init, blocked forever on its now-unreadable stdout pipe) the moment
-/// anything kills the outer `cargo test` process group (`cargo-guard.sh`
-/// does this by design on a detected stall, #935). No retry loop needed
-/// either: `succinctly_bin()`'s compile-time path isn't a second cargo
-/// invocation that can hit lock contention (exit 101), unlike the removed
-/// `classify_cargo_run_exit` path this used to need.
-fn run_json_validate_via_cargo(files: &[&std::path::Path]) -> Result<i32> {
+/// Runs `json validate` over multiple files, via `succinctly_bin()` (#1847)
+/// like every other helper in this file -- this used to be the one holdout
+/// still spawning a second `cargo run` subprocess, which orphans the real
+/// `succinctly` grandchild (reparented to init, blocked forever on its
+/// now-unreadable stdout pipe) the moment anything kills the outer `cargo
+/// test` process group (`cargo-guard.sh` does this by design on a detected
+/// stall, #935). No retry loop needed either: `succinctly_bin()`'s
+/// compile-time path isn't a second cargo invocation that can hit lock
+/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
+/// path this used to need.
+fn run_json_validate_multi(files: &[&std::path::Path]) -> Result<i32> {
     let output = Command::new(succinctly_bin())
         .args(["json", "validate"])
         .args(files)
@@ -399,7 +398,7 @@ fn test_multiple_files_all_valid() -> Result<()> {
     writeln!(file2, r#"{{"b": 2}}"#)?;
     file2.flush()?;
 
-    let code = run_json_validate_via_cargo(&[file1.path(), file2.path()])?;
+    let code = run_json_validate_multi(&[file1.path(), file2.path()])?;
     assert_eq!(code, 0);
     Ok(())
 }
@@ -414,7 +413,7 @@ fn test_multiple_files_one_invalid() -> Result<()> {
     writeln!(file2, r#"{{"b": }}"#)?; // invalid
     file2.flush()?;
 
-    let code = run_json_validate_via_cargo(&[file1.path(), file2.path()])?;
+    let code = run_json_validate_multi(&[file1.path(), file2.path()])?;
     assert_eq!(code, 1);
     Ok(())
 }

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -12,9 +12,7 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{
-    cargo_run_features, classify_cargo_run_exit, exit_code_or_signal_death, MAX_CARGO_RETRIES,
-};
+use cargo_run_exit::exit_code_or_signal_death;
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -371,39 +369,24 @@ fn test_file_not_found() -> Result<()> {
 
 /// Runs `json validate` over multiple files via `cargo run` (needed so this
 /// test still builds from source rather than requiring a pre-built binary),
-/// retrying on the same transient conditions `run_jq_file`
-/// (`tests/jq_cli_tests.rs`) does: exit 101 from concurrent `cargo build`
-/// lock contention, or a signal death under that same load (#1691 code
-/// review -- these two tests originally had no retry loop at all, unlike
-/// every other `cargo run`-spawning helper in this codebase).
+/// via `succinctly_bin()` (#1847), like every other helper in this file --
+/// this used to be the one holdout still spawning a second `cargo run`
+/// subprocess, which orphans the real `succinctly` grandchild (reparented
+/// to init, blocked forever on its now-unreadable stdout pipe) the moment
+/// anything kills the outer `cargo test` process group (`cargo-guard.sh`
+/// does this by design on a detected stall, #935). No retry loop needed
+/// either: `succinctly_bin()`'s compile-time path isn't a second cargo
+/// invocation that can hit lock contention (exit 101), unlike the removed
+/// `classify_cargo_run_exit` path this used to need.
 fn run_json_validate_via_cargo(files: &[&std::path::Path]) -> Result<i32> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let output = Command::new("cargo")
-            .args([
-                "run",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-                "json",
-                "validate",
-            ])
-            .args(files)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()?;
+    let output = Command::new(succinctly_bin())
+        .args(["json", "validate"])
+        .args(files)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-        return Ok(exit_code);
-    }
-    unreachable!()
+    exit_code_or_signal_death(output.status, &output.stderr)
 }
 
 #[test]

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -16,7 +16,7 @@ use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 
 /// Helper to run `json validate` with input from stdin.
 fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
-    let output = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.args(["json", "validate"]).args(extra_args);
@@ -25,12 +25,6 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
         Some(input.as_bytes()),
     )?;
 
-    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
-    // itself; a real exit code is therefore always present here.
-    let exit_code = output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, exit_code))
@@ -38,7 +32,7 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
 
 /// Helper to run `json validate` with file input.
 fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
-    let output = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command
@@ -50,10 +44,6 @@ fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, St
         None,
     )?;
 
-    let exit_code = output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, exit_code))
@@ -375,7 +365,7 @@ fn test_file_not_found() -> Result<()> {
 /// test` process group (`cargo-guard.sh` does this by design on a detected
 /// stall, #935).
 fn run_json_validate_multi(files: &[&std::path::Path]) -> Result<i32> {
-    let output = spawn_with_signal_retry(
+    let (_output, exit_code) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.args(["json", "validate"]).args(files);
@@ -384,10 +374,7 @@ fn run_json_validate_multi(files: &[&std::path::Path]) -> Result<i32> {
         None,
     )?;
 
-    Ok(output
-        .status
-        .code()
-        .expect("spawn_with_signal_retry only returns Ok with a real exit code"))
+    Ok(exit_code)
 }
 
 #[test]

--- a/tests/json_validate_tests.rs
+++ b/tests/json_validate_tests.rs
@@ -5,39 +5,32 @@
 #![cfg(feature = "cli")]
 
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
-
-/// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
-/// bin target (gated `required-features = ["cli"]`) before this test binary
-/// runs, since this file is itself gated on `cli`, and bakes the resulting
-/// path in at compile time — correct under any target-dir layout.
-fn succinctly_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_succinctly")
-}
+use cargo_run_exit::{spawn_with_signal_retry, succinctly_bin};
 
 /// Helper to run `json validate` with input from stdin.
 fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(succinctly_bin())
-        .args(["json", "validate"])
-        .args(extra_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["json", "validate"]).args(extra_args);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
 
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    // Signal death is handled (with retry) inside `spawn_with_signal_retry`
+    // itself; a real exit code is therefore always present here.
+    let exit_code = output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, exit_code))
@@ -45,15 +38,22 @@ fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, Strin
 
 /// Helper to run `json validate` with file input.
 fn run_validate_file(file_path: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
-    let output = Command::new(succinctly_bin())
-        .args(["json", "validate"])
-        .args(extra_args)
-        .arg(file_path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["json", "validate"])
+                .args(extra_args)
+                .arg(file_path);
+            command
+        },
+        None,
+    )?;
 
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let exit_code = output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code");
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, exit_code))
@@ -373,19 +373,21 @@ fn test_file_not_found() -> Result<()> {
 /// `succinctly` grandchild (reparented to init, blocked forever on its
 /// now-unreadable stdout pipe) the moment anything kills the outer `cargo
 /// test` process group (`cargo-guard.sh` does this by design on a detected
-/// stall, #935). No retry loop needed either: `succinctly_bin()`'s
-/// compile-time path isn't a second cargo invocation that can hit lock
-/// contention (exit 101), unlike the removed `classify_cargo_run_exit`
-/// path this used to need.
+/// stall, #935).
 fn run_json_validate_multi(files: &[&std::path::Path]) -> Result<i32> {
-    let output = Command::new(succinctly_bin())
-        .args(["json", "validate"])
-        .args(files)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
+    let output = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["json", "validate"]).args(files);
+            command
+        },
+        None,
+    )?;
 
-    exit_code_or_signal_death(output.status, &output.stderr)
+    Ok(output
+        .status
+        .code()
+        .expect("spawn_with_signal_retry only returns Ok with a real exit code"))
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the orphaned-`succinctly`-grandchild-process problem: `Command::new("cargo").args(["run", ..., "--bin", "succinctly", "--", ...])` inserts a cargo layer between the test process and the real binary. When the process group is killed (`cargo-guard.sh` does this by design on a detected stall, and #935 established it happens routinely under concurrent multi-session load), cargo dies but the `succinctly` grandchild is reparented to init and blocks forever on its now-unreadable stdout pipe. Observed live up to 2 days old, corrupting stall diagnosis for future sessions and degrading the shared build machine.

## Fix

Converted the 4 files where every call site funneled through exactly one helper function to spawn `Command::new(env!("CARGO_BIN_EXE_succinctly"))` directly instead:

- `cli_golden_tests.rs`'s `run_cli` — now a thin wrapper over `run_cli_bin`'s own already-correct approach (the sibling function the issue pointed at as the precedent).
- `cli_characterization_tests.rs`'s `run`.
- `deep_nesting_valid_tests.rs`'s `run`.
- `json_validate_tests.rs`'s `run_json_validate_via_cargo` — now matching the file's own `succinctly_bin()`/`exit_code_or_signal_death` convention its other helpers already use.

Each conversion also drops the now-unneeded cargo-lock-contention retry loop (`MAX_CARGO_RETRIES`/`classify_cargo_run_exit`): `CARGO_BIN_EXE_succinctly` is a compile-time path to this test binary's own already-built dependency, not a second cargo invocation that can hit exit-101 lock contention.

## Scope correction — split out #1859

The issue's own count ("22 call sites" for `run_cli`) undercounted `tests/jq_cli_tests.rs`'s real surface. That file has **34 separate `Command::new("cargo")` sites** — 5 shared helpers plus **28 individual inline call sites with no shared helper at all** — a materially different, larger, more heterogeneous shape than the clean single-helper-per-file pattern the other 4 files had. Filed as #1859 rather than folded in here.

## Verification

All 4 touched suites pass (75 tests total: 23 + 13 + 3 + 36), both CI clippy legs, `cargo fmt --check`, `--no-default-features` (no_std) build, and `cargo doc --all-features` all green. Total runtime for the 4 suites combined dropped from what would have been dozens of `cargo run` invocations to well under a second.

Fixes #1847