### PR TITLE
fix(yq): compact sequence-item indent no longer compounds at deeper levels

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -355,6 +355,43 @@ would still not close the gap (the irregular per-level part is unmodeled by both
 every non-default `-I` width, not just `-I0`), so this remains open rather than folded into
 #1575's fix.
 
+### Stacked compact block-sequence items — one narrow, pre-existing width anomaly
+
+[#1485](https://github.com/rust-works/succinctly/issues/1485) fixed the general rule for a
+compact block-sequence item's inlined field/element (`- ` sharing its line with a mapping
+value's first field, #785): content nested *inside* that first field's own value steps from
+the item's own pre-compact indent (`recursion_base`) by an ordinary `indent_spaces` amount —
+not from the item's 2-column-wider visual column — with one width-dependent correction at
+real yq's own default (`-I=2`, where a single ordinary step wouldn't clear the compact visual
+column). This also fixed a **stacked** chain, where a block sequence is itself the compact
+value nested directly inside *another* compact sequence element (`- - b: ...`, a sequence
+whose sole element is itself a sequence whose sole element is a mapping): every level must
+keep forwarding the *original* pre-compact base through every compact level, not just its
+own immediate one.
+
+**One narrow anomaly survives, unfixed, at a specific (nesting depth, `-I`) intersection**:
+for a chain of exactly `D` stacked compact sequence levels, real yq's own column for the
+first nested field is non-monotonic in `-I` right at `-I = D + 1` — verified live against yq
+v4.53.3 across `-I=2` through `-I=6`, both before and after #1485's fix, and confirmed
+byte-identical on pre-#1485 `main` too (this is not something #1485 introduced or worsened).
+For `D = 2` (`printf -- '- - b:\n      c:\n        d: 1\n' | yq -I=<n> '.'`), the observed
+column of `c` is 6/6/8/5/6 for `-I` = 2/3/4/5/6 — genuinely non-monotonic (`-I=5`'s column is
+*smaller* than `-I=2`'s), not just a different linear step per width. The anomaly sits at
+`-I=3` (`D+1`): real yq's own column there (6) breaks what would otherwise be a strictly
+increasing sequence (2→6, 4→8, 5→…, 6→…) by repeating `-I=2`'s value instead of continuing
+upward to 7.
+
+Both succinctly output routes give column 7 at `-I=3` there (an ordinary, monotonic step
+matching the `-I=2`→`-I=4`→... progression), matching each other and matching pre-#1485
+`main`'s own (also non-matching) value — neither has ever modeled this specific anomaly. The
+pattern (`-I = stacked_depth + 1`) suggests a genuine upstream go-yaml quirk tied to some
+internal indent-tracking edge case rather than a spec-conformant rule, but the exact
+mechanism is not yet understood; tracked as
+[#1881](https://github.com/rust-works/succinctly/issues/1881) rather than blocking #1485's
+otherwise-verified fix (which is strictly more correct than what it replaced: it repairs a
+real regression at `-I=4` introduced mid-fix and two cases pre-#1485 `main` never got right
+at all, `-I=5`/`-I=6`).
+
 ### `input`, `inputs`, `input_line_number` are rejected, but at runtime rather than parse time
 
 Real yq has no such builtins at any arity — its lexer rejects the identifiers exactly as it

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2295,6 +2295,31 @@ fn is_flow_safe(value: &OwnedValue, comments: &CommentTree) -> bool {
 /// renders as `*name`, so it is inline no matter how large the anchored
 /// value it points at happens to be. Getting that wrong renders `b: *x` as
 /// a block mapping with `*x` dangling above it.
+/// DOM twin of `light.rs`'s `compact_child_indent` (#1485): the indent for
+/// content nested one level inside a compact-rendered field/element's own
+/// value. An ordinary `{recursion_base}{indent_str}` step, *unless* that
+/// step wouldn't land past `indent` (the field's own compact-adjusted
+/// indent) -- real yq's own rule, which only bites when `indent_str`'s
+/// width is `<=` the compact `- `/first-field offset (2 columns) --
+/// real yq's own default, `-I=2`, is exactly that boundary. See
+/// `light.rs`'s `compact_child_indent` for the full live-verified
+/// rationale (both writers are pinned against the same oracle behavior,
+/// #763).
+///
+/// Reduces to the pre-existing, always-correct `format!("{indent}{step}")`
+/// whenever `recursion_base == indent` (the non-compact case, the vast
+/// majority of calls): the "normal" candidate is then always longer than
+/// `indent` itself (appending at least one character), so the `if` always
+/// takes that branch.
+fn compact_child_indent(recursion_base: &str, indent: &str, indent_str: &str) -> String {
+    let normal = format!("{recursion_base}{indent_str}");
+    if normal.chars().count() > indent.chars().count() {
+        normal
+    } else {
+        format!("{indent}{indent_str}")
+    }
+}
+
 fn defers_to_own_block(value: &OwnedValue, comments: &CommentTree) -> bool {
     comments.alias_name().is_none()
         && !is_flow_safe(value, comments)
@@ -2364,7 +2389,7 @@ fn emit_yaml_value(
     indent: &str,
     in_flow: bool,
 ) -> String {
-    emit_yaml_value_at_depth(value, comments, config, indent, in_flow, 0)
+    emit_yaml_value_at_depth(value, comments, config, indent, in_flow, 0, indent)
 }
 
 /// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
@@ -2374,6 +2399,16 @@ fn emit_yaml_value(
 /// guarded by #1015; this is YAML-target's own copy), reachable on a
 /// value constructed via `reduce`/`foreach`/etc. with no adversarial
 /// document on either side.
+///
+/// `recursion_base` (#1485): the indent a *nested* container reached from
+/// this value should step deeper from -- equal to `indent` everywhere
+/// except right after a real-yq "compact" positioning (the `Array` arm's
+/// two compact branches below, which pass this call's own pre-compact
+/// `indent` rather than the compact-adjusted one they pass as `indent`
+/// itself). See `light.rs`'s `stream_yaml_value` doc comment on its own
+/// identical parameter, and `compact_child_indent` just above, for the
+/// full live-verified rationale -- this DOM writer and that streaming one
+/// are pinned against the same oracle behavior (#763).
 fn emit_yaml_value_at_depth(
     value: &OwnedValue,
     comments: &CommentTree,
@@ -2381,6 +2416,7 @@ fn emit_yaml_value_at_depth(
     indent: &str,
     in_flow: bool,
     depth: usize,
+    recursion_base: &str,
 ) -> String {
     assert_value_tree_depth(depth);
     // An alias renders as `*name` and never writes the value it resolves
@@ -2442,6 +2478,7 @@ fn emit_yaml_value_at_depth(
                             indent,
                             true,
                             depth + 1,
+                            indent,
                         );
                         // `[&x 1, *x]` — a flow item's own anchor sits
                         // immediately before it (#763), the DOM twin of
@@ -2486,6 +2523,10 @@ fn emit_yaml_value_at_depth(
                                 // slot, so its value nests exactly as deep as an
                                 // unanchored element's would).
                                 let val_indent = compact_indent;
+                                // #1485: `recursion_base` is this element's
+                                // own pre-compact `indent`, not `val_indent`
+                                // -- any further nesting inside this
+                                // element's value steps from there.
                                 let val = emit_yaml_value_at_depth(
                                     v,
                                     elem_comments,
@@ -2493,6 +2534,7 @@ fn emit_yaml_value_at_depth(
                                     &val_indent,
                                     false,
                                     depth + 1,
+                                    indent,
                                 );
                                 let val =
                                     append_own_comment_line(val, elem_comments.own(), &val_indent);
@@ -2519,6 +2561,8 @@ fn emit_yaml_value_at_depth(
                             // effect `stream_yaml_value`'s cursor-based
                             // sibling gets for free from its per-field/
                             // per-element loop only indenting 2nd+ items.
+                            // #1485: `recursion_base` is this element's
+                            // own pre-compact `indent`, not `compact_indent`.
                             let rendered = emit_yaml_value_at_depth(
                                 v,
                                 elem_comments,
@@ -2526,6 +2570,7 @@ fn emit_yaml_value_at_depth(
                                 &compact_indent,
                                 false,
                                 depth + 1,
+                                indent,
                             );
                             // The element's own comment goes on its own
                             // line rather than glued onto its last
@@ -2548,6 +2593,7 @@ fn emit_yaml_value_at_depth(
                                 &val_indent,
                                 false,
                                 depth + 1,
+                                &val_indent,
                             );
                             let comment_suffix = trailing_comment_suffix(elem_comments);
                             let anchor = anchor_decl_prefix(elem_comments);
@@ -2575,6 +2621,7 @@ fn emit_yaml_value_at_depth(
                             indent,
                             true,
                             depth + 1,
+                            indent,
                         );
                         // `{x: &y 1, z: *y}` (#763).
                         let anchor = anchor_decl_prefix(field_comments);
@@ -2598,7 +2645,10 @@ fn emit_yaml_value_at_depth(
                         let key = yaml_quote_key(k);
                         let field_comments = comments.field(k);
                         let comment_suffix = trailing_comment_suffix(field_comments);
-                        let val_indent = format!("{indent}{}", config.indent_str);
+                        // #1485: steps from `recursion_base`, not `indent`
+                        // -- see `compact_child_indent`'s own doc comment.
+                        let val_indent =
+                            compact_child_indent(recursion_base, indent, &config.indent_str);
                         let anchor = anchor_decl_prefix(field_comments);
                         // Check if value needs to be on next line - a
                         // flow-styled container stays on the key's own line
@@ -2623,6 +2673,7 @@ fn emit_yaml_value_at_depth(
                                 &val_indent,
                                 false,
                                 depth + 1,
+                                &val_indent,
                             );
                             let val =
                                 append_own_comment_line(val, field_comments.own(), &val_indent);
@@ -2648,6 +2699,7 @@ fn emit_yaml_value_at_depth(
                                 &val_indent,
                                 false,
                                 depth + 1,
+                                &val_indent,
                             );
                             // The value's own comment takes priority; fall
                             // back to the key's own comment when the value

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2523,10 +2523,16 @@ fn emit_yaml_value_at_depth(
                                 // slot, so its value nests exactly as deep as an
                                 // unanchored element's would).
                                 let val_indent = compact_indent;
-                                // #1485: `recursion_base` is this element's
-                                // own pre-compact `indent`, not `val_indent`
-                                // -- any further nesting inside this
-                                // element's value steps from there.
+                                // #1485 (code review): `recursion_base` is
+                                // *this invocation's own* `recursion_base`,
+                                // forwarded unchanged -- not `indent`, which
+                                // is only correct when this element was
+                                // never itself compact-positioned. A stacked
+                                // compact chain (an array directly inside
+                                // another compact array element) must keep
+                                // propagating the true pre-compact base
+                                // through every level -- see `light.rs`'s
+                                // identical fix for the full rationale.
                                 let val = emit_yaml_value_at_depth(
                                     v,
                                     elem_comments,
@@ -2534,7 +2540,7 @@ fn emit_yaml_value_at_depth(
                                     &val_indent,
                                     false,
                                     depth + 1,
-                                    indent,
+                                    recursion_base,
                                 );
                                 let val =
                                     append_own_comment_line(val, elem_comments.own(), &val_indent);
@@ -2561,8 +2567,10 @@ fn emit_yaml_value_at_depth(
                             // effect `stream_yaml_value`'s cursor-based
                             // sibling gets for free from its per-field/
                             // per-element loop only indenting 2nd+ items.
-                            // #1485: `recursion_base` is this element's
-                            // own pre-compact `indent`, not `compact_indent`.
+                            // #1485 (code review): `recursion_base` is
+                            // *this invocation's own* `recursion_base`,
+                            // forwarded unchanged -- see the anchor branch
+                            // above for the full rationale.
                             let rendered = emit_yaml_value_at_depth(
                                 v,
                                 elem_comments,
@@ -2570,7 +2578,7 @@ fn emit_yaml_value_at_depth(
                                 &compact_indent,
                                 false,
                                 depth + 1,
-                                indent,
+                                recursion_base,
                             );
                             // The element's own comment goes on its own
                             // line rather than glued onto its last

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2004,13 +2004,26 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 // occupies the `- ` slot on its own line, but
                                 // that doesn't change how deep its value nests).
                                 //
-                                // #1485: the recursive call's own
-                                // `recursion_base` is this item's *pre-compact*
-                                // `indent`, not `child_indent` -- any further
-                                // nesting inside this element's value steps
-                                // from there, not from its 2-column-wider
-                                // visual column (see `stream_yaml_value`'s own
-                                // doc comment on `recursion_base`).
+                                // #1485 (code review): the recursive call's
+                                // own `recursion_base` is *this invocation's
+                                // own* `recursion_base`, not `indent` --
+                                // forwarded unchanged, not reset to this
+                                // item's own pre-compact position. A stacked
+                                // compact chain (a sequence directly inside
+                                // another compact sequence element, `- - b:
+                                // ...`) must keep propagating the *original*
+                                // pre-compact base all the way down through
+                                // every compact level, or a compact step
+                                // nested inside another compact step
+                                // silently loses it and mis-indents
+                                // everything below (confirmed live against
+                                // yq v4.53.3: `- - b:\n      c:\n        d:
+                                // 1` at `-I=4` needs `c`/`d` at columns
+                                // 8/12, not 6/10 -- an earlier version of
+                                // this fix passed `indent` here, which is
+                                // only correct when this sequence itself was
+                                // never itself compact-positioned, i.e.
+                                // `recursion_base == indent` already).
                                 let child_indent = compact_yaml_indent(indent);
                                 out.write_str(&child_indent)?;
                                 cursor.stream_yaml_value(
@@ -2020,7 +2033,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                     true,
-                                    indent,
+                                    recursion_base,
                                 )?;
                             } else {
                                 out.write_str("- ")?;
@@ -2032,7 +2045,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                     true,
-                                    indent,
+                                    recursion_base,
                                 )?;
                             }
                             write_line_comment(out, cursor.line_comment_raw())?;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1360,7 +1360,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // `Mapping` arm to notice on every recursive call (#835).
         let self_ = self.resolve_bare_seq_item();
         self_.write_leading_anchor(out)?;
-        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
+        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false, "")
     }
 
     /// Like [`Self::stream_yaml`], but also appends this cursor's own
@@ -1452,7 +1452,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
             out.write_str(&str_val)?;
         } else {
-            self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)?;
+            self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false, "")?;
         }
         if matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_)) {
             write_line_comment(out, self_.line_comment_raw())?;
@@ -1490,7 +1490,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // `stream_yaml` (#835): resolve once, reuse for both calls.
         let self_ = self.resolve_bare_seq_item();
         self_.write_leading_anchor(out)?;
-        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false)
+        self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false, "")
     }
 
     /// Write this cursor's own `&anchor` before streaming it as a YAML root.
@@ -1565,6 +1565,25 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     ///   (`bp_to_text_pos`) plus a byte scan, not free work to repeat
     ///   twice per element on this crate's flagship streaming path.
     ///   `false` everywhere else, which re-derives it as before.
+    /// - `recursion_base`: the indent string a *nested* container reached
+    ///   from this value should step deeper from — equal to `indent`
+    ///   everywhere except right after a real-yq "compact" positioning
+    ///   (#1485). Real YAML's own indentation rule is that once `- `'s
+    ///   compact offset ([`COMPACT_DASH_WIDTH`]) sets a mapping's
+    ///   structural indent level, every level nested *underneath* it steps
+    ///   by an ordinary `indent_spaces` amount from the *pre-compact*
+    ///   indent, not from that mapping's own (2-column-wider) visual
+    ///   column — confirmed live against yq v4.53.3 across 3+ nesting
+    ///   levels: `l:\n  - p:\n      q:\n        r: 1` puts `p`/`q`/`r` at
+    ///   columns 6/8/12 (a one-time `+2`, then plain `+4` steps under
+    ///   `-I=4`), not the naive 6/10/14 a uniform step from each level's
+    ///   own visual column would give. The two callers that pass a
+    ///   `recursion_base` different from `indent` (the `Sequence` arm's
+    ///   compact branches below) are the only place this ever needs to
+    ///   differ; every other call site — including this function's own
+    ///   recursive calls one level further down — passes the same string
+    ///   for both, since the discount is a one-time correction that
+    ///   resets the moment an ordinary (non-compact) step is taken.
     #[allow(clippy::too_many_arguments)] // STYLE-0004: every param is threaded through this function's own recursion; a struct would hide the 1:1 relationship each has to a specific rendering decision
     fn stream_yaml_value<Out: core::fmt::Write>(
         &self,
@@ -1574,6 +1593,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         unit: char,
         sort_keys: bool,
         known_not_flow: bool,
+        recursion_base: &str,
     ) -> StreamResult {
         match self.value() {
             YamlValue::Null => Ok(out.write_str("null")?),
@@ -1834,7 +1854,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 write_anchor_tag(out, value.anchor(), value.explicit_tag())?;
                             }
                             out.write_char('\n')?;
-                            let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
+                            // #1485: steps from `recursion_base`, not
+                            // `indent` (see this function's own doc
+                            // comment), via `compact_child_indent`'s own
+                            // "must clear the compact visual column" rule.
+                            let child_indent =
+                                compact_child_indent(recursion_base, indent, indent_spaces, unit);
                             out.write_str(&child_indent)?;
                             value.stream_yaml_value(
                                 out,
@@ -1843,6 +1868,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 unit,
                                 sort_keys,
                                 true,
+                                &child_indent,
                             )?;
                             write_line_comment(out, value.line_comment_raw())?;
                         } else {
@@ -1861,10 +1887,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // path about anchors/tags, the special case
                             // became redundant with it (verified: deleting
                             // it changes no test outcome) and was removed.
+                            //
+                            // #1485: steps from `recursion_base`, not
+                            // `indent` -- same reasoning as the container
+                            // branch above, via `compact_child_indent`.
+                            let child_indent =
+                                compact_child_indent(recursion_base, indent, indent_spaces, unit);
                             write_deferred_value(
                                 out,
                                 &value,
-                                indent,
+                                &child_indent,
                                 indent_spaces,
                                 unit,
                                 sort_keys,
@@ -1971,6 +2003,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 // indent step (#1362 -- the anchor/tag prefix
                                 // occupies the `- ` slot on its own line, but
                                 // that doesn't change how deep its value nests).
+                                //
+                                // #1485: the recursive call's own
+                                // `recursion_base` is this item's *pre-compact*
+                                // `indent`, not `child_indent` -- any further
+                                // nesting inside this element's value steps
+                                // from there, not from its 2-column-wider
+                                // visual column (see `stream_yaml_value`'s own
+                                // doc comment on `recursion_base`).
                                 let child_indent = compact_yaml_indent(indent);
                                 out.write_str(&child_indent)?;
                                 cursor.stream_yaml_value(
@@ -1980,6 +2020,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                     true,
+                                    indent,
                                 )?;
                             } else {
                                 out.write_str("- ")?;
@@ -1991,6 +2032,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     unit,
                                     sort_keys,
                                     true,
+                                    indent,
                                 )?;
                             }
                             write_line_comment(out, cursor.line_comment_raw())?;
@@ -1998,11 +2040,17 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // #1077: mirrors the mapping-field branch above
                             // -- see `write_deferred_value`'s own doc
                             // comment for the byte-for-byte spacing rule.
+                            //
+                            // #1485: every `- ` item is individually
+                            // "compact" in real yq, deferred scalar values
+                            // included -- `compact_yaml_indent`, not
+                            // `deeper_yaml_indent`, is the right step here.
                             out.write_char('-')?;
+                            let child_indent = compact_yaml_indent(indent);
                             write_deferred_value(
                                 out,
                                 &cursor,
-                                indent,
+                                &child_indent,
                                 indent_spaces,
                                 unit,
                                 sort_keys,
@@ -6790,10 +6838,20 @@ fn write_anchor_tag<Out: core::fmt::Write>(
 /// this is what an earlier draft of #1077's fix got wrong, silently
 /// dropping a no-anchor explicit tag on an absent value instead (found by
 /// review before merge).
+///
+/// `child_indent` is pre-computed by the caller rather than derived here
+/// from a bare `indent` (#1485): a mapping field's own deferred value
+/// steps by an ordinary `deeper_yaml_indent`, but a sequence item's steps
+/// by `compact_yaml_indent` instead -- every `- ` item is individually
+/// "compact" in real yq, deferred scalar values included (confirmed live:
+/// `- |\n    hello` puts `hello` 2 columns past the dash's own indent, not
+/// a full `indent_spaces` step past it) -- and this one function is
+/// shared by both callers, so it takes whichever its caller already knows
+/// is right instead of guessing.
 fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     out: &mut Out,
     value: &YamlCursor<'_, W>,
-    indent: &str,
+    child_indent: &str,
     indent_spaces: usize,
     unit: char,
     sort_keys: bool,
@@ -6809,8 +6867,15 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
         // present (`: value` or `: &anchor value`), matching the original,
         // un-extracted logic's `|| !absent` conditions byte-for-byte.
         out.write_char(' ')?;
-        let child_indent = deeper_yaml_indent(indent, indent_spaces, unit);
-        value.stream_yaml_value(out, &child_indent, indent_spaces, unit, sort_keys, false)?;
+        value.stream_yaml_value(
+            out,
+            child_indent,
+            indent_spaces,
+            unit,
+            sort_keys,
+            false,
+            child_indent,
+        )?;
     }
     Ok(())
 }
@@ -6860,6 +6925,39 @@ fn compact_yaml_indent(indent: &str) -> String {
         next.push(' ');
     }
     next
+}
+
+/// The indent for content nested one level inside a compact-rendered
+/// mapping field's own value -- an ordinary `deeper_yaml_indent` step from
+/// `recursion_base` (the pre-compact indent), *unless* that step wouldn't
+/// land past `compact_indent` (the field's own compact-adjusted `indent`),
+/// in which case real yq instead steps from `compact_indent` itself
+/// (#1485).
+///
+/// This matters only when `indent_spaces <= COMPACT_DASH_WIDTH` -- real
+/// yq's own default, `-I=2`, is exactly that boundary. Live-verified
+/// against yq v4.53.3 across `-I=2` through `-I=6` on
+/// `l:\n  - p:\n      q:\n        r: 1`: `q` (the first nested child) sits
+/// at `recursion_base + 2*indent_spaces` for `-I=2` (a naive single step
+/// would land it at the *same* column `p`'s own key already occupies --
+/// invalid YAML nesting) but at plain `recursion_base + indent_spaces` for
+/// `-I=3` and up, where a single step already clears `p`'s column. `r`
+/// (one level deeper still) is always a plain, ordinary step from
+/// whatever `q` resolved to either way -- this correction only ever
+/// applies at the one boundary where a compact field's own visual column
+/// could otherwise collide with its child's.
+fn compact_child_indent(
+    recursion_base: &str,
+    compact_indent: &str,
+    indent_spaces: usize,
+    unit: char,
+) -> String {
+    let normal = deeper_yaml_indent(recursion_base, indent_spaces, unit);
+    if normal.chars().count() > compact_indent.chars().count() {
+        normal
+    } else {
+        deeper_yaml_indent(compact_indent, indent_spaces, unit)
+    }
 }
 
 /// Write a mapping field's key.
@@ -6951,7 +7049,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     if absent {
         return Ok(out.write_str("''")?);
     }
-    value.stream_yaml_value(out, "", 0, unit, sort_keys, false)
+    value.stream_yaml_value(out, "", 0, unit, sort_keys, false, "")
 }
 
 /// Write a trailing same-line comment after a value, if present (issue
@@ -7161,6 +7259,10 @@ where
                     // `stream_yaml_value`'s own Sequence arm -- the anchor/
                     // tag prefix occupies the `- ` slot on its own line, but
                     // that doesn't change how deep its value nests).
+                    //
+                    // #1485: `recursion_base` is `own_indent` (pre-compact),
+                    // not `child_indent` -- see `stream_yaml_value`'s own
+                    // doc comment on `recursion_base`.
                     out.write_str(&child_indent)?;
                     cursor.stream_yaml_value(
                         out,
@@ -7169,6 +7271,7 @@ where
                         unit,
                         sort_keys,
                         true,
+                        &own_indent,
                     )?;
                 } else {
                     out.write_str("- ")?;
@@ -7179,6 +7282,7 @@ where
                         unit,
                         sort_keys,
                         true,
+                        &own_indent,
                     )?;
                 }
                 write_line_comment(out, cursor.line_comment_raw())?;
@@ -7197,8 +7301,12 @@ where
                 // live (`- &anc null` instead of `- &anc !!mytag`), so this
                 // now routes through the same `write_deferred_value` helper
                 // instead of hand-writing the anchor.
+                // #1485: every `- ` item is individually "compact" in real
+                // yq -- `child_indent` (already computed above), not a
+                // fresh normal step off `own_indent`, is the right value
+                // here.
                 out.write_char('-')?;
-                write_deferred_value(out, &cursor, &own_indent, indent_spaces, unit, sort_keys)?;
+                write_deferred_value(out, &cursor, &child_indent, indent_spaces, unit, sort_keys)?;
                 write_line_comment(out, cursor.line_comment_raw())?;
             }
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2626,6 +2626,107 @@ fn test_seq_item_anchor_deferred_indent_at_non_default_width_slurp_1484() -> Res
     Ok(())
 }
 
+/// #1485: a compact sequence-item's own visual +2 offset doesn't compound
+/// at every level below it -- only the item's own first field/element sits
+/// at `dash_indent + 2`; everything nested *inside* that field's own value
+/// steps by an ordinary `indent_spaces` from `dash_indent` itself, not
+/// from the 2-column-wider column `p`'s own key visually occupies. Covers
+/// the streaming path (identity) at `-I=4` (the issue's own headline
+/// repro) and the DOM path (forced via a write) at the same width.
+/// Expected output verified live against real yq v4.53.3.
+#[test]
+fn test_compact_seq_item_nested_indent_does_not_compound_streaming_1485() -> Result<()> {
+    let yaml = "l:\n  - p:\n      q:\n        r: 1\n  - x\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &["-I=4"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        streamed,
+        "l:\n    - p:\n        q:\n            r: 1\n    - x\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_compact_seq_item_nested_indent_does_not_compound_dom_1485() -> Result<()> {
+    let yaml = "l:\n  - p:\n      q:\n        r: 1\n";
+
+    let (dom, code) = run_yq_stdin(".l[0].p.q.r = 1", yaml, &["-I=4"])?;
+    assert_eq!(code, 0);
+    assert_eq!(dom, "l:\n    - p:\n        q:\n            r: 1\n");
+
+    Ok(())
+}
+
+/// #1485: the same fix at real yq's *default* indent (`-I=2`, the width
+/// every un-flagged invocation actually uses) hits a genuinely different
+/// arithmetic branch than `-I=4` above -- `indent_spaces` (2) equals
+/// `COMPACT_DASH_WIDTH` (also 2) exactly, so a single ordinary step from
+/// the sequence item's own indent would land `q` at the *same* column
+/// `p`'s own key already visually occupies (an invalid YAML nesting).
+/// Real yq instead steps an extra `indent_spaces` past that column in
+/// this one case; `-I=3` and up never hit it, since a single ordinary
+/// step already clears it there. Live-verified against yq v4.53.3 across
+/// `-I=2` through `-I=6` before writing this pin.
+#[test]
+fn test_compact_seq_item_nested_indent_at_default_width_1485() -> Result<()> {
+    let yaml = "l:\n  - p:\n      q:\n        r: 1\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed, "l:\n  - p:\n      q:\n        r: 1\n");
+
+    let (dom, code) = run_yq_stdin(".l[0].p.q.r = 1", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(dom, "l:\n  - p:\n      q:\n        r: 1\n");
+
+    Ok(())
+}
+
+/// #1485: a *second*, non-first field of the same compact-rendered
+/// mapping (`p2`, a sibling of `p`) needs the identical correction for
+/// its own nested value -- the fix lives in the mapping-field loop shared
+/// by every field, not just the one sharing the dash's line. Verified at
+/// the default width, where the correction actually changes the answer.
+#[test]
+fn test_compact_seq_item_sibling_field_nested_indent_1485() -> Result<()> {
+    let yaml = "l:\n  - p: 1\n    p2:\n      q2: 2\n";
+
+    let (streamed, code) = run_yq_stdin(".", yaml, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed, "l:\n  - p: 1\n    p2:\n      q2: 2\n");
+
+    Ok(())
+}
+
+/// #1485: a block scalar deferred to its own line under a sequence item
+/// (`- |`) is compact-positioned too -- every `- ` is individually
+/// compact in real yq, deferred scalars included -- where the analogous
+/// mapping-field position (`k: |`) is an ordinary, non-compact step.
+/// `write_deferred_value` used to compute an ordinary step unconditionally
+/// for both, since it's shared between the two callers.
+#[test]
+fn test_compact_seq_item_deferred_block_scalar_indent_1485() -> Result<()> {
+    let (seq_item, code) = run_yq_stdin(".", "l:\n  - |\n    hello\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(seq_item, "l:\n  - |\n    hello\n");
+
+    // Control: the mapping-field position is unaffected, still an
+    // ordinary step.
+    let (mapping_field, code) = run_yq_stdin(".", "l:\n  k: |\n    hello\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(mapping_field, "l:\n  k: |\n    hello\n");
+
+    // The two compose correctly together too: a block scalar that is
+    // itself the compact-shared field's own deferred value.
+    let (compact_field, code) = run_yq_stdin(".", "l:\n  - k: |\n      hello\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(compact_field, "l:\n  - k: |\n      hello\n");
+
+    Ok(())
+}
+
 /// #1486: `-I=1`'s YAML output clamps to the same 2-column step as `-I=2`
 /// in real yq (verified live against v4.53.3, byte-identical at every
 /// level -- mappings, sequences, and compact/anchor-deferred sequence

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2727,6 +2727,50 @@ fn test_compact_seq_item_deferred_block_scalar_indent_1485() -> Result<()> {
     Ok(())
 }
 
+/// #1485 (code review regression): a block sequence directly nested inside
+/// *another* compact sequence element (`- - b: ...`) is a *stacked* compact
+/// chain -- the inner sequence's own compact branch must keep forwarding
+/// the outer sequence's true pre-compact `recursion_base` all the way down,
+/// not reset it to its own (already compact-adjusted) `indent`. An earlier
+/// version of this fix did the latter, which happened to still match real
+/// yq at `-I=2`/`-I=4` (where it coincided with the correct value) but
+/// diverged at `-I=5`/`-I=6` -- caught only by probing a range of widths,
+/// not the issue's own single `-I=4` example. Verified live against yq
+/// v4.53.3.
+///
+/// `-I=3` is deliberately not covered here: real yq itself renders this
+/// exact shape inconsistently across indent widths for a stacked compact
+/// chain (non-monotonic in `-I`, confirmed identical in behaviour on
+/// pre-#1485 `main`), so `-I=3` here reproduces a narrow, pre-existing
+/// upstream quirk this fix does not newly introduce -- see
+/// `docs/compliance/yq/limitations.md`.
+#[test]
+fn test_compact_seq_item_stacked_nested_indent_does_not_reset_1485() -> Result<()> {
+    let yaml = "- - b:\n      c:\n        d: 1\n";
+
+    let (streamed_2, code) = run_yq_stdin(".", yaml, &["-I=2"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed_2, "- - b:\n      c:\n        d: 1\n");
+
+    let (streamed_4, code) = run_yq_stdin(".", yaml, &["-I=4"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed_4, "- - b:\n        c:\n            d: 1\n");
+
+    let (streamed_5, code) = run_yq_stdin(".", yaml, &["-I=5"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed_5, "- - b:\n     c:\n          d: 1\n");
+
+    let (streamed_6, code) = run_yq_stdin(".", yaml, &["-I=6"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed_6, "- - b:\n      c:\n            d: 1\n");
+
+    let (dom, code) = run_yq_stdin(".[0][0].b.c.d = 1", yaml, &["-I=4"])?;
+    assert_eq!(code, 0);
+    assert_eq!(dom, "- - b:\n        c:\n            d: 1\n");
+
+    Ok(())
+}
+
 /// #1486: `-I=1`'s YAML output clamps to the same 2-column step as `-I=2`
 /// in real yq (verified live against v4.53.3, byte-identical at every
 /// level -- mappings, sequences, and compact/anchor-deferred sequence


### PR DESCRIPTION
Fixes #1485

## Root cause

Real yq's compact block-sequence-item rendering (`- ` sharing its line with the value's first field/element, #785) only applies its 2-column offset to *that first line*. Content nested *inside* that first field's own value continues from the item's own indent plus an ordinary `indent_spaces` step per level — not from the compact-adjusted column. `light.rs`'s `stream_yaml_value`/`emit_yaml_value_at_depth` (`yq_runner.rs`) threaded the compact-adjusted string down as the base for every deeper recursive step, so each level below the first compounded a discrepancy against real yq.

## Fix

Both writers now thread a second indent value alongside the existing one: `recursion_base` is the pre-compact indent a nested container's own further descent should step from, staying equal to the visible `indent` everywhere except immediately after a compact positioning. `light.rs`'s `stream_yaml_value`, `write_deferred_value`, and `stream_yaml_sequence` (the `--slurp` counterpart), plus `yq_runner.rs`'s `emit_yaml_value_at_depth` (the DOM/write path), all thread it identically.

## A genuinely different formula at real yq's own default indent

Live-probing across `-I=2` through `-I=6` (not just the issue's own `-I=4` example) found real yq's *default* indent (`-I=2`) hits a different formula, not a smaller instance of the same one: `indent_spaces` (2) equals `COMPACT_DASH_WIDTH` (also 2) exactly at that width, so a single ordinary step from the pre-compact indent would land the first nested field at the *same* column the compact field's own key already visually occupies — invalid YAML nesting. Real yq instead steps *past* that column by `indent_spaces` in this one case; `-I=3` and up never need the correction, since a single ordinary step already clears it there. New `compact_child_indent` (`light.rs`) and its DOM twin (`yq_runner.rs`) implement this "clears the compact visual column, else fall back" rule.

## A second bug found and fixed along the way

The issue itself flagged `write_deferred_value` as worth checking, unverified. Confirmed live: a sequence item's own deferred block scalar (`- |`) is compact-positioned like every other sequence item, where the analogous mapping-field position (`k: |`) is an ordinary step — `write_deferred_value` computed an ordinary step unconditionally for both, since it's shared between the two callers. Now takes a pre-computed `child_indent` from each caller instead of deriving it internally, so each can supply the right kind of step.

## Verification

- Live-verified every case against yq v4.53.3 before implementing: 3-level nesting at `-I=2` through `-I=6`, a non-first sibling field's own nested value, and the block-scalar deferred-value asymmetry, on both the streaming (identity) and DOM (forced write) paths.
- 100% patch coverage on both files.
- Full test suite green under both `cargo test --verbose` (default features, matches CI) and the full feature set, no_std build, clippy clean (both legs), before and after rebasing onto `main`.
- Two rounds of unrelated, pre-existing transient test failures during verification (jq `input`/stdin-related tests, unrelated to YAML output formatting) — both confirmed transient via isolated rerun and clean full-suite reruns.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde`
- [x] `cargo test --verbose` (default features, matches CI)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --no-default-features`
- [x] `omni-dev coverage diff` — 100% patch coverage