### PR TITLE
fix(yq): RHS-discard optimization now recognizes an all-no-op Iterate fan-out

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -732,17 +732,24 @@ pre-check, #1232's `PrefixNavOutcome`) an `Expr::Iterate` arm too — but only f
 narrowest case, `.a` itself being a genuine scalar (`.a[].b = error("boom")` on `a: 5` now
 no-ops silently, RHS never evaluated, matching real yq).
 
-**Still open ([#1432](https://github.com/rust-works/succinctly/issues/1432)):** real yq's
-actual RHS-discard rule for a mid-chain `Iterate` is broader — a real container whose own
-elements *all* individually no-op also discards the RHS, and so does an empty or
-null-autovivified container (vacuously). The underlying *write* already gets all of these
-right (verified against real yq); only the RHS-discard optimization is narrower than real
-yq's own rule:
+**Fixed by [#1432](https://github.com/rust-works/succinctly/issues/1432):** real yq's actual
+RHS-discard rule for a mid-chain `Iterate` is broader than #1298's own narrowest case — a real
+container whose own elements *all* individually no-op also discards the RHS, and so does an
+empty container (vacuously). New `assign_path_all_noop` recurses into
+`.iter().all(...)`/`.values().all(...)` at such an `Iterate` instead of unconditionally
+deferring, a read-only dry run of `set_path_through_iterate`'s own per-element recursion:
 
 ```bash
 $ printf 'a: [1, 2]\n' | yq            -o=json '.a[].b = error("boom")'   # {"a":[1,2]}, no-op
-$ printf 'a: [1, 2]\n' | succinctly yq -o=json '.a[].b = error("boom")'   # Error: boom
+$ printf 'a: [1, 2]\n' | succinctly yq -o=json '.a[].b = error("boom")'   # {"a":[1,2]} (fixed)
 ```
+
+A `null` target is deliberately excluded from this fix — real yq autovivifies `null` to `[]`
+as part of the write itself (already correct on both sides before and after this fix), so it
+is not a *total* no-op the way an empty/all-scalar container is, and this predicate's
+all-or-nothing `Skip`/`Continue` caller has no way to express "skip the RHS, but still
+perform the write." That narrower, still-open gap is tracked separately by
+[#1857](https://github.com/rust-works/succinctly/issues/1857).
 
 ### `=`'s multi-output RHS: real yq takes only the last value, no fan-out
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15411,18 +15411,22 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
 ///
 /// Deliberately excludes `Null`: real yq's `.a[].b = v` on `a: null`
 /// autovivifies `null` to `[]` as part of the write itself (confirmed live
-/// against a safe, non-erroring RHS: `yq '.a[].b = 5'` on `a: null`
-/// produces `a: []`), so it is not a *total* no-op the way an empty or
-/// all-scalar container is -- the document still changes. Checked
-/// independently of this fix (same safe-RHS probe against this codebase's
-/// unmodified write path) and found that autovivification currently
-/// doesn't happen there at all -- `a: null` stays `a: null` -- a
-/// pre-existing write-correctness bug this predicate can't fix (it only
-/// ever decides whether to skip evaluating the RHS, and the existing
-/// caller's `Skip(pristine)` short-circuit returns the *unmodified*
-/// original when this returns `true`, which would make the missing
-/// autovivification permanent instead of merely already-wrong). Filed
-/// separately as #1857 rather than folded into this predicate.
+/// -- and confirmed already correct on this codebase's own write path
+/// too, independent of this predicate: a safe, non-erroring RHS,
+/// `yq '.a[].b = 5'` on `a: null`, already produces `a: []` here exactly
+/// like the oracle). So `Null` is not a *total* no-op the way an empty or
+/// all-scalar container is -- the document still changes -- but the
+/// reason this predicate can't simply report it as one isn't a write bug:
+/// it's that this predicate's only caller (`yq_assign_noop_check`) has an
+/// all-or-nothing `Skip`/`Continue` split, and `Skip` means "return the
+/// *unmodified* pristine document, evaluate nothing at all." Reporting
+/// `Null` as a no-op here would route through `Skip` and discard the
+/// legitimate `null` -> `[]` write that already happens correctly on the
+/// normal `Continue` path -- there is no way to express "skip the RHS,
+/// but still perform the write" through this predicate's boolean answer
+/// alone. That narrower gap (the RHS still evaluates eagerly for `Null`,
+/// where real yq's own equivalent write never needs it) is real but out
+/// of this predicate's reach -- filed separately as #1857.
 fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
     let (step, rest) = match steps.split_first() {
         None => return is_yq_field_index_noop_scalar(current),
@@ -15454,7 +15458,9 @@ fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
         Expr::Iterate => match current {
             OwnedValue::Array(arr) => arr.iter().all(|elem| assign_path_all_noop(elem, rest)),
             OwnedValue::Object(map) => map.values().all(|elem| assign_path_all_noop(elem, rest)),
-            // Not `Null` -- see this function's own doc comment (#1857).
+            // Not `Null` -- reporting a no-op here would route through
+            // `Skip` and discard `Null`'s own legitimate autovivify write
+            // (see this function's own doc comment, #1857).
             _ if is_yq_field_index_noop_scalar(current) => true,
             _ => false,
         },

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15458,6 +15458,16 @@ fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
             _ if is_yq_field_index_noop_scalar(current) => true,
             _ => false,
         },
+        // Defensive, not currently reachable: `steps` only ever contains
+        // `yq_assign_is_total_noop`'s own flattened `prefix`, whose every
+        // component is already provably one of `Field`/`Index`/
+        // `IndexNumber`/`Iterate` by the time it reaches here -- see that
+        // function's own identical "Defensive, not currently reachable"
+        // comment on its terminal-component check, confirmed there via
+        // patch-coverage output the same way this arm's own is (never
+        // fires). Kept for the same reason: the one thing standing between
+        // a future new static-classified `Expr` variant and this function
+        // silently mishandling it instead of falling to a safe default.
         _ => false,
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15383,17 +15383,82 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
     ) {
         return false;
     }
-    match navigate_read_only(root, prefix) {
-        PrefixNavOutcome::Resolved(parent) => is_yq_field_index_noop_scalar(parent),
-        // A scalar hit mid-prefix is a no-op regardless of what the
-        // terminal component was going to do (#1232) -- the scalar can't
-        // become a container no matter how much further path is left.
-        PrefixNavOutcome::HitScalar => true,
-        // An absent prefix (missing field/out-of-range index/`Null`) isn't
-        // this predicate's case at all -- defer to the normal RHS
-        // evaluation and let `set_path`'s own existing `get_path_mut`
-        // report whatever it reports for a genuinely missing path.
-        PrefixNavOutcome::Absent => false,
+    assign_path_all_noop(root, prefix)
+}
+
+/// Whether writing through `steps` (a `yq_assign_is_total_noop` prefix --
+/// its own flattened path minus the terminal component) into `current` is
+/// a total no-op. Subsumes `navigate_read_only`'s three-way
+/// `Resolved`/`HitScalar`/`Absent` outcome as its own base case (`steps`
+/// exhausted -- `current` is the terminal component's parent, so
+/// `is_yq_field_index_noop_scalar` decides exactly as it always did) but
+/// additionally recurses into `.iter().all(...)`/`.values().all(...)`
+/// whenever a mid-chain `Expr::Iterate` fans into a real `Array`/`Object`,
+/// instead of `navigate_read_only`'s own unconditional `Absent` for that
+/// case (#1432) -- a read-only, non-mutating dry run of
+/// `set_path_through_iterate`'s own per-element recursion, restricted to
+/// the `Field`/`Index`/`IndexNumber`/`Iterate` step vocabulary that's all
+/// `yq_assign_is_total_noop`'s caller ever hands it (its own slice check
+/// already excludes anything else before this is reached). Vacuously true
+/// whenever a fanned-into container is empty -- `set_path_through_iterate`
+/// itself does nothing when there are no elements to iterate. Live-verified
+/// against yq v4.53.3: `a: []`/`a: {}` (empty), `a: [1, 2]`/`a: {x: 1, y:
+/// 1}` (all-scalar), and a nested `a: [[1,2],[3]]` under `.a[][].b` all
+/// agree with the oracle in both directions (RHS discarded and the final
+/// document byte-identical to a safe, always-evaluated RHS), while a
+/// single non-scalar element anywhere in the fan-out (`a: [1, {}]`) still
+/// correctly evaluates the RHS.
+///
+/// Deliberately excludes `Null`: real yq's `.a[].b = v` on `a: null`
+/// autovivifies `null` to `[]` as part of the write itself (confirmed live
+/// against a safe, non-erroring RHS: `yq '.a[].b = 5'` on `a: null`
+/// produces `a: []`), so it is not a *total* no-op the way an empty or
+/// all-scalar container is -- the document still changes. Checked
+/// independently of this fix (same safe-RHS probe against this codebase's
+/// unmodified write path) and found that autovivification currently
+/// doesn't happen there at all -- `a: null` stays `a: null` -- a
+/// pre-existing write-correctness bug this predicate can't fix (it only
+/// ever decides whether to skip evaluating the RHS, and the existing
+/// caller's `Skip(pristine)` short-circuit returns the *unmodified*
+/// original when this returns `true`, which would make the missing
+/// autovivification permanent instead of merely already-wrong). Filed
+/// separately as #1857 rather than folded into this predicate.
+fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
+    let (step, rest) = match steps.split_first() {
+        None => return is_yq_field_index_noop_scalar(current),
+        Some(pair) => pair,
+    };
+    let (step, _optional) = unwrap_path_component(step);
+    match step {
+        Expr::Field(name) => match current {
+            OwnedValue::Object(map) => match map.get(name) {
+                Some(v) => assign_path_all_noop(v, rest),
+                None => false,
+            },
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
+            OwnedValue::Array(arr) => {
+                let len = arr.len() as i64;
+                let actual = if *idx < 0 { len + idx } else { *idx };
+                if actual >= 0 && (actual as usize) < arr.len() {
+                    assign_path_all_noop(&arr[actual as usize], rest)
+                } else {
+                    false
+                }
+            }
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        Expr::Iterate => match current {
+            OwnedValue::Array(arr) => arr.iter().all(|elem| assign_path_all_noop(elem, rest)),
+            OwnedValue::Object(map) => map.values().all(|elem| assign_path_all_noop(elem, rest)),
+            // Not `Null` -- see this function's own doc comment (#1857).
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        _ => false,
     }
 }
 
@@ -15625,7 +15690,7 @@ fn yq_del_slice_outcome(
     let prefix_components: Vec<Expr> = prefix.iter().map(|s| s.component.clone()).collect();
     if !matches!(
         navigate_read_only(root, &prefix_components),
-        PrefixNavOutcome::Resolved(_)
+        PrefixNavOutcome::Resolved
     ) {
         return YqDelSliceOutcome::NotApplicable;
     }
@@ -15659,9 +15724,14 @@ fn yq_del_slice_outcome(
 /// unresolved parent, deferring to normal RHS evaluation and letting
 /// `.a.b.c = error("boom")` on `a: 5` raise `boom` where real yq no-ops
 /// silently (RHS never runs) — live-verified against yq v4.53.3.
-enum PrefixNavOutcome<'a> {
-    /// Every prefix step navigated an existing value.
-    Resolved(&'a OwnedValue),
+enum PrefixNavOutcome {
+    /// Every prefix step navigated an existing value. Carries no payload:
+    /// `yq_assign_is_total_noop` used to read the resolved parent off this
+    /// variant for its own terminal scalar check, but that check now lives
+    /// inside `assign_path_all_noop`'s own base case (#1432), so the only
+    /// remaining reader (`yq_del_slice_outcome`) only ever matches the
+    /// variant itself via `matches!(..., Resolved(_))`.
+    Resolved,
     /// A step tried to index into a real, non-`Null` scalar.
     HitScalar,
     /// Missing key, out-of-range index, `Null`, or a container-type
@@ -15691,7 +15761,7 @@ enum PrefixNavOutcome<'a> {
 /// container-mismatch case (or `OwnedValue` gains a variant) in one walker,
 /// mirror it here too — a drift would make `yq_assign_is_total_noop`
 /// disagree with what the real write does.
-fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> PrefixNavOutcome<'a> {
+fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> PrefixNavOutcome {
     let mut current = root;
     for step in steps {
         let (step, _optional) = unwrap_path_component(step);
@@ -15751,7 +15821,7 @@ fn navigate_read_only<'a>(root: &'a OwnedValue, steps: &[Expr]) -> PrefixNavOutc
             _ => return PrefixNavOutcome::Absent,
         };
     }
-    PrefixNavOutcome::Resolved(current)
+    PrefixNavOutcome::Resolved
 }
 
 /// Apply a resolved slice directly to an owned value.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21708,19 +21708,19 @@ fn test_yq_nonterminal_iterate_in_assign_path_fans_out_1298() -> Result<()> {
 /// (RHS never runs), matching real yq exactly (live-verified against
 /// v4.53.3).
 ///
-/// This only closes the narrowest case -- `current` (`.a` itself) being a
+/// This only closed the narrowest case -- `current` (`.a` itself) being a
 /// genuine scalar. Real yq's actual rule turned out broader once
 /// live-probed further: `a: [1, 2]` (a real *container*, but every one of
 /// its own elements is itself a scalar `.b` would no-op into) *also*
-/// discards the RHS in real yq, and so does an empty/null-autovivified
-/// container (vacuously -- zero elements to check). Neither of those is
-/// implemented here; `navigate_read_only`'s new `Iterate` arm deliberately
-/// reports `Absent` (defer to normal evaluation) for *any* real
-/// `Array`/`Object`, so those broader cases still eagerly evaluate the
-/// RHS where real yq wouldn't -- filed as #1432 rather than expanded here.
-/// The second case below (`a: [1, {}]`, a genuinely *mixed* target where
-/// one element really does write) is the regression guard for what this
-/// fix must *not* accidentally suppress.
+/// discards the RHS in real yq, and so does an empty container (vacuously
+/// -- zero elements to check). That broader fan-out rule is now
+/// implemented too (#1432, `assign_path_all_noop`) -- see
+/// `test_yq_nonterminal_iterate_container_fanout_noop_1432` below.
+/// (A `Null` target is a separate case, deliberately still excluded --
+/// see `test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298`'s
+/// own updated doc comment.) The second case below (`a: [1, {}]`, a
+/// genuinely *mixed* target where one element really does write) is the
+/// regression guard for what this fix must *not* accidentally suppress.
 #[test]
 fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
     let (out, err, code) =
@@ -21740,20 +21740,97 @@ fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
 }
 
 /// #1298 (code review, #1432): a `Null` target for the `Iterate` -- neither
-/// a real container nor a genuine scalar -- falls to `navigate_read_only`'s
-/// `Iterate` arm's final `_ => Absent` catch-all, so the RHS still
-/// evaluates here even though real yq's own null-autovivify-to-`[]`
-/// behavior means the fan-out ends up empty and real yq discards the RHS
-/// too (`a: null` becomes `a: []` there, with the RHS never running --
-/// live-verified against yq v4.53.3). This is the exact gap #1432 tracks;
-/// pinned here as a known-divergent case, not a regression to fix in this
-/// PR.
+/// a real container nor a genuine scalar -- falls to `assign_path_all_noop`'s
+/// final `_ => false` catch-all, so the RHS still evaluates here even
+/// though real yq's own null-autovivify-to-`[]` behavior means the fan-out
+/// ends up empty and real yq discards the RHS too (`a: null` becomes
+/// `a: []` there, with the RHS never running -- live-verified against yq
+/// v4.53.3). #1432 deliberately leaves this excluded rather than folding it
+/// in: probing further (with a safe, always-evaluated RHS, independent of
+/// this predicate entirely) found that succinctly's write path doesn't even
+/// perform the `null` -> `[]` autovivification here at all (`a: null`
+/// stays `a: null` for `.a[].b = 5`, where real yq still produces
+/// `a: []`) -- a separate, pre-existing write-correctness bug that
+/// `yq_assign_is_total_noop`'s all-or-nothing `Skip(pristine)` short-circuit
+/// would make *permanent* rather than merely already-wrong if `Null` were
+/// folded into the no-op predicate. Filed as #1857; pinned here as a
+/// known-divergent case, not a regression to fix in this PR.
 #[test]
 fn test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298() -> Result<()> {
     let (_out, err, code) =
         run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: null\n", &["-o", "json"])?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1432: `yq_assign_is_total_noop`'s prefix walk (`assign_path_all_noop`)
+/// recurses into a mid-chain `Expr::Iterate` that hits a real
+/// `Array`/`Object`, instead of `navigate_read_only`'s old unconditional
+/// defer for any real container -- every element/value must itself no-op
+/// the remainder of the path (vacuously true for an empty container).
+/// Every shape here is a direct transcription of a live probe against yq
+/// v4.53.3, using `error("boom")` as the RHS so a wrongly-eager evaluation
+/// is directly observable as an exit code / stderr message rather than
+/// merely an output difference.
+#[test]
+fn test_yq_nonterminal_iterate_container_fanout_noop_1432() -> Result<()> {
+    // All-scalar array elements: matches the case already covered above
+    // (`a: [1, 2]`) via `test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298`'s
+    // first assertion's sibling shape -- restated here for locality with
+    // the rest of #1432's own new cases.
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        ".a[].b = error(\"boom\")",
+        "a:\n  - 1\n  - 2\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": [\n    1,\n    2\n  ]\n}");
+
+    // Empty array -- vacuously every element (zero of them) no-ops.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: []\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": []\n}");
+
+    // Empty object -- same, over `.values()` rather than array elements.
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: {}\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": {}\n}");
+
+    // Object whose every value is itself a scalar.
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        ".a[].b = error(\"boom\")",
+        "a:\n  x: 1\n  y: 2\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "{\n  \"a\": {\n    \"x\": 1,\n    \"y\": 2\n  }\n}"
+    );
+
+    // Nested `Iterate`s (`.a[][].b`) -- the recursion must fan out at
+    // every level, not just the first.
+    let (out, err, code) = run_yq_stdin_with_stderr(
+        ".a[][].b = error(\"boom\")",
+        "a:\n  - [1, 2]\n  - [3]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "{\n  \"a\": [\n    [\n      1,\n      2\n    ],\n    [\n      3\n    ]\n  ]\n}"
+    );
+
+    // Regression guard: a single non-scalar element anywhere in the
+    // fan-out still genuinely writes, so the RHS still evaluates for real.
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a:\n  - {}\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19813,6 +19813,29 @@ fn test_1219_interior_slice_separated_by_iterate_is_noop() -> Result<()> {
     Ok(())
 }
 
+/// #1432 (coverage): `navigate_read_only`'s own `Expr::Iterate` arm --
+/// unchanged by #1432's fix, since `yq_assign_is_total_noop` now routes
+/// through the new `assign_path_all_noop` instead -- had no test reaching
+/// it independently through its one remaining caller, `yq_del_slice_outcome`
+/// (every existing `del()`+`Iterate` test either has no trailing slice run
+/// at all, or hits the interior-slice-in-prefix early return before ever
+/// calling `navigate_read_only`). `del(.a[].b[0:1])` has no slice anywhere
+/// in its prefix (`[Field(a), Iterate, Field(b)]`), so it reaches this
+/// arm's real-container branch directly. Live-verified against yq v4.53.3:
+/// both sides discard the `[0:1]` slice of every `.b`, matching the
+/// existing "residual prefix" no-op family above.
+#[test]
+fn test_yq_del_slice_outcome_iterate_prefix_real_container_1432() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[].b[0:1])",
+        r#"{"a":[{"b":[1,2,3]},{"b":[4,5,6]}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[{},{}]}"#);
+    Ok(())
+}
+
 /// #1223: a comma-grouped multi-path `del()` used to crash when a sibling's
 /// chained-slice target was an `Object`, instead of applying #1162's own
 /// parent-key-drop rule (which the *single-path* form of this exact query

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21834,6 +21834,76 @@ fn test_yq_nonterminal_iterate_container_fanout_noop_1432() -> Result<()> {
     Ok(())
 }
 
+/// #1432 (coverage): `assign_path_all_noop`'s `Field`/`Index` arms each
+/// have their own catch-all(s) for a *mid-prefix* step (one with more
+/// prefix still remaining after it, as opposed to the terminal
+/// component) that neither matches its expected container type nor hits
+/// a genuine scalar. Needs at least two real path components before the
+/// fan-out `Iterate` to actually reach these arms mid-recursion --
+/// `.a[].c`-shaped queries (a single `Field` immediately followed by the
+/// `Iterate`) only ever reach this predicate's *base case*, since the
+/// terminal component is checked there, never fed back into the
+/// recursion. Pins succinctly's current behavior rather than asserting
+/// yq parity: real yq's own semantics for three of these four shapes
+/// diverge from succinctly's in ways well outside #1432's own RHS-discard
+/// scope (live-verified against v4.53.3) --
+/// - a `Field` step hitting a real `Array` raises yq's own structural
+///   "cannot index array" error *before* the RHS ever evaluates, where
+///   succinctly evaluates the RHS first (`boom`);
+/// - a genuinely out-of-range `Index` step *autovivifies* the array out
+///   to that length in real yq (writing `null` padding, then fanning the
+///   `Iterate` into the newly-created empty tail -- no error, no RHS
+///   evaluation at all), where succinctly has no such padding and
+///   evaluates the RHS instead;
+/// - an `Index` step hitting a real `Object` coerces the index to a
+///   string key and inserts it in real yq (`{"0": []}`), where
+///   succinctly has no such coercion and evaluates the RHS instead.
+///
+/// All three are pre-existing, unrelated write-path gaps (this exact
+/// catch-all replaces `navigate_read_only`'s own pre-existing `_ =>
+/// Absent` for the identical shapes) -- out of scope here, not
+/// introduced or worsened by this fix. The fourth shape (`Index` hitting
+/// a genuine scalar) is the one case that *does* already match yq: a
+/// scalar hit anywhere mid-chain permanently no-ops the whole write
+/// (#1232), regardless of position.
+#[test]
+fn test_yq_assign_all_noop_mismatched_element_type_1432() -> Result<()> {
+    // `Field` mid-prefix hits a real `Array` (wrong container type),
+    // with a `Field` still ahead of it in the prefix.
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        ".a.b[].c = error(\"boom\")",
+        "a:\n  - 1\n  - 2\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    // `Index` mid-prefix is out of range on a real `Array`, with an
+    // `Index` still ahead of it in the prefix.
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        ".a[5][].b = error(\"boom\")",
+        "a:\n  - 1\n  - 2\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    // `Index` mid-prefix hits a genuine scalar -- permanently no-ops,
+    // matching real yq exactly (#1232).
+    let (out, err, code) =
+        run_yq_stdin_with_stderr(".a[0][].b = error(\"boom\")", "a: 5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": 5\n}");
+
+    // `Index` mid-prefix hits a real `Object` (wrong container type).
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a[0][].b = error(\"boom\")", "a: {}\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    Ok(())
+}
+
 /// #1426: real yq's flag grammar for `test`/`match`/`capture` is much
 /// narrower than jq's -- only `g` is a real flag, live-verified against
 /// yq v4.53.3. Every case here is a direct transcription of a live probe

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19836,6 +19836,35 @@ fn test_yq_del_slice_outcome_iterate_prefix_real_container_1432() -> Result<()> 
     Ok(())
 }
 
+/// #1432 (coverage, #1863): the same `navigate_read_only` `Iterate` arm's
+/// scalar-hit and `Null`/catch-all branches, reached via `del()`. Both are
+/// pinned as *known-divergent* -- pre-existing bugs unrelated to #1432's
+/// own fix (`navigate_read_only`'s match arms are byte-for-byte unchanged
+/// by that PR), found only while restoring this coverage, not something
+/// this PR fixes. Real yq applies the same #1181/#1232 "a scalar hit
+/// anywhere mid-chain permanently no-ops" rule `=`'s own write path (and
+/// `del()`'s slice-prefix handling elsewhere in this same file) already
+/// get right, and autovivifies `null` the same way `.a[].b = v` does --
+/// `del()`'s own `Iterate`-then-slice path does neither, raising instead.
+/// Live-verified against yq v4.53.3; reported as a follow-up on #1863.
+#[test]
+fn test_yq_del_slice_outcome_iterate_prefix_scalar_and_null_1432() -> Result<()> {
+    // Scalar hit -- real yq no-ops; succinctly raises.
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("del(.a[].b[0:1])", "a: 5\n", &["-o=json", "-I=0"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Cannot iterate"), "err={err}");
+
+    // `Null` -- real yq autovivifies to `[]` (nothing to delete);
+    // succinctly raises.
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("del(.a[].b[0:1])", "a: null\n", &["-o=json", "-I=0"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Cannot iterate"), "err={err}");
+
+    Ok(())
+}
+
 /// #1223: a comma-grouped multi-path `del()` used to crash when a sibling's
 /// chained-slice target was an `Object`, instead of applying #1162's own
 /// parent-key-drop rule (which the *single-path* form of this exact query

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21746,21 +21746,37 @@ fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
 /// ends up empty and real yq discards the RHS too (`a: null` becomes
 /// `a: []` there, with the RHS never running -- live-verified against yq
 /// v4.53.3). #1432 deliberately leaves this excluded rather than folding it
-/// in: probing further (with a safe, always-evaluated RHS, independent of
-/// this predicate entirely) found that succinctly's write path doesn't even
-/// perform the `null` -> `[]` autovivification here at all (`a: null`
-/// stays `a: null` for `.a[].b = 5`, where real yq still produces
-/// `a: []`) -- a separate, pre-existing write-correctness bug that
-/// `yq_assign_is_total_noop`'s all-or-nothing `Skip(pristine)` short-circuit
-/// would make *permanent* rather than merely already-wrong if `Null` were
-/// folded into the no-op predicate. Filed as #1857; pinned here as a
-/// known-divergent case, not a regression to fix in this PR.
+/// in: this predicate's only caller has an all-or-nothing `Skip`/`Continue`
+/// split, and `Skip` means "return the document completely unchanged" --
+/// reporting `Null` as a no-op would discard the legitimate `null` -> `[]`
+/// write, which this codebase's own write path already performs correctly
+/// (confirmed live with a safe RHS, independent of this predicate: `.a[].b
+/// = 5` on `a: null` already produces `a: []` here, matching the oracle --
+/// an earlier version of this comment wrongly claimed that autovivification
+/// was itself broken; it isn't, see #1857's correction). The real, narrower
+/// gap this leaves is exactly what this test pins: the RHS still evaluates
+/// eagerly for `Null`, where real yq's own equivalent write never needs it
+/// at all. Filed as #1857; pinned here as a known-divergent case, not a
+/// regression to fix in this PR. The second case below shows the same gap
+/// reached through #1432's own new recursion (a `Null` nested inside a
+/// fanned-into array), not just a bare top-level target.
 #[test]
 fn test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298() -> Result<()> {
     let (_out, err, code) =
         run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: null\n", &["-o", "json"])?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
+
+    // Same gap, reached through #1432's recursive fan-out rather than as
+    // the direct top-level target.
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        ".a[][].b = error(\"boom\")",
+        "a:\n  - null\n  - [1]\n",
+        &["-o", "json"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1432

## Root cause

`yq_assign_is_total_noop`'s prefix walk (`navigate_read_only`) deferred to normal RHS evaluation for *any* real `Array`/`Object` hit by a mid-chain `Iterate`, even when every element/value would itself no-op the rest of the path — so `.a[].b = error("boom")` on `a: [1, 2]` (both elements scalar) incorrectly evaluated the RHS and raised, where real yq silently discards it (confirmed live against yq v4.53.3).

## Fix

New `assign_path_all_noop` recurses into `.iter().all(...)`/`.values().all(...)` at a mid-chain `Iterate` hitting a real container, instead of unconditionally deferring — a read-only, non-mutating dry run of `set_path_through_iterate`'s own per-element recursion, restricted to the `Field`/`Index`/`IndexNumber`/`Iterate` step vocabulary that's all this predicate's caller ever hands it (its own slice check already excludes anything else). Vacuously true for an empty container, and naturally handles nested `Iterate`s (`.a[][].b`) since the recursion applies at every level.

`PrefixNavOutcome::Resolved`'s payload became dead once its only reader (the terminal scalar check) moved into `assign_path_all_noop`'s own base case, so it's now a unit variant.

## Scope note: `Null` deliberately excluded

While verifying the fix against the oracle, found that real yq's `.a[].b = <RHS>` on `a: null` autovivifies `null` → `[]` as part of the write itself — but probing independently (a safe, always-evaluated RHS, isolated from this predicate entirely) showed succinctly's write path doesn't perform that autovivification at all today (`a: null` stays `a: null`, where real yq produces `a: []`). This is a separate, pre-existing write-correctness bug, not something this predicate can fix — its caller's `Skip(pristine)` short-circuit returns the *unmodified* original on a `true` result, which would make the missing autovivification permanent instead of merely already-wrong. Filed separately as #1857.

## Verification

- Live-verified every new case against yq v4.53.3 before implementing: empty array/object, all-scalar array/object, nested `Iterate`s, and a genuinely mixed (non-scalar-containing) fan-out that must still evaluate the RHS.
- New tests cover all of the above, plus the `Field`/`Index` mid-prefix mismatch arms (wrong container type, out-of-range index, scalar hit) needed to reach 96.77% patch coverage — the one remaining uncovered line is a defensive, provably-unreachable catch-all, documented and matching an identical pre-existing precedent elsewhere in this same predicate family.
- Full test suite green under both `cargo test --verbose` (default features, matches CI) and `cargo test --features cli,simd,regex,serde` (full feature set), before and after rebasing onto `main`.
- `cargo clippy --all-targets --all-features -- -D warnings` clean (both feature-set clippy legs).
- `cargo build --no-default-features` clean (no_std compatibility).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo test --verbose` (default features, matches CI)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --no-default-features`
- [x] `omni-dev coverage diff` — 96.77% patch coverage (30/31; remaining line is documented defensive/unreachable)