### PR TITLE
perf(jq): bound path(limit(n; .[])) to O(n) for the bare .[] shape

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19561,39 +19561,13 @@ fn resolve_node<'a, S: EvalSemantics>(
                     EvalError::invalid_path_expression_near_iterate(value).into(),
                 ));
             }
-            match value {
-                OwnedValue::Array(items) => {
-                    let root = PathPrefix::root();
-                    Ok(items
-                        .iter()
-                        .enumerate()
-                        .map(|(i, v)| {
-                            PathBranch::new(
-                                PathPrefix::extend(&root, Expr::Index(i as i64)),
-                                Cow::Borrowed(v),
-                                true,
-                            )
-                        })
-                        .collect())
-                }
-                OwnedValue::Object(map) => {
-                    let root = PathPrefix::root();
-                    Ok(map
-                        .iter()
-                        .map(|(k, v)| {
-                            PathBranch::new(
-                                PathPrefix::extend(&root, Expr::Field(k.clone())),
-                                Cow::Borrowed(v),
-                                true,
-                            )
-                        })
-                        .collect())
-                }
-                other => Err((
-                    Vec::new(),
-                    EvalError::cannot_iterate_with(S::TAG, other).into(),
-                )),
-            }
+            // #1850 code review: delegates to `resolve_iterate_bounded`
+            // (`resolve_limit_one_n`'s own fast path) with `n = usize::MAX`
+            // -- a transparent no-op bound -- instead of keeping a second
+            // copy of this Array/Object/other match. One definition means a
+            // future change to how `.[]` builds path branches can't apply
+            // to only one of the two call sites.
+            resolve_iterate_bounded::<S>(value, usize::MAX)
         }
 
         Expr::IndexExpr { target, key } => {
@@ -20377,15 +20351,24 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
     take_path_branches(resolve_node::<S>(expr, value, trackable, snapshot), n)
 }
 
-/// `.[]` bounded to at most `n` branches (#1850) -- mirrors `resolve_node`'s
-/// own `Expr::Iterate` arm exactly (same `PathBranch`/`PathPrefix`
-/// construction, same [`EvalError::cannot_iterate_with`] for every other
-/// value shape), with `.take(n)` inserted into each container's iterator so
-/// [`resolve_limit_one_n`] never visits more than `n` elements. `items.iter()`/
-/// `map.iter()` are already lazy; the only change from the unbounded arm is
-/// stopping the walk early, not the values or error it produces -- confirmed
-/// live to be byte-identical to the old eager-then-truncate path for `n`
-/// under, at, and over the container's length.
+/// `.[]`'s own path-branch construction (#1850), bounded to at most `n`
+/// branches -- both `resolve_node`'s `Expr::Iterate` arm (`n = usize::MAX`,
+/// a transparent no-op bound) and [`resolve_limit_one_n`]'s fast path
+/// (`n` from `limit`) call this instead of keeping two copies of the
+/// `Array`/`Object`/`other` match. `items.iter()`/`map.iter()` are already
+/// lazy; `.take(n)` is the only change from the old unbounded form -- same
+/// `PathBranch`/`PathPrefix` construction, same
+/// [`EvalError::cannot_iterate_with`] for every other value shape,
+/// confirmed live to be byte-identical to the old eager-then-truncate path
+/// for `n` under, at, and over the container's length.
+///
+/// **Precondition, not re-checked here:** the caller must already know
+/// `value` is trackable (#843) before calling this -- both call sites gate
+/// on `trackable` first and raise `invalid_path_expression_near_iterate`
+/// themselves when it's false, exactly mirroring what the single combined
+/// arm used to do inline. This function has no `trackable` parameter of its
+/// own and never raises that error; a future third call site must add its
+/// own gate rather than assuming this function covers it.
 fn resolve_iterate_bounded<S: EvalSemantics>(
     value: &OwnedValue,
     n: usize,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20362,7 +20362,64 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
     if n == 0 {
         return Ok(Vec::new());
     }
+    // #1850: bare `.[]` (the shape the issue itself measures) is bounded
+    // directly via `.take(n)` on the same iterator `resolve_node`'s own
+    // `Expr::Iterate` arm builds, making `path(limit(n; .[]))` O(n)
+    // instead of O(document size) -- see `resolve_iterate_bounded`'s own
+    // doc comment for why this is scoped to exactly this shape rather than
+    // `resolve_node`'s generator path in general: every other arm there
+    // returns a fully materialized `Vec<PathBranch>` with no
+    // sink/early-stop protocol to plug into, so a fully general fix is a
+    // separate, much wider design question this issue itself left open.
+    if trackable && matches!(unwrap_paren(expr), Expr::Iterate) {
+        return resolve_iterate_bounded::<S>(value, n);
+    }
     take_path_branches(resolve_node::<S>(expr, value, trackable, snapshot), n)
+}
+
+/// `.[]` bounded to at most `n` branches (#1850) -- mirrors `resolve_node`'s
+/// own `Expr::Iterate` arm exactly (same `PathBranch`/`PathPrefix`
+/// construction, same [`EvalError::cannot_iterate_with`] for every other
+/// value shape), with `.take(n)` inserted into each container's iterator so
+/// [`resolve_limit_one_n`] never visits more than `n` elements. `items.iter()`/
+/// `map.iter()` are already lazy; the only change from the unbounded arm is
+/// stopping the walk early, not the values or error it produces -- confirmed
+/// live to be byte-identical to the old eager-then-truncate path for `n`
+/// under, at, and over the container's length.
+fn resolve_iterate_bounded<S: EvalSemantics>(
+    value: &OwnedValue,
+    n: usize,
+) -> PathResolveResult<'_> {
+    let root = PathPrefix::root();
+    match value {
+        OwnedValue::Array(items) => Ok(items
+            .iter()
+            .enumerate()
+            .take(n)
+            .map(|(i, v)| {
+                PathBranch::new(
+                    PathPrefix::extend(&root, Expr::Index(i as i64)),
+                    Cow::Borrowed(v),
+                    true,
+                )
+            })
+            .collect()),
+        OwnedValue::Object(map) => Ok(map
+            .iter()
+            .take(n)
+            .map(|(k, v)| {
+                PathBranch::new(
+                    PathPrefix::extend(&root, Expr::Field(k.clone())),
+                    Cow::Borrowed(v),
+                    true,
+                )
+            })
+            .collect()),
+        other => Err((
+            Vec::new(),
+            EvalError::cannot_iterate_with(S::TAG, other).into(),
+        )),
+    }
 }
 
 /// Convert a static, non-`Identity` path component into the `OwnedValue` jq

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10956,6 +10956,28 @@ fn test_path_limit_bare_iterate_through_parens_bounded_1850() -> Result<()> {
     Ok(())
 }
 
+/// #1850 code review: an untrackable value (#843) reaching the bare `.[]`
+/// fast path through `limit` must raise the same "near attempt to iterate"
+/// error the plain (non-`limit`) `Expr::Iterate` arm always has -- both call
+/// sites gate on `trackable` themselves before ever calling
+/// `resolve_iterate_bounded`, which has no such check of its own. Oracle-verified
+/// against jq 1.7.1: the caught scalar `5` is the value named, not a
+/// `cannot_iterate_with` "Cannot iterate over number" message.
+#[test]
+fn test_path_limit_bare_iterate_untrackable_value_still_near_attempt_error_1850() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(try (.a, error(5)) catch limit(3; .[]))"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]");
+    assert!(
+        stderr.contains("near attempt to iterate through 5"),
+        "{stderr}"
+    );
+    Ok(())
+}
+
 /// #1850 companion: a compound expression (`.[] | select(...)`) is not the
 /// bare `Expr::Iterate` shape the fast path targets, so it still takes the
 /// original eager `resolve_node` + `take_path_branches` route -- confirming

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10896,6 +10896,81 @@ fn test_resolve_limit_path_context_rejects_non_numeric_n() -> Result<()> {
     Ok(())
 }
 
+/// #1850: `path(limit(n; .[]))` on a bare `.[]` now resolves via
+/// `resolve_iterate_bounded`'s `.take(n)`-bounded iterator instead of
+/// `resolve_node` + `take_path_branches`'s eager-materialize-then-truncate
+/// pattern. Output must stay byte-identical for `n` under, at, and over the
+/// array's length -- the bound only changes how much work is done, never
+/// which branches are produced. Oracle-verified against jq 1.7.1.
+#[test]
+fn test_path_limit_bare_iterate_array_bounded_1850() -> Result<()> {
+    let input = r"[10,20,30,40,50]";
+    for (n, want) in [
+        ("3", "[0]\n[1]\n[2]"),
+        ("5", "[0]\n[1]\n[2]\n[3]\n[4]"),
+        ("100", "[0]\n[1]\n[2]\n[3]\n[4]"),
+        ("0", ""),
+    ] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-c", &format!("path(limit({n}; .[]))")], Some(input))?;
+        assert_eq!(code, 0, "n={n} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "n={n}");
+    }
+    Ok(())
+}
+
+/// #1850 companion: the same bounded fast path for an object, matching
+/// jq's own insertion-order `.[]` iteration.
+#[test]
+fn test_path_limit_bare_iterate_object_bounded_1850() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(limit(2; .[]))"],
+        Some(r#"{"a":1,"b":2,"c":3}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[\"a\"]\n[\"b\"]");
+    Ok(())
+}
+
+/// #1850 companion: a non-iterable target still raises the same
+/// `cannot_iterate_with` error the unbounded `Expr::Iterate` arm always
+/// did -- the bounded fast path must not silently swallow this into an
+/// empty result.
+#[test]
+fn test_path_limit_bare_iterate_non_container_still_errors_1850() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path(limit(3; .[]))"], Some("5"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("Cannot iterate"), "{stderr}");
+    Ok(())
+}
+
+/// #1850 companion: a redundantly-parenthesized `.[]` (`(.[])`) must still
+/// take the bounded fast path -- `unwrap_paren` peels the wrapper before
+/// the `Expr::Iterate` shape check, matching `resolve_node`'s own
+/// paren-transparency elsewhere.
+#[test]
+fn test_path_limit_bare_iterate_through_parens_bounded_1850() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path(limit(2; (.[])))"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[0]\n[1]");
+    Ok(())
+}
+
+/// #1850 companion: a compound expression (`.[] | select(...)`) is not the
+/// bare `Expr::Iterate` shape the fast path targets, so it still takes the
+/// original eager `resolve_node` + `take_path_branches` route -- confirming
+/// the fast path's narrower scope doesn't regress the general case.
+#[test]
+fn test_path_limit_compound_iterate_still_correct_1850() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(limit(2; .[] | select(. > 15)))"],
+        Some("[10,20,30,40]"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1]\n[2]");
+    Ok(())
+}
+
 #[test]
 fn test_as_binding_propagates_halt_from_bind_expression() -> Result<()> {
     // `eval_as`'s `bound_result` match: a halt while evaluating the bind


### PR DESCRIPTION
## Summary

`resolve_limit_one_n` (`path(limit(n; expr))`'s path-context resolver, the
sibling of the value-context `each_take_n`) called `resolve_node` fully
unbounded to materialize every path branch, then truncated the already-complete
`Vec<PathBranch>` down to `n` via `take_path_branches`. O(document size)
regardless of how small `n` is.

## Fix

Add `resolve_iterate_bounded`: for the exact bare `.[]` shape (through any
wrapping parens, via the existing `unwrap_paren` helper), resolve directly via
a `.take(n)`-bounded iterator over the same `Array`/`Object` data
`resolve_node`'s own `Expr::Iterate` arm walks — same `PathBranch`/`PathPrefix`
construction, same `cannot_iterate_with` error for every other value shape,
just stopping the walk early instead of collecting everything first.

Every other expression shape (`.[] | select(...)`, `recurse`, etc.) still
takes the original eager `resolve_node` + `take_path_branches` route — #1850
itself only measured/motivated the bare `.[]` case, and a fully general fix
would need `resolve_node`'s entire ~30+-arm match to gain a sink/early-stop
protocol none of them currently have (every arm returns a fully materialized
`Vec<PathBranch>` by value — see the doc comment on `resolve_iterate_bounded`
for why this is a separate, much wider design question, not attempted here).

## Verification

Live-verified against jq 1.7.1 across `n` under/at/over the container length,
objects (insertion-order iteration), the non-container error path, and
redundant parens (`(.[])`). Compound expressions still take the eager
fallback and remain correct (unaffected by this change).

## Important caveat on the measured perf win

Isolating `resolve_limit_one_n`'s own marginal cost from the shared
`to_owned_checked` conversion every path-context query pays
(`time(path(limit(3;.[]))) - time(path(.))`, same binary, same 300K-element
input) shows this fix removes that marginal cost entirely — before the fix,
~0.02-0.1s; after, indistinguishable from `path(.)`'s own baseline.

**But** that marginal cost was only a small fraction of the ~0.55-0.66s
`#1850` itself measured end-to-end. The rest (~0.5s) is `eval_pipe`'s
unconditional `to_owned_checked` conversion of the *entire* document to
`OwnedValue` the moment *any* path-context builtin is used — present
identically in `path(.)`, which does zero navigation once it has an
`OwnedValue`. That's a separate, much larger cost, filed as **#1909** rather
than attempted here (a substantially bigger architectural question: making
path-context evaluation work against the lazy cursor instead of requiring a
full upfront conversion).

So: this fix is correct and does exactly what `resolve_limit_one_n`'s own
text asked for, and it will matter more once/if #1909's larger cost is
addressed (avoiding stacking a second unnecessary O(n) term on top of a fixed
O(document) one) — but on its own, for large documents, it is not the
dominant term in `#1850`'s own wall-clock numbers. Documenting this now so a
future investigation doesn't need to re-discover it.

## Test plan

- [x] New tests: bare `.[]` on arrays (n under/at/over length, n=0), objects,
      non-container error preservation, redundant-parens shape, and a
      compound-expression control case confirming the narrower fast path
      doesn't regress the general one.
- [x] All adjacent existing `limit`+path tests (`_972`, `_1313`, `_1517`,
      `_824`, `_1663`, the non-numeric-`n` rejection test) still pass
      unmodified.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde
      --no-fail-fast`): 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and CI's
      second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,
      mmap-tests`): both clean.
- [x] `cargo fmt --check`: clean.

Fixes #1850
Related: #1909 (the actual dominant cost this fix's own measurement surfaced)