### PR TITLE
test(jq): stop tests/jq_cli_tests.rs orphaning cargo-run grandchildren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests --test jq_cli_tests
 
       # `tests/orchestrate_cli_tests.rs` is `#![cfg(feature = "bench-runner")]`
       # and was never previously built or run by any `cargo test` step here
@@ -255,7 +255,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests --test jq_cli_tests
 
       - name: Run bench-runner-gated tests
         if: needs.gate.outputs.code == 'true'
@@ -357,7 +357,7 @@ jobs:
 
       - name: Run cli-gated tests
         if: needs.gate.outputs.code == 'true'
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests --test jq_cli_tests
 
       - name: Run bench-runner-gated tests
         if: needs.gate.outputs.code == 'true'
@@ -423,7 +423,7 @@ jobs:
         run: cargo build --features cli --bin succinctly
 
       - name: Run cli-gated tests
-        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests
+        run: cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests --test jq_cli_tests
 
       - name: Run bench-runner-gated tests
         run: cargo test --features cli,bench-runner --test orchestrate_cli_tests

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -150,12 +150,14 @@ pub fn succinctly_bin() -> &'static str {
 ///
 /// Shared by every direct-spawn CLI test helper (#1847 review) --
 /// `cli_golden_tests.rs`, `cli_characterization_tests.rs`,
-/// `deep_nesting_valid_tests.rs` and `json_validate_tests.rs` each
-/// independently dropped this retry (along with the lock-contention case
-/// that genuinely no longer applies) when first converting away from
-/// `cargo run`; sharing one copy here instead of four independently
-/// drifting ones is the same fix `classify_cargo_run_exit`'s own doc
-/// comment already describes for the exit-code-classification half of
+/// `deep_nesting_valid_tests.rs`, `json_validate_tests.rs`, and (via #1884's
+/// follow-up fix, after that file's own bespoke copy was found to have
+/// silently dropped this exact retry) `jq_cli_tests.rs` each independently
+/// dropped this retry (along with the lock-contention case that genuinely
+/// no longer applies) when first converting away from `cargo run`; sharing
+/// one copy here instead of five independently drifting ones is the same
+/// fix `classify_cargo_run_exit`'s own doc comment already describes for
+/// the exit-code-classification half of
 /// this same problem.
 ///
 /// `build` is called fresh on each retry attempt, since a spawned

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -138,12 +138,15 @@ pub fn succinctly_bin() -> &'static str {
 
 /// Spawns `build()` (already configured with args), optionally writing
 /// `stdin_input` to it, retrying the whole spawn+wait up to
-/// [`MAX_CARGO_RETRIES`] times if the child was killed by a signal rather
-/// than exiting with a real code -- an OOM kill, another session's
-/// `pkill`, or a stall-guard's process-group kill (`cargo-guard.sh`, by
-/// design, on a detected stall, #935) catching this specific child, all
-/// just as plausible under this repo's routine heavy concurrent
-/// multi-session load as the cargo-lock-contention case
+/// [`MAX_CARGO_RETRIES`] times on either of two transient failures: `spawn()`
+/// itself returning `ENOENT` (a concurrent, differently-featured `cargo
+/// test` invocation sharing this `target/` directory can be transiently
+/// mid-relink of the shared `succinctly_bin()` path, #550), or the spawned
+/// child being killed by a signal rather than exiting with a real code -- an
+/// OOM kill, another session's `pkill`, or a stall-guard's process-group
+/// kill (`cargo-guard.sh`, by design, on a detected stall, #935) catching
+/// this specific child, all just as plausible under this repo's routine
+/// heavy concurrent multi-session load as the cargo-lock-contention case
 /// `classify_cargo_run_exit` retries for. Unlike that function, there is
 /// no exit-101 case to also retry on here: a direct `succinctly_bin()`
 /// spawn has no cargo invocation of its own to contend on a lock.
@@ -152,13 +155,17 @@ pub fn succinctly_bin() -> &'static str {
 /// `cli_golden_tests.rs`, `cli_characterization_tests.rs`,
 /// `deep_nesting_valid_tests.rs`, `json_validate_tests.rs`, and (via #1884's
 /// follow-up fix, after that file's own bespoke copy was found to have
-/// silently dropped this exact retry) `jq_cli_tests.rs` each independently
-/// dropped this retry (along with the lock-contention case that genuinely
-/// no longer applies) when first converting away from `cargo run`; sharing
-/// one copy here instead of five independently drifting ones is the same
-/// fix `classify_cargo_run_exit`'s own doc comment already describes for
-/// the exit-code-classification half of
-/// this same problem.
+/// silently dropped signal-death retry) `jq_cli_tests.rs` each independently
+/// dropped some or all of this retry surface (along with the lock-contention
+/// case that genuinely no longer applies) when first converting away from
+/// `cargo run`; sharing one copy here instead of five independently
+/// drifting ones is the same fix `classify_cargo_run_exit`'s own doc comment
+/// already describes for the exit-code-classification half of this same
+/// problem. (#1884 code review, round 3: this function's own `spawn()` call
+/// used a bare `?` with no `ENOENT` handling until this paragraph's fix --
+/// the one piece of `spawn_jq_full`'s old protection that got lost when
+/// `jq_cli_tests.rs` first adopted this shared helper, since this function
+/// didn't have it either at the time.)
 ///
 /// `build` is called fresh on each retry attempt, since a spawned
 /// `std::process::Command` cannot be reused. `stdout`/`stderr` are always
@@ -203,7 +210,16 @@ pub fn spawn_with_signal_retry(
             } else {
                 std::process::Stdio::null()
             });
-        let mut child = command.spawn()?;
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound && attempt + 1 < MAX_CARGO_RETRIES =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
         if let Some(input) = stdin_input {
             use std::io::Write;
             if let Some(mut sin) = child.stdin.take() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -141,24 +141,35 @@ fn run_jq_stdin_streams(
 /// cargo writes its own `Finished`/`Running` progress lines to stderr, which
 /// would be indistinguishable from the diagnostics under test, and that also
 /// makes the lock-contention retry unnecessary. Delegates to the shared
-/// `spawn_with_signal_retry` (#1884 code review) rather than a file-local
-/// reimplementation, so this file's ~190 `run_jq_stdin`/`run_jq_null`-routed
-/// call sites get the same signal-death retry the four files #1847 migrated
-/// already share -- a file-local copy here would have been a fifth,
-/// independently-drifting one for the exact problem that helper's own doc
-/// comment says sharing one copy was meant to stop.
+/// `spawn_jq` (in turn `spawn_with_signal_retry`, #1884 code review) rather
+/// than a file-local reimplementation, so this file's ~190
+/// `run_jq_stdin`/`run_jq_null`-routed call sites get the same
+/// spawn/signal-death retry the four files #1847 migrated already share --
+/// a file-local copy here would have been a fifth, independently-drifting
+/// one for the exact problem that helper's own doc comment says sharing one
+/// copy was meant to stop.
 fn run_jq_full(args: &[&str], input: Option<&str>) -> Result<(String, String, i32)> {
-    let (output, exit_code) = spawn_with_signal_retry(
+    let (output, exit_code) = spawn_jq(args, input.map(str::as_bytes))?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    Ok((stdout, stderr, exit_code))
+}
+
+/// Spawns `succinctly jq <args>`, writing `stdin_input` when `Some` -- the
+/// one place every direct-binary jq invocation in this file builds its
+/// `Command`, so a future change to how the subcommand is invoked (a new
+/// common flag, a different `succinctly_bin()` argv shape) is a single
+/// edit rather than the six near-identical copies code review found here
+/// before this consolidation (#1884).
+fn spawn_jq(args: &[&str], stdin_input: Option<&[u8]>) -> Result<(std::process::Output, i32)> {
+    spawn_with_signal_retry(
         || {
             let mut command = Command::new(succinctly_bin());
             command.arg("jq").args(args);
             command
         },
-        input.map(str::as_bytes),
-    )?;
-    let stdout = String::from_utf8(output.stdout)?;
-    let stderr = String::from_utf8(output.stderr)?;
-    Ok((stdout, stderr, exit_code))
+        stdin_input,
+    )
 }
 
 /// Helper to run jq with null input (-n)
@@ -4107,14 +4118,7 @@ fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
 fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, i32)> {
     let mut args: Vec<&str> = extra_args.to_vec();
     args.push(filter);
-    let (output, exit_code) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command.arg("jq").args(&args);
-            command
-        },
-        Some(input),
-    )?;
+    let (output, exit_code) = spawn_jq(&args, Some(input))?;
     Ok((output.stdout, exit_code))
 }
 
@@ -4255,9 +4259,9 @@ fn test_seq_malformed_record_with_rs_byte_does_not_warn_1525() -> Result<()> {
 /// RS-containing one still warns on real jq, with one of the other
 /// message templates #1723 tracks -- not this one; not exercised here.)
 ///
-/// Spawns via `spawn_with_signal_retry` (not a bare `Command::new(...).
-/// output()`) for its retry protection against a transient `ENOENT` or a
-/// signal-killed child under concurrent load (#550, #1884).
+/// Spawns via `spawn_jq` (not a bare `Command::new(...).output()`) for its
+/// retry protection against a transient `ENOENT` or a signal-killed child
+/// under concurrent load (#550, #1884).
 #[test]
 fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<()> {
     let mut valid_file = NamedTempFile::new()?;
@@ -4266,16 +4270,7 @@ fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<
 
     let valid_path = valid_file.path().to_str().unwrap();
     let empty_path = empty_file.path().to_str().unwrap();
-    let (output, _) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command
-                .arg("jq")
-                .args(["--seq", "-c", ".", valid_path, empty_path]);
-            command
-        },
-        None,
-    )?;
+    let (output, _) = spawn_jq(&["--seq", "-c", ".", valid_path, empty_path], None)?;
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8(output.stderr)?, "");
@@ -4286,8 +4281,8 @@ fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<
 
 /// #1525: two RS-less files report a line/column computed from their
 /// *concatenation*, not either file's own content alone -- oracle-verified
-/// against the pinned jq 1.7.1 binary. Spawns via `spawn_with_signal_retry`
-/// for its retry protection, same reason as the test above.
+/// against the pinned jq 1.7.1 binary. Spawns via `spawn_jq` for its retry
+/// protection, same reason as the test above.
 #[test]
 fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
     let mut file_a = NamedTempFile::new()?;
@@ -4297,14 +4292,7 @@ fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
 
     let path_a = file_a.path().to_str().unwrap();
     let path_b = file_b.path().to_str().unwrap();
-    let (output, _) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command.arg("jq").args(["--seq", "-c", ".", path_a, path_b]);
-            command
-        },
-        None,
-    )?;
+    let (output, _) = spawn_jq(&["--seq", "-c", ".", path_a, path_b], None)?;
 
     assert!(output.status.success());
     assert_eq!(
@@ -4325,14 +4313,7 @@ fn test_seq_no_rs_warning_column_counts_raw_bytes_not_substituted_1525() -> Resu
     input.push(0xFF); // invalid UTF-8 lead byte -> substituted to 3-byte U+FFFD
     input.extend_from_slice(b"cd");
 
-    let (output, _) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command.arg("jq").args(["--seq", "-c", "."]);
-            command
-        },
-        Some(&input),
-    )?;
+    let (output, _) = spawn_jq(&["--seq", "-c", "."], Some(&input))?;
 
     assert!(output.status.success());
     assert_eq!(
@@ -4388,14 +4369,7 @@ fn test_seq_no_rs_warning_strips_leading_bom_1525() -> Result<()> {
     input.extend_from_slice(b"\xEF\xBB\xBF");
     input.extend_from_slice(b"1 2");
 
-    let (output, _) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command.arg("jq").args(["--seq", "-c", "."]);
-            command
-        },
-        Some(&input),
-    )?;
+    let (output, _) = spawn_jq(&["--seq", "-c", "."], Some(&input))?;
 
     assert!(output.status.success());
     assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2,6 +2,7 @@
 //!
 //! These tests verify jq-compatible behavior and options.
 //! Run with: cargo test --features cli --test jq_cli_tests
+#![cfg(feature = "cli")]
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -12,16 +13,16 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{
-    cargo_run_features, classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES,
-};
+use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
 
 /// Maximum retries for spawning the pre-built binary directly.
 ///
-/// `run_jq_full` execs a fixed path (`CARGO_BIN_EXE_succinctly`) that other
-/// tests in this file concurrently rewrite via `cargo run` (see
-/// `run_jq_stdin_streams`). `spawn()` can transiently observe that path
-/// mid-replacement and fail with `ENOENT` (#550).
+/// Every test in this file execs a fixed path (`CARGO_BIN_EXE_succinctly`)
+/// rather than rebuilding it via `cargo run` (#1859) -- but `spawn()` can
+/// still transiently observe that path mid-write if a *concurrent* test
+/// binary elsewhere in the crate is still linking it (e.g. a differently
+/// featured `cargo test` invocation sharing the same `target/` directory)
+/// and fail with `ENOENT` (#550).
 const MAX_SPAWN_RETRIES: u32 = 3;
 
 /// #1516: a signal-killed child used to render as an inscrutable
@@ -132,43 +133,9 @@ fn run_jq_stdin_streams(
     input: &str,
     extra_args: &[&str],
 ) -> Result<(String, String, i32)> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let mut cmd = Command::new("cargo")
-            .args([
-                "run",
-                "--quiet",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-                "jq",
-            ])
-            .args(extra_args)
-            .arg(filter)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-
-        if let Some(mut stdin) = cmd.stdin.take() {
-            stdin.write_all(input.as_bytes())?;
-        }
-
-        let output = cmd.wait_with_output()?;
-        let lossy_stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &lossy_stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
-        return Ok((stdout, stderr, exit_code));
-    }
-    unreachable!()
+    let mut args: Vec<&str> = extra_args.to_vec();
+    args.push(filter);
+    run_jq_full(&args, Some(input))
 }
 
 /// Run jq with an arbitrary argument list, returning stdout, stderr and the
@@ -226,71 +193,13 @@ fn spawn_jq_full(args: &[&str]) -> std::io::Result<std::process::Child> {
     unreachable!()
 }
 
-/// Helper to run jq command with file input
-#[allow(dead_code)]
-fn run_jq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(String, i32)> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let output = Command::new("cargo")
-            .args([
-                "run",
-                "--quiet",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-                "jq",
-            ])
-            .args(extra_args)
-            .arg(filter)
-            .arg(file_path)
-            .output()?;
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        let stdout = String::from_utf8(output.stdout)?;
-        return Ok((stdout, exit_code));
-    }
-    unreachable!()
-}
-
 /// Helper to run jq with null input (-n)
 fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let output = Command::new("cargo")
-            .args([
-                "run",
-                "--quiet",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-                "jq",
-            ])
-            .arg("-n")
-            .args(extra_args)
-            .arg(filter)
-            .output()?;
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        let stdout = String::from_utf8(output.stdout)?;
-        return Ok((stdout, exit_code));
-    }
-    unreachable!()
+    let mut args: Vec<&str> = vec!["-n"];
+    args.extend_from_slice(extra_args);
+    args.push(filter);
+    let (stdout, _stderr, exit_code) = run_jq_full(&args, None)?;
+    Ok((stdout, exit_code))
 }
 
 // =============================================================================
@@ -406,18 +315,8 @@ fn test_arithmetic() -> Result<()> {
 #[test]
 fn test_unary_minus() -> Result<()> {
     // Negate input value - use -- to prevent option parsing of -. filter
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "--",
-            "-.",
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "--", "-."])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -435,18 +334,8 @@ fn test_unary_minus() -> Result<()> {
 #[test]
 fn test_unary_minus_expression() -> Result<()> {
     // Negate a complex expression
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "--",
-            "-(.a + .b)",
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "--", "-(.a + .b)"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -464,18 +353,8 @@ fn test_unary_minus_expression() -> Result<()> {
 #[test]
 fn test_double_negation() -> Result<()> {
     // Double negation should return original value
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "--",
-            "--.",
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "--", "--."])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -559,16 +438,8 @@ fn test_slurp_with_raw_input_multiple_files() -> Result<()> {
     let mut file2 = NamedTempFile::new()?;
     writeln!(file2, "b")?;
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
         .arg("-R")
         .arg("-s")
         .arg("-c")
@@ -1296,16 +1167,8 @@ fn test_from_file() -> Result<()> {
     let mut input_file = NamedTempFile::new()?;
     writeln!(input_file, r#"{{"name":"Alice"}}"#)?;
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
         .arg("-f")
         .arg(filter_file.path())
         .arg(input_file.path())
@@ -1532,16 +1395,8 @@ fn test_multiple_file_inputs() -> Result<()> {
     let mut file2 = NamedTempFile::new()?;
     writeln!(file2, r#"{{"name":"Bob"}}"#)?;
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
         .arg("-r")
         .arg(".name")
         .arg(file1.path())
@@ -1604,17 +1459,8 @@ fn test_builtin_first_last_on_empty_array_output_null() -> Result<()> {
 fn test_builtin_first_on_non_array_errors() -> Result<()> {
     // jq: 5 | first => error. The error goes to stderr and nothing to stdout,
     // and the process exits 5 so the failure is visible to a shell (#355).
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "first",
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "first"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1649,16 +1495,8 @@ fn test_builtin_first_on_non_array_errors() -> Result<()> {
 /// The jq golden corpus cannot host these: it compares stdout only and requires
 /// exit 0.
 fn jq_stderr(filter: &str, input: &str, extra_args: &[&str]) -> Result<String> {
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
         .args(extra_args)
         .arg(filter)
         .stdin(Stdio::piped())
@@ -1870,18 +1708,8 @@ fn test_contains_type_mismatch_errors() -> Result<()> {
     // CLI's generic evaluator, which reaches the check by delegating to the full
     // one. Like `first` above, the exit status is not asserted: runtime eval
     // errors still exit 0 rather than jq's 5 (#355).
-    let mut cmd = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-c",
-            r#"contains("a")"#,
-        ])
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-c", r#"contains("a")"#])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -2385,16 +2213,8 @@ fn test_reduce() -> Result<()> {
 #[test]
 fn test_default_identity_filter() -> Result<()> {
     // When no filter is provided, should default to "."
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("jq")
         .arg("-c")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -2413,17 +2233,8 @@ fn test_default_identity_filter() -> Result<()> {
 
 #[test]
 fn test_jq_help() -> Result<()> {
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "--help",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "--help"])
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
@@ -3788,14 +3599,8 @@ fn test_large_integer_literal_prints_like_jq() -> Result<()> {
 fn test_args_positional() -> Result<()> {
     // Test --args: positional args become $ARGS.positional
     // Note: Use pipe syntax since parser doesn't support $VAR.field directly
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
             "jq",
             "-n",
             "-c",
@@ -3813,14 +3618,8 @@ fn test_args_positional() -> Result<()> {
 #[test]
 fn test_jsonargs_positional() -> Result<()> {
     // Test --jsonargs: positional args are parsed as JSON
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
             "jq",
             "-n",
             "-c",
@@ -3839,14 +3638,8 @@ fn test_jsonargs_positional() -> Result<()> {
 #[test]
 fn test_args_named() -> Result<()> {
     // Test $ARGS.named contains all named args
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
             "jq",
             "-n",
             "--arg",
@@ -3869,24 +3662,8 @@ fn test_args_named() -> Result<()> {
 fn test_args_combined() -> Result<()> {
     // Test $ARGS with both named and positional args
     // Named args first, then filter, then --args with values
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "--arg",
-            "x",
-            "1",
-            "$ARGS",
-            "--args",
-            "a",
-            "b",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "--arg", "x", "1", "$ARGS", "--args", "a", "b"])
         .output()?;
     let stdout = String::from_utf8(output.stdout)?;
     let parsed: serde_json::Value = serde_json::from_str(&stdout)?;
@@ -3904,16 +3681,9 @@ fn test_args_combined() -> Result<()> {
 fn test_no_color_env_var() -> Result<()> {
     // Test that NO_COLOR environment variable disables color output
     // When NO_COLOR is set and no explicit -C/-M flag is given, colors should be disabled.
-    let mut child = Command::new("cargo")
+    let mut child = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            ".", // No -C or -M flag
+            "jq", ".", // No -C or -M flag
         ])
         .env("NO_COLOR", "1")
         .stdin(Stdio::piped())
@@ -3940,18 +3710,10 @@ fn test_jq_colors_env_var() -> Result<()> {
     // Test that JQ_COLORS environment variable customizes colors
     // Format: "null:false:true:numbers:strings:arrays:objects:objectkeys"
     // Use a distinctive color for null (red = 31) to verify it works
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-C", // Force color output
-            "-n",
-            "null",
+            "jq", "-C", // Force color output
+            "-n", "null",
         ])
         .env("JQ_COLORS", "0;31:::::::") // Red null, defaults for rest
         .stdout(Stdio::piped())
@@ -3969,14 +3731,8 @@ fn test_jq_colors_env_var() -> Result<()> {
 #[test]
 fn test_color_output_overrides_no_color() -> Result<()> {
     // Test that -C flag overrides NO_COLOR env var
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
             "jq",
             "-C", // Force color
             "-n",
@@ -3998,14 +3754,8 @@ fn test_color_output_overrides_no_color() -> Result<()> {
 #[test]
 fn test_monochrome_overrides_jq_colors() -> Result<()> {
     // Test that -M flag disables colors even if JQ_COLORS is set
-    let output = Command::new("cargo")
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
         .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
             "jq",
             "-M", // Monochrome output
             "-n",
@@ -4028,19 +3778,8 @@ fn test_monochrome_overrides_jq_colors() -> Result<()> {
 fn test_jq_colors_invalid_spec_warns_and_uses_defaults() -> Result<()> {
     // A malformed JQ_COLORS spec is rejected as a whole: jq warns on stderr,
     // falls back to the default scheme, and still exits successfully.
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-C",
-            "-n",
-            "null",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-C", "-n", "null"])
         .env("JQ_COLORS", "bogus")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -4076,17 +3815,8 @@ fn test_color_output_materializes_cursor_values() -> Result<()> {
 #[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "--build-configuration",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "--build-configuration"])
         .stdout(Stdio::piped())
         .output()?;
 
@@ -4112,18 +3842,8 @@ fn test_include_directive() -> Result<()> {
     std::fs::write(&module_path, "def double: . * 2;")?;
 
     // Test include directive
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "-L",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "-L"])
         .arg(temp_dir.path())
         .arg(r#"include "utils"; 21 | double"#)
         .stdout(Stdio::piped())
@@ -4149,18 +3869,8 @@ fn test_import_directive() -> Result<()> {
     std::fs::write(&module_path, "def triple: . * 3;")?;
 
     // Test import directive with namespaced function call
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "-L",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "-L"])
         .arg(temp_dir.path())
         .arg(r#"import "mymod" as m; 10 | m::triple"#)
         .stdout(Stdio::piped())
@@ -4181,20 +3891,8 @@ fn test_import_directive() -> Result<()> {
 #[test]
 fn test_library_path_option() -> Result<()> {
     // Test -L option with a non-existent path (should still parse)
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "-L",
-            "/nonexistent/path",
-            ".",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "-L", "/nonexistent/path", "."])
         .stdout(Stdio::piped())
         .output()?;
 
@@ -4211,17 +3909,8 @@ fn test_jq_library_path_env() -> Result<()> {
     std::fs::write(&module_path, "def quadruple: . * 4;")?;
 
     // Test JQ_LIBRARY_PATH environment variable
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n"])
         .arg(r#"include "envmod"; 5 | quadruple"#)
         .env("JQ_LIBRARY_PATH", temp_dir.path())
         .stdout(Stdio::piped())
@@ -4242,17 +3931,8 @@ fn test_jq_library_path_env() -> Result<()> {
 #[test]
 fn test_module_not_found_error() -> Result<()> {
     // Test that a missing module produces an appropriate error
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n"])
         .arg(r#"include "nonexistent_module_xyz"; ."#)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -4271,17 +3951,8 @@ fn test_module_not_found_error() -> Result<()> {
 #[test]
 fn test_namespaced_call_parse() -> Result<()> {
     // Test that namespaced calls parse correctly
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n"])
         .arg("mymod::func")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -4306,18 +3977,8 @@ fn test_home_jq_file_autoload() -> Result<()> {
     std::fs::write(&jq_file, "def my_custom_func: . * 100;")?;
 
     // Test that function from ~/.jq is available
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "5 | my_custom_func",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "5 | my_custom_func"])
         .env("HOME", temp_home.path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -4350,17 +4011,8 @@ fn test_home_jq_dir_search_path() -> Result<()> {
     std::fs::write(jq_dir.join("homemod.jq"), "def home_func: . + 1000;")?;
 
     // Test that module from ~/.jq directory can be included
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n"])
         .arg(r#"include "homemod"; 7 | home_func"#)
         .env("HOME", temp_home.path())
         .stdout(Stdio::piped())
@@ -4386,18 +4038,8 @@ fn test_import_with_namespace() -> Result<()> {
     std::fs::write(&module_path, "def double: . * 2; def triple: . * 3;")?;
 
     // Test import with namespace - should be able to call mymath::double
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--features",
-            cargo_run_features(),
-            "--bin",
-            "succinctly",
-            "--",
-            "jq",
-            "-n",
-            "-L",
-        ])
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["jq", "-n", "-L"])
         .arg(temp_dir.path())
         .arg(r#"import "mymath" as mymath; 5 | mymath::double"#)
         .stdout(Stdio::piped())
@@ -4505,41 +4147,20 @@ fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
 
 /// Helper to run jq command with binary input (for testing --seq with RS characters)
 fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, i32)> {
-    for attempt in 0..MAX_CARGO_RETRIES {
-        let mut cmd = Command::new("cargo")
-            .args([
-                "run",
-                "--quiet",
-                "--features",
-                cargo_run_features(),
-                "--bin",
-                "succinctly",
-                "--",
-                "jq",
-            ])
-            .args(extra_args)
-            .arg(filter)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
+    let mut args: Vec<&str> = extra_args.to_vec();
+    args.push(filter);
+    let mut cmd = spawn_jq_full(&args)?;
 
-        if let Some(mut stdin) = cmd.stdin.take() {
-            stdin.write_all(input)?;
-        }
-
-        let output = cmd.wait_with_output()?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(exit_code) =
-            classify_cargo_run_exit(output.status, &stderr, attempt, MAX_CARGO_RETRIES)?
-        else {
-            std::thread::sleep(Duration::from_millis(100 * (attempt as u64 + 1)));
-            continue;
-        };
-
-        return Ok((output.stdout, exit_code));
+    if let Some(mut stdin) = cmd.stdin.take() {
+        stdin.write_all(input)?;
     }
-    unreachable!()
+
+    let output = cmd.wait_with_output()?;
+    let Some(exit_code) = output.status.code() else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(signal_death_error(output.status, &stderr));
+    };
+    Ok((output.stdout, exit_code))
 }
 
 #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6,24 +6,16 @@
 
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 use anyhow::Result;
 use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::{classify_cargo_run_exit, signal_death_error, MAX_CARGO_RETRIES};
-
-/// Maximum retries for spawning the pre-built binary directly.
-///
-/// Every test in this file execs a fixed path (`CARGO_BIN_EXE_succinctly`)
-/// rather than rebuilding it via `cargo run` (#1859) -- but `spawn()` can
-/// still transiently observe that path mid-write if a *concurrent* test
-/// binary elsewhere in the crate is still linking it (e.g. a differently
-/// featured `cargo test` invocation sharing the same `target/` directory)
-/// and fail with `ENOENT` (#550).
-const MAX_SPAWN_RETRIES: u32 = 3;
+use cargo_run_exit::{
+    classify_cargo_run_exit, signal_death_error, spawn_with_signal_retry, succinctly_bin,
+    MAX_CARGO_RETRIES,
+};
 
 /// #1516: a signal-killed child used to render as an inscrutable
 /// `left: -1, right: 0` panic -- exercises `classify_cargo_run_exit`
@@ -125,9 +117,9 @@ fn run_jq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(Strin
 /// Helper to run jq command with input from stdin, keeping stderr.
 ///
 /// Most tests only care about stdout and the exit code; use this when the
-/// absence of a diagnostic is itself the thing under test. `--quiet` keeps
-/// cargo's own progress lines ("Compiling", "Blocking waiting for file lock")
-/// off stderr, so what remains is the binary's.
+/// absence of a diagnostic is itself the thing under test. Delegates to
+/// `run_jq_full`, which execs the pre-built binary directly (#1859), so
+/// stderr here is exactly the binary's own -- no cargo output to filter.
 fn run_jq_stdin_streams(
     filter: &str,
     input: &str,
@@ -145,52 +137,28 @@ fn run_jq_stdin_streams(
 /// it unusable for the diagnostics in #355 — those live entirely on stderr and
 /// in the exit code, and their `(at <file>:<line>)` marker needs a real file.
 ///
-/// Invokes the built binary directly rather than through `cargo run`: cargo
-/// writes its own `Finished`/`Running` progress lines to stderr, which would be
-/// indistinguishable from the diagnostics under test. That also makes the
-/// lock-contention retry unnecessary — but the direct spawn can still race
-/// concurrent rebuilds of the same path, so it gets its own retry below (#550).
+/// Invokes the built binary directly rather than through `cargo run` (#1859):
+/// cargo writes its own `Finished`/`Running` progress lines to stderr, which
+/// would be indistinguishable from the diagnostics under test, and that also
+/// makes the lock-contention retry unnecessary. Delegates to the shared
+/// `spawn_with_signal_retry` (#1884 code review) rather than a file-local
+/// reimplementation, so this file's ~190 `run_jq_stdin`/`run_jq_null`-routed
+/// call sites get the same signal-death retry the four files #1847 migrated
+/// already share -- a file-local copy here would have been a fifth,
+/// independently-drifting one for the exact problem that helper's own doc
+/// comment says sharing one copy was meant to stop.
 fn run_jq_full(args: &[&str], input: Option<&str>) -> Result<(String, String, i32)> {
-    let mut cmd = spawn_jq_full(args)?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        if let Some(input) = input {
-            stdin.write_all(input.as_bytes())?;
-        }
-    }
-
-    let output = cmd.wait_with_output()?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.arg("jq").args(args);
+            command
+        },
+        input.map(str::as_bytes),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-    let Some(exit_code) = output.status.code() else {
-        return Err(signal_death_error(output.status, &stderr));
-    };
     Ok((stdout, stderr, exit_code))
-}
-
-/// Spawns the pre-built `succinctly` binary, retrying on `ENOENT`.
-///
-/// See `MAX_SPAWN_RETRIES` for why this retry exists.
-fn spawn_jq_full(args: &[&str]) -> std::io::Result<std::process::Child> {
-    for attempt in 0..MAX_SPAWN_RETRIES {
-        match Command::new(env!("CARGO_BIN_EXE_succinctly"))
-            .arg("jq")
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-        {
-            Ok(child) => return Ok(child),
-            Err(e)
-                if e.kind() == std::io::ErrorKind::NotFound && attempt + 1 < MAX_SPAWN_RETRIES =>
-            {
-                std::thread::sleep(Duration::from_millis(50 * (attempt as u64 + 1)));
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    unreachable!()
 }
 
 /// Helper to run jq with null input (-n)
@@ -4124,19 +4092,9 @@ fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
     // An empty operand used to reach `result_to_owned`, which reported it as
     // `Error("no value")` and printed a diagnostic. jq emits nothing at all,
     // quietly. The goldens compare stdout only, so stderr is asserted here.
-    //
-    // Matching on the absence of a diagnostic rather than on a byte-empty
-    // stderr keeps the test independent of whatever else may reach that stream:
-    // `--quiet` silences cargo's own progress lines, but not a rustc warning
-    // from the build it triggers. Requiring stderr to be empty would couple this
-    // assertion to the whole workspace compiling warning-free, which is not what
-    // it is testing.
     let (stdout, stderr, code) = run_jq_stdin_streams("empty and true", "null", &["-c"])?;
     assert_eq!(stdout, "", "expected no output");
-    assert!(
-        !stderr.contains("jq: error"),
-        "expected no diagnostic on stderr, got: {stderr}"
-    );
+    assert_eq!(stderr, "", "expected no diagnostic on stderr");
     assert_eq!(code, 0, "expected success");
     Ok(())
 }
@@ -4149,17 +4107,14 @@ fn test_boolean_with_empty_operand_is_silent() -> Result<()> {
 fn run_jq_binary_stdin(filter: &str, input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, i32)> {
     let mut args: Vec<&str> = extra_args.to_vec();
     args.push(filter);
-    let mut cmd = spawn_jq_full(&args)?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input)?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let Some(exit_code) = output.status.code() else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(signal_death_error(output.status, &stderr));
-    };
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.arg("jq").args(&args);
+            command
+        },
+        Some(input),
+    )?;
     Ok((output.stdout, exit_code))
 }
 
@@ -4300,10 +4255,9 @@ fn test_seq_malformed_record_with_rs_byte_does_not_warn_1525() -> Result<()> {
 /// RS-containing one still warns on real jq, with one of the other
 /// message templates #1723 tracks -- not this one; not exercised here.)
 ///
-/// Spawns via `spawn_jq_full` (not a bare `Command::new(...).output()`)
-/// for its `ENOENT`-retry protection: other tests in this file rebuild
-/// the shared binary path concurrently (see `MAX_SPAWN_RETRIES`'s own
-/// doc comment, #550).
+/// Spawns via `spawn_with_signal_retry` (not a bare `Command::new(...).
+/// output()`) for its retry protection against a transient `ENOENT` or a
+/// signal-killed child under concurrent load (#550, #1884).
 #[test]
 fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<()> {
     let mut valid_file = NamedTempFile::new()?;
@@ -4312,9 +4266,16 @@ fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<
 
     let valid_path = valid_file.path().to_str().unwrap();
     let empty_path = empty_file.path().to_str().unwrap();
-    let mut cmd = spawn_jq_full(&["--seq", "-c", ".", valid_path, empty_path])?;
-    drop(cmd.stdin.take());
-    let output = cmd.wait_with_output()?;
+    let (output, _) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .arg("jq")
+                .args(["--seq", "-c", ".", valid_path, empty_path]);
+            command
+        },
+        None,
+    )?;
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8(output.stderr)?, "");
@@ -4325,8 +4286,8 @@ fn test_seq_no_rs_warning_suppressed_by_another_source_with_rs_1525() -> Result<
 
 /// #1525: two RS-less files report a line/column computed from their
 /// *concatenation*, not either file's own content alone -- oracle-verified
-/// against the pinned jq 1.7.1 binary. Spawns via `spawn_jq_full` for its
-/// `ENOENT`-retry protection, same reason as the test above.
+/// against the pinned jq 1.7.1 binary. Spawns via `spawn_with_signal_retry`
+/// for its retry protection, same reason as the test above.
 #[test]
 fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
     let mut file_a = NamedTempFile::new()?;
@@ -4336,9 +4297,14 @@ fn test_seq_no_rs_warning_across_multiple_files_1525() -> Result<()> {
 
     let path_a = file_a.path().to_str().unwrap();
     let path_b = file_b.path().to_str().unwrap();
-    let mut cmd = spawn_jq_full(&["--seq", "-c", ".", path_a, path_b])?;
-    drop(cmd.stdin.take());
-    let output = cmd.wait_with_output()?;
+    let (output, _) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.arg("jq").args(["--seq", "-c", ".", path_a, path_b]);
+            command
+        },
+        None,
+    )?;
 
     assert!(output.status.success());
     assert_eq!(
@@ -4359,11 +4325,14 @@ fn test_seq_no_rs_warning_column_counts_raw_bytes_not_substituted_1525() -> Resu
     input.push(0xFF); // invalid UTF-8 lead byte -> substituted to 3-byte U+FFFD
     input.extend_from_slice(b"cd");
 
-    let mut cmd = spawn_jq_full(&["--seq", "-c", "."])?;
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(&input)?;
-    }
-    let output = cmd.wait_with_output()?;
+    let (output, _) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.arg("jq").args(["--seq", "-c", "."]);
+            command
+        },
+        Some(&input),
+    )?;
 
     assert!(output.status.success());
     assert_eq!(
@@ -4419,11 +4388,14 @@ fn test_seq_no_rs_warning_strips_leading_bom_1525() -> Result<()> {
     input.extend_from_slice(b"\xEF\xBB\xBF");
     input.extend_from_slice(b"1 2");
 
-    let mut cmd = spawn_jq_full(&["--seq", "-c", "."])?;
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(&input)?;
-    }
-    let output = cmd.wait_with_output()?;
+    let (output, _) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.arg("jq").args(["--seq", "-c", "."]);
+            command
+        },
+        Some(&input),
+    )?;
 
     assert!(output.status.success());
     assert_eq!(
@@ -6113,9 +6085,11 @@ fn test_number_literal_underflow_beyond_i32_exponent_range_1099() -> Result<()> 
 ///
 /// CLI-level counterpart to `value.rs`'s
 /// `test_format_number_jq_compat_subnormal_preserves_mantissa_1177` (same
-/// #1099-established pattern: `run_jq_stdin` spawns a subprocess, invisible
-/// to `cargo llvm-cov`, so both an in-process and a CLI-level test exist
-/// for the same fix rather than one being redundant with the other).
+/// #1099-established pattern: `run_jq_stdin` spawns the real binary through
+/// its actual argv/stdin/stdout process boundary, which an in-process
+/// function call can't exercise -- CLI argument parsing, stdin piping, and
+/// stdout serialization are each their own surface a fix can regress
+/// independently of the underlying formatting logic).
 #[test]
 fn test_number_literal_subnormal_preserves_mantissa_1177() -> Result<()> {
     let (output, code) = run_jq_stdin(".", "5e-324", &["-c"])?;
@@ -6139,8 +6113,9 @@ fn test_number_literal_subnormal_preserves_mantissa_1177() -> Result<()> {
 
 /// CLI-level counterpart to
 /// `test_format_number_jq_compat_scientific_notation_preserves_trailing_zeros_1206`
-/// (`run_jq_stdin` spawns `cargo run`, invisible to `cargo llvm-cov`, so both
-/// an in-process and a CLI-level test exist for the same fix).
+/// (`run_jq_stdin` exercises the real CLI argv/stdin/stdout boundary, which
+/// an in-process function call can't -- see the matching comment on
+/// `test_number_literal_subnormal_preserves_mantissa_1177` above).
 #[test]
 fn test_number_literal_scientific_notation_preserves_trailing_zeros_via_cli_1206() -> Result<()> {
     let (output, code) = run_jq_stdin(".", "1.50e10", &["-c"])?;
@@ -6349,9 +6324,7 @@ fn test_as_binding_non_iterable_literal_still_raises_945() -> Result<()> {
 /// (the root-level defaults) whenever they weren't the very first pipe stage:
 /// the CLI's streaming evaluator (`eval_generic.rs`) bridged only the bare
 /// trailing builtin to the full evaluator, discarding the pipe structure
-/// `eval.rs`'s `needs_path_context` routing needs to see (#554). Uses
-/// `run_jq_full` (the pre-built binary), not the `cargo run`-based
-/// `run_jq_stdin`, so this is actually covered by `cargo llvm-cov`.
+/// `eval.rs`'s `needs_path_context` routing needs to see (#554).
 #[test]
 fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
     let (output, _, code) = run_jq_full(&["-c", ".a | path"], Some(r#"{"a":1}"#))?;
@@ -7836,8 +7809,7 @@ fn test_keys_unsorted_lazy_output_140() -> Result<()> {
 /// decoding or sorting, while bare `keys`/`.[]`/`.[n]`/`first`/`last` stay
 /// byte-identical to today's eager-sorted output (`JqValue::LazyKeysArray`
 /// is document-order-only, so a sorted result never reaches it -- see the
-/// `generic_result_to_jq_values` fix in `jq_runner.rs`). Uses `run_jq_full`
-/// (the pre-built binary), not `cargo run` (invisible to coverage).
+/// `generic_result_to_jq_values` fix in `jq_runner.rs`).
 #[test]
 fn test_keys_lazy_length_output_683() -> Result<()> {
     let input = r#"{"b":1,"a":2,"c":3}"#;


### PR DESCRIPTION
## Summary

#1847 fixed the orphaned-`succinctly`-grandchild-process problem (`cargo run`
spawning a second, uninstrumented binary that gets reparented to init and
blocks forever on its stdout pipe once the outer process group is killed) in
`cli_golden_tests.rs`, `cli_characterization_tests.rs`,
`deep_nesting_valid_tests.rs`, and `json_validate_tests.rs`. `jq_cli_tests.rs`
was deliberately left out of that PR's scope: 34 separate
`Command::new("cargo").args(["run", ..., "--bin", "succinctly", "--", "jq",
...])` sites, not funneled through one helper.

All 34 now exec the pre-built binary directly via
`env!("CARGO_BIN_EXE_succinctly")`, matching the established pattern.
Deleted `run_jq_file` (dead code, zero callers).

## A real, separate bug this surfaced

`jq_cli_tests.rs` had no `#![cfg(feature = "cli")]` gate. Its already-migrated
tests were passing in CI only because an earlier, unrelated CI step ("Build
CLI (for integration tests)") happens to leave a compatible
`target/debug/succinctly` on disk that a *later* step's `cargo test
--verbose` (no `cli` active) then finds by accident of step ordering.
Confirmed live: running `cargo test --test jq_cli_tests` in isolation fails
9 tests with "No such file or directory." Added `#![cfg(feature = "cli")]`
plus `--test jq_cli_tests` to all 4 of `ci.yml`'s "Run cli-gated tests"
steps to make this deterministic.

## Review rounds 2–3: closed two retry-mechanism regressions

Round 2 found the initial `run_jq_full`/`spawn_jq_full` (a bespoke
ENOENT-only retry, predating this PR but newly serving ~190 more call sites)
silently dropped the retry-on-signal-death behavior those call sites
previously had. Rewrote them to delegate to the already-shared
`spawn_with_signal_retry` (`tests/common/cargo_run_exit.rs`, used by the 4
files #1847 migrated) instead of keeping a fifth, independently-weaker copy.

Round 3 found (independently, 4 times across different finder angles) that
this migration then *lost* the ENOENT-on-spawn retry in the other direction
— `spawn_with_signal_retry` itself never had one, even for the 4 files
already using it. Fixed the shared helper directly rather than
reintroducing a file-local workaround. Also consolidated 6 near-identical
`Command::new(succinctly_bin()).arg("jq").args(...)` closures into one
`spawn_jq` helper per a reuse/simplification finding, and fixed several doc
comments the mechanical conversion left stale (claiming `run_jq_stdin` is
"invisible to `cargo llvm-cov`", no longer true).

Filed **#1889** (remaining ~32 individually-converted inline sites have no
retry at all — not a new regression, pre-existing, real restructuring work
better scoped separately) and **#1891** (a pre-existing, low-severity
zombie-child-on-failed-write edge case in `spawn_with_signal_retry` itself,
unrelated to this PR's own changes but found while fixing the ENOENT gap
above).

## Test plan

- `cargo test --features cli --test jq_cli_tests`: 1090 passed, 0 failed,
  ~2s (down from 200+s under the old cargo-run-per-test pattern).
- `cargo test --test jq_cli_tests` (no `cli`): `running 0 tests` — confirms
  the gate works.
- Full CI "Run cli-gated tests" step reproduced locally, plus all 4 sibling
  files sharing `cargo_run_exit.rs` (`cli_golden_tests`,
  `cli_characterization_tests`, `deep_nesting_valid_tests`,
  `json_validate_tests`): all pass, confirming the shared-helper ENOENT fix
  didn't regress its existing consumers.
- `cargo test` (plain, default features): pass.
- Both clippy legs (`--all-features` and CI's `std,simd,serde,cli,regex,
  bench-runner,large-tests,mmap-tests`): clean, `-D warnings`.
- `cargo fmt --check`: clean.
- `cargo doc --all-features --no-deps`: clean.
- `cargo build --no-default-features`: clean.

Fixes #1859