### PR TITLE
fix(jq): catch the nesting-depth panic on the materializing CLI branch too

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1039,17 +1039,21 @@ never gets this far). Falls under ADR-0018's "would take the host process down" 
 the fix that turned this from an uncaught process panic into a clean, catchable
 diagnostic.
 
-This fix is scoped to the CLI's default (lazy) per-document dispatch, matching #1793's own
-repro — the identical panic remains uncaught via any of: a CLI flag that forces
-whole-batch materialization up front (`--slurp`, `-S`/`--sort-keys`, `-C`/`--color-output`,
-`--ascii-output`, `--slurpfile`); a filter using `input`/`inputs`/`input_line_number`,
-which routes to that same materializing branch with *no flag at all* (#1818); `-e`/
+#1793's own fix was scoped to the CLI's default (lazy) per-document dispatch, matching its
+own repro. #1818 closed the identical gap on the CLI's *other* top-level branch — a CLI
+flag that forces whole-batch materialization up front (`--slurp`, `-S`/`--sort-keys`,
+`-C`/`--color-output`, `--ascii-output`, `--slurpfile`), or a filter using
+`input`/`inputs`/`input_line_number`, which routes to that same materializing branch with
+*no flag at all* — via `validate_json_delimiters`'s own checked guard
+(`check_nesting_depth`, `src/jq/eval_generic.rs`) rather than `catch_unwind`, since that
+walk already threads a `Result` and runs before any user filter evaluates at all.
+
+Still uncaught, tracked separately, not fixed by either #1793 or #1818: `-e`/
 `--exit-status`'s own separate materializer (`src/jq/lazy.rs`, already pinned uncaught by
 `test_exit_status_query_rejects_adversarial_nesting_998`); and `succinctly yq`, which has
-no equivalent guard on either its default or materializing path at all (#1817). Tracked
-separately, not fixed here. Confirmed live, also pre-existing and unrelated to this fix:
-`print_json`'s own guard can flush corrupted/truncated JSON to stdout before it fires
-(#1819).
+no equivalent guard on either its default or materializing path at all (#1817). Confirmed
+live, also pre-existing and unrelated to either fix: `print_json`'s own guard can flush
+corrupted/truncated JSON to stdout before it fires (#1819).
 
 ## Regex flags `l` and `n`
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors};
 use succinctly::jq::eval_generic::{
-    assert_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult,
+    check_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult,
     MAX_NESTING_DEPTH,
 };
 use succinctly::jq::walk::map_builtin_subexprs;
@@ -4376,10 +4376,20 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
 /// though the default `sjq -c .` path already rejects it since #1643.
 ///
 /// `depth` guards against a stack overflow on adversarially deep input the
-/// same way [`generic_to_owned`]'s own recursion does (`assert_nesting_depth`,
-/// #998) -- this walk runs *before* that one on the same document, so it
-/// needs the identical ceiling rather than risking a raw stack overflow at
-/// some other depth first.
+/// same way [`generic_to_owned`]'s own recursion does, but as a catchable
+/// error (`check_nesting_depth`, #1818) rather than a panic
+/// (`assert_nesting_depth`, #998): this walk runs *before* any user filter
+/// evaluation even begins (`parse_json_stream`'s fallback, backing `-S`,
+/// `-C`, `--slurp`, `--ascii-output`, `--slurpfile`, and any filter using
+/// `input`/`inputs`), so there's no `try`/`catch`-reachability concern the
+/// way there is for `to_owned`'s own hot-path guard -- and a clean,
+/// reported error beats a bare panic exiting 101 with an un-jq-shaped
+/// message, matching `print_json`'s own `anyhow::ensure!`-based guard for
+/// the analogous case on the lazy identity-path (confirmed live: an
+/// adversarially deep document between 256 and 384 levels used to panic
+/// here uncaught -- `succinctly jq -c --sort-keys '.' deep.json` exited 101
+/// with `thread 'main' panicked at ...: nesting depth exceeds limit of
+/// 256` instead of a clean jq-channel error).
 ///
 /// Not a hot path: `parse_json_stream_strict`'s `serde_json` validation
 /// already runs first and only fails (routing here) for a real jq leniency
@@ -4390,7 +4400,7 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,
 ) -> core::result::Result<(), EvalError> {
-    assert_nesting_depth(depth);
+    check_nesting_depth(depth)?;
     match cursor.value() {
         StandardJson::Array(elements) => {
             let mut saw_any = false;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4584,7 +4584,8 @@ where
 {
     anyhow::ensure!(
         level < MAX_VALUE_TREE_DEPTH,
-        "nesting depth exceeds limit of {MAX_VALUE_TREE_DEPTH}"
+        "{}",
+        succinctly::jq::nesting_depth_exceeded_message(MAX_VALUE_TREE_DEPTH)
     );
     let compact = config.compact;
     let indent = &config.indent_string;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -120,6 +120,27 @@ pub fn assert_nesting_depth(depth: usize) {
     super::value::assert_depth(depth, MAX_NESTING_DEPTH);
 }
 
+/// Checked sibling of [`assert_nesting_depth`] (#1818).
+///
+/// Same [`MAX_NESTING_DEPTH`] ceiling, the identical message
+/// `assert_depth`'s own `panic!`/`print_json`'s own `anyhow::ensure!` both
+/// use, but as a catchable `EvalError` instead of a panic -- for a caller
+/// that isn't the evaluator's own hot recursion (where a panic is
+/// deliberate, see `to_owned`'s own doc comment on why an `EvalError` there
+/// would make a stack-overflow guard catchable by `try`/`catch`) but a
+/// CLI-level input-validation walk (`jq_runner.rs`'s
+/// `validate_json_delimiters`, reached before any user filter runs) that
+/// already threads a `Result` and has no such concern.
+pub fn check_nesting_depth(depth: usize) -> Result<(), EvalError> {
+    if depth < MAX_NESTING_DEPTH {
+        Ok(())
+    } else {
+        Err(EvalError::new(format!(
+            "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+        )))
+    }
+}
+
 /// Convert a DocumentValue to an OwnedValue.
 ///
 /// This enables the evaluator to work with both JSON and YAML inputs.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -122,22 +122,26 @@ pub fn assert_nesting_depth(depth: usize) {
 
 /// Checked sibling of [`assert_nesting_depth`] (#1818).
 ///
-/// Same [`MAX_NESTING_DEPTH`] ceiling, the identical message
-/// `assert_depth`'s own `panic!`/`print_json`'s own `anyhow::ensure!` both
-/// use, but as a catchable `EvalError` instead of a panic -- for a caller
-/// that isn't the evaluator's own hot recursion (where a panic is
-/// deliberate, see `to_owned`'s own doc comment on why an `EvalError` there
-/// would make a stack-overflow guard catchable by `try`/`catch`) but a
-/// CLI-level input-validation walk (`jq_runner.rs`'s
+/// Same [`MAX_NESTING_DEPTH`] ceiling as `assert_depth`'s own `panic!`,
+/// sharing its message-building via `value::nesting_depth_exceeded_message`
+/// (also used by `print_json`'s own `anyhow::ensure!`, though that guard
+/// checks against the separate, wider `MAX_VALUE_TREE_DEPTH` ceiling since
+/// #1819 -- the shared function takes `max` as a parameter precisely so the
+/// message text can't drift between guards that legitimately check
+/// different ceilings). This one is a catchable `EvalError` instead of a
+/// panic -- for a caller that isn't the evaluator's own hot recursion
+/// (where a panic is deliberate, see `to_owned`'s own doc comment on why an
+/// `EvalError` there would make a stack-overflow guard catchable by
+/// `try`/`catch`) but a CLI-level input-validation walk (`jq_runner.rs`'s
 /// `validate_json_delimiters`, reached before any user filter runs) that
 /// already threads a `Result` and has no such concern.
 pub fn check_nesting_depth(depth: usize) -> Result<(), EvalError> {
     if depth < MAX_NESTING_DEPTH {
         Ok(())
     } else {
-        Err(EvalError::new(format!(
-            "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
-        )))
+        Err(EvalError::new(
+            super::value::nesting_depth_exceeded_message(MAX_NESTING_DEPTH),
+        ))
     }
 }
 

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -110,7 +110,8 @@ pub use parser::{
 };
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_value_tree_depth, format_number_jq_compat, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
+    assert_value_tree_depth, format_number_jq_compat, nesting_depth_exceeded_message, NumberRepr,
+    OwnedValue, MAX_VALUE_TREE_DEPTH,
 };
 // `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
 // code review, #1193/PR #1314) need this from outside `jq::value` --

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -89,7 +89,18 @@ pub const MAX_VALUE_TREE_DEPTH: usize = 384;
 /// code review).
 #[track_caller]
 pub fn assert_depth(depth: usize, max: usize) {
-    assert!(depth < max, "nesting depth exceeds limit of {max}");
+    assert!(depth < max, "{}", nesting_depth_exceeded_message(max));
+}
+
+/// The message every depth-limit guard reports past `max` levels of nesting.
+///
+/// Shared by every guard -- panicking (`assert_depth`) or checked
+/// ([`eval_generic::check_nesting_depth`](super::eval_generic::check_nesting_depth),
+/// `jq_runner.rs`'s `print_json`) -- so a wording change can't drift
+/// between the forms the way two independent copies of this exact string
+/// already did once before being consolidated into `assert_depth` (#998).
+pub fn nesting_depth_exceeded_message(max: usize) -> String {
+    format!("nesting depth exceeds limit of {max}")
 }
 
 /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16970,6 +16970,103 @@ fn test_unrelated_value_tree_depth_panic_is_not_caught_by_1793_fix() -> Result<(
     Ok(())
 }
 
+/// #1818: `run_jq`'s *other* top-level branch -- taken whenever
+/// `can_use_lazy_path` is `false` (`--slurp`/`-s`, `-S`/`--sort-keys`,
+/// `-C`/`--color-output`, `--ascii-output`, `--slurpfile`, or a filter using
+/// `input`/`inputs`/`input_line_number`) -- reaches
+/// `validate_json_delimiters` (`parse_json_stream`'s fallback) with no
+/// equivalent guard against #1793's own `MAX_NESTING_DEPTH` panic, unlike
+/// the lazy path that fix already covers. Confirmed live before this fix:
+/// each flag below panicked uncaught (exit 101, a bare `thread 'main'
+/// panicked at ...` message) rather than reporting a clean jq-channel
+/// error.
+///
+/// This branch materializes the whole batch up front, so (unlike
+/// `test_adversarial_nesting_does_not_abort_rest_of_stream_1793`'s lazy-path
+/// isolation) there's no expectation of processing documents on either side
+/// of the adversarial one -- only that the failure is a clean, catchable
+/// error instead of a panic.
+#[test]
+fn test_slurp_reports_clean_error_on_adversarial_nesting_1818() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "--slurp", "."], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1818 sibling case: `-S`/`--sort-keys` reaches the identical fallback
+/// path as `--slurp` above.
+#[test]
+fn test_sort_keys_reports_clean_error_on_adversarial_nesting_1818() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "--sort-keys", "."], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1818 sibling case: `-C`/`--color-output` forces the same
+/// whole-batch-materializing branch.
+#[test]
+fn test_color_output_reports_clean_error_on_adversarial_nesting_1818() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-C", "."], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1818 sibling case: `--ascii-output`, the fourth flag named in the
+/// issue's own repro.
+#[test]
+fn test_ascii_output_reports_clean_error_on_adversarial_nesting_1818() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "--ascii-output", "."], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1818 sibling case: a filter using `inputs` also forces the
+/// whole-batch-materializing branch (`can_use_lazy_path` excludes it), even
+/// with no special CLI flag at all.
+#[test]
+fn test_inputs_filter_reports_clean_error_on_adversarial_nesting_1818() -> Result<()> {
+    let input = nested_arrays(500);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[inputs]"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the five tests above: legitimately-nested input well under
+/// the limit must still succeed through this branch too, unaffected by the
+/// new checked guard.
+#[test]
+fn test_slurp_accepts_nesting_under_limit_1818() -> Result<()> {
+    let input = nested_arrays(100);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "--slurp", "."], Some(&input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), format!("[{input}]"));
+    Ok(())
+}
+
 /// #1008 (yq PR) code review: `format_number_jq_compat`'s `value == 0.0`/
 /// `value as i64` checks don't distinguish -0.0 from 0.0 (IEEE 754), so a
 /// negative-zero exponent literal silently lost its sign across all three


### PR DESCRIPTION
Fixes #1818.

## Summary

#1793 fixed the CLI's default (lazy) per-document dispatch against an
uncaught `MAX_NESTING_DEPTH` panic, but `run_jq`'s **other** top-level
branch — taken whenever `can_use_lazy_path` is `false` (`--slurp`,
`-S`/`--sort-keys`, `-C`/`--color-output`, `--ascii-output`, `--slurpfile`,
or a filter using `input`/`inputs`/`input_line_number`) — reaches the
identical guard via `validate_json_delimiters` (`parse_json_stream`'s
fallback) with no equivalent protection.

## Repro (confirmed live against `main`, pre-fix)

```console
$ python3 -c "print('['*500 + '1' + ']'*500)" > deep.json
$ succinctly jq -c --sort-keys '.' deep.json
thread 'main' panicked at src/bin/succinctly/jq_runner.rs:4393:5:
nesting depth exceeds limit of 256
$ echo $?
101
```

Same result for `--slurp`, `-C`, `--ascii-output`, and a filter using
`inputs` with no flag at all.

## Fix

Added `check_nesting_depth`, a checked sibling of `assert_nesting_depth`
sharing the exact same `MAX_NESTING_DEPTH` ceiling and message
(`print_json`'s own `anyhow::ensure!` guard already uses this message for
the analogous lazy-path case). `validate_json_delimiters` already threads a
`Result` and runs entirely at the CLI's input-validation stage before any
user filter evaluates, so there's no `try`/`catch`-reachability concern the
way there is for `to_owned`'s own hot-path panic (documented in that
function's own doc comment) — unlike that guard, this one can just return
an error instead of panicking.

```console
$ succinctly jq -c --sort-keys '.' deep.json
jq: error (at deep.json:0): nesting depth exceeds limit of 256
$ echo $?
5
```

Confirmed `--slurpfile`'s own error-reporting shape (a plain `Error: ...`
at exit 1, not jq's `jq: error (at ...)` at exit 5) is pre-existing and
consistent with how it reports every other error type too (verified
against a malformed-JSON `--slurpfile` control case) — not a new
inconsistency introduced here.

## Testing

Added 6 new tests covering `--slurp`, `-S`, `-C`, `--ascii-output`, a
filter using `inputs`, and a positive control (legitimately-nested input
under the limit still succeeds). Updated `docs/compliance/jq/limitations.md`'s
existing #1793 entry to reflect the narrowed scope of what remains uncaught
(`-e`/`--exit-status`'s separate materializer, and `succinctly yq` entirely
— both tracked separately, #1817).

Full local verification: build/test/clippy under both default and full
(`cli,simd,regex,serde`) feature sets, plus `--no-default-features` and
`cargo doc --all-features`.