### PR TITLE
perf(jq): give .[] over a real array its own lazy eval_each_generic arm

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1406,6 +1406,32 @@ the already-checked, always-walks `fold_lazy_keys_stage`. Pinned by
 and
 [`test_jq_keys_unsorted_demand_aware_still_known_gap_past_what_it_pulled_1770`](../../../tests/jq_cli_tests.rs).
 
+## A truncating consumer of a plain array `.[]` skips a malformed comma it never needed
+
+Sibling of the `map(f)`/`keys_unsorted[]` divergences above, for the same underlying
+reason. [#1597](https://github.com/rust-works/succinctly/issues/1597) gave `.[]` over a
+real array its own demand-aware walk (`each_lazy_array_iterate_sink`,
+`src/jq/eval_generic.rs`) so `first(.[])`/`limit(n; .[])` stop pulling cursors after `n`
+elements instead of materializing every one first (a 2M-element array's `first(.[] | .)`
+went from ~92 MB peak RSS to matching the ~28 MB `length` control). The walk still checks
+each element's own preceding `,` (#1677) as it goes — an element the sink *actually pulls*
+is checked exactly as before — but a malformed comma sitting *after* whatever the consumer
+stopped at is never reached:
+
+```
+$ printf '[,1,3]' | succinctly jq -c 'first(.[])'   # error, exit 5 (malformed comma IS the first thing examined)
+$ printf '[1,,3]' | succinctly jq -c 'first(.[])'   # 1, exit 0    (malformed comma is past element 1)
+$ printf '[1,,3]' | succinctly jq -c '.[]'          # error, exit 5 (unaffected -- always exhausts)
+```
+
+Deliberate, for the same reason the two divergences above are: restoring the check here
+would mean walking past the point the demand-aware sink stopped, defeating the reason
+`each_lazy_array_iterate_sink` exists rather than routing through the always-eager
+`collect_cursors_checked`. Objects are unaffected by this specific change — a plain `.[]`
+over an object still takes the original eager path (`.[]`'s duplicate-key collapse
+semantics need `DistinctKeyCursors`'s streaming-collapse machinery extended to also carry
+value cursors, deferred as separate, larger remaining scope on #1597).
+
 ## `limit`'s own `n` argument is not demand-aware when it is itself a generator
 
 Real jq passes `limit($n; f)`'s `$n` through the same backtracking arg-passing convention

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1424,6 +1424,20 @@ $ printf '[1,,3]' | succinctly jq -c 'first(.[])'   # 1, exit 0    (malformed co
 $ printf '[1,,3]' | succinctly jq -c '.[]'          # error, exit 5 (unaffected -- always exhausts)
 ```
 
+A bound *larger* than what the array can supply before the defect still reaches it, and
+still streams whatever was already confirmed good first — the same shape the
+`keys_unsorted[]` entry above already documents for `limit(2; keys_unsorted[])`:
+
+```
+$ printf '[1,2,,4]' | succinctly jq -c 'limit(3;.[])'   # 1, 2, then error, exit 5
+```
+
+This is not a separate divergence from the one above — it is the same "only checked as
+far as the sink actually pulled" rule, just landing on a bound the sink *did* need rather
+than one it stopped short of. The `keys_unsorted[]` entry's own `limit(2; ...)` example
+already established this exact shape for objects; this is its array counterpart, not a new
+kind of gap.
+
 Deliberate, for the same reason the two divergences above are: restoring the check here
 would mean walking past the point the demand-aware sink stopped, defeating the reason
 `each_lazy_array_iterate_sink` exists rather than routing through the always-eager
@@ -1431,6 +1445,13 @@ would mean walking past the point the demand-aware sink stopped, defeating the r
 over an object still takes the original eager path (`.[]`'s duplicate-key collapse
 semantics need `DistinctKeyCursors`'s streaming-collapse machinery extended to also carry
 value cursors, deferred as separate, larger remaining scope on #1597).
+
+Format-generic, not jq-mode-specific: `each_lazy_array_iterate_sink` takes no
+`S: EvalSemantics` and is reached identically via `succinctly yq`. Currently inert for
+YAML, though — every YAML cursor's `preceding_delimiter_ok` uses the trait default (always
+`true`), since YAML's own parser validates delimiters while parsing rather than deferring
+to this evaluator-level check the way JSON's semi-index does — so there is no YAML input
+this gap check can actually catch or skip either way, today.
 
 ## `limit`'s own `n` argument is not demand-aware when it is itself a generator
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -170,6 +170,26 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         true
     }
 
+    /// [`preceding_delimiter_ok`](Self::preceding_delimiter_ok), resolving
+    /// `expected` from `is_first` (`None` for a container's first child,
+    /// `Some(b',')` otherwise) and skipping the check entirely when this
+    /// cursor has no `text_position()` -- the #1677 array-element gap check,
+    /// as one definition shared by every caller that walks elements one at
+    /// a time, instead of each re-deriving `expected`/the `None`-position
+    /// skip itself (#1597 code review: `DocumentElements::collect_cursors_checked`
+    /// below and `eval_generic::each_lazy_array_iterate_sink` had drifted
+    /// into two independent copies of this exact check before this
+    /// extraction).
+    fn element_gap_ok(&self, is_first: bool) -> bool {
+        match self.text_position() {
+            Some(pos) => {
+                let expected = if is_first { None } else { Some(b',') };
+                self.preceding_delimiter_ok(pos, expected)
+            }
+            None => true,
+        }
+    }
+
     /// The error to raise when [`preceding_delimiter_ok`](Self::preceding_delimiter_ok)
     /// answers `false`.
     ///
@@ -2122,11 +2142,8 @@ pub trait DocumentElements: Sized + Copy + Clone {
         let mut elems = *self;
         let mut is_first = true;
         while let Some((cursor, rest)) = elems.uncons_cursor() {
-            if let Some(pos) = cursor.text_position() {
-                let expected = if is_first { None } else { Some(b',') };
-                if !cursor.preceding_delimiter_ok(pos, expected) {
-                    return Err(self.malformed_element_error());
-                }
+            if !cursor.element_gap_ok(is_first) {
+                return Err(self.malformed_element_error());
             }
             cursors.push(cursor);
             elems = rest;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4029,6 +4029,63 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     )
 }
 
+/// Demand-aware `Expr::Iterate` fan-out for an array (#1597 part 2): walks
+/// `uncons_cursor()` one element at a time, pushing each straight to `sink`,
+/// instead of `eval_single`'s `Expr::Iterate` arm, which calls
+/// `collect_cursors_checked` -- a full upfront walk into a `Vec` -- before
+/// the first cursor ever reaches a consumer. `first(.[])`/`first(.[] | f)`
+/// paid for materializing every element's cursor on a 2M-element array to
+/// answer a query needing exactly one (#1597).
+///
+/// No `rest`/pipe-stage parameter, unlike [`each_lazy_keys_iterate_sink`]/
+/// [`each_lazy_seq_iterate_sink`]: those exist to unpack a `GenericResult::
+/// LazyKeys`/`LazySeq` marker `fold_pipe_stages_sink` already knows is
+/// followed immediately by `.[]` in a *known* stage list. A bare `.[]`
+/// reached through [`eval_each_generic`]'s own per-node dispatch has no such
+/// marker or stage list -- `sink` here already *is* "whatever the caller
+/// needs done with each element" (chaining through the rest of a `Pipe`,
+/// feeding a `Comma` branch, etc.), the same as every other native arm in
+/// that match (`each_if_generic` and siblings) that calls `sink` directly.
+///
+/// Reimplements, rather than reuses, [`DocumentElements::collect_cursors_checked`]'s
+/// #1677 gap check (`preceding_delimiter_ok` against the expected `,`/none
+/// for the first element) per element instead of over the whole container
+/// up front -- the array counterpart of `collect_cursors_checked`'s own
+/// per-element loop, just yielding as it goes instead of only returning once
+/// finished.
+///
+/// **Deliberate divergence**, the same shape [`each_lazy_seq_iterate_sink`]'s
+/// own doc comment already accepts for `LazySeq`: a malformed comma *after*
+/// whatever the consumer actually pulled is never detected, since the walk
+/// that would find it never runs past what was asked for. `first(.[])` on
+/// `[1,,3]` still raises correctly (the fault is on the very first element
+/// examined); `first(.[])` on a well-formed `1` followed by a *later*
+/// malformed gap does not see it. Every eager caller of
+/// `collect_cursors_checked` (`.[]` reached through the rest of the
+/// evaluator, `to_entries`) is unaffected -- only this demand-aware path
+/// takes the trade. Recorded in `docs/compliance/jq/limitations.md`.
+fn each_lazy_array_iterate_sink<V: DocumentValue>(
+    elements: V::Elements,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut elems = elements;
+    let mut is_first = true;
+    while let Some((cursor, next)) = elems.uncons_cursor() {
+        if let Some(pos) = cursor.text_position() {
+            let expected = if is_first { None } else { Some(b',') };
+            if !cursor.preceding_delimiter_ok(pos, expected) {
+                return Flow::Escaped(Control::Error(elems.malformed_element_error()));
+            }
+        }
+        is_first = false;
+        elems = next;
+        if sink(GenericItem::OneCursor(cursor)) == Demand::Stop {
+            return Flow::Stopped { pending: None };
+        }
+    }
+    Flow::Exhausted
+}
+
 /// Demand-aware twin of `fold_pipe_stages` (#1565): folds an already-produced
 /// `LazyKeys`/`LazyIndexRange`/`LazySeq` item through the remaining pipe
 /// stages one at a time, honoring `sink`'s `Demand` the moment `Expr::Iterate`
@@ -5007,6 +5064,19 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         Expr::Limit { n, expr } => {
             each_limit_generic::<S, V>(n, expr, value, optional, cursor, sink)
         }
+
+        // #1597 part 2: `.[]` over an array, walked lazily -- see
+        // `each_lazy_array_iterate_sink`'s own doc comment. Every other
+        // shape (object, non-container, decode failure) still falls back
+        // to `eval_single`'s existing, correct-but-eager handling -- an
+        // object's own duplicate-key collapse semantics need
+        // `DistinctKeyCursors`' streaming-collapse machinery extended to
+        // also carry value cursors, a separate and larger change not
+        // attempted here.
+        Expr::Iterate => match value.as_array() {
+            Some(elements) => each_lazy_array_iterate_sink(elements, sink),
+            None => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
+        },
 
         _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4047,12 +4047,11 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// feeding a `Comma` branch, etc.), the same as every other native arm in
 /// that match (`each_if_generic` and siblings) that calls `sink` directly.
 ///
-/// Reimplements, rather than reuses, [`DocumentElements::collect_cursors_checked`]'s
-/// #1677 gap check (`preceding_delimiter_ok` against the expected `,`/none
-/// for the first element) per element instead of over the whole container
-/// up front -- the array counterpart of `collect_cursors_checked`'s own
-/// per-element loop, just yielding as it goes instead of only returning once
-/// finished.
+/// Shares [`DocumentCursor::element_gap_ok`]'s #1677 gap check with
+/// [`DocumentElements::collect_cursors_checked`] rather than duplicating
+/// it -- the loop shape differs (this one yields as it goes instead of
+/// only returning once finished, since that is the entire point), but the
+/// check itself is the same one definition either way.
 ///
 /// **Deliberate divergence**, the same shape [`each_lazy_seq_iterate_sink`]'s
 /// own doc comment already accepts for `LazySeq`: a malformed comma *after*
@@ -4071,11 +4070,16 @@ fn each_lazy_array_iterate_sink<V: DocumentValue>(
     let mut elems = elements;
     let mut is_first = true;
     while let Some((cursor, next)) = elems.uncons_cursor() {
-        if let Some(pos) = cursor.text_position() {
-            let expected = if is_first { None } else { Some(b',') };
-            if !cursor.preceding_delimiter_ok(pos, expected) {
-                return Flow::Escaped(Control::Error(elems.malformed_element_error()));
-            }
+        if !cursor.element_gap_ok(is_first) {
+            // `elements.malformed_element_error()`, not `elems` (the
+            // per-iteration state at the point of failure) -- matching
+            // `collect_cursors_checked`'s own `self.malformed_element_error()`
+            // convention (#1597 code review). Every format shipped today
+            // ignores the receiver entirely (the default) or re-derives from
+            // the whole document regardless of which cursor calls it (JSON),
+            // so this has no observable effect now, but keeps both call
+            // sites' conventions identical for a future format where it might.
+            return Flow::Escaped(Control::Error(elements.malformed_element_error()));
         }
         is_first = false;
         elems = next;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23358,6 +23358,118 @@ fn test_first_over_lazy_seq_iterate_skips_later_error_1565() -> Result<()> {
     Ok(())
 }
 
+/// #1597 part 2: `.[]` over a real array now walks lazily
+/// (`each_lazy_array_iterate_sink`), so `first`/`limit` stop pulling cursors
+/// instead of collecting every one up front. Output must stay byte-identical
+/// to jq for every ordinary shape -- correctness is unaffected, only how
+/// much of the array gets touched.
+#[test]
+fn test_array_iterate_lazy_correctness_1597() -> Result<()> {
+    let input = r"[10,20,30,40,50]";
+    for (args, want_out) in [
+        (&["-c", "first(.[])"][..], "10\n"),
+        (&["-c", "first(.[] | . + 1)"][..], "11\n"),
+        (&["-c", "[limit(2; .[])]"][..], "[10,20]\n"),
+        (&["-c", "[limit(100; .[])]"][..], "[10,20,30,40,50]\n"),
+        (&["-c", "[.[]]"][..], "[10,20,30,40,50]\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(args, Some(input))?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            (want_out, 0),
+            "`{}` -- stderr: {stderr}",
+            args.join(" ")
+        );
+    }
+
+    // Empty array: `.[]` produces zero outputs, so `first` produces none
+    // either -- no output at all, not `null`. Oracle-verified against jq
+    // 1.7.1 (`echo '[]' | jq -c 'first(.[])'` prints nothing, exit 0).
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(.[])"], Some("[]"))?;
+    assert_eq!((stdout.as_str(), code), ("", 0), "stderr: {stderr}");
+
+    // Non-array target still raises the same error as before.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(.[])"], Some("5"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("Cannot iterate"), "{stderr}");
+
+    Ok(())
+}
+
+/// #1597 part 2 companion: a later error is skipped exactly like
+/// #1565's `map(f) | .[]` divergence -- the same trade, now for a plain
+/// array `.[]` reached without any `map`/`keys_unsorted` producer in
+/// between. `first`/`limit` never evaluate past what they needed, so an
+/// element that would error past the stopping point never runs at all.
+#[test]
+fn test_array_iterate_lazy_skips_unneeded_later_evaluation_1597() -> Result<()> {
+    let input = r#"[1,"x",3]"#;
+    // Diverges from jq: jq's `.[] | error` here still only evaluates one
+    // output before `first` stops, same as succinctly -- this is testing
+    // laziness of *evaluation*, already true before #1597 (#1461/#1565); the
+    // point is confirming the new arm didn't regress it.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "first(.[] | if type == \"string\" then error(\"boom\") else . end)",
+        ],
+        Some(input),
+    )?;
+    assert_eq!((stdout.as_str(), code), ("1\n", 0), "stderr: {stderr}");
+
+    // A `limit` that never reaches the failing element also stays clean.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "[limit(1; .[] | if type == \"string\" then error(\"boom\") else . end)]",
+        ],
+        Some(input),
+    )?;
+    assert_eq!((stdout.as_str(), code), ("[1]\n", 0), "stderr: {stderr}");
+
+    // Reaching the failing element still raises, same as jq.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "[limit(2; .[] | if type == \"string\" then error(\"boom\") else . end)]",
+        ],
+        Some(input),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("boom"), "{stderr}");
+
+    Ok(())
+}
+
+/// #1597 part 2 (#1677 sibling of #1565/#1770): a malformed `,` sitting
+/// *after* whatever a truncating consumer actually pulled is never
+/// detected, since `each_lazy_array_iterate_sink` never walks past the
+/// point `sink` stopped at. See `docs/compliance/jq/limitations.md`'s "A
+/// truncating consumer of a plain array `.[]` skips a malformed comma it
+/// never needed" for the full writeup -- there is no meaningful jq
+/// comparison here (jq's own strict parser rejects this input outright
+/// before either evaluator runs), so this pins succinctly's own
+/// lazy-vs-eager behavior directly instead.
+#[test]
+fn test_array_iterate_lazy_skips_later_malformed_comma_1597() -> Result<()> {
+    // The malformed comma sits between element 1 and element 2 -- past
+    // what `first(.[])` needed, so it goes undetected.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(.[])"], Some("[1,,3]"))?;
+    assert_eq!((stdout.as_str(), code), ("1\n", 0), "stderr: {stderr}");
+
+    // A malformed comma *before* the first element is the very first thing
+    // examined, so it is still caught.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(.[])"], Some("[,1,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    // Plain `.[]` (no truncation) still walks the whole array and always
+    // catches it, unaffected by this change.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[]"], Some("[1,,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #1519, found while implementing #1462's own oracle sweep: real jq's
 /// short-circuiting builtins are macro-expanded `label $out | ... break
 /// $out` definitions, and its `?//`-alternatives operator retries the next

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23463,9 +23463,47 @@ fn test_array_iterate_lazy_skips_later_malformed_comma_1597() -> Result<()> {
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
 
     // Plain `.[]` (no truncation) still walks the whole array and always
-    // catches it, unaffected by this change.
+    // catches it, unaffected by this change -- and produces no output at
+    // all, not just a nonzero exit, since it never routes through the new
+    // lazy arm in the first place (`evaluate_bytes_lazy`'s bare `.[]` path
+    // calls `eval_single` directly). Asserting `stdout` too, not just
+    // `code`, so this stays a real regression guard if a future change
+    // ever does route a top-level bare `.[]` through `eval_each_generic`.
     let (stdout, stderr, code) = run_jq_full(&["-c", ".[]"], Some("[1,,3]"))?;
+    assert_eq!((stdout.as_str(), code), ("", 5), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #1597 code review: `limit`/`first` *reaching into* a malformed comma
+/// while trying to satisfy a bound greater than what the array can supply
+/// still streams whatever was already confirmed good before erroring --
+/// unlike `test_array_iterate_lazy_skips_later_malformed_comma_1597` above
+/// (which never needed the defective element at all), `limit(3; .[])` on
+/// `[1,2,,4]` *did* want a 3rd element, and discovering the defect while
+/// trying to produce it happens only after 1 and 2 have already been sunk.
+///
+/// This is not a new class of divergence: it is the array counterpart of
+/// the already-shipped, already-tested `keys_unsorted[]` behavior
+/// (`test_jq_keys_unsorted_demand_aware_raises_on_pulled_malformed_key_1770`'s
+/// `limit(2; keys_unsorted[])` case, which streams `"a"` before erroring on
+/// a malformed key past it the same way). Pinning it explicitly here so a
+/// future reviewer sees it as a deliberate, precedented decision rather
+/// than an unexamined side effect of #1597's own laziness.
+#[test]
+fn test_array_iterate_lazy_limit_streams_confirmed_prefix_before_reaching_malformed_comma_1597(
+) -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "limit(3;.[])"], Some("[1,2,,4]"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n2\n");
+
+    // Control: a well-formed array satisfies the same bound cleanly.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "limit(3;.[])"], Some("[1,2,3,4]"))?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("1\n2\n3\n", 0),
+        "stderr: {stderr}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`eval_single`'s `Expr::Iterate` arm called `collect_cursors_checked` — a
full upfront walk into a `Vec` — before the first cursor ever reached a
consumer, so `first(.[])`/`limit(n; .[])` paid for materializing every
element's cursor to answer a query needing far fewer.

```
2M-element array, 17 MB input (release build, /usr/bin/time -l):

length (control)      0.09s   28 MB
first(.[] | .)         0.05s   96 MB   <- ~66 MB above control
```

This confirms the issue's own "part 2" — `eval_single`'s `Expr::Iterate`
arm — is real and still reproducing (its "part 1", `each_lazy_keys_iterate_sink`'s
`!sorted` branch, turns out to already be fixed: `first(keys_unsorted | .[] | .)`
now measures ~55MB, matching the `length`/`.["1"]` controls, down from the
issue's documented 131MB — verified live before starting on this).

## Fix

Add `each_lazy_array_iterate_sink`: a native `Expr::Iterate` arm in
`eval_each_generic` for the array case, walking `uncons_cursor()` one
element at a time and pushing straight to `sink`, instead of falling
through to `eval_single` + `drain_result_generic`. Reimplements
`collect_cursors_checked`'s own #1677 gap check (the preceding-comma
validation) per element instead of over the whole container up front.

```
After the fix:
first(.[] | .)         0.03s   30 MB   <- matches the length control
```

No `rest`/pipe-stage parameter needed, unlike `each_lazy_keys_iterate_sink`/
`each_lazy_seq_iterate_sink`: those exist to unpack a `GenericResult::LazyKeys`/
`LazySeq` marker `fold_pipe_stages_sink` already knows is followed by `.[]` in
a *known* stage list. A bare `.[]` reached through `eval_each_generic`'s own
per-node dispatch has no such marker — `sink` already *is* "whatever the
caller needs done with each element," same as every other native arm in that
match (`each_if_generic` and siblings).

## Deliberate divergence (same shape as #1565/#1770)

A malformed comma sitting *after* whatever a truncating consumer actually
pulled is never detected, since the walk that would find it never runs past
what was asked for:

```
$ printf '[,1,3]' | succinctly jq -c 'first(.[])'   # error, exit 5 (comma IS the first thing examined)
$ printf '[1,,3]' | succinctly jq -c 'first(.[])'   # 1, exit 0    (comma is past element 1)
$ printf '[1,,3]' | succinctly jq -c '.[]'          # error, exit 5 (unaffected -- always exhausts)
```

Recorded in `docs/compliance/jq/limitations.md` alongside its two existing
siblings (the `map(f)` and `keys_unsorted[]` divergences).

## Deliberately out of scope: the object case

`.[]` on an **object** still takes the original eager path. Object iteration
has "collapse a repeated key to its first position but last-seen value"
semantics (#1398) that `DistinctKeyCursors` already implements via a
streaming-then-confirm-collapse mechanism — but that structure is
specifically built to *not* touch field values at all (its own doc comment:
"this iterator never reads a field's value"), since key-only consumers
(`keys`/`keys_unsorted`) never need them. Making `.[]`-over-object lazy would
mean generalizing that same collapse-detection algorithm to also carry value
cursors through it correctly — a separate, materially larger, and riskier
change than this PR's array-only fix. #1597's own "Likely fix" section
named this split explicitly ("the harder one... `GenericResult::ManyCursor`
is a `Vec` by construction").

## Test plan

- [x] New correctness tests: `first`/`limit`/full-consumption on arrays,
      empty array, non-container error preservation — all byte-identical to
      jq 1.7.1.
- [x] New laziness test: a later-erroring element is skipped exactly like
      #1565's `map(f) | .[]` divergence, confirming the new arm didn't
      regress existing "evaluate lazily" behavior (already true before this
      PR via #1461/#1565) while adding "allocate lazily" too.
- [x] New malformed-comma divergence test, matching the documented tradeoff.
- [x] Existing acceptance-criteria tests named by the issue still pass:
      `test_first_over_lazy_prefix_applies_every_stage_1565`,
      `test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451`.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde
      --no-fail-fast`): 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and CI's
      second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,
      mmap-tests`): both clean.
- [x] `cargo fmt --check`: clean.

Refs #1597 (object case remains open, narrowing comment to follow)