### PR TITLE
fix(jq): Builtin::Map's path-context arm forces optional=false, self-catches

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26424,7 +26424,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
                             return stop;
@@ -26440,7 +26440,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
                             return stop;
@@ -26779,6 +26779,24 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // "rest is empty" fast path never fires here -- it degenerates
             // to exactly the `eval_pipe_with_path_context_internal` call
             // `map(f)` needs, no separate helper required.
+            //
+            // Each element's own step is run with `optional` forced to
+            // `false`, not the ambient value this arm itself received --
+            // the exact `Expr::Array` path-context arm's own fix (#1302),
+            // applied here for the first live-reachable repro of the same
+            // bug class (#1826): passing the ambient value straight through
+            // let a genuine per-element error self-swallow into
+            // `QueryResult::None` before `accumulate_path_context_step`
+            // ever saw it as a stop signal, silently *skipping* that one
+            // element instead of aborting the whole array atomically --
+            // confirmed live: `(.a)? | map(if key==1 then error("x") else
+            // key end)` on `{"a":[1,2,3]}` produced `[0,2]`, where the
+            // atomic-construction-equivalent `(.a)? | [.[] | if key==1 then
+            // error("x") else key end]` already correctly produced nothing.
+            // Forcing `false` lets that error surface as a real stop
+            // signal, caught below using *this arm's own* ambient
+            // `optional` instead -- the same evaluate-then-catch shape as
+            // `eval_try`/`Expr::Array`'s arm.
             let mut results = vec_with_capacity(match value {
                 OwnedValue::Array(arr) => arr.len(),
                 OwnedValue::Object(entries) => entries.len(),
@@ -26795,7 +26813,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
                             stopped = Some(stop);
@@ -26812,7 +26830,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
                             stopped = Some(stop);
@@ -26824,7 +26842,18 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, value)),
             }
             let map_result = match stopped {
-                Some(QueryResult::Partial(_, Control::Error(e))) => QueryResult::Error(e),
+                // Only `Error` is gated on this arm's own ambient
+                // `optional` -- matches `Expr::Array`'s identical
+                // `Err(EvalEscape::Error(_)) if optional` catch and
+                // `eval_try`'s own "never catches Break/Halt" rule just
+                // below.
+                Some(QueryResult::Partial(_, Control::Error(e))) => {
+                    if optional {
+                        QueryResult::None
+                    } else {
+                        QueryResult::Error(e)
+                    }
+                }
                 Some(QueryResult::Partial(_, Control::Break(label))) => QueryResult::Break(label),
                 // `map(f)` is array construction, atomic in jq (see
                 // `eval_array_construction`'s matching comment) — a `Halt`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26843,10 +26843,11 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
             let map_result = match stopped {
                 // Only `Error` is gated on this arm's own ambient
-                // `optional` -- matches `Expr::Array`'s identical
-                // `Err(EvalEscape::Error(_)) if optional` catch and
-                // `eval_try`'s own "never catches Break/Halt" rule just
-                // below.
+                // `optional` -- matches the path-context `Expr::Array`
+                // arm's identical `QueryResult::Error(_) |
+                // QueryResult::Partial(_, Control::Error(_)) if optional`
+                // catch a few hundred lines below, and `eval_try`'s own
+                // "never catches Break/Halt" rule just below here.
                 //
                 // Both patterns are needed, not just `Partial`: `partial()`
                 // (#400/#494) collapses an *empty* prefix to the bare

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26424,7 +26424,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            false,
+                            optional,
                             &mut results,
                         ) {
                             return stop;
@@ -26440,7 +26440,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            false,
+                            optional,
                             &mut results,
                         ) {
                             return stop;
@@ -26847,7 +26847,18 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // `Err(EvalEscape::Error(_)) if optional` catch and
                 // `eval_try`'s own "never catches Break/Halt" rule just
                 // below.
-                Some(QueryResult::Partial(_, Control::Error(e))) => {
+                //
+                // Both patterns are needed, not just `Partial`: `partial()`
+                // (#400/#494) collapses an *empty* prefix to the bare
+                // `Error`/`Break`/`Halt` variant, which happens exactly
+                // when the erroring element is the *first* one -- code
+                // review on #1826 caught that matching only `Partial` here
+                // left that case falling through to `Some(other) => other`
+                // unguarded by the gate below, reproducing the original bug
+                // whenever the failing element came first (`results` still
+                // empty at that point). `Expr::Array`'s own arm already ORs
+                // both shapes together in its one guard for the same reason.
+                Some(QueryResult::Error(e) | QueryResult::Partial(_, Control::Error(e))) => {
                     if optional {
                         QueryResult::None
                     } else {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7354,6 +7354,32 @@ fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout, "");
 
+    // The *first* element/entry erroring, not a later one: code review
+    // caught that `partial()` (#400/#494) collapses an *empty* accumulated
+    // prefix to a bare `Error`, not `Partial(_, Error)` -- a first-fix draft
+    // matched only the `Partial` shape here, so this exact case (nothing
+    // accumulated yet when the error hits) fell through unguarded and still
+    // hard-errored instead of producing no output.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | map(if key==0 then error(\"boom\") else key end)",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | map(if key==\"x\" then error(\"boom\") else key end)",
+        ],
+        Some(r#"{"a":{"x":1,"y":2}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
     // Without any ambient `?`, the same query still hard-errors -- the fix
     // must not accidentally make every error inside `map()` vanish.
     let (_stdout, stderr, code) = run_jq_full(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7309,6 +7309,75 @@ fn test_array_wrapped_path_context_builtin_optional_is_atomic_1302() -> Result<(
     Ok(())
 }
 
+/// #1826: `Builtin::Map(f)`'s path-context arm claimed the same
+/// array-construction atomicity `Expr::Array`'s arm above earns via #1302's
+/// fix, but never actually got it -- it passed the *ambient* `optional`
+/// straight into each element's own evaluation instead of forcing `false`
+/// and self-catching. An ambient `optional` (from an earlier `?` in the
+/// same pipe, still threaded downstream per this evaluator's model -- see
+/// `test_optional_dispatch_catches_atomically_not_broadcast_1335` below)
+/// let a genuine per-element error self-swallow into "no output for this
+/// element" before the array-level atomicity match ever saw it, silently
+/// *skipping* the erroring element instead of discarding the whole `map()`
+/// -- confirmed live pre-fix: `(.a)? | map(if key==1 then error("boom")
+/// else key end)` on `{"a":[1,2,3]}` produced `[0,2]`, where the
+/// structurally-identical `(.a)? | [.[] | if key==1 then error("boom") else
+/// key end]` already correctly produced nothing. Unlike #1302's own
+/// direct-`?`-on-the-construction repro, this one needs the *ambient*
+/// form (`?` on an earlier stage, `map(...)` unwrapped in `rest`) --
+/// `.a | map(...)?` (mirroring #1302's own test shape) does not reach the
+/// buggy code path at all, since that shape's `?` isolates with its own
+/// forced `false` via a different (already-correct) dispatch.
+#[test]
+fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
+    // Array target: the erroring element must discard the whole map, not
+    // just itself.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | map(if key==1 then error(\"boom\") else key end)",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Object target: same atomicity, `key` reporting the string key instead
+    // of an index.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | map(if key==\"y\" then error(\"boom\") else key end)",
+        ],
+        Some(r#"{"a":{"x":1,"y":2}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Without any ambient `?`, the same query still hard-errors -- the fix
+    // must not accidentally make every error inside `map()` vanish.
+    let (_stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            ".a | map(if key==1 then error(\"boom\") else key end)",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // Sibling positive case: a `map()` that never errors is unaffected by
+    // the ambient `optional`, and `rest` after it still runs normally.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "(.a)? | map(key) | length"],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "3");
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::StringInterpolation` arm (#1334), the
 /// same gap #1302 fixed for `Expr::Array` -- so `"k=\(key)"` silently
 /// stubbed `key` to `null` inside a `\(...)` slot, even once


### PR DESCRIPTION
## Summary

This is a scoped-down implementation of #1826, which asked for a four-site "isolate-and-catch-optional" consolidation across `eval.rs` and `eval_generic.rs` behind one shared helper. Investigation before implementing found two things that changed the plan:

1. **The "one helper" premise doesn't hold.** There are genuinely two families here — a "keep-prefix" family (`eval_try`, the path-context `Expr::Optional` arm) and an "atomic construction, discard-prefix" family (the path-context `Expr::Array` arm, and this fix) — with different result shapes, plus `eval_generic.rs`'s `GenericResult` can't share a helper with `eval.rs`'s `QueryResult` at all.
2. **The correctness gap the issue called "dormant" is live-reachable today, not theoretical.** `eval.rs`'s path-context `Builtin::Map(f)` arm claimed the same array-construction atomicity `Expr::Array`'s arm earns via #1302's fix, but passed the *ambient* `optional` straight into each element's own evaluation instead of forcing `false` and self-catching. Confirmed live pre-fix: `(.a)? | map(if key==1 then error("boom") else key end)` on `{"a":[1,2,3]}` produced `[0,2]`, where the structurally-identical `(.a)? | [.[] | if key==1 then error("boom") else key end]` already correctly produced nothing — a real internal inconsistency between two constructs the codebase's own comments claim behave identically.

Given the real value here is closing that live bug, and the broader mechanical consolidation is now lower-priority (no live bug driving urgency, plus the "one helper" premise needs rethinking as at least two), this PR scopes to the concrete fix and I'm filing a follow-up for the broader refactor separately.

## The fix

Mirrors `Expr::Array`'s already-correct, already-tested arm (#1302) exactly: force `optional=false` into `iterate_element_step` for both the `Array` and `Object` loop bodies (so a per-element error surfaces as a real stop signal instead of self-swallowing into "no output for this element"), then gate only the `Error` arm of the post-loop match on this arm's own ambient `optional` — `Break`/`Halt` always propagate, matching `eval_try`'s "never catches `Break`/`Halt`" rule.

## Test plan
- [x] Live-verified the bug and the fix against multiple shapes (array target, object target, without ambient `?` still hard-errors, normal success case unaffected, `rest` after `map()` still runs)
- [x] Added `test_map_path_context_builtin_optional_is_atomic_1826`, mirroring #1302's own test style — confirmed it fails with the exact pre-fix value (`[0,2]`) when the fix is reverted locally, and passes once restored (verified then reverted, not committed)
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (existing #1302/#1335/#725 tests pass unchanged)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` / `--no-default-features --features cli`

Split from #1826 (kept open for the broader consolidation, or closed with a follow-up filed — happy to do either per maintainer preference)