### PR TITLE
fix(jq): merge_owned's error-path prefix no longer corrupts on decode failure

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1629,20 +1629,17 @@ fn collect_recursive<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// substituting `""` for an undecodable string instead of raising.
 ///
 /// `Control::Halt` is deliberately excluded from the preemption (#1832
-/// review): unlike `Error`/`Break`, `halt` is not a catchable signal, and
-/// downstream (`yq_runner.rs`) treats `Control::Halt` as "stop the whole
-/// process now" versus `Control::Error` as "report and continue" --
-/// downgrading an already-triggered halt into a continuable error would
-/// resume processing later documents a halting script explicitly meant to
-/// stop, a worse outcome than the corrupted-value bug this function exists
-/// to fix. The halt is kept, but the corrupted element (and anything
-/// `promote_borrowed_checked` never reached past it) is dropped from the
-/// reported prefix rather than leaking the old `""` substitution -- neither
-/// silently wrong output nor a silently resumed process. Whether a
-/// decode failure discovered this way should surface at all when it
-/// collides with a halt is a real, narrower design question of its own
-/// (#1899) -- this only guarantees the two specific wrong outcomes above
-/// don't happen while that's unresolved.
+/// review): unlike `Error`/`Break`, `halt` is not a catchable signal --
+/// this file already has a long-established rule for exactly this
+/// (`resolve_leaf`'s own doc comment, #987: "an already-triggered halt
+/// must not be downgraded into a catchable path error"). Converting it to
+/// `Control::Error` here would violate that same rule for a caller that
+/// treats `Halt` as "stop everything now" and `Error` as "report and
+/// continue" -- a worse outcome than the corrupted-value bug this function
+/// exists to fix. The halt is kept, but the corrupted element (and
+/// anything `promote_borrowed_checked` never reached past it) is dropped
+/// from the reported prefix rather than leaking the old `""` substitution
+/// -- neither silently wrong output nor a silently downgraded halt.
 fn resolve_terminal_prefix<W: Clone + AsRef<[u64]>>(
     borrowed: Vec<StandardJson<'_, W>>,
     owned: Option<Vec<OwnedValue>>,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1253,10 +1253,15 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // (#1755/#1843's own instance of this exact bug shape).
             QueryResult::One(v) => {
                 if let Err(e) = push_promoted(core::iter::once(v), &mut borrowed, &mut owned) {
-                    // push_promoted only errors from its `Some(acc)` arm, so
-                    // `owned` is always `Some` here.
-                    let merged = owned.expect("push_promoted only errors when owned is Some");
-                    return partial(merged, Control::Error(e));
+                    // #1832 review: `push_promoted` only errors from its
+                    // `Some(acc)` arm, so `owned` is always `Some` here --
+                    // but go through the same checked resolution every
+                    // other terminal arm uses (`eval_pipe`'s matching arms
+                    // already did) rather than assume the invariant via
+                    // `.expect()` and panic if a future refactor breaks it.
+                    let (prefix, control) =
+                        resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
+                    return partial(prefix, control);
                 }
             }
             QueryResult::OneCursor(_) => {
@@ -1264,27 +1269,22 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             QueryResult::Many(vs) => {
                 if let Err(e) = push_promoted(vs, &mut borrowed, &mut owned) {
-                    let merged = owned.expect("push_promoted only errors when owned is Some");
-                    return partial(merged, Control::Error(e));
+                    let (prefix, control) =
+                        resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
+                    return partial(prefix, control);
                 }
             }
             QueryResult::Owned(v) => {
-                if owned.is_none() {
-                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                        Ok(acc) => owned = Some(acc),
-                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                    }
+                if let Err((prefix, e)) =
+                    promote_and_extend(&mut borrowed, &mut owned, core::iter::once(v))
+                {
+                    return partial(prefix, Control::Error(e));
                 }
-                owned.as_mut().unwrap().push(v);
             }
             QueryResult::ManyOwned(vs) => {
-                if owned.is_none() {
-                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                        Ok(acc) => owned = Some(acc),
-                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                    }
+                if let Err((prefix, e)) = promote_and_extend(&mut borrowed, &mut owned, vs) {
+                    return partial(prefix, Control::Error(e));
                 }
-                owned.as_mut().unwrap().extend(vs);
             }
             QueryResult::None => {}
             // A sibling that errors or breaks no longer discards the outputs
@@ -1292,27 +1292,23 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // now carries `1` forward as `Partial`'s prefix instead of
             // collapsing straight to a bare `Error`.
             QueryResult::Error(e) => {
-                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
                 return partial(prefix, control);
             }
             QueryResult::Break(label) => {
                 let (prefix, control) =
-                    resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Break(label));
                 return partial(prefix, control);
             }
             QueryResult::Halt(code) => {
                 let (prefix, control) =
-                    resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Halt(code));
                 return partial(prefix, control);
             }
             QueryResult::Partial(vs, control) => {
-                return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
-                    Ok(mut prefix) => {
-                        prefix.extend(vs);
-                        partial(prefix, control)
-                    }
-                    Err((prefix, e)) => partial(prefix, Control::Error(e)),
-                };
+                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, vs, control);
+                return partial(prefix, control);
             }
         }
     }
@@ -1615,7 +1611,9 @@ fn collect_recursive<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// whichever promotion point set `owned` -- every push after that point
 /// goes to `owned`, never back to `borrowed`), otherwise checked-promoting
 /// whatever's left in `borrowed` for the first time via the existing
-/// [`promote_borrowed_checked`].
+/// [`promote_borrowed_checked`]. `extra` is appended on success -- the
+/// `Partial(vs, control)` arm's own already-produced `vs`; every other
+/// caller passes an empty `Vec`.
 ///
 /// Fallible (#1832): an undecodable element in `borrowed` was never
 /// checked, because nothing forced promotion before this later element's
@@ -1629,14 +1627,37 @@ fn collect_recursive<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// the terminal-control path those two never covered. Before this fix,
 /// `borrowed`'s conversion here ran through unchecked `to_owned`, silently
 /// substituting `""` for an undecodable string instead of raising.
+///
+/// `Control::Halt` is deliberately excluded from the preemption (#1832
+/// review): unlike `Error`/`Break`, `halt` is not a catchable signal, and
+/// downstream (`yq_runner.rs`) treats `Control::Halt` as "stop the whole
+/// process now" versus `Control::Error` as "report and continue" --
+/// downgrading an already-triggered halt into a continuable error would
+/// resume processing later documents a halting script explicitly meant to
+/// stop, a worse outcome than the corrupted-value bug this function exists
+/// to fix. The halt is kept, but the corrupted element (and anything
+/// `promote_borrowed_checked` never reached past it) is dropped from the
+/// reported prefix rather than leaking the old `""` substitution -- neither
+/// silently wrong output nor a silently resumed process. Whether a
+/// decode failure discovered this way should surface at all when it
+/// collides with a halt is a real, narrower design question of its own
+/// (#1899) -- this only guarantees the two specific wrong outcomes above
+/// don't happen while that's unresolved.
 fn resolve_terminal_prefix<W: Clone + AsRef<[u64]>>(
     borrowed: Vec<StandardJson<'_, W>>,
     owned: Option<Vec<OwnedValue>>,
+    extra: Vec<OwnedValue>,
     control: Control,
 ) -> (Vec<OwnedValue>, Control) {
     match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
-        Ok(prefix) => (prefix, control),
-        Err((prefix, e)) => (prefix, Control::Error(e)),
+        Ok(mut prefix) => {
+            prefix.extend(extra);
+            (prefix, control)
+        }
+        Err((prefix, e)) => match control {
+            Control::Halt(_) => (prefix, control),
+            Control::Error(_) | Control::Break(_) => (prefix, Control::Error(e)),
+        },
     }
 }
 
@@ -4032,8 +4053,12 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
             // eval_pipe/eval_comma, just never applied here.
             QueryResult::One(v) => {
                 if let Err(e) = push_promoted(core::iter::once(v), &mut borrowed, &mut owned) {
-                    let merged = owned.expect("push_promoted only errors when owned is Some");
-                    return partial(merged, Control::Error(e));
+                    // #1832 review: see eval_comma's matching arm for why
+                    // this goes through the checked resolution rather than
+                    // `.expect()`-asserting the invariant.
+                    let (prefix, control) =
+                        resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
+                    return partial(prefix, control);
                 }
             }
             QueryResult::OneCursor(_) => {
@@ -4041,58 +4066,49 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
             }
             QueryResult::Many(vs) => {
                 if let Err(e) = push_promoted(vs, &mut borrowed, &mut owned) {
-                    let merged = owned.expect("push_promoted only errors when owned is Some");
-                    return partial(merged, Control::Error(e));
+                    let (prefix, control) =
+                        resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
+                    return partial(prefix, control);
                 }
             }
             QueryResult::Owned(v) => {
-                if owned.is_none() {
-                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                        Ok(acc) => owned = Some(acc),
-                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                    }
+                if let Err((prefix, e)) =
+                    promote_and_extend(&mut borrowed, &mut owned, core::iter::once(v))
+                {
+                    return partial(prefix, Control::Error(e));
                 }
-                owned.as_mut().unwrap().push(v);
             }
             QueryResult::ManyOwned(vs) => {
-                if owned.is_none() {
-                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                        Ok(acc) => owned = Some(acc),
-                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                    }
+                if let Err((prefix, e)) = promote_and_extend(&mut borrowed, &mut owned, vs) {
+                    return partial(prefix, Control::Error(e));
                 }
-                owned.as_mut().unwrap().extend(vs);
             }
             QueryResult::None => {}
             QueryResult::Error(e) => {
-                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
                 return partial(prefix, control);
             }
             QueryResult::Break(label) => {
                 let (prefix, control) =
-                    resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Break(label));
                 return partial(prefix, control);
             }
             QueryResult::Halt(code) => {
                 let (prefix, control) =
-                    resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                    resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Halt(code));
                 return partial(prefix, control);
             }
             QueryResult::Partial(vs, control) => {
-                return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
-                    Ok(mut prefix) => {
-                        prefix.extend(vs);
-                        partial(prefix, control)
-                    }
-                    Err((prefix, e)) => partial(prefix, Control::Error(e)),
-                };
+                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, vs, control);
+                return partial(prefix, control);
             }
         }
     }
 
     match cond_control {
         Some(control) => {
-            let (prefix, control) = resolve_terminal_prefix(borrowed, owned, control);
+            let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Vec::new(), control);
             partial(prefix, control)
         }
         None => match owned {
@@ -14338,6 +14354,29 @@ fn promote_borrowed_checked<W: Clone + AsRef<[u64]>>(
     Ok(acc)
 }
 
+/// Promote `*owned` from `*borrowed` on first use (via
+/// [`promote_borrowed_checked`]), then extend it with `values` -- the
+/// `Owned`/`ManyOwned` arm of `eval_comma`/`eval_fanout`/`eval_pipe`'s
+/// identical `Many`-branch loops (#1832 review: `eval_fanout`'s own copy of
+/// this exact block was independently written a third time when its
+/// sibling `merge_owned` bug was fixed, instead of reusing one definition
+/// -- the same "duplicated predicates diverge silently" shape as #106).
+/// `borrowed` is left empty either way: either it never had anything (the
+/// `Some` branch, `owned` already promoted by an earlier call), or
+/// `core::mem::take` already moved everything out of it into
+/// `promote_borrowed_checked`.
+fn promote_and_extend<W: Clone + AsRef<[u64]>>(
+    borrowed: &mut Vec<StandardJson<'_, W>>,
+    owned: &mut Option<Vec<OwnedValue>>,
+    values: impl IntoIterator<Item = OwnedValue>,
+) -> Result<(), (Vec<OwnedValue>, EvalError)> {
+    if owned.is_none() {
+        *owned = Some(promote_borrowed_checked(core::mem::take(borrowed))?);
+    }
+    owned.as_mut().unwrap().extend(values);
+    Ok(())
+}
+
 /// Evaluate a pipe (chain) of expressions.
 fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     exprs: &[Expr],
@@ -14392,63 +14431,70 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // refactor -- go through the same checked
                             // resolution as every other terminal arm rather
                             // than assume the invariant silently.
-                            let (prefix, control) =
-                                resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                            let (prefix, control) = resolve_terminal_prefix(
+                                borrowed,
+                                owned,
+                                Vec::new(),
+                                Control::Error(e),
+                            );
                             return partial(prefix, control);
                         }
                     }
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Many(rs) => {
                         if let Err(e) = push_promoted(rs, &mut borrowed, &mut owned) {
-                            let (prefix, control) =
-                                resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                            let (prefix, control) = resolve_terminal_prefix(
+                                borrowed,
+                                owned,
+                                Vec::new(),
+                                Control::Error(e),
+                            );
                             return partial(prefix, control);
                         }
                     }
                     QueryResult::Owned(r) => {
-                        if owned.is_none() {
-                            match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                                Ok(acc) => owned = Some(acc),
-                                Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                            }
+                        if let Err((prefix, e)) =
+                            promote_and_extend(&mut borrowed, &mut owned, core::iter::once(r))
+                        {
+                            return partial(prefix, Control::Error(e));
                         }
-                        owned.as_mut().unwrap().push(r);
                     }
                     QueryResult::ManyOwned(rs) => {
-                        if owned.is_none() {
-                            match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
-                                Ok(acc) => owned = Some(acc),
-                                Err((prefix, e)) => return partial(prefix, Control::Error(e)),
-                            }
+                        if let Err((prefix, e)) = promote_and_extend(&mut borrowed, &mut owned, rs)
+                        {
+                            return partial(prefix, Control::Error(e));
                         }
-                        owned.as_mut().unwrap().extend(rs);
                     }
                     QueryResult::None => {}
                     // A downstream error/break no longer discards outputs
                     // already piped through from earlier elements (#400).
                     QueryResult::Error(e) => {
                         let (prefix, control) =
-                            resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                            resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Error(e));
                         return partial(prefix, control);
                     }
                     QueryResult::Break(label) => {
-                        let (prefix, control) =
-                            resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                        let (prefix, control) = resolve_terminal_prefix(
+                            borrowed,
+                            owned,
+                            Vec::new(),
+                            Control::Break(label),
+                        );
                         return partial(prefix, control);
                     }
                     QueryResult::Halt(code) => {
-                        let (prefix, control) =
-                            resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                        let (prefix, control) = resolve_terminal_prefix(
+                            borrowed,
+                            owned,
+                            Vec::new(),
+                            Control::Halt(code),
+                        );
                         return partial(prefix, control);
                     }
                     QueryResult::Partial(rs, control) => {
-                        return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
-                            Ok(mut prefix) => {
-                                prefix.extend(rs);
-                                partial(prefix, control)
-                            }
-                            Err((prefix, e)) => partial(prefix, Control::Error(e)),
-                        };
+                        let (prefix, control) =
+                            resolve_terminal_prefix(borrowed, owned, rs, control);
+                        return partial(prefix, control);
                     }
                 }
             }
@@ -38540,6 +38586,45 @@ mod tests {
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
                 assert_eq!(e.message, "boom");
+            }
+        );
+    }
+
+    /// #1832 review: unlike `Error`/`Break`, an already-triggered `halt`
+    /// must never be downgraded into a catchable, continuable error --
+    /// `resolve_leaf`'s own long-established rule (#987) for exactly this
+    /// invariant, elsewhere in this file. A decode failure discovered only
+    /// while resolving the prefix for a `halt` signal keeps the halt; the
+    /// corrupted element (and anything queued after it) is dropped from
+    /// the reported prefix instead, rather than leaking the pre-#1832
+    /// `""` substitution or silently resuming past a halt that should have
+    /// stopped everything.
+    #[test]
+    fn test_eval_comma_halt_is_not_downgraded_by_decode_failure_1832() {
+        // Nothing decodable came before the corrupted element, so the
+        // reported prefix is empty and `partial` collapses to a bare
+        // `Halt`, matching `test_halt_basic`'s own no-prefix shape.
+        //
+        // `halt_error` is deliberately not used here: it JSON-encodes the
+        // *current* input value (the whole document, not just the earlier
+        // comma operand) for its own error message, so it raises its own,
+        // unrelated decode failure on this exact document regardless of
+        // this fix -- `halt` takes no such implicit argument, so `.a,
+        // halt` isolates the behavior this test is actually pinning.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a, halt",
+            QueryResult::Halt(0) => {}
+        );
+        // A decodable element before the corrupted one survives as the
+        // `Partial` prefix, same as `test_halt_keeps_prior_output_as_a_
+        // partial_prefix`'s own established shape -- the corrupted element
+        // itself is simply not part of the (still-halting) output.
+        query!(
+            b"{\"a\": \"ok\", \"b\": \"\xff\xfe\"}",
+            ".a, .b, halt",
+            QueryResult::Partial(vs, Control::Halt(0)) => {
+                assert_eq!(vs, vec![OwnedValue::String("ok".to_string())]);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1632,11 +1632,15 @@ fn collect_recursive<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// review): unlike `Error`/`Break`, `halt` is not a catchable signal --
 /// this file already has a long-established rule for exactly this
 /// (`resolve_leaf`'s own doc comment, #987: "an already-triggered halt
-/// must not be downgraded into a catchable path error"). Converting it to
-/// `Control::Error` here would violate that same rule for a caller that
-/// treats `Halt` as "stop everything now" and `Error` as "report and
-/// continue" -- a worse outcome than the corrupted-value bug this function
-/// exists to fix. The halt is kept, but the corrupted element (and
+/// must not be downgraded into a catchable path error"). This isn't only a
+/// library-API concern either: `yq_runner.rs`'s own `evaluate_input` calls
+/// this same `jq::eval` directly (for `--slurp`/`--eval-all`/etc.), and its
+/// `query_result_to_owned_values` genuinely treats the two differently --
+/// `Halt` calls `sink.request_halt(code)` (no diagnostic, short-circuits
+/// the run) where `Partial(_, Control::Error(e))` calls `sink.report(...)`
+/// and keeps going. Converting one into the other here would silently
+/// resume processing a real CLI invocation meant to stop, not just violate
+/// an abstract rule. The halt is kept, but the corrupted element (and
 /// anything `promote_borrowed_checked` never reached past it) is dropped
 /// from the reported prefix rather than leaking the old `""` substitution
 /// -- neither silently wrong output nor a silently downgraded halt.
@@ -40455,6 +40459,21 @@ mod tests {
         );
     }
 
+    /// #1832 review: `eval_fanout`'s own `resolve_terminal_prefix` call
+    /// site for `Control::Halt` needs its own pin, not just `eval_comma`'s
+    /// -- a future edit could swap which branch reaches which control at
+    /// this specific call site without `eval_comma`'s test catching it.
+    /// See `test_eval_comma_halt_is_not_downgraded_by_decode_failure_1832`
+    /// for the full rationale.
+    #[test]
+    fn test_eval_fanout_halt_is_not_downgraded_by_decode_failure_1832() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "if (true, false) then .a else halt end",
+            QueryResult::Halt(0) => {}
+        );
+    }
+
     /// #1832: `eval_pipe`'s own `Many`-branch loop shares the identical
     /// `merge_owned` (now `resolve_terminal_prefix`) terminal-control bug
     /// as `eval_comma`/`eval_fanout` -- an undecodable element from an
@@ -40479,6 +40498,19 @@ mod tests {
                 assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
                 assert_eq!(e.message, "boom");
             }
+        );
+    }
+
+    /// #1832 review: `eval_pipe`'s own `resolve_terminal_prefix` call site
+    /// for `Control::Halt` needs its own pin too -- see
+    /// `test_eval_comma_halt_is_not_downgraded_by_decode_failure_1832` for
+    /// the full rationale.
+    #[test]
+    fn test_eval_pipe_many_branch_halt_is_not_downgraded_by_decode_failure_1832() {
+        query!(
+            b"{\"arr\": [\"\xff\xfe\", 5]}",
+            ".arr[] | if type == \"string\" then . else halt end",
+            QueryResult::Halt(0) => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1292,27 +1292,27 @@ fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // now carries `1` forward as `Partial`'s prefix instead of
             // collapsing straight to a bare `Error`.
             QueryResult::Error(e) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Error(e),
-                );
+                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                return partial(prefix, control);
             }
             QueryResult::Break(label) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Break(label),
-                );
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                return partial(prefix, control);
             }
             QueryResult::Halt(code) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Halt(code),
-                );
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                return partial(prefix, control);
             }
             QueryResult::Partial(vs, control) => {
-                let mut merged = merge_owned(borrowed, owned.unwrap_or_default());
-                merged.extend(vs);
-                return partial(merged, control);
+                return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
+                    Ok(mut prefix) => {
+                        prefix.extend(vs);
+                        partial(prefix, control)
+                    }
+                    Err((prefix, e)) => partial(prefix, Control::Error(e)),
+                };
             }
         }
     }
@@ -1608,17 +1608,36 @@ fn collect_recursive<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Merge a borrowed accumulator and an owned accumulator into one owned
-/// prefix, in the order their values were produced. Shared by every
-/// stream-combining function that promotes a borrowed `Vec<StandardJson>` to
-/// owned the moment an owned value (or a terminal control) forces it.
-fn merge_owned<W: Clone + AsRef<[u64]>>(
+/// Resolve the accumulated prefix for a terminal control arm (`Error`/
+/// `Break`/`Halt`/`Partial`) across `eval_comma`/`eval_fanout`/`eval_pipe`'s
+/// identical `Many`-branch loops: `owned` directly if promotion already
+/// happened (in which case `borrowed` is always already empty, moved out by
+/// whichever promotion point set `owned` -- every push after that point
+/// goes to `owned`, never back to `borrowed`), otherwise checked-promoting
+/// whatever's left in `borrowed` for the first time via the existing
+/// [`promote_borrowed_checked`].
+///
+/// Fallible (#1832): an undecodable element in `borrowed` was never
+/// checked, because nothing forced promotion before this later element's
+/// own `control` signal fired. That undecodable element sits *earlier* in
+/// evaluation order than `control`, so it wins -- real jq's single-pass
+/// evaluation would have raised on it first. Returns the shorter,
+/// successfully-converted prefix paired with the decode error in place of
+/// `control`, the same "keep the prefix, earliest error wins" rule
+/// `push_promoted`/`promote_borrowed_checked` already established for the
+/// main promotion path (#1755/#1790) -- this is that rule's other half, for
+/// the terminal-control path those two never covered. Before this fix,
+/// `borrowed`'s conversion here ran through unchecked `to_owned`, silently
+/// substituting `""` for an undecodable string instead of raising.
+fn resolve_terminal_prefix<W: Clone + AsRef<[u64]>>(
     borrowed: Vec<StandardJson<'_, W>>,
-    owned: Vec<OwnedValue>,
-) -> Vec<OwnedValue> {
-    let mut merged: Vec<OwnedValue> = borrowed.iter().map(to_owned).collect();
-    merged.extend(owned);
-    merged
+    owned: Option<Vec<OwnedValue>>,
+    control: Control,
+) -> (Vec<OwnedValue>, Control) {
+    match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
+        Ok(prefix) => (prefix, control),
+        Err((prefix, e)) => (prefix, Control::Error(e)),
+    }
 }
 
 /// Collapse a `Vec<T>` accumulator into the smallest shape representing it:
@@ -4007,62 +4026,75 @@ fn eval_fanout<'a, W: Clone + AsRef<[u64]>>(
 
     for bit in bits {
         match body(bit).materialize_cursor() {
-            QueryResult::One(v) => match owned.as_mut() {
-                Some(acc) => acc.push(to_owned(&v)),
-                None => borrowed.push(v),
-            },
+            // #1832: push_promoted/promote_borrowed_checked, not unchecked
+            // to_owned -- eval_fanout had the identical #1755/#1790
+            // silently-corrupt-on-promotion bug shape already fixed for
+            // eval_pipe/eval_comma, just never applied here.
+            QueryResult::One(v) => {
+                if let Err(e) = push_promoted(core::iter::once(v), &mut borrowed, &mut owned) {
+                    let merged = owned.expect("push_promoted only errors when owned is Some");
+                    return partial(merged, Control::Error(e));
+                }
+            }
             QueryResult::OneCursor(_) => {
                 unreachable!("materialize_cursor should have converted this")
             }
-            QueryResult::Many(vs) => match owned.as_mut() {
-                Some(acc) => acc.extend(vs.iter().map(to_owned)),
-                None => borrowed.extend(vs),
-            },
-            QueryResult::Owned(v) => owned
-                .get_or_insert_with(|| {
-                    core::mem::take(&mut borrowed)
-                        .iter()
-                        .map(to_owned)
-                        .collect()
-                })
-                .push(v),
-            QueryResult::ManyOwned(vs) => owned
-                .get_or_insert_with(|| {
-                    core::mem::take(&mut borrowed)
-                        .iter()
-                        .map(to_owned)
-                        .collect()
-                })
-                .extend(vs),
+            QueryResult::Many(vs) => {
+                if let Err(e) = push_promoted(vs, &mut borrowed, &mut owned) {
+                    let merged = owned.expect("push_promoted only errors when owned is Some");
+                    return partial(merged, Control::Error(e));
+                }
+            }
+            QueryResult::Owned(v) => {
+                if owned.is_none() {
+                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                        Ok(acc) => owned = Some(acc),
+                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                    }
+                }
+                owned.as_mut().unwrap().push(v);
+            }
+            QueryResult::ManyOwned(vs) => {
+                if owned.is_none() {
+                    match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                        Ok(acc) => owned = Some(acc),
+                        Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                    }
+                }
+                owned.as_mut().unwrap().extend(vs);
+            }
             QueryResult::None => {}
             QueryResult::Error(e) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Error(e),
-                );
+                let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                return partial(prefix, control);
             }
             QueryResult::Break(label) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Break(label),
-                );
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                return partial(prefix, control);
             }
             QueryResult::Halt(code) => {
-                return partial(
-                    merge_owned(borrowed, owned.unwrap_or_default()),
-                    Control::Halt(code),
-                );
+                let (prefix, control) =
+                    resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                return partial(prefix, control);
             }
             QueryResult::Partial(vs, control) => {
-                let mut merged = merge_owned(borrowed, owned.unwrap_or_default());
-                merged.extend(vs);
-                return partial(merged, control);
+                return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
+                    Ok(mut prefix) => {
+                        prefix.extend(vs);
+                        partial(prefix, control)
+                    }
+                    Err((prefix, e)) => partial(prefix, Control::Error(e)),
+                };
             }
         }
     }
 
     match cond_control {
-        Some(control) => partial(merge_owned(borrowed, owned.unwrap_or_default()), control),
+        Some(control) => {
+            let (prefix, control) = resolve_terminal_prefix(borrowed, owned, control);
+            partial(prefix, control)
+        }
         None => match owned {
             Some(acc) => owned_vec_to_result(acc),
             None => borrowed_vec_to_result(borrowed),
@@ -14354,15 +14386,23 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         if let Err(e) =
                             push_promoted(core::iter::once(r), &mut borrowed, &mut owned)
                         {
-                            let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                            return partial(prefix, Control::Error(e));
+                            // #1832: push_promoted's own error already came
+                            // from a checked conversion, but `owned` could
+                            // in principle still be `None` here in a future
+                            // refactor -- go through the same checked
+                            // resolution as every other terminal arm rather
+                            // than assume the invariant silently.
+                            let (prefix, control) =
+                                resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                            return partial(prefix, control);
                         }
                     }
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Many(rs) => {
                         if let Err(e) = push_promoted(rs, &mut borrowed, &mut owned) {
-                            let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                            return partial(prefix, Control::Error(e));
+                            let (prefix, control) =
+                                resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                            return partial(prefix, control);
                         }
                     }
                     QueryResult::Owned(r) => {
@@ -14387,21 +14427,28 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     // A downstream error/break no longer discards outputs
                     // already piped through from earlier elements (#400).
                     QueryResult::Error(e) => {
-                        let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                        return partial(prefix, Control::Error(e));
+                        let (prefix, control) =
+                            resolve_terminal_prefix(borrowed, owned, Control::Error(e));
+                        return partial(prefix, control);
                     }
                     QueryResult::Break(label) => {
-                        let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                        return partial(prefix, Control::Break(label));
+                        let (prefix, control) =
+                            resolve_terminal_prefix(borrowed, owned, Control::Break(label));
+                        return partial(prefix, control);
                     }
                     QueryResult::Halt(code) => {
-                        let prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                        return partial(prefix, Control::Halt(code));
+                        let (prefix, control) =
+                            resolve_terminal_prefix(borrowed, owned, Control::Halt(code));
+                        return partial(prefix, control);
                     }
                     QueryResult::Partial(rs, control) => {
-                        let mut prefix = owned.unwrap_or_else(|| merge_owned(borrowed, Vec::new()));
-                        prefix.extend(rs);
-                        return partial(prefix, control);
+                        return match owned.map_or_else(|| promote_borrowed_checked(borrowed), Ok) {
+                            Ok(mut prefix) => {
+                                prefix.extend(rs);
+                                partial(prefix, control)
+                            }
+                            Err((prefix, e)) => partial(prefix, Control::Error(e)),
+                        };
                     }
                 }
             }
@@ -38449,6 +38496,54 @@ mod tests {
         );
     }
 
+    /// #1832: `eval_comma`'s terminal-control arms (`Error`/`Break`/`Halt`/
+    /// `Partial`) shared the identical unchecked-`to_owned` promotion bug
+    /// #1790 fixed for the main promotion path, just reached via
+    /// `merge_owned` (now `resolve_terminal_prefix`) instead of
+    /// `push_promoted`/`promote_borrowed_checked` directly -- an
+    /// undecodable *earlier* branch never gets checked before a *later*
+    /// branch's own error/break/halt forces the prefix to be built. The
+    /// earlier, still-unchecked decode failure must win over the later
+    /// signal, matching the evaluation order real jq's single pass implies.
+    #[test]
+    fn test_eval_comma_error_path_prefix_raises_on_decode_failure_1832() {
+        // `.a` (borrowed, undecodable) sits unchecked until `error("boom")`
+        // forces the prefix -- the decode failure must win over "boom".
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a, error(\"boom\")",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // `break` must be preempted by the same earlier decode failure.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "label $out | (.a, break $out)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // A `Partial` arriving from a nested control construct still goes
+        // through the same checked resolution before its own `vs` is
+        // appended -- the earlier decode failure preempts it entirely,
+        // discarding `vs` rather than appending it to a prefix that was
+        // never actually valid.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a, (1, error(\"boom\"))",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
+    /// #1832 positive control: valid data through the same terminal-control
+    /// shapes is unaffected by routing through the checked resolution.
+    #[test]
+    fn test_eval_comma_error_path_prefix_valid_data_unaffected_1832() {
+        query!(br#"{"a":"x"}"#, ".a, error(\"boom\")",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
+                assert_eq!(e.message, "boom");
+            }
+        );
+    }
+
     /// #1620: a decode failure reached through this module's own dispatch
     /// (the public `succinctly::jq::eval` library API, not the CLI's
     /// `eval_generic.rs` bridge) must not be suppressed by `?` -- same rule,
@@ -40226,6 +40321,82 @@ mod tests {
         // `None`, not `Many(vec![])`. Confirmed live against jq 1.7.1.
         query!(br"1", "if (true, false) then empty else empty end",
             QueryResult::None => {}
+        );
+    }
+
+    /// #1832: `eval_fanout`'s own main promotion path (the `Owned`/
+    /// `ManyOwned` arms) had the identical unchecked-`to_owned` bug shape
+    /// #1755/#1790 already fixed for `eval_pipe`/`eval_comma` -- an
+    /// undecodable *earlier* branch (`.a`, borrowed) never gets checked
+    /// before a *later* owned branch (`1`) forces the whole batch to
+    /// promote. `eval_fanout` was never given the equivalent fix, unlike
+    /// the two functions its own tail match was already known to mirror
+    /// (see `test_fanout_all_empty_branches_collapse_to_none_1043` above).
+    #[test]
+    fn test_eval_fanout_main_path_raises_on_decode_failure_1832() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "if (true, false) then .a else 1 end",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
+    /// #1832: `eval_fanout`'s terminal-control arms (`Error`/`Break`/`Halt`/
+    /// `Partial`) shared the same `merge_owned` (now `resolve_terminal_
+    /// prefix`) bug as `eval_comma`'s identical arms -- see
+    /// `test_eval_comma_error_path_prefix_raises_on_decode_failure_1832`
+    /// for the equivalent `eval_comma` case this mirrors.
+    #[test]
+    fn test_eval_fanout_error_path_prefix_raises_on_decode_failure_1832() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "if (true, false) then .a else error(\"boom\") end",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
+    /// #1832 positive control: valid data through both `eval_fanout` shapes
+    /// above is unaffected by routing through the checked promotion/
+    /// resolution.
+    #[test]
+    fn test_eval_fanout_decode_paths_valid_data_unaffected_1832() {
+        query!(br#"{"a":"x"}"#, "if (true, false) then .a else 1 end",
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string()), OwnedValue::Int(1)]);
+            }
+        );
+        query!(br#"{"a":"x"}"#, "if (true, false) then .a else error(\"boom\") end",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
+                assert_eq!(e.message, "boom");
+            }
+        );
+    }
+
+    /// #1832: `eval_pipe`'s own `Many`-branch loop shares the identical
+    /// `merge_owned` (now `resolve_terminal_prefix`) terminal-control bug
+    /// as `eval_comma`/`eval_fanout` -- an undecodable element from an
+    /// *earlier* array element, still sitting unchecked in `borrowed`,
+    /// must win over a *later* element's own `error(...)`.
+    #[test]
+    fn test_eval_pipe_many_branch_error_path_prefix_raises_on_decode_failure_1832() {
+        query!(
+            b"{\"arr\": [\"\xff\xfe\", 5]}",
+            ".arr[] | if type == \"string\" then . else error(\"boom\") end",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+    }
+
+    /// #1832 positive control: valid data through the same `eval_pipe`
+    /// `Many`-branch shape is unaffected.
+    #[test]
+    fn test_eval_pipe_many_branch_error_path_prefix_valid_data_unaffected_1832() {
+        query!(br#"{"arr": ["x", 5]}"#,
+            ".arr[] | if type == \"string\" then . else error(\"boom\") end",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string())]);
+                assert_eq!(e.message, "boom");
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

`merge_owned` silently substituted `""` for an undecodable string element
(via unchecked `to_owned`) when constructing the *prefix* for a
`partial(...)` result, whenever a downstream `Error`/`Break`/`Halt`/
`Partial` control signal forced `eval_comma`/`eval_fanout`/`eval_pipe`'s
`Many`-branch loop to build its prefix before the borrowed element was
ever checked — the same #1746/#1755 bug shape already fixed for the *main*
promotion path, just reached via a different, until-now-unfixed call site.

Replaced `merge_owned` with `resolve_terminal_prefix`, delegating to the
already-existing `promote_borrowed_checked` instead of duplicating its
logic. An undecodable element discovered only now happened *earlier* in
evaluation order, so it wins for `Error`/`Break` — matching
`push_promoted`'s own "keep the prefix, earliest error wins" rule.

## An additional, independently-discovered bug

`eval_fanout`'s own main promotion path (`Owned`/`ManyOwned` arms) still
had the bare-`to_owned` bug #1755/#1790 already fixed for `eval_pipe` and
`eval_comma` — a third, independently-discovered instance, never applied
to `eval_fanout`. Fixed using the same `push_promoted`/
`promote_borrowed_checked` helpers `eval_comma` already uses.

## Three review rounds found and fixed real issues in the fix itself

1. **A genuine correctness bug**: the first version unconditionally
   converted `Control::Halt` into `Control::Error` on a decode failure.
   Unlike `Error`/`Break`, `halt` is not catchable — this file has a
   long-established rule (`resolve_leaf`, #987) that an already-triggered
   halt must never be downgraded into a catchable error, and this is
   CLI-observable, not just a library-API concern: `yq_runner.rs`'s
   `evaluate_input` calls `jq::eval` directly for `--slurp`/`--eval-all`/
   etc., and its `query_result_to_owned_values` genuinely short-circuits on
   `Halt` (`sink.request_halt`) versus continuing on `Error`
   (`sink.report`). Fixed to keep the halt, dropping only the corrupted
   element from the reported prefix.
2. **Triplicated logic**: folded the 3 hand-inlined `Partial`-arm copies
   into `resolve_terminal_prefix` itself (now takes an `extra` values
   parameter), added a shared `promote_and_extend` helper for the
   `Owned`/`ManyOwned` arms that were about to become a *third*
   independent copy, and unified `eval_comma`/`eval_fanout`'s
   `push_promoted`-error handling (a panicking `.expect()`) with
   `eval_pipe`'s existing defensive fallback.
3. Added dedicated `Halt`-preservation regression tests for `eval_fanout`
   and `eval_pipe` too (round 1 only pinned `eval_comma`'s own call site).

## Follow-ups filed (found adjacent to this fix, deliberately out of scope
here to keep this PR bounded to what it can verify end-to-end)

- #1897 — `eval_index_expr`'s `Targets::Borrowed` arm has the identical
  unchecked-`to_owned` shape, a 4th independent instance (including its own
  `Halt` sub-case).
- #1898 — `push_truthiness`/`json_is_truthy` never checks whether a
  borrowed *condition* value decodes, so `if`/`select`/`and`/`or` silently
  treat a corrupted string as truthy.
- #1902 — `eval_as`/`eval_reduce`/`eval_foreach`'s bound-value conversion
  has the same shape but *worse*: no error surfaces at all in the simple
  case, since there's no competing control signal to force a check.

Also noted, deliberately not implemented: a few remaining DRY/ergonomics
suggestions from review (a `Control::is_catchable()`-style method instead
of the inline match, folding `partial()` into `resolve_terminal_prefix` to
drop the `let (prefix, control) = ...; return partial(...)` boilerplate at
~19 call sites, `#[inline]` hints on the new hot-loop helpers). These are
reasonable follow-on polish, not correctness issues, and are left as
noted rather than expanding this PR's already-substantial diff further.

## Test plan

- 10 new tests covering all 3 fixed functions, the additional `eval_fanout`
  main-path bug, and `Halt`-preservation (now pinned per-function, not just
  once), each paired with a valid-data positive control where applicable.
- Full `jq::eval` unit test module (1133 tests): pass.
- `cargo test --features cli,simd,regex,serde --no-fail-fast` (full suite,
  including doctests): pass.
- `cargo test` (plain, default features): pass.
- Both clippy legs (`--all-features` and CI's `std,simd,serde,cli,regex,
  bench-runner,large-tests,mmap-tests`): clean, `-D warnings`.
- `cargo fmt --check`: clean.
- `cargo doc --all-features --no-deps`: clean.
- `cargo build --no-default-features`: clean.

Fixes #1832