### PR TITLE
fix(jq): stop through_slice demanding array from a no-op null tail

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -374,8 +374,6 @@ have to be recorded here.
 
 | Filter             | Input   | jq                                  | succinctly                        |
 |--------------------|---------|-------------------------------------|-----------------------------------|
-| `.[1:2] = ["x"]`   | `null`  | `["x"]`                             | `Cannot index null with object`   |
-| `.[1:2] \|= ["x"]` | `null`  | `["x"]`                             | `Cannot index null with object`   |
 | `@uri`             | `[1,2]` | `"%5B1%2C2%5D"`                     | `expected string, got array`      |
 | `@base64`          | `5`     | `"NQ=="`                            | `expected string, got number`     |
 | `flatten("x")`     | `[1,2]` | `[1,2]` (ignores non-integer depth) | `expected number, got non-number` |
@@ -1139,8 +1137,13 @@ probes, so the two-sided manifest check forced them to start matching in the sam
 
 What #366 did *not* build: computed bounds. `.[$a:$b]` is still a parse error, because the
 parser folds slice bounds to integer literals; see
-[docs/reference/jq-language.md](../../reference/jq-language.md). And writing through a
-slice does not vivify `null` — see the table above for why that was deliberate.
+[docs/reference/jq-language.md](../../reference/jq-language.md). Writing through a slice
+against `null` used to raise `Cannot index null with object` instead of auto-vivifying —
+[#1340](https://github.com/rust-works/succinctly/issues/1340) brought that in line with
+jq's own `setpath()` behavior, and [#1873](https://github.com/rust-works/succinctly/issues/1873)
+later fixed a gap in that same auto-vivification for a slice with more path *after* it
+(`.a[0:1][]? = 9` on a missing `.a` now no-ops instead of raising a write-time error, matching
+jq).
 
 ## Reading a path is indexing
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17241,9 +17241,38 @@ fn through_slice<E: From<EvalError>>(
         // `-=`/`*=` on a null slice target exactly as unaffected by this
         // fix as `#1340`'s own issue text was ever scoped to be (jq mode
         // only) — not newly right, but not newly wrong either.
+        //
+        // `!terminal_write` no-op (#1873): the doc comment above described
+        // `edit`'s result as always having to become an array once it's
+        // done, but that's only true when the slice itself is the write.
+        // When there's a real tail after it (`.a[0:1][]? = 9` on missing
+        // `.a`), `edit` is `set_path`'s own recursion into that tail
+        // against a fresh `Null` -- and if the tail's navigation
+        // determines there's nothing to write (here, iterating zero
+        // elements over nothing, with the `cannot_iterate` error swallowed
+        // by `?`), it leaves `sub` untouched at `Null` and returns `Ok`
+        // without ever attempting a real write. Forcing that case through
+        // the array requirement raises "A slice of an array can only be
+        // assigned another array" where real jq leaves the whole document
+        // unchanged (confirmed live for `.a[0:1][]? = 9` and its `|=`
+        // twin, on `null`/`{}`/`{"a":null}`). A tail that *does* write
+        // something -- autovivifying a field (`.a[0:1].b = 9` -> `sub`
+        // becomes an `Object`) or an element (`.a[0:1][0] = 9` -> `sub`
+        // becomes an `Array`) -- never leaves `sub` as `Null`, so it still
+        // falls through to the same array requirement below, matching jq
+        // still erroring on the first of those two (an object can't splice
+        // into a slice) and succeeding on the second (already an array).
+        // Only reachable when `terminal_write` is false in the first
+        // place: `.a[0:1] = null` (a literal-`null` RHS as the slice's own
+        // terminal write) still has to raise the same error, since there
+        // `sub` staying `Null` reflects the RHS itself, not a swallowed
+        // no-op -- confirmed live it still errors in real jq.
         OwnedValue::Null if !container_noop => {
             let mut sub = OwnedValue::Null;
             edit(&mut sub)?;
+            if !terminal_write && matches!(sub, OwnedValue::Null) {
+                return Ok(());
+            }
             let OwnedValue::Array(items) = sub else {
                 return Err(EvalError::slice_assign_non_array().into());
             };
@@ -55464,6 +55493,111 @@ mod tests {
         query!(br#"{"b":[10,20,30]}"#, r".b[0:1].c = 9",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, r#"Cannot index array with string "c""#);
+            }
+        );
+    }
+
+    /// #1873: `through_slice`'s `Null` arm (added by #1340 above) required
+    /// `edit`'s result to become an `Array` unconditionally, even for a
+    /// mid-chain tail (`terminal_write: false`) whose own navigation
+    /// determines there's nothing to write at all -- a `?`-suppressed
+    /// `cannot_iterate` over the empty slice range leaves `edit`'s `sub`
+    /// untouched at `Null`, which used to be forced through the array
+    /// check and raise "A slice of an array can only be assigned another
+    /// array" where real jq leaves the whole document unchanged. Every
+    /// case here is oracle-verified against real jq 1.7.1. The residual
+    /// `.a: null` stub #1428 already tracks (eager `Field` autovivification
+    /// during navigation, unrelated to slices) is a separate, pre-existing,
+    /// broader issue -- out of scope here, and not asserted against below.
+    #[test]
+    fn test_assign_slice_mid_chain_iterate_over_null_noops_1873() {
+        // The trailing `.a: null` stub in every one of these outputs is
+        // #1428's separate, pre-existing, broader bug (eager `Field`
+        // autovivification during navigation, reachable with no slice
+        // involved at all -- `null | .a[]? = 9` already leaves the same
+        // stub behind on unmodified `main`) -- not something this fix
+        // touches. What this fix removes is the write-time error that
+        // used to fire instead of reaching that (separately imperfect)
+        // no-op at all.
+        query!(br"null", r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#);
+            }
+        );
+        query!(br"{}", r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#);
+            }
+        );
+        query!(br#"{"a":null}"#, r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#);
+            }
+        );
+        query!(br#"{"b":1}"#, r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"b":1,"a":null}"#);
+            }
+        );
+        // `|=` shares `through_slice`, so it shares the bug and the fix.
+        query!(br"null", r".a[0:1][]? |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#);
+            }
+        );
+        query!(br"{}", r".a[0:1][]? |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#);
+            }
+        );
+        // A non-optional `Iterate` tail still raises the ordinary
+        // navigation failure -- unaffected by this fix since `edit`
+        // propagates the error before `sub` is ever inspected.
+        query!(br"null", r".a[0:1][] = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot iterate over null (null)");
+            }
+        );
+        // A `Field` tail after the slice still has to raise the array
+        // requirement -- `edit` autovivifies `sub` into an `Object`, never
+        // leaving it `Null`, so it still falls through to the existing
+        // check (matching real jq erroring here too, `?` or not).
+        query!(br"null", r".a[0:1].b = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        query!(br"null", r".a[0:1].b? = 9",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        // A literal `null` RHS on the terminal slice write itself is a
+        // different shape (`terminal_write: true`) and must still error --
+        // `sub` staying `Null` there reflects the RHS, not a swallowed
+        // no-op.
+        query!(br"null", r".a[0:1] = null",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "A slice of an array can only be assigned another array");
+            }
+        );
+        // An `Index` tail after the slice still auto-vivifies successfully
+        // -- `edit` leaves `sub` as a real `Array`, never `Null`.
+        query!(br"null", r".a[0:1][0]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":[9]}"#);
+            }
+        );
+        // An existing array parent is unaffected either way -- `root`
+        // never reaches the `Null` arm at all for this shape.
+        query!(br#"{"a":[1,2,3]}"#, r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":[9,2,3]}"#);
+            }
+        );
+        query!(br#"{"a":[1,2,3]}"#, r".a[0:1][]? |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":[9,2,3]}"#);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17267,6 +17267,17 @@ fn through_slice<E: From<EvalError>>(
         // terminal write) still has to raise the same error, since there
         // `sub` staying `Null` reflects the RHS itself, not a swallowed
         // no-op -- confirmed live it still errors in real jq.
+        //
+        // This reads "`sub` is still `Null`" as "nothing was written,"
+        // which is sound only because every tail shape `edit` can recurse
+        // into today either leaves `sub` as something other than `Null`
+        // (`Field`/`Index` always autovivify a container first) or
+        // propagates a real `Err` before `sub` is ever inspected
+        // (`Expr::Optional`'s error classification only swallows a
+        // *non*-write-time-application error). If a future tail shape ever
+        // produced a genuine write that happened to leave `sub` at `Null`,
+        // this check would misread it as a no-op -- there is no compiler-
+        // enforced link between the two, only this invariant.
         OwnedValue::Null if !container_noop => {
             let mut sub = OwnedValue::Null;
             edit(&mut sub)?;
@@ -30213,6 +30224,24 @@ fn delete_at_path(
                     // make this string case look fixed relative to #1219's
                     // own array/object case when it isn't. jq mode is
                     // unaffected either way.
+                    //
+                    // `container_noop: false` unconditionally (#1873 code
+                    // review): unlike `set_path`/`update_path`'s call sites,
+                    // which thread `S::TAG == EvalTag::Yq` so `through_slice`
+                    // can tell the two modes apart, this one hardcodes
+                    // `false` for both -- currently inert only because the
+                    // guarded arm above (`if matches!(root, OwnedValue::
+                    // Null)`) always intercepts a literal-`Null` root before
+                    // the match ever reaches here, in both modes, so
+                    // `through_slice`'s own `Null` arm (gated `!container_
+                    // noop`, and since #1873 also `!terminal_write`) is
+                    // unreachable from this call site regardless of what
+                    // `container_noop` says. A future change to that
+                    // preceding guard's condition, or to this match's arm
+                    // order, would silently let jq-mode `del()` start
+                    // auto-vivifying a `null` slice target through #1873's
+                    // arm -- a semantics never oracle-verified for `del()`
+                    // -- with nothing here to catch it.
                     Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
                         through_slice(
                             root,
@@ -55504,55 +55533,33 @@ mod tests {
     /// `cannot_iterate` over the empty slice range leaves `edit`'s `sub`
     /// untouched at `Null`, which used to be forced through the array
     /// check and raise "A slice of an array can only be assigned another
-    /// array" where real jq leaves the whole document unchanged. Every
-    /// case here is oracle-verified against real jq 1.7.1. The residual
-    /// `.a: null` stub #1428 already tracks (eager `Field` autovivification
-    /// during navigation, unrelated to slices) is a separate, pre-existing,
-    /// broader issue -- out of scope here, and not asserted against below.
+    /// array" where real jq leaves the whole document unchanged (verified
+    /// live against `/usr/bin/jq` 1.7.1: `null | .a[0:1][]? = 9` is `null`).
+    /// This test asserts only the no-error/error split and the shapes whose
+    /// exact output does match jq byte-for-byte -- the sibling test below
+    /// characterizes the one shape whose exact output does not (a separate,
+    /// pre-existing bug, #1428).
     #[test]
     fn test_assign_slice_mid_chain_iterate_over_null_noops_1873() {
-        // The trailing `.a: null` stub in every one of these outputs is
-        // #1428's separate, pre-existing, broader bug (eager `Field`
-        // autovivification during navigation, reachable with no slice
-        // involved at all -- `null | .a[]? = 9` already leaves the same
-        // stub behind on unmodified `main`) -- not something this fix
-        // touches. What this fix removes is the write-time error that
-        // used to fire instead of reaching that (separately imperfect)
-        // no-op at all.
-        query!(br"null", r".a[0:1][]? = 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#);
-            }
-        );
-        query!(br"{}", r".a[0:1][]? = 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#);
-            }
-        );
-        query!(br#"{"a":null}"#, r".a[0:1][]? = 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#);
-            }
-        );
-        query!(br#"{"b":1}"#, r".a[0:1][]? = 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"b":1,"a":null}"#);
-            }
-        );
-        // `|=` shares `through_slice`, so it shares the bug and the fix.
-        query!(br"null", r".a[0:1][]? |= 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#);
-            }
-        );
-        query!(br"{}", r".a[0:1][]? |= 9",
-            QueryResult::Owned(v) => {
-                assert_eq!(v.to_json(), r#"{"a":null}"#);
-            }
-        );
+        // The fix itself: no longer a write-time error. `null`, `{}` and
+        // `{"a":null}` all reach `through_slice` with byte-identical state
+        // (`Field("a")` navigation converges every one of them to a fresh
+        // `&mut Null`), so one representative root suffices here -- the
+        // sibling characterization test below is where the exact resulting
+        // value (which does differ per root, via #1428) is pinned.
+        query!(br"null", r".a[0:1][]? = 9", QueryResult::Owned(_) => {});
+        // `|=` and every compound assignment operator desugar through the
+        // same `through_slice`/`set_path`-or-`update_path` arm, so they
+        // share the bug and the fix identically -- oracle-verified each
+        // one is a no-op on `null` in real jq too (`+=`/`-=`/`*=`/`//=`/
+        // `%=`, not just `|=`).
+        for op in ["|=", "+=", "-=", "*=", "//=", "%="] {
+            query!(br"null", &format!(".a[0:1][]? {op} 9"), QueryResult::Owned(_) => {});
+        }
         // A non-optional `Iterate` tail still raises the ordinary
         // navigation failure -- unaffected by this fix since `edit`
-        // propagates the error before `sub` is ever inspected.
+        // propagates the error before `sub` is ever inspected. Oracle-
+        // verified: `/usr/bin/jq` raises the identical message.
         query!(br"null", r".a[0:1][] = 9",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "Cannot iterate over null (null)");
@@ -55561,12 +55568,9 @@ mod tests {
         // A `Field` tail after the slice still has to raise the array
         // requirement -- `edit` autovivifies `sub` into an `Object`, never
         // leaving it `Null`, so it still falls through to the existing
-        // check (matching real jq erroring here too, `?` or not).
-        query!(br"null", r".a[0:1].b = 9",
-            QueryResult::Error(e) => {
-                assert_eq!(e.message, "A slice of an array can only be assigned another array");
-            }
-        );
+        // check. Oracle-verified this errors identically with or without
+        // `?` on the field (`?` never suppresses this error class), so one
+        // case covers both.
         query!(br"null", r".a[0:1].b? = 9",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "A slice of an array can only be assigned another array");
@@ -55575,21 +55579,25 @@ mod tests {
         // A literal `null` RHS on the terminal slice write itself is a
         // different shape (`terminal_write: true`) and must still error --
         // `sub` staying `Null` there reflects the RHS, not a swallowed
-        // no-op.
+        // no-op. Oracle-verified: `/usr/bin/jq` raises the identical error.
         query!(br"null", r".a[0:1] = null",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "A slice of an array can only be assigned another array");
             }
         );
         // An `Index` tail after the slice still auto-vivifies successfully
-        // -- `edit` leaves `sub` as a real `Array`, never `Null`.
+        // -- `edit` leaves `sub` as a real `Array`, never `Null`, so this
+        // exact value is oracle-verified against `/usr/bin/jq` (no #1428
+        // stub involved: the result never touches the eager-autovivify
+        // path, since `sub` genuinely becomes the array being spliced in).
         query!(br"null", r".a[0:1][0]? = 9",
             QueryResult::Owned(v) => {
                 assert_eq!(v.to_json(), r#"{"a":[9]}"#);
             }
         );
         // An existing array parent is unaffected either way -- `root`
-        // never reaches the `Null` arm at all for this shape.
+        // never reaches the `Null` arm at all for this shape. Exact values
+        // oracle-verified.
         query!(br#"{"a":[1,2,3]}"#, r".a[0:1][]? = 9",
             QueryResult::Owned(v) => {
                 assert_eq!(v.to_json(), r#"{"a":[9,2,3]}"#);
@@ -55598,6 +55606,40 @@ mod tests {
         query!(br#"{"a":[1,2,3]}"#, r".a[0:1][]? |= 9",
             QueryResult::Owned(v) => {
                 assert_eq!(v.to_json(), r#"{"a":[9,2,3]}"#);
+            }
+        );
+    }
+
+    /// Characterization test (see `.claude/skills/testing/SKILL.md`'s
+    /// "Pinning Known-Wrong Behaviour" section): pins the exact `.a: null`
+    /// stub #1873's fix above leaves behind, which is *not* what real jq
+    /// produces (`/usr/bin/jq` 1.7.1 leaves `null`/`{}`/`{"b":1}` completely
+    /// untouched for these queries). The stub is issue #1428's separate,
+    /// pre-existing, broader defect -- eager `Field` autovivification
+    /// during path navigation, reachable with no slice involved at all
+    /// (`null | .a[]? = 9` already produces the identical `{"a":null}` on
+    /// `main`, before and after #1873's fix). This is not asserting
+    /// desired behaviour -- if #1428 is ever fixed, update these
+    /// expectations to match real jq instead.
+    #[test]
+    fn test_assign_slice_mid_chain_iterate_over_null_leaves_field_stub_characterize_preexisting_bug_1428(
+    ) {
+        query!(br"null", r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#,
+                    "#1428 fixed? update this expectation to match real jq's \"null\"");
+            }
+        );
+        query!(br#"{"b":1}"#, r".a[0:1][]? = 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"b":1,"a":null}"#,
+                    "#1428 fixed? update this expectation to match real jq's {{\"b\":1}}");
+            }
+        );
+        query!(br"null", r".a[0:1][]? |= 9",
+            QueryResult::Owned(v) => {
+                assert_eq!(v.to_json(), r#"{"a":null}"#,
+                    "#1428 fixed? update this expectation to match real jq's \"null\"");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17268,16 +17268,24 @@ fn through_slice<E: From<EvalError>>(
         // `sub` staying `Null` reflects the RHS itself, not a swallowed
         // no-op -- confirmed live it still errors in real jq.
         //
-        // This reads "`sub` is still `Null`" as "nothing was written,"
-        // which is sound only because every tail shape `edit` can recurse
-        // into today either leaves `sub` as something other than `Null`
-        // (`Field`/`Index` always autovivify a container first) or
-        // propagates a real `Err` before `sub` is ever inspected
-        // (`Expr::Optional`'s error classification only swallows a
-        // *non*-write-time-application error). If a future tail shape ever
-        // produced a genuine write that happened to leave `sub` at `Null`,
-        // this check would misread it as a no-op -- there is no compiler-
-        // enforced link between the two, only this invariant.
+        // This reads "`sub` is still `Null`" as "nothing was written," which
+        // holds for a tail that is *directly* a swallowed no-op (`Field`/
+        // `Index` always autovivify a container first; `Expr::Optional`
+        // only swallows a non-write-time-application `Err`) -- but not in
+        // general: a tail with a `Field`/`Index` step *before* the swallowed
+        // no-op leaves `sub` as an autovivified husk (e.g. `Object({"c":
+        // Null})`), not bare `Null`, so this check misses it. Confirmed live
+        // this narrower gap already exists, unrelated to and unmoved by
+        // this fix: `null | .a[0:1].c[]? = 9` still wrongly raises this
+        // arm's array-required error (real jq no-ops), and `null |
+        // .a[0:1][0]?.c[]? = 9` wrongly *commits* a write real jq no-ops
+        // (`{"a":[{"c":null}]}` vs jq's `null`) -- both identical before and
+        // after this fix. That's the same family of bug #1428 tracks (a
+        // write-time decision inferred from what navigation left behind
+        // rather than from an explicit "did anything actually get written"
+        // signal), just one nesting level deeper than what this fix
+        // narrowly closes; not attempted here since #1428 is already being
+        // worked as its own, more structural fix.
         OwnedValue::Null if !container_noop => {
             let mut sub = OwnedValue::Null;
             edit(&mut sub)?;
@@ -55551,9 +55559,9 @@ mod tests {
         // `|=` and every compound assignment operator desugar through the
         // same `through_slice`/`set_path`-or-`update_path` arm, so they
         // share the bug and the fix identically -- oracle-verified each
-        // one is a no-op on `null` in real jq too (`+=`/`-=`/`*=`/`//=`/
-        // `%=`, not just `|=`).
-        for op in ["|=", "+=", "-=", "*=", "//=", "%="] {
+        // one is a no-op on `null` in real jq too (`+=`/`-=`/`*=`/`/=`/
+        // `//=`/`%=`, not just `|=`).
+        for op in ["|=", "+=", "-=", "*=", "/=", "//=", "%="] {
             query!(br"null", &format!(".a[0:1][]? {op} 9"), QueryResult::Owned(_) => {});
         }
         // A non-optional `Iterate` tail still raises the ordinary


### PR DESCRIPTION
## Summary

`through_slice`'s `Null` arm (added by #1340) required the `edit` closure's
result to become an `Array` unconditionally, even for a mid-chain tail
(`terminal_write: false`) whose own navigation determines there's nothing to
write at all. A `?`-suppressed `cannot_iterate` over the empty slice range
left `edit`'s `sub` untouched at `Null`, which the arm forced through the
array check anyway, raising "A slice of an array can only be assigned
another array" where real jq leaves the whole document unchanged.

```
$ echo null | jq -c '.a[0:1][]? = 9'
null
$ echo null | succinctly jq -c '.a[0:1][]? = 9'   # before this fix
jq: error: A slice of an array can only be assigned another array
```

Verified live against the pinned oracle (`/usr/bin/jq` 1.7.1) that `=`,
`|=`, and every compound-assignment operator (`+=`/`-=`/`*=`/`/=`/`//=`/
`%=`) share this bug (all go through the same `through_slice` choke point),
and that the fix doesn't regress any of the surrounding shapes: a
non-optional `Iterate` tail still raises "Cannot iterate over null", a
`Field` tail after the slice still raises the array requirement (matching
jq erroring there too), a literal-`null` RHS on the slice's own terminal
write still errors, an `Index` tail still auto-vivifies successfully, and
an existing array parent is untouched by this arm entirely.

## Scope: this closes the reported shape, not the whole class

Round-2 review found a deeper, related gap: a tail with a `Field`/`Index`
step *before* the swallowed no-op (`null | .a[0:1].c[]? = 9`) still wrongly
errors, and one shape (`null | .a[0:1][0]?.c[]? = 9`) wrongly *commits* a
write real jq no-ops on. Both confirmed byte-for-byte identical before and
after this PR's fix — not a regression, not newly introduced. This is the
same family of bug as **#1428** (a write-time decision inferred from what
navigation left behind, rather than an explicit "did anything actually get
written" signal), just one nesting level deeper than what #1873 itself was
ever scoped to. #1428 is already being worked as its own, more structural
fix in a separate, further-along branch — not attempted here.

## Other notes from review

- The residual `.a: null` stub in every no-op output (e.g. `null |
  .a[0:1][]? = 9` → `{"a":null}` instead of real jq's untouched `null`) is
  also #1428's territory (eager `Field` autovivification during
  navigation, reachable with no slice involved at all). Pinned explicitly
  in a separate characterization test, not conflated with this fix's own
  verification.
- Filed **#1876** (string-slice terminal write skips `edit`'s side effects)
  and **#1877** (`|= empty` through a nested terminal slice) for two
  unrelated pre-existing gaps found adjacent to this code during review.
- `docs/compliance/jq/limitations.md` had two stale rows/a stale sentence
  left over from #1340 (claiming slice-null writes still error) — fixed
  here since it's directly adjacent to what this PR touches.

## Test plan

- New tests: `test_assign_slice_mid_chain_iterate_over_null_noops_1873`
  (the fix itself, every assertion either error-message-exact or
  oracle-byte-exact) and a separate, explicitly-labeled characterization
  test for the pre-existing #1428 stub.
- Full `jq::eval` unit test module (1118 tests): pass.
- `cargo test --features cli,simd,regex,serde --no-fail-fast` (full suite,
  including doctests): pass.
- `cargo test` (plain, default features): pass.
- Both clippy legs (`--all-features` and CI's `std,simd,serde,cli,regex,
  bench-runner,large-tests,mmap-tests`): clean, `-D warnings`.
- `cargo fmt --check`: clean.
- `cargo doc --all-features --no-deps`: clean (pre-existing unrelated dead-code warnings only).
- `cargo build --no-default-features`: clean.

Fixes #1873