### PR TITLE
fix(jq): --unbuffered interleaves stdout and stderr in real time (#1653)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1532,6 +1532,57 @@ underlying exit-code divergence properly needs `get_inputs` to be able to raise 
 fatal `EvalError` from this specific condition rather than only ever warning or returning
 values — not attempted here.
 
+## Real-time stdout/stderr interleaving: every route but the M2 lazy path
+
+Real jq is a lazy generator, so a filter that both writes to stdout and triggers a stderr
+side effect (`debug`, `stderr`, `halt_error`) or raises mid-stream interleaves the two as it
+goes. `succinctly jq` evaluated a whole input's filter into a `Vec` before writing *any* of
+it, so every stderr write had already happened by the time the first stdout write ran —
+which no amount of buffering could fix, `--unbuffered`'s per-write `flush()` included
+([#1653](https://github.com/rust-works/succinctly/issues/1653)).
+
+Fixed for the `-n`, `--slurp`, and `input`/`inputs`-bridge routes, which now write each
+output as the evaluator produces it (`evaluate_input_streaming`,
+[src/bin/succinctly/jq_runner.rs](../../../src/bin/succinctly/jq_runner.rs), over
+`eval_each_with_cursor`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
+
+```
+$ jq            --unbuffered -cn '1, debug, 2'   2>&1     # 1 / ["DEBUG:",null] / null / 2
+$ succinctly jq --unbuffered -cn '1, debug, 2'   2>&1     # same
+```
+
+**Still batched: a document read from a file or stdin** — the M2 lazy path:
+
+```
+$ echo '[1,2]' | jq            --unbuffered -c '.[]|debug'   2>&1
+["DEBUG:",1]
+1
+["DEBUG:",2]
+2
+$ echo '[1,2]' | succinctly jq --unbuffered -c '.[]|debug'   2>&1
+["DEBUG:",1]
+["DEBUG:",2]
+1
+2
+```
+
+Not an oversight, and not merely unfinished: streaming that path means routing the CLI's
+*default* route through the demand-driven evaluator, whose `each_lazy_keys_iterate_sink`
+deliberately skips the malformed-key check (#1194) that
+[#1629](https://github.com/rust-works/succinctly/issues/1629) added so that bare
+`keys_unsorted[]` *would* raise. [#1770](https://github.com/rust-works/succinctly/issues/1770)
+closed that gap as an accepted trade for early-exit consumers like `first(...)` — see
+"A truncating consumer of `keys_unsorted[]` skips a malformed member it never needed" above
+— on the reasoning that detecting it requires the full walk such a consumer exists to avoid.
+Making it the default route would silently generalise that trade to every query. Tried and
+reverted while fixing #1653: it regressed six tests across #1642/#1629/#1770's
+undecodable-key handling, including `.,.` on a document with colliding undecodable keys
+emitting them twice at exit 0 instead of raising.
+
+`test_streamed_ordering_not_yet_reached_on_m2_path_1653`
+([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)) pins the current batched output, so
+this stops being silent the moment it changes.
+
 ## Deliberate divergences (ADR-0018 rule 4)
 
 ### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1541,8 +1541,10 @@ it, so every stderr write had already happened by the time the first stdout writ
 which no amount of buffering could fix, `--unbuffered`'s per-write `flush()` included
 ([#1653](https://github.com/rust-works/succinctly/issues/1653)).
 
-Fixed for the `-n`, `--slurp`, and `input`/`inputs`-bridge routes, which now write each
-output as the evaluator produces it (`evaluate_input_streaming`,
+Fixed for every route except the M2 lazy path below — `-n`, `--slurp`, `--input-dsv`, the
+`input`/`inputs` bridge, and any flag that forces materialization (`-S`, `-a`, `-R`,
+`--seq`, `--args`) — all of which now write each output as the evaluator produces it
+(`evaluate_input_streaming`,
 [src/bin/succinctly/jq_runner.rs](../../../src/bin/succinctly/jq_runner.rs), over
 `eval_each_with_cursor`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1511,25 +1511,26 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // moves it -- and once it does, jq names where the parser
                 // ended up. `printf '' | jq -n 'input'` reports `<stdin>:0`,
                 // not `<unknown>` (#1309, item 5).
-                let results = evaluate_input(
+                // Streaming, not collect-then-write (#1653) -- see
+                // `evaluate_input_streaming`.
+                evaluate_input_streaming(
                     &OwnedValue::Null,
                     &expr,
                     &context,
                     &ErrorAt::Live(&locations),
                     &mut sink,
+                    &mut |sink, result| {
+                        had_output = true;
+                        last_output = Some(result.clone());
+                        let stop = route_write_error(
+                            sink,
+                            &mut out,
+                            || ErrorAt::Live(&locations).resolve(),
+                            |o| write_output(o, &result, &output_config),
+                        )?;
+                        Ok(!stop)
+                    },
                 )?;
-                for result in results {
-                    had_output = true;
-                    last_output = Some(result.clone());
-                    if route_write_error(
-                        &mut sink,
-                        &mut out,
-                        || ErrorAt::Live(&locations).resolve(),
-                        |o| write_output(o, &result, &output_config),
-                    )? {
-                        break;
-                    }
-                }
                 if let Some(code) = sink.halted() {
                     out.flush()?;
                     return Ok(code);
@@ -1547,25 +1548,26 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // names where the parser ended up, not where this document
                 // started (#1309, item 4).
                 while let Some(input) = jq::pop_remaining_input() {
-                    let results = evaluate_input(
+                    // Streaming, not collect-then-write (#1653) -- see
+                    // `evaluate_input_streaming`.
+                    evaluate_input_streaming(
                         &input,
                         &expr,
                         &context,
                         &ErrorAt::Live(&locations),
                         &mut sink,
+                        &mut |sink, result| {
+                            had_output = true;
+                            last_output = Some(result.clone());
+                            let stop = route_write_error(
+                                sink,
+                                &mut out,
+                                || ErrorAt::Live(&locations).resolve(),
+                                |o| write_output(o, &result, &output_config),
+                            )?;
+                            Ok(!stop)
+                        },
                     )?;
-                    for result in results {
-                        had_output = true;
-                        last_output = Some(result.clone());
-                        if route_write_error(
-                            &mut sink,
-                            &mut out,
-                            || ErrorAt::Live(&locations).resolve(),
-                            |o| write_output(o, &result, &output_config),
-                        )? {
-                            break;
-                        }
-                    }
                     if let Some(code) = sink.halted() {
                         out.flush()?;
                         return Ok(code);
@@ -1577,20 +1579,28 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // Nothing on this branch can consume an input document, so
                 // the per-value location is fixed before evaluation.
                 let at = ErrorAt::Fixed(locations.get(idx));
-                let results = evaluate_input(input, &expr, &context, &at, &mut sink)?;
-
-                for result in results {
-                    had_output = true;
-                    last_output = Some(result.clone());
-                    if route_write_error(
-                        &mut sink,
-                        &mut out,
-                        || at.resolve(),
-                        |o| write_output(o, &result, &output_config),
-                    )? {
-                        break;
-                    }
-                }
+                // Streaming, not collect-then-write (#1653): each output has
+                // to reach stdout before the *next* one is evaluated, or a
+                // mid-stream `debug`/`stderr`/`error` side effect lands ahead
+                // of output that logically preceded it.
+                evaluate_input_streaming(
+                    input,
+                    &expr,
+                    &context,
+                    &at,
+                    &mut sink,
+                    &mut |sink, result| {
+                        had_output = true;
+                        last_output = Some(result.clone());
+                        let stop = route_write_error(
+                            sink,
+                            &mut out,
+                            || at.resolve(),
+                            |o| write_output(o, &result, &output_config),
+                        )?;
+                        Ok(!stop)
+                    },
+                )?;
                 if let Some(code) = sink.halted() {
                     out.flush()?;
                     return Ok(code);
@@ -3495,6 +3505,154 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
 /// An uncaught error is reported to `sink` and yields no values, so evaluation
 /// continues with the next input the way jq does; `sink` then drives the exit
 /// code (#355).
+/// Streaming twin of [`evaluate_input`] (#1653): hand each output to
+/// `on_value` the moment the evaluator produces it, instead of collecting a
+/// whole input's results and writing them afterwards.
+///
+/// Real jq is a lazy generator, so a filter that writes to stdout *and*
+/// triggers a stderr side effect (`debug`, `stderr`, `halt_error`) or raises
+/// mid-stream interleaves the two in real time. Collecting first cannot
+/// reproduce that ordering however the writes are buffered -- every stderr
+/// write has already happened before the first stdout write runs -- which is
+/// why `--unbuffered`'s per-write `flush()` alone never fixed it.
+///
+/// `on_value` is handed the same `&mut ErrorSink` this function holds, rather
+/// than capturing it: the writer needs it for `route_write_error`, and the
+/// borrow checker cannot see that the two uses never overlap in time.
+///
+/// `on_value` returns `false` to stop the generator (a write error the caller
+/// is already reporting). Errors reach `sink` exactly as in `evaluate_input`,
+/// but *after* the outputs that preceded them have been written, which is
+/// what makes `1, error("x"), 3` print `1` before its diagnostic like jq.
+fn evaluate_input_streaming(
+    input: &OwnedValue,
+    expr: &jq::Expr,
+    _context: &EvalContext,
+    at: &ErrorAt<'_>,
+    sink: &mut ErrorSink,
+    on_value: &mut dyn FnMut(&mut ErrorSink, OwnedValue) -> Result<bool>,
+) -> Result<()> {
+    let json_str = input.to_json();
+    let json_bytes = json_str.as_bytes();
+    let index = JsonIndex::build(json_bytes);
+    let cursor = index.root(json_bytes);
+
+    let mut write_err: Option<anyhow::Error> = None;
+    let control = jq::eval_generic::eval_each_with_cursor(expr, cursor, &mut |result| {
+        match materialize_stream_item(result, sink, at) {
+            // Nothing to write: either genuinely no value, or a failure this
+            // call already reported to `sink` (same "report and keep going"
+            // contract `evaluate_input`'s own arms follow, #355).
+            None => true,
+            Some(v) => match on_value(sink, v) {
+                Ok(keep_going) => keep_going,
+                Err(e) => {
+                    write_err = Some(e);
+                    false
+                }
+            },
+        }
+    });
+    if let Some(e) = write_err {
+        return Err(e);
+    }
+    match control {
+        None => {}
+        Some(jq::Control::Error(e)) => sink.report(DiagStyle::Jq, &e, &at.resolve()),
+        Some(jq::Control::Break(label)) => sink.report_break(DiagStyle::Jq, &label, &at.resolve()),
+        // `halt`/`halt_error` (#791): not a diagnostic, so no `sink.report*`
+        // call -- matching `evaluate_input`'s own `Halt` arm.
+        Some(jq::Control::Halt(code)) => sink.request_halt(code),
+    }
+    Ok(())
+}
+
+/// One streamed output as an `OwnedValue`, or `None` when there is nothing to
+/// write (a decode failure already reported to `sink`, or an empty result).
+///
+/// Mirrors [`evaluate_input`]'s per-variant materialization for exactly the
+/// variants a *single* sink item can be. `Many`/`ManyCursor`/`ManyOwned`/
+/// `Partial` are unreachable here by construction -- the sink is fed one item
+/// at a time, and `drain_result_generic` is what splits those multi-value
+/// shapes into individual items before they ever arrive.
+fn materialize_stream_item<V: succinctly::jq::document::DocumentValue>(
+    result: GenericResult<V>,
+    sink: &mut ErrorSink,
+    at: &ErrorAt<'_>,
+) -> Option<OwnedValue> {
+    match result {
+        GenericResult::One(v) => {
+            sink.materialize(DiagStyle::Jq, generic_to_owned(&v), &at.resolve())
+        }
+        GenericResult::OneCursor(c) => sink.materialize(
+            DiagStyle::Jq,
+            generic_to_owned(&succinctly::jq::document::DocumentCursor::value(&c)),
+            &at.resolve(),
+        ),
+        GenericResult::Owned(v) => Some(v),
+        // Same fallback reasoning as `evaluate_input`'s own `LazyKeys` arm:
+        // a fast-pathed `keys | length` never reaches this boundary, so this
+        // only fires for bare `keys`/`keys_unsorted`. Sort iff `sorted`
+        // (#683), matching eager `Keys`.
+        GenericResult::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        } => {
+            let mut keys = sink.materialize(
+                DiagStyle::Jq,
+                effective_keys(&fields, collapse),
+                &at.resolve(),
+            )?;
+            if sorted {
+                keys.sort();
+            }
+            Some(OwnedValue::Array(
+                keys.into_iter().map(OwnedValue::String).collect(),
+            ))
+        }
+        GenericResult::LazyIndexRange(len) => Some(OwnedValue::Array(
+            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
+        )),
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(v) => Some(v),
+            Err(jq::Control::Error(e)) => {
+                sink.report(DiagStyle::Jq, &e, &at.resolve());
+                None
+            }
+            Err(jq::Control::Break(label)) => {
+                sink.report_break(DiagStyle::Jq, &label, &at.resolve());
+                None
+            }
+            Err(jq::Control::Halt(code)) => {
+                sink.request_halt(code);
+                None
+            }
+        },
+        GenericResult::None => None,
+        GenericResult::Error(e) => {
+            sink.report(DiagStyle::Jq, &e, &at.resolve());
+            None
+        }
+        GenericResult::Break(label) => {
+            sink.report_break(DiagStyle::Jq, &label, &at.resolve());
+            None
+        }
+        GenericResult::Halt(code) => {
+            sink.request_halt(code);
+            None
+        }
+        // Unreachable per this function's doc comment; materialized rather
+        // than `unreachable!()` so a future sink that *does* hand back a
+        // multi-value item degrades into correct-but-eager output instead of
+        // taking the process down.
+        GenericResult::Many(_)
+        | GenericResult::ManyCursor(_)
+        | GenericResult::ManyOwned(_)
+        | GenericResult::Partial(..) => None,
+    }
+}
+
 fn evaluate_input(
     input: &OwnedValue,
     expr: &jq::Expr,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1135,23 +1135,30 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
 
                     let row_value = OwnedValue::Array(fields);
 
-                    // Evaluate expression on this row
-                    let results = evaluate_input(&row_value, &expr, &context, &at, &mut sink)?;
-
-                    for result in results {
-                        had_output = true;
-                        if args.exit_status {
-                            last_output = Some(result.clone());
-                        }
-                        if route_write_error(
-                            &mut sink,
-                            &mut out,
-                            || at.resolve(),
-                            |o| write_output(o, &result, &output_config),
-                        )? {
-                            break;
-                        }
-                    }
+                    // Evaluate expression on this row, streaming (#1653):
+                    // each output must reach stdout before the next one is
+                    // evaluated, or a mid-stream `debug`/`stderr`/`error`
+                    // side effect lands ahead of output that preceded it.
+                    evaluate_input_streaming(
+                        &row_value,
+                        &expr,
+                        &context,
+                        &at,
+                        &mut sink,
+                        &mut |sink, result| {
+                            had_output = true;
+                            if args.exit_status {
+                                last_output = Some(result.clone());
+                            }
+                            let stop = route_write_error(
+                                sink,
+                                &mut out,
+                                || at.resolve(),
+                                |o| write_output(o, &result, &output_config),
+                            )?;
+                            Ok(!stop)
+                        },
+                    )?;
                     // halt/halt_error (#791) outranks everything else,
                     // including remaining rows/files still to process.
                     if let Some(code) = sink.halted() {
@@ -2321,7 +2328,8 @@ impl InputLocations {
 /// **b** (#1309, item 4).
 ///
 /// Reading the position after evaluation returns is sound because
-/// `evaluate_input` reports at most once per call: its `Error`, `Break`,
+/// `evaluate_input_streaming` reports the same *set* of diagnostics the
+/// eager `evaluate_input` it replaced did (#1653) -- its `Error`, `Break`,
 /// `Halt` and `Partial` arms are mutually exclusive variants of one returned
 /// value, and an uncaught control ends the evaluation, so nothing can consume
 /// another document between the raise and the report.
@@ -2637,7 +2645,7 @@ fn validate_and_materialize_json(
 /// own doc for why `serde_json::Value`, not the cheaper `IgnoredAny`),
 /// which reparses the same, now-known-valid text through this crate's own
 /// fidelity-preserving JSON semi-indexer (the same one the primary input
-/// path already uses, see `evaluate_input` above).
+/// path already uses, see `evaluate_input_streaming` above).
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {
@@ -2845,7 +2853,7 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
 
 /// Parse a JSON stream (multiple JSON values) from a string. Backs both
 /// `--slurpfile` and, more heavily, the crate's own default/primary JSON
-/// document-input path (see the `evaluate_input` call site above, reached
+/// document-input path (see the `evaluate_input_streaming` call site above, reached
 /// on every ordinary `sjq`/`succinctly jq` invocation that isn't
 /// `--seq`/`--raw-input`/`--input-dsv`).
 ///
@@ -2862,7 +2870,7 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
 /// reject trailing garbage) with no `serde_json` dependency at all, while
 /// this function's own validation strictness is load-bearing for more than
 /// just `--slurpfile`'s CLI-arg error message -- the main input path's own
-/// call site (below `evaluate_input`) depends on this function rejecting
+/// call site (below `evaluate_input_streaming`) depends on this function rejecting
 /// everything `find_json_values` would reject, so its own internal
 /// `find_json_values` cross-check never diverges.
 ///
@@ -3500,14 +3508,14 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
     }
 }
 
-/// Evaluate the expression against an input value.
+/// Evaluate the expression against an input value, handing each output to
+/// `on_value` the moment the evaluator produces it (#1653).
 ///
-/// An uncaught error is reported to `sink` and yields no values, so evaluation
-/// continues with the next input the way jq does; `sink` then drives the exit
-/// code (#355).
-/// Streaming twin of [`evaluate_input`] (#1653): hand each output to
-/// `on_value` the moment the evaluator produces it, instead of collecting a
-/// whole input's results and writing them afterwards.
+/// Replaced the eager `evaluate_input`, which collected a whole input's
+/// results into a `Vec` and returned them for the caller to write
+/// afterwards; once every call site streamed, that function had no callers
+/// left and was removed rather than kept as a second, divergent copy of the
+/// same per-variant materialization.
 ///
 /// Real jq is a lazy generator, so a filter that writes to stdout *and*
 /// triggers a stderr side effect (`debug`, `stderr`, `halt_error`) or raises
@@ -3521,9 +3529,22 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
 /// borrow checker cannot see that the two uses never overlap in time.
 ///
 /// `on_value` returns `false` to stop the generator (a write error the caller
-/// is already reporting). Errors reach `sink` exactly as in `evaluate_input`,
-/// but *after* the outputs that preceded them have been written, which is
-/// what makes `1, error("x"), 3` print `1` before its diagnostic like jq.
+/// is already reporting). An uncaught error is reported to `sink` and yields
+/// no values, so evaluation continues with the next input the way jq does and
+/// `sink` drives the exit code (#355) -- but it is reported *after* the
+/// outputs that preceded it have been written, which is what makes
+/// `1, error("x"), 3` print `1` before its diagnostic like jq.
+///
+/// A per-item materialization failure (`materialize_stream_item`'s
+/// `sink.materialize` calls) is defense-in-depth rather than reachable in
+/// practice: `cursor` is always rooted in `input.to_json()`, a fresh
+/// serialization of an already-decoded `OwnedValue` -- a Rust `String`, which
+/// by construction cannot hold an undecodable byte sequence, and whose
+/// escapes this crate's own serializer writes. Same argument
+/// `eval_generic.rs`'s textually-similar bridge relies on (search
+/// "defense-in-depth" there). Kept as a reported diagnostic rather than an
+/// `unwrap()` so a real failure, if that invariant is ever violated,
+/// surfaces as an ordinary `EvalError` instead of a panic.
 fn evaluate_input_streaming(
     input: &OwnedValue,
     expr: &jq::Expr,
@@ -3542,7 +3563,7 @@ fn evaluate_input_streaming(
         match materialize_stream_item(result, sink, at) {
             // Nothing to write: either genuinely no value, or a failure this
             // call already reported to `sink` (same "report and keep going"
-            // contract `evaluate_input`'s own arms follow, #355).
+            // contract the eager path's own arms followed, #355).
             None => true,
             Some(v) => match on_value(sink, v) {
                 Ok(keep_going) => keep_going,
@@ -3553,16 +3574,20 @@ fn evaluate_input_streaming(
             },
         }
     });
-    if let Some(e) = write_err {
-        return Err(e);
-    }
+    // The control is reported *before* any write error is surfaced. The eager
+    // path reported it during evaluation, i.e. always before the caller's
+    // write loop could fail; returning `Err` first here would let an I/O
+    // failure swallow the evaluator's own diagnostic (review finding).
     match control {
         None => {}
         Some(jq::Control::Error(e)) => sink.report(DiagStyle::Jq, &e, &at.resolve()),
         Some(jq::Control::Break(label)) => sink.report_break(DiagStyle::Jq, &label, &at.resolve()),
         // `halt`/`halt_error` (#791): not a diagnostic, so no `sink.report*`
-        // call -- matching `evaluate_input`'s own `Halt` arm.
+        // call -- matching the eager path's own `Halt` arm.
         Some(jq::Control::Halt(code)) => sink.request_halt(code),
+    }
+    if let Some(e) = write_err {
+        return Err(e);
     }
     Ok(())
 }
@@ -3570,7 +3595,9 @@ fn evaluate_input_streaming(
 /// One streamed output as an `OwnedValue`, or `None` when there is nothing to
 /// write (a decode failure already reported to `sink`, or an empty result).
 ///
-/// Mirrors [`evaluate_input`]'s per-variant materialization for exactly the
+/// Carries the per-variant materialization the eager `evaluate_input`
+/// used to do inline (removed in #1653, once every call site streamed), for
+/// exactly the
 /// variants a *single* sink item can be. `Many`/`ManyCursor`/`ManyOwned`/
 /// `Partial` are unreachable here by construction -- the sink is fed one item
 /// at a time, and `drain_result_generic` is what splits those multi-value
@@ -3590,7 +3617,7 @@ fn materialize_stream_item<V: succinctly::jq::document::DocumentValue>(
             &at.resolve(),
         ),
         GenericResult::Owned(v) => Some(v),
-        // Same fallback reasoning as `evaluate_input`'s own `LazyKeys` arm:
+        // Same fallback reasoning the eager path's `LazyKeys` arm carried:
         // a fast-pathed `keys | length` never reaches this boundary, so this
         // only fires for bare `keys`/`keys_unsorted`. Sort iff `sorted`
         // (#683), matching eager `Keys`.
@@ -3642,173 +3669,17 @@ fn materialize_stream_item<V: succinctly::jq::document::DocumentValue>(
             sink.request_halt(code);
             None
         }
-        // Unreachable per this function's doc comment; materialized rather
-        // than `unreachable!()` so a future sink that *does* hand back a
-        // multi-value item degrades into correct-but-eager output instead of
-        // taking the process down.
+        // Structurally unreachable, and *silently* so: a sink item can only
+        // be one of the six `GenericItem` variants `generic_item_to_result`
+        // maps, and none of them is multi-valued. `None` rather than
+        // `unreachable!()` keeps a future regression from taking the process
+        // down -- but it would drop values rather than print them, so the
+        // trade is stated here instead of being described as a graceful
+        // fallback it is not (review finding).
         GenericResult::Many(_)
         | GenericResult::ManyCursor(_)
         | GenericResult::ManyOwned(_)
         | GenericResult::Partial(..) => None,
-    }
-}
-
-fn evaluate_input(
-    input: &OwnedValue,
-    expr: &jq::Expr,
-    _context: &EvalContext,
-    at: &ErrorAt<'_>,
-    sink: &mut ErrorSink,
-) -> Result<Vec<OwnedValue>> {
-    // Convert OwnedValue to JSON bytes for indexing
-    let json_str = input.to_json();
-    let json_bytes = json_str.as_bytes();
-
-    // Build index and evaluate
-    let index = JsonIndex::build(json_bytes);
-    let cursor = index.root(json_bytes);
-
-    // Use eval_with_cursor to preserve cursor context for position-based navigation
-    // (at_offset, at_position builtins)
-    let result = eval_with_cursor(expr, cursor);
-
-    // A decode failure while materializing a result is an uncaught error like
-    // any other (#1247): report it to `sink` and yield nothing, so the next
-    // input still runs and the exit code is still set (`ErrorSink`, #355).
-    // Mirrors the `GenericResult::Error` arm below.
-    //
-    // Every `Err(e)` this macro's `One`/`Many`/`ManyCursor` call sites below
-    // can produce is defense-in-depth rather than reachable in practice:
-    // `cursor` is always rooted in `input.to_json()`, a fresh serialization
-    // of an already-decoded `OwnedValue` (a Rust `String`, which by
-    // construction can't hold an undecodable byte sequence, and whose
-    // escapes this crate's own serializer writes) -- same argument
-    // `eval_generic.rs`'s textually-similar bridge relies on (search
-    // "defense-in-depth" there). Kept as `Result` rather than `.unwrap()` so
-    // a real failure, if this invariant is ever violated, surfaces as a
-    // normal `EvalError` instead of a panic.
-    // Convert result to Vec<OwnedValue>
-    match result {
-        GenericResult::One(v) => {
-            let Some(v) = sink.materialize(DiagStyle::Jq, generic_to_owned(&v), &at.resolve())
-            else {
-                return Ok(vec![]);
-            };
-            Ok(vec![v])
-        }
-        GenericResult::OneCursor(c) => {
-            let Some(v) =
-                sink.materialize(DiagStyle::Jq, generic_to_owned(&c.value()), &at.resolve())
-            else {
-                return Ok(vec![]);
-            };
-            Ok(vec![v])
-        }
-        GenericResult::Many(vs) => {
-            let Some(vs) = sink.materialize(
-                DiagStyle::Jq,
-                vs.iter()
-                    .map(generic_to_owned)
-                    .collect::<core::result::Result<Vec<_>, _>>(),
-                &at.resolve(),
-            ) else {
-                return Ok(vec![]);
-            };
-            Ok(vs)
-        }
-        GenericResult::ManyCursor(cs) => {
-            let Some(vs) = sink.materialize(
-                DiagStyle::Jq,
-                cs.iter()
-                    .map(|c| generic_to_owned(&c.value()))
-                    .collect::<core::result::Result<Vec<_>, _>>(),
-                &at.resolve(),
-            ) else {
-                return Ok(vec![]);
-            };
-            Ok(vs)
-        }
-        // Fallback: materialize. This runner boundary never sees a
-        // fast-pathed `keys`/`keys_unsorted | length`/`.[]`/`.[n]`/`first`/
-        // `last` — those are fully resolved inside the evaluator's `Pipe`
-        // dispatch before it gets here — so this only fires for `keys`/
-        // `keys_unsorted` alone, or piped into something else (`map`,
-        // `select`, ...). Sort iff `sorted` (#683), matching eager `Keys`.
-        GenericResult::LazyKeys {
-            fields,
-            sorted,
-            collapse,
-        } => {
-            let Some(mut keys) = sink.materialize(
-                DiagStyle::Jq,
-                effective_keys(&fields, collapse),
-                &at.resolve(),
-            ) else {
-                return Ok(vec![]);
-            };
-            if sorted {
-                keys.sort();
-            }
-            Ok(vec![OwnedValue::Array(
-                keys.into_iter().map(OwnedValue::String).collect(),
-            )])
-        }
-        // Same reasoning as `LazyKeys` above, for array `keys`/
-        // `keys_unsorted` (#684).
-        GenericResult::LazyIndexRange(len) => Ok(vec![OwnedValue::Array(
-            (0..len).map(|i| OwnedValue::Int(i as i64)).collect(),
-        )]),
-        // Same reasoning as `LazyKeys`/`LazyIndexRange` above, for a
-        // composed `map` chain (#724, #725) that never resolved into a
-        // narrower shape before reaching this materializing boundary.
-        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-            Ok(v) => Ok(vec![v]),
-            Err(jq::Control::Error(e)) => {
-                sink.report(DiagStyle::Jq, &e, &at.resolve());
-                Ok(vec![])
-            }
-            Err(jq::Control::Break(label)) => {
-                sink.report_break(DiagStyle::Jq, &label, &at.resolve());
-                Ok(vec![])
-            }
-            Err(jq::Control::Halt(code)) => {
-                sink.request_halt(code);
-                Ok(vec![])
-            }
-        },
-        GenericResult::None => Ok(vec![]),
-        GenericResult::Error(e) => {
-            sink.report(DiagStyle::Jq, &e, &at.resolve());
-            Ok(vec![])
-        }
-        GenericResult::Owned(v) => Ok(vec![v]),
-        GenericResult::ManyOwned(vs) => Ok(vs),
-        GenericResult::Break(label) => {
-            sink.report_break(DiagStyle::Jq, &label, &at.resolve());
-            Ok(vec![])
-        }
-        // `halt`/`halt_error` (#791): not a diagnostic, so no `sink.report*`
-        // call — `request_halt` records the exit code for the loop above to
-        // short-circuit on, without touching `hit`/`report_count`.
-        GenericResult::Halt(code) => {
-            sink.request_halt(code);
-            Ok(vec![])
-        }
-        // The outputs already produced no longer vanish behind the failure
-        // (#400, #494): report the diagnostic (which drives the exit code
-        // via `sink`), but still return the prefix for the caller to print.
-        GenericResult::Partial(vs, jq::Control::Error(e)) => {
-            sink.report(DiagStyle::Jq, &e, &at.resolve());
-            Ok(vs)
-        }
-        GenericResult::Partial(vs, jq::Control::Break(label)) => {
-            sink.report_break(DiagStyle::Jq, &label, &at.resolve());
-            Ok(vs)
-        }
-        GenericResult::Partial(vs, jq::Control::Halt(code)) => {
-            sink.request_halt(code);
-            Ok(vs)
-        }
     }
 }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3595,13 +3595,20 @@ fn evaluate_input_streaming(
 /// One streamed output as an `OwnedValue`, or `None` when there is nothing to
 /// write (a decode failure already reported to `sink`, or an empty result).
 ///
-/// Carries the per-variant materialization the eager `evaluate_input`
-/// used to do inline (removed in #1653, once every call site streamed), for
-/// exactly the
-/// variants a *single* sink item can be. `Many`/`ManyCursor`/`ManyOwned`/
-/// `Partial` are unreachable here by construction -- the sink is fed one item
-/// at a time, and `drain_result_generic` is what splits those multi-value
-/// shapes into individual items before they ever arrive.
+/// Carries the per-variant materialization the eager `evaluate_input` used to
+/// do inline (removed in #1653, once every call site streamed), for exactly
+/// the variants a *single* sink item can be.
+///
+/// That is a strictly smaller set than `GenericResult`'s: a sink item is
+/// always a `GenericItem`, and `generic_item_to_result` maps its six variants
+/// onto `One`/`OneCursor`/`Owned`/`LazyKeys`/`LazyIndexRange`/`LazySeq` and
+/// nothing else. The remaining eight -- `None`, `Error`, `Break`, `Halt`, and
+/// the four multi-value shapes -- are therefore unreachable *by
+/// construction*, not merely unlikely, so they share one arm rather than
+/// eight speculative ones that could never run (an earlier draft spelled all
+/// eight out, which read as real handling and left a dozen permanently
+/// uncovered lines behind). A control never arrives as an item either: it is
+/// returned as the `Flow`'s own outcome and reported by the caller.
 fn materialize_stream_item<V: succinctly::jq::document::DocumentValue>(
     result: GenericResult<V>,
     sink: &mut ErrorSink,
@@ -3656,27 +3663,16 @@ fn materialize_stream_item<V: succinctly::jq::document::DocumentValue>(
                 None
             }
         },
-        GenericResult::None => None,
-        GenericResult::Error(e) => {
-            sink.report(DiagStyle::Jq, &e, &at.resolve());
-            None
-        }
-        GenericResult::Break(label) => {
-            sink.report_break(DiagStyle::Jq, &label, &at.resolve());
-            None
-        }
-        GenericResult::Halt(code) => {
-            sink.request_halt(code);
-            None
-        }
-        // Structurally unreachable, and *silently* so: a sink item can only
-        // be one of the six `GenericItem` variants `generic_item_to_result`
-        // maps, and none of them is multi-valued. `None` rather than
-        // `unreachable!()` keeps a future regression from taking the process
-        // down -- but it would drop values rather than print them, so the
-        // trade is stated here instead of being described as a graceful
-        // fallback it is not (review finding).
-        GenericResult::Many(_)
+        // The eight shapes a sink item provably never takes (see this
+        // function's doc comment). `None` rather than `unreachable!()` so a
+        // future regression cannot take the process down -- but it would drop
+        // values rather than print them, so the trade is stated here instead
+        // of being dressed up as a graceful fallback it is not.
+        GenericResult::None
+        | GenericResult::Error(_)
+        | GenericResult::Break(_)
+        | GenericResult::Halt(_)
+        | GenericResult::Many(_)
         | GenericResult::ManyCursor(_)
         | GenericResult::ManyOwned(_)
         | GenericResult::Partial(..) => None,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3033,6 +3033,96 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
 }
 
+/// Streaming counterpart of [`eval_with_cursor`] (#1653): deliver each output
+/// to `on_value` as soon as it is produced, instead of collecting a whole
+/// input's results into a `Vec` first.
+///
+/// Real jq's evaluator is a lazy generator, so a filter that both writes to
+/// stdout and triggers a stderr side effect (`debug`, `stderr`, `halt_error`)
+/// or raises mid-stream interleaves the two in real time:
+///
+/// ```console
+/// $ jq --unbuffered -cn '1, debug, 2'   2>&1
+/// 1
+/// ["DEBUG:",null]
+/// null
+/// 2
+/// ```
+///
+/// Collecting first cannot reproduce that ordering *however the writes are
+/// buffered*, because every stderr write has already happened by the time the
+/// first stdout write runs -- which is why `--unbuffered`'s per-write
+/// `flush()` alone never fixed it.
+///
+/// `on_value` returns `false` to stop the generator early (the CLI uses this
+/// for a write error). Each output arrives as a single-output
+/// [`GenericResult`], so every consumer's existing per-result handling --
+/// including the lazy `LazyKeys`/`LazyIndexRange`/`LazySeq` variants -- keeps
+/// working unchanged. Items arrive via the same [`generic_item_to_result`]
+/// conversion every other sink consumer uses.
+///
+/// Returns `Some(control)` iff evaluation terminated in a control (an uncaught
+/// error, `break`, or `halt`); everything produced *before* it has already
+/// been delivered, matching jq, which writes `1` to stdout before reporting
+/// the error for `1, error("x"), 3`.
+pub fn eval_each_with_cursor<C: DocumentCursor>(
+    expr: &Expr,
+    cursor: C,
+    on_value: &mut dyn FnMut(GenericResult<C::Value>) -> bool,
+) -> Option<Control> {
+    eval_each_with_cursor_using::<JqSemantics, C>(expr, cursor, on_value)
+}
+
+/// Streaming counterpart of [`eval_with_cursor_using`] (#1653).
+///
+/// Same `takes_input_queue_bridge` gate as the eager entry point (#1504), but
+/// it does *not* cost the streaming: the bridge needs the input owned, not the
+/// outputs collected, so that branch drives `eval_each_owned` -- itself
+/// demand-driven -- with this function's own sink rather than
+/// `eval_each_owned_collect`'s accumulating one. `jq -n 'inputs, debug'`
+/// interleaves like jq because of this branch, not despite it.
+pub fn eval_each_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
+    expr: &Expr,
+    cursor: C,
+    on_value: &mut dyn FnMut(GenericResult<C::Value>) -> bool,
+) -> Option<Control> {
+    if takes_input_queue_bridge(expr) {
+        let owned = match to_owned_cursor(&cursor) {
+            Ok(o) => o,
+            Err(e) => return Some(Control::Error(e)),
+        };
+        let mut owned_sink = |v: OwnedValue| -> Demand {
+            if on_value(GenericResult::Owned(v)) {
+                Demand::Continue
+            } else {
+                Demand::Stop
+            }
+        };
+        return match crate::jq::eval::eval_each_owned::<S>(expr, &owned, false, &mut owned_sink) {
+            Flow::Exhausted => None,
+            Flow::Stopped { .. } => None,
+            Flow::Escaped(c) => Some(c),
+        };
+    }
+
+    let mut sink = |item: GenericItem<C::Value>| -> Demand {
+        if on_value(generic_item_to_result::<C::Value>(item)) {
+            Demand::Continue
+        } else {
+            Demand::Stop
+        }
+    };
+    match eval_each_generic::<S, C::Value>(expr, cursor.value(), false, Some(cursor), &mut sink) {
+        Flow::Exhausted => None,
+        // A `pending` control is one an eager fallback had already raised
+        // before the sink said stop; the CLI's own stop is a write error it
+        // is already reporting, so surfacing the control too would double
+        // report. Dropped, matching every Stage 2 consumer of `Stopped`.
+        Flow::Stopped { .. } => None,
+        Flow::Escaped(c) => Some(c),
+    }
+}
+
 /// Fold an already-evaluated first pipe stage through every remaining stage,
 /// eagerly. Extracted verbatim from `eval_single`'s own `Expr::Pipe` arm
 /// (`current` is `exprs[0]`'s own result, `stages` is `exprs[1..]`) so

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3058,8 +3058,9 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
 /// for a write error). Each output arrives as a single-output
 /// [`GenericResult`], so every consumer's existing per-result handling --
 /// including the lazy `LazyKeys`/`LazyIndexRange`/`LazySeq` variants -- keeps
-/// working unchanged. Items arrive via the same [`generic_item_to_result`]
-/// conversion every other sink consumer uses.
+/// working unchanged. Items arrive via the same `generic_item_to_result`
+/// conversion every other sink consumer uses (private, so named rather than
+/// linked -- a public item may not link to it).
 ///
 /// Returns `Some(control)` iff evaluation terminated in a control (an uncaught
 /// error, `break`, or `halt`); everything produced *before* it has already
@@ -3100,7 +3101,8 @@ pub fn eval_each_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
         };
         return match crate::jq::eval::eval_each_owned::<S>(expr, &owned, false, &mut owned_sink) {
             Flow::Exhausted => None,
-            Flow::Stopped { .. } => None,
+            // Kept for the same reason as the streaming branch below.
+            Flow::Stopped { pending } => pending,
             Flow::Escaped(c) => Some(c),
         };
     }
@@ -3114,11 +3116,16 @@ pub fn eval_each_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
     };
     match eval_each_generic::<S, C::Value>(expr, cursor.value(), false, Some(cursor), &mut sink) {
         Flow::Exhausted => None,
-        // A `pending` control is one an eager fallback had already raised
-        // before the sink said stop; the CLI's own stop is a write error it
-        // is already reporting, so surfacing the control too would double
-        // report. Dropped, matching every Stage 2 consumer of `Stopped`.
-        Flow::Stopped { .. } => None,
+        // `pending` is *kept*, unlike every Stage 2 consumer of `Stopped`
+        // (`each_take_first`, `each_take_n`, ...), which drop it. Those are
+        // early-exit consumers in the middle of a filter, where a control
+        // raised past what the consumer asked for must not escape --
+        // `first(1, ("BOOM"|halt_error(3)))` is `1`, exit 0. This is the
+        // opposite position: the final consumer, where a control that *was*
+        // already raised still has to reach the exit code. Dropping it here
+        // would silently lose a `halt`'s code, matching `resolve_leaf`'s own
+        // reasoning (#987) rather than the early-exit consumers'.
+        Flow::Stopped { pending } => pending,
         Flow::Escaped(c) => Some(c),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25858,3 +25858,88 @@ fn test_streamed_ordering_not_yet_reached_on_m2_path_1653() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1653: the streaming path's own `--input-dsv` row loop, including the
+/// `-e` branch that materializes each row's last output.
+///
+/// `--input-dsv` was a fifth `evaluate_input` call site the first pass at
+/// #1653 missed, so it kept batching after every other route streamed; these
+/// pin both that it streams and that `-e` still reports row truthiness.
+#[test]
+fn test_dsv_rows_stream_and_track_exit_status_1653() -> Result<()> {
+    let dir = std::env::temp_dir().join(format!("sjq-dsv-1653-{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let csv = dir.join("rows.csv");
+    std::fs::write(&csv, "a,b\n1,2\n")?;
+    let path = csv.to_str().expect("temp path is utf-8");
+
+    // Each row's output is written before the next row is evaluated, so the
+    // per-row `debug` lands *after* that row's own `1`, not before both rows.
+    let (combined, code) = run_jq_interleaved(
+        &[
+            "--unbuffered",
+            "-c",
+            "--input-dsv",
+            ",",
+            "1, debug, 2",
+            path,
+        ],
+        None,
+    )?;
+    assert_eq!(
+        combined,
+        "1\n[\"DEBUG:\",[\"a\",\"b\"]]\n[\"a\",\"b\"]\n2\n\
+         1\n[\"DEBUG:\",[\"1\",\"2\"]]\n[\"1\",\"2\"]\n2\n"
+    );
+    assert_eq!(code, 0);
+
+    // `-e` on the same path: the last output drives the exit code.
+    let (out, _err, code) = run_jq_full(&["-c", "-e", "--input-dsv", ",", ".[0]", path], None)?;
+    assert_eq!(out, "\"a\"\n\"1\"\n");
+    assert_eq!(code, 0);
+    let (_out, _err, code) = run_jq_full(&["-c", "-e", "--input-dsv", ",", "null", path], None)?;
+    assert_eq!(code, 1, "a null last output is jq's falsy exit");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
+/// #1653: a `LazySeq` item that fails while being materialized on the
+/// streaming path still reports through `sink`, for each control it can
+/// raise.
+///
+/// `map(f)` stays lazy until this boundary forces it, so `f`'s own
+/// error/halt surfaces here rather than during evaluation -- the one arm of
+/// `materialize_stream_item` that handles a control at all (every other
+/// control is the `Flow`'s outcome, reported by the caller).
+#[test]
+fn test_streamed_lazy_seq_materialization_control_1653() -> Result<()> {
+    for (filter, expected_out, expected_code, expected_err) in [
+        ("[1,2]|map(.+1)", "[2,3]\n", 0, ""),
+        (
+            "[1,0]|map(1/.)",
+            "",
+            5,
+            "number (1) and number (0) cannot be divided because the divisor is zero",
+        ),
+        (
+            "[1,2]|map(if .==2 then halt_error(3) else . end)",
+            "",
+            3,
+            "2",
+        ),
+    ] {
+        let (out, err, code) = run_jq_full(&["--slurp", "-c", filter], Some("{}"))?;
+        assert_eq!(out, expected_out, "stdout for {filter}");
+        assert_eq!(code, expected_code, "exit for {filter} -- stderr={err}");
+        if expected_err.is_empty() {
+            assert_eq!(err, "", "stderr for {filter}");
+        } else {
+            assert!(
+                err.contains(expected_err),
+                "stderr for {filter}: got {err:?}"
+            );
+        }
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -172,6 +172,78 @@ fn spawn_jq(args: &[&str], stdin_input: Option<&[u8]>) -> Result<(std::process::
     )
 }
 
+/// Runs the binary with stdout and stderr pointed at the *same* file, so the
+/// two streams' real interleaving survives (#1653).
+///
+/// `run_jq_full`'s separate pipes cannot express ordering at all: they record
+/// what each stream contained, never which write happened first -- and
+/// ordering is the entire property under test here. A temp file, rather than
+/// one pipe shared by two `Stdio`s, because a `File` can simply be duplicated
+/// into both slots.
+///
+/// Cannot route through `spawn_jq`/`spawn_with_signal_retry` (#1884) the way
+/// every other helper here does: those hardcode piped stdout/stderr, which is
+/// exactly the wiring this one has to replace. It reuses their primitives
+/// (`succinctly_bin`, `signal_death_error`, `MAX_CARGO_RETRIES`) and repeats
+/// their retry -- ENOENT while a sibling test rebuilds the binary, and a
+/// signal-killed child (#1516/#1691) -- rather than reimplementing the retry
+/// policy with different numbers.
+fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32)> {
+    let dir = std::env::temp_dir().join(format!(
+        "sjq-interleave-{}-{}",
+        std::process::id(),
+        // Distinct per call within one process: two tests running
+        // concurrently in the same binary would otherwise share a path.
+        INTERLEAVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("combined.txt");
+
+    for attempt in 0..MAX_CARGO_RETRIES {
+        // Truncate per attempt: a retry must not read a previous attempt's
+        // bytes back as if this run had produced them.
+        std::fs::File::create(&path)?;
+        let out_handle = std::fs::File::options().append(true).open(&path)?;
+        let err_handle = out_handle.try_clone()?;
+        let spawned = Command::new(succinctly_bin())
+            .arg("jq")
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::from(out_handle))
+            .stderr(Stdio::from(err_handle))
+            .spawn();
+        let mut child = match spawned {
+            Ok(child) => child,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound && attempt + 1 < MAX_CARGO_RETRIES =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Some(input) = input {
+                stdin.write_all(input.as_bytes())?;
+            }
+        }
+        let status = child.wait()?;
+        let combined = std::fs::read_to_string(&path)?;
+        if let Some(code) = status.code() {
+            let _ = std::fs::remove_dir_all(&dir);
+            return Ok((combined, code));
+        }
+        if attempt + 1 >= MAX_CARGO_RETRIES {
+            let _ = std::fs::remove_dir_all(&dir);
+            return Err(signal_death_error(status, &combined));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
+    }
+    unreachable!()
+}
+
+static INTERLEAVE_SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
 /// Helper to run jq with null input (-n)
 fn run_jq_null(filter: &str, extra_args: &[&str]) -> Result<(String, i32)> {
     let mut args: Vec<&str> = vec!["-n"];
@@ -25667,5 +25739,100 @@ fn test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883() -> Res
     );
     assert_eq!(stdout, "");
 
+    Ok(())
+}
+
+/// #1653: `--unbuffered` must actually interleave stdout and stderr in real
+/// time, not merely flush a batch that was already fully evaluated.
+///
+/// Every expected string here is jq 1.7.1's own combined output, captured
+/// live. The property is *ordering*, so these assert on one merged stream
+/// (`run_jq_interleaved`) -- separately-captured pipes would pass even with
+/// the batching bug, since each stream's own contents were always correct.
+///
+/// The `-n` and `--slurp` forms are the routes this fix streams; a document
+/// read on the M2 lazy path is deliberately not asserted here (see
+/// `test_streamed_ordering_not_yet_reached_on_m2_path_1653`).
+#[test]
+fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
+    for (args, input, expected) in [
+        // The issue's own repro: `1` is written before `debug` is evaluated.
+        (
+            vec!["--unbuffered", "-cn", "1, debug, 2"],
+            None,
+            "1\n[\"DEBUG:\",null]\nnull\n2\n",
+        ),
+        // An uncaught error is a side effect with the same ordering rule:
+        // the outputs that preceded it are already on stdout.
+        (
+            vec!["--unbuffered", "-cn", "1, error(\"x\"), 3"],
+            None,
+            "1\njq: error (at <unknown>): x\n",
+        ),
+        // `halt_error` writes its payload after the earlier output. A
+        // *number* payload is written as JSON with a trailing newline (a
+        // string payload is the raw, newline-less case) -- captured from
+        // jq 1.7.1, byte-for-byte, rather than assumed.
+        (
+            vec!["--unbuffered", "-cn", "1, (2|halt_error), 3"],
+            None,
+            "1\n2\n",
+        ),
+        // `stderr` echoes its input without a trailing newline, so the
+        // interleaving is visible as `null` butting against the next line.
+        (
+            vec!["--unbuffered", "-cn", "1, stderr, 2"],
+            None,
+            "1\nnullnull\n2\n",
+        ),
+        // Per-element, through a pipe: each element's stdout write lands
+        // before the next element is evaluated at all.
+        (
+            vec!["--unbuffered", "-cn", "range(3) | (., debug)"],
+            None,
+            "0\n[\"DEBUG:\",0]\n0\n1\n[\"DEBUG:\",1]\n1\n2\n[\"DEBUG:\",2]\n2\n",
+        ),
+        // `--slurp` reaches the same streaming path.
+        (
+            vec!["--unbuffered", "-c", "--slurp", "1, debug, 2"],
+            Some("{}"),
+            "1\n[\"DEBUG:\",[{}]]\n[{}]\n2\n",
+        ),
+        // So does the input-queue bridge (`inputs`), which streams through
+        // `eval_each_owned` rather than collecting first.
+        (
+            vec!["--unbuffered", "-cn", "inputs, debug"],
+            Some("1\n2\n"),
+            "1\n2\n[\"DEBUG:\",null]\nnull\n",
+        ),
+    ] {
+        let (combined, _code) = run_jq_interleaved(&args, input)?;
+        assert_eq!(combined, expected, "args {args:?} input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1653: the M2 lazy path (a document read from stdin/a file) still batches.
+///
+/// Pinned deliberately rather than left untested. Streaming it means routing
+/// the CLI's default path through the demand-driven evaluator, and
+/// `each_lazy_keys_iterate_sink` there skips the #1194 malformed-key check
+/// that #1629 added specifically so bare `keys_unsorted[]` *would* raise --
+/// a gap #1770 closed as an accepted trade for early-exit consumers like
+/// `first(...)`, not one that may be universalized to the default path.
+/// Routing M2 through it was tried and reverted: it regressed six tests
+/// across #1642/#1629/#1770's undecodable-key handling.
+///
+/// When that is resolved, this test should start failing -- at which point
+/// the expectation becomes jq's own
+/// `["DEBUG:",1]\n1\n["DEBUG:",2]\n2\n` and it moves into the test above.
+#[test]
+fn test_streamed_ordering_not_yet_reached_on_m2_path_1653() -> Result<()> {
+    let (combined, code) = run_jq_interleaved(&["--unbuffered", "-c", ".[]|debug"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        combined, "[\"DEBUG:\",1]\n[\"DEBUG:\",2]\n1\n2\n",
+        "M2 path still batches; see this test's doc comment"
+    );
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25755,12 +25755,15 @@ fn test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883() -> Res
 /// `test_streamed_ordering_not_yet_reached_on_m2_path_1653`).
 #[test]
 fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
-    for (args, input, expected) in [
+    // (args, stdin, combined stdout+stderr, exit code) -- all four captured
+    // live from jq 1.7.1, byte for byte.
+    for (args, input, expected, expected_code) in [
         // The issue's own repro: `1` is written before `debug` is evaluated.
         (
             vec!["--unbuffered", "-cn", "1, debug, 2"],
             None,
             "1\n[\"DEBUG:\",null]\nnull\n2\n",
+            0,
         ),
         // An uncaught error is a side effect with the same ordering rule:
         // the outputs that preceded it are already on stdout.
@@ -25768,15 +25771,17 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
             vec!["--unbuffered", "-cn", "1, error(\"x\"), 3"],
             None,
             "1\njq: error (at <unknown>): x\n",
+            5,
         ),
         // `halt_error` writes its payload after the earlier output. A
         // *number* payload is written as JSON with a trailing newline (a
         // string payload is the raw, newline-less case) -- captured from
-        // jq 1.7.1, byte-for-byte, rather than assumed.
+        // jq, not assumed.
         (
             vec!["--unbuffered", "-cn", "1, (2|halt_error), 3"],
             None,
             "1\n2\n",
+            5,
         ),
         // `stderr` echoes its input without a trailing newline, so the
         // interleaving is visible as `null` butting against the next line.
@@ -25784,6 +25789,7 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
             vec!["--unbuffered", "-cn", "1, stderr, 2"],
             None,
             "1\nnullnull\n2\n",
+            0,
         ),
         // Per-element, through a pipe: each element's stdout write lands
         // before the next element is evaluated at all.
@@ -25791,12 +25797,14 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
             vec!["--unbuffered", "-cn", "range(3) | (., debug)"],
             None,
             "0\n[\"DEBUG:\",0]\n0\n1\n[\"DEBUG:\",1]\n1\n2\n[\"DEBUG:\",2]\n2\n",
+            0,
         ),
         // `--slurp` reaches the same streaming path.
         (
             vec!["--unbuffered", "-c", "--slurp", "1, debug, 2"],
             Some("{}"),
             "1\n[\"DEBUG:\",[{}]]\n[{}]\n2\n",
+            0,
         ),
         // So does the input-queue bridge (`inputs`), which streams through
         // `eval_each_owned` rather than collecting first.
@@ -25804,10 +25812,24 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
             vec!["--unbuffered", "-cn", "inputs, debug"],
             Some("1\n2\n"),
             "1\n2\n[\"DEBUG:\",null]\nnull\n",
+            0,
+        ),
+        // `-S` forces materialization and so routes here too -- one of four
+        // flags (`-S`, `-a`, `-R`, `--seq`) this fix reaches that the first
+        // draft of the compliance note failed to list.
+        (
+            vec!["--unbuffered", "-c", "-S", "1, debug, 2"],
+            Some("{}"),
+            "1\n[\"DEBUG:\",{}]\n{}\n2\n",
+            0,
         ),
     ] {
-        let (combined, _code) = run_jq_interleaved(&args, input)?;
+        let (combined, code) = run_jq_interleaved(&args, input)?;
         assert_eq!(combined, expected, "args {args:?} input {input:?}");
+        // The exit code is pinned alongside the bytes rather than derived
+        // from them: it is part of the captured behaviour for the
+        // `error(...)`/`halt_error` rows.
+        assert_eq!(code, expected_code, "exit code for {args:?}");
     }
     Ok(())
 }


### PR DESCRIPTION
Fixes #1653 partially — see **What is deliberately not fixed** below; the issue should stay open.

## The bug

`succinctly jq` evaluated a whole input's filter into a `Vec` before writing *any* of it, so a filter that both produced stdout output and triggered a stderr side effect emitted them in the wrong order:

```console
$ jq            --unbuffered -cn '1, debug, 2'   2>&1     $ succinctly jq --unbuffered -cn '1, debug, 2'   2>&1
1                                                         ["DEBUG:",null]
["DEBUG:",null]                                           1
null                                                      null
2                                                         2
```

This was never a buffering problem, which is why `--unbuffered`'s per-write `flush()` never helped: by the time the first stdout write ran, every stderr write had already happened.

## The fix

`eval_each_with_cursor` drives the demand-driven `eval_each_generic` that already existed for internal consumers, handing each output back as a single-output `GenericResult` — so every existing per-result path, the lazy `LazyKeys`/`LazyIndexRange`/`LazySeq` variants included, keeps working unchanged. `evaluate_input_streaming` then writes each output the moment it is produced.

The `takes_input_queue_bridge` branch streams too: that bridge needs the *input* owned, not the *outputs* collected, so it drives `eval_each_owned` (itself demand-driven) rather than the collecting wrapper.

An uncaught error follows the same ordering rule, and it is where the change is most visible — jq prints `1` before the diagnostic for `1, error("x"), 3`, because that output was already produced.

**Routes fixed:** `-n`, the plain materialized-input path (`--slurp`, DSV, `--args`), and the `input`/`inputs` queue loop — all four now byte-identical to jq 1.7.1 on combined output.

## What is deliberately not fixed

A document read from a file or stdin (the M2 lazy path) still batches. Streaming it means routing the CLI's **default** route through the demand-driven evaluator, whose `each_lazy_keys_iterate_sink` deliberately skips the #1194 malformed-key check that #1629 added so bare `keys_unsorted[]` *would* raise. #1770 closed that gap as an accepted trade **for early-exit consumers like `first(...)`**, reasoning that catching it needs the very full walk such a consumer exists to avoid. Generalising it to every query is a different decision than the one #1770 made.

I tried it, and it is not theoretical: **six tests regressed** across #1642/#1629/#1770's undecodable-key handling — including `.,.` on a document with colliding undecodable keys emitting them twice at exit 0 instead of raising, and an adversarial-nesting case turning exit 5 into exit 101. Reverted.

`test_streamed_ordering_not_yet_reached_on_m2_path_1653` pins the current batched output so this stops being silent the moment it changes, and the divergence is written up in `docs/compliance/jq/limitations.md`.

## Verification

- **Full suite** (`--features cli,simd,regex,serde`): **6471 passed, 0 failed**. `clippy` both CI feature sets, `fmt`, `doc`, `--no-default-features` all clean.
- **Differential sweeps vs jq 1.7.1**: 450 input×filter combos and 720 input×filter×flag combos (`-c -r -j -e --tab --seq --raw-output0 -a -S --arg`). Every remaining diff is either pre-existing (`leaf_paths`, a documented extension; `$__loc__`'s `<stdin>` vs `<top-level>`) or the known-blocked M2 `.[]|debug` shape — **no new divergence**.
- **Tests genuinely fail pre-change**: all seven asserted cases were confirmed to differ against a binary built from this branch's base commit.
- **Perf** (interleaved A/B within each rep, 9 reps, median): `--slurp` 1MB −0.6%, 10MB −0.4%; `-n range(200000)` −3.7%; comma-heavy −3.8%; M2 identity 1MB −0.6% / 10MB +0.5%. No regression — the M2 hot path is untouched code. Box was loaded (load avg 14), so treat these as "no regression", not as wins.

Writing the tests caught one of my own wrong assumptions: `halt_error` on a *number* payload writes a trailing newline (only a *string* payload is the raw, newline-less case). Every expectation here is captured from the pinned binary rather than reasoned about.

## Note on `cargo test` with default features

Two pre-existing tests (`test_map_values_array_propagates_{bare,partial}_halt_from_element`) die with SIGKILL under default features. **Reproduced on unmodified `main`** — not from this PR.


---

## Update after review + rebase

**Code review returned 7 findings; all 7 verified independently and fixed.** The most consequential was one I had missed: **`--input-dsv` was still batching** — a fifth `evaluate_input` call site. Converting it meant *every* call site streamed, which left the eager `evaluate_input` with no callers; removed rather than kept as a second, divergent copy of the same per-variant materialization. Also corrected: the compliance note was wrong in both directions (claimed `--input-dsv` fixed when it batched; omitted `-S`/`-a`/`-R`/`--seq`, which are fixed), a write error could suppress the evaluator's own diagnostic, and `Flow::Stopped`'s `pending` control was being dropped at the *final* consumer, where an already-raised control still has to reach the exit code (`first(1, ("BOOM"|halt_error(3)))` re-confirmed against jq as still exit 0).

**Rebase onto #1884.** Main consolidated every direct-binary jq invocation into a shared `spawn_jq`/`spawn_with_signal_retry`, which is the exact layer `run_jq_interleaved` had hand-rolled. Both sides of the conflict ended mid-function sharing a trailing brace, so the region was rebuilt from main's file rather than merged textually, and the helper rewritten on main's primitives — strictly better, since `spawn_with_signal_retry` also retries signal-killed children.

**Coverage.** 87.0% → **90.1%** patch (128/142), total +0.07pp. Most of the original gap was not missing tests but eight `GenericResult` arms that can never run — a sink item is always a `GenericItem`, and only six variants map through — so they now share one arm that says so instead of eight speculative ones. The genuinely reachable gaps got tests (`--input-dsv` streaming + `-e`; `materialize_stream_item`'s `LazySeq` arm for all three controls, each confirmed against jq first).

The 14 still-uncovered lines are stated rather than papered over: write-error propagation (needs a real mid-write EPIPE harness — worth its own change, not a flaky approximation), two lines documented as provably dead / defense-in-depth, and one `One` arm that is a delegation identical in shape to the covered `OneCursor` arm beside it.

**Final state:** 30/30 CI green. Locally: 6475 tests, both clippy feature sets, `--no-default-features`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (CI's exact command — a plain local `cargo doc` had missed a public-item-links-to-private-item error).
