### PR TITLE
fix(jq): --seq no longer writes RS before raw (-r/-j) output

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4168,15 +4168,16 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
         reject_raw_output0_nul(s, config)?;
     }
 
-    // In seq mode, prepend RS (Record Separator) before each *JSON* value
-    // only -- real jq never writes it before a genuinely raw (`-r`/`-j`)
-    // string output, confirmed live against jq 1.7.1 (`--seq -r` produces
-    // no leading `\x1e` at all, #1913). `raw_str` already carries exactly
-    // that distinction: `None` here covers both "not in raw-output mode"
-    // and "`-r`'s value isn't a string," and jq's own `-r` on a non-string
-    // value falls back to JSON output *with* the separator, which this
-    // reuse gets right for free.
-    if config.seq && raw_str.is_none() {
+    // #1913: see `should_write_seq_separator`'s own doc comment. This is
+    // `write_output_jq_value`'s copy of the identical fix in `write_output`
+    // below -- currently dead in practice, since this function's only call
+    // site is gated by `can_use_lazy_path`, which already excludes
+    // `args.seq` entirely (`--seq` always takes the materializing path
+    // through `write_output` instead). Kept anyway as a correctness
+    // guarantee that doesn't depend on that gate staying in place: if a
+    // future change ever let `--seq` reach the lazy path, this would
+    // already be right instead of silently reintroducing #1913.
+    if should_write_seq_separator(config, raw_str.is_some()) {
         out.write_all(&[ASCII_RS])?;
     }
 
@@ -4231,6 +4232,35 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
 /// ASCII RS (Record Separator) character for JSON sequence format (RFC 7464)
 const ASCII_RS: u8 = 0x1E;
 
+/// Whether `--seq` should prepend the RS separator to this record (#1913).
+///
+/// Real jq writes it before each *JSON* output, but not before a
+/// genuinely raw string produced by `-r`/`-j` -- confirmed live against jq
+/// 1.7.1 (`--seq -r` produces no leading `\x1e` at all). `is_raw_output`
+/// is the caller's own `raw_str.is_some()`, which already distinguishes
+/// "not in raw-output mode" and "`-r`'s value isn't a string" from a
+/// genuine raw write -- reusing it here (rather than checking `config.seq`
+/// alone) gets a real-jq subtlety right for free: when `-r` falls back to
+/// JSON output for a non-string value, `raw_str` is `None` there too, so
+/// the separator is still written, matching jq.
+///
+/// Shared by both `write_output_jq_value` and `write_output` so the
+/// condition can't drift between them -- see `write_output_jq_value`'s own
+/// call site for why one of the two is currently unreachable under
+/// `--seq` regardless.
+///
+/// Caveat this function doesn't attempt to fix: `raw_str`'s `None` can
+/// also mean "the string failed to decode" (e.g. an unpaired UTF-16
+/// surrogate `JqValue::as_str()` gives up on) rather than "genuinely not a
+/// string" -- a separate, pre-existing gap in how undecodable strings are
+/// classified, not a `--seq`-specific one. In practice this particular
+/// codebase's parser already accepts input real jq rejects as a parse
+/// error before either write path is ever reached, so no live divergence
+/// was found for this combination; not investigated further here.
+fn should_write_seq_separator(config: &OutputConfig, is_raw_output: bool) -> bool {
+    config.seq && !is_raw_output
+}
+
 fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig) -> Result<()> {
     // Raw-output string, if any -- resolved and NUL-checked before
     // writing *any* byte of this record, including the `--seq` RS
@@ -4249,10 +4279,8 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
         reject_raw_output0_nul(s, config)?;
     }
 
-    // In seq mode, prepend RS (Record Separator) before each *JSON* value
-    // only -- see `write_output_jq_value`'s identical fix (#1913) for the
-    // full rationale; `raw_str` already carries the same distinction here.
-    if config.seq && raw_str.is_none() {
+    // #1913: see `should_write_seq_separator`'s own doc comment.
+    if should_write_seq_separator(config, raw_str.is_some()) {
         out.write_all(&[ASCII_RS])?;
     }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4168,8 +4168,15 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
         reject_raw_output0_nul(s, config)?;
     }
 
-    // In seq mode, prepend RS (Record Separator) before each value
-    if config.seq {
+    // In seq mode, prepend RS (Record Separator) before each *JSON* value
+    // only -- real jq never writes it before a genuinely raw (`-r`/`-j`)
+    // string output, confirmed live against jq 1.7.1 (`--seq -r` produces
+    // no leading `\x1e` at all, #1913). `raw_str` already carries exactly
+    // that distinction: `None` here covers both "not in raw-output mode"
+    // and "`-r`'s value isn't a string," and jq's own `-r` on a non-string
+    // value falls back to JSON output *with* the separator, which this
+    // reuse gets right for free.
+    if config.seq && raw_str.is_none() {
         out.write_all(&[ASCII_RS])?;
     }
 
@@ -4242,8 +4249,10 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
         reject_raw_output0_nul(s, config)?;
     }
 
-    // In seq mode, prepend RS (Record Separator) before each value
-    if config.seq {
+    // In seq mode, prepend RS (Record Separator) before each *JSON* value
+    // only -- see `write_output_jq_value`'s identical fix (#1913) for the
+    // full rationale; `raw_str` already carries the same distinction here.
+    if config.seq && raw_str.is_none() {
         out.write_all(&[ASCII_RS])?;
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4183,6 +4183,44 @@ fn test_seq_output_format() -> Result<()> {
     Ok(())
 }
 
+/// #1913: real jq's `--seq` writes the RS separator before each *JSON*
+/// output, but not before a genuinely raw (`-r`/`-j`) string output --
+/// confirmed live against jq 1.7.1. `succinctly jq` used to write it
+/// unconditionally, corrupting every `--seq -r`/`--seq -j` record with a
+/// leading `\x1e` byte jq does not emit.
+#[test]
+fn test_seq_omits_rs_before_raw_output_1913() -> Result<()> {
+    // `-r`: no leading RS at all.
+    let (output, code) = run_jq_binary_stdin(".", b"\x1e\"a\"\n\x1e\"b\"\n", &["--seq", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, b"a\nb\n");
+
+    // `-j`: same, and no trailing newline either.
+    let (output, code) = run_jq_binary_stdin(".", b"\x1e\"a\"\n\x1e\"b\"\n", &["--seq", "-j"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, b"ab");
+
+    // Control: plain `--seq` (no `-r`/`-j`) still gets the separator.
+    let (output, code) = run_jq_binary_stdin(".", b"\x1e\"a\"\n", &["--seq", "-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, b"\x1e\"a\"\n");
+
+    // `-r` falling back to JSON output for a non-string value still gets
+    // the separator -- real jq's own behavior, confirmed live.
+    let (output, code) = run_jq_binary_stdin(".", b"\x1e42\n", &["--seq", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, b"\x1e42\n");
+
+    // The `-n`/`inputs` materializing path (a separate writer function)
+    // gets the same fix.
+    let (output, code) =
+        run_jq_binary_stdin("inputs", b"\x1e\"a\"\n\x1e\"b\"\n", &["--seq", "-n", "-r"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, b"a\nb\n");
+
+    Ok(())
+}
+
 #[test]
 fn test_seq_input_parsing() -> Result<()> {
     // --seq should parse RS-separated input values


### PR DESCRIPTION
## Summary

Real jq's `--seq` (RFC 7464) writes the record separator (`\x1e`) before each *JSON* output, but not before a genuinely raw string produced by `-r`/`-j` — confirmed live against jq 1.7.1. `succinctly jq` wrote it unconditionally in both `write_output_jq_value` (the streaming path) and `write_output` (the `-n`/`inputs` materializing path), corrupting every `--seq -r`/`--seq -j` record with a leading `\x1e` byte jq does not emit.

## Fix

Both functions already compute `raw_str` (`Some` when this record is a genuine raw-string write) to decide the raw-vs-JSON output branch — this reuses that exact distinction to gate the RS write, rather than adding a new one:

```rust
if config.seq && raw_str.is_none() {
    out.write_all(&[ASCII_RS])?;
}
```

This gets a subtlety right for free: when `-r` falls back to JSON output for a non-string value (`echo '\x1e42' | jq --seq -c -r .` → `\x1e42`), `raw_str` is already `None` in that case too, so the separator is still written — matching real jq.

## Verification

- Every repro in the issue, plus `-a`, `--raw-output0`, plain `--seq` (control), and the `-r`-on-non-string fallback case, confirmed byte-identical to jq 1.7.1 via `od -c` comparison.
- The `-n`/`inputs` materializing path (`write_output`, a separate function) verified fixed too.
- `cargo test` under default features (3022 passed) and `--features cli,simd,regex,serde` (3070 passed) — 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second leg — clean.
- `cargo build --no-default-features` (no_std) and `cargo fmt --check` — clean.

Fixes #1913