### PR TITLE
fix(yq): an untracked comma branch is a no-op for path()/=/|=, not an error

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -667,7 +667,7 @@ its M2 fast path shares `stream_cursor!` with stdout, so an M2-eligible `map` ke
 and style through `-i` too — #1349 is about the `--inplace` **DOM fallback**, which a
 non-M2-eligible filter still reaches.
 
-### An untracked `Expr::Comma` branch — resolved for `path()`/`=`/`|=`, still open for `del()`
+### An untracked terminal path branch — resolved for `path()`/`=`/`|=`/compound-assigns, still open for `del()` and for trailing navigation
 
 [#1764](https://github.com/rust-works/succinctly/issues/1764): `reject_untracked_at_terminal`
 (`eval.rs`) is the shared check answering "is a `path()`/`del()`/`=`/`|=` branch that resolved
@@ -675,9 +675,9 @@ to a *computed* value, rather than a real navigation, actually an error" — jq'
 always yes (`Invalid path expression with result <v>`), and this check used to raise
 unconditionally for both modes.
 
-Real yq's answer for `path()`/`=`/`|=` is no: an untracked comma branch is a silent no-op,
-and every *other* branch is still written normally, regardless of the untracked branch's
-position or how it was produced:
+Real yq's answer for `path()`/`=`/`|=`/the compound-assign operators (`+=`/`-=`/`*=`; yq has
+no `/=`/`%=`/`//=` syntax at all to check against) is no: an untracked terminal branch is a
+silent no-op, and every *other* branch is still written normally, regardless of position:
 
 ```bash
 $ echo 'a: 1
@@ -688,7 +688,22 @@ b: 2' | succinctly yq '(.a, 1) = 5'   # matches, was: Error: Invalid path expres
 
 Confirmed position-independent (untracked first, middle, or last; all-branches-untracked;
 a computed value from an arbitrary expression rather than a bare literal) — every case gives
-the same "skip the untracked branch, write every other one" result.
+the same "skip the untracked branch, write every other one" result. **Not specific to a
+multi-branch `Expr::Comma` despite the check's own name**: a single bare untracked
+expression with no comma at all is the identical no-op —
+`(1) = 5` on `{a: 1}` leaves it unchanged too. A genuine error/break/halt produced *while
+computing* what would otherwise be an untracked value is not itself untracked and still
+propagates normally: `(.a, error("boom")) = 5` still raises `boom`.
+
+**Only the terminal position is fixed.** An untracked branch followed by *further
+navigation* — `(.a, 1 | .[]) = 5`, still real yq's own no-op — never reaches
+`reject_untracked_at_terminal` at all: `resolve_node`'s own `Expr::Iterate` arm (and
+`resolve_index_expr`'s analogous dynamic-key check) each raise independently and
+unconditionally before a branch gets anywhere near the terminal check. Fixing that needs
+`is_del`-equivalent awareness threaded into `resolve_node`, a 21-call-site function with its
+own scattered, independently jq-mode-verified checks — a materially larger and riskier
+surface than this fix's single terminal-position check, so left open rather than guessed at
+here. Tracked as [#1868](https://github.com/rust-works/succinctly/issues/1868).
 
 **`del()` does not share this model and is deliberately excluded from the fix.** Its real
 behaviour, confirmed live across argument-order permutations, is order-*dependent* in a way

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -675,9 +675,9 @@ to a *computed* value, rather than a real navigation, actually an error" — jq'
 always yes (`Invalid path expression with result <v>`), and this check used to raise
 unconditionally for both modes.
 
-Real yq's answer for `path()`/`=`/`|=`/the compound-assign operators (`+=`/`-=`/`*=`; yq has
-no `/=`/`%=`/`//=` syntax at all to check against) is no: an untracked terminal branch is a
-silent no-op, and every *other* branch is still written normally, regardless of position:
+Real yq's answer for `path()`/`=`/`|=`/the compound-assign operators (`+=`/`-=`/`*=`) is no:
+an untracked terminal branch is a silent no-op, and every *other* branch is still written
+normally, regardless of position:
 
 ```bash
 $ echo 'a: 1
@@ -686,24 +686,39 @@ $ echo 'a: 1
 b: 2' | succinctly yq '(.a, 1) = 5'   # matches, was: Error: Invalid path expression with result 1
 ```
 
+(Real yq has no `/=`/`%=`/`//=` syntax at all — confirmed live, `'/'`/`'%'`/`'//'` all
+report "expects 2 args but there is 1" rather than being recognized as compound-assign
+operators, the same "no real yq syntax to check against" gap already recorded elsewhere in
+this file. succinctly's own support for those three forms is a pre-existing, unrelated
+extension-surface question — they parse and inherit this same skip in yq mode, but that is
+not itself a divergence claim, since there is nothing in real yq to diverge from.)
+
 Confirmed position-independent (untracked first, middle, or last; all-branches-untracked;
 a computed value from an arbitrary expression rather than a bare literal) — every case gives
 the same "skip the untracked branch, write every other one" result. **Not specific to a
 multi-branch `Expr::Comma` despite the check's own name**: a single bare untracked
-expression with no comma at all is the identical no-op —
-`(1) = 5` on `{a: 1}` leaves it unchanged too. A genuine error/break/halt produced *while
-computing* what would otherwise be an untracked value is not itself untracked and still
-propagates normally: `(.a, error("boom")) = 5` still raises `boom`.
+expression with no comma at all is the identical no-op — `(1) = 5` on `{a: 1}` leaves it
+unchanged too, and neither is it specific to a bare-literal *origin* — an untracked value
+produced by an upstream mechanism like a `try`/`catch` handler run on a caught error's
+payload is computationally identical by the time it reaches the check, and gets the same
+"write every trackable branch, skip this one" result rather than aborting the whole write
+the way it did (and, in jq mode, still does) before this fix. A genuine error/break/halt
+produced *while computing* what would otherwise be an untracked value is not itself
+untracked and still propagates normally: `(.a, error("boom")) = 5` still raises `boom`.
 
-**Only the terminal position is fixed.** An untracked branch followed by *further
-navigation* — `(.a, 1 | .[]) = 5`, still real yq's own no-op — never reaches
-`reject_untracked_at_terminal` at all: `resolve_node`'s own `Expr::Iterate` arm (and
-`resolve_index_expr`'s analogous dynamic-key check) each raise independently and
-unconditionally before a branch gets anywhere near the terminal check. Fixing that needs
-`is_del`-equivalent awareness threaded into `resolve_node`, a 21-call-site function with its
-own scattered, independently jq-mode-verified checks — a materially larger and riskier
-surface than this fix's single terminal-position check, so left open rather than guessed at
-here. Tracked as [#1868](https://github.com/rust-works/succinctly/issues/1868).
+**`path()`'s own trailing-iterate case is covered; `=`/`|=`/compound-assign's is not.**
+`path()` strips a trailing bare iterate off its own path expression before resolving it
+(`defer_trailing_iterate`, #888) and re-splices it after the terminal check runs — so
+`path(1 | .[])` *is* covered by this fix (confirmed live: now no-ops in yq mode, matching
+the same general rule above, where it used to raise jq's "near attempt to iterate through 1"
+wording). `=`/`|=`/compound-assign never defer a trailing iterate at all, so the identical
+shape in *their* context — `(.a, 1 | .[]) = 5`, still real yq's own no-op — never reaches
+the terminal check: `resolve_node`'s own `Expr::Iterate` arm (and `resolve_index_expr`'s
+analogous dynamic-key check) each raise independently and unconditionally first. Fixing that
+needs the same kind of skip-untracked awareness threaded into `resolve_node`, a 21-call-site
+function with its own scattered, independently jq-mode-verified checks — a materially larger
+and riskier surface than this fix's single terminal-position check, so left open rather than
+guessed at here. Tracked as [#1868](https://github.com/rust-works/succinctly/issues/1868).
 
 **`del()` does not share this model and is deliberately excluded from the fix.** Its real
 behaviour, confirmed live across argument-order permutations, is order-*dependent* in a way

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -667,6 +667,58 @@ its M2 fast path shares `stream_cursor!` with stdout, so an M2-eligible `map` ke
 and style through `-i` too — #1349 is about the `--inplace` **DOM fallback**, which a
 non-M2-eligible filter still reaches.
 
+### An untracked `Expr::Comma` branch — resolved for `path()`/`=`/`|=`, still open for `del()`
+
+[#1764](https://github.com/rust-works/succinctly/issues/1764): `reject_untracked_at_terminal`
+(`eval.rs`) is the shared check answering "is a `path()`/`del()`/`=`/`|=` branch that resolved
+to a *computed* value, rather than a real navigation, actually an error" — jq's answer is
+always yes (`Invalid path expression with result <v>`), and this check used to raise
+unconditionally for both modes.
+
+Real yq's answer for `path()`/`=`/`|=` is no: an untracked comma branch is a silent no-op,
+and every *other* branch is still written normally, regardless of the untracked branch's
+position or how it was produced:
+
+```bash
+$ echo 'a: 1
+b: 2' | yq            '(.a, 1) = 5'   # a: 5\nb: 2 -- untracked "1" contributes nothing
+$ echo 'a: 1
+b: 2' | succinctly yq '(.a, 1) = 5'   # matches, was: Error: Invalid path expression with result 1
+```
+
+Confirmed position-independent (untracked first, middle, or last; all-branches-untracked;
+a computed value from an arbitrary expression rather than a bare literal) — every case gives
+the same "skip the untracked branch, write every other one" result.
+
+**`del()` does not share this model and is deliberately excluded from the fix.** Its real
+behaviour, confirmed live across argument-order permutations, is order-*dependent* in a way
+none of its three siblings are:
+
+```bash
+$ echo 'a: 1
+b: 2' | yq 'del(.a, 1)'      # a: 1\nb: 2  -- nothing deleted
+$ echo 'a: 1
+b: 2' | yq 'del(1, .a)'      # b: 2       -- .a IS deleted (same two arguments, reversed)
+$ echo 'a: 1
+b: 2
+c: 3' | yq 'del(.a, .c, 1)'  # a: 1\nb: 2\nc: 3 -- nothing deleted, even though .a/.c precede "1"
+$ echo 'a: 1
+b: 2
+c: 3' | yq 'del(.a, 1, .c)'  # a: 1\nb: 2       -- only .c deleted, not .a
+```
+
+The pattern across all four is consistent with `del()` processing its targets in *reverse*
+of the given argument order and aborting every remaining one — without undoing whatever
+already completed — the instant it hits an untracked target. Simply extending the other
+three operations' "skip and continue in given order" fix to `del()` would make it delete
+*more* than real yq does for some orderings (`del(.a, 1)` would delete `.a`, which real yq
+leaves untouched) — a data-loss-shaped divergence in the wrong direction, not a cosmetic
+one. `del()` therefore keeps raising `reject_untracked_at_terminal`'s pre-existing error
+(via the same `short_circuit_del_root` flag `resolve_dynamic_indexes` already uses to
+distinguish `del()`'s call shape from its three siblings) until the real reverse-order/
+abort-without-rollback algorithm is implemented, tracked as
+[#1865](https://github.com/rust-works/succinctly/issues/1865) rather than guessed at here.
+
 ### Comma-grouped scalar-target assignment no-op
 
 [#1233](https://github.com/rust-works/succinctly/issues/1233) taught `=`/`+=`/`-=`/`*=`/`//=`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22409,13 +22409,47 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     ///
     /// Branches already produced ahead of the offending one are kept and
     /// returned as the `Err` prefix, matching jq's never-un-emit streaming.
-    fn reject_untracked_at_terminal(
+    ///
+    /// yq mode does not raise here for `path()`/`=`/`|=` (`is_del == false`,
+    /// #1764): a computed/untracked `Expr::Comma` branch is real yq's own
+    /// silent no-op there, not an error -- confirmed live against yq
+    /// v4.53.3, position-independent (`(.a, 1) = 5`, `(1, .a, .c) = 5`,
+    /// `(.a, .c, 1) = 5`, all-branches-untracked, and a computed value
+    /// produced by an arbitrary expression rather than a bare literal all
+    /// leave every trackable branch written normally and the untracked one
+    /// contributing nothing). `near_iterate`'s own wording distinction is
+    /// moot for those contexts: there is no error to word either way.
+    ///
+    /// `del()` (`is_del == true`) is deliberately **excluded** from that
+    /// skip and keeps raising here, unlike its three siblings: real yq's
+    /// `del()` turns out not to share their simple per-branch-independent
+    /// model at all. Confirmed live: `del(.a, 1)` on `{a: 1, b: 2}` deletes
+    /// *nothing* (`a: 1\nb: 2`, both keys survive) where `del(1, .a)` -- the
+    /// same two arguments, reversed -- deletes `.a` (`b: 2`), and
+    /// `del(.a, .c, 1)` on a 3-key document deletes only `.c`, not `.a`,
+    /// even though `.a` comes *before* the untracked `1` in the argument
+    /// list. The pattern (verified across argument-order permutations) is
+    /// consistent with real yq's `del()` processing its targets in
+    /// *reverse* of the given order and aborting the remaining ones --
+    /// without undoing whatever already completed -- the moment it hits an
+    /// untracked one; simply mirroring the other three operations' skip
+    /// here would make `del()` delete *more* than real yq does for some
+    /// orderings (e.g. `del(.a, 1)` would delete `.a`, which real yq
+    /// leaves alone) -- a data-loss-shaped divergence in the wrong
+    /// direction, not merely a cosmetic one. Left on the pre-existing raise
+    /// until that ordering is implemented for real; tracked as a follow-up
+    /// rather than guessed at here.
+    fn reject_untracked_at_terminal<S: EvalSemantics>(
         branches: Vec<PathBranch<'_>>,
         near_iterate: bool,
+        is_del: bool,
     ) -> Result<Vec<PathBranch<'_>>, (Vec<PathBranch<'_>>, EvalEscape)> {
         let mut kept = vec_with_capacity(branches.len());
         for branch in branches {
             if !branch.trackable {
+                if S::TAG == EvalTag::Yq && !is_del {
+                    continue;
+                }
                 let error = if near_iterate {
                     EvalError::invalid_path_expression_near_iterate(&branch.value).into()
                 } else {
@@ -22446,9 +22480,10 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// surfacing the later sibling's error instead of jq's real one and
     /// leaking that untracked branch's stale path into the assembled prefix
     /// (#1560).
-    fn reject_untracked_prefix_too(
+    fn reject_untracked_prefix_too<S: EvalSemantics>(
         result: PathResolveResult<'_>,
         near_iterate: bool,
+        is_del: bool,
     ) -> PathResolveResult<'_> {
         let (prefix, escape) = match result {
             Ok(branches) => (branches, None),
@@ -22458,8 +22493,13 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         // `prefix` propagates immediately, discarding `escape` (a later
         // sibling's own error/break/halt that never got the chance to run
         // in real jq either) -- exactly `path_result`'s own `Some`/`None`
-        // combine once a violation-free `prefix` reaches it.
-        let checked = reject_untracked_at_terminal(prefix, near_iterate)?;
+        // combine once a violation-free `prefix` reaches it. In yq mode,
+        // for every context but `del()`, `reject_untracked_at_terminal`
+        // never returns `Err` at all (#1764), so this `?` is a no-op there
+        // and `escape` -- a genuine error/break/halt, never just an
+        // untracked value -- still always propagates through `path_result`
+        // below unchanged.
+        let checked = reject_untracked_at_terminal::<S>(prefix, near_iterate, is_del)?;
         path_result(checked, escape)
     }
 
@@ -22529,8 +22569,11 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         // frozen `$x` snapshot, so ambient `snapshot` starts `false` here,
         // same as it does at this function's other top-level entry point
         // below (#1591).
-        return match reject_untracked_prefix_too(resolve_node::<S>(expr, input, true, false), false)
-        {
+        return match reject_untracked_prefix_too::<S>(
+            resolve_node::<S>(expr, input, true, false),
+            false,
+            short_circuit_del_root,
+        ) {
             Ok(branches) => {
                 if short_circuit_del_root && branches.iter().any(|b| b.path.depth() == 0) {
                     return Ok(vec![Expr::Identity]);
@@ -22546,7 +22589,11 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         1 => flat.into_iter().next().expect("len checked"),
         _ => Expr::Pipe(flat),
     };
-    match reject_untracked_prefix_too(resolve_node::<S>(&reduced_expr, input, true, false), true) {
+    match reject_untracked_prefix_too::<S>(
+        resolve_node::<S>(&reduced_expr, input, true, false),
+        true,
+        short_circuit_del_root,
+    ) {
         Ok(branches) => Ok(assemble(branches)
             .into_iter()
             .map(|e| append_trailing(e, &trailing))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22341,16 +22341,17 @@ fn resolve_seq<'a, S: EvalSemantics>(
 /// never finds a `depth() == 0` branch here and pays the full flatten
 /// regardless — that shape is tracked separately, not fixed by this flag.
 ///
-/// Reused, unchanged, as `reject_untracked_at_terminal`/
-/// `reject_untracked_prefix_too`'s own `is_del` parameter (#1764 review):
-/// since this flag's own value is already exactly "is this call `del()`'s
-/// call shape," it happens to be the identical condition those two
-/// functions need to gate their own, entirely separate concern (does an
-/// untracked terminal branch raise, or silently no-op) on. The two
-/// concerns are independent -- nothing here requires them to always
-/// travel together -- they simply have not yet needed to diverge, since
-/// `del()` remains the only caller wanting either non-default behavior.
-/// If a future caller needs one without the other, this flag should be
+/// Also feeds `reject_untracked_at_terminal`/`reject_untracked_prefix_too`'s
+/// own `skip_untracked` parameter below (#1764 review), via `skip_untracked
+/// = S::TAG == EvalTag::Yq && !short_circuit_del_root`: since this flag's
+/// own value is already exactly "is this call `del()`'s call shape," it
+/// happens to be the identical condition those two functions need to gate
+/// their own, entirely separate concern (does an untracked terminal branch
+/// raise, or silently no-op) on. The two concerns are independent --
+/// nothing here requires them to always travel together -- they simply
+/// have not yet needed to diverge, since `del()` remains the only caller
+/// wanting either non-default behavior. If a future caller needs one
+/// without the other, this flag should be
 /// split into two.
 fn resolve_dynamic_indexes<S: EvalSemantics>(
     expr: &Expr,
@@ -22422,41 +22423,53 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// Branches already produced ahead of the offending one are kept and
     /// returned as the `Err` prefix, matching jq's never-un-emit streaming.
     ///
-    /// yq mode does not raise here for `path()`/`=`/`|=`/compound-assigns
-    /// (`is_del == false`, #1764): an untracked terminal branch is real
-    /// yq's own silent no-op there, not an error. Confirmed live against
+    /// `skip_untracked` (#1764): when set, an untracked terminal branch is
+    /// real yq's own silent no-op, not an error -- confirmed live against
     /// yq v4.53.3, and **not specific to `Expr::Comma`** despite this
     /// function's own name: a single bare untracked expression with no
     /// comma at all is the identical no-op (`(1) = 5` on `{a: 1}` leaves
     /// it unchanged, matching `(.a, 1) = 5`'s "skip only the untracked
     /// one") -- the real rule is "any untracked terminal branch, however
-    /// many others accompany it, however it was produced." Confirmed
+    /// many others accompany it, however it was produced." That also
+    /// covers a branch an *upstream* mechanism (not a bare literal)
+    /// leaves untracked, e.g. `select`/`getpath` run as a `try`/`catch`
+    /// handler on a caught error's payload: `try (.a, error({"y":99}))
+    /// catch select(true) = "X"` writes `.a` and silently drops the
+    /// caught, untracked branch, the same "skip only the untracked one"
+    /// result as the bare-literal case, since by the time either reaches
+    /// this function they are computationally identical -- there is no
+    /// way, or reason, for this check to tell them apart. Confirmed
     /// position-independent for a genuine multi-branch comma too (`(.a,
     /// 1) = 5`, `(1, .a, .c) = 5`, `(.a, .c, 1) = 5`, all-branches-
     /// untracked): every trackable branch is still written normally and
     /// the untracked one(s) contribute nothing. `near_iterate`'s own
-    /// wording distinction is moot for those contexts: there is no error
-    /// to word either way. A genuine error/break/halt produced *while
-    /// computing* what would otherwise be an untracked value is not
-    /// itself untracked and still propagates normally -- confirmed live,
-    /// `(.a, error("boom")) = 5` still raises `boom`, not a no-op.
+    /// wording distinction is moot when `skip_untracked` is set: there is
+    /// no error to word either way. A genuine error/break/halt produced
+    /// *while computing* what would otherwise be an untracked value is
+    /// not itself untracked and still propagates normally -- confirmed
+    /// live, `(.a, error("boom")) = 5` still raises `boom`, not a no-op.
     ///
-    /// **Only the terminal check is patched here.** An untracked branch
-    /// followed by *further navigation* (e.g. `(.a, 1 | .[]) = 5`) never
-    /// reaches this function at all -- `resolve_node`'s own `Expr::
-    /// Iterate` arm (and `resolve_index_expr`'s analogous dynamic-key
-    /// check) each raise independently, unconditionally, before a branch
-    /// gets anywhere near here. That gap is real (confirmed live: real
-    /// yq still no-ops there too) and deliberately not fixed by this
-    /// patch -- tracked as
-    /// [#1868](https://github.com/rust-works/succinctly/issues/1868),
-    /// since fixing it needs `is_del`-equivalent awareness threaded into
-    /// `resolve_node`, a 21-call-site function with its own independent
-    /// jq-mode-verified history at each scattered check, not just this
-    /// one terminal position.
+    /// **Only reachable call shapes are patched.** `path()` passes
+    /// `near_iterate = true` here for a trailing bare iterate stripped
+    /// off its own path expression (`defer_trailing_iterate = true`,
+    /// #888) -- that case *is* covered (confirmed live: `path(1 | .[])`
+    /// in yq mode now no-ops rather than raising jq's "near attempt to
+    /// iterate" wording, matching the same general rule above). `=`/
+    /// `|=`/compound-assigns never defer a trailing iterate at all, so an
+    /// untracked branch followed by further navigation in *those*
+    /// contexts (`(.a, 1 | .[]) = 5`) never reaches this function --
+    /// `resolve_node`'s own `Expr::Iterate` arm (and `resolve_index_expr`'s
+    /// analogous dynamic-key check) each raise independently and
+    /// unconditionally first. That gap is real (confirmed live: real yq
+    /// still no-ops there too) and deliberately not fixed by this patch --
+    /// tracked as [#1868](https://github.com/rust-works/succinctly/issues/1868),
+    /// since fixing it needs `skip_untracked`-equivalent awareness
+    /// threaded into `resolve_node`, a 21-call-site function with its own
+    /// independent jq-mode-verified history at each scattered check, not
+    /// just this one terminal position.
     ///
-    /// `del()` (`is_del == true`) is deliberately **excluded** from that
-    /// skip and keeps raising here, unlike its three siblings: real yq's
+    /// `del()` (`skip_untracked == false`) is deliberately **excluded**
+    /// from the skip and keeps raising here, unlike its three siblings: real yq's
     /// `del()` turns out not to share their simple per-branch-independent
     /// model at all. Confirmed live: `del(.a, 1)` on `{a: 1, b: 2}` deletes
     /// *nothing* (`a: 1\nb: 2`, both keys survive) where `del(1, .a)` -- the
@@ -22474,15 +22487,15 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// direction, not merely a cosmetic one. Left on the pre-existing raise
     /// until that ordering is implemented for real; tracked as a follow-up
     /// rather than guessed at here.
-    fn reject_untracked_at_terminal<S: EvalSemantics>(
+    fn reject_untracked_at_terminal(
         branches: Vec<PathBranch<'_>>,
         near_iterate: bool,
-        is_del: bool,
+        skip_untracked: bool,
     ) -> Result<Vec<PathBranch<'_>>, (Vec<PathBranch<'_>>, EvalEscape)> {
         let mut kept = vec_with_capacity(branches.len());
         for branch in branches {
             if !branch.trackable {
-                if S::TAG == EvalTag::Yq && !is_del {
+                if skip_untracked {
                     continue;
                 }
                 let error = if near_iterate {
@@ -22515,10 +22528,10 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// surfacing the later sibling's error instead of jq's real one and
     /// leaking that untracked branch's stale path into the assembled prefix
     /// (#1560).
-    fn reject_untracked_prefix_too<S: EvalSemantics>(
+    fn reject_untracked_prefix_too(
         result: PathResolveResult<'_>,
         near_iterate: bool,
-        is_del: bool,
+        skip_untracked: bool,
     ) -> PathResolveResult<'_> {
         let (prefix, escape) = match result {
             Ok(branches) => (branches, None),
@@ -22528,13 +22541,13 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         // `prefix` propagates immediately, discarding `escape` (a later
         // sibling's own error/break/halt that never got the chance to run
         // in real jq either) -- exactly `path_result`'s own `Some`/`None`
-        // combine once a violation-free `prefix` reaches it. In yq mode,
-        // for every context but `del()`, `reject_untracked_at_terminal`
-        // never returns `Err` at all (#1764), so this `?` is a no-op there
-        // and `escape` -- a genuine error/break/halt, never just an
-        // untracked value -- still always propagates through `path_result`
-        // below unchanged.
-        let checked = reject_untracked_at_terminal::<S>(prefix, near_iterate, is_del)?;
+        // combine once a violation-free `prefix` reaches it. When
+        // `skip_untracked` is set, `reject_untracked_at_terminal` never
+        // returns `Err` at all (#1764), so this `?` is a no-op there and
+        // `escape` -- a genuine error/break/halt, never just an untracked
+        // value -- still always propagates through `path_result` below
+        // unchanged.
+        let checked = reject_untracked_at_terminal(prefix, near_iterate, skip_untracked)?;
         path_result(checked, escape)
     }
 
@@ -22599,15 +22612,25 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         }
     }
 
+    // #1764 review: computed once here, as a plain `bool`, rather than
+    // threading `S: EvalSemantics` itself into `reject_untracked_at_
+    // terminal`/`reject_untracked_prefix_too` -- those two are otherwise
+    // non-generic, so making them generic purely to evaluate one `S::TAG`
+    // comparison would monomorphize (and so duplicate the compiled code
+    // for) both of them per `EvalSemantics` impl, for zero behavioral
+    // benefit over resolving the same fact once, here, where `S` is
+    // already bound.
+    let skip_untracked = S::TAG == EvalTag::Yq && !short_circuit_del_root;
+
     if trailing.is_empty() {
         // `input` is this call's own fresh document root — never itself a
         // frozen `$x` snapshot, so ambient `snapshot` starts `false` here,
         // same as it does at this function's other top-level entry point
         // below (#1591).
-        return match reject_untracked_prefix_too::<S>(
+        return match reject_untracked_prefix_too(
             resolve_node::<S>(expr, input, true, false),
             false,
-            short_circuit_del_root,
+            skip_untracked,
         ) {
             Ok(branches) => {
                 if short_circuit_del_root && branches.iter().any(|b| b.path.depth() == 0) {
@@ -22624,10 +22647,10 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         1 => flat.into_iter().next().expect("len checked"),
         _ => Expr::Pipe(flat),
     };
-    match reject_untracked_prefix_too::<S>(
+    match reject_untracked_prefix_too(
         resolve_node::<S>(&reduced_expr, input, true, false),
         true,
-        short_circuit_del_root,
+        skip_untracked,
     ) {
         Ok(branches) => Ok(assemble(branches)
             .into_iter()

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22340,6 +22340,18 @@ fn resolve_seq<'a, S: EvalSemantics>(
 /// include the root (`del(.. | select(cond))` where `cond` rejects `.`)
 /// never finds a `depth() == 0` branch here and pays the full flatten
 /// regardless — that shape is tracked separately, not fixed by this flag.
+///
+/// Reused, unchanged, as `reject_untracked_at_terminal`/
+/// `reject_untracked_prefix_too`'s own `is_del` parameter (#1764 review):
+/// since this flag's own value is already exactly "is this call `del()`'s
+/// call shape," it happens to be the identical condition those two
+/// functions need to gate their own, entirely separate concern (does an
+/// untracked terminal branch raise, or silently no-op) on. The two
+/// concerns are independent -- nothing here requires them to always
+/// travel together -- they simply have not yet needed to diverge, since
+/// `del()` remains the only caller wanting either non-default behavior.
+/// If a future caller needs one without the other, this flag should be
+/// split into two.
 fn resolve_dynamic_indexes<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
@@ -22410,15 +22422,38 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     /// Branches already produced ahead of the offending one are kept and
     /// returned as the `Err` prefix, matching jq's never-un-emit streaming.
     ///
-    /// yq mode does not raise here for `path()`/`=`/`|=` (`is_del == false`,
-    /// #1764): a computed/untracked `Expr::Comma` branch is real yq's own
-    /// silent no-op there, not an error -- confirmed live against yq
-    /// v4.53.3, position-independent (`(.a, 1) = 5`, `(1, .a, .c) = 5`,
-    /// `(.a, .c, 1) = 5`, all-branches-untracked, and a computed value
-    /// produced by an arbitrary expression rather than a bare literal all
-    /// leave every trackable branch written normally and the untracked one
-    /// contributing nothing). `near_iterate`'s own wording distinction is
-    /// moot for those contexts: there is no error to word either way.
+    /// yq mode does not raise here for `path()`/`=`/`|=`/compound-assigns
+    /// (`is_del == false`, #1764): an untracked terminal branch is real
+    /// yq's own silent no-op there, not an error. Confirmed live against
+    /// yq v4.53.3, and **not specific to `Expr::Comma`** despite this
+    /// function's own name: a single bare untracked expression with no
+    /// comma at all is the identical no-op (`(1) = 5` on `{a: 1}` leaves
+    /// it unchanged, matching `(.a, 1) = 5`'s "skip only the untracked
+    /// one") -- the real rule is "any untracked terminal branch, however
+    /// many others accompany it, however it was produced." Confirmed
+    /// position-independent for a genuine multi-branch comma too (`(.a,
+    /// 1) = 5`, `(1, .a, .c) = 5`, `(.a, .c, 1) = 5`, all-branches-
+    /// untracked): every trackable branch is still written normally and
+    /// the untracked one(s) contribute nothing. `near_iterate`'s own
+    /// wording distinction is moot for those contexts: there is no error
+    /// to word either way. A genuine error/break/halt produced *while
+    /// computing* what would otherwise be an untracked value is not
+    /// itself untracked and still propagates normally -- confirmed live,
+    /// `(.a, error("boom")) = 5` still raises `boom`, not a no-op.
+    ///
+    /// **Only the terminal check is patched here.** An untracked branch
+    /// followed by *further navigation* (e.g. `(.a, 1 | .[]) = 5`) never
+    /// reaches this function at all -- `resolve_node`'s own `Expr::
+    /// Iterate` arm (and `resolve_index_expr`'s analogous dynamic-key
+    /// check) each raise independently, unconditionally, before a branch
+    /// gets anywhere near here. That gap is real (confirmed live: real
+    /// yq still no-ops there too) and deliberately not fixed by this
+    /// patch -- tracked as
+    /// [#1868](https://github.com/rust-works/succinctly/issues/1868),
+    /// since fixing it needs `is_del`-equivalent awareness threaded into
+    /// `resolve_node`, a 21-call-site function with its own independent
+    /// jq-mode-verified history at each scattered check, not just this
+    /// one terminal position.
     ///
     /// `del()` (`is_del == true`) is deliberately **excluded** from that
     /// skip and keeps raising here, unlike its three siblings: real yq's

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18073,6 +18073,67 @@ fn test_yq_untracked_comma_branch_del_still_raises_1764() -> Result<()> {
     Ok(())
 }
 
+/// #1764: the no-op is not specific to a multi-branch `Expr::Comma` --
+/// a single bare untracked expression, with no comma at all, is the
+/// identical no-op. Confirmed live against yq v4.53.3: `(1) = 5` on
+/// `{a: 1}` leaves it unchanged, the degenerate case of `(.a, 1) = 5`
+/// skipping only its untracked branch.
+#[test]
+fn test_yq_untracked_bare_noncomma_branch_noop_1764() -> Result<()> {
+    for filter in ["(1) = 5", "1 = 5", "(1+1) = 5"] {
+        let (out, code) = run_yq_stdin(filter, "a: 1\n", &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, serde_json::json!({"a": 1}), "{filter}");
+    }
+    Ok(())
+}
+
+/// #1764: `+=`/`-=`/`*=` share the same no-op skip as `=`/`|=` --
+/// confirmed live against yq v4.53.3. yq has no `/=`/`%=`/`//=` syntax at
+/// all to check against (a pre-existing, unrelated question about
+/// whether succinctly's own support for those three forms corresponds to
+/// any real yq syntax), so they're not exercised here.
+#[test]
+fn test_yq_untracked_comma_branch_compound_assign_noop_1764() -> Result<()> {
+    for (filter, expected) in [
+        ("(.a, 1) += 5", serde_json::json!({"a": 6, "b": 2})),
+        ("(.a, 1) -= 5", serde_json::json!({"a": -4, "b": 2})),
+        ("(.a, 1) *= 5", serde_json::json!({"a": 5, "b": 2})),
+    ] {
+        let (out, code) = run_yq_stdin(filter, "a: 1\nb: 2\n", &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, expected, "{filter}");
+    }
+    Ok(())
+}
+
+/// #1764: `path()` (gated behind `--jq-extensions`, so no real yq builtin
+/// to verify against directly) inherits the same terminal-check skip as
+/// its `=`/`|=` siblings -- an untracked branch is simply absent from the
+/// emitted paths, including the all-untracked case yielding no paths at
+/// all, rather than raising.
+#[test]
+fn test_yq_untracked_comma_branch_path_noop_1764() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "[path((.a, 1))]",
+        "a: 1\nb: 2\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[[\"a\"]]");
+
+    let (out, code) = run_yq_stdin(
+        "[path((1, 2))]",
+        "a: 1\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
 /// #1764 negative control: `succinctly jq`'s own path-expression check is
 /// unaffected -- real jq raises for every untracked comma branch
 /// regardless of the surrounding operation, and still must.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18134,6 +18134,80 @@ fn test_yq_untracked_comma_branch_path_noop_1764() -> Result<()> {
     Ok(())
 }
 
+/// #1764: unlike `=`/`|=`/compound-assign (whose trailing-iterate gap is
+/// #1868), `path()`'s own trailing-iterate case *is* covered by this fix
+/// -- `path()` strips a trailing bare iterate off its path expression
+/// before the terminal check runs and re-splices it after, so the
+/// untracked value still reaches `reject_untracked_at_terminal` (with
+/// `near_iterate = true`) rather than `resolve_node`'s own unconditional
+/// `Expr::Iterate` raise. Confirmed live: this used to raise jq's "near
+/// attempt to iterate through 1" wording; now no-ops, matching the same
+/// general rule as every other shape in this file.
+#[test]
+fn test_yq_untracked_branch_path_trailing_iterate_noop_1764() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "[path(1 | .[])]",
+        "a: 1\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// #1764: the skip is not specific to a bare-literal *origin* for the
+/// untracked value -- one produced by a `try`/`catch` handler run on a
+/// caught error's payload (the #843/#1297 write-corruption-prevention
+/// mechanism) is computationally identical by the time it reaches
+/// `reject_untracked_at_terminal`, and gets the same "write the
+/// trackable branch, skip the untracked one" result rather than
+/// aborting the whole write the way it did (and, in jq mode, still
+/// does) before this fix. `del()` is unaffected -- still raises, since
+/// it's excluded from the skip entirely (`skip_untracked == false`).
+#[test]
+fn test_yq_untracked_branch_via_try_catch_noop_1764() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"try (.a, error({"y":99})) catch select(true) = "X""#,
+        "a: 10\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": "X"}));
+
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        r#"del(try (.a, error({"y":99})) catch select(true))"#,
+        "a: 10\n",
+        &["--jq-extensions", "-o=json", "-I=0"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Invalid path expression"), "err={err}");
+    Ok(())
+}
+
+/// #1764: succinctly's own `/=`/`%=`/`//=` extension forms (yq has no
+/// such syntax at all -- see `docs/compliance/yq/limitations.md`) inherit
+/// the same skip as `+=`/`-=`/`*=`, for internal consistency rather than
+/// an external-compat claim.
+#[test]
+fn test_yq_untracked_comma_branch_extension_compound_assign_noop_1764() -> Result<()> {
+    let (out, code) = run_yq_stdin("(.a, 1) /= 2", "a: 4\nb: 2\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": 2.0, "b": 2}));
+
+    let (out, code) = run_yq_stdin("(.a, 1) %= 3", "a: 4\nb: 2\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": 1, "b": 2}));
+
+    let (out, code) = run_yq_stdin("(.a, 1) //= 5", "a: null\nb: 2\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": 5, "b": 2}));
+    Ok(())
+}
+
 /// #1764 negative control: `succinctly jq`'s own path-expression check is
 /// unaffected -- real jq raises for every untracked comma branch
 /// regardless of the surrounding operation, and still must.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -17999,6 +17999,91 @@ fn test_yq_comma_lhs_mixed_noop_and_real_write_still_evaluates_rhs_1233() -> Res
     Ok(())
 }
 
+/// #1764: an untracked (computed, non-navigable) `Expr::Comma` branch is
+/// real yq's own silent no-op for `=`/`|=`, not an error -- confirmed
+/// position-independent against yq v4.53.3: untracked first, middle, or
+/// last all give the same "skip it, write every other branch normally"
+/// result. `succinctly jq` is unaffected -- real jq raises
+/// "Invalid path expression" here and still must.
+#[test]
+fn test_yq_untracked_comma_branch_assignment_noop_1764() -> Result<()> {
+    for filter in ["(.a, 1) = 5", "(1, .a) = 5"] {
+        let (out, code) = run_yq_stdin(filter, "a: 1\nb: 2\n", &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, serde_json::json!({"a": 5, "b": 2}), "{filter}");
+    }
+    Ok(())
+}
+
+/// #1764: position-independence across a 3-way comma, and `|=` (not just
+/// `=`) taking the same no-op path.
+#[test]
+fn test_yq_untracked_comma_branch_three_way_and_compound_assign_1764() -> Result<()> {
+    let doc = "a: 1\nb: 2\nc: 3\n";
+    for filter in ["(.a, 1, .c) = 5", "(1, .a, .c) = 5", "(.a, .c, 1) = 5"] {
+        let (out, code) = run_yq_stdin(filter, doc, &["-o", "json"])?;
+        assert_eq!(code, 0, "{filter}");
+        let v: serde_json::Value = serde_json::from_str(&out)?;
+        assert_eq!(v, serde_json::json!({"a": 5, "b": 2, "c": 5}), "{filter}");
+    }
+
+    let (out, code) = run_yq_stdin("(.a, 1) |= . + 100", "a: 1\nb: 2\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": 101, "b": 2}));
+    Ok(())
+}
+
+/// #1764: every branch untracked is a complete no-op, not an error.
+#[test]
+fn test_yq_untracked_comma_branch_all_untracked_noop_1764() -> Result<()> {
+    let (out, code) = run_yq_stdin("(1, 2) = 5", "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&out)?;
+    assert_eq!(v, serde_json::json!({"a": 1}));
+    Ok(())
+}
+
+/// #1764: a genuine error inside an untracked comma branch still
+/// propagates normally -- only a *successfully computed* untracked value
+/// is a no-op, not an escape (error/break/halt) that happened to occur
+/// while producing one.
+#[test]
+fn test_yq_untracked_comma_branch_genuine_error_still_propagates_1764() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("(.a, error(\"boom\")) = 5", "a: 1\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1764: `del()` is deliberately *excluded* from the no-op fix and keeps
+/// raising -- real yq's own `del()` has order-dependent reverse/abort
+/// semantics unlike its three siblings (tracked separately as #1865); the
+/// safe default (an error) is kept rather than guessing at that algorithm,
+/// since naively extending the no-op fix to `del()` would delete more than
+/// real yq does for some argument orderings.
+#[test]
+fn test_yq_untracked_comma_branch_del_still_raises_1764() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("del(.a, 1)", "a: 1\nb: 2\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Invalid path expression"), "err={err}");
+    Ok(())
+}
+
+/// #1764 negative control: `succinctly jq`'s own path-expression check is
+/// unaffected -- real jq raises for every untracked comma branch
+/// regardless of the surrounding operation, and still must.
+#[test]
+fn test_jq_untracked_comma_branch_still_raises_1764() -> Result<()> {
+    let (_out, err, code) = run_jq_stdin_with_stderr("(.a, 1) = 5", "{\"a\":1,\"b\":2}", &["-c"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Invalid path expression"), "err={err}");
+    Ok(())
+}
+
 // ============================================================================
 // @urid / @base64d scalar-stringification (#1109)
 // ============================================================================


### PR DESCRIPTION
## Summary

\`reject_untracked_at_terminal\` (the shared check answering "is a \`path()\`/\`del()\`/\`=\`/\`|=\` branch that resolved to a computed value, rather than a real navigation, actually an error") raised jq's "Invalid path expression" unconditionally in both modes. Real yq's answer for \`path()\`/\`=\`/\`|=\` is different: the untracked branch is a silent no-op, and every other branch is still written normally — confirmed position-independent against yq v4.53.3 (untracked first, middle, or last; all-branches-untracked; a computed value from an arbitrary expression, not just a bare literal).

```bash
$ yq            '(.a, 1) = 5'   # a: 5, b: 2 -- untracked "1" contributes nothing
$ succinctly yq '(.a, 1) = 5'   # matches now; was: Error: Invalid path expression with result 1
```

A genuine error/break/halt inside a comma branch still propagates normally — only a successfully-computed untracked *value* is a no-op, verified separately (\`(.a, error("boom")) = 5\` still raises \`boom\`).

## \`del()\` is deliberately excluded

Investigating the issue's own open question ("the exact shape of yq's silent no-op rule... needs its own verification pass") turned up a real complication: \`del()\` does **not** share the simple per-branch-independent model its three siblings do.

```bash
$ yq 'del(.a, 1)'      # a: 1, b: 2  -- nothing deleted
$ yq 'del(1, .a)'      # b: 2       -- .a IS deleted (same two arguments, reversed!)
```

The pattern (verified across several argument-order permutations) is consistent with \`del()\` processing its targets in *reverse* of the given order and aborting the rest — without undoing whatever already completed — the instant it hits an untracked one. Naively extending this PR's fix to \`del()\` would make it delete *more* than real yq does for some orderings (\`del(.a, 1)\` would delete \`.a\`, which real yq leaves alone) — a data-loss-shaped divergence in the wrong direction, not a cosmetic one.

\`del()\` therefore keeps the pre-existing (safe) raise, gated via the \`short_circuit_del_root\` flag \`resolve_dynamic_indexes\` already threads to distinguish \`del()\`'s call shape from its siblings. Filed the reverse-order/abort algorithm as its own follow-up: #1865.

## Verification

Full \`jq_cli_tests\`/\`yq_cli_tests\` suites (1079 + 1282, +6 new), \`eval::\` unit tests, both clippy legs, \`--no-default-features\` (no_std), \`cargo fmt --check\`, and \`cargo doc --all-features\` all green.

Fixes #1764