### PR TITLE
fix(jq): through_slice's |= empty raises/writes-null where jq deletes

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17323,18 +17323,15 @@ fn set_path<S: EvalSemantics>(
                             },
                             // `set_path` (`=`) has no `|= empty` concept --
                             // its RHS is always a real, already-materialized
-                            // value -- so this adapts its `Result<(), E>`
-                            // into `through_slice`'s `Result<bool, E>` by
-                            // always reporting `true` (#1877/#1894).
+                            // value (#1877/#1894, see `always_wrote`).
                             |sub| {
-                                set_path::<S>(
+                                always_wrote(set_path::<S>(
                                     sub,
                                     &split.tail,
                                     new_value.clone(),
                                     scalar_noop,
                                     container_noop,
-                                )
-                                .map(|()| true)
+                                ))
                             },
                         )
                         .map(|_| ())
@@ -17363,8 +17360,13 @@ fn set_path<S: EvalSemantics>(
                         // See the probe closure above for why this always
                         // reports `true`.
                         |sub| {
-                            set_path::<S>(sub, &split.tail, new_value, scalar_noop, container_noop)
-                                .map(|()| true)
+                            always_wrote(set_path::<S>(
+                                sub,
+                                &split.tail,
+                                new_value,
+                                scalar_noop,
+                                container_noop,
+                            ))
                         },
                     )
                     .map(|_| ()),
@@ -17601,6 +17603,14 @@ struct SliceEditFlags {
     terminal_write: bool,
 }
 
+/// Adapts a caller with no `|= empty` concept (`set_path`'s three
+/// `through_slice` call sites, `delete_at_path`'s one) into `through_slice`'s
+/// `edit` signature by always reporting `true` -- see `through_slice`'s own
+/// doc comment for what the `bool` means and why these callers are exempt.
+fn always_wrote<E>(result: Result<(), E>) -> Result<bool, E> {
+    result.map(|()| true)
+}
+
 /// `edit`'s `bool` payload (#1877/#1894): whether a real value reached this
 /// slot, as opposed to `|= empty` running out with nothing to write. `true`
 /// covers both an ordinary value and an already-completed nested delete
@@ -17609,8 +17619,9 @@ struct SliceEditFlags {
 /// begin with," which only the terminal `Array`/`String`/`Null` arms below
 /// ever act on -- every other caller of `through_slice` (`set_path`'s three
 /// call sites, `delete_at_path`'s one) has no `|= empty` concept at all and
-/// adapts its own `Result<(), E>` edit into this shape by always reporting
-/// `true`.
+/// adapts its own `Result<(), E>` edit into this shape via [`always_wrote`],
+/// discarding `through_slice`'s own returned `bool` the same way via a
+/// plain `.map(|_| ())` at the call site.
 fn through_slice<E: From<EvalError>>(
     root: &mut OwnedValue,
     start: Option<i64>,
@@ -17679,6 +17690,13 @@ fn through_slice<E: From<EvalError>>(
                 return Err(EvalError::slice_assign_non_array().into());
             };
             arr.splice(range, items);
+            // Always `true` past this point, even when `!terminal_write`
+            // and `wrote` was `false`: `root` here is already a real Array
+            // (this arm only matches an existing one, never a freshly
+            // autovivified `Null`), so the caller that would need to undo
+            // an over-eager autovivification (`update_path`'s Field/Index
+            // "stranded" check, gated on `matches!(*current, Null)`) can
+            // never fire for this slot regardless of what's reported here.
             Ok(true)
         }
         // jq reads a string slice but will not write one back, whatever the
@@ -17723,6 +17741,13 @@ fn through_slice<E: From<EvalError>>(
                     Err(EvalError::cannot_delete_fields_from("string").into())
                 }
             } else {
+                // Always `true`, regardless of `wrote`: reaching this arm
+                // at all means `root` was already a String on entry (the
+                // `Null` arm below only ever promotes `Null` to `Array`,
+                // never to `String`), so the ancestor slot that could have
+                // been freshly autovivified is necessarily something else
+                // -- the same "can't be the stranded slot" reasoning as
+                // the `Array` arm's own trailing `Ok(true)` above.
                 Ok(true)
             }
         }
@@ -17749,6 +17774,11 @@ fn through_slice<E: From<EvalError>>(
         _ if scalar_noop && is_yq_slice_empty_container_scalar(root) => {
             let mut throwaway = OwnedValue::Array(Vec::new());
             edit(&mut throwaway)?;
+            // Always `true`: this is yq's own unconditional slice no-op
+            // (unrelated to #1877/#1894's jq-only `|= empty` mechanism --
+            // `container_noop`/`undo_stranded` already gate the new logic
+            // out of yq mode entirely, so this arm's answer is never
+            // actually consulted).
             Ok(true)
         }
         // A `Null` target that reaches here in *jq* mode still needs a
@@ -17854,6 +17884,9 @@ fn through_slice<E: From<EvalError>>(
             *root = OwnedValue::Array(items);
             Ok(true)
         }
+        // Always `true`: a target this arm applies to (a scalar not
+        // covered by any arm above) was never `Null` to begin with, so
+        // it's never the slot an ancestor's stranding check is watching.
         _ if optional => Ok(true),
         other => Err(EvalError::cannot_index_with_type(owned_type_name(other), "object").into()),
     }
@@ -18482,6 +18515,18 @@ fn update_path<S: EvalSemantics>(
                                 // `Iterate` is involved) -- both answer the
                                 // same question, "was anything really
                                 // written," just via different evidence.
+                                //
+                                // Neither clause subsumes the other: this
+                                // function's own `Iterate` arms (both the
+                                // terminal one and the mid-chain copy just
+                                // below) always report `Ok(true)` for an
+                                // `Array`/`Object` root regardless of how
+                                // many elements they actually touch,
+                                // including zero -- so an iterate over a
+                                // freshly-created empty container never
+                                // registers as `Ok(false)`, and
+                                // `reaches_iterate` stays the only signal
+                                // that catches it.
                                 let stranded = created
                                     && undo_stranded
                                     && (reaches_iterate(&rest) || matches!(result, Ok(false)))
@@ -31086,12 +31131,9 @@ fn delete_at_path(
                                 terminal_write: yq_mode,
                             },
                             // `del()` has its own, already-correct deletion
-                            // mechanism with no `|= empty` concept -- adapt
-                            // its `Result<(), E>` into `through_slice`'s
-                            // `Result<bool, E>` by always reporting `true`
-                            // (#1877/#1894, mirroring `set_path`'s own
-                            // adapters).
-                            |sub| delete_at_path(sub, &rest, optional, yq_mode).map(|()| true),
+                            // mechanism with no `|= empty` concept (#1877/
+                            // #1894, see `always_wrote`).
+                            |sub| always_wrote(delete_at_path(sub, &rest, optional, yq_mode)),
                         )
                         .map(|_| ())
                     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17321,6 +17321,11 @@ fn set_path<S: EvalSemantics>(
                                 container_noop,
                                 terminal_write: matches!(split.tail, Expr::Identity),
                             },
+                            // `set_path` (`=`) has no `|= empty` concept --
+                            // its RHS is always a real, already-materialized
+                            // value -- so this adapts its `Result<(), E>`
+                            // into `through_slice`'s `Result<bool, E>` by
+                            // always reporting `true` (#1877/#1894).
                             |sub| {
                                 set_path::<S>(
                                     sub,
@@ -17329,8 +17334,10 @@ fn set_path<S: EvalSemantics>(
                                     scalar_noop,
                                     container_noop,
                                 )
+                                .map(|()| true)
                             },
                         )
+                        .map(|_| ())
                     })?
                 {
                     return Ok(());
@@ -17353,10 +17360,14 @@ fn set_path<S: EvalSemantics>(
                             // arm reached it (#1321).
                             terminal_write: matches!(split.tail, Expr::Identity),
                         },
+                        // See the probe closure above for why this always
+                        // reports `true`.
                         |sub| {
                             set_path::<S>(sub, &split.tail, new_value, scalar_noop, container_noop)
+                                .map(|()| true)
                         },
-                    ),
+                    )
+                    .map(|_| ()),
                 }
             } else {
                 // Navigate to parent
@@ -17461,11 +17472,13 @@ fn set_path<S: EvalSemantics>(
                 container_noop,
                 terminal_write: true,
             },
+            // Always `true` -- see the sibling call sites above.
             |sub| {
                 *sub = new_value;
-                Ok(())
+                Ok(true)
             },
-        ),
+        )
+        .map(|_| ()),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -17588,13 +17601,23 @@ struct SliceEditFlags {
     terminal_write: bool,
 }
 
+/// `edit`'s `bool` payload (#1877/#1894): whether a real value reached this
+/// slot, as opposed to `|= empty` running out with nothing to write. `true`
+/// covers both an ordinary value and an already-completed nested delete
+/// (the sub-value it leaves behind is real content either way, to be
+/// spliced back normally); `false` means "there was never anything here to
+/// begin with," which only the terminal `Array`/`String`/`Null` arms below
+/// ever act on -- every other caller of `through_slice` (`set_path`'s three
+/// call sites, `delete_at_path`'s one) has no `|= empty` concept at all and
+/// adapts its own `Result<(), E>` edit into this shape by always reporting
+/// `true`.
 fn through_slice<E: From<EvalError>>(
     root: &mut OwnedValue,
     start: Option<i64>,
     end: Option<i64>,
     flags: SliceEditFlags,
-    edit: impl FnOnce(&mut OwnedValue) -> Result<(), E>,
-) -> Result<(), E> {
+    edit: impl FnOnce(&mut OwnedValue) -> Result<bool, E>,
+) -> Result<bool, E> {
     let SliceEditFlags {
         optional,
         scalar_noop,
@@ -17632,17 +17655,31 @@ fn through_slice<E: From<EvalError>>(
             let mut throwaway = slice_owned_value(root, start, end, optional)?
                 .expect("Array/String target always yields Some from slice_owned_value");
             edit(&mut throwaway)?;
-            Ok(())
+            Ok(true)
         }
         OwnedValue::Array(arr) => {
             let range = SliceBounds::from_literals(start, end).resolve(arr.len());
             let mut sub = OwnedValue::Array(arr[range.clone()].to_vec());
-            edit(&mut sub)?;
+            let wrote = edit(&mut sub)?;
+            // `|= empty` (#1894): jq's `_modify` falls back to `delpaths`
+            // when the update filter produces no output at all, and
+            // deleting a slice-shaped path removes that whole range --
+            // splicing in nothing is exactly that (`[1,2,3] | .[0:2] |=
+            // empty` is `[3]`, confirmed live). Only trusted when this
+            // call's own edit *is* the write (`terminal_write`): a `false`
+            // surfacing from further down a chain already reflects a real,
+            // completed splice at that inner level (reported back as
+            // `true`, since `sub` now holds genuine content to propagate),
+            // so it never reaches here as `false` in the first place.
+            if terminal_write && !wrote {
+                arr.splice(range, core::iter::empty());
+                return Ok(true);
+            }
             let OwnedValue::Array(items) = sub else {
                 return Err(EvalError::slice_assign_non_array().into());
             };
             arr.splice(range, items);
-            Ok(())
+            Ok(true)
         }
         // jq reads a string slice but will not write one back, whatever the
         // replacement -- but that refusal (`terminal_write: true`) is only
@@ -17671,11 +17708,22 @@ fn through_slice<E: From<EvalError>>(
         OwnedValue::String(_) => {
             let mut throwaway = slice_owned_value(root, start, end, optional)?
                 .expect("Array/String target always yields Some from slice_owned_value");
-            edit(&mut throwaway)?;
+            let wrote = edit(&mut throwaway)?;
             if terminal_write {
-                Err(EvalError::cannot_update_string_slices().into())
+                if wrote {
+                    Err(EvalError::cannot_update_string_slices().into())
+                } else {
+                    // `|= empty` (#1894): jq's `_modify` falls back to
+                    // `delpaths` on empty output, and deleting a string
+                    // slice raises a different sentence than writing one
+                    // does -- confirmed live, `"hello" | .[0:2] |= empty`
+                    // and `del(.[0:2])` both raise this, not "Cannot
+                    // update string slices" (which is what a *non-empty*
+                    // `|=`/`=` still raises, unaffected above).
+                    Err(EvalError::cannot_delete_fields_from("string").into())
+                }
             } else {
-                Ok(())
+                Ok(true)
             }
         }
         // yq's slice-assignment no-op (#1101, generalized to any nesting
@@ -17701,7 +17749,7 @@ fn through_slice<E: From<EvalError>>(
         _ if scalar_noop && is_yq_slice_empty_container_scalar(root) => {
             let mut throwaway = OwnedValue::Array(Vec::new());
             edit(&mut throwaway)?;
-            Ok(())
+            Ok(true)
         }
         // A `Null` target that reaches here in *jq* mode still needs a
         // real attempt, not a silent skip: real jq auto-vivifies a null
@@ -17774,25 +17822,39 @@ fn through_slice<E: From<EvalError>>(
         // arm's array-required error (real jq no-ops), and `null |
         // .a[0:1][0]?.c[]? = 9` wrongly *commits* a write real jq no-ops
         // (`{"a":[{"c":null}]}` vs jq's `null`) -- both identical before and
-        // after this fix. That's the same family of bug #1428 tracks (a
-        // write-time decision inferred from what navigation left behind
-        // rather than from an explicit "did anything actually get written"
-        // signal), just one nesting level deeper than what this fix
-        // narrowly closes; not attempted here since #1428 is already being
-        // worked as its own, more structural fix.
+        // after this fix. That's the same family of bug #1428 fixed for
+        // `Field`/`Index` (a write-time decision inferred from what
+        // navigation left behind rather than from an explicit "did
+        // anything actually get written" signal), just one nesting level
+        // deeper than what this fix narrowly closes; not attempted here.
+        //
+        // `edit`'s own `bool` (#1877/#1894), checked first: when this
+        // call's edit *is* the write (`terminal_write`) and it reports
+        // `false` -- the update filter was `|= empty`, not a literal
+        // `null` -- there is nothing to create just to immediately delete
+        // it (`null | .a[0:1][0:2]? |= empty` stays `null`, confirmed
+        // live), so `root` is left untouched rather than materialized into
+        // `[]`. This is a different, more precise signal than the
+        // pre-existing `!terminal_write && matches!(sub, Null)` check
+        // below: that one infers "nothing written" from what a *tail*
+        // left behind, which can't tell an explicit `null` apart from an
+        // empty filter at the point the slice itself is the write.
         OwnedValue::Null if !container_noop => {
             let mut sub = OwnedValue::Null;
-            edit(&mut sub)?;
+            let wrote = edit(&mut sub)?;
+            if terminal_write && !wrote {
+                return Ok(false);
+            }
             if !terminal_write && matches!(sub, OwnedValue::Null) {
-                return Ok(());
+                return Ok(false);
             }
             let OwnedValue::Array(items) = sub else {
                 return Err(EvalError::slice_assign_non_array().into());
             };
             *root = OwnedValue::Array(items);
-            Ok(())
+            Ok(true)
         }
-        _ if optional => Ok(()),
+        _ if optional => Ok(true),
         other => Err(EvalError::cannot_index_with_type(owned_type_name(other), "object").into()),
     }
 }
@@ -18206,13 +18268,23 @@ fn get_path_mut<'a>(
 }
 
 /// Update a value at a path by applying a filter.
+///
+/// Returns whether a real value reached `root` (#1877/#1894): `false` only
+/// ever originates at the terminal [`Expr::Identity`] arm, when
+/// `filter_expr` produced no output at all (`|= empty`) -- every other arm
+/// either forwards its single recursive call's answer unchanged, or, where
+/// it can suppress a write itself (an `optional`/yq-no-op branch, or an
+/// `Iterate`/mid-chain arm that legitimately touches zero or many
+/// elements), reports its own outcome directly. The only consumer today is
+/// `through_slice`'s `Null`/`Array`/`String` arms, which use it to
+/// distinguish `|= empty` from a literal `null` write.
 fn update_path<S: EvalSemantics>(
     root: &mut OwnedValue,
     path_expr: &Expr,
     filter_expr: &Expr,
     optional: bool,
     scalar_noop: bool,
-) -> Result<(), EvalEscape> {
+) -> Result<bool, EvalEscape> {
     // #1428 is a jq-mode divergence, and deliberately stays one: real yq
     // *wants* the chain a suppressed write leaves behind (`null | .a[] = 99`
     // is `{"a": []}` there, #1181), so undoing it in yq mode would trade one
@@ -18263,12 +18335,18 @@ fn update_path<S: EvalSemantics>(
             // output, so a trailing `error(...)`/`break` after it must not
             // surface -- `.a |= (1, error("x"))` is `{"a":1}` in jq 1.7.1,
             // not an error.
-            let v = eval_owned_multi_first::<S>(filter_expr, root)?
-                .into_iter()
-                .next()
-                .unwrap_or(OwnedValue::Null);
-            *root = v;
-            Ok(())
+            //
+            // A zero-output filter still falls back to `Null` here -- `.a
+            // |= empty` leaves `"a":null` rather than deleting the key the
+            // way real jq does, a separate, pre-existing bug this fix does
+            // not change (#1877/#1894 are scoped to `through_slice`'s own
+            // arms, not this general field/index case). The `false`
+            // returned alongside it is the one place that signal
+            // originates -- see this function's own doc comment.
+            let outputs = eval_owned_multi_first::<S>(filter_expr, root)?;
+            let wrote = !outputs.is_empty();
+            *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
+            Ok(wrote)
         }
         Expr::Field(name) => {
             autovivify_object(root);
@@ -18285,7 +18363,7 @@ fn update_path<S: EvalSemantics>(
                 // doesn't implement yet (#1340's own follow-up).
                 || noop_scalar
             {
-                Ok(())
+                Ok(false)
             } else {
                 Err(EvalError::cannot_index_with_field(owned_type_name(root), name).into())
             }
@@ -18301,7 +18379,7 @@ fn update_path<S: EvalSemantics>(
                     scalar_noop,
                 )
             } else if optional || noop_scalar {
-                Ok(())
+                Ok(false)
             } else {
                 Err(EvalError::cannot_index_with_type(owned_type_name(root), "number").into())
             }
@@ -18327,7 +18405,7 @@ fn update_path<S: EvalSemantics>(
                             scalar_noop,
                         )?;
                     }
-                    Ok(())
+                    Ok(true)
                 }
                 OwnedValue::Object(map) => {
                     for value in map.values_mut() {
@@ -18339,9 +18417,9 @@ fn update_path<S: EvalSemantics>(
                             scalar_noop,
                         )?;
                     }
-                    Ok(())
+                    Ok(true)
                 }
-                _ if optional || noop_scalar => Ok(()),
+                _ if optional || noop_scalar => Ok(false),
                 _ => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
             }
         }
@@ -18395,11 +18473,19 @@ fn update_path<S: EvalSemantics>(
                                 // created, so only there does "still `Null`"
                                 // mean "never written". Without it, a
                                 // legitimate `null` write (`(.a|.) |= null`)
-                                // is undone.
+                                // is undone. OR'd with `result == Ok(false)`
+                                // (#1877/#1894): the more precise signal from
+                                // an update filter that genuinely produced no
+                                // output anywhere in `rest` (e.g. a nested
+                                // slice's own `|= empty`, which `reaches_
+                                // iterate` doesn't recognize at all since no
+                                // `Iterate` is involved) -- both answer the
+                                // same question, "was anything really
+                                // written," just via different evidence.
                                 let stranded = created
-                                    && result.is_ok()
                                     && undo_stranded
-                                    && reaches_iterate(&rest)
+                                    && (reaches_iterate(&rest) || matches!(result, Ok(false)))
+                                    && result.is_ok()
                                     && matches!(*current, OwnedValue::Null);
                                 (result, stranded)
                             };
@@ -18419,7 +18505,7 @@ fn update_path<S: EvalSemantics>(
                             // on a scalar root) no-ops instead of erroring.
                             || noop_scalar
                         {
-                            Ok(())
+                            Ok(false)
                         } else {
                             Err(
                                 EvalError::cannot_index_with_field(owned_type_name(root), name)
@@ -18445,10 +18531,11 @@ fn update_path<S: EvalSemantics>(
                                     optional,
                                     scalar_noop,
                                 );
-                                // See the `Field` arm above.
-                                let stranded = result.is_ok()
-                                    && undo_stranded
-                                    && reaches_iterate(&rest)
+                                // See the `Field` arm above, including the
+                                // `Ok(false)` OR-clause (#1877/#1894).
+                                let stranded = undo_stranded
+                                    && (reaches_iterate(&rest) || matches!(result, Ok(false)))
+                                    && result.is_ok()
                                     && matches!(*current, OwnedValue::Null);
                                 (result, stranded)
                             };
@@ -18460,7 +18547,7 @@ fn update_path<S: EvalSemantics>(
                             }
                             result
                         } else if here || noop_scalar {
-                            Ok(())
+                            Ok(false)
                         } else {
                             Err(
                                 EvalError::cannot_index_with_type(owned_type_name(root), "number")
@@ -18473,15 +18560,15 @@ fn update_path<S: EvalSemantics>(
                             for elem in arr.iter_mut() {
                                 update_path::<S>(elem, &rest, filter_expr, optional, scalar_noop)?;
                             }
-                            Ok(())
+                            Ok(true)
                         }
                         OwnedValue::Object(map) => {
                             for value in map.values_mut() {
                                 update_path::<S>(value, &rest, filter_expr, optional, scalar_noop)?;
                             }
-                            Ok(())
+                            Ok(true)
                         }
-                        _ if here || noop_scalar => Ok(()),
+                        _ if here || noop_scalar => Ok(false),
                         _ => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
                     },
                     // `resolve_node`'s `?` arm emits `Optional(Pipe([…]))`
@@ -30998,8 +31085,15 @@ fn delete_at_path(
                                 container_noop: false,
                                 terminal_write: yq_mode,
                             },
-                            |sub| delete_at_path(sub, &rest, optional, yq_mode),
+                            // `del()` has its own, already-correct deletion
+                            // mechanism with no `|= empty` concept -- adapt
+                            // its `Result<(), E>` into `through_slice`'s
+                            // `Result<bool, E>` by always reporting `true`
+                            // (#1877/#1894, mirroring `set_path`'s own
+                            // adapters).
+                            |sub| delete_at_path(sub, &rest, optional, yq_mode).map(|()| true),
                         )
+                        .map(|_| ())
                     }
                     _ => delete_at_path(root, first, here, yq_mode),
                 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25865,6 +25865,91 @@ fn test_string_slice_terminal_write_runs_edit_before_refusing_1876_1883() -> Res
     Ok(())
 }
 
+/// #1894: `through_slice`'s `OwnedValue::Array`/`OwnedValue::String`
+/// terminal-write arms didn't special-case an update filter that produced
+/// no output at all (`|= empty`). Real jq's `_modify` falls back to
+/// `delpaths` when the update filter yields nothing, and deleting a
+/// slice-shaped path removes that whole range -- for an array that's
+/// exactly "splice in nothing"; for a string, jq raises a different
+/// sentence than a non-empty write does. Every case confirmed live against
+/// jq 1.7.1.
+#[test]
+fn test_slice_delete_on_empty_update_filter_1894() -> Result<()> {
+    // Array: the sliced range is spliced out, shrinking the array.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[0:2] |= empty"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[3]");
+
+    // String: a different message than a non-empty string-slice write.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:2] |= empty"], Some("\"hello\""))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot delete fields from string"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Cannot update string slices"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // `?` does not suppress this -- it's a write-time application error,
+    // not a navigation failure, confirmed live.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:2]? |= empty"], Some("\"hello\""))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot delete fields from string"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // Control: a literal `null` write (not an empty filter) still raises
+    // the pre-existing, unaffected error -- the fix distinguishes "no
+    // output" from "output is null".
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:2] |= null"], Some("[1,2,3]"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("A slice of an array can only be assigned another array"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    Ok(())
+}
+
+/// #1877: a *nested* terminal slice (reached through another slice, or
+/// through an inline `?`) with `|= empty` used to raise "A slice of an
+/// array can only be assigned another array" on a `null`/absent target,
+/// where real jq leaves the whole document untouched -- confirmed live
+/// against jq 1.7.1. This is the same `|= empty` delete/no-op mechanism as
+/// #1894, just for the case where nothing exists yet to delete from.
+#[test]
+fn test_nested_slice_delete_on_empty_update_filter_noops_on_null_1877() -> Result<()> {
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a[0:1][0:2]? |= empty"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    // Two slices chained directly (no `?`, no absent field) on an existing
+    // array -- the inner slice's own delete-and-splice composes correctly
+    // with the outer one's.
+    let (stdout, _stderr, code) =
+        run_jq_full(&["-c", "(.[0:3] | .[0:1]) |= empty"], Some("[1,2,3,4,5]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[2,3,4,5]");
+
+    // Regression guard: a slice followed by a plain `Index` (not another
+    // slice) is a separate, pre-existing, out-of-scope divergence (the
+    // general "`.a |= empty` should delete the key/element, not write
+    // `null`" gap for `Field`/`Index`, #1894's own follow-up territory) --
+    // confirmed unchanged before and after this fix, not newly broken by
+    // it.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[0:2][0] |= empty"], Some("[1,2,3,4]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[null,2,3,4]");
+
+    Ok(())
+}
+
 /// #1653: `--unbuffered` must actually interleave stdout and stderr in real
 /// time, not merely flush a batch that was already fully evaluated.
 ///


### PR DESCRIPTION
## Summary

Real jq's `_modify` (the shared machinery behind `|=`/`+=`/etc.) falls back to `delpaths` when the update filter produces no output at all, rather than writing a literal `null`. `through_slice`'s `Array`/`String`/`Null` arms in `src/jq/eval.rs` had no way to distinguish "the filter produced empty" from "the filter's output was literally `null`" — both collapsed to `update_path`'s terminal `Identity` arm's `null` fallback, which then failed `through_slice`'s array-shape check (#1877) or hit its unconditional string-slice refusal (#1894) instead of deleting the addressed range or no-oping.

- **#1877**: a nested terminal slice (through another slice, or an inline `?`) with `|= empty` on a `null`/absent target raised "A slice of an array can only be assigned another array" where jq leaves the document untouched.
- **#1894**: `through_slice`'s flat `String`/`Array` terminal-write arms didn't special-case an empty-yielding update filter at all.

## Fix

Threads a `wrote: bool` through `update_path`'s and `through_slice`'s return values (`Result<bool, E>`, originating solely at the terminal `Identity` arm — `false` iff the filter produced zero outputs) so the `Array`/`String`/`Null` arms can act on it:

- **Array**: an empty filter deletes the sliced range (splices in nothing) — `[1,2,3] | .[0:2] |= empty` => `[3]`, matching jq.
- **String**: raises `Cannot delete fields from string` (jq's real sentence for this case, distinct from a non-empty write's `Cannot update string slices`).
- **Null**: leaves the target untouched rather than materializing an empty array just to immediately delete it — `null | .a[0:1][0:2]? |= empty` stays `null`.

`set_path`'s (`=`) and `delete_at_path`'s own `through_slice` call sites have no `|= empty` concept at all — their edit closures are adapted to always report `true`, so their behavior is unaffected.

## Scope

Deliberately narrow to `through_slice`'s own arms. The general "`.a |= empty` should delete the key, not write `null`" gap for plain `Field`/`Index`/`Iterate` targets is a different, confirmed-still-present, pre-existing divergence — filed separately as #1916 rather than attempted here (it needs per-element removal semantics for `Iterate` that don't fit this PR's single aggregate boolean).

## Verification

- Every repro in both issues confirmed live against jq 1.7.1 before and after.
- Full regression sweep against #1428/#1873/#1876/#1883's own previously-fixed cases — all unchanged.
- Confirmed the compound `.[0:2][0] |= empty`-style cases (slice into an `Index`, not another slice) are byte-identical before/after this PR — that's #1916's territory, not silently changed here.
- `cargo test` under default features (3019 passed) and `--features cli,simd,regex,serde` (3067 passed) — 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second leg (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`) — clean.
- `cargo build --no-default-features` (no_std) — clean.
- `cargo fmt --check` — clean.

Fixes #1877, Fixes #1894