### PR TITLE
fix(jq): --seq no longer drops a record holding several JSON values (#1723)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1509,9 +1509,24 @@ $ printf '\x1exyz\n'           | jq --seq -c '.'
 jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)
 ```
 
-`succinctly jq --seq` emits nothing on stderr for any of these — output-wise it's already
-correct (RFC 7464's own recommended failure mode, #1093/#1267/#1243: the malformed record is
-dropped either way), the gap is purely the missing diagnostic. Matching these needs enough
+`succinctly jq --seq` emits nothing on stderr for any of these. Output-wise a *wholly*
+malformed record is already correct (RFC 7464's own recommended failure mode,
+#1093/#1267/#1243: it is dropped either way), but a record that is well-formed up to a
+malformed suffix is not: real jq emits the values it managed to read first, and succinctly
+drops the record entire.
+
+```
+$ printf '\x1e1 {invalid\n' | jq --seq -c '.'          # jq:         warns, then prints 1
+$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'  # succinctly: prints nothing
+```
+
+That prefix-emission gap is the same problem as the missing diagnostic, not a separate one:
+both need to know *where* in the record jq's parser gave up. (jq's own answer here is not
+always "everything before the error" either — `\x1e1,2\n` prints `2`, not `1`.)
+
+A record holding several *well-formed* values is no longer affected: #1723 fixed
+`succinctly jq --seq` dropping those in full (`\x1e1 "x" [2]\n` is three outputs, as in real
+jq), which was silent data loss rather than a diagnostic gap. Matching these needs enough
 of jq's own incremental-parser failure classification to know which of its internal states a
 segment would have failed in, not just whether it parses — deliberately deferred, tracked in
 [#1723](https://github.com/rust-works/succinctly/issues/1723).

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3233,6 +3233,9 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
             .map(|(i, _)| i + 1),
     );
     let last_idx = segment_starts.len() - 1;
+    // `segment_starts` always holds a leading 0, so more than one entry
+    // means at least one RS byte was found.
+    let has_rs = segment_starts.len() > 1;
 
     // The stream's own trailing record, when real jq's incremental reader
     // never resolves it (malformed, or an ambiguous bare number at true
@@ -3269,18 +3272,39 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         if segment.is_empty() {
             continue;
         }
-        if i == last_idx && drop_trailing {
+        // Two different conditions reach `drop_trailing`, and #1723 only
+        // relaxes one of them.
+        //
+        // *No RS byte anywhere* (`has_rs` false) is #1525's abandonment
+        // case: real jq drops the entire input, however well-formed its
+        // content is (`printf '1 2\n' | jq --seq -c .` prints nothing), so
+        // the record is still skipped wholesale. Relaxing this was a
+        // regression the differential sweep caught -- it started emitting
+        // `1` and `2` there.
+        //
+        // With an RS byte present, only a *malformed* trailing record is
+        // skipped wholesale. When it scans, its own last value may still be
+        // an ambiguous bare number, but the values before it are real
+        // output real jq emits (`\x1e1 2` => `1`), so that decision moved
+        // into `seq_record_values`, per value.
+        if i == last_idx && drop_trailing && (!has_rs || !seq_record_parses(segment)) {
             continue;
         }
 
         // Try to parse as JSON, silently ignore failures
         if seq_record_parses(segment) {
-            // Skipped, not raised: this function has no error channel by
-            // design -- RFC 7464 says a malformed segment is dropped, which
-            // is the same answer for a segment that parses but won't decode
-            // (#1247).
-            if let Ok(v) = crate::output::json_bytes_to_owned_value(segment.as_bytes()) {
-                results.push((v, end));
+            // One RFC 7464 record can hold *more than one* JSON value, and
+            // real jq emits every one of them (#1723): `\x1e1 "x" [2]\n`
+            // is three outputs, not a malformed record. `seq_record_parses`
+            // above only answers "does this record parse at all", so the
+            // split into individual values happens here, reusing the same
+            // `find_json_values` scanner the ordinary document path uses.
+            //
+            // Before this, a multi-value record failed whole-segment
+            // validation and was dropped in full -- silent data loss on a
+            // record real jq reads fine, not merely a missing diagnostic.
+            for (v, value_end) in seq_record_values(segment, &s[start..raw_end], start, end) {
+                results.push((v, value_end));
             }
         }
         // Genuine parse failures are silently ignored per RFC 7464
@@ -3289,16 +3313,137 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     results
 }
 
+/// Every JSON value inside one already-parse-checked `--seq` record, paired
+/// with the absolute end offset each value should report (#1723).
+///
+/// `segment` is the trimmed record text and `raw_segment` the *untrimmed*
+/// text between record boundaries -- both are needed: values are scanned out
+/// of the trimmed text, but the trailing-whitespace question below can only
+/// be asked of the untrimmed one (asking the trimmed text makes every bare
+/// number look unterminated, which silently dropped even a plain `\x1e1\n`
+/// in the first draft of this function). `segment_start` is the record's
+/// offset in the whole input, and `trimmed_end` its trailing-whitespace-
+/// trimmed end -- the offset the pre-#1723 single-value path reported, kept
+/// as the last value's end so a one-value record's reported line is
+/// byte-identical to before.
+///
+/// **The last value can still be dropped.** Real jq's incremental number
+/// scanner cannot rule out more digits arriving while a bare number is the
+/// last thing before a record boundary with no terminating byte after it,
+/// so it abandons that value -- the same ambiguity
+/// [`seq_trailing_record_is_dropped`] already encoded for the *stream's*
+/// final record, which turns out to apply per *record*, oracle-verified:
+///
+/// ```text
+/// printf '\x1e1 2\x1e3\n'   | jq --seq -c .   =>  1, 3      (the `2` is dropped)
+/// printf '\x1e1 2\n\x1e3\n' | jq --seq -c .   =>  1, 2, 3   (a newline disambiguates it)
+/// ```
+///
+/// Without this, adding multi-value support would have *introduced* a
+/// divergence on the first shape while fixing the second.
+fn seq_record_values(
+    segment: &str,
+    raw_segment: &str,
+    segment_start: usize,
+    trimmed_end: usize,
+) -> Vec<(OwnedValue, usize)> {
+    let Some((text, ranges)) = seq_record_scan(segment) else {
+        // `seq_record_parses` said yes and this says no: nothing to emit,
+        // and no error channel here by design (RFC 7464 drops the record
+        // either way).
+        return Vec::new();
+    };
+    let text = text.as_ref();
+
+    let mut out = Vec::new();
+    let last = ranges.len().saturating_sub(1);
+    for (i, (vs, ve)) in ranges.iter().copied().enumerate() {
+        let is_last = i == last;
+        if is_last && seq_record_last_value_is_ambiguous(&text[vs..ve], raw_segment) {
+            continue;
+        }
+        let Ok(v) = crate::output::json_bytes_to_owned_value(&text.as_bytes()[vs..ve]) else {
+            // Parses but will not decode (#1247): dropped, exactly as the
+            // pre-#1723 single-value path dropped it.
+            continue;
+        };
+        // The last value keeps the record's own trimmed end so a
+        // single-value record reports the identical line it always did;
+        // earlier values report their own end, which is what jq's
+        // per-value line reporting needs.
+        let end = if is_last {
+            trimmed_end
+        } else {
+            segment_start + ve
+        };
+        out.push((v, end));
+    }
+    out
+}
+
+/// Whether a record's final value is a bare number real jq would abandon as
+/// potentially truncated -- the per-record form of
+/// [`seq_trailing_record_is_dropped`]'s own third case, sharing its exact
+/// predicate: a leading `-`/digit, and no trailing whitespace in the
+/// *untrimmed* record after it.
+fn seq_record_last_value_is_ambiguous(value_text: &str, raw_segment: &str) -> bool {
+    let is_bare_number = matches!(value_text.as_bytes().first(), Some(b'-' | b'0'..=b'9'));
+    is_bare_number && raw_segment.trim_end() == raw_segment
+}
+
 /// Whether a trimmed, non-empty `--seq` record segment parses as JSON --
 /// [`parse_json_seq_with_ends`]'s own per-segment success check, factored out so
 /// [`seq_trailing_record_is_dropped`] can ask the identical question about
 /// one specific segment without duplicating the leading-zero retry logic.
 fn seq_record_parses(segment: &str) -> bool {
-    if validate::validate(segment.as_bytes()).is_ok() {
-        return true;
-    }
+    seq_record_scan(segment).is_some()
+}
+
+/// The text a `--seq` record's values were scanned out of, and each value's
+/// `(start, end)` range within it.
+///
+/// The text is a `Cow` because the leading-zero retry (#1243) has to scan a
+/// *normalized* copy, while the ordinary case borrows the record as-is.
+type SeqRecordScan<'a> = (Cow<'a, str>, Vec<(usize, usize)>);
+
+/// Split a trimmed, non-empty `--seq` record into its JSON values, or `None`
+/// if it is malformed.
+///
+/// One record can hold more than one value (#1723), so this cannot be a
+/// single whole-segment `validate::validate` call the way it was before --
+/// that call is what made `\x1e1 2\n` look malformed and silently dropped
+/// both values. Each extracted value is *still* validated strictly and
+/// individually, so the scanner (which is a tokenizer, not a validator)
+/// cannot widen what this accepts: `find_json_values` locates the value
+/// boundaries, `validate::validate` decides whether each one is legal JSON.
+///
+/// The leading-zero retry (`007e5`) is unchanged in effect, just expressed
+/// as a second pass over the normalized text; offsets stay usable across it
+/// because normalization only rewrites digits in place, never reorders or
+/// inserts.
+fn seq_record_scan(segment: &str) -> Option<SeqRecordScan<'_>> {
     let normalized = normalize_leading_zero_numbers(segment);
-    normalized != segment && validate_json_str(&normalized).is_ok()
+    let mut candidates: Vec<Cow<'_, str>> = vec![Cow::Borrowed(segment)];
+    // Only worth a second pass when normalization actually changed
+    // something; identical text would fail the identical way.
+    if normalized != segment {
+        candidates.push(Cow::Owned(normalized));
+    }
+    for text in candidates {
+        let Ok(ranges) = find_json_values(text.as_bytes()) else {
+            continue;
+        };
+        if ranges.is_empty() {
+            continue;
+        }
+        if ranges
+            .iter()
+            .all(|&(a, b)| validate::validate(&text.as_bytes()[a..b]).is_ok())
+        {
+            return Some((text, ranges));
+        }
+    }
+    None
 }
 
 /// Whether `raw`'s trailing `--seq` record (RFC 7464, everything after the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3245,7 +3245,7 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     // real jq, not `[1,2]`, even though "2" alone is perfectly valid JSON.
     // Computed once, up front, and checked only against the last segment
     // below -- the already-malformed case is caught either way (this
-    // check, or `seq_record_parses` failing on its own a few lines down),
+    // check, or `seq_record_scan` failing on its own a few lines down),
     // but the ambiguous-number case parses just fine on its own and needs
     // this explicit exclusion to be dropped at all.
     let drop_trailing = seq_trailing_record_is_dropped(s);
@@ -3268,10 +3268,27 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
 
         // Full (both-sides) trim to decide parse-eligibility -- matches
         // the original per-segment `segment.trim()` check exactly.
-        let segment = s[start..raw_end].trim();
+        let raw_segment = &s[start..raw_end];
+        let segment = raw_segment.trim();
         if segment.is_empty() {
             continue;
         }
+        // Anything before the *first* RS byte is not a record at all, and
+        // real jq discards it however well-formed it is: `printf '"a"
+        // \x1e3\n' | jq --seq -c .` prints only `3`. Segment 0 is that
+        // prefix whenever the input has an RS byte -- and when it has none,
+        // segment 0 *is* the whole input and #1525's abandonment rule below
+        // owns it instead. (A review caught this: multi-value support made
+        // a pre-existing single-value leak here emit every value in the
+        // prefix, widening the divergence rather than introducing it.)
+        if has_rs && i == 0 {
+            continue;
+        }
+        // Scanned once here and reused for both the drop decision and the
+        // value extraction below -- a review found this record being
+        // re-scanned up to three times, each pass allocating and
+        // re-tokenizing.
+        let scanned = seq_record_scan(segment);
         // Two different conditions reach `drop_trailing`, and #1723 only
         // relaxes one of them.
         //
@@ -3287,15 +3304,15 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         // an ambiguous bare number, but the values before it are real
         // output real jq emits (`\x1e1 2` => `1`), so that decision moved
         // into `seq_record_values`, per value.
-        if i == last_idx && drop_trailing && (!has_rs || !seq_record_parses(segment)) {
+        if i == last_idx && drop_trailing && (!has_rs || scanned.is_none()) {
             continue;
         }
 
         // Try to parse as JSON, silently ignore failures
-        if seq_record_parses(segment) {
+        if let Some(ranges) = scanned {
             // One RFC 7464 record can hold *more than one* JSON value, and
             // real jq emits every one of them (#1723): `\x1e1 "x" [2]\n`
-            // is three outputs, not a malformed record. `seq_record_parses`
+            // is three outputs, not a malformed record. `seq_record_scan`
             // above only answers "does this record parse at all", so the
             // split into individual values happens here, reusing the same
             // `find_json_values` scanner the ordinary document path uses.
@@ -3303,7 +3320,16 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
             // Before this, a multi-value record failed whole-segment
             // validation and was dropped in full -- silent data loss on a
             // record real jq reads fine, not merely a missing diagnostic.
-            for (v, value_end) in seq_record_values(segment, &s[start..raw_end], start, end) {
+            // `trimmed_start`, not `start`: the ranges index the *trimmed*
+            // segment, so pairing them with the untrimmed record start
+            // reported offsets that were short by the leading whitespace --
+            // enough to name the wrong line, and across files the wrong
+            // file (a review found `\x1e  "a"\n"b"\n` naming lines 0/2
+            // where jq names 1/2).
+            let trimmed_start = start + (raw_segment.len() - raw_segment.trim_start().len());
+            for (v, value_end) in
+                seq_record_values(segment, raw_segment, &ranges, trimmed_start, end)
+            {
                 results.push((v, value_end));
             }
         }
@@ -3313,19 +3339,17 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     results
 }
 
-/// Every JSON value inside one already-parse-checked `--seq` record, paired
-/// with the absolute end offset each value should report (#1723).
+/// Every JSON value inside one `--seq` record, paired with the absolute end
+/// offset each value should report (#1723).
 ///
-/// `segment` is the trimmed record text and `raw_segment` the *untrimmed*
-/// text between record boundaries -- both are needed: values are scanned out
-/// of the trimmed text, but the trailing-whitespace question below can only
-/// be asked of the untrimmed one (asking the trimmed text makes every bare
-/// number look unterminated, which silently dropped even a plain `\x1e1\n`
-/// in the first draft of this function). `segment_start` is the record's
-/// offset in the whole input, and `trimmed_end` its trailing-whitespace-
-/// trimmed end -- the offset the pre-#1723 single-value path reported, kept
-/// as the last value's end so a one-value record's reported line is
-/// byte-identical to before.
+/// `segment` is the trimmed record text and `ranges` its values' byte ranges
+/// within it (from [`seq_record_scan`], computed once by the caller rather
+/// than re-derived here -- a review found this function re-scanning a record
+/// the caller had already scanned twice). `trimmed_start`/`trimmed_end` are
+/// that trimmed text's own absolute bounds, so an earlier value's reported
+/// offset lands on the value itself; the last value keeps `trimmed_end`
+/// exactly, so a one-value record's reported line stays byte-identical to
+/// the pre-#1723 single-value path.
 ///
 /// **The last value can still be dropped.** Real jq's incremental number
 /// scanner cannot rule out more digits arriving while a bare number is the
@@ -3344,39 +3368,31 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
 fn seq_record_values(
     segment: &str,
     raw_segment: &str,
-    segment_start: usize,
+    ranges: &[(usize, usize)],
+    trimmed_start: usize,
     trimmed_end: usize,
 ) -> Vec<(OwnedValue, usize)> {
-    let Some((text, ranges)) = seq_record_scan(segment) else {
-        // `seq_record_parses` said yes and this says no: nothing to emit,
-        // and no error channel here by design (RFC 7464 drops the record
-        // either way).
-        return Vec::new();
-    };
-    let text = text.as_ref();
-
     let mut out = Vec::new();
     let last = ranges.len().saturating_sub(1);
-    for (i, (vs, ve)) in ranges.iter().copied().enumerate() {
+    for (i, &(vs, ve)) in ranges.iter().enumerate() {
         let is_last = i == last;
-        if is_last && seq_record_last_value_is_ambiguous(&text[vs..ve], raw_segment) {
+        let value_text = &segment[vs..ve];
+        if is_last && seq_record_last_value_is_ambiguous(value_text, raw_segment) {
             continue;
         }
-        let Ok(v) = crate::output::json_bytes_to_owned_value(&text.as_bytes()[vs..ve]) else {
+        let Some(v) = seq_value_to_owned(value_text) else {
             // Parses but will not decode (#1247): dropped, exactly as the
             // pre-#1723 single-value path dropped it.
             continue;
         };
-        // The last value keeps the record's own trimmed end so a
-        // single-value record reports the identical line it always did;
-        // earlier values report their own end, which is what jq's
-        // per-value line reporting needs.
-        let end = if is_last {
-            trimmed_end
-        } else {
-            segment_start + ve
-        };
-        out.push((v, end));
+        out.push((
+            v,
+            if is_last {
+                trimmed_end
+            } else {
+                trimmed_start + ve
+            },
+        ));
     }
     out
 }
@@ -3391,59 +3407,56 @@ fn seq_record_last_value_is_ambiguous(value_text: &str, raw_segment: &str) -> bo
     is_bare_number && raw_segment.trim_end() == raw_segment
 }
 
-/// Whether a trimmed, non-empty `--seq` record segment parses as JSON --
-/// [`parse_json_seq_with_ends`]'s own per-segment success check, factored out so
-/// [`seq_trailing_record_is_dropped`] can ask the identical question about
-/// one specific segment without duplicating the leading-zero retry logic.
-fn seq_record_parses(segment: &str) -> bool {
-    seq_record_scan(segment).is_some()
+/// Split a trimmed, non-empty `--seq` record into its JSON values' byte
+/// ranges, or `None` if it is malformed.
+///
+/// One record can hold more than one value (#1723), so this cannot be the
+/// single whole-segment `validate::validate` call it was before -- that call
+/// is what made `\x1e1 2\n` look malformed and silently dropped both values.
+/// Each range is *still* validated strictly and individually, so the scanner
+/// (a tokenizer, not a validator) cannot widen what `--seq` accepts:
+/// `find_json_values` locates the boundaries, `validate::validate` decides
+/// whether each one is legal JSON.
+///
+/// **Ranges index `segment` itself, never a normalized copy.** #1243's
+/// leading-zero retry is applied per value instead, to decide validity and
+/// again to build the value. Re-scanning a normalized string was an offset
+/// bug a review caught: `normalize_leading_zero_numbers` *deletes* leading
+/// zeros rather than rewriting in place, so ranges taken from the normalized
+/// text are shorter than the original and name the wrong line
+/// (`\x1e0007\n"b"\n` reported lines 0/2 where jq reports 1/2).
+fn seq_record_scan(segment: &str) -> Option<Vec<(usize, usize)>> {
+    let ranges = find_json_values(segment.as_bytes()).ok()?;
+    if ranges.is_empty() {
+        return None;
+    }
+    ranges
+        .iter()
+        .all(|&(a, b)| seq_value_is_valid(&segment[a..b]))
+        .then_some(ranges)
 }
 
-/// The text a `--seq` record's values were scanned out of, and each value's
-/// `(start, end)` range within it.
-///
-/// The text is a `Cow` because the leading-zero retry (#1243) has to scan a
-/// *normalized* copy, while the ordinary case borrows the record as-is.
-type SeqRecordScan<'a> = (Cow<'a, str>, Vec<(usize, usize)>);
+/// Whether one value out of a `--seq` record is legal JSON, allowing the
+/// same leading-zero form (`007e5`) `--seq` has accepted since #1243.
+fn seq_value_is_valid(value_text: &str) -> bool {
+    if validate::validate(value_text.as_bytes()).is_ok() {
+        return true;
+    }
+    let normalized = normalize_leading_zero_numbers(value_text);
+    normalized != value_text && validate_json_str(&normalized).is_ok()
+}
 
-/// Split a trimmed, non-empty `--seq` record into its JSON values, or `None`
-/// if it is malformed.
-///
-/// One record can hold more than one value (#1723), so this cannot be a
-/// single whole-segment `validate::validate` call the way it was before --
-/// that call is what made `\x1e1 2\n` look malformed and silently dropped
-/// both values. Each extracted value is *still* validated strictly and
-/// individually, so the scanner (which is a tokenizer, not a validator)
-/// cannot widen what this accepts: `find_json_values` locates the value
-/// boundaries, `validate::validate` decides whether each one is legal JSON.
-///
-/// The leading-zero retry (`007e5`) is unchanged in effect, just expressed
-/// as a second pass over the normalized text; offsets stay usable across it
-/// because normalization only rewrites digits in place, never reorders or
-/// inserts.
-fn seq_record_scan(segment: &str) -> Option<SeqRecordScan<'_>> {
-    let normalized = normalize_leading_zero_numbers(segment);
-    let mut candidates: Vec<Cow<'_, str>> = vec![Cow::Borrowed(segment)];
-    // Only worth a second pass when normalization actually changed
-    // something; identical text would fail the identical way.
-    if normalized != segment {
-        candidates.push(Cow::Owned(normalized));
+/// One `--seq` record value as an `OwnedValue`, applying #1243's
+/// leading-zero normalization to that value alone.
+fn seq_value_to_owned(value_text: &str) -> Option<OwnedValue> {
+    if let Ok(v) = crate::output::json_bytes_to_owned_value(value_text.as_bytes()) {
+        return Some(v);
     }
-    for text in candidates {
-        let Ok(ranges) = find_json_values(text.as_bytes()) else {
-            continue;
-        };
-        if ranges.is_empty() {
-            continue;
-        }
-        if ranges
-            .iter()
-            .all(|&(a, b)| validate::validate(&text.as_bytes()[a..b]).is_ok())
-        {
-            return Some((text, ranges));
-        }
+    let normalized = normalize_leading_zero_numbers(value_text);
+    if normalized == value_text {
+        return None;
     }
-    None
+    crate::output::json_bytes_to_owned_value(normalized.as_bytes()).ok()
 }
 
 /// Whether `raw`'s trailing `--seq` record (RFC 7464, everything after the
@@ -3455,7 +3468,7 @@ fn seq_record_scan(segment: &str) -> Option<SeqRecordScan<'_>> {
 ///
 /// Two shapes, both silently swallowed by real jq's own `--seq` reader:
 ///
-/// - **Genuinely malformed/truncated** -- [`seq_record_parses`] fails on it
+/// - **Genuinely malformed/truncated** -- [`seq_record_scan`] returns `None`
 ///   (an unterminated string/object, e.g.), matching
 ///   [`parse_json_seq_with_ends`]'s own silent-drop rule (RFC 7464's
 ///   recommended failure mode, #1243).
@@ -3490,11 +3503,17 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     if segment.is_empty() {
         return false;
     }
-    if !seq_record_parses(segment) {
+    let Some(ranges) = seq_record_scan(segment) else {
         return true;
-    }
-    let is_bare_number = matches!(segment.as_bytes().first(), Some(b'-' | b'0'..=b'9'));
-    is_bare_number && tail.trim_end() == tail
+    };
+    // The record's *last* value decides this, not its first byte. Before
+    // #1723 a record was always exactly one value, so the two were the same
+    // question; now they are not, and asking the first byte gets both
+    // multi-value shapes wrong in opposite directions -- a review found
+    // `\x1e"a" 2` reporting a line where jq reports `<unknown>`, and
+    // `\x1e1 "a"` the reverse.
+    let (vs, ve) = ranges[ranges.len() - 1];
+    seq_record_last_value_is_ambiguous(&segment[vs..ve], tail)
 }
 
 /// Whether `--seq -s`'s trailing record, read across every file on the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3380,7 +3380,7 @@ fn seq_record_values(
         if is_last && seq_record_last_value_is_ambiguous(value_text, raw_segment) {
             continue;
         }
-        let Some(v) = seq_value_to_owned(value_text) else {
+        let Ok(v) = crate::output::json_bytes_to_owned_value(value_text.as_bytes()) else {
             // Parses but will not decode (#1247): dropped, exactly as the
             // pre-#1723 single-value path dropped it.
             continue;
@@ -3438,25 +3438,18 @@ fn seq_record_scan(segment: &str) -> Option<Vec<(usize, usize)>> {
 
 /// Whether one value out of a `--seq` record is legal JSON, allowing the
 /// same leading-zero form (`007e5`) `--seq` has accepted since #1243.
+///
+/// Normalization is needed *here* and only here: `validate::validate` is
+/// strict RFC 8259 and rejects a leading zero, while the semi-indexer behind
+/// `json_bytes_to_owned_value` already reads `0007` as `7` on its own -- so
+/// the value-building side needs no fallback (an earlier draft had one, and
+/// coverage showed it could never run).
 fn seq_value_is_valid(value_text: &str) -> bool {
     if validate::validate(value_text.as_bytes()).is_ok() {
         return true;
     }
     let normalized = normalize_leading_zero_numbers(value_text);
     normalized != value_text && validate_json_str(&normalized).is_ok()
-}
-
-/// One `--seq` record value as an `OwnedValue`, applying #1243's
-/// leading-zero normalization to that value alone.
-fn seq_value_to_owned(value_text: &str) -> Option<OwnedValue> {
-    if let Ok(v) = crate::output::json_bytes_to_owned_value(value_text.as_bytes()) {
-        return Some(v);
-    }
-    let normalized = normalize_leading_zero_numbers(value_text);
-    if normalized == value_text {
-        return None;
-    }
-    crate::output::json_bytes_to_owned_value(normalized.as_bytes()).ok()
 }
 
 /// Whether `raw`'s trailing `--seq` record (RFC 7464, everything after the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26253,3 +26253,102 @@ fn test_seq_multivalue_still_drops_what_jq_abandons_1723() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1723 code review: content before the *first* RS byte is not a record,
+/// and real jq discards it however well-formed it is.
+///
+/// Multi-value support made a pre-existing single-value leak here emit
+/// *every* value in that prefix, widening the divergence rather than
+/// introducing it -- `"a" "b"\x1e3` printed all three. Both the widened and
+/// the original leak are fixed: only `3` survives, as in jq.
+#[test]
+fn test_seq_discards_content_before_first_rs_byte_1723() -> Result<()> {
+    for (input, expected, why) in [
+        (
+            "\"a\" \"b\"\x1e3\n",
+            "3\n",
+            "multi-value prefix, widened by #1723",
+        ),
+        (
+            "\"a\"\x1e3\n",
+            "3\n",
+            "single-value prefix, leaked on main too",
+        ),
+        ("1 2\x1e3\n", "3\n", "numeric prefix"),
+        (
+            "1 2\n",
+            "",
+            "no RS at all: #1525 abandonment still owns this",
+        ),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?} -- {why}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1723 code review: the error-location marker a `--seq` value reports.
+///
+/// Three separate offset defects, none of which any existing test could
+/// catch because none assert the `(at file:line)` marker at all:
+///
+/// - `seq_trailing_record_is_dropped` tested the trailing record's *first
+///   byte* for "ambiguous bare number". Before #1723 a record was always one
+///   value, so first-byte and last-value were the same question; with
+///   multi-value records they differ, and `\x1e1 "a"` reported `<unknown>`
+///   where jq names the line.
+/// - Non-last values paired ranges taken from the *trimmed* record with the
+///   *untrimmed* record's start offset, so leading whitespace shifted the
+///   reported line (`\x1e  "a"\n"b"\n`).
+/// - Scanning a leading-zero-normalized copy produced ranges shorter than
+///   the original, because normalization *deletes* zeros rather than
+///   rewriting in place (`\x1e0007\n"b"\n`). Ranges now always index the
+///   original text, with normalization applied per value.
+#[test]
+fn test_seq_value_error_location_marker_1723() -> Result<()> {
+    let dir = std::env::temp_dir().join(format!("sjq-seq-1723-{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let file = dir.join("z.json");
+    let path = file.to_str().expect("temp path is utf-8");
+
+    for (input, expected_marker, why) in [
+        ("\x1e1 \"a\"", "z.json:0", "last value is not a bare number"),
+        (
+            "\x1e\"a\" 2",
+            "<unknown>",
+            "last value IS an ambiguous bare number",
+        ),
+        (
+            "\x1e  \"a\"\n\"b\"\n",
+            "z.json:2",
+            "leading whitespace must not shift the line",
+        ),
+        (
+            "\x1e0007\n\"b\"\n",
+            "z.json:2",
+            "normalization must not shift the line",
+        ),
+        ("\x1e\"a\"", "z.json:0", "single value, unchanged"),
+        (
+            "\x1e1\n\x1e2",
+            "<unknown>",
+            "single trailing bare number, unchanged",
+        ),
+    ] {
+        std::fs::write(&file, input)?;
+        let (_out, stderr, _code) =
+            run_jq_full(&["--seq", "-s", "-c", "error(\"x\")", path], None)?;
+        let marker = stderr
+            .lines()
+            .find(|l| l.starts_with("jq: error"))
+            .unwrap_or_default();
+        assert!(
+            marker.contains(expected_marker),
+            "input {input:?} -- {why}: expected {expected_marker:?} in {marker:?}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26163,3 +26163,93 @@ fn test_streamed_lazy_seq_materialization_control_1653() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1723: one RFC 7464 record can hold more than one JSON value, and real jq
+/// emits every one of them.
+///
+/// `succinctly jq --seq` used to drop such a record **in full**, exit 0 --
+/// silent data loss on a record real jq reads fine, not the missing-warning
+/// gap #1723 was filed as. The cause was `seq_record_parses` validating the
+/// whole record as a single value, so `1 2` looked malformed.
+///
+/// Every expectation captured from jq 1.7.1.
+#[test]
+fn test_seq_record_with_multiple_values_emits_all_1723() -> Result<()> {
+    for (input, expected) in [
+        // Mixed types, whitespace-separated.
+        ("\x1e1 \"x\" [2]\n", "1\n\"x\"\n[2]\n"),
+        // A newline is just whitespace inside a record -- not a boundary.
+        ("\x1e1\n2\n", "1\n2\n"),
+        ("\x1enull null\n", "null\nnull\n"),
+        ("\x1e\"a\" \"b\"\n", "\"a\"\n\"b\"\n"),
+        ("\x1etrue false null\n", "true\nfalse\nnull\n"),
+        ("\x1e[1] 2 {\"a\":3}\n", "[1]\n2\n{\"a\":3}\n"),
+        ("\x1e{\"a\":1} {\"b\":2}\n", "{\"a\":1}\n{\"b\":2}\n"),
+        ("\x1e{} []\n", "{}\n[]\n"),
+        ("\x1e-1 -2\n", "-1\n-2\n"),
+        ("\x1e1  2\n", "1\n2\n"),
+        // Multi-value records interleave with ordinary single-value ones.
+        ("\x1e1 2\n\x1e3\n", "1\n2\n3\n"),
+        // The leading-zero retry (#1243) still applies, in either position.
+        ("\x1e007e5 1\n", "7E+5\n1\n"),
+        ("\x1e1 007e5\n", "1\n7E+5\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?} -- stderr={stderr}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1723: adding multi-value support must not resurrect a value real jq
+/// abandons.
+///
+/// Two rules would have been broken by a naive "emit every value in the
+/// record" change, and each is pinned here because the differential sweep
+/// caught them as regressions in the first drafts:
+///
+/// 1. A record's *last* value is dropped when it is a bare number with no
+///    terminating byte after it -- jq's incremental number scanner cannot
+///    rule out more digits arriving. That rule was already encoded for the
+///    stream's final record; it is really per-record, so `\x1e1 2\x1e3`
+///    keeps `1` and `3` but drops the `2`, while a single newline after the
+///    `2` disambiguates it and all three survive.
+/// 2. Input with **no RS byte anywhere** is abandoned wholesale (#1525),
+///    however well-formed its content is -- relaxing the trailing-record
+///    skip for multi-value records started emitting it.
+#[test]
+fn test_seq_multivalue_still_drops_what_jq_abandons_1723() -> Result<()> {
+    for (input, expected, why) in [
+        (
+            "\x1e1 2\x1e3\n",
+            "1\n3\n",
+            "bare number before RS is ambiguous",
+        ),
+        (
+            "\x1e1 2\n\x1e3\n",
+            "1\n2\n3\n",
+            "a newline disambiguates it",
+        ),
+        ("\x1e1 2", "1\n", "bare number at EOF is ambiguous"),
+        ("\x1e1 2 ", "1\n2\n", "trailing space disambiguates it"),
+        (
+            "1 2\n",
+            "",
+            "no RS byte anywhere: whole input abandoned (#1525)",
+        ),
+        (
+            "\x1e1\n\x1e2",
+            "1\n",
+            "single-value trailing bare number, unchanged",
+        ),
+        ("\x1e1\n", "1\n", "plain single-value record, unchanged"),
+        ("\x1e{\"a\":1\n", "", "malformed record still dropped whole"),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?} -- {why}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Refs #1723 — fixes a **data-loss bug found while investigating it**, not the diagnostics that issue asks for. #1723 stays open.

## What this fixes

One RFC 7464 record can hold more than one JSON value, and real jq emits every one. `succinctly jq --seq` dropped such a record **in full**, exit 0:

```console
$ printf '\x1e1 "x" [2]\n' | jq            --seq -c '.'   →  1 / "x" / [2]
$ printf '\x1e1 "x" [2]\n' | succinctly jq --seq -c '.'   →  (nothing)
```

Same for `\x1e1\n2\n`, `\x1enull null\n`, `\x1e{"a":1} {"b":2}\n`, `\x1etrue false null\n` — every multi-value record, silently.

#1723 is filed as *"Severity: Low-Medium, diagnostic-only, no data loss"*, and it flagged exactly this shape as unverified:

> Worth confirming succinctly's own `parse_json_seq` already matches this (unverified as part of this filing).

It did not. A well-formed record was being discarded in full, which is a different severity class from a missing warning.

## Cause and fix

`seq_record_parses` validated the whole record with one `validate::validate` call, so `1 2` looked malformed. `seq_record_scan` now locates value boundaries with the same `find_json_values` scanner the ordinary document path uses, then validates each extracted value **strictly and individually** — the scanner is a tokenizer, not a validator, so this cannot widen what `--seq` accepts.

## Two rules the oracle forced (both were regressions in earlier drafts)

- **The "ambiguous trailing bare number" rule is per-record, not per-stream.** jq abandons a record's last value when it's a bare number with no terminating byte: `\x1e1 2\x1e3` → `1, 3`, but `\x1e1 2\n\x1e3` → `1, 2, 3`. That rule existed only for the stream's *final* record. Without generalizing it, fixing multi-value would have **introduced** a divergence on the first shape while fixing the second. My first draft also passed the *trimmed* record text to the check, which makes every bare number look unterminated and silently dropped even a plain `\x1e1\n`.
- **No RS byte anywhere stays abandoned wholesale** (#1525). Relaxing the trailing-record skip started emitting `1` and `2` for `printf '1 2\n'`, where jq prints nothing. Caught by the sweep, now gated on RS presence.

## Verification

- **Oracle shapes: 20/22 match, up from 2.** The two remaining are records well-formed up to a *malformed suffix*, where jq emits the prefix it read — that needs the same "where did the parser give up" answer the missing diagnostics do, so it stays with #1723. Documented in `docs/compliance/jq/limitations.md`, including jq's own quirk that the surviving prefix isn't always the leading one (`\x1e1,2\n` prints `2`, not `1`).
- **Differential sweep**: 114 input×flag combos (`-c`, `-s`, `-e`, `-r`, `-j`, `-S`) — zero diffs except one pre-existing, unrelated issue filed separately as #1913 (`--seq` writes the RS separator before `-r`/`-j` raw output, where jq does not; reproduced on `main`).
- **Tests genuinely fail pre-change**: all 13 asserted multi-value shapes — 12 produced nothing at all, the 13th produced only its second record.
- **Full suite 6478 passed / 0 failed**; both clippy feature sets, `fmt`, `--no-default-features`, and CI's exact rustdoc command all clean.

## Note

`cargo test` was green while both clippy legs failed on two real lints (`sliced_string_as_bytes`, `type_complexity`) — fixed properly rather than `#[allow]`-ed.


---

## Update after code review

**Five findings, all reproduced against jq 1.7.1 and against `main`'s own binary before acting on them.** Four were offset/predicate defects, and the reason they reached CI green is worth stating: **no test in the suite asserts the `(at file:line)` marker at all**. This PR now adds one that does.

| Finding | Effect |
|---|---|
| **Regression vs `main`** — content before the first RS byte emitted every value it held (`"a" "b"\x1e3` printed all three; jq prints `3`) | Fixed; also fixes the narrower single-value leak `main` already had |
| `seq_trailing_record_is_dropped` tested the record's *first byte*, not its last value | Fixed — the two multi-value shapes were wrong in opposite directions |
| Non-last values paired *trimmed* ranges with the *untrimmed* record start | Fixed — wrong line, and across files the wrong file |
| Ranges came from a leading-zero-*normalized* copy, which **deletes** zeros rather than rewriting in place, so they were short | Fixed — ranges always index the original; normalization is now per value |
| The record was scanned up to 3× (two `seq_record_parses` calls plus one inside `seq_record_values`) | Fixed — scanned once, ranges passed down; `seq_record_parses` had no callers left and is gone |

**26 of 26 oracle shapes now match**, up from 2 before this PR — including two that `main` gets wrong (`\x1e  "a"\n"b"\n` and `\x1e0007\n"b"\n` both named the wrong line there).

Final gates: **6507 tests / 0 failed**, both clippy feature sets, `fmt`, `--no-default-features`, and CI's exact rustdoc command all clean. The only remaining `--seq` divergence in the 114-combo flag sweep is the pre-existing RS-before-raw-output issue filed separately as #1913.
