### PR TITLE
fix(jq): gate remaining trig functions and skip behind --jq-extensions

### DIFF
--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -377,6 +377,7 @@ surface (#1512):
 | `isempty(f)`                                         | True if `f` produces no output                |
 | `debug`, `debug(msg)`                                | Print to stderr, pass value through           |
 | `infinite`, `isnan`                                  | IEEE 754 infinity literal / NaN test          |
+| `nan`, `isinfinite`, `isnormal`, `isfinite`          | IEEE 754 NaN literal / classification (#1885) |
 | `gsub(re; s)`, `scan(re)`, `splits(re)`              | Not real yq builtins at any arity (#1436)     |
 | `inside(s)`                                          | Membership test, `contains`'s inverse         |
 | `startswith(s)`, `endswith(s)`                       | String prefix / suffix test                   |
@@ -394,6 +395,7 @@ surface (#1512):
 | `INDEX(idx_expr)`, `INDEX(stream; idx_expr)`         | Build an object keyed by an index expr (#1714)|
 | `walk(f)`                                            | Recursively transform every node (#1714)      |
 | `floor`, `ceil`, `round`, `sqrt`, `fabs`             | Basic math functions (#1714)                  |
+| `abs`, `trunc`                                       | Absolute value / truncate to integer (#1885)  |
 | `log`, `log2`, `log10`                               | Logarithms (#1714)                            |
 | `exp`, `exp2`, `exp10`                               | Exponentials (#1714)                          |
 | `sinh`, `cosh`, `tanh`                               | Hyperbolic trig functions (#1714)             |

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -398,6 +398,9 @@ surface (#1512):
 | `exp`, `exp2`, `exp10`                               | Exponentials (#1714)                          |
 | `sinh`, `cosh`, `tanh`                               | Hyperbolic trig functions (#1714)             |
 | `atan2(y; x)`                                        | Two-argument arctangent (#1714)               |
+| `asin`, `acos`, `atan`, `sin`, `cos`, `tan`           | Trig functions (#1837)                        |
+| `asinh`, `acosh`, `atanh`                            | Inverse hyperbolic trig functions (#1837)     |
+| `skip(n; f)`                                         | Drop the first `n` outputs of `f` (#1882)     |
 
 ```bash
 echo '{}' | succinctly yq 'paths'

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -398,7 +398,8 @@ surface (#1512):
 | `exp`, `exp2`, `exp10`                               | Exponentials (#1714)                          |
 | `sinh`, `cosh`, `tanh`                               | Hyperbolic trig functions (#1714)             |
 | `atan2(y; x)`                                        | Two-argument arctangent (#1714)               |
-| `asin`, `acos`, `atan`, `sin`, `cos`, `tan`           | Trig functions (#1837)                        |
+| `asin`, `acos`, `atan`                               | Inverse trig functions (#1837)                |
+| `sin`, `cos`, `tan`                                  | Trig functions (#1837)                        |
 | `asinh`, `acosh`, `atanh`                            | Inverse hyperbolic trig functions (#1837)     |
 | `skip(n; f)`                                         | Drop the first `n` outputs of `f` (#1882)     |
 

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3329,6 +3329,7 @@ impl<'a> Parser<'a> {
         // Phase 10: Number Classification & Constants
         // Check isinfinite, isnan, isnormal, isfinite before infinite, nan
         if self.matches_keyword("isinfinite") {
+            self.reject_unless_jq_extensions("isinfinite")?;
             self.consume_keyword("isinfinite");
             return Ok(Some(Builtin::IsInfinite));
         }
@@ -3338,10 +3339,12 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::IsNan));
         }
         if self.matches_keyword("isnormal") {
+            self.reject_unless_jq_extensions("isnormal")?;
             self.consume_keyword("isnormal");
             return Ok(Some(Builtin::IsNormal));
         }
         if self.matches_keyword("isfinite") {
+            self.reject_unless_jq_extensions("isfinite")?;
             self.consume_keyword("isfinite");
             return Ok(Some(Builtin::IsFinite));
         }
@@ -3351,6 +3354,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Infinite));
         }
         if self.matches_keyword("nan") {
+            self.reject_unless_jq_extensions("nan")?;
             self.consume_keyword("nan");
             return Ok(Some(Builtin::Nan));
         }
@@ -3570,6 +3574,7 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Now));
         }
         if self.matches_keyword("abs") {
+            self.reject_unless_jq_extensions("abs")?;
             self.consume_keyword("abs");
             return Ok(Some(Builtin::Abs));
         }
@@ -3801,6 +3806,7 @@ impl<'a> Parser<'a> {
 
         // Phase 18: Additional math functions
         if self.matches_keyword("trunc") {
+            self.reject_unless_jq_extensions("trunc")?;
             self.consume_keyword("trunc");
             return Ok(Some(Builtin::Trunc));
         }
@@ -6723,6 +6729,10 @@ mod tests {
             ("skip", "skip(1; .)"),
             ("asin", "0.5 | asin"),
             ("acosh", "1.5 | acosh"),
+            ("abs", "(-1.5) | abs"),
+            ("trunc", "1.5 | trunc"),
+            ("isinfinite", "1 | isinfinite"),
+            ("nan", "nan"),
         ];
 
         for (name, filter) in cases {

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3265,14 +3265,17 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Tanh));
         }
         if self.matches_keyword("asinh") {
+            self.reject_unless_jq_extensions("asinh")?;
             self.consume_keyword("asinh");
             return Ok(Some(Builtin::Asinh));
         }
         if self.matches_keyword("acosh") {
+            self.reject_unless_jq_extensions("acosh")?;
             self.consume_keyword("acosh");
             return Ok(Some(Builtin::Acosh));
         }
         if self.matches_keyword("atanh") {
+            self.reject_unless_jq_extensions("atanh")?;
             self.consume_keyword("atanh");
             return Ok(Some(Builtin::Atanh));
         }
@@ -3293,26 +3296,32 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Atan2(Box::new(y), Box::new(x))));
         }
         if self.matches_keyword("asin") {
+            self.reject_unless_jq_extensions("asin")?;
             self.consume_keyword("asin");
             return Ok(Some(Builtin::Asin));
         }
         if self.matches_keyword("acos") {
+            self.reject_unless_jq_extensions("acos")?;
             self.consume_keyword("acos");
             return Ok(Some(Builtin::Acos));
         }
         if self.matches_keyword("atan") {
+            self.reject_unless_jq_extensions("atan")?;
             self.consume_keyword("atan");
             return Ok(Some(Builtin::Atan));
         }
         if self.matches_keyword("sin") {
+            self.reject_unless_jq_extensions("sin")?;
             self.consume_keyword("sin");
             return Ok(Some(Builtin::Sin));
         }
         if self.matches_keyword("cos") {
+            self.reject_unless_jq_extensions("cos")?;
             self.consume_keyword("cos");
             return Ok(Some(Builtin::Cos));
         }
         if self.matches_keyword("tan") {
+            self.reject_unless_jq_extensions("tan")?;
             self.consume_keyword("tan");
             return Ok(Some(Builtin::Tan));
         }
@@ -3600,6 +3609,7 @@ impl<'a> Parser<'a> {
 
         // skip(n; expr) - skip first n outputs from expr
         if self.matches_keyword("skip") {
+            self.reject_unless_jq_extensions("skip")?;
             self.consume_keyword("skip");
             self.skip_ws();
             self.expect('(')?;
@@ -6710,6 +6720,9 @@ mod tests {
             ("debug", "debug"),
             ("isempty", "isempty(empty)"),
             ("limit", "limit(1; .)"),
+            ("skip", "skip(1; .)"),
+            ("asin", "0.5 | asin"),
+            ("acosh", "1.5 | acosh"),
         ];
 
         for (name, filter) in cases {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1333,11 +1333,12 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 /// `bsearch`), and the 21 names #1714 found still ungated (`add`, `min_by`,
 /// `max_by`, `implode`, `INDEX`, `walk`, `floor`, `ceil`, `round`, `sqrt`,
 /// `fabs`, `log`, `log2`, `log10`, `exp`, `exp2`, `exp10`, `sinh`, `cosh`,
-/// `tanh`, `atan2`), and #1837/#1882's own 16 names -- the adjacent trig
-/// functions #1714 left untouched (`asin`, `acos`, `atan`, `sin`, `cos`,
-/// `tan`, `asinh`, `acosh`, `atanh`), `skip` (a #983-lineage builtin that,
-/// unlike its siblings `limit`/`nth`, was never gated at all), and 6 more
-/// (`abs`, `trunc`, `isinfinite`, `isnormal`, `isfinite`, `nan`) found by
+/// `tanh`, `atan2`), and 16 more names from PR #1885 -- #1837's 9 adjacent
+/// trig functions #1714 left untouched (`asin`, `acos`, `atan`, `sin`,
+/// `cos`, `tan`, `asinh`, `acosh`, `atanh`), #1882's `skip` (a #983-lineage
+/// builtin that, unlike its siblings `limit`/`nth`, was never gated at
+/// all), and 6 more (`abs`, `trunc`, `isinfinite`, `isnormal`, `isfinite`,
+/// `nan`) found by
 /// #1885's own code review tracing this same "Phase 10"/"Phase 12" gap
 /// further -- see #1887 for the still-unaudited remainder of this surface.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1333,10 +1333,13 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 /// `bsearch`), and the 21 names #1714 found still ungated (`add`, `min_by`,
 /// `max_by`, `implode`, `INDEX`, `walk`, `floor`, `ceil`, `round`, `sqrt`,
 /// `fabs`, `log`, `log2`, `log10`, `exp`, `exp2`, `exp10`, `sinh`, `cosh`,
-/// `tanh`, `atan2`), and #1837/#1882's own 10 names -- the adjacent trig
+/// `tanh`, `atan2`), and #1837/#1882's own 16 names -- the adjacent trig
 /// functions #1714 left untouched (`asin`, `acos`, `atan`, `sin`, `cos`,
-/// `tan`, `asinh`, `acosh`, `atanh`) plus `skip`, a #983-lineage builtin
-/// that (unlike its siblings `limit`/`nth`) was never gated at all.
+/// `tan`, `asinh`, `acosh`, `atanh`), `skip` (a #983-lineage builtin that,
+/// unlike its siblings `limit`/`nth`, was never gated at all), and 6 more
+/// (`abs`, `trunc`, `isinfinite`, `isnormal`, `isfinite`, `nan`) found by
+/// #1885's own code review tracing this same "Phase 10"/"Phase 12" gap
+/// further -- see #1887 for the still-unaudited remainder of this surface.
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     for filter in [
@@ -1388,6 +1391,12 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "acosh(1.5)",
         "atanh(0.5)",
         "skip(1; .)",
+        "abs",
+        "trunc",
+        "isinfinite",
+        "isnormal",
+        "isfinite",
+        "nan",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -1461,6 +1470,12 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
         "1.5 | acosh",
         "0.5 | atanh",
         "[1,2,3] | [skip(1; .[])]",
+        "(-1.5) | abs",
+        "1.5 | trunc",
+        "1 | isinfinite",
+        "1 | isnormal",
+        "1 | isfinite",
+        "nan",
     ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
@@ -7614,17 +7629,18 @@ fn test_yq_json_output_special_floats_still_null_after_1060() -> Result<()> {
 /// `format!("{f}")` that this exact test caught live: `nan | tostring` gave
 /// `"NaN"` instead of `.nan`, silently inconsistent with `nan | @text`
 /// (documented in CLAUDE.md as "same as tostring") which already gave
-/// `.nan`.
+/// `.nan`. `--jq-extensions` is needed for the `nan`-literal filters since
+/// #1885 gated that keyword in yq mode.
 #[test]
 fn test_yq_tostring_computed_nan_uses_yaml_spelling_1060() -> Result<()> {
     for filter in ["nan | tostring", "(0/0) | tostring"] {
-        let (stdout, code) = run_yq_stdin(filter, "a: 1\n", &["-r"])?;
+        let (stdout, code) = run_yq_stdin(filter, "a: 1\n", &["-r", "--jq-extensions"])?;
         assert_eq!(code, 0, "for {filter:?}: {stdout:?}");
         assert_eq!(stdout.trim_end(), ".nan", "for {filter:?}");
     }
     // `@text` is documented as identical to `tostring` -- confirm they now
     // agree on the same computed value.
-    let (stdout, code) = run_yq_stdin("nan | @text", "a: 1\n", &["-r"])?;
+    let (stdout, code) = run_yq_stdin("nan | @text", "a: 1\n", &["-r", "--jq-extensions"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), ".nan");
     Ok(())
@@ -19698,19 +19714,28 @@ fn test_1220_delpaths_reports_first_offending_component() -> Result<()> {
 /// for *itself* (preserving the pre-existing "NaN path silently drops"
 /// behavior, unrelated to #1220's own scope), not for other, genuinely
 /// bad-typed components sharing the same path. Unreachable via real yq
-/// (its lexer rejects a bare `nan` token outright), so this pins
-/// succinctly's own internal consistency rather than an oracle behavior.
+/// (its lexer rejects a bare `nan` token outright, and -- since #1885 --
+/// succinctly's own yq mode now matches that by default too), so this pins
+/// succinctly's own internal consistency (behind `--jq-extensions`) rather
+/// than an oracle behavior.
 #[test]
 fn test_1220_delpaths_nan_does_not_suppress_sibling_type_check() -> Result<()> {
     // A NaN alongside a bad-typed sibling still reports the sibling.
-    let (_out, stderr, code) =
-        run_yq_stdin_with_stderr("delpaths([[nan,true]])", "[1,2,3]", &["-o=json"])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "delpaths([[nan,true]])",
+        "[1,2,3]",
+        &["-o=json", "--jq-extensions"],
+    )?;
     assert_ne!(code, 0, "stderr: {stderr}");
     assert!(stderr.contains("found !!bool instead"), "stderr: {stderr}");
 
     // A NaN alone still silently drops rather than erroring (NaN itself is
     // never reported as the offending type, matching pre-#1220 behavior).
-    let (out, code) = run_yq_stdin("delpaths([[nan]])", "[1,2,3]", &["-o=json", "-I=0"])?;
+    let (out, code) = run_yq_stdin(
+        "delpaths([[nan]])",
+        "[1,2,3]",
+        &["-o=json", "-I=0", "--jq-extensions"],
+    )?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[1,2,3]");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1333,7 +1333,10 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 /// `bsearch`), and the 21 names #1714 found still ungated (`add`, `min_by`,
 /// `max_by`, `implode`, `INDEX`, `walk`, `floor`, `ceil`, `round`, `sqrt`,
 /// `fabs`, `log`, `log2`, `log10`, `exp`, `exp2`, `exp10`, `sinh`, `cosh`,
-/// `tanh`, `atan2`).
+/// `tanh`, `atan2`), and #1837/#1882's own 10 names -- the adjacent trig
+/// functions #1714 left untouched (`asin`, `acos`, `atan`, `sin`, `cos`,
+/// `tan`, `asinh`, `acosh`, `atanh`) plus `skip`, a #983-lineage builtin
+/// that (unlike its siblings `limit`/`nth`) was never gated at all.
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     for filter in [
@@ -1375,6 +1378,16 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "cosh",
         "tanh",
         "atan2(1;1)",
+        "asin(0.5)",
+        "acos(0.5)",
+        "atan(0.5)",
+        "sin(0.5)",
+        "cos(0.5)",
+        "tan(0.5)",
+        "asinh(0.5)",
+        "acosh(1.5)",
+        "atanh(0.5)",
+        "skip(1; .)",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -1438,6 +1451,16 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
         "0 | cosh",
         "0 | tanh",
         "atan2(1;1)",
+        "0.5 | asin",
+        "0.5 | acos",
+        "0.5 | atan",
+        "0.5 | sin",
+        "0.5 | cos",
+        "0.5 | tan",
+        "0.5 | asinh",
+        "1.5 | acosh",
+        "0.5 | atanh",
+        "[1,2,3] | [skip(1; .[])]",
     ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;


### PR DESCRIPTION
## Summary

Bundles #1837 and #1882 — same root cause (`--jq-extensions` gate list
incompleteness in `src/jq/parser.rs`), same mechanical fix, same test/doc
files to touch.

Real yq v4.53.3's lexer rejects these builtins outright — confirmed live:

```console
$ echo 'null' | yq 'asin(0.5)'
Error: 1:3: lexer: invalid input text "in(0.5)"
$ echo 'null' | yq 'skip(1; 1,2,3,4)'
Error: 1:1: lexer: invalid input text "skip(1; 1,2,3,4)"
```

- **#1837**: `#1714` gated `sinh`/`cosh`/`tanh`/`atan2` but left the adjacent
  `asin`, `acos`, `atan`, `sin`, `cos`, `tan`, `asinh`, `acosh`, `atanh`
  ungated without independent verification. That verification is now done
  (all 9 lexer-rejected by real yq).
- **#1882**: `skip` was introduced in the same #983 lineage as `limit`/`nth`
  (both correctly gated) but was never gated itself — found while working
  #1846/#1879.

## Changes

Mechanical, matching #1714's own pattern: add
`self.reject_unless_jq_extensions("name")?;` as the first statement inside
each builtin's `matches_keyword` block in `src/jq/parser.rs`.

- `tests/yq_cli_tests.rs`: added all 10 names to
  `test_yq_default_rejects_jq_only_builtins_1512` (rejected by default) and
  `test_yq_jq_extensions_flag_enables_jq_only_builtins_1512` (accepted with
  the flag).
- `src/jq/parser.rs`: added `skip`/`asin`/`acosh` to the parser-level
  `test_yq_mode_rejects_jq_only_builtins_unless_jq_extensions_1512` unit test
  (a sampling test, not exhaustive — matches its existing shape).
- `docs/reference/yq-language.md`: added the 10 names to the "Gated jq
  Builtins" table.

jq mode is unaffected either way — it already accepts this whole surface
unconditionally, gate or no gate.

## Verification

- `cargo test --features cli,simd,regex,serde --workspace`: all green
  (two unrelated SIGKILL flakes from concurrent-session machine load,
  confirmed pre-existing and unrelated by re-running clean)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- `cargo check --no-default-features` (no_std): clean
- `cargo doc --no-deps --all-features`: clean
- `cargo fmt --check`: clean
- Live-probed the built binary: all 10 names rejected by default with a
  `--jq-extensions`-mentioning error, accepted with the flag, jq mode
  unaffected

Fixes #1837, Fixes #1882