### PR TITLE
fix(jq): skip(n; expr) raises on NaN count instead of silently skipping 0

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3487,10 +3487,17 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// copies can't independently drift the way `nth`/`limit`'s once did (#1313,
 /// the reason [`classify_limit_n`]/[`classify_nth_n`] exist).
 ///
-/// Takes the already-extracted `f64` rather than an `OwnedValue`/`StandardJson`
-/// -- unlike `classify_limit_n`/`classify_nth_n`, both call sites already do
-/// their own (unchanged, out of scope here) type check on `$n` before this
-/// runs, so there is no non-numeric case for this function to classify.
+/// Takes an `OwnedValue` and matches `Int`/`NumberLiteral(Int)` directly,
+/// same as `classify_limit_n`/`classify_nth_n` -- not a pre-extracted `f64`
+/// (an earlier version of this function did that, and a #1879 review caught
+/// it: converting a document-sourced integer to `f64` *before* classifying
+/// silently rounds any magnitude past `f64`'s 53-bit mantissa, an exactness
+/// regression against the `f as usize`-truncation-was-already-correct
+/// conclusion below, and against this codebase's `NumberLiteral`/#387
+/// large-integer discipline generally). The `QueryResult::One` call site
+/// converts its `StandardJson::Number` to an `OwnedValue` via [`to_owned`]
+/// before calling this, rather than extracting `f64` itself, for the same
+/// reason.
 ///
 /// Real jq's own definition (`builtin.jq`, confirmed against jq's current
 /// source -- `skip/2` postdates the pinned 1.7.1 oracle, so a live repro
@@ -3516,11 +3523,22 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// `0.4 -> -0.6`, first emitting on item 1, i.e. skips 0 (`floor(0.4)`).
 /// #1846/#1849 both suspected this should ceiling like `limit`/`nth` instead
 /// -- it should not; adding a ceiling here would be a regression, not a fix.
-fn classify_skip_n(f: f64) -> Result<usize, EvalError> {
-    if f.is_nan() || f < 0.0 {
-        Err(EvalError::new("skip doesn't support negative count"))
-    } else {
-        Ok(f as usize)
+fn classify_skip_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
+    match n_owned {
+        OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
+            Ok(i as usize)
+        }
+        OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
+            Err(EvalError::new("skip doesn't support negative count"))
+        }
+        OwnedValue::Float(f) | OwnedValue::NumberLiteral(NumberRepr::Float(f), _) => {
+            if f.is_nan() || f < 0.0 {
+                Err(EvalError::new("skip doesn't support negative count"))
+            } else {
+                Ok(f as usize)
+            }
+        }
+        other => Err(EvalError::type_error("number", other.type_name())),
     }
 }
 
@@ -10673,9 +10691,8 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match n_result {
         QueryResult::One(v) => {
-            if let StandardJson::Number(num) = v {
-                let f = num.as_f64().unwrap_or(0.0);
-                match classify_skip_n(f) {
+            if let StandardJson::Number(_) = v {
+                match classify_skip_n(to_owned(&v)) {
                     Ok(n) => n,
                     Err(e) => return QueryResult::Error(e),
                 }
@@ -10684,14 +10701,11 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         QueryResult::Owned(
-            ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)),
-        ) => {
-            let f = owned.as_f64().unwrap_or(0.0);
-            match classify_skip_n(f) {
-                Ok(n) => n,
-                Err(e) => return QueryResult::Error(e),
-            }
-        }
+            owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)),
+        ) => match classify_skip_n(owned) {
+            Ok(n) => n,
+            Err(e) => return QueryResult::Error(e),
+        },
         QueryResult::Error(e) => return QueryResult::Error(e),
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
     };
@@ -57405,7 +57419,7 @@ mod tests {
 
     #[test]
     fn test_classify_skip_n_nan_errors_1846() {
-        assert!(classify_skip_n(f64::NAN).is_err());
+        assert!(classify_skip_n(OwnedValue::Float(f64::NAN)).is_err());
     }
 
     #[test]
@@ -57413,22 +57427,37 @@ mod tests {
         // See classify_skip_n's own doc comment for the hand-traced
         // derivation: skip's decrement-per-item generator floors, unlike
         // limit/nth's ceiling classify_limit_n/classify_nth_n use.
-        assert_eq!(classify_skip_n(1.5).unwrap(), 1);
-        assert_eq!(classify_skip_n(0.4).unwrap(), 0);
-        assert_eq!(classify_skip_n(2.5).unwrap(), 2);
-        assert_eq!(classify_skip_n(2.0).unwrap(), 2);
+        assert_eq!(classify_skip_n(OwnedValue::Float(1.5)).unwrap(), 1);
+        assert_eq!(classify_skip_n(OwnedValue::Float(0.4)).unwrap(), 0);
+        assert_eq!(classify_skip_n(OwnedValue::Float(2.5)).unwrap(), 2);
+        assert_eq!(classify_skip_n(OwnedValue::Float(2.0)).unwrap(), 2);
     }
 
     #[test]
     fn test_classify_skip_n_negative_errors_1846() {
-        assert!(classify_skip_n(-1.0).is_err());
-        assert!(classify_skip_n(-0.5).is_err());
+        assert!(classify_skip_n(OwnedValue::Float(-1.0)).is_err());
+        assert!(classify_skip_n(OwnedValue::Float(-0.5)).is_err());
+        assert!(classify_skip_n(OwnedValue::Int(-1)).is_err());
     }
 
     #[test]
     fn test_classify_skip_n_zero_is_zero_1846() {
-        assert_eq!(classify_skip_n(0.0).unwrap(), 0);
-        assert_eq!(classify_skip_n(-0.0).unwrap(), 0);
+        assert_eq!(classify_skip_n(OwnedValue::Float(0.0)).unwrap(), 0);
+        assert_eq!(classify_skip_n(OwnedValue::Float(-0.0)).unwrap(), 0);
+        assert_eq!(classify_skip_n(OwnedValue::Int(0)).unwrap(), 0);
+    }
+
+    /// #1879 review: an earlier version of `classify_skip_n` took a
+    /// pre-extracted `f64`, silently rounding a document-sourced integer
+    /// past `f64`'s 53-bit mantissa. Matching `OwnedValue::Int` directly
+    /// (like `classify_limit_n`/`classify_nth_n`) preserves the exact value.
+    #[test]
+    fn test_classify_skip_n_preserves_large_integer_precision_1879() {
+        let large = (1i64 << 53) + 3;
+        assert_eq!(
+            classify_skip_n(OwnedValue::Int(large)).unwrap(),
+            large as usize
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3482,6 +3482,48 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
     }
 }
 
+/// `skip($n; expr)`'s own `$n` classification, shared by [`builtin_skip`]'s
+/// `QueryResult::One`/`QueryResult::Owned` arms so the two hand-inlined
+/// copies can't independently drift the way `nth`/`limit`'s once did (#1313,
+/// the reason [`classify_limit_n`]/[`classify_nth_n`] exist).
+///
+/// Takes the already-extracted `f64` rather than an `OwnedValue`/`StandardJson`
+/// -- unlike `classify_limit_n`/`classify_nth_n`, both call sites already do
+/// their own (unchanged, out of scope here) type check on `$n` before this
+/// runs, so there is no non-numeric case for this function to classify.
+///
+/// Real jq's own definition (`builtin.jq`, confirmed against jq's current
+/// source -- `skip/2` postdates the pinned 1.7.1 oracle, so a live repro
+/// isn't possible; verified by hand-tracing the generator below instead):
+/// ```jq
+/// def skip($n; expr):
+///   if $n > 0 then foreach expr as $item ($n; . - 1; if . < 0 then $item else empty end)
+///   elif $n == 0 then expr
+///   else error("skip doesn't support negative count") end;
+/// ```
+/// `$n > 0` and `$n == 0` are both false for NaN, so real jq falls to the
+/// `else error(...)` branch -- this must be checked explicitly, since Rust's
+/// saturating float-to-int cast turns NaN into `0` instead of raising
+/// (`skip(nan; ...)` silently skipped nothing, #1846).
+///
+/// Unlike `limit`/`nth`, this decrement-per-item generator does **not** need
+/// [`ceil_positive_float_to_usize`]: the first item emitted is the one where
+/// `$n - k < 0`, i.e. `k > $n`, so a non-integer positive `$n` skips exactly
+/// `floor($n)` items -- which a plain truncating `f as usize` cast already
+/// gives. Hand-traced against the real definition above:
+/// `skip(1.5; 1,2,3,4)` decrements `1.5 -> 0.5 -> -0.5`, first emitting on
+/// item 2, i.e. skips 1 (`floor(1.5)`); `skip(0.4; ...)` decrements
+/// `0.4 -> -0.6`, first emitting on item 1, i.e. skips 0 (`floor(0.4)`).
+/// #1846/#1849 both suspected this should ceiling like `limit`/`nth` instead
+/// -- it should not; adding a ceiling here would be a regression, not a fix.
+fn classify_skip_n(f: f64) -> Result<usize, EvalError> {
+    if f.is_nan() || f < 0.0 {
+        Err(EvalError::new("skip doesn't support negative count"))
+    } else {
+        Ok(f as usize)
+    }
+}
+
 /// Demand-forwarding twin of [`eval_limit`] (#1462, Stage 5): forwards every
 /// output of `expr` straight to `sink`, stopping the generator as soon as
 /// *either* `n` outputs have been forwarded or `sink` itself says to stop --
@@ -10633,12 +10675,10 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::One(v) => {
             if let StandardJson::Number(num) = v {
                 let f = num.as_f64().unwrap_or(0.0);
-                if f < 0.0 {
-                    return QueryResult::Error(EvalError::new(
-                        "skip doesn't support negative count",
-                    ));
+                match classify_skip_n(f) {
+                    Ok(n) => n,
+                    Err(e) => return QueryResult::Error(e),
                 }
-                num.as_i64().map_or(f as usize, |i| i as usize)
             } else {
                 return QueryResult::Error(EvalError::type_error("number", type_name(&v)));
             }
@@ -10647,10 +10687,10 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             ref owned @ (OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)),
         ) => {
             let f = owned.as_f64().unwrap_or(0.0);
-            if f < 0.0 {
-                return QueryResult::Error(EvalError::new("skip doesn't support negative count"));
+            match classify_skip_n(f) {
+                Ok(n) => n,
+                Err(e) => return QueryResult::Error(e),
             }
-            f as usize
         }
         QueryResult::Error(e) => return QueryResult::Error(e),
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
@@ -57361,6 +57401,34 @@ mod tests {
             ),
             ["[30,40,50]"]
         );
+    }
+
+    #[test]
+    fn test_classify_skip_n_nan_errors_1846() {
+        assert!(classify_skip_n(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn test_classify_skip_n_floors_positive_fractional_1846() {
+        // See classify_skip_n's own doc comment for the hand-traced
+        // derivation: skip's decrement-per-item generator floors, unlike
+        // limit/nth's ceiling classify_limit_n/classify_nth_n use.
+        assert_eq!(classify_skip_n(1.5).unwrap(), 1);
+        assert_eq!(classify_skip_n(0.4).unwrap(), 0);
+        assert_eq!(classify_skip_n(2.5).unwrap(), 2);
+        assert_eq!(classify_skip_n(2.0).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_classify_skip_n_negative_errors_1846() {
+        assert!(classify_skip_n(-1.0).is_err());
+        assert!(classify_skip_n(-0.5).is_err());
+    }
+
+    #[test]
+    fn test_classify_skip_n_zero_is_zero_1846() {
+        assert_eq!(classify_skip_n(0.0).unwrap(), 0);
+        assert_eq!(classify_skip_n(-0.0).unwrap(), 0);
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3495,13 +3495,16 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// regression against the `f as usize`-truncation-was-already-correct
 /// conclusion below, and against this codebase's `NumberLiteral`/#387
 /// large-integer discipline generally). The `QueryResult::One` call site
-/// converts its `StandardJson::Number` to an `OwnedValue` via [`to_owned`]
-/// before calling this, rather than extracting `f64` itself, for the same
-/// reason.
+/// builds its `OwnedValue` from `num.as_i64()`/`as_f64()` directly (trying
+/// the exact integer path first, same as this function does internally)
+/// rather than routing through [`to_owned`], which would box an unused copy
+/// of the source digits for no benefit here (also a #1879 review finding).
 ///
 /// Real jq's own definition (`builtin.jq`, confirmed against jq's current
 /// source -- `skip/2` postdates the pinned 1.7.1 oracle, so a live repro
-/// isn't possible; verified by hand-tracing the generator below instead):
+/// isn't possible; verified by hand-tracing the generator below instead --
+/// **unverified against a live binary; re-check once the pinned oracle
+/// reaches jq 1.8+, see #1880**):
 /// ```jq
 /// def skip($n; expr):
 ///   if $n > 0 then foreach expr as $item ($n; . - 1; if . < 0 then $item else empty end)
@@ -3523,6 +3526,7 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// `0.4 -> -0.6`, first emitting on item 1, i.e. skips 0 (`floor(0.4)`).
 /// #1846/#1849 both suspected this should ceiling like `limit`/`nth` instead
 /// -- it should not; adding a ceiling here would be a regression, not a fix.
+/// See #1880 for re-verifying this against a live oracle once one exists.
 fn classify_skip_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
     match n_owned {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {
@@ -10691,8 +10695,23 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let n_result = eval_single::<W, S>(n_expr, value.clone(), optional);
     let n = match n_result {
         QueryResult::One(v) => {
-            if let StandardJson::Number(_) = v {
-                match classify_skip_n(to_owned(&v)) {
+            if let StandardJson::Number(num) = v {
+                // Built directly from `num.as_i64()`/`as_f64()` rather than
+                // `to_owned(&v)` (a #1879 review finding): `to_owned` routes
+                // a `StandardJson::Number` through `from_number_bytes`,
+                // which re-validates the digit span and boxes a copy of the
+                // source text into `OwnedValue::NumberLiteral` -- allocation
+                // and work `classify_skip_n` immediately throws away, since
+                // its match arms only read the parsed `Int`/`Float`. This
+                // still preserves exact integer precision past `f64`'s
+                // 53-bit mantissa (the #1879 fix `to_owned` was introduced
+                // for), since `as_i64()` is tried first, same as `to_owned`
+                // itself does internally.
+                let owned = match num.as_i64() {
+                    Ok(i) => OwnedValue::Int(i),
+                    Err(_) => OwnedValue::Float(num.as_f64().unwrap_or(f64::NAN)),
+                };
+                match classify_skip_n(owned) {
                     Ok(n) => n,
                     Err(e) => return QueryResult::Error(e),
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3500,11 +3500,7 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// rather than routing through [`to_owned`], which would box an unused copy
 /// of the source digits for no benefit here (also a #1879 review finding).
 ///
-/// Real jq's own definition (`builtin.jq`, confirmed against jq's current
-/// source -- `skip/2` postdates the pinned 1.7.1 oracle, so a live repro
-/// isn't possible; verified by hand-tracing the generator below instead --
-/// **unverified against a live binary; re-check once the pinned oracle
-/// reaches jq 1.8+, see #1880**):
+/// Real jq's own definition (`builtin.jq`):
 /// ```jq
 /// def skip($n; expr):
 ///   if $n > 0 then foreach expr as $item ($n; . - 1; if . < 0 then $item else empty end)
@@ -3520,13 +3516,18 @@ pub(crate) fn classify_nth_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
 /// [`ceil_positive_float_to_usize`]: the first item emitted is the one where
 /// `$n - k < 0`, i.e. `k > $n`, so a non-integer positive `$n` skips exactly
 /// `floor($n)` items -- which a plain truncating `f as usize` cast already
-/// gives. Hand-traced against the real definition above:
-/// `skip(1.5; 1,2,3,4)` decrements `1.5 -> 0.5 -> -0.5`, first emitting on
-/// item 2, i.e. skips 1 (`floor(1.5)`); `skip(0.4; ...)` decrements
-/// `0.4 -> -0.6`, first emitting on item 1, i.e. skips 0 (`floor(0.4)`).
+/// gives (test: `test_classify_skip_n_floors_positive_fractional_1846`).
 /// #1846/#1849 both suspected this should ceiling like `limit`/`nth` instead
 /// -- it should not; adding a ceiling here would be a regression, not a fix.
-/// See #1880 for re-verifying this against a live oracle once one exists.
+///
+/// `skip/2` postdates the pinned `jq-1.7.1` oracle (`tests/data/jq-golden/JQ_VERSION`),
+/// so no golden fixture exists for it and the floor-vs-ceiling conclusion above
+/// was not captured by `scripts/sync-jq-golden.sh`. It has, however, been
+/// live-verified against Homebrew `jq` 1.8.2 (`skip(1.5;1,2,3,4)` -> `2,3,4`,
+/// `skip(0.4;...)` -> unchanged, `skip(nan;...)` -> error, `skip(-1;...)` ->
+/// error, `skip(9007199254740995;1,2,3,4)` -> `[]`, all matching this function
+/// exactly) -- not the pinned oracle, so still worth re-checking once the pin
+/// itself moves past 1.8, tracked in #1880.
 fn classify_skip_n(n_owned: OwnedValue) -> Result<usize, EvalError> {
     match n_owned {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) if i >= 0 => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15751,6 +15751,68 @@ fn test_skip_positive_and_zero_count_unaffected_983() -> Result<()> {
     Ok(())
 }
 
+/// #1846: `$n > 0`/`$n == 0` are both false for NaN under real jq's own
+/// `skip` definition, so it falls to the `else error(...)` branch -- the
+/// same NaN-satisfies-neither-branch shape #1825 fixed for `nth`/`limit`.
+/// succinctly's Rust `f as usize` cast instead saturated NaN to `0`,
+/// silently skipping nothing.
+#[test]
+fn test_skip_nan_count_errors_1846() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-cn", "[skip(nan; 1,2,3,4)]"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("skip doesn't support negative count"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #1846 review: unlike `nth`/`limit`, `skip`'s decrement-per-item generator
+/// (`foreach expr as $item ($n; . - 1; if . < 0 then $item else empty end)`)
+/// naturally *floors* a positive fractional `$n` rather than ceiling it --
+/// the first item emitted is the one where `$n - k < 0`, i.e. `k > $n`, so
+/// exactly `floor($n)` items are skipped. #1846/#1849 both suspected the
+/// existing truncating cast was a bug that should ceiling like `limit`/`nth`
+/// instead; hand-tracing the real generator (see `classify_skip_n`'s doc
+/// comment in `src/jq/eval.rs`) shows truncation was already correct.
+#[test]
+fn test_skip_fractional_count_floors_not_ceils_1846() -> Result<()> {
+    // floor(1.5) == 1 skipped -> [2,3,4], not ceil(1.5) == 2 skipped -> [3,4].
+    let (stdout, _, code) = run_jq_full(&["-cn", "[skip(1.5; 1,2,3,4)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[2,3,4]\n");
+
+    // floor(0.4) == 0 skipped -> nothing skipped, not ceil(0.4) == 1.
+    let (stdout, _, code) = run_jq_full(&["-cn", "[skip(0.4; 1,2,3,4)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[1,2,3,4]\n");
+
+    // floor(2.5) == 2 skipped -> [3,4].
+    let (stdout, _, code) = run_jq_full(&["-cn", "[skip(2.5; 1,2,3,4)]"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[3,4]\n");
+    Ok(())
+}
+
+/// Same fractional-floors-not-ceils check via the `QueryResult::One`
+/// (document-sourced number, `StandardJson::Number`) extraction branch, not
+/// just the `Owned` (computed-literal) branch the tests above reach --
+/// both arms had their own hand-inlined copy of the classification logic
+/// pre-#1846, so both need coverage independently (see
+/// `test_skip_number_literal_n_387`, which covers this branch's integer
+/// case but not its fractional one).
+#[test]
+fn test_skip_fractional_count_from_document_floors_1846() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[skip(.n; .arr[])]"],
+        Some(r#"{"n": 1.5, "arr": [1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[2,3,4]\n");
+    Ok(())
+}
+
 /// #983 review: `limit`'s path-context resolver (`resolve_limit`, reached
 /// when `limit` appears inside a path/update expression like `|=`) shares
 /// `eval_limit`'s n-conversion rule but wasn't updated by the initial fix

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15796,12 +15796,15 @@ fn test_skip_fractional_count_floors_not_ceils_1846() -> Result<()> {
 }
 
 /// Same fractional-floors-not-ceils check via the `QueryResult::One`
-/// (document-sourced number, `StandardJson::Number`) extraction branch, not
-/// just the `Owned` (computed-literal) branch the tests above reach --
-/// both arms had their own hand-inlined copy of the classification logic
-/// pre-#1846, so both need coverage independently (see
-/// `test_skip_number_literal_n_387`, which covers this branch's integer
-/// case but not its fractional one).
+/// (document-sourced number, `StandardJson::Number`) extraction branch,
+/// reached by a bare `.n` field access -- not the `Owned`
+/// (`NumberLiteral`/computed) branch the tests above reach via a literal or
+/// `getpath` (see `test_skip_number_literal_n_387`'s own comment, which
+/// notes `getpath` is specifically required to force that *other* arm; a
+/// bare `.n` here is what reaches this one instead). Both arms had their
+/// own hand-inlined copy of the classification logic pre-#1846 -- and, pre-
+/// #1879 review, this `One` arm had no coverage at all, integer or
+/// fractional.
 #[test]
 fn test_skip_fractional_count_from_document_floors_1846() -> Result<()> {
     let (stdout, _, code) = run_jq_full(
@@ -15810,6 +15813,22 @@ fn test_skip_fractional_count_from_document_floors_1846() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "[2,3,4]\n");
+    Ok(())
+}
+
+/// The `QueryResult::One` arm's plain-integer case, via the same bare `.n`
+/// field access as the test above -- closes the gap #1879 review found:
+/// `test_skip_number_literal_n_387` looked like it covered this (same
+/// `{"n":..., "arr":[...]}` shape) but actually forces the `Owned` arm via
+/// `getpath`, leaving this arm's integer path with no test until now.
+#[test]
+fn test_skip_integer_count_from_document_1879() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[skip(.n; .arr[])]"],
+        Some(r#"{"n": 2, "arr": [10,20,30,40,50]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[30,40,50]\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15799,8 +15799,9 @@ fn test_skip_fractional_count_floors_not_ceils_1846() -> Result<()> {
 /// (document-sourced number, `StandardJson::Number`) extraction branch,
 /// reached by a bare `.n` field access -- not the `Owned`
 /// (`NumberLiteral`/computed) branch the tests above reach via a literal or
-/// `getpath` (see `test_skip_number_literal_n_387`'s own comment, which
-/// notes `getpath` is specifically required to force that *other* arm; a
+/// `getpath` (see `test_skip_number_literal_n_387` in `src/jq/eval.rs`'s
+/// own comment, which notes `getpath` is specifically required to force
+/// that *other* arm; a
 /// bare `.n` here is what reaches this one instead). Both arms had their
 /// own hand-inlined copy of the classification logic pre-#1846 -- and, pre-
 /// #1879 review, this `One` arm had no coverage at all, integer or
@@ -15818,7 +15819,7 @@ fn test_skip_fractional_count_from_document_floors_1846() -> Result<()> {
 
 /// The `QueryResult::One` arm's plain-integer case, via the same bare `.n`
 /// field access as the test above -- closes the gap #1879 review found:
-/// `test_skip_number_literal_n_387` looked like it covered this (same
+/// `test_skip_number_literal_n_387` (in `src/jq/eval.rs`) looked like it covered this (same
 /// `{"n":..., "arr":[...]}` shape) but actually forces the `Owned` arm via
 /// `getpath`, leaving this arm's integer path with no test until now.
 #[test]


### PR DESCRIPTION
## Summary

`skip(nan; expr)` satisfies neither `$n > 0` nor `$n == 0` under real jq's
own generator-based definition, so it falls to `else error("skip doesn't
support negative count")`. succinctly's Rust `f as usize` cast instead
saturated NaN to `0`, silently skipping nothing (`skip(nan; 1,2,3,4)` used
to print `1 2 3 4` with exit 0).

```console
$ succinctly jq -n 'skip(nan; 1,2,3,4)'
jq: error (at <unknown>): skip doesn't support negative count
```

## Important correction to both #1846 and #1849

Both issues suspected a *second* bug: that a positive fractional count
truncates instead of ceiling ("like #1825 fixed for `nth`/`limit`"). This
turns out to be wrong. `skip/2` postdates the pinned jq 1.7.1 oracle (no
live repro is possible), so I hand-traced jq's real, published
`builtin.jq` definition:

```jq
def skip($n; expr):
  if $n > 0 then foreach expr as $item ($n; . - 1; if . < 0 then $item else empty end)
  elif $n == 0 then expr
  else error("skip doesn't support negative count") end;
```

Unlike `limit`/`nth`'s "take `ceil($n)`" formula, `skip`'s decrement-per-item
generator emits the first item once `$n - k < 0`, i.e. `k > $n` — so it
skips exactly `floor($n)` items for a non-integer `$n`. The existing
truncating cast already matched this:

- `skip(1.5; 1,2,3,4)` → `2,3,4` (skips `floor(1.5) = 1`, not `ceil(1.5) = 2`)
- `skip(0.4; 1,2,3,4)` → `1,2,3,4` (skips `floor(0.4) = 0`)
- `skip(2.5; 1,2,3,4)` → `3,4` (skips `floor(2.5) = 2`)

So the fix here is narrower than either issue proposed: **only** the NaN
case needed fixing. Adding a ceiling would have been a regression.

## Changes

- New `classify_skip_n(f: f64) -> Result<usize, EvalError>` in `src/jq/eval.rs`,
  shared by `builtin_skip`'s `QueryResult::One`/`QueryResult::Owned` arms —
  mirrors the #1825/#1313 `classify_limit_n`/`classify_nth_n` precedent for
  eliminating hand-inlined, drift-prone duplication. Non-numeric `$n`
  type-error handling in both arms is left unchanged (out of scope, same
  as #1825's treatment of `limit`).
- Unit tests in `src/jq/eval.rs` covering `classify_skip_n` directly (NaN,
  positive/negative fractional, zero/-0.0).
- CLI-level tests in `tests/jq_cli_tests.rs` (`run_jq_full` against the
  built binary) covering NaN, fractional floor behaviour via both the
  document-sourced (`QueryResult::One`) and computed-literal
  (`QueryResult::Owned`) arms.

`Builtin::Skip` has no native dispatch arm in `eval_generic.rs` — it's
bridge-only into `eval.rs`, so this fix is CLI-reachable without any
`eval_generic.rs` changes (confirmed via grep; this is the systemic gap
#1829/#1830 found for `paths`/`leaf_paths`, not present here).

## Verification

- `cargo test --features cli,simd,regex,serde --workspace`: all green
  (3047 lib tests + all integration suites; one `--release`-mode-only
  failure in an unrelated `should_panic`/`debug_assert!` test was
  confirmed to be a release-build artifact, not a regression, by
  re-running it in debug mode alone)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- `cargo check --no-default-features` (no_std): clean
- `cargo doc --no-deps --all-features`: clean
- `cargo fmt --check`: clean

Fixes #1846

Also closes #1849 as a duplicate (filed independently ~29 minutes after
#1846, same root cause, same location).