### PR TITLE
fix(jq): yq-mode assignment through a null-autovivify skips the unused RHS

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -867,8 +867,28 @@ A `null` target is deliberately excluded from this fix — real yq autovivifies 
 as part of the write itself (already correct on both sides before and after this fix), so it
 is not a *total* no-op the way an empty/all-scalar container is, and this predicate's
 all-or-nothing `Skip`/`Continue` caller has no way to express "skip the RHS, but still
-perform the write." That narrower, still-open gap is tracked separately by
-[#1857](https://github.com/rust-works/succinctly/issues/1857).
+perform the write." That narrower gap was tracked separately as #1857 -- see the entry below.
+
+**Fixed by [#1857](https://github.com/rust-works/succinctly/issues/1857):** a *mid-chain*
+`Iterate` autovivifying `null` into `[]` still evaluated the RHS eagerly, where real yq's
+equivalent write never needs it (zero elements to write into). New `assign_path_rhs_unused`
+answers a broader question than `assign_path_all_noop`'s total-no-op check -- "is the RHS
+ever actually read" -- recognizing `null` under a mid-chain `Iterate` as one more case where
+it isn't, and `yq_assign_noop_check` performs the (already fully determined) write with a
+placeholder value instead of evaluating the RHS at all:
+
+```bash
+$ printf 'a: null\n' | yq            -o=json '.a[].b = error("boom")'   # {"a":[]}, RHS never runs
+$ printf 'a: null\n' | succinctly yq -o=json '.a[].b = error("boom")'   # {"a":[]} (fixed)
+```
+
+Reaches every yq-mode assignment operator routed through this mechanism (`=`, `+=`, `-=`,
+`*=`, `/=`, `%=`, `//=`). A **terminal** `Iterate` (`.a[] = v`, the assignment target itself)
+is a different, still-open case neither this fix nor #1432's own covers — see
+[#1921](https://github.com/rust-works/succinctly/issues/1921). Plain `|=` doesn't share this
+mechanism at all and turned out to have a separate, more severe divergence (a hard error
+instead of missing autovivification) — see
+[#1919](https://github.com/rust-works/succinctly/issues/1919).
 
 ### `=`'s multi-output RHS: real yq takes only the last value, no fan-out
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15582,13 +15582,71 @@ fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
     !is_owned_container(target) && !matches!(target, OwnedValue::Null)
 }
 
-/// Whether writing `path` (a single *resolved* assignment-target path, one
-/// `resolve_dynamic_indexes` entry) into `root` would be real yq's
-/// field/index/iterate scalar-target no-op (#1181): navigating every
-/// component *before* the last reaches a genuine scalar. When true for
-/// every resolved path, real yq discards the RHS/filter entirely rather
-/// than merely skipping the write (#1233, live-verified v4.53.3) --
-/// `eval_assign`'s own caller is what actually skips RHS evaluation; this
+/// The outcome of walking a resolved static path against `set_path`'s own
+/// write semantics, without actually performing the write. Replaces two
+/// independently-hand-synced boolean predicates that used to exist here
+/// (`assign_path_all_noop`/`assign_path_rhs_unused`, and their outer
+/// wrappers, the current [`yq_assign_is_total_noop`]/[`yq_assign_rhs_unused`])
+/// -- #1920 review (round 2) found the split cost a full second tree-walk
+/// on every non-total-noop yq-mode assignment, and risked exactly the
+/// "duplicated predicates diverge silently" failure this codebase has
+/// already hit once (#106): the two boolean walks were near-identical
+/// copies whose *only* intentional difference (an `Expr::Iterate` reaching
+/// `Null`) had to be applied by hand to one and not the other. One walk
+/// producing a 3-way answer removes that risk structurally instead of by
+/// doc-comment discipline; the two outer functions are now thin wrappers
+/// over [`yq_assign_classify`], keeping their own names/signatures
+/// unchanged so every existing cross-reference to them elsewhere in this
+/// file stays accurate.
+enum PathAssignOutcome {
+    /// Every write this path reaches is a no-op: the document doesn't
+    /// change at all.
+    TotalNoop,
+    /// Not a total no-op (the document does change), but the RHS value is
+    /// never actually read anywhere along it -- a mid-chain `Iterate`
+    /// autovivifying `Null` into an empty array, most commonly (#1857).
+    RhsUnusedButChanges,
+    /// A real, RHS-dependent write happens somewhere along this path.
+    NeedsRhs,
+}
+
+impl PathAssignOutcome {
+    fn is_total_noop(&self) -> bool {
+        matches!(self, Self::TotalNoop)
+    }
+
+    fn rhs_unused(&self) -> bool {
+        !matches!(self, Self::NeedsRhs)
+    }
+}
+
+fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
+    yq_assign_classify(path, root).is_total_noop()
+}
+
+/// [`yq_assign_is_total_noop`]'s twin for the narrower #1857 gap -- see
+/// [`PathAssignOutcome`]'s own doc comment for why both are now thin
+/// wrappers over one shared walk rather than independent ones.
+///
+/// Deliberately does **not** cover a *terminal* `Iterate` (`.a[] = v`, the
+/// `Iterate` itself is `last`, stripped into the flattened `prefix` before
+/// [`classify_yq_assign_prefix`] is ever reached) reaching an already-empty
+/// container or `Null` -- that shape needs the terminal step's own type
+/// available at the point its target is examined, which this prefix-only
+/// design structurally can't see (same reason the total-noop check never
+/// covered it either). Filed separately as #1921 rather than folded in
+/// here.
+fn yq_assign_rhs_unused(path: &Expr, root: &OwnedValue) -> bool {
+    yq_assign_classify(path, root).rhs_unused()
+}
+
+/// Shared implementation behind [`yq_assign_is_total_noop`] and
+/// [`yq_assign_rhs_unused`]: whether writing `path` (a single *resolved*
+/// assignment-target path, one `resolve_dynamic_indexes` entry) into `root`
+/// is a total no-op, RHS-unused-but-changing, or a real RHS-dependent write
+/// (#1181/#1233/#1857 -- see [`PathAssignOutcome`]'s own doc comment for
+/// the three-way split's own history). `eval_assign`'s own caller is what
+/// actually skips RHS evaluation on `TotalNoop`/`RhsUnusedButChanges`; this
 /// only answers the per-path question.
 ///
 /// `path` is flattened via [`push_path_components`] first -- the same
@@ -15619,14 +15677,35 @@ fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
 /// so `.[] = v` stays `Expr::Iterate` verbatim, same as `.a`/`.a.b` stay
 /// `Expr::Field`. Treated identically to a terminal `Field`/`Index` here,
 /// matching `set_path`'s own `Expr::Iterate` arm, which applies the
-/// identical `is_yq_field_index_noop_scalar` check for exactly this case.
-fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
+/// identical `is_yq_field_index_noop_scalar` check for exactly this case
+/// -- and, per [`classify_yq_assign_prefix`]'s own scope, only for a
+/// *mid-chain* `Iterate`: `last` itself is stripped off into `prefix`
+/// below before that function ever runs, so a *terminal* `Iterate` never
+/// reaches this classification at all (#1921).
+///
+/// Applies every gate needed before delegating to
+/// [`classify_yq_assign_prefix`] for the actual walk: the empty-flattened-
+/// list bail (bare `Expr::Identity`, `. = v` -- a direct overwrite, not
+/// indexing into anything), the slice-anywhere exclusion (`.[0:1] = v`'s
+/// own no-op, #1101/#1116, only ever skips the *write*, not the RHS --
+/// `.[0:1] = error("boom")` still genuinely errors, confirmed live and
+/// pinned by `test_slice_assign_scalar_noop_still_propagates_rhs_errors_1101`
+/// -- so a slice anywhere in the chain must never reach this fast path),
+/// and a defensive terminal-shape check (not currently reachable: every
+/// leaf `push_path_components` can push is one of `needs_path_prepass`'s
+/// own static-classified variants, and the slice check above already
+/// excludes `Slice`/`SliceNumber`, so by this point `last` can only be
+/// `Field`/`Index`/`IndexNumber`/`Iterate` -- confirmed via patch-coverage
+/// output, not just assumed; kept as the one thing standing between a
+/// future new static-classified `Expr` variant and this function silently
+/// treating an unrelated shape as a valid no-op terminal).
+fn yq_assign_classify(path: &Expr, root: &OwnedValue) -> PathAssignOutcome {
     let mut flat = Vec::new();
     push_path_components(&mut flat, path);
     // An empty flattened list is bare `Expr::Identity` (`. = v`) -- a
     // direct overwrite, not indexing into anything.
     let Some((last, prefix)) = flat.split_last() else {
-        return false;
+        return PathAssignOutcome::NeedsRhs;
     };
     // Deliberately excludes a path whose terminal component is a slice --
     // `.[0:1] = v`'s own no-op (#1101/#1116) only ever skips the *write*,
@@ -15635,7 +15714,7 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
     // `test_slice_assign_scalar_noop_still_propagates_rhs_errors_1101`) --
     // so a slice anywhere in the chain must never reach this fast path.
     if flat.iter().any(|e| unwrap_path_component(e).0.is_slice()) {
-        return false;
+        return PathAssignOutcome::NeedsRhs;
     }
     // Defensive, not currently reachable: every leaf `push_path_components`
     // can push here is one of `needs_path_prepass`'s own static-classified
@@ -15655,182 +15734,96 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
         unwrap_path_component(last).0,
         Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate
     ) {
-        return false;
+        return PathAssignOutcome::NeedsRhs;
     }
-    assign_path_all_noop(root, prefix)
+    classify_yq_assign_prefix(root, prefix)
 }
 
-/// [`yq_assign_is_total_noop`]'s twin for the narrower #1857 gap: a path is
-/// not a *total* no-op (the document does change) but still never actually
-/// reads the RHS value, because every write it reaches is either already a
-/// no-op (`assign_path_all_noop`'s own shape) or a *mid-chain* `Iterate`
-/// that autovivifies `Null` into an empty array -- zero elements, so
-/// whatever `set_path` gets handed as the value is never written anywhere.
-/// Shares every gate `yq_assign_is_total_noop` has (empty-flattened-list
-/// bail, slice-anywhere exclusion, terminal-shape check) since none of that
-/// reasoning changes here -- only the final predicate call differs.
-///
-/// Deliberately does **not** cover a *terminal* `Iterate` (`.a[] = v`, the
-/// `Iterate` itself is `last`, stripped into the caller's own `prefix`
-/// before this is ever reached) reaching an already-empty container or
-/// `Null` -- that shape needs the terminal step's own type available at the
-/// point its target is examined, which this prefix-only design structurally
-/// can't see (same reason `assign_path_all_noop` never covered it either).
-/// Filed separately as #1921 rather than folded in here.
-fn yq_assign_rhs_unused(path: &Expr, root: &OwnedValue) -> bool {
-    let mut flat = Vec::new();
-    push_path_components(&mut flat, path);
-    let Some((last, prefix)) = flat.split_last() else {
-        return false;
-    };
-    if flat.iter().any(|e| unwrap_path_component(e).0.is_slice()) {
-        return false;
-    }
-    if !matches!(
-        unwrap_path_component(last).0,
-        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate
-    ) {
-        return false;
-    }
-    assign_path_rhs_unused(root, prefix)
-}
-
-/// [`assign_path_all_noop`]'s twin for [`yq_assign_rhs_unused`]: same
-/// Field/Index/Iterate walk, but an `Expr::Iterate` reaching `Null`
-/// answers `true` here (RHS never read) where `assign_path_all_noop`
-/// answers `false` (document changes, so not a total no-op) -- `Null`
-/// autovivifies to `[]`, and iterating zero elements is vacuously true
-/// regardless of what `rest` still has left to say, exactly like the
-/// existing empty-`Array`/`Object` arms just below it. Every other arm is
-/// unchanged from `assign_path_all_noop`, including its own base case:
-/// `is_yq_field_index_noop_scalar` already answers "RHS unused" for a
-/// true no-op, which is a subset of what this function reports.
-fn assign_path_rhs_unused(current: &OwnedValue, steps: &[Expr]) -> bool {
-    let (step, rest) = match steps.split_first() {
-        None => return is_yq_field_index_noop_scalar(current),
-        Some(pair) => pair,
-    };
-    let (step, _optional) = unwrap_path_component(step);
-    match step {
-        Expr::Field(name) => match current {
-            OwnedValue::Object(map) => match map.get(name) {
-                Some(v) => assign_path_rhs_unused(v, rest),
-                None => false,
-            },
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
-        },
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
-            OwnedValue::Array(arr) => {
-                let len = arr.len() as i64;
-                let actual = if *idx < 0 { len + idx } else { *idx };
-                if actual >= 0 && (actual as usize) < arr.len() {
-                    assign_path_rhs_unused(&arr[actual as usize], rest)
-                } else {
-                    false
-                }
-            }
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
-        },
-        Expr::Iterate => match current {
-            OwnedValue::Array(arr) => arr.iter().all(|elem| assign_path_rhs_unused(elem, rest)),
-            OwnedValue::Object(map) => map.values().all(|elem| assign_path_rhs_unused(elem, rest)),
-            // Autovivifies to `[]` -- zero elements, so `rest` is never
-            // actually applied to anything, whatever it still contains.
-            OwnedValue::Null => true,
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
-/// Whether writing through `steps` (a `yq_assign_is_total_noop` prefix --
-/// its own flattened path minus the terminal component) into `current` is
-/// a total no-op. Subsumes `navigate_read_only`'s three-way
-/// `Resolved`/`HitScalar`/`Absent` outcome as its own base case (`steps`
-/// exhausted -- `current` is the terminal component's parent, so
-/// `is_yq_field_index_noop_scalar` decides exactly as it always did) but
-/// additionally recurses into `.iter().all(...)`/`.values().all(...)`
-/// whenever a mid-chain `Expr::Iterate` fans into a real `Array`/`Object`,
-/// instead of `navigate_read_only`'s own unconditional `Absent` for that
-/// case (#1432) -- a read-only, non-mutating dry run of
+/// Whether writing through `steps` (a `yq_assign_classify` prefix -- its
+/// own flattened path minus the terminal component) into `current` is a
+/// total no-op, RHS-unused-but-changing, or a real RHS-dependent write.
+/// Subsumes `navigate_read_only`'s three-way `Resolved`/`HitScalar`/
+/// `Absent` outcome as its own base case (`steps` exhausted -- `current` is
+/// the terminal component's parent, so `is_yq_field_index_noop_scalar`
+/// decides exactly as it always did) but additionally recurses into
+/// `Array`/`Object` elements whenever a mid-chain `Expr::Iterate` fans into
+/// a real container, instead of `navigate_read_only`'s own unconditional
+/// `Absent` for that case (#1432) -- a read-only, non-mutating dry run of
 /// `set_path_through_iterate`'s own per-element recursion, restricted to
 /// the `Field`/`Index`/`IndexNumber`/`Iterate` step vocabulary that's all
-/// `yq_assign_is_total_noop`'s caller ever hands it (its own slice check
-/// already excludes anything else before this is reached). Vacuously true
-/// whenever a fanned-into container is empty -- `set_path_through_iterate`
-/// itself does nothing when there are no elements to iterate. Live-verified
-/// against yq v4.53.3: `a: []`/`a: {}` (empty), `a: [1, 2]`/`a: {x: 1, y:
-/// 1}` (all-scalar), and a nested `a: [[1,2],[3]]` under `.a[][].b` all
-/// agree with the oracle in both directions (RHS discarded and the final
-/// document byte-identical to a safe, always-evaluated RHS), while a
-/// single non-scalar element anywhere in the fan-out (`a: [1, {}]`) still
-/// correctly evaluates the RHS.
-///
-/// Deliberately excludes `Null`: real yq's `.a[].b = v` on `a: null`
-/// autovivifies `null` to `[]` as part of the write itself (confirmed live
-/// -- and confirmed already correct on this codebase's own write path
-/// too, independent of this predicate: a safe, non-erroring RHS,
+/// `yq_assign_classify`'s own slice/terminal-shape gates ever let through.
+/// `TotalNoop` whenever a fanned-into container is empty --
+/// `set_path_through_iterate` itself does nothing when there are no
+/// elements to iterate -- and `RhsUnusedButChanges` (not `TotalNoop`)
+/// whenever a mid-chain `Iterate` reaches `Null`: real yq's `.a[].b = v` on
+/// `a: null` autovivifies `null` to `[]` as part of the write itself
+/// (confirmed live, and confirmed already correct on this codebase's own
+/// write path too, independent of this walk: a safe, non-erroring RHS,
 /// `yq '.a[].b = 5'` on `a: null`, already produces `a: []` here exactly
-/// like the oracle). So `Null` is not a *total* no-op the way an empty or
-/// all-scalar container is -- the document still changes -- but the
-/// reason this predicate can't simply report it as one isn't a write bug:
-/// it's that this predicate's only caller (`yq_assign_noop_check`) has an
-/// all-or-nothing `Skip`/`Continue` split, and `Skip` means "return the
-/// *unmodified* pristine document, evaluate nothing at all." Reporting
-/// `Null` as a no-op here would route through `Skip` and discard the
-/// legitimate `null` -> `[]` write that already happens correctly on the
-/// normal `Continue` path -- there is no way to express "skip the RHS,
-/// but still perform the write" through this predicate's boolean answer
-/// alone. That narrower gap (the RHS still evaluates eagerly for `Null`
-/// reached via a *mid-chain* `Iterate`, where real yq's own equivalent
-/// write never needs it) was filed as #1857 and is now handled by this
-/// function's own twin, [`assign_path_rhs_unused`], through the separate
-/// `yq_assign_noop_check` branch that calls it -- see that function's doc
-/// comment. A *terminal* `Iterate` reaching `Null` (`.a[] = v` with no
-/// further path after it) is a different, still-open case neither twin
-/// covers -- filed as #1921 for that shape.
-fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
+/// like the oracle) -- so the document does change, but the RHS this
+/// autovivify-only write receives is never actually read (#1857, zero
+/// elements to write into). `NeedsRhs` for a *terminal* `Iterate` (`.a[] =
+/// v`, no further steps) reaching an already-empty container or `Null` is
+/// a separate, still-open gap this walk doesn't attempt: a terminal
+/// `Iterate`'s own semantics (overwrite every real element, regardless of
+/// its type) genuinely differ from a mid-chain one's, and the terminal
+/// step is stripped into `yq_assign_classify`'s own `prefix` before this
+/// function ever sees it -- filed as #1921. Live-verified against yq
+/// v4.53.3 for every other case: `a: []`/`a: {}` (empty), `a: [1, 2]`/`a:
+/// {x: 1, y: 1}` (all-scalar), `a: null` under a mid-chain `Iterate`, and a
+/// nested `a: [[1,2],[3]]` under `.a[][].b` all agree with the oracle in
+/// both directions (RHS discarded and the final document byte-identical to
+/// a safe, always-evaluated RHS), while a single non-scalar element
+/// anywhere in the fan-out (`a: [1, {}]`) still correctly needs the RHS.
+fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssignOutcome {
     let (step, rest) = match steps.split_first() {
-        None => return is_yq_field_index_noop_scalar(current),
+        None => {
+            return if is_yq_field_index_noop_scalar(current) {
+                PathAssignOutcome::TotalNoop
+            } else {
+                PathAssignOutcome::NeedsRhs
+            };
+        }
         Some(pair) => pair,
     };
     let (step, _optional) = unwrap_path_component(step);
     match step {
         Expr::Field(name) => match current {
             OwnedValue::Object(map) => match map.get(name) {
-                Some(v) => assign_path_all_noop(v, rest),
-                None => false,
+                Some(v) => classify_yq_assign_prefix(v, rest),
+                None => PathAssignOutcome::NeedsRhs,
             },
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
+            _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
+            _ => PathAssignOutcome::NeedsRhs,
         },
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
             OwnedValue::Array(arr) => {
                 let len = arr.len() as i64;
                 let actual = if *idx < 0 { len + idx } else { *idx };
                 if actual >= 0 && (actual as usize) < arr.len() {
-                    assign_path_all_noop(&arr[actual as usize], rest)
+                    classify_yq_assign_prefix(&arr[actual as usize], rest)
                 } else {
-                    false
+                    PathAssignOutcome::NeedsRhs
                 }
             }
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
+            _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
+            _ => PathAssignOutcome::NeedsRhs,
         },
         Expr::Iterate => match current {
-            OwnedValue::Array(arr) => arr.iter().all(|elem| assign_path_all_noop(elem, rest)),
-            OwnedValue::Object(map) => map.values().all(|elem| assign_path_all_noop(elem, rest)),
-            // Not `Null` -- reporting a no-op here would route through
-            // `Skip` and discard `Null`'s own legitimate autovivify write
-            // (see this function's own doc comment, #1857).
-            _ if is_yq_field_index_noop_scalar(current) => true,
-            _ => false,
+            OwnedValue::Array(arr) => classify_yq_assign_fanout(arr.iter(), rest),
+            OwnedValue::Object(map) => classify_yq_assign_fanout(map.values(), rest),
+            // Autovivifies to `[]` -- zero elements, so `rest` is never
+            // actually applied to anything, whatever it still contains.
+            // Changes the document (`Null` -> `[]`), so not `TotalNoop`,
+            // but the RHS is never read either way -- see this function's
+            // own doc comment for why that's `RhsUnusedButChanges`, not
+            // `TotalNoop`.
+            OwnedValue::Null => PathAssignOutcome::RhsUnusedButChanges,
+            _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
+            _ => PathAssignOutcome::NeedsRhs,
         },
         // Defensive, not currently reachable: `steps` only ever contains
-        // `yq_assign_is_total_noop`'s own flattened `prefix`, whose every
+        // `yq_assign_classify`'s own flattened `prefix`, whose every
         // component is already provably one of `Field`/`Index`/
         // `IndexNumber`/`Iterate` by the time it reaches here -- see that
         // function's own identical "Defensive, not currently reachable"
@@ -15839,7 +15832,34 @@ fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
         // fires). Kept for the same reason: the one thing standing between
         // a future new static-classified `Expr` variant and this function
         // silently mishandling it instead of falling to a safe default.
-        _ => false,
+        _ => PathAssignOutcome::NeedsRhs,
+    }
+}
+
+/// The `Expr::Iterate` fan-out shared by both `Array`/`Object` arms of
+/// [`classify_yq_assign_prefix`]: walks every element once, short-circuits
+/// the instant any one needs the RHS for real (matching the old
+/// `.all()`-based walks' own short-circuit), and otherwise aggregates
+/// `TotalNoop`/`RhsUnusedButChanges` across all of them -- `TotalNoop` only
+/// if every element was (vacuously true for zero elements, matching
+/// `set_path_through_iterate`'s own no-op-on-empty behavior), the wider
+/// `RhsUnusedButChanges` as soon as even one element autovivified.
+fn classify_yq_assign_fanout<'a>(
+    elements: impl Iterator<Item = &'a OwnedValue>,
+    rest: &[Expr],
+) -> PathAssignOutcome {
+    let mut any_change = false;
+    for elem in elements {
+        match classify_yq_assign_prefix(elem, rest) {
+            PathAssignOutcome::TotalNoop => {}
+            PathAssignOutcome::RhsUnusedButChanges => any_change = true,
+            PathAssignOutcome::NeedsRhs => return PathAssignOutcome::NeedsRhs,
+        }
+    }
+    if any_change {
+        PathAssignOutcome::RhsUnusedButChanges
+    } else {
+        PathAssignOutcome::TotalNoop
     }
 }
 
@@ -16109,7 +16129,7 @@ enum PrefixNavOutcome {
     /// Every prefix step navigated an existing value. Carries no payload:
     /// `yq_assign_is_total_noop` used to read the resolved parent off this
     /// variant for its own terminal scalar check, but that check now lives
-    /// inside `assign_path_all_noop`'s own base case (#1432), so the only
+    /// inside `classify_yq_assign_prefix`'s own base case (#1432), so the only
     /// remaining reader (`yq_del_slice_outcome`) only ever matches the
     /// variant itself via `matches!(..., Resolved(_))`.
     Resolved,
@@ -16528,8 +16548,11 @@ pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
 /// internally consistent reading of that same premise.
 ///
 /// `None` means "doesn't apply" for any reason (jq mode, a dynamic path, a
-/// resolve error, or a path that isn't a total no-op) -- the caller falls
-/// through to its own unchanged RHS-evaluation flow either way.
+/// resolve error, or a path where the RHS is genuinely needed -- either a
+/// total no-op, per this function's own name, or (#1857) a path that
+/// changes the document but never reads the RHS, both routed through
+/// `YqAssignNoopCheck::Skip`) -- the caller falls through to its own
+/// unchanged RHS-evaluation flow either way.
 fn yq_assign_skip_rhs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     input: &StandardJson<'_, W>,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15663,12 +15663,20 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
 /// [`yq_assign_is_total_noop`]'s twin for the narrower #1857 gap: a path is
 /// not a *total* no-op (the document does change) but still never actually
 /// reads the RHS value, because every write it reaches is either already a
-/// no-op (`assign_path_all_noop`'s own shape) or a mid-chain `Iterate` that
-/// autovivifies `Null` into an empty array -- zero elements, so whatever
-/// `set_path` gets handed as the value is never written anywhere. Shares
-/// every gate `yq_assign_is_total_noop` has (empty-flattened-list bail,
-/// slice-anywhere exclusion, terminal-shape check) since none of that
+/// no-op (`assign_path_all_noop`'s own shape) or a *mid-chain* `Iterate`
+/// that autovivifies `Null` into an empty array -- zero elements, so
+/// whatever `set_path` gets handed as the value is never written anywhere.
+/// Shares every gate `yq_assign_is_total_noop` has (empty-flattened-list
+/// bail, slice-anywhere exclusion, terminal-shape check) since none of that
 /// reasoning changes here -- only the final predicate call differs.
+///
+/// Deliberately does **not** cover a *terminal* `Iterate` (`.a[] = v`, the
+/// `Iterate` itself is `last`, stripped into the caller's own `prefix`
+/// before this is ever reached) reaching an already-empty container or
+/// `Null` -- that shape needs the terminal step's own type available at the
+/// point its target is examined, which this prefix-only design structurally
+/// can't see (same reason `assign_path_all_noop` never covered it either).
+/// Filed separately as #1921 rather than folded in here.
 fn yq_assign_rhs_unused(path: &Expr, root: &OwnedValue) -> bool {
     let mut flat = Vec::new();
     push_path_components(&mut flat, path);
@@ -15776,9 +15784,14 @@ fn assign_path_rhs_unused(current: &OwnedValue, steps: &[Expr]) -> bool {
 /// legitimate `null` -> `[]` write that already happens correctly on the
 /// normal `Continue` path -- there is no way to express "skip the RHS,
 /// but still perform the write" through this predicate's boolean answer
-/// alone. That narrower gap (the RHS still evaluates eagerly for `Null`,
-/// where real yq's own equivalent write never needs it) is real but out
-/// of this predicate's reach -- filed separately as #1857.
+/// alone. That narrower gap (the RHS still evaluates eagerly for `Null`
+/// reached via a *mid-chain* `Iterate`, where real yq's own equivalent
+/// write never needs it) was filed as #1857 and is now handled by this
+/// function's own twin, [`assign_path_rhs_unused`], through the separate
+/// `yq_assign_noop_check` branch that calls it -- see that function's doc
+/// comment. A *terminal* `Iterate` reaching `Null` (`.a[] = v` with no
+/// further path after it) is a different, still-open case neither twin
+/// covers -- filed as #1921 for that shape.
 fn assign_path_all_noop(current: &OwnedValue, steps: &[Expr]) -> bool {
     let (step, rest) = match steps.split_first() {
         None => return is_yq_field_index_noop_scalar(current),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15585,19 +15585,19 @@ fn is_yq_field_index_noop_scalar(target: &OwnedValue) -> bool {
 /// The outcome of walking a resolved static path against `set_path`'s own
 /// write semantics, without actually performing the write. Replaces two
 /// independently-hand-synced boolean predicates that used to exist here
-/// (`assign_path_all_noop`/`assign_path_rhs_unused`, and their outer
-/// wrappers, the current [`yq_assign_is_total_noop`]/[`yq_assign_rhs_unused`])
-/// -- #1920 review (round 2) found the split cost a full second tree-walk
-/// on every non-total-noop yq-mode assignment, and risked exactly the
-/// "duplicated predicates diverge silently" failure this codebase has
-/// already hit once (#106): the two boolean walks were near-identical
-/// copies whose *only* intentional difference (an `Expr::Iterate` reaching
-/// `Null`) had to be applied by hand to one and not the other. One walk
-/// producing a 3-way answer removes that risk structurally instead of by
-/// doc-comment discipline; the two outer functions are now thin wrappers
-/// over [`yq_assign_classify`], keeping their own names/signatures
-/// unchanged so every existing cross-reference to them elsewhere in this
-/// file stays accurate.
+/// (`yq_assign_is_total_noop`/`yq_assign_rhs_unused`, plus their own inner
+/// twins `assign_path_all_noop`/`assign_path_rhs_unused`) -- #1920 review
+/// (round 2) found the split cost a full second tree-walk on every
+/// non-total-noop yq-mode assignment, and risked exactly the "duplicated
+/// predicates diverge silently" failure this codebase has already hit once
+/// (#106): the two boolean walks were near-identical copies whose *only*
+/// intentional difference (an `Expr::Iterate` reaching `Null`) had to be
+/// applied by hand to one and not the other. One walk producing a 3-way
+/// answer removes that risk structurally instead of by doc-comment
+/// discipline. All four of the old names are gone -- [`yq_assign_classify`]
+/// (path-level) and [`classify_yq_assign_prefix`] (prefix-level) are their
+/// sole replacements, called directly by this classification's one real
+/// consumer, `yq_assign_noop_check`.
 enum PathAssignOutcome {
     /// Every write this path reaches is a no-op: the document doesn't
     /// change at all.
@@ -15620,28 +15620,7 @@ impl PathAssignOutcome {
     }
 }
 
-fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
-    yq_assign_classify(path, root).is_total_noop()
-}
-
-/// [`yq_assign_is_total_noop`]'s twin for the narrower #1857 gap -- see
-/// [`PathAssignOutcome`]'s own doc comment for why both are now thin
-/// wrappers over one shared walk rather than independent ones.
-///
-/// Deliberately does **not** cover a *terminal* `Iterate` (`.a[] = v`, the
-/// `Iterate` itself is `last`, stripped into the flattened `prefix` before
-/// [`classify_yq_assign_prefix`] is ever reached) reaching an already-empty
-/// container or `Null` -- that shape needs the terminal step's own type
-/// available at the point its target is examined, which this prefix-only
-/// design structurally can't see (same reason the total-noop check never
-/// covered it either). Filed separately as #1921 rather than folded in
-/// here.
-fn yq_assign_rhs_unused(path: &Expr, root: &OwnedValue) -> bool {
-    yq_assign_classify(path, root).rhs_unused()
-}
-
-/// Shared implementation behind [`yq_assign_is_total_noop`] and
-/// [`yq_assign_rhs_unused`]: whether writing `path` (a single *resolved*
+/// Whether writing `path` (a single *resolved*
 /// assignment-target path, one `resolve_dynamic_indexes` entry) into `root`
 /// is a total no-op, RHS-unused-but-changing, or a real RHS-dependent write
 /// (#1181/#1233/#1857 -- see [`PathAssignOutcome`]'s own doc comment for
@@ -15791,8 +15770,25 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
         Expr::Field(name) => match current {
             OwnedValue::Object(map) => match map.get(name) {
                 Some(v) => classify_yq_assign_prefix(v, rest),
-                None => PathAssignOutcome::NeedsRhs,
+                // An absent key autovivifies exactly like an explicit
+                // `Null` value would (real yq's `.a.b[].z = v` on `a: {}`
+                // and on `a: {b: null}` behave identically, confirmed
+                // live) -- recurse the same way rather than giving up
+                // immediately, so a later `Iterate` in `rest` still gets
+                // to answer `RhsUnusedButChanges` for its own empty
+                // fan-out (round-3 review of #1920 found this gap: the
+                // old unconditional `NeedsRhs` here meant `.a.b[].z =
+                // error("boom")` on `a: {}`/`a: null` both still
+                // evaluated the RHS, where real yq needs it for neither).
+                None => classify_yq_assign_prefix(&OwnedValue::Null, rest),
             },
+            // Same reasoning as the `None` case just above -- an explicit
+            // `Null` here (as opposed to one this function itself just
+            // synthesized from an absent key) autovivifies identically,
+            // so it recurses the same way instead of falling into the
+            // catch-all below (which is reserved for a genuine type
+            // mismatch, e.g. `Field` against an `Array`).
+            OwnedValue::Null => classify_yq_assign_prefix(current, rest),
             _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
             _ => PathAssignOutcome::NeedsRhs,
         },
@@ -16623,7 +16619,17 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(paths) => paths,
         Err(_) => return Ok(YqAssignNoopCheck::NotChecked),
     };
-    if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
+    // Classified once per path and reused for both the total-noop and
+    // rhs-unused decisions below, instead of walking each path twice via
+    // separately-called `yq_assign_is_total_noop`/`yq_assign_rhs_unused`
+    // (#1920 round 3: an earlier version of this fix built the merged
+    // `classify_yq_assign_prefix` walk but never actually updated this,
+    // its only caller, to stop invoking it twice).
+    let outcomes: Vec<PathAssignOutcome> = paths
+        .iter()
+        .map(|p| yq_assign_classify(p, &pristine))
+        .collect();
+    if outcomes.iter().all(PathAssignOutcome::is_total_noop) {
         return Ok(YqAssignNoopCheck::Skip(pristine));
     }
     // #1857: not a total no-op (the document does change), but every
@@ -16631,10 +16637,11 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `Iterate` autovivifying `Null` into an empty array, most commonly.
     // Perform the write now with a placeholder value and route it through
     // the same `Skip` channel: `set_path` can't fail here and the
-    // placeholder is never actually read, since `yq_assign_rhs_unused`
-    // already proved every write this path reaches is either a no-op or an
-    // autovivify-only step with zero elements to write into.
-    if paths.iter().all(|p| yq_assign_rhs_unused(p, &pristine)) {
+    // placeholder is never actually read, since every outcome above is
+    // already known to be `TotalNoop`/`RhsUnusedButChanges`, proving every
+    // write this path reaches is either a no-op or an autovivify-only step
+    // with zero elements to write into.
+    if outcomes.iter().all(PathAssignOutcome::rhs_unused) {
         let mut result = pristine;
         for path in &paths {
             set_path::<S>(&mut result, path, OwnedValue::Null, true, true)?;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15660,6 +15660,84 @@ fn yq_assign_is_total_noop(path: &Expr, root: &OwnedValue) -> bool {
     assign_path_all_noop(root, prefix)
 }
 
+/// [`yq_assign_is_total_noop`]'s twin for the narrower #1857 gap: a path is
+/// not a *total* no-op (the document does change) but still never actually
+/// reads the RHS value, because every write it reaches is either already a
+/// no-op (`assign_path_all_noop`'s own shape) or a mid-chain `Iterate` that
+/// autovivifies `Null` into an empty array -- zero elements, so whatever
+/// `set_path` gets handed as the value is never written anywhere. Shares
+/// every gate `yq_assign_is_total_noop` has (empty-flattened-list bail,
+/// slice-anywhere exclusion, terminal-shape check) since none of that
+/// reasoning changes here -- only the final predicate call differs.
+fn yq_assign_rhs_unused(path: &Expr, root: &OwnedValue) -> bool {
+    let mut flat = Vec::new();
+    push_path_components(&mut flat, path);
+    let Some((last, prefix)) = flat.split_last() else {
+        return false;
+    };
+    if flat.iter().any(|e| unwrap_path_component(e).0.is_slice()) {
+        return false;
+    }
+    if !matches!(
+        unwrap_path_component(last).0,
+        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate
+    ) {
+        return false;
+    }
+    assign_path_rhs_unused(root, prefix)
+}
+
+/// [`assign_path_all_noop`]'s twin for [`yq_assign_rhs_unused`]: same
+/// Field/Index/Iterate walk, but an `Expr::Iterate` reaching `Null`
+/// answers `true` here (RHS never read) where `assign_path_all_noop`
+/// answers `false` (document changes, so not a total no-op) -- `Null`
+/// autovivifies to `[]`, and iterating zero elements is vacuously true
+/// regardless of what `rest` still has left to say, exactly like the
+/// existing empty-`Array`/`Object` arms just below it. Every other arm is
+/// unchanged from `assign_path_all_noop`, including its own base case:
+/// `is_yq_field_index_noop_scalar` already answers "RHS unused" for a
+/// true no-op, which is a subset of what this function reports.
+fn assign_path_rhs_unused(current: &OwnedValue, steps: &[Expr]) -> bool {
+    let (step, rest) = match steps.split_first() {
+        None => return is_yq_field_index_noop_scalar(current),
+        Some(pair) => pair,
+    };
+    let (step, _optional) = unwrap_path_component(step);
+    match step {
+        Expr::Field(name) => match current {
+            OwnedValue::Object(map) => match map.get(name) {
+                Some(v) => assign_path_rhs_unused(v, rest),
+                None => false,
+            },
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
+            OwnedValue::Array(arr) => {
+                let len = arr.len() as i64;
+                let actual = if *idx < 0 { len + idx } else { *idx };
+                if actual >= 0 && (actual as usize) < arr.len() {
+                    assign_path_rhs_unused(&arr[actual as usize], rest)
+                } else {
+                    false
+                }
+            }
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        Expr::Iterate => match current {
+            OwnedValue::Array(arr) => arr.iter().all(|elem| assign_path_rhs_unused(elem, rest)),
+            OwnedValue::Object(map) => map.values().all(|elem| assign_path_rhs_unused(elem, rest)),
+            // Autovivifies to `[]` -- zero elements, so `rest` is never
+            // actually applied to anything, whatever it still contains.
+            OwnedValue::Null => true,
+            _ if is_yq_field_index_noop_scalar(current) => true,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 /// Whether writing through `steps` (a `yq_assign_is_total_noop` prefix --
 /// its own flattened path minus the terminal component) into `current` is
 /// a total no-op. Subsumes `navigate_read_only`'s three-way
@@ -16471,7 +16549,13 @@ fn yq_assign_skip_rhs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// mean widening its signature for every caller, not just these two.
 /// Filed as #1414 rather than done here.
 enum YqAssignNoopCheck {
-    /// Total no-op -- return this value unchanged, skip the RHS entirely.
+    /// Skip the RHS entirely and return this value as-is. Two shapes reach
+    /// here: a true total no-op (the document really is unchanged), and
+    /// (#1857) a document that *does* change -- a mid-chain `Iterate`
+    /// autovivifying `Null` into an empty array -- but whose write is
+    /// already fully computed, since it never needed the RHS value to
+    /// begin with. Either way the caller's job is the same: return this,
+    /// evaluate nothing.
     Skip(OwnedValue),
     /// Not a no-op, but the static-path resolution already ran to answer
     /// that question -- reuse instead of re-deriving.
@@ -16503,13 +16587,25 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(paths) => paths,
         Err(_) => return Ok(YqAssignNoopCheck::NotChecked),
     };
-    Ok(
-        if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
-            YqAssignNoopCheck::Skip(pristine)
-        } else {
-            YqAssignNoopCheck::Continue { pristine, paths }
-        },
-    )
+    if paths.iter().all(|p| yq_assign_is_total_noop(p, &pristine)) {
+        return Ok(YqAssignNoopCheck::Skip(pristine));
+    }
+    // #1857: not a total no-op (the document does change), but every
+    // resolved path still never reads the RHS value -- a mid-chain
+    // `Iterate` autovivifying `Null` into an empty array, most commonly.
+    // Perform the write now with a placeholder value and route it through
+    // the same `Skip` channel: `set_path` can't fail here and the
+    // placeholder is never actually read, since `yq_assign_rhs_unused`
+    // already proved every write this path reaches is either a no-op or an
+    // autovivify-only step with zero elements to write into.
+    if paths.iter().all(|p| yq_assign_rhs_unused(p, &pristine)) {
+        let mut result = pristine;
+        for path in &paths {
+            set_path::<S>(&mut result, path, OwnedValue::Null, true, true)?;
+        }
+        return Ok(YqAssignNoopCheck::Skip(result));
+    }
+    Ok(YqAssignNoopCheck::Continue { pristine, paths })
 }
 
 /// `optional` is `=`'s own `?` (`(.a = 1)?`) -- see `eval_update`'s matching

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15767,31 +15767,35 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
     };
     let (step, _optional) = unwrap_path_component(step);
     match step {
-        Expr::Field(name) => match current {
-            OwnedValue::Object(map) => match map.get(name) {
+        Expr::Field(name) => {
+            // A missing key and an explicit `Null` value autovivify
+            // identically (real yq's `.a.b[].z = v` on `a: {}` and on
+            // `a: {b: null}`/`a: null` all behave the same, confirmed
+            // live) -- both resolve to the same "step into `Null`"
+            // child, recursing the same way rather than giving up
+            // immediately, so a later `Iterate` in `rest` still gets to
+            // answer `RhsUnusedButChanges` for its own empty fan-out
+            // (round-3 review of #1920 found this gap: an earlier
+            // version of this fix special-cased the two shapes with
+            // near-duplicate arms instead of one shared child
+            // resolution; `.a.b[].z = error("boom")` used to still
+            // evaluate the RHS either way, where real yq needs it for
+            // neither).
+            static NULL: OwnedValue = OwnedValue::Null;
+            let child = match current {
+                OwnedValue::Object(map) => Some(map.get(name).unwrap_or(&NULL)),
+                OwnedValue::Null => Some(current),
+                _ => None,
+            };
+            match child {
                 Some(v) => classify_yq_assign_prefix(v, rest),
-                // An absent key autovivifies exactly like an explicit
-                // `Null` value would (real yq's `.a.b[].z = v` on `a: {}`
-                // and on `a: {b: null}` behave identically, confirmed
-                // live) -- recurse the same way rather than giving up
-                // immediately, so a later `Iterate` in `rest` still gets
-                // to answer `RhsUnusedButChanges` for its own empty
-                // fan-out (round-3 review of #1920 found this gap: the
-                // old unconditional `NeedsRhs` here meant `.a.b[].z =
-                // error("boom")` on `a: {}`/`a: null` both still
-                // evaluated the RHS, where real yq needs it for neither).
-                None => classify_yq_assign_prefix(&OwnedValue::Null, rest),
-            },
-            // Same reasoning as the `None` case just above -- an explicit
-            // `Null` here (as opposed to one this function itself just
-            // synthesized from an absent key) autovivifies identically,
-            // so it recurses the same way instead of falling into the
-            // catch-all below (which is reserved for a genuine type
-            // mismatch, e.g. `Field` against an `Array`).
-            OwnedValue::Null => classify_yq_assign_prefix(current, rest),
-            _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
-            _ => PathAssignOutcome::NeedsRhs,
-        },
+                // Reached only for a genuine type mismatch (e.g. `Field`
+                // against an `Array`), or a real scalar -- not `Null`,
+                // which is always routed through the `child` match above.
+                None if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
+                None => PathAssignOutcome::NeedsRhs,
+            }
+        }
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
             OwnedValue::Array(arr) => {
                 let len = arr.len() as i64;
@@ -16643,8 +16647,15 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // with zero elements to write into.
     if outcomes.iter().all(PathAssignOutcome::rhs_unused) {
         let mut result = pristine;
-        for path in &paths {
-            set_path::<S>(&mut result, path, OwnedValue::Null, true, true)?;
+        // Only `RhsUnusedButChanges` paths actually need this write -- a
+        // `TotalNoop` one (this `all()` check doesn't require every
+        // outcome to be `RhsUnusedButChanges` specifically, just not
+        // `NeedsRhs`) already changes nothing, so writing a placeholder
+        // through it would be a wasted navigate-and-no-op.
+        for (path, outcome) in paths.iter().zip(&outcomes) {
+            if matches!(outcome, PathAssignOutcome::RhsUnusedButChanges) {
+                set_path::<S>(&mut result, path, OwnedValue::Null, true, true)?;
+            }
         }
         return Ok(YqAssignNoopCheck::Skip(result));
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22202,9 +22202,10 @@ fn test_yq_nonterminal_iterate_in_assign_path_fans_out_1298() -> Result<()> {
 /// -- zero elements to check). That broader fan-out rule is now
 /// implemented too (#1432, `assign_path_all_noop`) -- see
 /// `test_yq_nonterminal_iterate_container_fanout_noop_1432` below.
-/// (A `Null` target is a separate case, deliberately still excluded --
-/// see `test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298`'s
-/// own updated doc comment.) The second case below (`a: [1, {}]`, a
+/// (A `Null` target was a separate case, once deliberately excluded here
+/// and fixed by a different mechanism -- see
+/// `test_yq_nonterminal_iterate_null_target_skips_rhs_1298`'s own doc
+/// comment for why.) The second case below (`a: [1, {}]`, a
 /// genuinely *mixed* target where one element really does write) is the
 /// regression guard for what this fix must *not* accidentally suppress.
 #[test]
@@ -22227,42 +22228,76 @@ fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
 
 /// #1298 (code review, #1432): a `Null` target for the `Iterate` -- neither
 /// a real container nor a genuine scalar -- falls to `assign_path_all_noop`'s
-/// final `_ => false` catch-all, so the RHS still evaluates here even
-/// though real yq's own null-autovivify-to-`[]` behavior means the fan-out
-/// ends up empty and real yq discards the RHS too (`a: null` becomes
-/// `a: []` there, with the RHS never running -- live-verified against yq
-/// v4.53.3). #1432 deliberately leaves this excluded rather than folding it
-/// in: this predicate's only caller has an all-or-nothing `Skip`/`Continue`
-/// split, and `Skip` means "return the document completely unchanged" --
-/// reporting `Null` as a no-op would discard the legitimate `null` -> `[]`
-/// write, which this codebase's own write path already performs correctly
-/// (confirmed live with a safe RHS, independent of this predicate: `.a[].b
-/// = 5` on `a: null` already produces `a: []` here, matching the oracle --
-/// an earlier version of this comment wrongly claimed that autovivification
-/// was itself broken; it isn't, see #1857's correction). The real, narrower
-/// gap this leaves is exactly what this test pins: the RHS still evaluates
+/// final `_ => false` catch-all, so the document is correctly reported as
+/// *not* a total no-op (real yq's own null-autovivify-to-`[]` behavior does
+/// change the document: `a: null` becomes `a: []`, matching this codebase's
+/// own write path, confirmed live with a safe RHS independent of this
+/// predicate -- an earlier version of this comment wrongly claimed
+/// autovivification itself was broken; it isn't). #1432 deliberately
+/// stopped there rather than also skipping the RHS: `assign_path_all_noop`'s
+/// only caller at the time had an all-or-nothing `Skip`/`Continue` split,
+/// and `Skip` meant "return the document completely unchanged" -- reporting
+/// `Null` as a no-op there would have discarded the legitimate `null` ->
+/// `[]` write. The narrower gap that left -- the RHS still evaluating
 /// eagerly for `Null`, where real yq's own equivalent write never needs it
-/// at all. Filed as #1857; pinned here as a known-divergent case, not a
-/// regression to fix in this PR. The second case below shows the same gap
-/// reached through #1432's own new recursion (a `Null` nested inside a
-/// fanned-into array), not just a bare top-level target.
+/// at all -- was filed as #1857 and is fixed here:
+/// [`yq_assign_rhs_unused`]/[`assign_path_rhs_unused`] recognize this exact
+/// shape (RHS unused, document still changes) and route it through the same
+/// `Skip` channel with the autovivify write already applied. The second
+/// case below is the same gap reached through #1432's own recursion (a
+/// `Null` nested inside a fanned-into array), not just a bare top-level
+/// target.
 #[test]
-fn test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298() -> Result<()> {
-    let (_out, err, code) =
+fn test_yq_nonterminal_iterate_null_target_skips_rhs_1298() -> Result<()> {
+    let (out, err, code) =
         run_yq_stdin_with_stderr(".a[].b = error(\"boom\")", "a: null\n", &["-o", "json"])?;
-    assert_ne!(code, 0);
-    assert!(err.contains("boom"), "err={err}");
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out.trim(), "{\n  \"a\": []\n}");
 
     // Same gap, reached through #1432's recursive fan-out rather than as
     // the direct top-level target.
-    let (_out, err, code) = run_yq_stdin_with_stderr(
+    let (out, err, code) = run_yq_stdin_with_stderr(
         ".a[][].b = error(\"boom\")",
         "a:\n  - null\n  - [1]\n",
         &["-o", "json"],
     )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(
+        out.trim(),
+        "{\n  \"a\": [\n    [],\n    [\n      1\n    ]\n  ]\n}"
+    );
+
+    Ok(())
+}
+
+/// #1857 regression guard: a `Null` element alongside one that genuinely
+/// needs the RHS (a fresh `b` key being inserted into `{}`) must still
+/// evaluate it -- `yq_assign_rhs_unused`'s `paths.iter().all(...)` has to
+/// require *every* resolved path to be RHS-unused, not just skip the RHS
+/// because *some* element happened to be `Null`.
+#[test]
+fn test_yq_nonterminal_iterate_null_mixed_with_real_write_still_evaluates_rhs_1857() -> Result<()> {
+    let (_out, err, code) = run_yq_stdin_with_stderr(
+        ".a[][].b = error(\"boom\")",
+        "a:\n  - null\n  - [{}]\n",
+        &["-o", "json"],
+    )?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
 
+/// #1857: the same autovivify-skips-RHS fix applies to every yq-mode
+/// assignment operator that routes through `yq_assign_skip_rhs`
+/// (`eval_compound_assign`/`eval_alternative_assign`), not just plain `=`.
+#[test]
+fn test_yq_nonterminal_iterate_null_target_skips_rhs_compound_operators_1857() -> Result<()> {
+    for op in ["+=", "-=", "*=", "/=", "%=", "//="] {
+        let filter = format!(".a[].b {op} error(\"boom\")");
+        let (out, err, code) = run_yq_stdin_with_stderr(&filter, "a: null\n", &["-o", "json"])?;
+        assert_eq!(code, 0, "op={op:?} err={err}");
+        assert_eq!(out.trim(), "{\n  \"a\": []\n}", "op={op:?}");
+    }
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22240,11 +22240,11 @@ fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
 /// `Null` as a no-op there would have discarded the legitimate `null` ->
 /// `[]` write. The narrower gap that left -- the RHS still evaluating
 /// eagerly for `Null`, where real yq's own equivalent write never needs it
-/// at all -- was filed as #1857 and is fixed here:
-/// [`yq_assign_rhs_unused`]/[`assign_path_rhs_unused`] recognize this exact
-/// shape (RHS unused, document still changes) and route it through the same
-/// `Skip` channel with the autovivify write already applied. The second
-/// case below is the same gap reached through #1432's own recursion (a
+/// at all -- was filed as #1857 and is fixed here: `PathAssignOutcome`'s
+/// `RhsUnusedButChanges` case recognizes this exact shape (RHS unused,
+/// document still changes) and `yq_assign_noop_check` routes it through
+/// the same `Skip` channel with the autovivify write already applied. The
+/// second case below is the same gap reached through #1432's own recursion (a
 /// `Null` nested inside a fanned-into array), not just a bare top-level
 /// target.
 ///
@@ -22277,9 +22277,9 @@ fn test_yq_nonterminal_iterate_null_target_skips_rhs_1298() -> Result<()> {
 
 /// #1857 regression guard: a `Null` element alongside one that genuinely
 /// needs the RHS (a fresh `b` key being inserted into `{}`) must still
-/// evaluate it -- `yq_assign_rhs_unused`'s `paths.iter().all(...)` has to
-/// require *every* resolved path to be RHS-unused, not just skip the RHS
-/// because *some* element happened to be `Null`.
+/// evaluate it -- `yq_assign_noop_check`'s `outcomes.iter().all(...)` has
+/// to require *every* resolved path to be RHS-unused, not just skip the
+/// RHS because *some* element happened to be `Null`.
 #[test]
 fn test_yq_nonterminal_iterate_null_mixed_with_real_write_still_evaluates_rhs_1857() -> Result<()> {
     let (_out, err, code) = run_yq_stdin_with_stderr(
@@ -22287,6 +22287,42 @@ fn test_yq_nonterminal_iterate_null_mixed_with_real_write_still_evaluates_rhs_18
         "a:\n  - null\n  - [{}]\n",
         &["-o", "json"],
     )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1857 (round-3 review): an *absent* field autovivifies exactly like an
+/// explicit `Null` value would -- `classify_yq_assign_prefix`'s `Field`
+/// arm used to give up immediately on a missing key (`None =>
+/// PathAssignOutcome::NeedsRhs`), never letting a later mid-chain
+/// `Iterate` in `rest` answer `RhsUnusedButChanges` for its own empty
+/// fan-out. Both the absent-key and explicit-`Null` spellings must behave
+/// identically -- confirmed live against yq v4.53.3.
+#[test]
+fn test_yq_absent_field_before_iterate_skips_rhs_like_null_1857() -> Result<()> {
+    for input in ["{}\n", "a: null\n"] {
+        let (out, err, code) =
+            run_yq_stdin_with_stderr(".a.b[].z = error(\"boom\")", input, &["-o", "json"])?;
+        assert_eq!(code, 0, "input={input:?} err={err}");
+        assert_eq!(
+            out.trim(),
+            "{\n  \"a\": {\n    \"b\": []\n  }\n}",
+            "input={input:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1857 regression guard: an absent field followed by a *terminal* write
+/// (not a further `Iterate`) still needs the RHS -- a genuine key
+/// insertion, not an empty fan-out. Distinguishes this from the sibling
+/// test above, where the same absent-field shape *does* skip the RHS
+/// because what follows is an `Iterate` into nothing.
+#[test]
+fn test_yq_absent_field_terminal_write_still_evaluates_rhs_1857() -> Result<()> {
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a.b = error(\"boom\")", "a: null\n", &["-o", "json"])?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22247,6 +22247,11 @@ fn test_yq_nonterminal_iterate_scalar_noop_discards_rhs_1298() -> Result<()> {
 /// case below is the same gap reached through #1432's own recursion (a
 /// `Null` nested inside a fanned-into array), not just a bare top-level
 /// target.
+///
+/// Scoped to a *mid-chain* `Iterate` only (`.a[].b = v`, something after
+/// the `[]`) -- a *terminal* one (`.a[] = v`, the assignment target
+/// itself) is a different, still-open case this fix doesn't reach, filed
+/// separately as #1921.
 #[test]
 fn test_yq_nonterminal_iterate_null_target_skips_rhs_1298() -> Result<()> {
     let (out, err, code) =
@@ -22282,6 +22287,30 @@ fn test_yq_nonterminal_iterate_null_mixed_with_real_write_still_evaluates_rhs_18
         "a:\n  - null\n  - [{}]\n",
         &["-o", "json"],
     )?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+    Ok(())
+}
+
+/// #1921 (known gap, not fixed by #1857): a *terminal* `Iterate` -- the
+/// assignment target itself, no further path after it -- always evaluates
+/// the RHS, even over an already-empty container or `Null`. Real yq skips
+/// it (`.a[] = error("boom")` on `a: []`/`a: null` both stay/become `[]`,
+/// live-verified v4.53.3); succinctly still errors. Pinned here as a known
+/// divergence rather than silently left uncovered -- see #1921 for why
+/// this needs its own fix, not a #1857 extension (a terminal `Iterate`'s
+/// own semantics -- overwrite every real element regardless of type --
+/// genuinely differ from a mid-chain one's).
+#[test]
+fn test_yq_terminal_iterate_empty_or_null_target_still_evaluates_rhs_known_gap_1921() -> Result<()>
+{
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a[] = error(\"boom\")", "a: []\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("boom"), "err={err}");
+
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr(".a[] = error(\"boom\")", "a: null\n", &["-o", "json"])?;
     assert_ne!(code, 0);
     assert!(err.contains("boom"), "err={err}");
     Ok(())


### PR DESCRIPTION
## Summary

A mid-chain \`Iterate\` autovivifying \`Null\` into an empty array has zero
elements to write into, so real yq never evaluates the RHS:

\`\`\`console
$ echo 'a: null' | yq -o=json '.a[].b = error("boom")'
{
  "a": []
}
$ echo 'a: null' | succinctly yq -o=json '.a[].b = error("boom")'   # before this fix
Error: boom
\`\`\`

#1432's \`yq_assign_noop_check\` deliberately excluded \`Null\` from its
\`Skip\`/\`Continue\` split to avoid discarding the legitimate \`null\` -> \`[]\`
write (reporting it as a total no-op would have thrown the write away) —
leaving the RHS to evaluate eagerly anyway. That's the exact gap #1432
filed as #1857.

## Fix

Added \`yq_assign_rhs_unused\`/\`assign_path_rhs_unused\` as a twin of the
existing \`yq_assign_is_total_noop\`/\`assign_path_all_noop\` pair — same
walk, but an \`Iterate\` reaching \`Null\` now answers "RHS unused" (\`true\`)
instead of falling to the catch-all \`false\`, since autovivifying to \`[]\`
means zero elements regardless of what the remaining path steps say.

\`yq_assign_noop_check\` performs the write immediately with a placeholder
value when every resolved path satisfies this new check (\`set_path\` can't
fail here — the placeholder is proven never actually read) and routes it
through the same \`Skip\` channel \`eval_assign\`/\`eval_compound_assign\`/
\`eval_alternative_assign\` already use, so **no caller-side changes were
needed** — the fix is entirely contained inside \`yq_assign_noop_check\`.

## Scope

Reaches every yq-mode assignment operator that routes through this
mechanism (\`=\`, \`+=\`, \`-=\`, \`*=\`, \`/=\`, \`%=\`, \`//=\`), confirmed live against
yq v4.53.3. Plain \`|=\` doesn't share this mechanism at all (\`eval_update\`
has no pre-check, per \`yq_assign_noop_check\`'s own doc comment) and turned
out to have a **separate, more severe** divergence during investigation —
a hard \`Cannot iterate over null\` error instead of missing
autovivification entirely — filed as #1919 rather than folded in here.

## Verification

- Live-confirmed against yq v4.53.3 for the top-level case, the nested
  recursive case (\`.a[][].b\` with \`a: [null, [1]]\`), all 6 assignment
  operators, and a regression guard (\`Null\` mixed with a genuine write
  target still evaluates the RHS and still errors)
- Updated \`test_yq_nonterminal_iterate_null_target_still_evaluates_rhs_1298\`
  (renamed to \`..._skips_rhs_1298\`) to assert the fixed behavior instead
  of pinning the bug
- Added \`test_yq_nonterminal_iterate_null_mixed_with_real_write_still_evaluates_rhs_1857\`
  and \`test_yq_nonterminal_iterate_null_target_skips_rhs_compound_operators_1857\`
- \`cargo test --features cli,simd,regex,serde --workspace\`: all green
- \`cargo clippy\` (both feature legs), \`cargo check --no-default-features\`,
  \`cargo doc --no-deps --all-features\`, \`cargo fmt --check\`: all clean

Fixes #1857