### PR TITLE
ci: add dedicated adr/arch/bench-docs/guides commit scopes

### DIFF
--- a/.omni-dev/scopes.yaml
+++ b/.omni-dev/scopes.yaml
@@ -51,6 +51,22 @@ scopes:
     description: "Documentation and optimization notes"
     examples: ["docs: update AVX-512 results", "docs: add PFSM integration guide"]
     file_patterns: ["docs/**", "*.md", ".claude/**"]
+  - name: "adr"
+    description: "Architecture Decision Records"
+    examples: ["adr: add ADR-0019 for jq path-context tracking", "adr: fix no-line-numbers rule"]
+    file_patterns: ["docs/adrs/**"]
+  - name: "arch"
+    description: "Architecture and design documentation"
+    examples: ["arch: document semi-indexing overview", "arch: add JSON parsing architecture doc"]
+    file_patterns: ["docs/architecture/**"]
+  - name: "bench-docs"
+    description: "Benchmark results and reports"
+    examples: ["bench-docs: update jq benchmark table", "bench-docs: regenerate yq comparison"]
+    file_patterns: ["docs/benchmarks/**"]
+  - name: "guides"
+    description: "Project guides and tutorials"
+    examples: ["guides: update release checklist", "guides: add benchmarking A/B method"]
+    file_patterns: ["docs/guides/**"]
   - name: "ci"
     description: "CI/CD pipelines, GitHub Actions, and commit-lint configuration"
     examples: ["ci: add SIMD feature matrix", "ci: fix benchmark workflow"]


### PR DESCRIPTION
## Summary

The generic `docs` scope bundled ADRs, architecture docs, benchmark reports,
and guides under one label, making it harder to filter commit history or
apply scope-specific automation. Adds four dedicated scopes:

| Scope | File patterns |
|---|---|
| `adr` | `docs/adrs/**` |
| `arch` | `docs/architecture/**` |
| `bench-docs` | `docs/benchmarks/**` |
| `guides` | `docs/guides/**` |

## No exclusion patterns needed

`resolve_scope` (`omni-dev`'s deterministic scope resolver) picks the
*most specific* matching pattern by literal path-component count,
regardless of `scopes.yaml` definition order — so the new, more specific
patterns automatically win over `docs/**` for their subpaths without
needing `!`-negation on the existing `docs` entry. Confirmed live via a
throwaway test commit:

```console
$ omni-dev git commit message lint --suggest <commit touching docs/adrs/README.md with an unknown scope>
   Suggested message:
      docs(adr): touch an adr file to test scope suggestion
```

(not `docs(adr, docs)` — no tie.)

## Verification

- `omni-dev config scopes lint --root src --root docs`: 20 scopes, 237
  files checked, 0 violations (no dead patterns, no unscoped files)
- Live-confirmed specificity-based resolution picks `adr` cleanly for a
  `docs/adrs/` file (see above)
- Confirmed `.omni-dev/scopes.yaml` changes are themselves scoped `ci`
  (matching `.omni-dev/**`'s existing pattern), not `docs`
- `docs/STYLE_GUIDE.md`/`CONTRIBUTING.md` both point to
  `.omni-dev/scopes.yaml` as the single canonical source rather than
  duplicating the scope list, so no other doc needed updating
- `cargo build --release --features cli`: unaffected (YAML-only change)

Fixes #1456