### PR TITLE
fix(jq): unify print_json's depth ceiling with MAX_VALUE_TREE_DEPTH

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -18,7 +18,7 @@ use succinctly::jq::eval_generic::{
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
     self, format_number_jq_compat, nonfinite_display_string, EvalError, Expr, JqSemantics, JqValue,
-    OwnedValue, Program,
+    OwnedValue, Program, MAX_VALUE_TREE_DEPTH,
 };
 use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -4497,10 +4497,33 @@ fn json_bytes_to_owned_value_checked(bytes: &[u8]) -> core::result::Result<Owned
 ///
 /// Guarded against adversarially deep JSON input (thousands of nested
 /// arrays/objects, which would otherwise recurse this writer once per
-/// nesting level and overflow the stack) by the shared
-/// [`succinctly::jq::eval_generic::MAX_NESTING_DEPTH`] ceiling -- see that
-/// constant's own doc comment for how 256 was chosen, including this
-/// function's own measured debug-build crash boundary of depth 600-700.
+/// nesting level and overflow the stack) by the
+/// [`succinctly::jq::MAX_VALUE_TREE_DEPTH`] ceiling (384) -- **not**
+/// [`succinctly::jq::eval_generic::MAX_NESTING_DEPTH`] (256), despite this
+/// function importing that constant too for an unrelated panic-message
+/// check elsewhere in this file. Before #1819, this writer used
+/// `MAX_NESTING_DEPTH` for its own guard, one level lower than
+/// `MAX_VALUE_TREE_DEPTH` -- the ceiling every *other* value-tree consumer
+/// in the binary already honors (`OwnedValue::to_json`, `compare_values`,
+/// `eval.rs`'s own `to_owned`, `reconcile_presentation`,
+/// `format_json_impl`). A value strictly between the two limits passed
+/// every construction-time guard, started printing, and only failed
+/// **mid-write** -- after this function had already flushed up to 256
+/// levels of syntactically-incomplete JSON to `out` (`anyhow::ensure!`
+/// fires per-level, so every shallower stack frame's own opening
+/// delimiter is already written by the time a deeper frame raises).
+/// Matching `MAX_VALUE_TREE_DEPTH` closes that gap: nothing that passes
+/// this crate's own construction-time depth ceiling can trip a *stricter*
+/// one at print time. This function's own measured debug-build crash
+/// boundary is 600-700 (see `MAX_NESTING_DEPTH`'s doc comment), so 384
+/// leaves the same order of headroom `MAX_VALUE_TREE_DEPTH` itself was
+/// tuned against for its own tightest consumer (580) -- comfortably safe.
+/// A pure-cursor document deeper than 384 (no `OwnedValue` construction
+/// involved at all) still hits this same corrupted-partial-output pattern,
+/// just at the higher threshold -- eliminating that residual would need a
+/// depth pre-check ahead of any writing, which isn't cheap to do generically
+/// for an arbitrary cursor; #1819 scopes this fix to closing the
+/// construction/print ceiling mismatch, not that broader limitation.
 /// Unlike `eval_generic::to_owned`'s own guard (a panic, since that
 /// function sits too deep in the evaluator's hot path for a `Result`-based
 /// fix), this one is a clean, catchable `anyhow` error: a query like the
@@ -4550,8 +4573,8 @@ where
     Wrd: Clone + AsRef<[u64]>,
 {
     anyhow::ensure!(
-        level < MAX_NESTING_DEPTH,
-        "nesting depth exceeds limit of {MAX_NESTING_DEPTH}"
+        level < MAX_VALUE_TREE_DEPTH,
+        "nesting depth exceeds limit of {MAX_VALUE_TREE_DEPTH}"
     );
     let compact = config.compact;
     let indent = &config.indent_string;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -76,22 +76,31 @@ use crate::json::JsonIndex;
 /// materialization step — a 128 limit broke that test outright. Measured
 /// directly on a debug build (the more fragile of the two, larger
 /// per-frame stack cost than release): the real crash boundary for this
-/// function sits between depth 2000 (safe) and 3000 (overflow), and for
-/// `print_json` in `src/bin/succinctly/jq_runner.rs` (same limit, guards
-/// the identity-query fast path this function's own guard can't reach)
-/// between 600 (safe) and 700 (overflow) — 256 clears the 200 floor with
-/// margin and sits comfortably under both boundaries, including headroom
-/// for a CI runner with a smaller default stack than the dev machine this
-/// was measured on.
+/// function sits between depth 2000 (safe) and 3000 (overflow) — 256 clears
+/// the 200 floor with margin and sits comfortably under that boundary,
+/// including headroom for a CI runner with a smaller default stack than the
+/// dev machine this was measured on.
 ///
 /// `pub`, not private: every recursive tree-materialization function that
 /// isn't itself one of this module's own (`to_owned`/`to_owned_cursor`/
 /// `to_owned_with_comments`, all guarded via [`assert_nesting_depth`] below)
-/// needs the same ceiling -- `jq_runner.rs`'s `print_json` and `lazy.rs`'s
-/// `cursor_to_owned` both import this rather than hand-rolling their own
-/// copy, so the whole binary has exactly one number to retune (#998 review:
-/// two independent copies of this same constant had already drifted apart
-/// in wording, if not value, before this consolidation).
+/// needs the same ceiling -- `lazy.rs`'s `cursor_to_owned` imports this
+/// rather than hand-rolling its own copy, so the whole binary has exactly
+/// one number to retune for this guard family (#998 review: two independent
+/// copies of this same constant had already drifted apart in wording, if
+/// not value, before this consolidation).
+///
+/// `jq_runner.rs`'s `print_json` also imports this constant, but only for an
+/// unrelated purpose: recognizing `to_owned_cursor_at_depth`'s own panic
+/// message text (see `nesting_depth_panic_message`) so it can be
+/// distinguished from an unrelated panic. `print_json`'s *own* recursion
+/// guard was moved to [`super::value::MAX_VALUE_TREE_DEPTH`] by #1819 --
+/// see that constant's doc comment and `print_json`'s own for why one
+/// shared ceiling was wrong for this specific pairing: `print_json` prints
+/// values this crate has already promised (via `MAX_VALUE_TREE_DEPTH`) to
+/// support up to that depth, and its own measured crash boundary (600-700,
+/// noted above) has room to match that promise instead of failing 128
+/// levels earlier.
 pub const MAX_NESTING_DEPTH: usize = 256;
 
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998).

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -30,7 +30,10 @@ use super::expr::Literal;
 ///
 /// Guards [`OwnedValue::to_json`]/`to_json_for_reindex`/`==`/
 /// `eval::compare_values`/`eval.rs`'s own `to_owned`/
-/// `yq_runner::reconcile_presentation`/`output::format_json_impl`.
+/// `yq_runner::reconcile_presentation`/`output::format_json_impl`/
+/// `jq_runner::print_json` (#1819 -- moved here from the stricter,
+/// mismatched `eval_generic::MAX_NESTING_DEPTH`, see that function's own
+/// doc comment).
 ///
 /// Deliberately a *separate* constant from
 /// [`eval_generic::MAX_NESTING_DEPTH`](super::eval_generic::MAX_NESTING_DEPTH)

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -38,14 +38,18 @@ use super::expr::Literal;
 /// Deliberately a *separate* constant from
 /// [`eval_generic::MAX_NESTING_DEPTH`](super::eval_generic::MAX_NESTING_DEPTH)
 /// (256), not a reuse of it: that ceiling guards cursor-to-`OwnedValue`
-/// *conversion* functions, individually tuned against their own measured
-/// crash boundaries (600-700 for the tightest of that set, `print_json`).
-/// This constant's own guarded functions are a different shape with
-/// different measured boundaries (debug build, default 2MiB test-thread
-/// stack — the more fragile of debug/release, matching how 256 was itself
-/// measured): `reconcile_presentation` crashes between depth 580-600 (the
-/// tightest of this set), `format_json_impl` between 650-700, and
-/// `eval.rs`'s own `to_owned` between 1800-2000. Reusing 256 here would be
+/// *conversion* functions (`to_owned`/`to_owned_cursor`/`cursor_to_owned`),
+/// individually tuned against their own measured crash boundaries --
+/// `to_owned`'s own sits between 1800-2000. (`print_json` used to share
+/// that ceiling too; #1819 moved it to this one instead, since it was the
+/// wrong pairing -- see this constant's "Guards" list above and
+/// `print_json`'s own doc comment.) This constant's own guarded functions
+/// are a different shape with different measured boundaries (debug build,
+/// default 2MiB test-thread stack — the more fragile of debug/release,
+/// matching how 256 was itself measured): `reconcile_presentation` crashes
+/// between depth 580-600 (the tightest of this set), `format_json_impl`
+/// between 650-700, `print_json` between 600-700, and `eval.rs`'s own
+/// `to_owned` between 1800-2000. Reusing 256 here would be
 /// wrong in the *other* direction: 256 does not clear
 /// `tests/jq_recurse_depth_tests.rs`'s deliberately-pinned depth-300
 /// correctness capability for `path(..)`/`path(recurse)` (#626's de-risk

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -16711,13 +16711,18 @@ fn test_func_def_arity_overload_through_path_context_evaluator_1376() -> Result<
 /// for it -- confirmed live before this fix, `succinctly jq '.'` on a
 /// 200,000-level-deep document aborted with a raw stack overflow (SIGABRT,
 /// exit 134), not a clean error. `print_json` needs its own guard.
+///
+/// #1819 moved that guard's own ceiling from `MAX_NESTING_DEPTH` (256) to
+/// `MAX_VALUE_TREE_DEPTH` (384) -- this test's 500-deep input still clears
+/// either ceiling, so it keeps demonstrating the same rejection, just with
+/// the new number.
 #[test]
 fn test_identity_query_rejects_adversarial_nesting_998() -> Result<()> {
     let input = nested_arrays(500);
     let (_stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
     assert_eq!(code, 1, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("nesting depth exceeds limit of 256"),
+        stderr.contains("nesting depth exceeds limit of 384"),
         "stderr: {stderr:?}"
     );
     Ok(())
@@ -16731,6 +16736,69 @@ fn test_identity_query_accepts_nesting_under_limit_998() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}
+
+/// #1819: `MAX_NESTING_DEPTH` (256, `print_json`'s old ceiling) and
+/// `MAX_VALUE_TREE_DEPTH` (384, every other value-tree consumer's ceiling,
+/// including the construction-time guards a `reduce`-built value passes
+/// through) used to disagree, so a value strictly between them passed
+/// construction and then failed **mid-print** -- after `print_json` had
+/// already flushed a large amount of syntactically-incomplete JSON to
+/// stdout. Confirmed live before this fix: this exact query corrupted
+/// output and exited 1 with a raw `anyhow` message instead of printing a
+/// complete, valid document. 300 is the issue's own repro depth, squarely
+/// inside the former 257-384 gap.
+#[test]
+fn test_reduce_built_value_in_former_depth_gap_prints_cleanly_1819() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "reduce range(300) as $i (null; [.])"], Some("1"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    let want = format!("{}null{}", "[".repeat(300), "]".repeat(300));
+    assert_eq!(stdout.trim_end(), want);
+    Ok(())
+}
+
+/// #1819 companion: the identity path (pure cursor navigation, no
+/// `OwnedValue` construction at all) must round-trip the same former-gap
+/// depths cleanly, not just the `reduce`-constructed case above --
+/// `print_json` is the only guard either shape ever reaches.
+#[test]
+fn test_identity_query_in_former_depth_gap_prints_cleanly_1819() -> Result<()> {
+    let input = nested_arrays(300);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}
+
+/// #1819 boundary: exactly `MAX_VALUE_TREE_DEPTH - 1` (383) levels deep must
+/// still succeed -- the last depth the new ceiling accepts.
+#[test]
+fn test_identity_query_accepts_exactly_384_boundary_minus_one_1819() -> Result<()> {
+    let input = nested_arrays(383);
+    let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), input);
+    Ok(())
+}
+
+/// #1819 boundary: exactly `MAX_VALUE_TREE_DEPTH` (384) levels deep must
+/// still raise cleanly -- the new ceiling has a real edge, it didn't just
+/// move the corruption threshold out without limit. This is the
+/// crate's own documented depth-support ceiling (`MAX_VALUE_TREE_DEPTH`,
+/// #1005), so failing here -- rather than silently accepting arbitrarily
+/// deep input -- is deliberate, matching every other value-tree consumer's
+/// own boundary tests.
+#[test]
+fn test_identity_query_rejects_exactly_384_boundary_1819() -> Result<()> {
+    let input = nested_arrays(384);
+    let (_stdout, stderr, code) = run_jq_full(&["-c", "."], Some(&input))?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 384"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`print_json`'s own recursion guard used `eval_generic::MAX_NESTING_DEPTH`
(256), one level lower than `MAX_VALUE_TREE_DEPTH` (384) — the ceiling
every other value-tree consumer in the binary honors (`OwnedValue::to_json`,
`compare_values`, `eval.rs`'s own `to_owned`, `reconcile_presentation`,
`format_json_impl`). A value strictly between the two limits passed every
construction-time guard, started printing, and only failed **mid-write** —
after `print_json` had already flushed a large amount of
syntactically-incomplete JSON to stdout.

```console
$ printf '1' | succinctly jq -c 'reduce range(300) as $i (null; [.])'
[[[[[[[[[...  (256 levels of unmatched `[`, then:)
Error: nesting depth exceeds limit of 256
```

## Fix

Move `print_json`'s guard from `MAX_NESTING_DEPTH` to `MAX_VALUE_TREE_DEPTH`
(384). Nothing that passes this crate's own construction-time depth ceiling
can now trip a *stricter* one at print time. `print_json`'s own measured
debug-build crash boundary (600-700, already documented on
`MAX_NESTING_DEPTH`) leaves 216 levels of headroom under 384 — the same
order of margin `MAX_VALUE_TREE_DEPTH` itself was tuned against for its
own tightest consumer (580).

`eval_generic::MAX_NESTING_DEPTH` itself is untouched — `to_owned`/
`to_owned_cursor`/`cursor_to_owned` keep their existing 256 ceiling. Only
`print_json`'s own `anyhow::ensure!` moved. This matters because
`print_json` also imports `MAX_NESTING_DEPTH` for an unrelated purpose
(recognizing `to_owned_cursor_at_depth`'s own panic-message text so it can
be told apart from an unrelated panic) — that use is untouched.

Verified live:

```console
$ printf '1' | ./target/debug/succinctly jq -c 'reduce range(300) as $i (null; [.])'
[[[...300 levels...[null]...]]]     # now succeeds, valid JSON
```

## Residual, deliberately out of scope

A pure-cursor document deeper than 384 — no `OwnedValue` construction
involved at all, e.g. `succinctly jq '.[0]'` on a 500-deep raw JSON file —
still hits this same corrupted-partial-output pattern, just at the higher
threshold instead of 256:

```console
$ python3 -c "print('['*500 + '1' + ']'*500)" > deep.json
$ succinctly jq -c '.[0]' deep.json
[[[...384 levels...
Error: nesting depth exceeds limit of 384
```

Eliminating that residual would need a depth pre-check ahead of any
writing, which isn't cheap to do generically for an arbitrary cursor (the
issue's own "Suggested approach" section names this as one option and
flags the cost). This fix is scoped to the specific 256-384 gap the issue
is titled after — every depth up to this crate's own documented
depth-support ceiling (384) now prints cleanly, matching every other
value-tree consumer's own promise.

## Test plan

- [x] New tests for the exact gap: `reduce`-constructed depth 300 (the
      issue's own repro) and pure cursor-navigation depth 300 both now
      print cleanly and round-trip exactly.
- [x] Boundary tests: depth 383 succeeds, depth 384 raises cleanly with
      the new "384" message.
- [x] Updated `test_identity_query_rejects_adversarial_nesting_998`'s
      expected message (256 → 384) — its 500-deep input still clears
      either ceiling.
- [x] Confirmed the *unrelated* `to_owned_cursor_at_depth` guard (`-e`,
      `sort`, `join`, `map(.)` fallback paths, #1793's tests) is
      untouched — still reports "256", confirming this fix didn't
      accidentally also raise that ceiling.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde
      --no-fail-fast`): 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the
      CI's second clippy leg (`std,simd,serde,cli,regex,bench-runner,
      large-tests,mmap-tests`): both clean.
- [x] `cargo build --no-default-features` (no_std): unaffected.

Fixes #1819