### PR TITLE
fix(jq): paths/leaf_paths/pick/omit silently drop malformed object keys

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -846,19 +846,30 @@ coverage differs:
 
 A library caller who follows the documented `eval()` example and evaluates straight off a
 fresh cursor gets #1677 protection only from `keys`/`keys_unsorted`/`to_entries`; every other
-builtin in this file, checked or not on the decode-failure/#1194 axis, still misses it. The CLI
-itself never reaches this path except through the reindex bridge, which only ever feeds it an
-already-validated `OwnedValue`, so `sjq`/`syq` are unaffected. The remaining #1677 call sites
-(`with_entries`'s own post-`to_entries` reassembly step, `map_values`, `paths`, `leaf_paths`, and
-the `pick`/`omit` pair review surfaced alongside this issue) are tracked as a follow-up (#1829)
-rather than folded into #1677 itself, which scoped itself to `eval_generic.rs`.
+builtin in this file, checked or not on the decode-failure/#1194 axis, still misses it.
 
-Only `with_entries` routes through `to_entries` internally (it calls `builtin_to_entries`
-directly), so it inherits this fix's #1194/#1642/#1677 coverage for free on the decode step --
-though it still needs its own audit for whatever it does with the *reconstructed* object
-afterward before this issue can consider it closed. `map_values` is a separate, independent
-hand-rolled walk with the identical silent-`continue` shape `keys`/`to_entries` had before their
-own fixes -- unrelated to `to_entries` and not covered by this change at all.
+**#1829 closed the remaining gap** (`map_values` via #1835/#1848/#1854; `with_entries`
+confirmed to inherit `to_entries`'s fix for free, needing no separate change; `paths`,
+`leaf_paths`, and the `pick`/`omit` pair via #1862) -- but not uniformly through this file's own
+`to_owned`/`effective_fields` family. `map_values`/`pick`/`omit` did route through this file's
+own `effective_fields_checked`, matching the paragraph above. `paths`/`leaf_paths` did not: their
+*actual* fix landed in `eval_generic.rs`'s `collect_paths_generic`, the CLI's own native
+`Builtin::Paths`/`Builtin::LeafPaths` dispatch -- **the "CLI unaffected" claim this paragraph
+used to make here was wrong for those two.** `sjq`/`syq paths`/`leaf_paths` do *not* reach this
+file at all; they bypass the reindex bridge entirely via their own `eval_generic.rs` arm, which
+carried the identical #1194 silent-drop bug independently (confirmed live against a built
+release binary: `printf '{"a":1,"b"}' | succinctly jq paths` returned `["a"]` at exit 0 even
+after this file's own `builtin_paths`/`builtin_leaf_paths` were fixed, until `collect_paths_generic`
+was fixed too). `pick`/`omit` have no native `eval_generic.rs` arm, so the "CLI unaffected" claim
+does hold for them -- the reindex bridge they fall through to already fed them an
+already-validated `OwnedValue` before this file's own fix, making that fix real for the library
+API but largely redundant for `sjq`/`syq`.
+
+**The durable lesson**: a unit test against `succinctly::jq::eval` (this file's own entry point)
+proves a fix reaches library callers, never that it reaches the CLI -- only a build-and-run
+check against the actual binary proves that, and is worth doing for any future builtin that has
+(or might grow) its own native `eval_generic.rs` implementation rather than falling through to
+this file via the bridge.
 
 ## Refusing an allocation jq does not survive
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34362,20 +34362,28 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Ok(f) => f,
                 Err(e) => return QueryResult::Error(e),
             };
+            // Resolve each field's display key once, not once per
+            // requested key (code review, #1829): the raw scan the fix
+            // above replaced re-decoded every field's key on every outer
+            // iteration -- O(keys * fields) decodes where `checked`'s own
+            // keys never change across that loop. Unreachable in practice
+            // -- `effective_fields_checked` already rejected a
+            // structurally malformed key (#1194) -- checked anyway,
+            // matching `effective_keys`'s own defensive style rather than
+            // assuming.
+            let mut resolved_fields = vec_with_capacity(checked.len());
+            for field in &checked {
+                let Some(key) = key_display_string(&field.key) else {
+                    return QueryResult::Error(fields.malformed_member_error());
+                };
+                resolved_fields.push((key, field));
+            }
             // For objects, pick specified string keys
             let mut result = IndexMap::new();
             for key in keys {
                 if let OwnedValue::String(k) = key {
                     // Find the field in the object
-                    for field in &checked {
-                        // `effective_fields_checked` already rejected a
-                        // structurally malformed key (#1194), so `None`
-                        // here is unreachable in practice -- checked
-                        // anyway, matching `effective_keys`'s own
-                        // defensive style rather than assuming.
-                        let Some(resolved) = key_display_string(&field.key) else {
-                            return QueryResult::Error(fields.malformed_member_error());
-                        };
+                    for (resolved, field) in &resolved_fields {
                         if resolved.as_ref() == k.as_str() {
                             // #1755: to_owned_checked, not to_owned
                             // -- an undecodable picked value must
@@ -38019,6 +38027,44 @@ mod tests {
     fn test_builtin_paths_filter_raises_on_structurally_malformed_key_1829() {
         query!(br#"{"a":1,"b"}"#, "paths(true)",
             QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829 code review: `pick`/`omit(...)?` must suppress the new
+    /// malformed-key errors via the outer `Expr::Optional` catch, matching
+    /// `keys?`/`to_entries?`/`map_values(...)?`'s already-tested convention
+    /// -- flagged as a coverage gap (no runtime bug; both already behaved
+    /// correctly) since `pick`/`omit` were the only two of the five #1829
+    /// builtins in this slice without a dedicated test pinning it.
+    #[test]
+    fn test_builtin_pick_omit_optional_suppresses_malformed_key_errors_1829() {
+        query!(br#"{"a":1,"b"}"#, "pick([\"a\"])?", QueryResult::None => {});
+        query!(br#"{"a":1,"b"}"#, "omit([\"a\"])?", QueryResult::None => {});
+        query!(br#"{"a" 1, "b": 2}"#, "pick([\"b\"])?", QueryResult::None => {});
+        query!(br#"{"a" 1, "b": 2}"#, "omit([\"b\"])?", QueryResult::None => {});
+    }
+
+    /// #1829 code review: the object arm's `effective_fields_checked`
+    /// rewrite collapses a duplicate key to its last occurrence *before*
+    /// `pick` ever looks for it (jq mode) -- real jq collapses a repeated
+    /// document key at parse time, before any filter runs (`{"a":1,"a":2}
+    /// | .` is `{"a":2}`, confirmed live against jq 1.7.1), so `pick`
+    /// finding the *last* value here isn't a `pick`-specific policy, it's
+    /// `pick` correctly seeing the same document jq itself would. The old
+    /// raw `for field in *fields` scan `effective_fields_checked` replaced
+    /// found the *first* occurrence instead (`{"a":1}`), an undocumented
+    /// side effect this PR's diff didn't call out; pinned here so a future
+    /// change back to a raw scan doesn't silently regress it. `omit` is
+    /// unaffected either way -- its `IndexMap::insert` overwrite-on-
+    /// duplicate-key already produced last-value-wins under the old scan
+    /// too, since it walks (and inserts) every occurrence rather than
+    /// stopping at the first match the way `pick`'s lookup does.
+    #[test]
+    fn test_builtin_pick_finds_last_value_for_duplicate_key_1829() {
+        query!(br#"{"a":1,"a":2}"#, "pick([\"a\"])",
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(o.get("a"), Some(&OwnedValue::Int(2)));
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34371,30 +34371,71 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // structurally malformed key (#1194) -- checked anyway,
             // matching `effective_keys`'s own defensive style rather than
             // assuming.
+            //
+            // `key_display_string_kind`, not the plain `key_display_string`
+            // -- code review (#1829): the first version of this fix looked
+            // up a match with a bare linear scan, so two distinct
+            // undecodable keys sharing the same #1642 fallback spelling
+            // (e.g. `{"\xff\xfe":1,"\xff\xfd":2}`, both lossy-decoding to
+            // the same replacement text) silently resolved to whichever
+            // came first in document order -- inconsistent with
+            // `omit`/`map_values`/`to_entries` on the identical document,
+            // which all raise `colliding_display_key` for this shape via
+            // `DisplayKeyGuard`. `pick` doesn't build an `IndexMap` over
+            // every field the way those three do, so it can't reuse
+            // `DisplayKeyGuard` directly (that type answers "does the map
+            // already contain this key", not "do two *candidates* for the
+            // same lookup collide") -- the loop below applies the same
+            // underlying rule (a collision is only real when at least one
+            // colliding occurrence is itself a fallback key; an ordinary
+            // repeated key, reachable only in yq mode since jq mode
+            // collapses via `S::COLLAPSE_DUPLICATE_KEYS` above, is not an
+            // error) directly against the two matching candidates instead.
             let mut resolved_fields = vec_with_capacity(checked.len());
             for field in &checked {
-                let Some(key) = key_display_string(&field.key) else {
+                let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
                     return QueryResult::Error(fields.malformed_member_error());
                 };
-                resolved_fields.push((key, field));
+                resolved_fields.push((key, is_fallback, field));
             }
             // For objects, pick specified string keys
             let mut result = IndexMap::new();
             for key in keys {
                 if let OwnedValue::String(k) = key {
-                    // Find the field in the object
-                    for (resolved, field) in &resolved_fields {
-                        if resolved.as_ref() == k.as_str() {
-                            // #1755: to_owned_checked, not to_owned
-                            // -- an undecodable picked value must
-                            // raise, not silently become "".
-                            let owned = match to_owned_checked(&field.value) {
-                                Ok(v) => v,
-                                Err(e) => return QueryResult::Error(e),
-                            };
-                            result.insert(k.clone(), owned);
-                            break;
+                    // Find every field matching this requested key -- not
+                    // just the first -- so a genuine #1642 collision
+                    // between two candidates can be told apart from an
+                    // ordinary repeated key sharing the same match.
+                    let mut found = None;
+                    let mut collides = false;
+                    for (resolved, is_fallback, field) in &resolved_fields {
+                        if resolved.as_ref() != k.as_str() {
+                            continue;
                         }
+                        match found {
+                            None => found = Some((*is_fallback, field)),
+                            Some((first_is_fallback, _)) if first_is_fallback || *is_fallback => {
+                                collides = true;
+                                break;
+                            }
+                            // An ordinary duplicate match: first occurrence
+                            // wins, matching this loop's own pre-#1829
+                            // behavior for the non-fallback case.
+                            Some(_) => {}
+                        }
+                    }
+                    if collides {
+                        return QueryResult::Error(EvalError::colliding_display_key(k));
+                    }
+                    if let Some((_, field)) = found {
+                        // #1755: to_owned_checked, not to_owned
+                        // -- an undecodable picked value must
+                        // raise, not silently become "".
+                        let owned = match to_owned_checked(&field.value) {
+                            Ok(v) => v,
+                            Err(e) => return QueryResult::Error(e),
+                        };
+                        result.insert(k.clone(), owned);
                     }
                     // If key not found, yq silently skips it
                 }
@@ -38064,6 +38105,36 @@ mod tests {
         query!(br#"{"a":1,"a":2}"#, "pick([\"a\"])",
             QueryResult::Owned(OwnedValue::Object(o)) => {
                 assert_eq!(o.get("a"), Some(&OwnedValue::Int(2)));
+            }
+        );
+    }
+
+    /// #1829 code review: two distinct undecodable keys whose #1642
+    /// fallback spellings collide must raise for `pick` too, matching
+    /// `omit`/`map_values`/`to_entries` on the identical document --
+    /// `pick` doesn't build a real `IndexMap` over every field the way
+    /// those three do, so it can't reuse `DisplayKeyGuard` directly, but
+    /// still must not silently resolve the ambiguity by picking whichever
+    /// candidate comes first in document order.
+    #[test]
+    fn test_builtin_pick_raises_on_colliding_fallback_keys_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"\xff\xfd\": 2}";
+        query!(doc, "pick([\"\u{fffd}\u{fffd}\"])",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829 code review: an *ordinary* repeated key (no decode failure on
+    /// either side) reaching `pick`'s match loop -- only possible in yq
+    /// mode, since jq mode's `S::COLLAPSE_DUPLICATE_KEYS` already collapsed
+    /// it away before this loop ever runs -- must not be treated as a
+    /// #1642 collision. First occurrence wins, matching this loop's own
+    /// pre-#1829 behavior for the non-fallback case.
+    #[test]
+    fn test_builtin_pick_yq_mode_ordinary_duplicate_key_is_not_a_collision_1829() {
+        yq_query!(br#"{"a": 1, "a": 2}"#, "pick([\"a\"])",
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(o.get("a"), Some(&OwnedValue::Int(1)));
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27919,11 +27919,25 @@ fn builtin_truncate_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
 /// Builtin: paths - all paths to values (excluding empty paths)
 /// Returns each path as a separate output (streaming), matching jq behavior
+///
+/// #1829: `to_owned_checked`, not `to_owned` -- an undecodable object key
+/// was previously dropped silently (a shrunk object, not an error), where
+/// `path(.[])`/`tojson`/`keys`/`to_entries`/`map_values` all raise or
+/// preserve it via `resolve_display_key`'s #1642 fallback spelling.
+/// `_optional` stays unused, matching `builtin_path`'s own root
+/// `to_owned_checked` call: catchability is handled uniformly one level up
+/// by `eval_try`, which passes the *same* `optional` this function received
+/// down through `eval_single` already -- so a wrapping `paths?` suppresses
+/// a catchable result here without this function needing to consult it
+/// itself, and `is_decode_failure()` errors stay uncatchable regardless.
 fn builtin_paths<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
-    let owned = to_owned(&value);
+    let owned = match to_owned_checked(&value) {
+        Ok(owned) => owned,
+        Err(e) => return QueryResult::Error(e),
+    };
     let mut paths = Vec::new();
     collect_paths(&owned, &mut Vec::new(), &mut paths);
     // Stream individual paths instead of wrapping in array
@@ -28002,7 +28016,16 @@ fn each_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
-    let owned = to_owned(&value);
+    // #1829: `to_owned_checked`, not `to_owned` -- shares `builtin_paths`'s
+    // own fix (an undecodable key was previously dropped silently instead
+    // of raising or preserving its #1642 fallback spelling). Same
+    // "eager and unconditional" placement as the root node_filter pre-check
+    // just below: nothing has been pushed to `sink` yet, so this is always
+    // a bare `Error`, never a `Partial`.
+    let owned = match to_owned_checked(&value) {
+        Ok(owned) => owned,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
 
     if let Err(control) = eval_owned_expr_ctrl::<S>(filter, &owned, optional) {
         return Flow::Escaped(control);
@@ -28149,11 +28172,18 @@ fn collect_leaf_paths(
 /// also yields paths to `null` values and empty `{}`/`[]`, which that
 /// recipe's `scalars` filter excludes. See `collect_leaf_paths` and #771.
 /// Returns each path as a separate output (streaming).
+///
+/// #1829: `to_owned_checked`, not `to_owned` -- shares `builtin_paths`'s own
+/// fix and its reasoning for leaving `_optional` unused (see that function's
+/// doc comment).
 fn builtin_leaf_paths<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     _optional: bool,
 ) -> QueryResult<'_, W> {
-    let owned = to_owned(&value);
+    let owned = match to_owned_checked(&value) {
+        Ok(owned) => owned,
+        Err(e) => return QueryResult::Error(e),
+    };
     let mut paths = Vec::new();
     collect_leaf_paths(&owned, &mut Vec::new(), &mut paths);
     // Stream individual paths instead of wrapping in array
@@ -34319,26 +34349,43 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     match &value {
         StandardJson::Object(fields) => {
+            // #1829: route through `effective_fields_checked` (matching
+            // `map_values`/`to_entries`'s established Object-arm pattern)
+            // instead of a raw `for field in *fields` scan -- the raw scan
+            // silently skipped any field whose key failed to decode (#1642)
+            // or was structurally malformed/unpaired (#1194/#1677) rather
+            // than raising or making it reachable via its #1642 fallback
+            // spelling, so `pick(["<undecodable key's fallback
+            // spelling>"])` could never find it, and a malformed document
+            // pick'd from without any indication.
+            let checked = match effective_fields_checked(fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                Ok(f) => f,
+                Err(e) => return QueryResult::Error(e),
+            };
             // For objects, pick specified string keys
             let mut result = IndexMap::new();
             for key in keys {
                 if let OwnedValue::String(k) = key {
                     // Find the field in the object
-                    for field in *fields {
-                        if let StandardJson::String(key_str) = field.key() {
-                            if let Ok(cow) = key_str.as_str() {
-                                if cow.as_ref() == k.as_str() {
-                                    // #1755: to_owned_checked, not to_owned
-                                    // -- an undecodable picked value must
-                                    // raise, not silently become "".
-                                    let owned = match to_owned_checked(&field.value()) {
-                                        Ok(v) => v,
-                                        Err(e) => return QueryResult::Error(e),
-                                    };
-                                    result.insert(k.clone(), owned);
-                                    break;
-                                }
-                            }
+                    for field in &checked {
+                        // `effective_fields_checked` already rejected a
+                        // structurally malformed key (#1194), so `None`
+                        // here is unreachable in practice -- checked
+                        // anyway, matching `effective_keys`'s own
+                        // defensive style rather than assuming.
+                        let Some(resolved) = key_display_string(&field.key) else {
+                            return QueryResult::Error(fields.malformed_member_error());
+                        };
+                        if resolved.as_ref() == k.as_str() {
+                            // #1755: to_owned_checked, not to_owned
+                            // -- an undecodable picked value must
+                            // raise, not silently become "".
+                            let owned = match to_owned_checked(&field.value) {
+                                Ok(v) => v,
+                                Err(e) => return QueryResult::Error(e),
+                            };
+                            result.insert(k.clone(), owned);
+                            break;
                         }
                     }
                     // If key not found, yq silently skips it
@@ -34466,22 +34513,46 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 })
                 .collect();
 
+            // #1829: route through `effective_fields_checked` (matching
+            // `map_values`/`to_entries`'s established Object-arm pattern)
+            // instead of a raw `for field in *fields` scan. Unlike `pick`'s
+            // identical fix above, this was the more severe axis: `omit`
+            // *keeps* everything not named, so the raw scan's silent skip
+            // on a decode-failure or structurally malformed key (#1642/
+            // #1194) silently **dropped** that field from the output --
+            // the opposite of what an unmatched key should do -- rather
+            // than raising or preserving it via its #1642 fallback
+            // spelling the way `keys`/`to_entries`/`map_values` do.
+            let checked = match effective_fields_checked(fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                Ok(f) => f,
+                Err(e) => return QueryResult::Error(e),
+            };
             let mut result = IndexMap::new();
-            for field in *fields {
-                if let StandardJson::String(key_str) = field.key() {
-                    if let Ok(cow) = key_str.as_str() {
-                        let key = cow.as_ref();
-                        if !omit_keys.contains(&key) {
-                            // #1755: to_owned_checked, not to_owned -- an
-                            // undecodable kept value must raise, not
-                            // silently become "".
-                            let owned = match to_owned_checked(&field.value()) {
-                                Ok(v) => v,
-                                Err(e) => return QueryResult::Error(e),
-                            };
-                            result.insert(key.to_string(), owned);
-                        }
+            // Two distinct undecodable keys whose #1642 fallback spellings
+            // collide must raise rather than silently overwrite one
+            // another in `result` -- same `DisplayKeyGuard` `map_values`
+            // uses for its own real `IndexMap` build.
+            let mut guard = DisplayKeyGuard::default();
+            for field in &checked {
+                // Unreachable in practice -- `effective_fields_checked`
+                // already rejected a structurally malformed key (#1194) --
+                // checked anyway, matching `effective_keys`'s own
+                // defensive style rather than assuming.
+                let Some((key, is_fallback)) = key_display_string_kind(&field.key) else {
+                    return QueryResult::Error(fields.malformed_member_error());
+                };
+                if !omit_keys.contains(key.as_ref()) {
+                    if !guard.check(&result, &key, is_fallback) {
+                        return QueryResult::Error(EvalError::colliding_display_key(&key));
                     }
+                    // #1755: to_owned_checked, not to_owned -- an
+                    // undecodable kept value must raise, not
+                    // silently become "".
+                    let owned = match to_owned_checked(&field.value) {
+                        Ok(v) => v,
+                        Err(e) => return QueryResult::Error(e),
+                    };
+                    result.insert(key.into_owned(), owned);
                 }
             }
             QueryResult::Owned(OwnedValue::Object(result))
@@ -37830,6 +37901,124 @@ mod tests {
                 assert!(!o.contains_key("a"));
                 assert_eq!(o.get("b"), Some(&OwnedValue::Int(2)));
             }
+        );
+    }
+
+    /// #1829: `pick`/`omit`'s *own field walk* (as opposed to the
+    /// keys-expression resolution #1755 above already fixed) used a raw
+    /// `for field in *fields` scan that silently skipped a field whose key
+    /// failed to decode -- `pick` could never locate it by its #1642
+    /// fallback spelling, and `omit` (the more severe direction, since it
+    /// *keeps* everything not named) silently dropped it from the output
+    /// entirely. `\xff\xfe`'s fallback spelling lossy-decodes to two
+    /// U+FFFD replacement characters (confirmed via `String::from_utf8_lossy`).
+    #[test]
+    fn test_builtin_pick_finds_undecodable_key_via_fallback_spelling_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+        query!(doc, "pick([\"\u{fffd}\u{fffd}\"])",
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(o.len(), 1);
+                assert_eq!(o.get("\u{fffd}\u{fffd}"), Some(&OwnedValue::Int(1)));
+            }
+        );
+    }
+
+    #[test]
+    fn test_builtin_omit_preserves_undecodable_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+        // Omitting an unrelated key must keep the undecodable one, not
+        // silently drop it.
+        query!(doc, "omit([\"a\"])",
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(o.len(), 1);
+                assert_eq!(o.get("\u{fffd}\u{fffd}"), Some(&OwnedValue::Int(1)));
+            }
+        );
+        // Omitting it by its own fallback spelling removes it.
+        query!(doc, "omit([\"\u{fffd}\u{fffd}\"])",
+            QueryResult::Owned(OwnedValue::Object(o)) => {
+                assert_eq!(o.len(), 1);
+                assert_eq!(o.get("a"), Some(&OwnedValue::Int(2)));
+            }
+        );
+    }
+
+    /// #1829: a structurally non-string/unpaired key (#1194,
+    /// `{"a":1,"b"}`) must raise for `pick`/`omit` too, matching
+    /// `keys`/`to_entries`/`map_values` -- previously silently ignored
+    /// (a shrunk or unaffected object, not an error).
+    #[test]
+    fn test_builtin_pick_omit_raise_on_structurally_malformed_key_1829() {
+        query!(br#"{"a":1,"b"}"#, "pick([\"a\"])",
+            QueryResult::Error(_) => {}
+        );
+        query!(br#"{"a":1,"b"}"#, "omit([\"c\"])",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829: a malformed `,`/`:` delimiter (#1677) now raises for
+    /// `pick`/`omit` too.
+    #[test]
+    fn test_builtin_pick_omit_raise_on_malformed_delimiter_1829() {
+        query!(br#"{"a" 1, "b": 2}"#, "pick([\"b\"])",
+            QueryResult::Error(_) => {}
+        );
+        query!(br#"{"a" 1, "b": 2}"#, "omit([\"b\"])",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829: two decode-failure keys whose fallback spellings collide
+    /// must raise for `omit` too, matching `map_values`'s own
+    /// `DisplayKeyGuard` fix -- `omit` builds a real `IndexMap` the same
+    /// way, so silently overwriting one with the other would lose data.
+    #[test]
+    fn test_builtin_omit_raises_on_colliding_fallback_keys_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"\xff\xfd\": 2}";
+        query!(doc, "omit([\"nonexistent\"])",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829: `leaf_paths` shares `paths`'s own #1642/#1194 fix (both call
+    /// through the same `to_owned`-vs-`to_owned_checked` fix at their root
+    /// materialization step) -- previously silently dropped an undecodable
+    /// key's path instead of raising or preserving it via its fallback
+    /// spelling.
+    #[test]
+    fn test_builtin_leaf_paths_preserves_undecodable_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+        query!(doc, "[leaf_paths] | length",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(br#"{"a":1,"b"}"#, "leaf_paths",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829: bare `paths` (not `paths(filter)`) previously silently
+    /// dropped an undecodable object key's path entirely instead of
+    /// raising or preserving it -- disagreeing with `path(.[])`/`tojson`/
+    /// `keys`/`to_entries`/`map_values` on the same document.
+    #[test]
+    fn test_builtin_paths_preserves_undecodable_key_1829() {
+        let doc: &[u8] = b"{\"\xff\xfe\": 1, \"a\": 2}";
+        query!(doc, "[paths] | length",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(br#"{"a":1,"b"}"#, "paths",
+            QueryResult::Error(_) => {}
+        );
+    }
+
+    /// #1829: `paths(filter)` (`Builtin::PathsFilter`, the lazy generator
+    /// `each_paths_filter`) shares `paths`'s own root-materialization fix
+    /// -- a separate call site from bare `paths` above.
+    #[test]
+    fn test_builtin_paths_filter_raises_on_structurally_malformed_key_1829() {
+        query!(br#"{"a":1,"b"}"#, "paths(true)",
+            QueryResult::Error(_) => {}
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6815,9 +6815,8 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
 /// `current_path.push`/`.pop()` around each recursive call (rather than a
 /// clone-and-extend style) is safe here because every `push` is followed,
 /// after the recursive call returns, by exactly one matching `pop` on every
-/// exit path -- the sole early exit before a `push` (`key_str()` returning
-/// `None`) is a `continue` that skips straight to the next field without
-/// ever pushing.
+/// exit path -- the sole early exit before a `push` (a malformed key) is a
+/// `return Err(..)` that unwinds the whole walk without ever pushing.
 ///
 /// The array branch walks `uncons()` directly rather than materializing
 /// `collect_values()`'s `Vec` first (code review, #868) -- arrays have no
@@ -6828,38 +6827,47 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
 /// `to_owned`/`to_owned_cursor` already carry -- `current_path.len()` tracks
 /// depth without a separate counter, same shape as `collect_paths`'s own
 /// `#1021` guard.
+///
+/// #1829: `effective_fields_checked`, not the infallible `effective_fields`
+/// -- this is the CLI's own native `Builtin::Paths`/`Builtin::LeafPaths`
+/// dispatch (`eval_generic.rs`'s `eval_builtin`), reached directly by
+/// `succinctly jq`/`succinctly yq`, not through `eval.rs`'s
+/// `StandardJson`-specific `builtin_paths`/`builtin_leaf_paths` (those are
+/// reachable only via the public library entry point
+/// `succinctly::jq::eval`, per #1755's own precedent comment on the
+/// sort/min/max family having the identical library-only gap). This
+/// function's own doc comment used to admit "no error channel to raise
+/// through" for a structurally malformed key (#1194) -- fixed by giving it
+/// one, matching `keys`/`to_entries`/`map_values`'s already-established
+/// #1194/#1677 policy on the same document.
 fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
     value: &V,
     current_path: &mut Vec<OwnedValue>,
     paths: &mut Vec<OwnedValue>,
     leaves_only: bool,
-) {
+) -> Result<(), EvalError> {
     assert_nesting_depth(current_path.len());
     if let Some(fields) = value.as_object() {
-        let fields = effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS);
-        if fields.is_empty() {
+        let checked = effective_fields_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS)?;
+        if checked.is_empty() {
             if leaves_only {
                 paths.push(OwnedValue::Array(current_path.clone()));
             }
-            return;
+            return Ok(());
         }
-        for field in fields {
-            // `key_display_string`, not `field.key_str()`: a key that will
-            // not *decode* (#1247/#1385) is preserved via its raw source
-            // span rather than skipped (#1642), matching
-            // `length`/`keys`/`keys_unsorted`/`.` -- this loop used to
-            // silently drop such a field's path, disagreeing with `keys`
-            // over the same document. A key the format's grammar never
-            // allowed at all (#1194) is still skipped, same as before this
-            // fix (this function has no error channel to raise through).
+        for field in checked {
+            // Unreachable in practice -- `effective_fields_checked` already
+            // rejected a structurally malformed key (#1194) -- checked
+            // anyway, matching `effective_keys`'s own defensive style
+            // rather than assuming.
             let Some(key) = key_display_string(&field.key) else {
-                continue;
+                return Err(fields.malformed_member_error());
             };
             current_path.push(OwnedValue::String(key.into_owned()));
             if !leaves_only {
                 paths.push(OwnedValue::Array(current_path.clone()));
             }
-            collect_paths_generic::<S, _>(&field.value, current_path, paths, leaves_only);
+            collect_paths_generic::<S, _>(&field.value, current_path, paths, leaves_only)?;
             current_path.pop();
         }
     } else if let Some(elements) = value.as_array() {
@@ -6867,7 +6875,7 @@ fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
             if leaves_only {
                 paths.push(OwnedValue::Array(current_path.clone()));
             }
-            return;
+            return Ok(());
         }
         let mut i = 0i64;
         let mut rest = elements;
@@ -6876,7 +6884,7 @@ fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
             if !leaves_only {
                 paths.push(OwnedValue::Array(current_path.clone()));
             }
-            collect_paths_generic::<S, _>(&elem, current_path, paths, leaves_only);
+            collect_paths_generic::<S, _>(&elem, current_path, paths, leaves_only)?;
             current_path.pop();
             i += 1;
             rest = tail;
@@ -6884,6 +6892,7 @@ fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
     } else if leaves_only {
         paths.push(OwnedValue::Array(current_path.clone()));
     }
+    Ok(())
 }
 
 /// Native `Builtin::Has` arm for the generic evaluator (#1739): checks
@@ -7488,24 +7497,28 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // just the root.
         Builtin::Paths => {
             let mut paths = Vec::new();
-            collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, false);
-            collapse_vec(
-                paths,
-                || GenericResult::None,
-                GenericResult::Owned,
-                GenericResult::ManyOwned,
-            )
+            match collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, false) {
+                Ok(()) => collapse_vec(
+                    paths,
+                    || GenericResult::None,
+                    GenericResult::Owned,
+                    GenericResult::ManyOwned,
+                ),
+                Err(e) => GenericResult::Error(e),
+            }
         }
 
         Builtin::LeafPaths => {
             let mut paths = Vec::new();
-            collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, true);
-            collapse_vec(
-                paths,
-                || GenericResult::None,
-                GenericResult::Owned,
-                GenericResult::ManyOwned,
-            )
+            match collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, true) {
+                Ok(()) => collapse_vec(
+                    paths,
+                    || GenericResult::None,
+                    GenericResult::Owned,
+                    GenericResult::ManyOwned,
+                ),
+                Err(e) => GenericResult::Error(e),
+            }
         }
 
         // The `is*` family reads through `tagged_type_name` rather than

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6813,10 +6813,15 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
 /// recorded, not in how the tree is traversed.
 ///
 /// `current_path.push`/`.pop()` around each recursive call (rather than a
-/// clone-and-extend style) is safe here because every `push` is followed,
-/// after the recursive call returns, by exactly one matching `pop` on every
-/// exit path -- the sole early exit before a `push` (a malformed key) is a
-/// `return Err(..)` that unwinds the whole walk without ever pushing.
+/// clone-and-extend style) is safe here despite an unbalanced `push` being
+/// reachable: the `?` on a nested recursive call (#1829) can now return
+/// `Err` right after a `push`, with no matching `pop`. That's fine only
+/// because `current_path` is never read again afterward -- every caller
+/// (`Builtin::Paths`/`Builtin::LeafPaths` in `eval_builtin`) passes a fresh
+/// `&mut Vec::new()` that is discarded whole the instant `Err` propagates
+/// out, not reused for a later path. A caller that ever needed to keep
+/// walking after absorbing this error (unlike today's "abort the whole
+/// builtin" policy) would have to restore the balance on that path too.
 ///
 /// The array branch walks `uncons()` directly rather than materializing
 /// `collect_values()`'s `Vec` first (code review, #868) -- arrays have no

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2940,6 +2940,38 @@ fn test_paths_and_leaf_paths_agree_with_keys_on_decode_failure_1642() -> Result<
     Ok(())
 }
 
+/// #1829: `paths`/`leaf_paths` dispatch, via the shipped CLI, straight to
+/// `eval_generic.rs`'s own native `Builtin::Paths`/`Builtin::LeafPaths` arm
+/// (`collect_paths_generic`) -- a *different* code path from the one
+/// `test_paths_and_leaf_paths_agree_with_keys_on_decode_failure_1642` above
+/// exercises for a merely-undecodable key. A structurally malformed key
+/// (#1194, the grammar never allowed it at all -- e.g. a trailing unpaired
+/// member) used to be silently skipped there instead of raising, so `paths`/
+/// `leaf_paths` disagreed with `keys` on the very shape #1194 exists to
+/// catch, and did so specifically at the CLI: this exact regression was
+/// invisible to a unit test that calls `succinctly::jq::eval` directly,
+/// since that library entry point routes through a completely different,
+/// separately-implemented `eval.rs` copy that never had this gap in the
+/// same way. Confirmed via `git bisect`-style manual check: unmodified
+/// `main`'s CLI binary returns `["a"]` (exit 0, `b`'s path silently
+/// dropped) for the first two queries below; this fix makes them agree
+/// with `keys`.
+#[test]
+fn test_paths_and_leaf_paths_raise_on_structurally_malformed_key_1829() -> Result<()> {
+    let doc = r#"{"a":1,"b"}"#;
+
+    let (_, _, code) = run_jq_full(&["-c", "paths"], Some(doc))?;
+    assert_ne!(code, 0, "paths must raise, not silently drop b's path");
+
+    let (_, _, code) = run_jq_full(&["-c", "leaf_paths"], Some(doc))?;
+    assert_ne!(code, 0, "leaf_paths must raise, not silently drop b's path");
+
+    let (_, _, code) = run_jq_full(&["-c", "keys"], Some(doc))?;
+    assert_ne!(code, 0, "sanity: keys already raises on this document");
+
+    Ok(())
+}
+
 /// #1642 follow-up: `to_owned`/`materialize` (`-S`, `-s`, a multi-result
 /// filter like `.,.`) build an `IndexMap<String, _>` keyed by
 /// `key_display_string`'s fallback. Two *different* decode-failure keys can


### PR DESCRIPTION
Part of #1829 -- the `paths`/`leaf_paths`/`pick`/`omit` slice, following #1835 (`keys`/`keys_unsorted`), #1848 (`to_entries`), and #1854 (`map_values`).

## The real bug (found during code review, not the first commit)

The first commit fixed `eval.rs`'s `StandardJson`-specific `builtin_paths`/`builtin_leaf_paths`/`each_paths_filter`/`builtin_pick`/`builtin_omit` -- but `succinctly jq`/`succinctly yq` dispatch bare `paths`/`leaf_paths` through **`eval_generic.rs`'s own native `Builtin::Paths`/`Builtin::LeafPaths` arm** (`collect_paths_generic`), never through `eval.rs`. `eval.rs`'s copy is reachable only via the public library entry point `succinctly::jq::eval`, not the shipped CLI.

Confirmed empirically against **built binaries**, not just unit tests: unmodified `main`'s CLI still silently drops a structurally malformed key's path even after the first commit's `eval.rs` fix --

```
$ printf '{"a":1,"b"}' | succinctly jq 'paths'   # first-commit binary
["a"]                                             # exit 0, b's path silently dropped
$ printf '{"a":1,"b"}' | succinctly jq 'keys'     # same binary, same document
jq: error (at <stdin>:0): Invalid JSON text: expected ':', found '}'   # exit 5
```

`paths`/`keys` disagreeing on the identical document was exactly the bug this PR claims to fix -- the first commit's own new unit tests passed while the shipped binary was unchanged, because those tests call `succinctly::jq::eval` directly, bypassing the CLI's real dispatch entirely.

**Fix:** `collect_paths_generic` (`eval_generic.rs`) now routes through `effective_fields_checked` instead of the infallible `effective_fields`, giving it the error channel its own doc comment used to admit it lacked. Verified against a clean release build of the actual CLI binary:

```
$ printf '{"a":1,"b"}' | succinctly jq 'paths'   # this PR's binary
jq: error (at <stdin>:0): Invalid JSON text: expected ':', found '}'   # exit 5, now agrees with keys
```

`pick`/`omit`'s `eval.rs` fix, by contrast, has **no CLI-facing effect in practice** -- `Builtin::Pick`/`Builtin::Omit` have no native `eval_generic.rs` arm, so the CLI always falls through to the shared reindex bridge, which already handled #1194/#1642 correctly before this PR (confirmed live on unmodified `main`). The fix is still correct and matters for the direct library API, but is defense-in-depth rather than a CLI bug fix for those two specifically. `paths(filter)` (`each_paths_filter`) is in the same boat -- already bridge-correct on `main`, fixed anyway for library-API consistency.

## What changed

- **`collect_paths_generic`** (`eval_generic.rs`, the CLI-reachable fix): `effective_fields_checked`, not `effective_fields`; both `Builtin::Paths`/`Builtin::LeafPaths` call sites updated to propagate the new `Result`.
- **`builtin_paths`, `each_paths_filter` (`paths(filter)`), `builtin_leaf_paths`** (`eval.rs`, library-API fix): `to_owned_checked`, not `to_owned`, mirroring `builtin_path`'s established pattern.
- **`builtin_pick`/`builtin_omit`'s Object arms** (`eval.rs`, library-API fix): routed through `effective_fields_checked` + `key_display_string`/`key_display_string_kind`, matching `map_values`'s established pattern, instead of a raw per-field scan that silently skipped malformed/undecodable keys. `omit` also gained a `DisplayKeyGuard` collision check since it builds a real `IndexMap`.

## Also from this round of review

- **Performance**: `builtin_pick`'s Object arm re-decoded every field's display key once *per requested key* (O(keys × fields)) instead of once total. Now resolved into a `Vec` up front (O(fields) decode + O(keys × fields) cheap string compare).
- **Behavior pinned, not changed**: `pick` on a document with a literal duplicate key now finds the *last* occurrence in jq mode, matching real jq's own document-level duplicate-key collapse (`{"a":1,"a":2} | .` is `{"a":2}`, confirmed live against jq 1.7.1) -- the old raw scan found the first occurrence instead. This was a real, oracle-verified correctness improvement the first commit's description didn't call out; now has a dedicated regression test. `omit` was already last-value-wins either way.
- **Coverage gap closed**: `pick`/`omit(...)?` lacked a dedicated test pinning that the outer `Expr::Optional` catch suppresses the new malformed-key errors, matching `keys?`/`to_entries?`/`map_values(...)?`'s established convention.
- **New CLI-level integration test** (`test_paths_and_leaf_paths_raise_on_structurally_malformed_key_1829`, `tests/jq_cli_tests.rs`) exercises the actual shipped binary via `run_jq_full`, not just the library entry point -- the exact gap that let the first commit's tests pass while the CLI stayed unfixed.

## Scope note

`with_entries` needed no separate fix -- it already delegates to `builtin_to_entries` and inherited that function's #1848 fix for free, with its own pinned regression test confirming it. Per #1829's own acceptance criteria, that leaves this slice closing out `paths`/`leaf_paths`/`pick`/`omit`, with #1829 itself still open for any further follow-up.

**Worth a follow-up audit**: this "library evaluator fixed, CLI's own native `eval_generic.rs` arm not" gap is specific to builtins with their own native `eval_generic.rs` implementation (`paths`/`leaf_paths` had one; `keys`/`to_entries`/`map_values` apparently didn't -- confirmed those three already behaved correctly via the CLI on `main` before this PR, so this isn't systemic across the whole #1829 family, but it's worth deliberately checking CLI-reachability for any future slice rather than assuming a `eval.rs` unit test alone proves the fix ships).

## Testing

New regression tests (all `_1829`-suffixed):
- `src/jq/eval.rs`: `test_builtin_pick_finds_undecodable_key_via_fallback_spelling_1829`, `test_builtin_omit_preserves_undecodable_key_1829`, `test_builtin_pick_omit_raise_on_structurally_malformed_key_1829`, `test_builtin_pick_omit_raise_on_malformed_delimiter_1829`, `test_builtin_omit_raises_on_colliding_fallback_keys_1829`, `test_builtin_leaf_paths_preserves_undecodable_key_1829`, `test_builtin_paths_preserves_undecodable_key_1829`, `test_builtin_paths_filter_raises_on_structurally_malformed_key_1829`, `test_builtin_pick_omit_optional_suppresses_malformed_key_errors_1829`, `test_builtin_pick_finds_last_value_for_duplicate_key_1829`.
- `tests/jq_cli_tests.rs`: `test_paths_and_leaf_paths_raise_on_structurally_malformed_key_1829` (CLI-level, via `run_jq_full`).

Full local suite green (3039 lib tests, 1079 jq CLI tests, 1276 yq CLI tests, yq golden conformance, cli_golden_tests, doc-tests -- 0 failures), run via `cargo-guard.sh` under concurrent multi-session load. `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second (`broadword-yaml`) clippy leg both clean. `cargo fmt --check`, `cargo build --no-default-features` (no_std), `cargo doc --no-deps --all-features`, and a plain default-features `cargo test` all clean. Live-verified against built release binaries throughout, not just `cargo test`.