### PR TITLE
fix(jq): --seq must never emit a value real jq does not (#1928)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1556,22 +1556,23 @@ $ printf '\x1exyz\n'           | jq --seq -c '.'
 jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)
 ```
 
-`succinctly jq --seq` emits nothing on stderr for any of these. Output-wise a *wholly*
-malformed record is already correct (RFC 7464's own recommended failure mode,
-#1093/#1267/#1243: it is dropped either way), but a record that is well-formed up to a
-malformed suffix is not: real jq emits the values it managed to read first, and succinctly
-drops the record entire.
+`succinctly jq --seq` emits nothing on stderr for any of these — the gap is now **purely the
+diagnostic**. The output side matches real jq, including a record that is well-formed up to a
+malformed suffix, which #1723 fixed:
 
 ```
-$ printf '\x1e1 {invalid\n' | jq --seq -c '.'          # jq:         warns, then prints 1
-$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'  # succinctly: prints nothing
+$ printf '\x1e1 {invalid\n' | jq            --seq -c '.'   # warns, then prints 1
+$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # prints 1, silently
 ```
 
-That prefix-emission gap is the same problem as the missing diagnostic, not a separate one:
-both need to know *where* in the record jq's parser gave up. (jq's own answer here is not
-always "everything before the error" either — `\x1e1,2\n` prints `2`, not `1`.)
+Reproducing jq's *values* here needed three rules, all oracle-derived and pinned by
+`test_seq_malformed_suffix_keeps_the_prefix_1723`: a token that scans is validated and
+dropped if invalid but never resynced into (`{"a":1 xyz}` yields nothing, not `"a"`); an
+unterminated `"`/`{`/`[` swallows the rest of the record while other junk resyncs (structural
+punctuation by one byte, a bad token up to the next whitespace); and a number is complete
+only when whitespace follows it, which is why `\x1e1,2\n` yields `2` alone.
 
-A record holding several *well-formed* values is no longer affected: #1723 fixed
+A record holding several *well-formed* values is likewise unaffected: #1723 fixed
 `succinctly jq --seq` dropping those in full (`\x1e1 "x" [2]\n` is three outputs, as in real
 jq), which was silent data loss rather than a diagnostic gap. Matching these needs enough
 of jq's own incremental-parser failure classification to know which of its internal states a

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1567,15 +1567,23 @@ $ printf '\x1e1,2\n'        | jq            --seq -c '.'   # prints 2
 $ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints nothing
 ```
 
-**The divergence is deliberately one-directional: succinctly's output is always a subset of
-jq's here, never a superset.** Reproducing the prefix needs the same thing the diagnostics
+**The divergence is deliberately one-directional: succinctly's output is a subset of jq's
+here, not a superset** -- measured, not proven, at 0 superset violations across 6,000
+randomly generated records (`main` has 787). Reproducing the prefix needs the same thing the diagnostics
 do -- jq's `--seq` reader is a streaming lexer/parser with error recovery, and knowing which
 values survive means knowing where its parser gave up. A token scanner cannot substitute for
 it, and trying was actively harmful: an attempt to emit the prefix by scanning tokens and
 skipping bad ones **fabricated output**, printing values real jq never prints (`\x1e1-2\n`
-became `1` and `-2`, where jq lexes one malformed number and prints nothing). Requiring
-whitespace after every token is what rules that out, at the cost of dropping records jq can
-partially read. Both directions are pinned by
+became `1` and `-2`, where jq lexes one malformed number and prints nothing). Requiring a
+*pending* token -- a number or bare `true`/`false`/`null`, neither of which carries a closing
+delimiter -- to be confirmed by whitespace or the start of a self-delimiting value is what
+rules that out, at the cost of dropping records jq can partially read. Strings, objects and
+arrays are exempt: they self-terminate, so `\x1e{"a":1}{"b":2}\n` and `\x1e1[1]\n` are two
+values apiece in both tools. Requiring whitespace after *every* token instead, as a first
+draft did, dropped 332 records real jq reads fully.
+
+The same pending-token rule applies at a record boundary, where `\x1etrue\x1e3\n` yields
+only `3` -- a bare literal is as truncatable as a bare number. Both directions are pinned by
 `test_seq_adjacent_tokens_never_fabricate_1723` and
 `test_seq_partially_readable_record_is_dropped_whole_1723`
 ([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1556,21 +1556,29 @@ $ printf '\x1exyz\n'           | jq --seq -c '.'
 jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)
 ```
 
-`succinctly jq --seq` emits nothing on stderr for any of these — the gap is now **purely the
-diagnostic**. The output side matches real jq, including a record that is well-formed up to a
-malformed suffix, which #1723 fixed:
+`succinctly jq --seq` emits nothing on stderr for any of these, and its *output* also
+diverges: real jq emits the values it managed to read before the malformed point, while
+succinctly drops the whole record.
 
 ```
 $ printf '\x1e1 {invalid\n' | jq            --seq -c '.'   # warns, then prints 1
-$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # prints 1, silently
+$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # prints nothing
+$ printf '\x1e1,2\n'        | jq            --seq -c '.'   # prints 2
+$ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints nothing
 ```
 
-Reproducing jq's *values* here needed three rules, all oracle-derived and pinned by
-`test_seq_malformed_suffix_keeps_the_prefix_1723`: a token that scans is validated and
-dropped if invalid but never resynced into (`{"a":1 xyz}` yields nothing, not `"a"`); an
-unterminated `"`/`{`/`[` swallows the rest of the record while other junk resyncs (structural
-punctuation by one byte, a bad token up to the next whitespace); and a number is complete
-only when whitespace follows it, which is why `\x1e1,2\n` yields `2` alone.
+**The divergence is deliberately one-directional: succinctly's output is always a subset of
+jq's here, never a superset.** Reproducing the prefix needs the same thing the diagnostics
+do -- jq's `--seq` reader is a streaming lexer/parser with error recovery, and knowing which
+values survive means knowing where its parser gave up. A token scanner cannot substitute for
+it, and trying was actively harmful: an attempt to emit the prefix by scanning tokens and
+skipping bad ones **fabricated output**, printing values real jq never prints (`\x1e1-2\n`
+became `1` and `-2`, where jq lexes one malformed number and prints nothing). Requiring
+whitespace after every token is what rules that out, at the cost of dropping records jq can
+partially read. Both directions are pinned by
+`test_seq_adjacent_tokens_never_fabricate_1723` and
+`test_seq_partially_readable_record_is_dropped_whole_1723`
+([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
 
 A record holding several *well-formed* values is likewise unaffected: #1723 fixed
 `succinctly jq --seq` dropping those in full (`\x1e1 "x" [2]\n` is three outputs, as in real

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1567,9 +1567,17 @@ $ printf '\x1e1,2\n'        | jq            --seq -c '.'   # prints 2
 $ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints nothing
 ```
 
-**The divergence is deliberately one-directional: succinctly's output is a subset of jq's
-here, not a superset** -- measured, not proven, at 0 superset violations across 6,000
-randomly generated records (`main` has 787). Reproducing the prefix needs the same thing the diagnostics
+**The divergence from *this* rule is one-directional: succinctly's output is a subset of
+jq's, not a superset** -- 0 superset violations across 6,000 randomly generated single
+records, where `main` has 787.
+
+That is a statement about malformed-record handling, not a guarantee about `--seq` as a
+whole. On multi-record streams a *separate, pre-existing* rule still diverges in the other
+direction: real jq drops a trailing record that is not newline-terminated, and succinctly
+keeps it (`printf '\x1e0007\n\x1e[]'` is `7` in jq, `7` and `[]` here -- identical on
+`main`, so not introduced by this work). Measured over 2,000 multi-record streams: 133 such
+cases here against `main`'s 610, the reduction coming entirely from the malformed-record
+rules above. Reproducing the prefix needs the same thing the diagnostics
 do -- jq's `--seq` reader is a streaming lexer/parser with error recovery, and knowing which
 values survive means knowing where its parser gave up. A token scanner cannot substitute for
 it, and trying was actively harmful: an attempt to emit the prefix by scanning tokens and

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1573,11 +1573,20 @@ records, where `main` has 787.
 
 That is a statement about malformed-record handling, not a guarantee about `--seq` as a
 whole. On multi-record streams a *separate, pre-existing* rule still diverges in the other
-direction: real jq drops a trailing record that is not newline-terminated, and succinctly
-keeps it (`printf '\x1e0007\n\x1e[]'` is `7` in jq, `7` and `[]` here -- identical on
-`main`, so not introduced by this work). Measured over 2,000 multi-record streams: 133 such
-cases here against `main`'s 610, the reduction coming entirely from the malformed-record
-rules above. Reproducing the prefix needs the same thing the diagnostics
+direction, and it is **not** simply "the trailing record lacks a newline" -- a first draft of
+this note said that, and the oracle contradicts it:
+
+```
+$ printf '\x1e"a"\x1e"b"'    | jq --seq -c '.'   # "a" and "b"  -- no newline anywhere, both kept
+$ printf '\x1e"a"\n\x1e"b"'  | jq --seq -c '.'   # "a" only     -- a newline earlier changes it
+$ printf '\x1e"a"\n\x1e"b"\n'| jq --seq -c '.'   # "a" and "b"
+```
+
+The trigger is a newline appearing *earlier in the stream*: once jq's reader has seen one, a
+later record must itself be newline-terminated to be emitted. succinctly keeps it either way
+(`printf '\x1e0007\n\x1e[]'` is `7` in jq, `7` and `[]` here) -- identical on `main`, so not
+introduced by this work. Measured over 2,000 multi-record streams: 133 such cases here
+against `main`'s 610, the reduction coming entirely from the malformed-record rules above. Reproducing the prefix needs the same thing the diagnostics
 do -- jq's `--seq` reader is a streaming lexer/parser with error recovery, and knowing which
 values survive means knowing where its parser gave up. A token scanner cannot substitute for
 it, and trying was actively harmful: an attempt to emit the prefix by scanning tokens and

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3245,16 +3245,6 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     // The stream's own trailing record, when real jq's incremental reader
     // never resolves it (malformed, or an ambiguous bare number at true
     // EOF -- see `seq_trailing_record_is_dropped`), is silently dropped
-    // from the *output* too, not just from the error-location computation
-    // (#1542): `printf '\x1e1\n\x1e2' | jq --seq -s '.'` gives `[1]` on
-    // real jq, not `[1,2]`, even though "2" alone is perfectly valid JSON.
-    // Computed once, up front, and checked only against the last segment
-    // below -- the already-malformed case is caught either way (this
-    // check, or `seq_record_scan` failing on its own a few lines down),
-    // but the ambiguous-number case parses just fine on its own and needs
-    // this explicit exclusion to be dropped at all.
-    let drop_trailing = seq_trailing_record_is_dropped(s);
-
     let mut results = Vec::new();
     for (i, &start) in segment_starts.iter().enumerate() {
         let raw_end = segment_starts
@@ -3279,23 +3269,23 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         if has_rs && i == 0 {
             continue;
         }
-        // Scanned once here and reused for both the drop decision and the
-        // value extraction below -- a review found this record being
-        // re-scanned up to three times, each pass allocating and
-        // re-tokenizing. The *untrimmed* text, so the number-terminator
-        // rule can see the whitespace that trimming would remove.
-        // `i < last_idx`: this record is followed by another RS byte, which
-        // is the boundary at which a bare literal is truncatable.
-        let ranges = seq_record_scan(raw_segment, i < last_idx).values;
         // *No RS byte anywhere* is #1525's abandonment case: real jq drops
         // the entire input, however well-formed its content is (`printf
-        // '1 2\n' | jq --seq -c .` prints nothing). With an RS byte present
-        // there is nothing extra to do here -- `seq_record_scan` has already
-        // decided, per value, what this record yields, and `ranges` is empty
-        // for a record it dropped.
-        if i == last_idx && drop_trailing && !has_rs {
+        // '1 2\n' | jq --seq -c .` prints nothing). Checked *before* the
+        // scan below, which would otherwise tokenize and validate the whole
+        // input only for it to be discarded. With an RS byte present there
+        // is nothing extra to do here -- `seq_record_scan` decides per value
+        // what a record yields, and returns nothing for one it drops.
+        if !has_rs {
             continue;
         }
+        // Scanned once and reused -- a review found this record being
+        // re-scanned up to three times, each pass allocating and
+        // re-tokenizing. The *untrimmed* text, so the pending-token rule can
+        // see the whitespace that trimming would remove. `i < last_idx`:
+        // this record is followed by another RS byte, the boundary at which
+        // a bare literal is truncatable.
+        let ranges = seq_record_scan(raw_segment, i < last_idx).values;
 
         // `ranges` is exactly the set of values `seq_record_scan` decided
         // this record yields -- empty for one it dropped, so there is no

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3261,16 +3261,6 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
             .get(i + 1)
             .map_or(bytes.len(), |&next| next - 1);
 
-        // Trailing-whitespace-only trim for the *reported* end offset, so a
-        // value's line lands on the record itself, not the separator/
-        // whitespace after it -- matches `json_seq_ends`'s own rule. Can't
-        // walk past `start`: the byte immediately before it is either the
-        // string start or an RS byte, and neither is whitespace.
-        let mut end = raw_end;
-        while end > start && bytes[end - 1].is_ascii_whitespace() {
-            end -= 1;
-        }
-
         // Full (both-sides) trim to decide parse-eligibility -- matches
         // the original per-segment `segment.trim()` check exactly.
         let raw_segment = &s[start..raw_end];
@@ -3294,31 +3284,22 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         // re-scanned up to three times, each pass allocating and
         // re-tokenizing. The *untrimmed* text, so the number-terminator
         // rule can see the whitespace that trimming would remove.
-        let ranges = seq_record_scan(raw_segment).values;
-        // Two different conditions reach `drop_trailing`, and #1723 only
-        // relaxes one of them.
-        //
-        // *No RS byte anywhere* (`has_rs` false) is #1525's abandonment
-        // case: real jq drops the entire input, however well-formed its
-        // content is (`printf '1 2\n' | jq --seq -c .` prints nothing), so
-        // the record is still skipped wholesale. Relaxing this was a
-        // regression the differential sweep caught -- it started emitting
-        // `1` and `2` there.
-        //
-        // With an RS byte present, only a *malformed* trailing record is
-        // skipped wholesale. When it scans, its own last value may still be
-        // an ambiguous bare number, but the values before it are real
-        // output real jq emits (`\x1e1 2` => `1`), so that decision moved
-        // into `seq_record_values`, per value.
-        if i == last_idx && drop_trailing && (!has_rs || ranges.is_empty()) {
+        // `i < last_idx`: this record is followed by another RS byte, which
+        // is the boundary at which a bare literal is truncatable.
+        let ranges = seq_record_scan(raw_segment, i < last_idx).values;
+        // *No RS byte anywhere* is #1525's abandonment case: real jq drops
+        // the entire input, however well-formed its content is (`printf
+        // '1 2\n' | jq --seq -c .` prints nothing). With an RS byte present
+        // there is nothing extra to do here -- `seq_record_scan` has already
+        // decided, per value, what this record yields, and `ranges` is empty
+        // for a record it dropped.
+        if i == last_idx && drop_trailing && !has_rs {
             continue;
         }
 
-        // Real jq emits every value it managed to read out of a record and
-        // resyncs past what it could not (#1723) -- a record is not
-        // all-or-nothing, so there is no "does this parse" gate here any
-        // more. `ranges` is already exactly the set of values that survived
-        // `seq_record_scan`'s three rules.
+        // `ranges` is exactly the set of values `seq_record_scan` decided
+        // this record yields -- empty for one it dropped, so there is no
+        // separate "does this parse" gate here.
         for &(vs, ve) in &ranges {
             let Ok(v) = crate::output::json_bytes_to_owned_value(&raw_segment.as_bytes()[vs..ve])
             else {
@@ -3368,7 +3349,7 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
 /// `docs/compliance/jq/limitations.md` rather than papered over. Reaching
 /// jq's own answer needs its incremental parser's failure classification,
 /// which is what #1723 asks for and is tracked there.
-fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
+fn seq_record_scan(raw_segment: &str, rs_terminated: bool) -> SeqRecordScan {
     let bytes = raw_segment.as_bytes();
     let mut values = Vec::new();
     let mut pos = 0;
@@ -3418,7 +3399,7 @@ fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
     // input arriving. `\x1e1 2` is `1`; `\x1e1 2 ` (trailing space) is `1`
     // and `2`; `\x1etrue\x1e3` is `3` alone.
     let trailing_unresolved = match values.last() {
-        Some(&(vs, ve)) if !seq_pending_token_is_terminated(bytes, vs, ve) => {
+        Some(&(vs, ve)) if !seq_pending_token_is_terminated(bytes, vs, ve, rs_terminated) => {
             values.pop();
             true
         }
@@ -3463,21 +3444,45 @@ fn seq_token_is_pending(bytes: &[u8], start: usize) -> bool {
     matches!(bytes[start], b'-' | b'.' | b'0'..=b'9' | b't' | b'f' | b'n')
 }
 
-/// Whether a *pending* token ending a record was confirmed by trailing
-/// whitespace.
+/// Whether a *pending* token ending a record was confirmed.
 ///
 /// jq's incremental scanner cannot rule out more input arriving for a token
-/// with no closing delimiter, so one that butts against the record boundary
-/// is abandoned. This covers literals as well as numbers -- oracle-verified
-/// at an RS boundary, where `\x1etrue\x1e3\n` and `\x1enull\x1e3\n` both
-/// yield only `3`, while `\x1e"a"\x1e3\n` and `\x1e[1]\x1e3\n` keep both.
-/// An earlier version checked numbers alone and left 92 shapes emitting a
-/// value jq drops.
-fn seq_pending_token_is_terminated(bytes: &[u8], start: usize, end: usize) -> bool {
-    if !seq_token_is_pending(bytes, start) {
+/// with no closing delimiter, so one butting against a record boundary may
+/// be abandoned -- but **numbers and literals differ on which boundary**,
+/// and conflating them cost data in both directions:
+///
+/// | token | at an RS byte | at real EOF |
+/// |-------|---------------|-------------|
+/// | number (`1`) | abandoned | abandoned |
+/// | literal (`true`) | abandoned | **kept** |
+/// | string/array/object | kept | kept |
+///
+/// Checking numbers alone left 92 shapes emitting a `true` jq drops;
+/// checking both at every boundary then dropped `printf '\x1etrue'`, which
+/// jq prints. Both were found by differential sweeps, not by reasoning.
+fn seq_pending_token_is_terminated(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    rs_terminated: bool,
+) -> bool {
+    if bytes.get(end).is_some_and(u8::is_ascii_whitespace) {
         return true;
     }
-    bytes.get(end).is_some_and(u8::is_ascii_whitespace)
+    match bytes[start] {
+        // A number is truncatable at *either* boundary: more digits could
+        // always follow, so jq abandons it at an RS byte and at real EOF
+        // alike (`\x1e1` and `\x1e1\x1e3` both drop the `1`).
+        b'-' | b'.' | b'0'..=b'9' => false,
+        // A bare literal is truncatable only at an RS byte. At real EOF jq
+        // has seen all the input there will ever be, so `true` is complete:
+        // `printf '\x1etrue'` prints `true`, while `\x1etrue\x1e3` prints
+        // only `3`. Treating the two boundaries alike dropped the EOF case
+        // and lost data real jq (and `main`) keep.
+        b't' | b'f' | b'n' => !rs_terminated,
+        // Self-delimiting: nothing to confirm.
+        _ => true,
+    }
 }
 
 /// Whether one value out of a `--seq` record is legal JSON, allowing the
@@ -3546,8 +3551,9 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     // the ambiguous trailing bare number this function used to ask about
     // separately -- now rule 3, applied per value. Scanned on `tail`
     // (untrimmed) so that rule can see the terminating whitespace.
-    let scan = seq_record_scan(tail);
-    scan.trailing_unresolved || scan.values.is_empty()
+    // `false`: this is the stream's trailing record by construction, so its
+    // end is real EOF, never an RS byte.
+    seq_record_scan(tail, false).trailing_unresolved
 }
 
 /// Whether `--seq -s`'s trailing record, read across every file on the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2497,36 +2497,8 @@ fn find_json_values(bytes: &[u8]) -> core::result::Result<Vec<(usize, usize)>, u
         }
 
         let start = pos;
-        let first_byte = bytes[pos];
 
-        // Determine end of this JSON value
-        let end = match first_byte {
-            b'{' | b'[' => {
-                // Object or array - find matching close
-                find_matching_close(bytes, pos)
-            }
-            b'"' => {
-                // String - find end quote
-                find_string_end(bytes, pos)
-            }
-            b't' | b'f' | b'n' => {
-                // true, false, null
-                find_literal_end(bytes, pos)
-            }
-            // Number. `number_literal_end` (shared with `light.rs`'s own
-            // materializer, #1171 review -- one validated implementation
-            // instead of independently-maintained copies) both finds the
-            // end of and validates the token: a `.` is accepted as a
-            // leading byte when at least one digit follows (`.5` -> `0.5`,
-            // matching real jq's own leniency beyond strict JSON), and a
-            // byte sequence that only *looks* number-shaped (`-e5`, `1e`,
-            // a bare `.`) is rejected outright rather than silently
-            // accepted as a truncated or zero-length span.
-            b'-' | b'.' | b'0'..=b'9' => succinctly::json::light::number_literal_end(bytes, pos),
-            _ => None,
-        };
-
-        match end {
+        match scan_one_json_token(bytes, pos) {
             Some(end) => {
                 values.push((start, end));
                 pos = end;
@@ -2536,6 +2508,40 @@ fn find_json_values(bytes: &[u8]) -> core::result::Result<Vec<(usize, usize)>, u
     }
 
     Ok(values)
+}
+
+/// Where the JSON token starting at `pos` ends, or `None` if no token can
+/// start there.
+///
+/// Extracted from [`find_json_values`] so `--seq`'s own lenient scanner
+/// (#1723) can ask the identical per-token question without a second copy of
+/// this dispatch drifting from it.
+///
+/// "Ends" is structural, not a validity verdict: `{"a":1 xyz}` scans as one
+/// token because its braces match, and only validation rejects it. That
+/// distinction is what makes real jq's resync behaviour reproducible -- it
+/// never resyncs *into* a container that scanned but failed to validate, and
+/// this function is where "scanned" is decided.
+fn scan_one_json_token(bytes: &[u8], pos: usize) -> Option<usize> {
+    match bytes[pos] {
+        // Object or array - find matching close
+        b'{' | b'[' => find_matching_close(bytes, pos),
+        // String - find end quote
+        b'"' => find_string_end(bytes, pos),
+        // true, false, null
+        b't' | b'f' | b'n' => find_literal_end(bytes, pos),
+        // Number. `number_literal_end` (shared with `light.rs`'s own
+        // materializer, #1171 review -- one validated implementation
+        // instead of independently-maintained copies) both finds the
+        // end of and validates the token: a `.` is accepted as a
+        // leading byte when at least one digit follows (`.5` -> `0.5`,
+        // matching real jq's own leniency beyond strict JSON), and a
+        // byte sequence that only *looks* number-shaped (`-e5`, `1e`,
+        // a bare `.`) is rejected outright rather than silently
+        // accepted as a truncated or zero-length span.
+        b'-' | b'.' | b'0'..=b'9' => succinctly::json::light::number_literal_end(bytes, pos),
+        _ => None,
+    }
 }
 
 /// Find the end of an object or array starting at `pos`.
@@ -3287,8 +3293,9 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         // Scanned once here and reused for both the drop decision and the
         // value extraction below -- a review found this record being
         // re-scanned up to three times, each pass allocating and
-        // re-tokenizing.
-        let scanned = seq_record_scan(segment);
+        // re-tokenizing. The *untrimmed* text, so the number-terminator
+        // rule can see the whitespace that trimming would remove.
+        let ranges = seq_record_scan(raw_segment).values;
         // Two different conditions reach `drop_trailing`, and #1723 only
         // relaxes one of them.
         //
@@ -3304,34 +3311,35 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         // an ambiguous bare number, but the values before it are real
         // output real jq emits (`\x1e1 2` => `1`), so that decision moved
         // into `seq_record_values`, per value.
-        if i == last_idx && drop_trailing && (!has_rs || scanned.is_none()) {
+        if i == last_idx && drop_trailing && (!has_rs || ranges.is_empty()) {
             continue;
         }
 
-        // Try to parse as JSON, silently ignore failures
-        if let Some(ranges) = scanned {
-            // One RFC 7464 record can hold *more than one* JSON value, and
-            // real jq emits every one of them (#1723): `\x1e1 "x" [2]\n`
-            // is three outputs, not a malformed record. `seq_record_scan`
-            // above only answers "does this record parse at all", so the
-            // split into individual values happens here, reusing the same
-            // `find_json_values` scanner the ordinary document path uses.
-            //
-            // Before this, a multi-value record failed whole-segment
-            // validation and was dropped in full -- silent data loss on a
-            // record real jq reads fine, not merely a missing diagnostic.
-            // `trimmed_start`, not `start`: the ranges index the *trimmed*
-            // segment, so pairing them with the untrimmed record start
-            // reported offsets that were short by the leading whitespace --
-            // enough to name the wrong line, and across files the wrong
-            // file (a review found `\x1e  "a"\n"b"\n` naming lines 0/2
-            // where jq names 1/2).
-            let trimmed_start = start + (raw_segment.len() - raw_segment.trim_start().len());
-            for (v, value_end) in
-                seq_record_values(segment, raw_segment, &ranges, trimmed_start, end)
-            {
-                results.push((v, value_end));
-            }
+        // Real jq emits every value it managed to read out of a record and
+        // resyncs past what it could not (#1723) -- a record is not
+        // all-or-nothing, so there is no "does this parse" gate here any
+        // more. `ranges` is already exactly the set of values that survived
+        // `seq_record_scan`'s three rules.
+        for &(vs, ve) in &ranges {
+            let Ok(v) = crate::output::json_bytes_to_owned_value(&raw_segment.as_bytes()[vs..ve])
+            else {
+                // Parses but will not decode (#1247): dropped, exactly as
+                // the pre-#1723 path dropped it.
+                continue;
+            };
+            // The record's own trimmed end for its last value, so a
+            // one-value record reports the identical line it always did;
+            // earlier values report their own end, which is what jq's
+            // per-value line reporting needs. Ranges index the untrimmed
+            // record, so `start` is the right base (an earlier pass mixed
+            // trimmed ranges with the untrimmed start and named the wrong
+            // line, and across files the wrong file).
+            let value_end = if (vs, ve) == ranges[ranges.len() - 1] {
+                end
+            } else {
+                start + ve
+            };
+            results.push((v, value_end));
         }
         // Genuine parse failures are silently ignored per RFC 7464
     }
@@ -3339,101 +3347,134 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     results
 }
 
-/// Every JSON value inside one `--seq` record, paired with the absolute end
-/// offset each value should report (#1723).
+/// Every JSON value a `--seq` record yields, as byte ranges into the record's
+/// *untrimmed* text, plus the offset of the first thing that went wrong.
 ///
-/// `segment` is the trimmed record text and `ranges` its values' byte ranges
-/// within it (from [`seq_record_scan`], computed once by the caller rather
-/// than re-derived here -- a review found this function re-scanning a record
-/// the caller had already scanned twice). `trimmed_start`/`trimmed_end` are
-/// that trimmed text's own absolute bounds, so an earlier value's reported
-/// offset lands on the value itself; the last value keeps `trimmed_end`
-/// exactly, so a one-value record's reported line stays byte-identical to
-/// the pre-#1723 single-value path.
+/// Real jq's `--seq` reader does not treat a record as all-or-nothing: it
+/// emits every value it managed to read and resyncs past what it could not
+/// (#1723). Three rules, each oracle-derived, together reproduce every shape
+/// I could find:
 ///
-/// **The last value can still be dropped.** Real jq's incremental number
-/// scanner cannot rule out more digits arriving while a bare number is the
-/// last thing before a record boundary with no terminating byte after it,
-/// so it abandons that value -- the same ambiguity
-/// [`seq_trailing_record_is_dropped`] already encoded for the *stream's*
-/// final record, which turns out to apply per *record*, oracle-verified:
+/// 1. **A token that scans is validated, and dropped if invalid -- never
+///    resynced into.** `{"a":1 xyz}` scans as one token (its braces match),
+///    fails validation, and jq emits *nothing* -- it does not go back and
+///    pick the `"a"` out of the middle. Scanning past it is what prevents
+///    that.
+/// 2. **A byte that cannot start a token is skipped, one byte at a time.**
+///    `} 5` emits `5`; `tru 5` emits `5`.
+/// 3. **A number is only complete when whitespace follows it.** jq's
+///    incremental scanner cannot rule out more digits arriving otherwise, so
+///    `1,2` emits only `2` (the `1` is lost to the `,`), `1 2,3` emits `1`
+///    and `3`, and `\x1e1 2\x1e3` emits `1` and `3`. This *subsumes* the
+///    trailing-bare-number rule an earlier pass at #1723 wrote as a separate
+///    last-value special case -- same rule, applied per value instead of
+///    once at the end.
 ///
-/// ```text
-/// printf '\x1e1 2\x1e3\n'   | jq --seq -c .   =>  1, 3      (the `2` is dropped)
-/// printf '\x1e1 2\n\x1e3\n' | jq --seq -c .   =>  1, 2, 3   (a newline disambiguates it)
-/// ```
-///
-/// Without this, adding multi-value support would have *introduced* a
-/// divergence on the first shape while fixing the second.
-fn seq_record_values(
-    segment: &str,
-    raw_segment: &str,
-    ranges: &[(usize, usize)],
-    trimmed_start: usize,
-    trimmed_end: usize,
-) -> Vec<(OwnedValue, usize)> {
-    let mut out = Vec::new();
-    let last = ranges.len().saturating_sub(1);
-    for (i, &(vs, ve)) in ranges.iter().enumerate() {
-        let is_last = i == last;
-        let value_text = &segment[vs..ve];
-        if is_last && seq_record_last_value_is_ambiguous(value_text, raw_segment) {
-            continue;
+/// Scanning the untrimmed text is what makes rule 3 expressible: the
+/// whitespace that terminates the final number is exactly what trimming
+/// removes.
+fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
+    let bytes = raw_segment.as_bytes();
+    let mut values = Vec::new();
+    // Whether the *last* thing the scan looked at failed. Distinct from
+    // "any failure": `\x1e"a" 2` yields a value AND ends unresolved, and
+    // that combination is exactly what leaves real jq's incremental parser
+    // with no EOF position to report (`<unknown>`, #1542).
+    let mut trailing_unresolved = false;
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
         }
-        let Ok(v) = crate::output::json_bytes_to_owned_value(value_text.as_bytes()) else {
-            // Parses but will not decode (#1247): dropped, exactly as the
-            // pre-#1723 single-value path dropped it.
-            continue;
-        };
-        out.push((
-            v,
-            if is_last {
-                trimmed_end
-            } else {
-                trimmed_start + ve
-            },
-        ));
+        if pos >= bytes.len() {
+            break;
+        }
+        match scan_one_json_token(bytes, pos) {
+            Some(end) => {
+                let text = &raw_segment[pos..end];
+                if !seq_value_is_valid(text) {
+                    trailing_unresolved = true;
+                    // A token that scanned but is not legal JSON is a *bad
+                    // token*: the rest of its non-whitespace run belongs to
+                    // it too, and must not be re-read as a value. `tru5`
+                    // scans only as far as `tru`, and resuming at the `5`
+                    // emitted a `5` real jq never does.
+                    pos = end;
+                    while pos < bytes.len() && !bytes[pos].is_ascii_whitespace() {
+                        pos += 1;
+                    }
+                } else if seq_number_is_terminated(bytes, pos, end) {
+                    values.push((pos, end));
+                    trailing_unresolved = false;
+                    pos = end;
+                } else {
+                    // Legal JSON, but an unterminated number (rule 3). Only
+                    // *this* value is dropped -- what follows is still read,
+                    // which is why this cannot consume the run the way an
+                    // invalid token does (`\x1e1,2\n` must still emit `2`).
+                    trailing_unresolved = true;
+                    pos = end;
+                }
+            }
+            None => {
+                trailing_unresolved = true;
+                // An *unterminated* `"`/`{`/`[` swallows the rest of the
+                // record -- jq never resyncs out of one, oracle-verified:
+                // `\x1e[1,2\n` and `\x1e"a 5\n` emit nothing at all, while
+                // `\x1e1 [1,2\n` still emits the `1` that preceded it. A
+                // byte that merely cannot *start* a value is different and
+                // does resync (`\x1e} 5\n`, `\x1efals 7\n`, `\x1e-e5 7\n`
+                // all emit `7`/`5`), which is why this is keyed on the
+                // opener rather than on "the token failed".
+                if matches!(bytes[pos], b'"' | b'{' | b'[') {
+                    break;
+                }
+                // Everything else resyncs, but by how much depends on what
+                // it is. Structural punctuation is a single stray byte and
+                // jq resumes right after it (`\x1e,2\n` emits `2`); any
+                // other junk is a *bad token*, consumed whole up to the next
+                // whitespace, so its interior is never re-read as a value.
+                // Oracle-verified: `\x1e-e5 7\n`, `\x1exy5 7\n`,
+                // `\x1etru5 7\n` and `\x1e@ 7\n` all emit only `7` -- a
+                // one-byte skip would have found the `5` inside `-e5`.
+                if matches!(bytes[pos], b',' | b'}' | b']' | b':') {
+                    pos += 1;
+                } else {
+                    while pos < bytes.len() && !bytes[pos].is_ascii_whitespace() {
+                        pos += 1;
+                    }
+                }
+            }
+        }
     }
-    out
+    SeqRecordScan {
+        values,
+        trailing_unresolved,
+    }
 }
 
-/// Whether a record's final value is a bare number real jq would abandon as
-/// potentially truncated -- the per-record form of
-/// [`seq_trailing_record_is_dropped`]'s own third case, sharing its exact
-/// predicate: a leading `-`/digit, and no trailing whitespace in the
-/// *untrimmed* record after it.
-fn seq_record_last_value_is_ambiguous(value_text: &str, raw_segment: &str) -> bool {
-    let is_bare_number = matches!(value_text.as_bytes().first(), Some(b'-' | b'0'..=b'9'));
-    is_bare_number && raw_segment.trim_end() == raw_segment
+/// What [`seq_record_scan`] found in one `--seq` record.
+struct SeqRecordScan {
+    /// Byte ranges, into the record's *untrimmed* text, of every value the
+    /// record yields.
+    values: Vec<(usize, usize)>,
+    /// Whether the record *ends* unresolved -- see the field's own note in
+    /// `seq_record_scan`.
+    trailing_unresolved: bool,
 }
 
-/// Split a trimmed, non-empty `--seq` record into its JSON values' byte
-/// ranges, or `None` if it is malformed.
+/// Rule 3 above: a number token counts as complete only when whitespace
+/// follows it inside the record.
 ///
-/// One record can hold more than one value (#1723), so this cannot be the
-/// single whole-segment `validate::validate` call it was before -- that call
-/// is what made `\x1e1 2\n` look malformed and silently dropped both values.
-/// Each range is *still* validated strictly and individually, so the scanner
-/// (a tokenizer, not a validator) cannot widen what `--seq` accepts:
-/// `find_json_values` locates the boundaries, `validate::validate` decides
-/// whether each one is legal JSON.
-///
-/// **Ranges index `segment` itself, never a normalized copy.** #1243's
-/// leading-zero retry is applied per value instead, to decide validity and
-/// again to build the value. Re-scanning a normalized string was an offset
-/// bug a review caught: `normalize_leading_zero_numbers` *deletes* leading
-/// zeros rather than rewriting in place, so ranges taken from the normalized
-/// text are shorter than the original and name the wrong line
-/// (`\x1e0007\n"b"\n` reported lines 0/2 where jq reports 1/2).
-fn seq_record_scan(segment: &str) -> Option<Vec<(usize, usize)>> {
-    let ranges = find_json_values(segment.as_bytes()).ok()?;
-    if ranges.is_empty() {
-        return None;
+/// Non-numbers self-terminate (`"`, `}`, `]`, the last letter of
+/// `true`/`false`/`null`) and are unaffected -- oracle-verified:
+/// `\x1e{"a":1},2\n` keeps the object, while `\x1e1,2\n` loses the `1`.
+fn seq_number_is_terminated(bytes: &[u8], start: usize, end: usize) -> bool {
+    if !matches!(bytes[start], b'-' | b'.' | b'0'..=b'9') {
+        return true;
     }
-    ranges
-        .iter()
-        .all(|&(a, b)| seq_value_is_valid(&segment[a..b]))
-        .then_some(ranges)
+    bytes.get(end).is_some_and(u8::is_ascii_whitespace)
 }
 
 /// Whether one value out of a `--seq` record is legal JSON, allowing the
@@ -3442,8 +3483,7 @@ fn seq_record_scan(segment: &str) -> Option<Vec<(usize, usize)>> {
 /// Normalization is needed *here* and only here: `validate::validate` is
 /// strict RFC 8259 and rejects a leading zero, while the semi-indexer behind
 /// `json_bytes_to_owned_value` already reads `0007` as `7` on its own -- so
-/// the value-building side needs no fallback (an earlier draft had one, and
-/// coverage showed it could never run).
+/// the value-building side needs no fallback.
 fn seq_value_is_valid(value_text: &str) -> bool {
     if validate::validate(value_text.as_bytes()).is_ok() {
         return true;
@@ -3492,21 +3532,19 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     let Some((_, tail)) = raw.rsplit_once('\u{1e}') else {
         return !raw.trim().is_empty();
     };
-    let segment = tail.trim();
-    if segment.is_empty() {
+    if tail.trim().is_empty() {
         return false;
     }
-    let Some(ranges) = seq_record_scan(segment) else {
-        return true;
-    };
-    // The record's *last* value decides this, not its first byte. Before
-    // #1723 a record was always exactly one value, so the two were the same
-    // question; now they are not, and asking the first byte gets both
-    // multi-value shapes wrong in opposite directions -- a review found
-    // `\x1e"a" 2` reporting a line where jq reports `<unknown>`, and
-    // `\x1e1 "a"` the reverse.
-    let (vs, ve) = ranges[ranges.len() - 1];
-    seq_record_last_value_is_ambiguous(&segment[vs..ve], tail)
+    // Dropped when the record ends *unresolved* -- not merely when it
+    // yields nothing. `\x1e"a" 2` yields `"a"` and still leaves real jq
+    // without an EOF position, because its trailing `2` never resolved
+    // (#1542); asking "did it yield anything" got that backwards and broke
+    // two location tests. `seq_record_scan`'s rules decide both, including
+    // the ambiguous trailing bare number this function used to ask about
+    // separately -- now rule 3, applied per value. Scanned on `tail`
+    // (untrimmed) so that rule can see the terminating whitespace.
+    let scan = seq_record_scan(tail);
+    scan.trailing_unresolved || scan.values.is_empty()
 }
 
 /// Whether `--seq -s`'s trailing record, read across every file on the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2518,10 +2518,9 @@ fn find_json_values(bytes: &[u8]) -> core::result::Result<Vec<(usize, usize)>, u
 /// this dispatch drifting from it.
 ///
 /// "Ends" is structural, not a validity verdict: `{"a":1 xyz}` scans as one
-/// token because its braces match, and only validation rejects it. That
-/// distinction is what makes real jq's resync behaviour reproducible -- it
-/// never resyncs *into* a container that scanned but failed to validate, and
-/// this function is where "scanned" is decided.
+/// token because its braces match, and only validation rejects it. Keeping
+/// the two separate is what lets the `--seq` caller reject a whole record
+/// without ever reading a value out of the middle of a malformed one.
 fn scan_one_json_token(bytes: &[u8], pos: usize) -> Option<usize> {
     match bytes[pos] {
         // Object or array - find matching close
@@ -3327,18 +3326,14 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
                 // the pre-#1723 path dropped it.
                 continue;
             };
-            // The record's own trimmed end for its last value, so a
-            // one-value record reports the identical line it always did;
-            // earlier values report their own end, which is what jq's
-            // per-value line reporting needs. Ranges index the untrimmed
-            // record, so `start` is the right base (an earlier pass mixed
-            // trimmed ranges with the untrimmed start and named the wrong
-            // line, and across files the wrong file).
-            let value_end = if (vs, ve) == ranges[ranges.len() - 1] {
-                end
-            } else {
-                start + ve
-            };
+            // Every value reports its own end. Handing the record's trimmed
+            // end to the *last* range was wrong once the pending-token rule
+            // could pop the real last token: the survivor then inherited a
+            // line past the value that was dropped (a review found
+            // `\x1e"a"\n\n\n2\x1e"z"\n` reporting line 3 where jq reports
+            // line 1). For a single-value record the two are identical
+            // anyway, since a value's end *is* the record's trimmed end.
+            let value_end = start + ve;
             results.push((v, value_end));
         }
         // Genuine parse failures are silently ignored per RFC 7464
@@ -3391,24 +3386,39 @@ fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
         if !seq_value_is_valid(&raw_segment[pos..end]) {
             return SeqRecordScan::dropped();
         }
-        // The delimiter check. A token may be followed by whitespace, or by
-        // nothing at all (the record's end); anything else means the record
-        // is not the clean sequence of values this function is willing to
-        // split, and a scanner's guess at where the boundary really lies is
-        // precisely what fabricated output.
-        if bytes.get(end).is_some_and(|b| !b.is_ascii_whitespace()) {
+        // The delimiter check, and it applies only to *pending* tokens.
+        //
+        // A string, object or array carries its own closing delimiter, so
+        // adjacency cannot mis-split it and jq reads `{"a":1}{"b":2}` and
+        // `"a""b"` as two values apiece -- requiring whitespace after those
+        // dropped records real jq reads fully (a review measured 332 such
+        // regressions). A number or literal has no closing delimiter: it is
+        // "pending" until something confirms it, which is exactly where a
+        // scanner and jq's lexer can disagree.
+        //
+        // What confirms one, oracle-verified: whitespace, or the start of a
+        // self-delimiting value (`1[1]` and `1"a"` are two values in jq).
+        // Anything else -- another digit, a letter, `-`, or structural
+        // punctuation -- means this record is not a clean sequence of
+        // values, and guessing at the boundary is what fabricated output.
+        if seq_token_is_pending(bytes, pos)
+            && bytes
+                .get(end)
+                .is_some_and(|b| !b.is_ascii_whitespace() && !matches!(b, b'"' | b'{' | b'['))
+        {
             return SeqRecordScan::dropped();
         }
         values.push((pos, end));
         pos = end;
     }
 
-    // Rule 3, and the only value-level drop that survives: a bare number
-    // ending the record with no whitespace after it is ambiguous to jq's
-    // incremental scanner, which cannot rule out more digits arriving.
-    // `\x1e1 2` is `1`; `\x1e1 2 ` (trailing space) is `1` and `2`.
+    // The only value-level drop that survives: a *pending* token (number or
+    // bare literal) ending the record with no whitespace after it is
+    // ambiguous to jq's incremental scanner, which cannot rule out more
+    // input arriving. `\x1e1 2` is `1`; `\x1e1 2 ` (trailing space) is `1`
+    // and `2`; `\x1etrue\x1e3` is `3` alone.
     let trailing_unresolved = match values.last() {
-        Some(&(vs, ve)) if !seq_number_is_terminated(bytes, vs, ve) => {
+        Some(&(vs, ve)) if !seq_pending_token_is_terminated(bytes, vs, ve) => {
             values.pop();
             true
         }
@@ -3444,14 +3454,27 @@ impl SeqRecordScan {
     }
 }
 
-/// Rule 3 above: a number token counts as complete only when whitespace
-/// follows it inside the record.
+/// Whether the token at `start..end` is *pending* -- a number or a bare
+/// `true`/`false`/`null`, neither of which carries a closing delimiter.
 ///
-/// Non-numbers self-terminate (`"`, `}`, `]`, the last letter of
-/// `true`/`false`/`null`) and are unaffected -- oracle-verified:
-/// `\x1e{"a":1},2\n` keeps the object, while `\x1e1,2\n` loses the `1`.
-fn seq_number_is_terminated(bytes: &[u8], start: usize, end: usize) -> bool {
-    if !matches!(bytes[start], b'-' | b'.' | b'0'..=b'9') {
+/// Strings, objects and arrays are self-delimiting and are never pending:
+/// `"`, `}` and `]` end them unambiguously.
+fn seq_token_is_pending(bytes: &[u8], start: usize) -> bool {
+    matches!(bytes[start], b'-' | b'.' | b'0'..=b'9' | b't' | b'f' | b'n')
+}
+
+/// Whether a *pending* token ending a record was confirmed by trailing
+/// whitespace.
+///
+/// jq's incremental scanner cannot rule out more input arriving for a token
+/// with no closing delimiter, so one that butts against the record boundary
+/// is abandoned. This covers literals as well as numbers -- oracle-verified
+/// at an RS boundary, where `\x1etrue\x1e3\n` and `\x1enull\x1e3\n` both
+/// yield only `3`, while `\x1e"a"\x1e3\n` and `\x1e[1]\x1e3\n` keep both.
+/// An earlier version checked numbers alone and left 92 shapes emitting a
+/// value jq drops.
+fn seq_pending_token_is_terminated(bytes: &[u8], start: usize, end: usize) -> bool {
+    if !seq_token_is_pending(bytes, start) {
         return true;
     }
     bytes.get(end).is_some_and(u8::is_ascii_whitespace)
@@ -3481,7 +3504,7 @@ fn seq_value_is_valid(value_text: &str) -> bool {
 ///
 /// Two shapes, both silently swallowed by real jq's own `--seq` reader:
 ///
-/// - **Genuinely malformed/truncated** -- [`seq_record_scan`] returns `None`
+/// - **Genuinely malformed/truncated** -- [`seq_record_scan`] yields no values
 ///   (an unterminated string/object, e.g.), matching
 ///   [`parse_json_seq_with_ends`]'s own silent-drop rule (RFC 7464's
 ///   recommended failure mode, #1243).

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3348,39 +3348,34 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
 }
 
 /// Every JSON value a `--seq` record yields, as byte ranges into the record's
-/// *untrimmed* text, plus the offset of the first thing that went wrong.
+/// *untrimmed* text.
 ///
-/// Real jq's `--seq` reader does not treat a record as all-or-nothing: it
-/// emits every value it managed to read and resyncs past what it could not
-/// (#1723). Three rules, each oracle-derived, together reproduce every shape
-/// I could find:
+/// **Conservative by construction: this never emits a value real jq would
+/// not.** A record whose tokens are not cleanly whitespace-separated, or any
+/// of whose tokens is not legal JSON, yields *nothing* -- the pre-#1723
+/// whole-record drop.
 ///
-/// 1. **A token that scans is validated, and dropped if invalid -- never
-///    resynced into.** `{"a":1 xyz}` scans as one token (its braces match),
-///    fails validation, and jq emits *nothing* -- it does not go back and
-///    pick the `"a"` out of the middle. Scanning past it is what prevents
-///    that.
-/// 2. **A byte that cannot start a token is skipped, one byte at a time.**
-///    `} 5` emits `5`; `tru 5` emits `5`.
-/// 3. **A number is only complete when whitespace follows it.** jq's
-///    incremental scanner cannot rule out more digits arriving otherwise, so
-///    `1,2` emits only `2` (the `1` is lost to the `,`), `1 2,3` emits `1`
-///    and `3`, and `\x1e1 2\x1e3` emits `1` and `3`. This *subsumes* the
-///    trailing-bare-number rule an earlier pass at #1723 wrote as a separate
-///    last-value special case -- same rule, applied per value instead of
-///    once at the end.
+/// That conservatism is the point, and it was learned the hard way. An
+/// earlier version of this function tried to reproduce jq's own resync
+/// (emit the values before a malformed suffix, skip the bad token, carry
+/// on). jq's `--seq` reader is a streaming lexer/parser with error recovery,
+/// and a token scanner cannot imitate it: the attempt **fabricated output**,
+/// emitting values real jq never emits. `\x1e1-2\n` is the clearest case --
+/// jq lexes `1-2` as one malformed number and prints nothing, while a
+/// scanner reads `1` then `-2` and prints both. `\x1e1null\n`, `\x1e12true\n`
+/// and `\x1etrue1\n` all fail the same way, and `\x1e5-3 7\n` printed `-3`
+/// out of the middle of a bad token.
 ///
-/// Scanning the untrimmed text is what makes rule 3 expressible: the
-/// whitespace that terminates the final number is exactly what trimming
-/// removes.
+/// Requiring whitespace after every token is what makes that impossible:
+/// the adjacency a scanner mis-splits is exactly what this rejects. The cost
+/// is that a record jq *can* partially read is dropped instead -- a
+/// divergence in the safe direction, recorded in
+/// `docs/compliance/jq/limitations.md` rather than papered over. Reaching
+/// jq's own answer needs its incremental parser's failure classification,
+/// which is what #1723 asks for and is tracked there.
 fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
     let bytes = raw_segment.as_bytes();
     let mut values = Vec::new();
-    // Whether the *last* thing the scan looked at failed. Distinct from
-    // "any failure": `\x1e"a" 2` yields a value AND ends unresolved, and
-    // that combination is exactly what leaves real jq's incremental parser
-    // with no EOF position to report (`<unknown>`, #1542).
-    let mut trailing_unresolved = false;
     let mut pos = 0;
 
     while pos < bytes.len() {
@@ -3390,64 +3385,36 @@ fn seq_record_scan(raw_segment: &str) -> SeqRecordScan {
         if pos >= bytes.len() {
             break;
         }
-        match scan_one_json_token(bytes, pos) {
-            Some(end) => {
-                let text = &raw_segment[pos..end];
-                if !seq_value_is_valid(text) {
-                    trailing_unresolved = true;
-                    // A token that scanned but is not legal JSON is a *bad
-                    // token*: the rest of its non-whitespace run belongs to
-                    // it too, and must not be re-read as a value. `tru5`
-                    // scans only as far as `tru`, and resuming at the `5`
-                    // emitted a `5` real jq never does.
-                    pos = end;
-                    while pos < bytes.len() && !bytes[pos].is_ascii_whitespace() {
-                        pos += 1;
-                    }
-                } else if seq_number_is_terminated(bytes, pos, end) {
-                    values.push((pos, end));
-                    trailing_unresolved = false;
-                    pos = end;
-                } else {
-                    // Legal JSON, but an unterminated number (rule 3). Only
-                    // *this* value is dropped -- what follows is still read,
-                    // which is why this cannot consume the run the way an
-                    // invalid token does (`\x1e1,2\n` must still emit `2`).
-                    trailing_unresolved = true;
-                    pos = end;
-                }
-            }
-            None => {
-                trailing_unresolved = true;
-                // An *unterminated* `"`/`{`/`[` swallows the rest of the
-                // record -- jq never resyncs out of one, oracle-verified:
-                // `\x1e[1,2\n` and `\x1e"a 5\n` emit nothing at all, while
-                // `\x1e1 [1,2\n` still emits the `1` that preceded it. A
-                // byte that merely cannot *start* a value is different and
-                // does resync (`\x1e} 5\n`, `\x1efals 7\n`, `\x1e-e5 7\n`
-                // all emit `7`/`5`), which is why this is keyed on the
-                // opener rather than on "the token failed".
-                if matches!(bytes[pos], b'"' | b'{' | b'[') {
-                    break;
-                }
-                // Everything else resyncs, but by how much depends on what
-                // it is. Structural punctuation is a single stray byte and
-                // jq resumes right after it (`\x1e,2\n` emits `2`); any
-                // other junk is a *bad token*, consumed whole up to the next
-                // whitespace, so its interior is never re-read as a value.
-                // Oracle-verified: `\x1e-e5 7\n`, `\x1exy5 7\n`,
-                // `\x1etru5 7\n` and `\x1e@ 7\n` all emit only `7` -- a
-                // one-byte skip would have found the `5` inside `-e5`.
-                if matches!(bytes[pos], b',' | b'}' | b']' | b':') {
-                    pos += 1;
-                } else {
-                    while pos < bytes.len() && !bytes[pos].is_ascii_whitespace() {
-                        pos += 1;
-                    }
-                }
-            }
+        let Some(end) = scan_one_json_token(bytes, pos) else {
+            return SeqRecordScan::dropped();
+        };
+        if !seq_value_is_valid(&raw_segment[pos..end]) {
+            return SeqRecordScan::dropped();
         }
+        // The delimiter check. A token may be followed by whitespace, or by
+        // nothing at all (the record's end); anything else means the record
+        // is not the clean sequence of values this function is willing to
+        // split, and a scanner's guess at where the boundary really lies is
+        // precisely what fabricated output.
+        if bytes.get(end).is_some_and(|b| !b.is_ascii_whitespace()) {
+            return SeqRecordScan::dropped();
+        }
+        values.push((pos, end));
+        pos = end;
     }
+
+    // Rule 3, and the only value-level drop that survives: a bare number
+    // ending the record with no whitespace after it is ambiguous to jq's
+    // incremental scanner, which cannot rule out more digits arriving.
+    // `\x1e1 2` is `1`; `\x1e1 2 ` (trailing space) is `1` and `2`.
+    let trailing_unresolved = match values.last() {
+        Some(&(vs, ve)) if !seq_number_is_terminated(bytes, vs, ve) => {
+            values.pop();
+            true
+        }
+        Some(_) => false,
+        None => true,
+    };
     SeqRecordScan {
         values,
         trailing_unresolved,
@@ -3459,9 +3426,22 @@ struct SeqRecordScan {
     /// Byte ranges, into the record's *untrimmed* text, of every value the
     /// record yields.
     values: Vec<(usize, usize)>,
-    /// Whether the record *ends* unresolved -- see the field's own note in
-    /// `seq_record_scan`.
+    /// Whether the record ends unresolved -- a malformed record, or one
+    /// whose final value is an ambiguous bare number. This is what leaves
+    /// real jq's incremental parser with no EOF position to report
+    /// (`<unknown>`, #1542), and it is *not* the same question as "yielded
+    /// nothing": `\x1e"a" 2` yields `"a"` and still ends unresolved.
     trailing_unresolved: bool,
+}
+
+impl SeqRecordScan {
+    /// A record that yields nothing and ends unresolved.
+    fn dropped() -> Self {
+        Self {
+            values: Vec::new(),
+            trailing_unresolved: true,
+        }
+    }
 }
 
 /// Rule 3 above: a number token counts as complete only when whitespace

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26916,15 +26916,31 @@ fn test_seq_self_delimiting_tokens_need_no_separator_1928() -> Result<()> {
     Ok(())
 }
 
-/// #1928: a bare `true`/`false`/`null` at a record boundary is truncated,
-/// exactly like a bare number.
+/// #1928: a bare `true`/`false`/`null` is truncated at an **RS byte** but
+/// not at real **EOF** -- unlike a bare number, which is truncated at both.
 ///
-/// Both lack a closing delimiter, so jq's incremental scanner cannot rule
-/// out more input arriving. Checking numbers alone left 92 shapes emitting a
-/// value jq drops.
+/// | token | at an RS byte | at real EOF |
+/// |-------|---------------|-------------|
+/// | number (`1`) | abandoned | abandoned |
+/// | literal (`true`) | abandoned | **kept** |
+/// | string/array/object | kept | kept |
+///
+/// A number can always take more digits; at EOF jq has seen all the input
+/// there will ever be, so a literal is complete. Both halves are pinned
+/// because each direction was got wrong once: checking numbers alone left 92
+/// shapes emitting a `true` jq drops, and then checking literals at every
+/// boundary dropped `printf '\x1etrue'`, which jq prints.
 #[test]
 fn test_seq_pending_literal_at_boundary_is_truncated_1928() -> Result<()> {
     for (input, expected, why) in [
+        // At real EOF a literal is complete -- the half a stricter rule broke.
+        ("\x1etrue", "true\n", "bare literal at EOF is kept"),
+        ("\x1enull", "null\n", "so is null"),
+        ("\x1e\"a\" true", "\"a\"\ntrue\n", "and after another value"),
+        ("\x1e{} null", "{}\nnull\n", "likewise"),
+        // A number is abandoned at EOF, which is the contrast that makes the
+        // rule per-token-kind rather than per-boundary.
+        ("\x1e1", "", "a bare number at EOF is still abandoned"),
         (
             "\x1etrue\x1e3\n",
             "3\n",

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26833,7 +26833,6 @@ fn test_seq_adjacent_tokens_never_fabricate_1723() -> Result<()> {
 fn test_seq_partially_readable_record_is_dropped_whole_1723() -> Result<()> {
     for (input, jq_would_emit) in [
         ("\x1e1 {invalid\n", "1"),
-        ("\x1e1[1]\n", "1 and [1]"),
         ("\x1e1,2\n", "2"),
         ("\x1e} 5\n", "5"),
         ("\x1e{\"a\":1} xyz\n", "{\"a\":1}"),
@@ -26887,5 +26886,60 @@ fn test_seq_trailing_unresolved_still_reports_unknown_1723() -> Result<()> {
         );
     }
     let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
+/// #1928: a self-delimiting token needs no separator after it.
+///
+/// The first version of this fix required whitespace after *every* token,
+/// which dropped records real jq reads fully — a review measured 332 such
+/// regressions. A string, object or array carries its own closing
+/// delimiter, so adjacency cannot mis-split it; only a number or bare
+/// literal is "pending" and genuinely ambiguous.
+#[test]
+fn test_seq_self_delimiting_tokens_need_no_separator_1928() -> Result<()> {
+    for (input, expected) in [
+        ("\x1e{\"a\":1}{\"b\":2}\n", "{\"a\":1}\n{\"b\":2}\n"),
+        ("\x1e\"a\"\"b\"\n", "\"a\"\n\"b\"\n"),
+        ("\x1e[1][2]\n", "[1]\n[2]\n"),
+        // A pending token is confirmed by the *start* of a self-delimiting
+        // value just as well as by whitespace.
+        ("\x1e1[1]\n", "1\n[1]\n"),
+        ("\x1e1\"a\"\n", "1\n\"a\"\n"),
+        ("\x1e1{\"b\":2}\n", "1\n{\"b\":2}\n"),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1928: a bare `true`/`false`/`null` at a record boundary is truncated,
+/// exactly like a bare number.
+///
+/// Both lack a closing delimiter, so jq's incremental scanner cannot rule
+/// out more input arriving. Checking numbers alone left 92 shapes emitting a
+/// value jq drops.
+#[test]
+fn test_seq_pending_literal_at_boundary_is_truncated_1928() -> Result<()> {
+    for (input, expected, why) in [
+        (
+            "\x1etrue\x1e3\n",
+            "3\n",
+            "bare literal before RS is abandoned",
+        ),
+        ("\x1enull\x1e3\n", "3\n", "so is null"),
+        ("\x1e5\x1e3\n", "3\n", "as for a bare number, unchanged"),
+        ("\x1etrue\n\x1e3\n", "true\n3\n", "a newline confirms it"),
+        ("\x1e\"a\"\x1e3\n", "\"a\"\n3\n", "a string self-terminates"),
+        ("\x1e[1]\x1e3\n", "[1]\n3\n", "so does an array"),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?} -- {why}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26782,98 +26782,68 @@ fn test_seq_value_error_location_marker_1723() -> Result<()> {
     Ok(())
 }
 
-/// #1723: a `--seq` record that is well-formed up to a malformed *suffix*
-/// still yields the values real jq managed to read.
+/// #1723: `--seq` must never emit a value real jq does not.
 ///
-/// Previously the whole record was dropped, so `\x1e1 {invalid` printed
-/// nothing where jq prints `1`. Three oracle-derived rules together
-/// reproduce every shape found:
+/// #1914 taught the record reader to split a record into several values,
+/// which is right for a cleanly separated record but wrong the moment tokens
+/// are *adjacent*: a scanner splits `1-2` into `1` and `-2`, while jq lexes
+/// it as one malformed number and prints nothing. That shipped, and it made
+/// `succinctly jq --seq` **fabricate output** on 205 of 1500 randomly
+/// generated records.
 ///
-/// 1. A token that *scans* is validated and dropped if invalid -- never
-///    resynced into. `{"a":1 xyz}` scans as one token (braces match), so jq
-///    emits nothing rather than picking the `"a"` out of its middle.
-/// 2. An **unterminated** `"`/`{`/`[` swallows the rest of the record;
-///    other junk resyncs -- structural punctuation by one byte, a bad token
-///    up to the next whitespace (so `-e5 7` is `7`, not `5` and `7`).
-/// 3. A number is complete only when whitespace follows it.
+/// A first attempt at this issue tried to imitate jq's resync instead
+/// (emit the prefix, skip the bad token, continue) and fabricated *more*,
+/// because jq's `--seq` reader is a streaming lexer/parser with error
+/// recovery and a token scanner cannot imitate one. Requiring whitespace
+/// after every token is what makes fabrication structurally impossible: the
+/// adjacency a scanner mis-splits is exactly what is now rejected.
+///
+/// Each row here emits nothing, matching jq. Before this fix every one of
+/// them emitted values.
 #[test]
-fn test_seq_malformed_suffix_keeps_the_prefix_1723() -> Result<()> {
-    for (input, expected, why) in [
+fn test_seq_adjacent_tokens_never_fabricate_1723() -> Result<()> {
+    for (input, why) in [
+        ("\x1e1-2\n", "one malformed number, not `1` and `-2`"),
+        ("\x1e1null\n", "not `1` and `null`"),
+        ("\x1e12true\n", "not `12` and `true`"),
+        ("\x1etrue1\n", "not `true` and `1`"),
         (
-            "\x1e1 {invalid\n",
-            "1\n",
-            "values before the malformed suffix survive",
+            "\x1e5-3 7\n",
+            "must not print `-3` out of the middle of a bad token",
         ),
-        (
-            "\x1e1 2 {invalid\n",
-            "1\n2\n",
-            "all of them, not just the first",
-        ),
-        (
-            "\x1e{\"a\":1} xyz\n",
-            "{\"a\":1}\n",
-            "a bad token after a good value",
-        ),
-        (
-            "\x1e1 \"a\n",
-            "1\n",
-            "unterminated string swallows only what follows it",
-        ),
-        ("\x1e1 [1,2\n", "1\n", "unterminated array likewise"),
-        // Rule 1: scanned-but-invalid containers are never resynced into.
-        (
-            "\x1e{\"a\":1 xyz}\n",
-            "",
-            "braces match, so it is one invalid token",
-        ),
-        ("\x1e[1,2 3]\n", "", "same for brackets"),
-        ("\x1e[1 2]\n", "", "same"),
-        // Rule 2: what resyncs, and by how much.
-        ("\x1e} 5\n", "5\n", "stray structural byte skips one"),
-        ("\x1e,2\n", "2\n", "so does a comma"),
-        ("\x1e{\"a\":1} } 7\n", "{\"a\":1}\n7\n", "and mid-record"),
-        (
-            "\x1e-e5 7\n",
-            "7\n",
-            "a bad token is consumed whole, not byte by byte",
-        ),
-        (
-            "\x1exy5 7\n",
-            "7\n",
-            "otherwise the 5 inside it would be emitted",
-        ),
-        (
-            "\x1etru5 7\n",
-            "7\n",
-            "including one that scans as a short literal run",
-        ),
-        ("\x1e@ 7\n", "7\n", "and punctuation that starts nothing"),
-        ("\x1efals 7\n", "7\n", "a failed literal"),
-        ("\x1exyz\n", "", "with nothing to resync onto"),
-        // Rule 3, now general rather than a last-value special case.
-        (
-            "\x1e1,2\n",
-            "2\n",
-            "a number before a comma is not terminated",
-        ),
-        ("\x1e1 2,3\n", "1\n3\n", "only the unterminated one is lost"),
-        (
-            "\x1e{\"a\":1},2\n",
-            "{\"a\":1}\n2\n",
-            "non-numbers self-terminate",
-        ),
-        ("\x1e\"a\",2\n", "\"a\"\n2\n", "including strings"),
-        ("\x1e1,\n", "", "nothing left to resync onto"),
-        (
-            "\x1e1,2,3\n",
-            "3\n",
-            "each unterminated number is dropped in turn",
-        ),
-        ("\x1e1 2 3,4\n", "1\n2\n4\n", "mixed"),
+        ("\x1e1.5true\n", "a fractional number is no different"),
+        ("\x1e0007null\n", "nor is a leading-zero one"),
     ] {
         let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
         let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
-        assert_eq!(stripped, expected, "input {input:?} -- {why}");
+        assert_eq!(stripped, "", "input {input:?} -- {why}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1723: the cost of never fabricating is that a record jq can *partially*
+/// read is dropped whole.
+///
+/// Recorded as a test, not just prose, so the divergence is visible and its
+/// direction is pinned: succinctly's output is always a subset of jq's here,
+/// never a superset. Reaching jq's own answer needs its incremental parser's
+/// failure classification, which is what #1723 still tracks.
+#[test]
+fn test_seq_partially_readable_record_is_dropped_whole_1723() -> Result<()> {
+    for (input, jq_would_emit) in [
+        ("\x1e1 {invalid\n", "1"),
+        ("\x1e1[1]\n", "1 and [1]"),
+        ("\x1e1,2\n", "2"),
+        ("\x1e} 5\n", "5"),
+        ("\x1e{\"a\":1} xyz\n", "{\"a\":1}"),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(
+            stripped, "",
+            "input {input:?}: dropped whole; real jq emits {jq_would_emit}"
+        );
         assert_eq!(code, 0, "input {input:?}");
     }
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26781,3 +26781,141 @@ fn test_seq_value_error_location_marker_1723() -> Result<()> {
     let _ = std::fs::remove_dir_all(&dir);
     Ok(())
 }
+
+/// #1723: a `--seq` record that is well-formed up to a malformed *suffix*
+/// still yields the values real jq managed to read.
+///
+/// Previously the whole record was dropped, so `\x1e1 {invalid` printed
+/// nothing where jq prints `1`. Three oracle-derived rules together
+/// reproduce every shape found:
+///
+/// 1. A token that *scans* is validated and dropped if invalid -- never
+///    resynced into. `{"a":1 xyz}` scans as one token (braces match), so jq
+///    emits nothing rather than picking the `"a"` out of its middle.
+/// 2. An **unterminated** `"`/`{`/`[` swallows the rest of the record;
+///    other junk resyncs -- structural punctuation by one byte, a bad token
+///    up to the next whitespace (so `-e5 7` is `7`, not `5` and `7`).
+/// 3. A number is complete only when whitespace follows it.
+#[test]
+fn test_seq_malformed_suffix_keeps_the_prefix_1723() -> Result<()> {
+    for (input, expected, why) in [
+        (
+            "\x1e1 {invalid\n",
+            "1\n",
+            "values before the malformed suffix survive",
+        ),
+        (
+            "\x1e1 2 {invalid\n",
+            "1\n2\n",
+            "all of them, not just the first",
+        ),
+        (
+            "\x1e{\"a\":1} xyz\n",
+            "{\"a\":1}\n",
+            "a bad token after a good value",
+        ),
+        (
+            "\x1e1 \"a\n",
+            "1\n",
+            "unterminated string swallows only what follows it",
+        ),
+        ("\x1e1 [1,2\n", "1\n", "unterminated array likewise"),
+        // Rule 1: scanned-but-invalid containers are never resynced into.
+        (
+            "\x1e{\"a\":1 xyz}\n",
+            "",
+            "braces match, so it is one invalid token",
+        ),
+        ("\x1e[1,2 3]\n", "", "same for brackets"),
+        ("\x1e[1 2]\n", "", "same"),
+        // Rule 2: what resyncs, and by how much.
+        ("\x1e} 5\n", "5\n", "stray structural byte skips one"),
+        ("\x1e,2\n", "2\n", "so does a comma"),
+        ("\x1e{\"a\":1} } 7\n", "{\"a\":1}\n7\n", "and mid-record"),
+        (
+            "\x1e-e5 7\n",
+            "7\n",
+            "a bad token is consumed whole, not byte by byte",
+        ),
+        (
+            "\x1exy5 7\n",
+            "7\n",
+            "otherwise the 5 inside it would be emitted",
+        ),
+        (
+            "\x1etru5 7\n",
+            "7\n",
+            "including one that scans as a short literal run",
+        ),
+        ("\x1e@ 7\n", "7\n", "and punctuation that starts nothing"),
+        ("\x1efals 7\n", "7\n", "a failed literal"),
+        ("\x1exyz\n", "", "with nothing to resync onto"),
+        // Rule 3, now general rather than a last-value special case.
+        (
+            "\x1e1,2\n",
+            "2\n",
+            "a number before a comma is not terminated",
+        ),
+        ("\x1e1 2,3\n", "1\n3\n", "only the unterminated one is lost"),
+        (
+            "\x1e{\"a\":1},2\n",
+            "{\"a\":1}\n2\n",
+            "non-numbers self-terminate",
+        ),
+        ("\x1e\"a\",2\n", "\"a\"\n2\n", "including strings"),
+        ("\x1e1,\n", "", "nothing left to resync onto"),
+        (
+            "\x1e1,2,3\n",
+            "3\n",
+            "each unterminated number is dropped in turn",
+        ),
+        ("\x1e1 2 3,4\n", "1\n2\n4\n", "mixed"),
+    ] {
+        let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
+        let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
+        assert_eq!(stripped, expected, "input {input:?} -- {why}");
+        assert_eq!(code, 0, "input {input:?}");
+    }
+    Ok(())
+}
+
+/// #1723: a record that *ends* unresolved leaves real jq with no EOF
+/// position, even when it yielded values first.
+///
+/// `\x1e"a" 2` emits `"a"` and still reports `<unknown>`, because its
+/// trailing `2` never resolved. Defining "dropped" as "yielded nothing"
+/// instead got this backwards and broke #1542's own location test — pinned
+/// here so the two questions cannot be conflated again.
+#[test]
+fn test_seq_trailing_unresolved_still_reports_unknown_1723() -> Result<()> {
+    let dir = std::env::temp_dir().join(format!("sjq-seq-unres-{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let file = dir.join("z.json");
+    let path = file.to_str().expect("temp path is utf-8");
+
+    for (input, expected_marker, why) in [
+        (
+            "\x1e\"a\" 2",
+            "<unknown>",
+            "yields \"a\", but ends unresolved",
+        ),
+        ("\x1e1 \"a\"", "z.json:0", "ends resolved"),
+        ("\x1e\"a\"", "z.json:0", "single resolved value"),
+        ("\x1e1", "<unknown>", "single unresolved bare number"),
+        ("\x1e{\"a\":1", "<unknown>", "unterminated container"),
+    ] {
+        std::fs::write(&file, input)?;
+        let (_out, stderr, _code) =
+            run_jq_full(&["--seq", "-s", "-c", "error(\"x\")", path], None)?;
+        let marker = stderr
+            .lines()
+            .find(|l| l.starts_with("jq: error"))
+            .unwrap_or_default();
+        assert!(
+            marker.contains(expected_marker),
+            "input {input:?} -- {why}: expected {expected_marker:?} in {marker:?}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1928. Refs #1723 (its diagnostics gap stays open).

## A regression fix, not an enhancement

#1914 (mine, merged earlier) taught the `--seq` reader to split a record into several values. Correct for a cleanly separated record; wrong the moment tokens are **adjacent**, because a token scanner and jq's lexer disagree about where a pending token ends. `main` fabricates output:

```console
$ printf '\x1e1-2\n'   | jq --seq -c '.'  →  (nothing)        succinctly →  1 and -2
$ printf '\x1etrue1\n' | jq --seq -c '.'  →  (nothing)        succinctly →  true and 1
$ printf '\x1e5-3 7\n' | jq --seq -c '.'  →  7                succinctly →  5, -3, 7
```

Both exit 0, so a consumer gets no signal.

## The rule

A **pending** token — a number or bare `true`/`false`/`null`, neither carrying a closing delimiter — must be confirmed. Strings, objects and arrays self-terminate and are exempt, so `{"a":1}{"b":2}` and `1[1]` are two values apiece, as in jq.

What confirms a pending token depends on the boundary, and this is per token *kind*:

| token | at an RS byte | at real EOF |
|---|---|---|
| number (`1`) | abandoned | abandoned |
| literal (`true`) | abandoned | **kept** |
| string/array/object | kept | kept |

## Measurements

Single records, 6,000 generated: **0** fabricated here vs **787** on `main`; 3,518 identical to jq vs 3,407.

Multi-record streams, 2,000 generated: **133** superset vs `main`'s **610**; **742** identical vs 654.

The remaining 133 are a *separate, pre-existing* rule — jq drops a trailing record that isn't newline-terminated — which behaves identically on `main` (`printf '\x1e0007\n\x1e[]'` → jq `7`, both builds `7` and `[]`). Documented, not claimed away.

## Three review rounds, three classes my own verification missed

Each was a corpus biased in exactly the dimension under test, and each is now covered:

1. Every shape in my 62-case matrix was whitespace-separated — nothing tested adjacency, the whole point. Found the fabrication.
2. The first fix over-corrected, requiring whitespace after self-delimiting tokens too, dropping **332** records `main` reads fine.
3. My corpus generated only *single* records, so nothing tested record boundaries — which hid that literals truncate at RS but not at EOF, silently regressing `printf '\x1etrue'`.

An earlier attempt on this branch to imitate jq's resync (emit the prefix, skip the bad token, continue) is also reverted: it fabricated *more*. jq's `--seq` reader is a streaming lexer/parser with error recovery, and a token scanner cannot substitute for one — which #1723 said and I underweighted.

## Cost, stated rather than claimed away

A record jq can *partially* read is dropped whole (`\x1e1 {invalid` → jq prints `1`, this prints nothing). Pinned by `test_seq_partially_readable_record_is_dropped_whole_1723` and recorded in `docs/compliance/jq/limitations.md`, which also loses two false claims of mine — that output "matches real jq", and an unqualified "always a subset".

## Gates

6533 tests / 0 failed; both clippy feature sets, `fmt`, `--no-default-features`, CI's exact rustdoc command. Every new test was confirmed to fail against the commit it guards.
