### PR TITLE
docs(jq): record ascii_downcase/ascii_upcase path() wording as a divergence

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -28,16 +28,16 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 219 probes in
+Measured against jq-1.7.1 over the 221 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
-| Dimension                                    | Result               | Meaning                                            |
-|----------------------------------------------|----------------------|----------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **219/219 = 100.0%** | Byte-identical to jq                               |
-| **Wording divergences**                      | **0**                | Every probe that errors in both errors identically |
-| **Behaviour / parser gaps**                  | **0**                | succinctly does not raise the error at all         |
+| Dimension                                    | Result              | Meaning                                                |
+|----------------------------------------------|---------------------|--------------------------------------------------------|
+| **Message text** (both evaluators, verbatim) | **219/221 = 99.1%** | Byte-identical to jq                                   |
+| **Wording divergences**                      | **2**               | Both evaluators raise, but word it differently from jq |
+| **Behaviour / parser gaps**                  | **0**               | succinctly does not raise the error at all             |
 
 These three numbers are asserted, not maintained by hand: `jq_error_message_tests.rs`
 parses them back out of this page and fails if they drift from the corpus (they went stale
@@ -1646,6 +1646,57 @@ already filed as [#1855](https://github.com/rust-works/succinctly/issues/1855) (
 is sticky (any-error) across multi-document input; real jq uses only the last document's
 outcome") before #1830 added this particular error class to the set of things that can trigger
 it. #1830 deliberately did not attempt a fix here, to avoid duplicating #1855's own scope.
+
+### `ascii_downcase`/`ascii_upcase` inside `path()` name the outer value, not jq's inner exploded-array step — no carve-out; recorded on its merits
+
+```console
+$ echo '{"a":"xyz"}' | jq -c 'path(.a | ascii_downcase)'
+jq: error (at <stdin>:1): Invalid path expression near attempt to iterate through [120,121,122]
+$ echo '{"a":"xyz"}' | succinctly jq -c 'path(.a | ascii_downcase)'
+jq: error (at <stdin>:1): Invalid path expression with result "xyz"
+```
+
+(same for `ascii_upcase`; both refuse with the same exit code, `5`, and the same
+`invalid_path_expression` message class -- only the parenthetical detail differs.)
+
+Real jq's `ascii_downcase`/`ascii_upcase` are `builtin.jq` prelude definitions
+(`explode | map(...) | implode`), so the path-expression check fails *inside*
+that definition, at the exploded array's iterate step, naming the codepoint
+array. succinctly implements both natively for performance, so its check
+fails at the outer call boundary and names the original string instead. The
+control case confirms it is the definition boundary and not the wording
+itself: `path(.a | explode)`, where both implementations are a single native
+step, agrees byte-for-byte in both tools.
+
+This does not fit any of ADR-0018 rule 4's four conditions: the output is not
+unreadable (a), nothing is corrupted or discarded (b), no process dies (c),
+and (d) is specifically about a dependency choice -- there is no crate to
+evaluate here, only an internal implementation choice between two options,
+both considered and rejected on cost:
+
+- **Re-derive `ascii_downcase`/`ascii_upcase` from the prelude definition**
+  (`explode | map(...) | implode`) instead of a native implementation.
+  Closes the gap, but degrades *every* ordinary (non-`path()`) call to these
+  two hot-path string builtins -- the common case pays a real performance
+  cost for an edge case that already errors either way.
+- **Special-case `path()` to detect these two builtins and report a
+  synthetic exploded-array step.** Closes the gap, but adds a second,
+  dedicated code path duplicating `explode`'s output just to build an error
+  message on an already-refused expression -- fragile (reports evaluation
+  that didn't actually happen) and only covers these two names, not the
+  general prelude-definition-vs-native-implementation gap other builtins
+  could hit the same way.
+
+Both candidates cost real complexity or a real performance regression to fix
+wording on an expression that already fails identically in both tools (same
+exit code, same error class) -- calling a string-transform builtin inside
+`path()` is already a user error jq itself refuses, so the value of matching
+its exact internal step name is near zero. Recorded here as a divergence
+accepted on its merits, following this page's own "A structurally malformed
+value doesn't abort the rest of a multi-value stream" entry above as
+precedent for a gap that doesn't fit the letter of rule 4 but is kept rather
+than silently left unrecorded. See
+[#1561](https://github.com/rust-works/succinctly/issues/1561).
 
 ## Provenance
 

--- a/tests/data/jq-error-known-divergences.txt
+++ b/tests/data/jq-error-known-divergences.txt
@@ -53,3 +53,12 @@
 # at all", which now raises `EvalError::invalid_path_expression`) took
 # `path_non_path_literal`, `path_non_path_builtin` and `path_non_path_arithmetic`
 # with them, emptying the list again.
+#
+# #1561: ascii_downcase/ascii_upcase are jq prelude definitions
+# (explode | map(...) | implode); succinctly implements them natively, so its
+# refusal names the outer value instead of jq's own exploded-array iterate
+# step. Recorded as a permanent divergence, not fixed — see
+# docs/compliance/jq/limitations.md.
+
+path_non_path_ascii_downcase_prelude_step  wording  jq's error names the exploded codepoint array, not the outer string — #1561
+path_non_path_ascii_upcase_prelude_step    wording  jq's error names the exploded codepoint array, not the outer string — #1561

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -217,6 +217,8 @@ path_non_path_keys	path(keys)	{"a":1}	Invalid path expression with result ["a"]
 path_non_path_pipe_to_builtin	path(.a | tostring)	{"a":1}	Invalid path expression with result "1"
 path_non_path_object_construction	path({a:1})	{"a":1}	Invalid path expression with result {"a":1}
 path_non_path_optional_not_suppressed	path(("a")?)	{"a":1}	Invalid path expression with result "a"
+path_non_path_ascii_downcase_prelude_step	path(.a | ascii_downcase)	{"a":"xyz"}	Invalid path expression near attempt to iterate through [120,121,122]
+path_non_path_ascii_upcase_prelude_step	path(.a | ascii_upcase)	{"a":"xyz"}	Invalid path expression near attempt to iterate through [120,121,122]
 infinite_preview	scan(infinite)	"x"	number (1.797693134...) is not a string
 neg_infinite_preview	scan(-infinite)	"x"	number (-1.79769313...) is not a string
 nan_preview	scan(nan)	"x"	number (null) is not a string

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -341,6 +341,12 @@ path_non_path_keys	path(keys)	{"a":1}
 path_non_path_pipe_to_builtin	path(.a | tostring)	{"a":1}
 path_non_path_object_construction	path({a:1})	{"a":1}
 path_non_path_optional_not_suppressed	path(("a")?)	{"a":1}
+# ascii_downcase/ascii_upcase are jq prelude definitions (explode | map(...) |
+# implode), so jq's own refusal fires one step deeper than the other
+# pipe-to-builtin probes above -- at the exploded array's iterate step, not
+# at the outer boundary (#1561).
+path_non_path_ascii_downcase_prelude_step	path(.a | ascii_downcase)	{"a":"xyz"}
+path_non_path_ascii_upcase_prelude_step	path(.a | ascii_upcase)	{"a":"xyz"}
 
 # ── non-finite float value previews (#930) ────────────────────────────────
 # describe()/dump_truncated() rendered an overflowed/infinite float preview


### PR DESCRIPTION
## Summary

```console
$ echo '{"a":"xyz"}' | jq -c 'path(.a | ascii_downcase)'
jq: error (at <stdin>:1): Invalid path expression near attempt to iterate through [120,121,122]
$ echo '{"a":"xyz"}' | succinctly jq -c 'path(.a | ascii_downcase)'
jq: error (at <stdin>:1): Invalid path expression with result "xyz"
```

Real jq defines `ascii_downcase`/`ascii_upcase` in its own prelude
(`explode | map(...) | implode`), so `path()`'s refusal fires *inside* that
definition, naming the exploded codepoint array. succinctly implements both
natively for performance, so the refusal fires at the outer call boundary
and names the original string instead. Both tools raise the identical exit
code (`5`) and error class — only the parenthetical detail differs. Control
case confirms it's the definition boundary, not the wording itself:
`path(.a | explode)` (a single native step in both) agrees byte-for-byte.

## Why documented, not fixed

Neither candidate fix is worth it:
- Re-deriving `ascii_downcase`/`ascii_upcase` from the prelude definition
  would degrade *every* ordinary call to these two hot-path string builtins,
  not just the `path()` edge case.
- Special-casing `path()` to report a synthetic exploded-array step adds a
  fragile, dedicated code path (reporting evaluation that didn't actually
  happen) covering only these two names.

This doesn't fit ADR-0018 rule 4(a)/(b)/(c), and (d) is specifically about a
dependency-selection cost/benefit — there's no crate to evaluate here, just
an internal implementation tradeoff. Recorded as an out-of-policy divergence
accepted on its merits, matching this page's existing "structurally
malformed value" precedent for exactly this situation.

## Changes

Wired into the existing probe/known-divergences machinery (this page's own
methodology is built around machine-verified wording divergences, not
free-form prose) rather than just adding prose:

- `tests/data/jq-error-probes.tsv`: two new probes,
  `path_non_path_ascii_downcase_prelude_step` /
  `path_non_path_ascii_upcase_prelude_step`
- `tests/data/jq-error-messages.tsv`: captured via
  `./scripts/sync-jq-error-messages.sh` against the pinned jq 1.7.1
- `tests/data/jq-error-known-divergences.txt`: both probes recorded with
  category `wording` and an issue link
- `docs/compliance/jq/limitations.md`: new "Deliberate divergences" entry
  with the candidates considered, plus updated summary-table numbers
  (219/221 = 99.1%, 2 wording divergences — asserted by
  `jq_error_message_tests.rs`, not hand-maintained)

## Verification

- `cargo test --features cli,regex --test jq_error_message_tests`: all 3
  tests pass (parity, known-divergences-reference-real-probes,
  limitations-page-quotes-the-real-numbers)
- `cargo test --features cli,simd,regex,serde --workspace`: all green
- `cargo clippy` (both feature legs), `cargo check --no-default-features`,
  `cargo doc --no-deps --all-features`, `cargo fmt --check`: all clean

Fixes #1561