### PR TITLE
fix(jq): do not leave autovivified structure behind a suppressed write

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16827,6 +16827,38 @@ fn write_index(arr: &mut Vec<OwnedValue>, idx: i64) -> Result<&mut OwnedValue, E
     Ok(&mut arr[actual_idx])
 }
 
+/// #1428: does reaching `tail` from a *freshly created* parent actually write
+/// anything?
+///
+/// Walking to a write target autovivifies every missing step on the way, but
+/// some tails then write nothing at all -- an `Iterate` over the `Null` that
+/// autovivification just produced has no elements to assign to. jq treats path
+/// collection as read-only until a write is confirmed, so it leaves the
+/// document alone; succinctly used to leave the fabricated chain behind
+/// (`null | .a[]? = 9` gave `{"a":null}` instead of `null`).
+///
+/// Running the real tail against a detached `Null` answers the question
+/// without touching the document, and without a second copy of the walking
+/// rules that could drift from the one that does the writing:
+///
+/// * it raises -> the error propagates and the document stays pristine
+///   (matching jq, which emits no document for `null | .a[] = 9` either);
+/// * it leaves the probe `Null` -> nothing would be written, so the caller
+///   must not create anything;
+/// * it leaves a value behind -> something genuinely wants that parent. yq's
+///   own `null`-to-`[]` autovivify (#1181: `null | .a[] = 99` is `{"a": []}`
+///   in real yq) lands here, so the caller goes on to build the chain.
+///
+/// Only called when the parent is known to be missing, so the common case
+/// pays nothing.
+fn tail_writes_from_fresh_parent(
+    run: impl FnOnce(&mut OwnedValue) -> Result<(), EvalError>,
+) -> Result<bool, EvalError> {
+    let mut probe = OwnedValue::Null;
+    run(&mut probe)?;
+    Ok(!matches!(probe, OwnedValue::Null))
+}
+
 /// Set a value at a path in an owned value.
 fn set_path(
     root: &mut OwnedValue,
@@ -16873,7 +16905,55 @@ fn set_path(
             if exprs.len() == 1 {
                 set_path(root, &exprs[0], new_value, scalar_noop, container_noop)
             } else if let Some(split) = split_at_iterate(exprs) {
-                match get_path_mut(root, &split.before, scalar_noop)? {
+                // #1428: walking to `split.before` autovivifies every missing
+                // step along the way, but an `Iterate` over the `Null` that
+                // creates yields *no* elements, so the tail writes nothing and
+                // the fabricated chain is stranded -- `null | .a[]? = 9` gave
+                // `{"a":null}` where jq leaves `null` untouched. jq treats path
+                // collection as read-only until a write is confirmed.
+                //
+                // Ask first whether `before` already resolves. If it does, no
+                // creation can happen and this is the pre-existing path,
+                // unchanged. If it does not, run the *same* tail against a
+                // detached `Null` to learn what reaching it would actually do,
+                // without touching `root`:
+                //
+                // * it raises (`.a[] = 9`, no `?`) -> propagate, `root` still
+                //   pristine, matching jq, which also emits no document;
+                // * it writes nothing -> return without creating anything;
+                // * it leaves a value behind -> yq's own `null`-to-`[]`
+                //   autovivify (#1181, `null | .a[] = 99` is `{"a": []}` in
+                //   real yq) genuinely wants the chain, so fall through and
+                //   build it for real.
+                //
+                // Probing costs one extra walk only when `before` is missing,
+                // and `new_value` is an already-computed value, so evaluating
+                // the tail twice cannot double any side effect.
+                let mut would_create = false;
+                if get_path_mut(root, &split.before, scalar_noop, false, &mut would_create)?
+                    .is_none()
+                    // Only when the parent is genuinely *missing*. A `None`
+                    // because an earlier component was `?`-suppressed
+                    // (`5 | .a?.b[].c = 9`) means the write is already
+                    // cancelled, and probing the tail from a `Null` would
+                    // manufacture a "Cannot iterate over null" that jq never
+                    // raises -- the creating walk below returns `Ok(())` for
+                    // that case on its own, exactly as it did before #1428.
+                    && would_create
+                    && !tail_writes_from_fresh_parent(|probe| {
+                        set_path_through_iterate(
+                            probe,
+                            split.optional,
+                            &split.tail,
+                            new_value.clone(),
+                            scalar_noop,
+                            container_noop,
+                        )
+                    })?
+                {
+                    return Ok(());
+                }
+                match get_path_mut(root, &split.before, scalar_noop, true, &mut false)? {
                     None => Ok(()),
                     Some(target) => set_path_through_iterate(
                         target,
@@ -16885,7 +16965,7 @@ fn set_path(
                     ),
                 }
             } else if let Some(split) = split_at_slice(exprs) {
-                match get_path_mut(root, &split.before, scalar_noop)? {
+                match get_path_mut(root, &split.before, scalar_noop, true, &mut false)? {
                     None => Ok(()),
                     Some(parent) => through_slice(
                         parent,
@@ -16911,7 +16991,31 @@ fn set_path(
                 let parent_path = &exprs[..exprs.len() - 1];
                 let last_path = &exprs[exprs.len() - 1];
 
-                match get_path_mut(root, parent_path, scalar_noop)? {
+                // #1428, same guard as the `split_at_iterate` arm above --
+                // needed separately because a *terminal* `Iterate`
+                // (`.a[]? = 9`) is explicitly not `split_at_iterate`'s case
+                // and lands here instead. A terminal `Field`/`Index` probe
+                // writes into the detached `Null` and so falls straight
+                // through, leaving `null | .a = 9` and friends untouched.
+                let mut would_create = false;
+                if get_path_mut(root, parent_path, scalar_noop, false, &mut would_create)?
+                    .is_none()
+                    // See the `split_at_iterate` arm above.
+                    && would_create
+                    && !tail_writes_from_fresh_parent(|probe| {
+                        set_path(
+                            probe,
+                            last_path,
+                            new_value.clone(),
+                            scalar_noop,
+                            container_noop,
+                        )
+                    })?
+                {
+                    return Ok(());
+                }
+
+                match get_path_mut(root, parent_path, scalar_noop, true, &mut false)? {
                     None => Ok(()),
                     Some(parent) => {
                         set_path(parent, last_path, new_value, scalar_noop, container_noop)
@@ -17558,6 +17662,8 @@ fn get_path_mut<'a>(
     root: &'a mut OwnedValue,
     path_parts: &[Expr],
     scalar_noop: bool,
+    create: bool,
+    would_create: &mut bool,
 ) -> Result<Option<&'a mut OwnedValue>, EvalError> {
     let mut current = root;
     // A working copy, not a plain slice iteration: `resolve_node`'s `?` arm
@@ -17613,12 +17719,37 @@ fn get_path_mut<'a>(
         current = match part {
             Expr::Identity => current,
             Expr::Field(name) => {
-                autovivify_object(current);
+                if create {
+                    autovivify_object(current);
+                } else if matches!(current, OwnedValue::Null) {
+                    // #1428 probe mode: a `Null` here is exactly what the
+                    // creating walk would autovivify, so report "absent".
+                    *would_create = true;
+                    return Ok(None);
+                }
                 if let OwnedValue::Object(map) = current {
-                    map.entry(name.clone()).or_insert(OwnedValue::Null)
+                    if create {
+                        map.entry(name.clone()).or_insert(OwnedValue::Null)
+                    } else {
+                        // Probe mode: a missing key is likewise something the
+                        // creating walk would add.
+                        match map.get_mut(name) {
+                            Some(existing) => existing,
+                            None => {
+                                *would_create = true;
+                                return Ok(None);
+                            }
+                        }
+                    }
                 } else if optional || noop_here {
                     return Ok(None);
                 } else {
+                    // Probe mode falls through to the *same* error the
+                    // creating walk raises. Reporting "absent" here instead
+                    // would let the caller skip a genuine type error --
+                    // `[] | .a[]? = 9` must still raise `Cannot index array
+                    // with string "a"`, because the `?` is on the iterate,
+                    // not on the field.
                     return Err(EvalError::cannot_index_with_field(
                         owned_type_name(current),
                         name,
@@ -17626,15 +17757,37 @@ fn get_path_mut<'a>(
                 }
             }
             Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-                autovivify_array(current);
+                if create {
+                    autovivify_array(current);
+                } else if matches!(current, OwnedValue::Null) {
+                    // Probe mode, as in the `Field` arm above.
+                    *would_create = true;
+                    return Ok(None);
+                }
                 if let OwnedValue::Array(arr) = current {
-                    // A still-negative index is the write-time bounds check,
-                    // not a walking failure, so `?` never covers it here
-                    // either — same reasoning as `set_path`'s `Expr::Optional`
-                    // arm, just with nothing to catch: `write_index` never
-                    // returns that error for a component this function can
-                    // itself elect to suppress.
-                    write_index(arr, *idx)?
+                    if !create {
+                        // Probe mode. `resolve_setpath_index` is shared with
+                        // `write_index`, so the index arithmetic (negative
+                        // indices in particular) cannot drift between the
+                        // probing and the creating walk; an index past the end
+                        // is what `write_index` would pad to, i.e. absent.
+                        let actual = resolve_setpath_index(&OwnedValue::Int(*idx), arr.len())?;
+                        match arr.get_mut(actual) {
+                            Some(existing) => existing,
+                            None => {
+                                *would_create = true;
+                                return Ok(None);
+                            }
+                        }
+                    } else {
+                        // A still-negative index is the write-time bounds check,
+                        // not a walking failure, so `?` never covers it here
+                        // either — same reasoning as `set_path`'s `Expr::Optional`
+                        // arm, just with nothing to catch: `write_index` never
+                        // returns that error for a component this function can
+                        // itself elect to suppress.
+                        write_index(arr, *idx)?
+                    }
                 } else if optional || noop_here {
                     return Ok(None);
                 } else {
@@ -17670,6 +17823,13 @@ fn update_path<S: EvalSemantics>(
     optional: bool,
     scalar_noop: bool,
 ) -> Result<(), EvalEscape> {
+    // #1428 is a jq-mode divergence, and deliberately stays one: real yq
+    // *wants* the chain a suppressed write leaves behind (`null | .a[] = 99`
+    // is `{"a": []}` there, #1181), so undoing it in yq mode would trade one
+    // divergence for another. `set_path`'s sibling guard needs no such flag --
+    // it probes the real tail, and yq's own `null`-to-`[]` autovivify makes
+    // that probe come back non-`Null`, so it falls through on its own.
+    let undo_stranded = S::TAG != EvalTag::Yq;
     // yq's slice-write container no-op (#1142) is unconditional on the
     // operator, unlike `scalar_noop` (a caller-gated parameter, `false` for
     // `-=`/`*=`) -- so it only needs `S::TAG`, not threading through every
@@ -17809,10 +17969,50 @@ fn update_path<S: EvalSemantics>(
 
                 match first {
                     Expr::Field(name) => {
+                        // #1428: mirror of the guard in `set_path`'s own
+                        // chain arms, in the shape this recursive walker
+                        // allows. `set_path` probes a detached `Null` up
+                        // front because its parent chain is built inside
+                        // `get_path_mut`'s loop, which cannot be walked back
+                        // up; here the frame that creates the slot is still
+                        // live when the recursion returns, so it can simply
+                        // undo it. Probing would be wrong on this side
+                        // anyway: `filter_expr` is a *filter*, and running it
+                        // once to decide and again for real would double any
+                        // side effect it has.
+                        //
+                        // A mid-chain slot left `Null` by the recursion was
+                        // never written: every component that can follow one
+                        // (`Field`/`Index`/`Iterate`/`Slice`) leaves a
+                        // container behind when it does write, and a bare
+                        // `.a |= null` is a *terminal* `Field`, handled by
+                        // the arm below rather than here.
+                        let root_was_null = matches!(root, OwnedValue::Null);
                         autovivify_object(root);
                         if let OwnedValue::Object(map) = root {
-                            let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                            update_path::<S>(current, &rest, filter_expr, optional, scalar_noop)
+                            let created = !map.contains_key(name);
+                            let (result, stranded) = {
+                                let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
+                                let result = update_path::<S>(
+                                    current,
+                                    &rest,
+                                    filter_expr,
+                                    optional,
+                                    scalar_noop,
+                                );
+                                let stranded = created
+                                    && result.is_ok()
+                                    && undo_stranded
+                                    && matches!(*current, OwnedValue::Null);
+                                (result, stranded)
+                            };
+                            if stranded {
+                                map.shift_remove(name);
+                                if root_was_null && map.is_empty() {
+                                    *root = OwnedValue::Null;
+                                }
+                            }
+                            result
                         } else if here
                             // #1232: this mid-chain arm is a separately-
                             // maintained copy of the terminal `Expr::Field`
@@ -17831,15 +18031,35 @@ fn update_path<S: EvalSemantics>(
                         }
                     }
                     Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+                        // #1428: see the `Field` arm above. `write_index` pads
+                        // with `Null`s to reach a positive out-of-range index,
+                        // so the undo restores the original length rather than
+                        // removing a single slot.
+                        let root_was_null = matches!(root, OwnedValue::Null);
                         autovivify_array(root);
                         if let OwnedValue::Array(arr) = root {
-                            update_path::<S>(
-                                write_index(arr, *idx)?,
-                                &rest,
-                                filter_expr,
-                                optional,
-                                scalar_noop,
-                            )
+                            let original_len = arr.len();
+                            let (result, stranded) = {
+                                let current = write_index(arr, *idx)?;
+                                let result = update_path::<S>(
+                                    current,
+                                    &rest,
+                                    filter_expr,
+                                    optional,
+                                    scalar_noop,
+                                );
+                                let stranded = result.is_ok()
+                                    && undo_stranded
+                                    && matches!(*current, OwnedValue::Null);
+                                (result, stranded)
+                            };
+                            if stranded && arr.len() > original_len {
+                                arr.truncate(original_len);
+                                if root_was_null && arr.is_empty() {
+                                    *root = OwnedValue::Null;
+                                }
+                            }
+                            result
                         } else if here || noop_scalar {
                             Ok(())
                         } else {
@@ -55003,6 +55223,8 @@ mod tests {
             &mut root,
             &[Expr::Field("a".to_string()), Expr::Field("b".to_string())],
             false,
+            true,
+            &mut false,
         )
         .unwrap()
         .unwrap();
@@ -58808,7 +59030,8 @@ mod tests {
         #[test]
         fn test_get_path_mut_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = get_path_mut(&mut root, &[unresolved()], false).unwrap_err();
+            let err =
+                get_path_mut(&mut root, &[unresolved()], false, true, &mut false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in path component"
@@ -58905,7 +59128,8 @@ mod tests {
         #[test]
         fn test_get_path_mut_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = get_path_mut(&mut root, &[unresolved()], false).unwrap_err();
+            let err =
+                get_path_mut(&mut root, &[unresolved()], false, true, &mut false).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in path component"

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16827,6 +16827,31 @@ fn write_index(arr: &mut Vec<OwnedValue>, idx: i64) -> Result<&mut OwnedValue, E
     Ok(&mut arr[actual_idx])
 }
 
+/// #1428: does this path step reach its target *through* an `Iterate`?
+///
+/// The guard below is only sound for an iterate. Over the `Null` that
+/// autovivification just produced, an iterate has no elements, so it writes
+/// nothing *structurally* -- that conclusion needs no inspection of the
+/// resulting value. Every other component (`Identity`, `Field`, `Index`,
+/// `Slice`) does write, and a write whose value happens to be `null` is
+/// indistinguishable from no write at all by looking at the target: an earlier
+/// version of this fix inferred "unwritten" from "still `Null`" and so dropped
+/// `null | (.a|.) = null` to `null` (jq, and yq, keep `{"a": null}`).
+fn reaches_iterate(expr: &Expr) -> bool {
+    match unwrap_path_component(expr).0 {
+        Expr::Iterate => true,
+        // Anywhere along the chain, not just at its head: `update_path`
+        // recurses one component at a time, and a frame two levels above the
+        // iterate (`.a` in `.a.b[]? |= 9`) still has to undo its own slot.
+        // The inner frame restores *its* parent to `Null` when it undoes, so
+        // by the time the outer frame looks, "still `Null`" is again an
+        // accurate reading -- but only if it knows an iterate was involved at
+        // all, which is what this answers.
+        Expr::Pipe(inner) => inner.iter().any(reaches_iterate),
+        _ => false,
+    }
+}
+
 /// #1428: does reaching `tail` from a *freshly created* parent actually write
 /// anything?
 ///
@@ -16998,8 +17023,9 @@ fn set_path(
                 // writes into the detached `Null` and so falls straight
                 // through, leaving `null | .a = 9` and friends untouched.
                 let mut would_create = false;
-                if get_path_mut(root, parent_path, scalar_noop, false, &mut would_create)?
-                    .is_none()
+                if reaches_iterate(last_path)
+                    && get_path_mut(root, parent_path, scalar_noop, false, &mut would_create)?
+                        .is_none()
                     // See the `split_at_iterate` arm above.
                     && would_create
                     && !tail_writes_from_fresh_parent(|probe| {
@@ -18000,9 +18026,16 @@ fn update_path<S: EvalSemantics>(
                                     optional,
                                     scalar_noop,
                                 );
+                                // `reaches_iterate`: only an iterate can
+                                // decline to write over the `Null` just
+                                // created, so only there does "still `Null`"
+                                // mean "never written". Without it, a
+                                // legitimate `null` write (`(.a|.) |= null`)
+                                // is undone.
                                 let stranded = created
                                     && result.is_ok()
                                     && undo_stranded
+                                    && reaches_iterate(&rest)
                                     && matches!(*current, OwnedValue::Null);
                                 (result, stranded)
                             };
@@ -18048,8 +18081,10 @@ fn update_path<S: EvalSemantics>(
                                     optional,
                                     scalar_noop,
                                 );
+                                // See the `Field` arm above.
                                 let stranded = result.is_ok()
                                     && undo_stranded
+                                    && reaches_iterate(&rest)
                                     && matches!(*current, OwnedValue::Null);
                                 (result, stranded)
                             };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -55952,36 +55952,34 @@ mod tests {
         );
     }
 
-    /// Characterization test (see `.claude/skills/testing/SKILL.md`'s
-    /// "Pinning Known-Wrong Behaviour" section): pins the exact `.a: null`
-    /// stub #1873's fix above leaves behind, which is *not* what real jq
-    /// produces (`/usr/bin/jq` 1.7.1 leaves `null`/`{}`/`{"b":1}` completely
-    /// untouched for these queries). The stub is issue #1428's separate,
-    /// pre-existing, broader defect -- eager `Field` autovivification
-    /// during path navigation, reachable with no slice involved at all
-    /// (`null | .a[]? = 9` already produces the identical `{"a":null}` on
-    /// `main`, before and after #1873's fix). This is not asserting
-    /// desired behaviour -- if #1428 is ever fixed, update these
-    /// expectations to match real jq instead.
+    /// Was a characterization test pinning the `.a: null` stub #1873's fix
+    /// left behind, with the standing instruction "if #1428 is ever fixed,
+    /// update these expectations to match real jq instead". #1428 is fixed,
+    /// so these now assert `/usr/bin/jq` 1.7.1's own answers: the document is
+    /// left completely untouched, because an `Iterate` over the `Null` that
+    /// autovivification produced has no elements to assign to, so the write
+    /// never happens and the chain built to reach it is never committed.
+    ///
+    /// Kept under its original subject (a slice with a mid-chain iterate
+    /// tail) rather than folded into the `#1428` tests in
+    /// `tests/jq_cli_tests.rs`: this exercises the library entry point
+    /// directly, and it is the shape where `through_slice`'s own `Null` arm
+    /// and #1428's parent-probe have to agree.
     #[test]
-    fn test_assign_slice_mid_chain_iterate_over_null_leaves_field_stub_characterize_preexisting_bug_1428(
-    ) {
+    fn test_assign_slice_mid_chain_iterate_over_null_leaves_document_untouched_1428() {
         query!(br"null", r".a[0:1][]? = 9",
             QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#,
-                    "#1428 fixed? update this expectation to match real jq's \"null\"");
+                assert_eq!(v.to_json(), r"null");
             }
         );
         query!(br#"{"b":1}"#, r".a[0:1][]? = 9",
             QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"b":1,"a":null}"#,
-                    "#1428 fixed? update this expectation to match real jq's {{\"b\":1}}");
+                assert_eq!(v.to_json(), r#"{"b":1}"#);
             }
         );
         query!(br"null", r".a[0:1][]? |= 9",
             QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#,
-                    "#1428 fixed? update this expectation to match real jq's \"null\"");
+                assert_eq!(v.to_json(), r"null");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16837,6 +16837,25 @@ fn write_index(arr: &mut Vec<OwnedValue>, idx: i64) -> Result<&mut OwnedValue, E
 /// indistinguishable from no write at all by looking at the target: an earlier
 /// version of this fix inferred "unwritten" from "still `Null`" and so dropped
 /// `null | (.a|.) = null` to `null` (jq, and yq, keep `{"a": null}`).
+/// #1428: is this remaining path effectively `Identity` -- i.e. does the
+/// caller's `edit` closure *itself* perform the write, rather than navigating
+/// further inside it?
+///
+/// [`SliceEditFlags::terminal_write`] draws exactly this distinction, and
+/// `set_path`'s slice arm has always computed it (`matches!(split.tail,
+/// Expr::Identity)`). `update_path`'s own slice arm hardcoded `false`, which
+/// was harmless while `through_slice`'s `Null` arm treated every unwritten
+/// `Null` as an error -- but once that arm learned to no-op for a genuine
+/// read-through, the hardcoded `false` started swallowing the real error for
+/// `null | (.a[0:1]|.) |= null`, which jq raises.
+fn is_effectively_identity(expr: &Expr) -> bool {
+    match unwrap_path_component(expr).0 {
+        Expr::Identity => true,
+        Expr::Pipe(inner) => inner.iter().all(is_effectively_identity),
+        _ => false,
+    }
+}
+
 fn reaches_iterate(expr: &Expr) -> bool {
     match unwrap_path_component(expr).0 {
         Expr::Iterate => true,
@@ -18209,7 +18228,13 @@ fn update_path<S: EvalSemantics>(
                                 optional: here,
                                 scalar_noop,
                                 container_noop,
-                                terminal_write: false,
+                                // #1428: computed, not hardcoded `false` --
+                                // mirroring `set_path`'s own slice arm. When
+                                // `rest` is effectively `Identity` the filter
+                                // applies straight to the slice, so this call
+                                // *is* the write and a resulting `Null` must
+                                // still raise (`(.a[0:1]|.) |= null`).
+                                terminal_write: is_effectively_identity(&rest),
                             },
                             |sub| update_path::<S>(sub, &rest, filter_expr, optional, scalar_noop),
                         )

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16990,6 +16990,58 @@ fn set_path(
                     ),
                 }
             } else if let Some(split) = split_at_slice(exprs) {
+                // #1428, the slice twin of the `split_at_iterate` guard above.
+                // A slice write on a missing parent usually *does* write
+                // (`null | .a[0:1] = [9]` is `{"a":[9]}`), which is why this
+                // arm was originally left alone -- but a slice can also be a
+                // read-through step whose own tail declines to write
+                // (`null | .a[0:1][]? = 9`), and then the `.a` built to reach
+                // it is stranded exactly as before.
+                //
+                // No `reaches_iterate` test is needed here: `through_slice`'s
+                // `Null` arm returns `Ok` with the probe still `Null` only
+                // when nothing was written at all, and a terminal slice
+                // assignment of `null` raises rather than landing there. So
+                // "the probe is still `Null`" is an exact reading on this
+                // path.
+                //
+                // jq mode only (`container_noop` is `S::TAG == EvalTag::Yq`
+                // at every call site, the same reading `through_slice`'s own
+                // `Null` arm relies on). Real yq keeps the chain here even
+                // though its container no-op discards the write itself:
+                // `null | .a[0:1] = 9` is `a: null` in yq v4.53.3, so the
+                // probe -- which sees only that nothing was written -- would
+                // wrongly skip creating `.a`.
+                let mut would_create = false;
+                if !container_noop
+                    && get_path_mut(root, &split.before, scalar_noop, false, &mut would_create)?
+                        .is_none()
+                    && would_create
+                    && !tail_writes_from_fresh_parent(|probe| {
+                        through_slice(
+                            probe,
+                            split.start,
+                            split.end,
+                            SliceEditFlags {
+                                optional: split.optional,
+                                scalar_noop,
+                                container_noop,
+                                terminal_write: matches!(split.tail, Expr::Identity),
+                            },
+                            |sub| {
+                                set_path(
+                                    sub,
+                                    &split.tail,
+                                    new_value.clone(),
+                                    scalar_noop,
+                                    container_noop,
+                                )
+                            },
+                        )
+                    })?
+                {
+                    return Ok(());
+                }
                 match get_path_mut(root, &split.before, scalar_noop, true, &mut false)? {
                     None => Ok(()),
                     Some(parent) => through_slice(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25560,3 +25560,115 @@ fn test_jq_mode_root_del_still_null_after_1702() -> Result<()> {
     }
     Ok(())
 }
+
+// =============================================================================
+// #1428: autovivification must not outlive a write that never happens
+// =============================================================================
+
+/// Walking to a write target autovivifies every missing step on the way, but
+/// an `Iterate` over the `Null` that creates has no elements to assign to, so
+/// the write never happens and the fabricated chain was left behind. jq treats
+/// path collection as read-only until a write is confirmed.
+///
+/// Every expectation here is the pinned jq 1.7.1's own output.
+#[test]
+fn test_suppressed_write_leaves_no_autovivified_chain_1428() -> Result<()> {
+    for (input, filter, expected) in [
+        // The issue's own repros.
+        ("null", ".a[]? = 9", "null\n"),
+        ("[1,2,3]", ".[5][]?[0] = 9", "[1,2,3]\n"),
+        ("null", ".a.b[]?[0] = 9", "null\n"),
+        // An *existing* object must not gain the key either.
+        ("{}", ".a[]? = 9", "{}\n"),
+        // Depth is not special: nothing at any level survives.
+        ("null", ".a.b.c[]? = 9", "null\n"),
+        // A tail after the iterate behaves the same.
+        ("null", ".a[]?.b = 9", "null\n"),
+        ("null", ".a[]?.b[]? = 9", "null\n"),
+        // `|=` shares the walker and the bug.
+        ("null", ".a[]? |= .+1", "null\n"),
+        ("{}", ".a[]? |= .+1", "{}\n"),
+        ("null", ".a[]?.b |= 9", "null\n"),
+        // ...and so do the compound operators built on it.
+        ("null", ".a[]? += 1", "null\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+    Ok(())
+}
+
+/// The other half of #1428, and the reason a naive "never autovivify" fix is
+/// wrong: a `?`-suppressed write that *does* happen still creates its chain.
+#[test]
+fn test_confirmed_write_still_autovivifies_1428() -> Result<()> {
+    for (input, filter, expected) in [
+        // `?` on a step that resolves: the write lands, so the chain stays.
+        ("null", ".a[0]? = 9", "{\"a\":[9]}\n"),
+        ("null", ".a?.b = 9", "{\"a\":{\"b\":9}}\n"),
+        // No `?` at all -- ordinary autovivification, untouched.
+        ("null", ".a = 9", "{\"a\":9}\n"),
+        ("null", ".a.b = 9", "{\"a\":{\"b\":9}}\n"),
+        ("null", ".a[2] |= 9", "{\"a\":[null,null,9]}\n"),
+        // A real iterate target writes to every element.
+        ("{\"a\":[1,2]}", ".a[]? = 9", "{\"a\":[9,9]}\n"),
+        ("{\"a\":{\"k\":1}}", ".a[]? = 9", "{\"a\":{\"k\":9}}\n"),
+        // An empty container is a legitimate zero-element write, and the key
+        // already exists, so the document is unchanged either way.
+        ("{\"a\":[]}", ".a[]? = 9", "{\"a\":[]}\n"),
+        // A slice write on a missing parent genuinely writes -- it must not be
+        // skipped along with the iterate cases.
+        ("null", ".a[0:1]? = [9]", "{\"a\":[9]}\n"),
+        // One path writing and another not, in a single assignment.
+        ("null", "(.a[]?, .b) = 9", "{\"b\":9}\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+    Ok(())
+}
+
+/// #1428 must not turn a genuine error into a silent no-op. The first version
+/// of the fix did exactly that -- reporting "absent" for a wrong-type
+/// container let the walker skip errors jq still raises, 59 of them across a
+/// differential sweep.
+///
+/// The distinction that matters: a `?` binds to the component it is written
+/// on. In `[] | .a[]? = 9` it is on the *iterate*, so the `.a`-on-an-array
+/// type error is still raised.
+#[test]
+fn test_suppressed_write_still_raises_real_type_errors_1428() -> Result<()> {
+    for (input, filter, needle) in [
+        ("[]", ".a[]? = 9", "Cannot index array with string"),
+        ("5", ".a[]? = 9", "Cannot index number with string"),
+        ("\"s\"", ".a.b[]? = 9", "Cannot index string with string"),
+        ("true", ".a[]?[0] = 9", "Cannot index boolean with string"),
+        (
+            "{\"a\":1}",
+            ".a.b[]? = 9",
+            "Cannot index number with string",
+        ),
+        ("{}", ".[5][]?[0] = 9", "Cannot index object with number"),
+        // No `?` anywhere: iterating a null still raises, and the document is
+        // never emitted, so nothing can be left fabricated in it.
+        ("null", ".a[] = 9", "Cannot iterate over null"),
+    ] {
+        let (_, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_ne!(code, 0, "{input} | {filter} must fail");
+        assert!(
+            stderr.contains(needle),
+            "{input} | {filter} -- want {needle:?}, got {stderr}"
+        );
+    }
+
+    // A `?` on an *earlier* component cancels the whole write, and must not be
+    // mistaken for "the parent is missing, go probe the tail" -- doing so
+    // manufactured a `Cannot iterate over null` that jq never raises (this is
+    // #1298's own case, which caught the second wrong version of this fix).
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a?.b[].c = 9"], Some("5"))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "5\n");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25793,3 +25793,40 @@ fn test_read_through_slice_that_writes_nothing_is_a_noop_1428() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1428 review follow-up: `update_path`'s slice arm must compute
+/// `terminal_write`, not hardcode `false`.
+///
+/// `set_path`'s slice arm has always derived it from its tail. `update_path`'s
+/// hardcoded `false` was harmless while `through_slice`'s `Null` arm treated
+/// every unwritten `Null` as an error -- but once that arm learned to no-op for
+/// a genuine read-through, the wrong flag made it swallow the real error for a
+/// filter that writes `null` directly to the slice.
+#[test]
+fn test_slice_update_with_identity_tail_still_raises_1428() -> Result<()> {
+    for (input, filter) in [
+        ("null", "(.a[0:1]|.) |= null"),
+        ("{\"a\":null}", "(.a[0:1]|.) |= null"),
+        ("null", "(.[0:1]|.) |= null"),
+        ("null", "(.a[0:1]|.) |= 9"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_ne!(code, 0, "{input} | {filter} must raise, got {stdout:?}");
+        assert!(
+            stderr.contains("slice of an array"),
+            "{input} | {filter} -- got {stderr}"
+        );
+    }
+
+    // The read-through spelling of the same shape still no-ops, which is the
+    // distinction `terminal_write` draws.
+    for (input, filter, expected) in [
+        ("null", ".a[0:1][]? |= 9", "null\n"),
+        ("null", ".a[0:1][0][]? |= 9", "null\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25591,6 +25591,16 @@ fn test_suppressed_write_leaves_no_autovivified_chain_1428() -> Result<()> {
         ("null", ".a[]?.b |= 9", "null\n"),
         // ...and so do the compound operators built on it.
         ("null", ".a[]? += 1", "null\n"),
+        // The probe's out-of-range *index* branch: the array exists, so the
+        // walk gets that far, but the index is past its end -- which is a slot
+        // `write_index` would pad into existence, i.e. "would create". Padding
+        // it and then discovering the iterate writes nothing is exactly the
+        // stranding this fix removes, here as trailing `null`s rather than a
+        // fabricated key.
+        ("{\"a\":[1]}", ".a[5][]? = 9", "{\"a\":[1]}\n"),
+        ("{\"a\":[1]}", ".a[5][]? |= 9", "{\"a\":[1]}\n"),
+        ("{\"a\":[1]}", ".a[5].b[]? = 9", "{\"a\":[1]}\n"),
+        ("[1]", ".[5][]? = 9", "[1]\n"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25736,3 +25736,60 @@ fn test_nested_suppressed_update_unwinds_every_level_1428() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1428 review follow-up: a slice can be a *read-through* step whose own tail
+/// declines to write, and then the chain built to reach it is stranded exactly
+/// like the plain iterate case.
+///
+/// This class was reached only after the guard started making tails legitimately
+/// write nothing: `through_slice`'s `Null` arm then saw an unwritten `Null` and
+/// raised its write-time "A slice of an array can only be assigned another
+/// array", turning a document jq leaves alone into a hard exit-5 failure. The
+/// arm now distinguishes the two using `terminal_write`, which exists for
+/// exactly that question -- when the edit *is* the write, a `Null` result means
+/// the RHS was `null`, and `null | .[0:1] = null` does still raise.
+#[test]
+fn test_read_through_slice_that_writes_nothing_is_a_noop_1428() -> Result<()> {
+    for (input, filter, expected) in [
+        ("null", ".[0:1][0][]? = 9", "null\n"),
+        ("null", ".[0:1][0][]? |= 9", "null\n"),
+        ("null", ".[0:1][0][]? += 1", "null\n"),
+        ("null", ".a[0:1][0][]? = 9", "null\n"),
+        // The slice immediately followed by an iterate -- filed as #1873 while
+        // it was still failing, and closed by this same fix.
+        ("null", ".a[0:1][]? = 9", "null\n"),
+        ("{}", ".a[0:1][]? = 9", "{}\n"),
+        ("null", ".[0:1][]? = 9", "null\n"),
+        // An existing `null` parent is untouched either way.
+        ("{\"a\":null}", ".a[0:1][]? = 9", "{\"a\":null}\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+
+    // A slice write that *does* write still builds its chain...
+    for (input, filter, expected) in [
+        ("null", ".a[0:1] = [9]", "{\"a\":[9]}\n"),
+        ("null", ".[0:1] = [9]", "[9]\n"),
+        ("null", ".a[0:1][0] = 9", "{\"a\":[9]}\n"),
+        ("null", ".a[0:1]? = [9]", "{\"a\":[9]}\n"),
+        ("[1,2,3]", ".[0:2] = [9]", "[9,3]\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+
+    // ...and a terminal slice assignment of a non-array still raises, which is
+    // what keeps the `terminal_write` distinction honest.
+    for filter in [".[0:1] = null", ".[0:1] = 9"] {
+        let (_, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_ne!(code, 0, "{filter} must raise");
+        assert!(
+            stderr.contains("slice of an array"),
+            "{filter} -- got {stderr}"
+        );
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25672,3 +25672,67 @@ fn test_suppressed_write_still_raises_real_type_errors_1428() -> Result<()> {
     assert_eq!(stdout, "5\n");
     Ok(())
 }
+
+/// #1428 review follow-up: a write whose *value* is `null` is still a write.
+///
+/// The first two versions of this fix inferred "nothing was written" from "the
+/// target is still `Null`", which is indistinguishable from a legitimate `null`
+/// write. `null | (.a|.) = null` dropped to `null` where jq (and yq) keep
+/// `{"a":null}` -- 56 distinct filter shapes regressed this way, none of them
+/// covered by the suite, because they all need an explicit `|` inside the path
+/// to produce an `Identity`-shaped tail.
+///
+/// The guard is now structural: it applies only where the deciding component
+/// is an `Iterate`, which over a freshly-created `Null` writes nothing *by
+/// construction* -- no inspection of the resulting value required.
+#[test]
+fn test_null_valued_write_is_still_a_write_1428() -> Result<()> {
+    for (input, filter, expected) in [
+        ("null", "(.a|.) = null", "{\"a\":null}\n"),
+        ("null", "(.a|.) = .x", "{\"a\":null}\n"),
+        ("null", "(.a|.b) = null", "{\"a\":{\"b\":null}}\n"),
+        ("null", "(.a|.) |= null", "{\"a\":null}\n"),
+        ("null", "(.a|.) |= .", "{\"a\":null}\n"),
+        ("null", "(.a|.) //= null", "{\"a\":null}\n"),
+        ("null", "(.a|.) += null", "{\"a\":null}\n"),
+        ("null", "(.a[0]|.) |= null", "{\"a\":[null]}\n"),
+        (
+            "null",
+            "(.[5]|.) = null",
+            "[null,null,null,null,null,null]\n",
+        ),
+        // A plain terminal write of `null` was never at risk, but pins the
+        // pair: the paren form above and this one must agree.
+        ("null", ".a = null", "{\"a\":null}\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, expected, "{input} | {filter}");
+    }
+    Ok(())
+}
+
+/// #1428 review follow-up: the `|=` walker recurses one component at a time, so
+/// a frame two or more levels above the iterate has to undo its own slot too.
+///
+/// Checking only the head of the remaining path left `null | .a.b[]? |= 9` as
+/// `{"a":{}}` -- the inner frame correctly removed `.b`, but `.a` was then an
+/// empty object rather than the `Null` it started as, so the outer frame could
+/// not tell. 40 (input, filter) pairs were still wrong at that point.
+#[test]
+fn test_nested_suppressed_update_unwinds_every_level_1428() -> Result<()> {
+    for (input, filter) in [
+        ("null", ".a.b[]? |= 9"),
+        ("null", ".a.b[]? |= null"),
+        ("null", ".a.b[]? += 1"),
+        ("null", ".a.b.c[]? |= 9"),
+        ("null", ".a.b.c.d[]? |= 9"),
+        ("null", ".a.b.c[]? //= null"),
+        ("{}", ".a.b[]? |= 9"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{input} | {filter} -- stderr={stderr}");
+        assert_eq!(stdout, format!("{input}\n"), "{input} | {filter}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Walking to a write target autovivifies every missing step on the way — but an `Iterate` over the `Null` that creates has no elements to assign to, so the write never happens and the fabricated chain was left behind. jq treats path collection as read-only until a write is confirmed.

```console
$ echo null | succinctly jq -c '.a[]? = 9'
{"a":null}                                   # jq 1.7.1: null
$ echo '[1,2,3]' | succinctly jq -c '.[5][]?[0] = 9'
[1,2,3,null,null,null]                       # jq 1.7.1: [1,2,3]
$ echo null | succinctly jq -c '.a.b[]?[0] = 9'
{"a":{"b":null}}                             # jq 1.7.1: null
```

`=` and `|=` are both affected, and so are the compound operators built on `|=`.

## The criterion is structural, not value-inferred

The guard applies **only where the deciding component is an `Iterate`**. Over a freshly autovivified `Null`, an iterate has no elements and so writes nothing *by construction* — that conclusion needs no inspection of the resulting value. Every other component (`Identity`, `Field`, `Index`, `Slice`) does write.

This matters because the obvious shortcut is wrong: an earlier version inferred "nothing was written" from "the target is still `Null`", which is indistinguishable from a legitimate `null` write. It dropped `null | (.a|.) = null` to `null` where jq and yq both keep `{"a":null}` — 56 distinct filter shapes, **including a yq regression**.

## Two mechanisms, because the two walkers differ

- **`set_path`** builds its parent chain inside `get_path_mut`'s loop, which cannot be walked back up to undo. It gains a probe mode that resolves only what is already there and reports *why* it found nothing — a missing slot the creating walk would add, versus an earlier component the `?` already cancelled. Only the first case runs the **real tail against a detached `Null`**, reusing the tail function rather than adding a second copy of the rules that could drift from the one doing the writing.
- **`update_path`** recurses, so the frame that creates a slot is still live when the recursion returns and can simply undo it. Probing would be wrong there: `|=` takes a *filter*, and running it once to decide and again for real would double any side effect. That undo is gated to jq mode — real yq genuinely wants the chain (#1181), and `set_path` needs no such gate because yq's own autovivify makes its probe come back non-`Null` and fall through.

`update_path` recurses one component at a time, so the iterate check looks along the whole remaining chain: checking only its head left `null | .a.b[]? |= 9` as `{"a":{}}` at depth ≥ 2.

## Four wrong versions preceded this one

Every one passed the issue's own repros. All were caught by differential sweeps against the pinned binary — never by hand-picked cases:

1. Reporting "absent" for a wrong-type container **swallowed real errors** — 59 regressions against 23 fixes. `[] | .a[]? = 9` must still raise `Cannot index array with string "a"`, because the `?` binds to the *iterate*, not the field.
2. Conflating "absent, would be created" with "already suppressed by `?`" manufactured a `Cannot iterate over null` for `5 | .a?.b[].c = 9` that jq never raises — caught by #1298's existing test.
3. Inferring "no write" from a `null` value (above).
4. Checking only the head of the remaining path (above).

## Verification

| | result |
|---|---|
| jq differential sweep (6,300 input × path × operator) | **601 fixed, 0 behavioural regressions** |
| jq sweep vs *current* `main` (2,640) | **216 fixed, 0 behavioural regressions** |
| yq differential sweep (1,824) | **byte-identical to pre-change** |
| full suite | 55 suites + doctests + 3,045 lib tests, 0 failures |
| rebased 3× onto new `main` commits touching the same write machinery | sweeps re-run each time, identical result |

Sweeps compare three ways — pinned `/usr/bin/jq` 1.7.1, the pre-change binary, and this branch — so pre-existing divergence is never mistaken for a fix or a regression.

**Performance:** the probe short-circuits on `reaches_iterate`, so a plain chained `.a.b = 9` never walks the parent twice. Interleaved A/B on a 598 KB document, 7 reps: 108.9 ms vs 109.0 ms.

**Fixes a regression `main` is carrying right now.** PR #1875 independently landed the same `through_slice` `Null`-arm no-op this branch had — but without correcting `update_path`'s hardcoded `terminal_write: false`, which that no-op depends on. So on current `main`, `null | (.a[0:1]|.) |= null` returns `{"a":null}` at exit 0 where jq raises exit 5, dropping a real error *and* stranding the chain. Reported on #1875; the fix is the third commit here. The rebase kept #1875's spelling of the `Null` arm over my equivalent one, and updated its characterization test (which deliberately pinned the #1428 bug, with a written instruction to update it once #1428 was fixed).

**#1873 is fixed here too.** I filed it during this issue's own first review round as a separate pre-existing bug, noting it was "not a regression, verified identical on `main`". That held only for the exact shape it named — the second review round found the sibling **slice → index → iterate** family, which is the same root cause, so both are fixed by the `terminal_write` distinction and the slice-split probe.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 55 suites, all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all --check`, `cargo doc --no-deps`, `cargo build --no-default-features` (no_std)
- [x] Diffed against pinned jq 1.7.1 and Homebrew yq v4.53.3 directly, not just goldens
- [x] 5 tests covering: the suppressed-write cases, the confirmed writes that must keep autovivifying, the type errors that must still raise, null-valued writes, and nested-depth unwinding — the first **confirmed to fail** against the unguarded walker
- [x] Full verification re-run after the rebase

Fixes #1428
Fixes #1873


