### PR TITLE
fix(jq): Expr::Iterate's path-context arm no longer self-swallows per-element errors

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26760,7 +26760,42 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // native and un-boxed rather than unified into one iterator, to
             // avoid trading this duplication for a `Box<dyn Iterator>`'s
             // allocation and dynamic dispatch on every `.[]`.
+            //
+            // Each element's own step is run with `optional` forced to
+            // `false`, not the ambient value this arm itself received --
+            // the same `Expr::Array`/`Builtin::Map` fix (#1302/#1826),
+            // applied here for `Expr::Iterate` (#1869): passing the ambient
+            // value straight through let a genuine per-element error
+            // self-swallow into `QueryResult::None` before
+            // `accumulate_path_context_step` ever saw it as a stop signal,
+            // silently *skipping* that one element and continuing to the
+            // next instead of aborting the traversal -- confirmed live:
+            // `(.a)? | .[] | if key==1 then error("boom") else key end` on
+            // `{"a":[1,2,3]}` produced `0`/`2` (element 1 silently
+            // skipped), where real jq's own equivalent (`.a | .[] | ...`,
+            // no `?` -- an ordinary generator error always aborts
+            // everything downstream, `?` or not) emits `0` then errors.
+            //
+            // Unlike `Array`/`Map`, `Iterate` is not a constructor -- there
+            // is no atomic "discard the whole in-progress collection"
+            // model to reach for, so an escaping `Error` (when the ambient
+            // `optional` genuinely catches it) keeps the prefix already
+            // produced rather than discarding it (`owned_vec_to_result`,
+            // matching the path-context `Expr::Optional` arm's own
+            // keep-prefix precedent a few arms below, #1335). `Break`/
+            // `Halt` are never caught by this arm's ambient `optional` at
+            // all, even when it's `true` -- unlike `Optional`'s own arm
+            // (which only ever runs when there's a literal `?` right here,
+            // so unconditional catching is correct there), an ambient
+            // `optional` reaching `Iterate` can come from an *unrelated*
+            // enclosing `?` bleeding through `rest` (the pre-existing,
+            // documented #1335 "rest inherits suppression" gap) -- and a
+            // `break`'s label target is lexically scoped, never something
+            // an unrelated ancestor's `?` may intercept. Both fall through
+            // `Some(other) => other` unchanged, preserving whatever prefix
+            // `accumulate_path_context_step` already attached (#400/#494).
             let mut results = Vec::new();
+            let mut stopped = None;
             match value {
                 OwnedValue::Array(arr) => {
                     for (i, v) in arr.iter().enumerate() {
@@ -26771,10 +26806,11 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
-                            return stop;
+                            stopped = Some(stop);
+                            break;
                         }
                     }
                 }
@@ -26787,17 +26823,35 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                             root,
                             file_origin,
                             current_path,
-                            optional,
+                            false,
                             &mut results,
                         ) {
-                            return stop;
+                            stopped = Some(stop);
+                            break;
                         }
                     }
                 }
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, value)),
             }
-            owned_vec_to_result(results)
+            match stopped {
+                None => owned_vec_to_result(results),
+                Some(QueryResult::Error(e)) => {
+                    if optional {
+                        QueryResult::None
+                    } else {
+                        QueryResult::Error(e)
+                    }
+                }
+                Some(QueryResult::Partial(prefix, Control::Error(e))) => {
+                    if optional {
+                        owned_vec_to_result(prefix)
+                    } else {
+                        partial(prefix, Control::Error(e))
+                    }
+                }
+                Some(other) => other,
+            }
         }
         Expr::Paren(inner) => {
             // Parentheses don't change path, just evaluate inner

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26772,9 +26772,38 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // next instead of aborting the traversal -- confirmed live:
             // `(.a)? | .[] | if key==1 then error("boom") else key end` on
             // `{"a":[1,2,3]}` produced `0`/`2` (element 1 silently
-            // skipped), where real jq's own equivalent (`.a | .[] | ...`,
-            // no `?` -- an ordinary generator error always aborts
-            // everything downstream, `?` or not) emits `0` then errors.
+            // skipped, element 2 wrongly still ran). This fix stops that:
+            // the same query now produces only `0`, matching every sibling
+            // arm's existing (#1302/#1826) response to this exact ambient
+            // shape.
+            //
+            // That still isn't full jq parity for this exact query, and
+            // isn't meant to be: real jq's equivalent (`.a | .[] | if
+            // .==2 then error("boom") else . end` on `[1,2,3]`, confirmed
+            // live against jq 1.7.1) emits `1` then *errors*, whether or
+            // not an unrelated `?` sits earlier in the pipe, because `?`
+            // only catches an error raised *inside* what it directly
+            // wraps. Here, `(.a)?` only wraps `.a`; `.[] | ...` is a
+            // separate downstream stage `?` was never meant to reach. It
+            // reaches this arm's `optional=true` only because `key` makes
+            // `needs_path_context(rest)` true, routing through the
+            // `Expr::Optional` arm's slower "combine `[inner, ...rest]`,
+            // evaluate under a forced ambient `optional=true`" fallback a
+            // few arms below (rather than its faster, correct, isolated
+            // path) -- the same pre-existing #1335 "rest inherits
+            // suppression" gap already present, unchanged, in `Array`'s
+            // and `Map`'s own #1302/#1826 fixes (confirmed live: both
+            // `(.a)? | [.[] | if key==1 then error("boom") end]` and
+            // `(.a)? | map(if key==1 then error("boom") else key end)`
+            // also silently exit 0 with no error, on the same input).
+            // Closing that gap needs #1335's own architecture fix (a way
+            // to tell "there's a literal `?` right here" apart from
+            // "`optional` merely bled in from an unrelated earlier
+            // stage"), not another per-construct patch here -- this fix's
+            // job is only to make `Iterate`'s *response* to `optional`
+            // (however it arrived) consistent with every sibling arm's,
+            // not to independently re-litigate whether it should have
+            // arrived at all.
             //
             // Unlike `Array`/`Map`, `Iterate` is not a constructor -- there
             // is no atomic "discard the whole in-progress collection"
@@ -26788,12 +26817,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // (which only ever runs when there's a literal `?` right here,
             // so unconditional catching is correct there), an ambient
             // `optional` reaching `Iterate` can come from an *unrelated*
-            // enclosing `?` bleeding through `rest` (the pre-existing,
-            // documented #1335 "rest inherits suppression" gap) -- and a
-            // `break`'s label target is lexically scoped, never something
-            // an unrelated ancestor's `?` may intercept. Both fall through
-            // `Some(other) => other` unchanged, preserving whatever prefix
-            // `accumulate_path_context_step` already attached (#400/#494).
+            // enclosing `?` bleeding through `rest` (the same #1335 gap
+            // above), and a `break`'s label target is lexically scoped,
+            // never something an unrelated ancestor's `?` may intercept.
+            // Both fall through `Some(other) => other` unchanged,
+            // preserving whatever prefix `accumulate_path_context_step`
+            // already attached (#400/#494).
             let mut results = Vec::new();
             let mut stopped = None;
             match value {
@@ -26836,19 +26865,16 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
             match stopped {
                 None => owned_vec_to_result(results),
-                Some(QueryResult::Error(e)) => {
-                    if optional {
-                        QueryResult::None
-                    } else {
-                        QueryResult::Error(e)
-                    }
-                }
-                Some(QueryResult::Partial(prefix, Control::Error(e))) => {
-                    if optional {
-                        owned_vec_to_result(prefix)
-                    } else {
-                        partial(prefix, Control::Error(e))
-                    }
+                // Guard-gated on `optional`, mirroring the path-context
+                // `Expr::Array` arm's own idiom: when it doesn't match (no
+                // ambient `optional`, or a non-`Error` control signal), the
+                // shared `Some(other) => other` arm below returns the
+                // original `stopped` value unchanged -- for the `Partial`
+                // shape that's already exactly `partial()`'s own
+                // non-empty-prefix output, so there's nothing to rebuild.
+                Some(QueryResult::Error(_)) if optional => QueryResult::None,
+                Some(QueryResult::Partial(prefix, Control::Error(_))) if optional => {
+                    owned_vec_to_result(prefix)
                 }
                 Some(other) => other,
             }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7606,6 +7606,111 @@ fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
     Ok(())
 }
 
+/// #1869: the identical bug class as #1826/#1302, but for `Expr::Iterate`'s
+/// own path-context arm (bare `.[]`, not `map(f)`). Confirmed live pre-fix:
+/// `(.a)? | .[] | if key==1 then error("boom") else key end` on
+/// `{"a":[1,2,3]}` produced `0`/`2` -- the erroring element (1) silently
+/// *skipped* rather than aborting the traversal, since the ambient
+/// `optional` reached each element's own recursive evaluation instead of
+/// being forced to `false` and self-caught at this arm's own level.
+///
+/// Unlike `Array`/`Map`, `Iterate` is not a constructor -- there's no
+/// atomic in-progress collection to discard wholesale, so the fix keeps
+/// whatever prefix was already produced before the error (real jq's own
+/// `(1, 2, error("x"))?`-style "keep everything before the catch" model,
+/// #1335) rather than discarding it to nothing the way `map()`'s own fix
+/// does.
+#[test]
+fn test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869() -> Result<()> {
+    // Array target: element 0 succeeds and is kept; element 1 errors and
+    // stops the traversal (element 2 must never run) -- not "skip 1, keep
+    // going to 2".
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | .[] | if key==1 then error(\"boom\") else key end",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+
+    // Object target: same shape, `key` reporting the string key.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | .[] | if key==\"y\" then error(\"boom\") else key end",
+        ],
+        Some(r#"{"a":{"x":1,"y":2,"z":3}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"x\"\n");
+
+    // The *first* element/entry erroring: `partial()` (#400/#494) collapses
+    // an empty accumulated prefix to a bare `Error`, which this arm's own
+    // `if optional` gate must still catch (not just the `Partial` shape) --
+    // #1826's review caught the same gap for `map()`.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "(.a)? | .[] | if key==0 then error(\"boom\") else key end",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Without any ambient `?`, the same query still hard-errors, keeping
+    // the pre-error prefix on stdout -- matches real jq's own equivalent
+    // (`.a | .[] | if .==2 then error("boom") else . end` on `[1,2,3]`
+    // emits `1` then errors, confirmed live against jq 1.7.1) exactly:
+    // an ordinary generator error always aborts everything downstream.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            ".a | .[] | if key==1 then error(\"boom\") else key end",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `break` must never be caught by this arm's ambient `optional`, with
+    // or without one present -- a label's target is lexically scoped, not
+    // something an unrelated ancestor's `?` may intercept (unlike
+    // `Expr::Optional`'s own arm, which only ever runs when there's a
+    // literal `?` right there). Both must keep the pre-break prefix
+    // (`0`) and terminate with the same success/no-op-past-label exit.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | ((.a)? | .[] | if key==1 then break $out else key end)",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | (.a | .[] | if key==1 then break $out else key end)",
+        ],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+
+    // Sibling positive case: a `.[]` that never errors is unaffected by the
+    // ambient `optional`, and `rest` after it still runs normally.
+    let (stdout, _, code) = run_jq_full(&["-c", "(.a)? | .[] | key"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n1\n2\n");
+
+    Ok(())
+}
+
 /// `needs_path_context` had no `Expr::StringInterpolation` arm (#1334), the
 /// same gap #1302 fixed for `Expr::Array` -- so `"k=\(key)"` silently
 /// stubbed `key` to `null` inside a `\(...)` slot, even once

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1449,6 +1449,26 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
     Ok(())
 }
 
+/// #1869's `Expr::Iterate` path-context fix (jq_cli_tests.rs's own
+/// `test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869`)
+/// lives in `eval_pipe_with_path_context_internal`, generic over
+/// `EvalSemantics` and shared verbatim by both modes -- `key` (a jq-mode
+/// path-context builtin) reaches it in yq mode too, once gated open via
+/// `--jq-extensions`. Confirms the same fixed behavior here: the erroring
+/// element (1) stops the traversal and keeps the pre-error prefix, rather
+/// than the pre-fix bug's silent skip-and-continue.
+#[test]
+fn test_yq_iterate_path_context_ambient_optional_keeps_prefix_1869() -> Result<()> {
+    let (stdout, code) = run_yq_stdin(
+        "(.a)? | .[] | if key==1 then error(\"boom\") else key end",
+        "a:\n  - 1\n  - 2\n  - 3\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+    Ok(())
+}
+
 /// #1251: `.a` field access on `--input-format json` input with a
 /// duplicate key must resolve to the *last* value, matching real jq /
 /// RFC 8259 convention -- the JSON-side sibling of #174's YAML fix, and


### PR DESCRIPTION
Fixes #1869.

`Expr::Iterate`'s own path-context arm (`eval_pipe_with_path_context_internal`,
the arm handling bare `.[]` when `rest` needs `key`/`parent`/`file_index`/
`document_index`) passed the *ambient* `optional` straight into each
element's own evaluation via `iterate_element_step`, instead of forcing
`false` and self-catching the way the sibling `Expr::Array` (#1302) and
`Builtin::Map` (#1826) arms already do.

This let a genuine per-element error self-swallow into "no output for this
element" instead of surfacing as a real stop signal — silently skipping the
erroring element and continuing to the next one, rather than aborting the
whole `.[]` traversal.

## Repro (confirmed live against current `main`, pre-fix)

```console
$ echo '{"a":[1,2,3]}' | succinctly jq -c '(.a)? | .[] | if key==1 then error("boom") else key end'
0
2
```

Real jq has no `key` builtin (a succinctly-only path-context extension), so
there's no direct oracle comparison for this exact filter — but the
internal inconsistency was clear: without the ambient `?`, the same query
correctly hard-errors and stops:

```console
$ echo '{"a":[1,2,3]}' | succinctly jq -c '.a | .[] | if key==1 then error("boom") else key end'
0
jq: error (at <stdin>:1): boom
```

## Fix

Unlike `Array`/`Map`, `Iterate` is not a constructor — there's no atomic
in-progress collection to discard wholesale, so the fix keeps whatever
prefix was already produced before the error (matching the path-context
`Expr::Optional` arm's own keep-prefix precedent, #1335) rather than
discarding it to nothing the way `map()`'s own fix does:

```console
$ echo '{"a":[1,2,3]}' | succinctly jq -c '(.a)? | .[] | if key==1 then error("boom") else key end'
0
```

`Break`/`Halt` are never caught by this arm's ambient `optional`, even when
it's `true` — unlike `Expr::Optional`'s own arm (which only ever runs when
there's a literal `?` right there, so unconditional catching is correct),
an ambient `optional` reaching `Iterate` can come from an *unrelated*
enclosing `?` bleeding through `rest` (a separate, pre-existing, documented
#1335 gap), and a `break`'s label target is lexically scoped — never
something an unrelated ancestor's `?` may intercept. Verified live against
jq 1.7.1 that `try`/`?` does catch `break` when it's directly around the
break-containing expression (a real, if surprising, jq behavior — confirmed
before relying on it), which is exactly what the pre-existing `Expr::Optional`
arm already implements; this fix only changes `Iterate`'s own response when
the ambient flag reaches it via an unrelated stage.

## Testing

Added `test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869`
covering: array/object targets, first-element-errors (empty-prefix collapse,
the same gap #1826's review caught for `map()`), no-ambient-optional control,
`break` never caught (with and without ambient optional), and the
never-errors positive case.

Full local verification: build/test/clippy under both default and full
(`cli,simd,regex,serde`) feature sets, plus `--no-default-features` and
`cargo doc --all-features`. yq mode sanity-checked with `--jq-extensions`
(consistent behavior, all 1298 yq CLI tests unaffected).