### PR TITLE
fix(jq): string-slice terminal write runs the update filter before refusing

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17443,40 +17443,38 @@ fn through_slice<E: From<EvalError>>(
             Ok(())
         }
         // jq reads a string slice but will not write one back, whatever the
-        // replacement — the refusal beats the non-array one above. But
-        // that refusal is only correct once the slice itself *is* the
-        // write; a chained path with more path after the slice
-        // (`terminal_write: false`) needs the read-through substring
-        // handed to `edit` instead, so *that* navigation's own outcome —
-        // a genuine failure (`del(.a[0:1].b)` -> "Cannot index string
-        // with string \"b\"", matching `.a[0:1].b = 5`'s identical real-jq
-        // message) or a `?`-suppressed no-op (`del(.a[0:1][0]?)`,
-        // `.a[0:1].b? = 5`) — is the answer, not this refusal (#1321,
-        // confirmed live both ways against real jq for `del()` and `=`).
-        OwnedValue::String(_) if !terminal_write => {
-            let mut throwaway = slice_owned_value(root, start, end, optional)?
-                .expect("Array/String target always yields Some from slice_owned_value");
-            edit(&mut throwaway)
-        }
-        // #1876/#1883: real jq evaluates the update filter's side effects
-        // (and surfaces its own errors) *before* refusing the write --
-        // this arm used to refuse immediately, discarding `edit` entirely,
-        // so a `debug`/`stderr` side effect never fired and a genuine
-        // `error(...)`/arithmetic type error inside the update filter was
-        // replaced by this generic message instead of propagating.
-        // Mirrors the `!terminal_write` arm just above: run `edit` against
-        // the same throwaway substring, propagate whatever it produces via
-        // `?`, and only *then* raise the refusal once `edit` itself has
-        // succeeded (confirmed live against jq 1.7.1: `"hello" | .[0:2] |=
-        // (debug|9)` prints the debug line before still refusing with this
-        // same message; `"hello" | .[0:2] |= error("boom")` raises "boom"
-        // instead; `"s" | .[0:1] += 1` raises the real arithmetic error,
-        // not this one).
+        // replacement -- but that refusal (`terminal_write: true`) is only
+        // correct once the slice itself *is* the write; a chained path with
+        // more path after the slice (`terminal_write: false`) needs the
+        // read-through substring handed to `edit` instead, so *that*
+        // navigation's own outcome -- a genuine failure (`del(.a[0:1].b)`
+        // -> "Cannot index string with string \"b\"", matching
+        // `.a[0:1].b = 5`'s identical real-jq message) or a
+        // `?`-suppressed no-op (`del(.a[0:1][0]?)`, `.a[0:1].b? = 5`) -- is
+        // the answer, not the refusal below (#1321, confirmed live both
+        // ways against real jq for `del()` and `=`).
+        //
+        // Either way, `edit` always runs first against the same throwaway
+        // substring and its outcome is always propagated via `?` before
+        // either disposition is decided (#1876/#1883): an earlier version
+        // of the `terminal_write: true` case refused immediately without
+        // ever calling `edit`, discarding a `debug`/`stderr` side effect
+        // entirely and replacing a genuine `error(...)`/arithmetic type
+        // error inside the update filter with this generic refusal instead
+        // of propagating it (confirmed live against jq 1.7.1: `"hello" |
+        // .[0:2] |= (debug|9)` prints the debug line before *still*
+        // refusing with this same message; `"hello" | .[0:2] |=
+        // error("boom")` raises "boom" instead; `"s" | .[0:1] += 1` raises
+        // the real arithmetic error, not this one).
         OwnedValue::String(_) => {
             let mut throwaway = slice_owned_value(root, start, end, optional)?
                 .expect("Array/String target always yields Some from slice_owned_value");
             edit(&mut throwaway)?;
-            Err(EvalError::cannot_update_string_slices().into())
+            if terminal_write {
+                Err(EvalError::cannot_update_string_slices().into())
+            } else {
+                Ok(())
+            }
         }
         // yq's slice-assignment no-op (#1101, generalized to any nesting
         // depth by #1116): `through_slice` is the single choke point every
@@ -30728,15 +30726,34 @@ fn delete_at_path(
                     // no-ops it (confirmed live, `del(.a[0:1].b)` on
                     // `a: hello` leaves `a: hello` untouched), which this PR
                     // doesn't attempt to fix. Forcing `terminal_write: true`
-                    // in yq mode keeps `through_slice`'s String arm on its
-                    // old, unconditional refusal there -- the exact same
-                    // wrong-but-unchanged "Cannot update string slices"
-                    // message yq mode already raised before this PR --
-                    // instead of trading it for a *different* wrong message
-                    // ("Cannot index string with string \"b\"") that would
-                    // make this string case look fixed relative to #1219's
-                    // own array/object case when it isn't. jq mode is
-                    // unaffected either way.
+                    // in yq mode keeps `through_slice`'s String arm ending
+                    // in its refusal here -- the same wrong-but-unchanged
+                    // "Cannot update string slices" message yq mode already
+                    // raised before this PR -- instead of trading it for a
+                    // *different* wrong message ("Cannot index string with
+                    // string \"b\"") that would make this string case look
+                    // fixed relative to #1219's own array/object case when
+                    // it isn't. jq mode is unaffected either way.
+                    //
+                    // #1876/#1883 code review: that arm now runs `edit`
+                    // (here, `delete_at_path(sub, &rest, ...)`, a real
+                    // recursive delete against the throwaway substring, not
+                    // a no-op) before reaching this refusal, where it used
+                    // to refuse unconditionally without calling `edit` at
+                    // all. A live-verified sweep (`del(.[][0:1].c)`,
+                    // `del(.[][0:1][0])`, `del(.[][0:1][])`,
+                    // `del(.[][0:1][2:3])`, `del(.[][0:1][2:3].c)`, computed
+                    // bounds) found no shape that reaches this call site
+                    // with `rest` still pending and a String `sub` --
+                    // `yq_del_slice_outcome`'s four outcomes either bypass
+                    // `through_slice` entirely (`Noop`, `DropParent`) or
+                    // recurse into `delete_at_path` with a prefix that
+                    // fails before ever reaching a trailing slice -- so
+                    // `edit` here is believed to always no-op/error before
+                    // producing an observable difference, not proven
+                    // structurally impossible. A future change to
+                    // `yq_del_slice_outcome` that makes this reachable
+                    // should re-verify that belief still holds.
                     //
                     // `container_noop: false` unconditionally (#1873 code
                     // review): unlike `set_path`/`update_path`'s call sites,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17458,7 +17458,26 @@ fn through_slice<E: From<EvalError>>(
                 .expect("Array/String target always yields Some from slice_owned_value");
             edit(&mut throwaway)
         }
-        OwnedValue::String(_) => Err(EvalError::cannot_update_string_slices().into()),
+        // #1876/#1883: real jq evaluates the update filter's side effects
+        // (and surfaces its own errors) *before* refusing the write --
+        // this arm used to refuse immediately, discarding `edit` entirely,
+        // so a `debug`/`stderr` side effect never fired and a genuine
+        // `error(...)`/arithmetic type error inside the update filter was
+        // replaced by this generic message instead of propagating.
+        // Mirrors the `!terminal_write` arm just above: run `edit` against
+        // the same throwaway substring, propagate whatever it produces via
+        // `?`, and only *then* raise the refusal once `edit` itself has
+        // succeeded (confirmed live against jq 1.7.1: `"hello" | .[0:2] |=
+        // (debug|9)` prints the debug line before still refusing with this
+        // same message; `"hello" | .[0:2] |= error("boom")` raises "boom"
+        // instead; `"s" | .[0:1] += 1` raises the real arithmetic error,
+        // not this one).
+        OwnedValue::String(_) => {
+            let mut throwaway = slice_owned_value(root, start, end, optional)?
+                .expect("Array/String target always yields Some from slice_owned_value");
+            edit(&mut throwaway)?;
+            Err(EvalError::cannot_update_string_slices().into())
+        }
         // yq's slice-assignment no-op (#1101, generalized to any nesting
         // depth by #1116): `through_slice` is the single choke point every
         // slice write passes through, in both `set_path` (`=`) and

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25607,11 +25607,16 @@ fn test_slice_update_with_identity_tail_still_raises_1428() -> Result<()> {
 #[test]
 fn test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883() -> Result<()> {
     // `debug`'s stderr side effect still fires even though the write is
-    // ultimately refused -- both jq and succinctly print the debug line,
-    // then refuse with the same generic message.
+    // ultimately refused -- both jq and succinctly print the debug line
+    // (with the *sliced* substring "he", proving `edit` really ran against
+    // the throwaway substring rather than the whole original string), then
+    // refuse with the same generic message.
     let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:2] |= (debug|9)"], Some("\"hello\""))?;
     assert_ne!(code, 0);
-    assert!(stderr.contains("DEBUG:"), "stderr: {stderr}");
+    assert!(
+        stderr.starts_with("[\"DEBUG:\",\"he\"]\n"),
+        "stderr: {stderr}"
+    );
     assert!(
         stderr.contains("Cannot update string slices"),
         "stderr: {stderr}"

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25594,3 +25594,73 @@ fn test_slice_update_with_identity_tail_still_raises_1428() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1876/#1883: `through_slice`'s `OwnedValue::String` *terminal-write* arm
+/// used to refuse with the generic `Cannot update string slices` message
+/// immediately, without ever running the update filter -- unlike its
+/// `!terminal_write` sibling just above it (and every other arm in this
+/// function), which always runs `edit` first. This discarded the filter's
+/// own side effects (`debug`/`stderr`) and swallowed its own genuine errors
+/// (an explicit `error(...)` call, or an arithmetic type error from `+=`/
+/// `-=`) behind the generic refusal instead of letting them propagate --
+/// confirmed live against jq 1.7.1 for all three repros below.
+#[test]
+fn test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883() -> Result<()> {
+    // `debug`'s stderr side effect still fires even though the write is
+    // ultimately refused -- both jq and succinctly print the debug line,
+    // then refuse with the same generic message.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:2] |= (debug|9)"], Some("\"hello\""))?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("DEBUG:"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // An explicit `error(...)` inside the update filter propagates as
+    // itself, not as the generic string-slice refusal.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".[0:2] |= error(\"boom\")"], Some("\"hello\""))?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // `+=`/`-=`'s own arithmetic type error surfaces instead of the generic
+    // refusal (#1883's own repro).
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:1] += 1"], Some("\"s\""))?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("cannot be added"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:1] -= 1"], Some("\"s\""))?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("cannot be subtracted"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // Control: when the update filter succeeds with an ordinary value, the
+    // write is still refused with the generic message (the refusal itself
+    // is correct jq behavior -- only the *ordering* relative to `edit`
+    // changed).
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:1] = \"X\""], Some("\"hello\""))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1876, Fixes #1883.

Bundled together (same root cause: `through_slice`'s `OwnedValue::String`
terminal-write arm in `src/jq/eval.rs`, both found via #1873's own code
review).

## Root cause

`through_slice`'s `OwnedValue::String` terminal-write arm refused with the
generic `Cannot update string slices` message immediately, without ever
running the update filter (`edit`) — unlike its `!terminal_write` sibling
just above it (and every other arm in this function), which always runs
`edit` first and only then decides what to do with the result.

Real jq evaluates the update filter's side effects and surfaces its own
errors *before* refusing the write.

## Repros (confirmed live against jq 1.7.1)

```console
$ echo '"hello"' | jq '.[0:2] |= (debug|9)'
["DEBUG:","he"]
jq: error (at <stdin>:0): Cannot update string slices
$ echo '"hello"' | succinctly jq '.[0:2] |= (debug|9)'   # pre-fix: no debug output at all
jq: error (at <stdin>:0): Cannot update string slices

$ echo '"hello"' | jq '.[0:2] |= error("boom")'
jq: error (at <stdin>:0): boom
$ echo '"hello"' | succinctly jq '.[0:2] |= error("boom")'   # pre-fix: "boom" never fires
jq: error (at <stdin>:0): Cannot update string slices

$ echo '"s"' | jq -c '.[0:1] += 1'
jq: error (at <stdin>:1): string ("s") and number (1) cannot be added
$ echo '"s"' | succinctly jq -c '.[0:1] += 1'   # pre-fix: wrong message
jq: error (at <stdin>:1): Cannot update string slices
```

## Fix

Mirrors the `!terminal_write` arm: run `edit` against the same throwaway
substring, propagate whatever it produces via `?`, and only raise the
refusal once `edit` itself has succeeded (matching the `debug` case above,
where the refusal is still correct — only the *ordering* relative to `edit`
changed).

Confirmed this doesn't reach yq mode at all: yq's string-slice writes
(`=`/`+=`/`-=`/`*=`) always route through the separate `OwnedValue::String
if container_noop` arm a few lines above, which was already correct and
unaffected either way (verified byte-identical against pre-fix `main` for
`+=`/`-=`/`=` on a YAML string-scalar slice).

## Testing

Added `test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883`
covering all repros above plus a control (an update filter that succeeds
with an ordinary value still gets refused, just after running).

Full local verification: build/test/clippy under both default and full
(`cli,simd,regex,serde`) feature sets, plus `--no-default-features` and
`cargo doc --all-features`. All existing slice-related tests (40) pass
unaffected.