### PR TITLE
fix(jq): give eval_single a native Expr::Try arm, close the try/catch gap

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4251,6 +4251,92 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// `try INNER catch CATCH` (`CATCH = None` is `?`'s own desugaring, #1812
+/// code review) -- `eval_single`'s twin of [`each_try_generic`], which
+/// already unifies `Expr::Optional`/`Expr::Try` this same way for
+/// `eval_each_generic`'s sink-based sibling. `Expr::Optional`/`Expr::Try`
+/// used to be two independently hand-rolled ~65-line matches here, each
+/// re-deriving the same decode-failure/`Error`/`Break`/`Partial`/`LazySeq`
+/// dispatch -- a duplicate the codebase's own precedent (this function's
+/// sink-based twin, 650 lines below) had already resolved the same way.
+///
+/// **This function and [`each_try_generic`] are still two separate
+/// implementations of the identical dispatch** (one for `eval_single`'s
+/// pull/`GenericResult` model, one for `eval_each_generic`'s push/`Flow`
+/// model, mirroring `eval.rs`'s own `eval_single`/`eval_each` split) — a
+/// future change to the catchability rules (another `#1620`-style
+/// exclusion, a new `Control` variant) needs applying to *both*, the same
+/// way `eval.rs`'s and `eval_generic.rs`'s own evaluator pair already needs
+/// any reindex-bridge fix applied in parallel. Currently consistent
+/// (verified: same `is_decode_failure()` exclusion, `Break` bound to
+/// `null`, `catch = None` suppression, `Halt` passthrough).
+///
+/// A decode failure (#1247) is never caught by either spelling, any more
+/// than real jq's own parse-time rejection could ever be caught (#1620) --
+/// checked before the ordinary `Error`/`Break` catch below so it falls
+/// through to `other => other` instead. `catch` runs bound to the raised
+/// payload for `Error`, or `null` for `Break` (#562, matching real jq
+/// binding its own internal break marker there instead, not worth
+/// replicating) -- `catch = None` collapses straight to
+/// [`GenericResult::None`], exactly `?`'s own suppression.
+///
+/// `prefix` is never empty in the `Partial` arms: `partial_generic` (and
+/// `eval::partial`, its mirror) already collapse an empty prefix to the
+/// bare `Error`/`Break` variant above before a `Partial` ever gets
+/// constructed (#400, #494). [`prepend_generic`] is routed through
+/// regardless (#1067): a future change that ever violates that invariant
+/// degrades gracefully instead of silently misbehaving.
+///
+/// A `LazySeq` hasn't necessarily failed *yet* -- it's lazy, so it never
+/// matches the `Error`/`Break`/`Partial` arms above even when pulling it
+/// would fail (#724, #725). This boundary needs to know *now* whether
+/// `inner` fails, so force it here -- same one-pass cost
+/// `materialize_atomic` already pays at every other materializing boundary
+/// in this file. Without this arm, `inner` falls through to `other =>
+/// other` below and escapes the boundary entirely: the error only surfaces
+/// later, at whatever downstream site finally pulls the `LazySeq`, by which
+/// point this `try`/`catch`/`?` is long gone (confirmed against real jq:
+/// `[1,2,"x"]|map(.+1)?` is empty/exit-0 in jq, but errored/exit-5 here
+/// before this arm existed). `halt` is never caught here either way,
+/// matching `Control`'s own pass-through guarantee and the `other => other`
+/// wildcard's identical treatment of a bare `GenericResult::Halt`.
+fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
+    inner: &Expr,
+    catch: Option<&Expr>,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
+    let run_catch = |payload: &OwnedValue| -> GenericResult<V> {
+        match catch {
+            Some(catch_expr) => eval_each_owned_collect::<S, V>(catch_expr, payload, optional),
+            None => GenericResult::None,
+        }
+    };
+    match eval_single::<S, _>(inner, value, optional, cursor) {
+        GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
+        GenericResult::Error(e) => run_catch(&e.payload()),
+        GenericResult::Break(_) => run_catch(&OwnedValue::Null),
+        GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+            GenericResult::Partial(prefix, Control::Error(e))
+        }
+        GenericResult::Partial(prefix, Control::Error(e)) => {
+            prepend_generic(prefix, run_catch(&e.payload()))
+        }
+        GenericResult::Partial(prefix, Control::Break(_)) => {
+            prepend_generic(prefix, run_catch(&OwnedValue::Null))
+        }
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(owned) => GenericResult::Owned(owned),
+            Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
+            Err(Control::Error(e)) => run_catch(&e.payload()),
+            Err(Control::Break(_)) => run_catch(&OwnedValue::Null),
+            Err(Control::Halt(code)) => GenericResult::Halt(code),
+        },
+        other => other,
+    }
+}
+
 /// Evaluate a single expression against a value with optional cursor context.
 fn eval_single<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
@@ -4417,153 +4503,24 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // masked error inside a natively-evaluated `Pipe` fan-out look like
         // ordinary `empty`, so the fan-out wrongly kept going instead of
         // stopping (#693).
-        Expr::Optional(inner) => match eval_single::<S, _>(inner, value, optional, cursor) {
-            // A decode failure (#1247) must never be suppressed by `?`, any
-            // more than it's caught by `try`/`catch` -- jq's own equivalent
-            // is a parse-time rejection no program could ever catch either
-            // (#1620). Checked before the ordinary `Error`/`Break` catch
-            // below so it falls through to `other => other` instead.
-            GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
-            GenericResult::Error(_) | GenericResult::Break(_) => GenericResult::None,
-            // `prefix` is never empty here: `partial_generic` (and
-            // `eval::partial`, its mirror) already collapse an empty prefix
-            // to the bare `Error`/`Break` variant above before a `Partial`
-            // ever gets constructed (#400, #494) — the same invariant the
-            // unconditional `.next().unwrap()` elsewhere in this file (e.g.
-            // `eval_first_or_last_generic`) relies on.
-            // Routed through `collapse_vec` anyway (#1067), so a future
-            // change that ever violates the "never empty here" invariant
-            // above degrades to `None` instead of silently returning
-            // `ManyOwned(vec![])` -- mirrors `eval::prepend`, which
-            // `eval::eval_try`'s identical jq-mode arm calls into and which
-            // already routes its own prefix-collapse through
-            // `owned_vec_to_result`/`collapse_vec`.
-            //
-            // Same #1620 decode-failure exclusion as the bare `Error` arm
-            // above -- a `Partial` ending in a decode failure must still
-            // propagate uncaught, not collapse its prefix into `None`.
-            GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
-                GenericResult::Partial(prefix, Control::Error(e))
-            }
-            GenericResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => collapse_vec(
-                prefix,
-                || GenericResult::None,
-                GenericResult::Owned,
-                GenericResult::ManyOwned,
-            ),
-            // A `LazySeq` hasn't necessarily failed *yet* -- it's lazy, so
-            // it never matches the `Error`/`Break`/`Partial` arms above even
-            // when pulling it would fail (#724, #725). `E?` needs to know
-            // *now* whether `E` fails, so force it here -- same one-pass
-            // cost `materialize_atomic` already pays at every other
-            // materializing boundary in this file. Without this arm, `inner`
-            // falls through to `other => other` below and escapes this `?`
-            // entirely: the error only surfaces later, at whatever
-            // downstream site finally pulls the `LazySeq`, by which point
-            // this `try`/`catch` boundary is long gone (confirmed against
-            // real jq: `[1,2,"x"]|map(.+1)?` is empty/exit-0 in jq, but
-            // errored/exit-5 here before this arm existed).
-            GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-                Ok(owned) => GenericResult::Owned(owned),
-                // Same #1620 exclusion as above: a decode failure surfacing
-                // only once the `LazySeq` is forced must still propagate
-                // uncaught, checked before the ordinary `Error`/`Break`
-                // catch right below.
-                Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
-                Err(Control::Error(_) | Control::Break(_)) => GenericResult::None,
-                // Unlike `Error`/`Break` just above, `?` must NOT catch a
-                // `halt` (verified against real jq: `("x"|halt_error)? //
-                // "fallback"` still exits 5, it does not fall back) — so this
-                // deliberately does not join the caught pattern; it
-                // propagates instead, mirroring how the `other => other`
-                // wildcard below already lets a bare `GenericResult::Halt`
-                // (and a `Partial` ending in `Control::Halt`) pass through
-                // uncaught.
-                Err(Control::Halt(code)) => GenericResult::Halt(code),
-            },
-            other => other,
-        },
+        // `E?` is `try E` with no catch handler -- see `try_single_generic`'s
+        // own doc comment for the full dispatch this delegates to.
+        Expr::Optional(inner) => try_single_generic::<S, V>(inner, None, value, optional, cursor),
 
-        // `try EXPR catch HANDLER` (#1812): mirrors `Expr::Optional` above
-        // exactly (same dispatch, same #1620 decode-failure exclusion, same
-        // `LazySeq`-forcing arm), but instead of collapsing a caught
-        // `Error`/`Break` to `None`, runs `catch` (if any) against the
-        // raised payload -- `null` for `Break` (#562), matching
-        // `eval::eval_try`'s identical jq-mode arm, which this is the
-        // cursor-native twin of. Without this arm, `Expr::Try` fell to the
-        // wildcard bridge below, which materializes the ambient value via
+        // `try EXPR catch HANDLER` (#1812) -- see `try_single_generic`'s own
+        // doc comment. Without this arm, `Expr::Try` fell to the wildcard
+        // bridge below, which materializes the ambient value via
         // `owned_or_err!` *before* ever reaching `full_eval`'s own
-        // catchability-aware `eval_try` -- an uncatchable-by-design error
-        // (a decode failure) was already correctly uncaught either way, but
-        // a genuinely catchable one (e.g. a #1194 malformed-key error) was
+        // catchability-aware `eval_try` -- an uncatchable-by-design error (a
+        // decode failure) was already correctly uncaught either way, but a
+        // genuinely catchable one (e.g. a #1194 malformed-key error) was
         // wrongly left uncaught too, since `owned_or_err!` has no
         // catchability check of its own at all. Confirmed live: `sort?` on
-        // `{123: 1}` already suppressed cleanly (routes through this same
-        // `Expr::Optional` arm's own `Error` case), while `try (1+1) catch
-        // "x"` raised uncaught before this fix.
+        // `{123: 1}` already suppressed cleanly (`Expr::Optional`'s own
+        // `Error` case), while `try (1+1) catch "x"` raised uncaught before
+        // this fix.
         Expr::Try { expr: inner, catch } => {
-            match eval_single::<S, _>(inner, value, optional, cursor) {
-                GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
-                GenericResult::Error(e) => match catch {
-                    Some(catch_expr) => {
-                        eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
-                    }
-                    None => GenericResult::None,
-                },
-                GenericResult::Break(_) => match catch {
-                    Some(catch_expr) => {
-                        eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
-                    }
-                    None => GenericResult::None,
-                },
-                GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
-                    GenericResult::Partial(prefix, Control::Error(e))
-                }
-                GenericResult::Partial(prefix, Control::Error(e)) => {
-                    let handled = match catch {
-                        Some(catch_expr) => {
-                            eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
-                        }
-                        None => GenericResult::None,
-                    };
-                    prepend_generic(prefix, handled)
-                }
-                GenericResult::Partial(prefix, Control::Break(_)) => {
-                    let handled = match catch {
-                        Some(catch_expr) => {
-                            eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
-                        }
-                        None => GenericResult::None,
-                    };
-                    prepend_generic(prefix, handled)
-                }
-                // Same reasoning as `Expr::Optional`'s own `LazySeq` arm: `try`
-                // needs to know *now* whether `inner` fails, so force it here
-                // rather than letting the failure surface only once some later
-                // consumer finally pulls the still-lazy sequence, long after
-                // this `try`/`catch` boundary is gone.
-                GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-                    Ok(owned) => GenericResult::Owned(owned),
-                    Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
-                    Err(Control::Error(e)) => match catch {
-                        Some(catch_expr) => {
-                            eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
-                        }
-                        None => GenericResult::None,
-                    },
-                    Err(Control::Break(_)) => match catch {
-                        Some(catch_expr) => {
-                            eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
-                        }
-                        None => GenericResult::None,
-                    },
-                    // `try`/`catch` never catches a `halt`, matching
-                    // `Expr::Optional`'s identical `Err(Control::Halt(code))`
-                    // arm and `Control`'s own pass-through guarantee.
-                    Err(Control::Halt(code)) => GenericResult::Halt(code),
-                },
-                other => other,
-            }
+            try_single_generic::<S, V>(inner, catch.as_deref(), value, optional, cursor)
         }
 
         // Parens are transparent to cursor-based evaluation: handled natively

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1734,6 +1734,46 @@ fn owned_vec_to_generic_result<V: DocumentValue>(vs: Vec<OwnedValue>) -> Generic
     )
 }
 
+/// Splice `prefix` in front of whatever `result` yields (#1812) -- the
+/// `eval_single`/`GenericResult` twin of [`super::eval::prepend`], used by
+/// `Expr::Try`'s own arm above the same way `eval::eval_try` uses its
+/// mirror: the body's outputs before an error/break, then the catch
+/// handler's own result spliced in after them.
+///
+/// `result` here is always [`eval_each_owned_collect`]'s own return value,
+/// whose contract (`owned_vec_to_generic_result`/`partial_generic`, both
+/// called there) only ever produces `None`/`Owned`/`ManyOwned`/`Error`/
+/// `Break`/`Halt`/`Partial` -- never `One`/`OneCursor`/`Many`/`ManyCursor`/
+/// a lazy variant, so this covers exactly that set rather than
+/// `GenericResult`'s full one.
+fn prepend_generic<V: DocumentValue>(
+    mut prefix: Vec<OwnedValue>,
+    result: GenericResult<V>,
+) -> GenericResult<V> {
+    if prefix.is_empty() {
+        return result;
+    }
+    match result {
+        GenericResult::None => owned_vec_to_generic_result(prefix),
+        GenericResult::Owned(v) => {
+            prefix.push(v);
+            owned_vec_to_generic_result(prefix)
+        }
+        GenericResult::ManyOwned(vs) => {
+            prefix.extend(vs);
+            owned_vec_to_generic_result(prefix)
+        }
+        GenericResult::Error(e) => partial_generic(prefix, Control::Error(e)),
+        GenericResult::Break(label) => partial_generic(prefix, Control::Break(label)),
+        GenericResult::Halt(code) => partial_generic(prefix, Control::Halt(code)),
+        GenericResult::Partial(more, control) => {
+            prefix.extend(more);
+            partial_generic(prefix, control)
+        }
+        other => other,
+    }
+}
+
 /// Evaluate `expr` against `input` through `eval.rs`'s demand-driven
 /// `eval_each_owned`, collecting every output instead of stopping after the
 /// first (that's [`each_take_first_generic`]'s job). This is what lets a
@@ -4443,6 +4483,88 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             },
             other => other,
         },
+
+        // `try EXPR catch HANDLER` (#1812): mirrors `Expr::Optional` above
+        // exactly (same dispatch, same #1620 decode-failure exclusion, same
+        // `LazySeq`-forcing arm), but instead of collapsing a caught
+        // `Error`/`Break` to `None`, runs `catch` (if any) against the
+        // raised payload -- `null` for `Break` (#562), matching
+        // `eval::eval_try`'s identical jq-mode arm, which this is the
+        // cursor-native twin of. Without this arm, `Expr::Try` fell to the
+        // wildcard bridge below, which materializes the ambient value via
+        // `owned_or_err!` *before* ever reaching `full_eval`'s own
+        // catchability-aware `eval_try` -- an uncatchable-by-design error
+        // (a decode failure) was already correctly uncaught either way, but
+        // a genuinely catchable one (e.g. a #1194 malformed-key error) was
+        // wrongly left uncaught too, since `owned_or_err!` has no
+        // catchability check of its own at all. Confirmed live: `sort?` on
+        // `{123: 1}` already suppressed cleanly (routes through this same
+        // `Expr::Optional` arm's own `Error` case), while `try (1+1) catch
+        // "x"` raised uncaught before this fix.
+        Expr::Try { expr: inner, catch } => {
+            match eval_single::<S, _>(inner, value, optional, cursor) {
+                GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
+                GenericResult::Error(e) => match catch {
+                    Some(catch_expr) => {
+                        eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
+                    }
+                    None => GenericResult::None,
+                },
+                GenericResult::Break(_) => match catch {
+                    Some(catch_expr) => {
+                        eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
+                    }
+                    None => GenericResult::None,
+                },
+                GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+                    GenericResult::Partial(prefix, Control::Error(e))
+                }
+                GenericResult::Partial(prefix, Control::Error(e)) => {
+                    let handled = match catch {
+                        Some(catch_expr) => {
+                            eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
+                        }
+                        None => GenericResult::None,
+                    };
+                    prepend_generic(prefix, handled)
+                }
+                GenericResult::Partial(prefix, Control::Break(_)) => {
+                    let handled = match catch {
+                        Some(catch_expr) => {
+                            eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
+                        }
+                        None => GenericResult::None,
+                    };
+                    prepend_generic(prefix, handled)
+                }
+                // Same reasoning as `Expr::Optional`'s own `LazySeq` arm: `try`
+                // needs to know *now* whether `inner` fails, so force it here
+                // rather than letting the failure surface only once some later
+                // consumer finally pulls the still-lazy sequence, long after
+                // this `try`/`catch` boundary is gone.
+                GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+                    Ok(owned) => GenericResult::Owned(owned),
+                    Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
+                    Err(Control::Error(e)) => match catch {
+                        Some(catch_expr) => {
+                            eval_each_owned_collect::<S, V>(catch_expr, &e.payload(), optional)
+                        }
+                        None => GenericResult::None,
+                    },
+                    Err(Control::Break(_)) => match catch {
+                        Some(catch_expr) => {
+                            eval_each_owned_collect::<S, V>(catch_expr, &OwnedValue::Null, optional)
+                        }
+                        None => GenericResult::None,
+                    },
+                    // `try`/`catch` never catches a `halt`, matching
+                    // `Expr::Optional`'s identical `Err(Control::Halt(code))`
+                    // arm and `Control`'s own pass-through guarantee.
+                    Err(Control::Halt(code)) => GenericResult::Halt(code),
+                },
+                other => other,
+            }
+        }
 
         // Parens are transparent to cursor-based evaluation: handled natively
         // (like `Expr::Optional` above) so `(.)` and friends keep threading

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -24918,6 +24918,95 @@ fn test_ordinary_type_error_still_suppressed_and_caught_1620() {
     assert_eq!(stdout.trim(), r#""caught""#);
 }
 
+/// #1812: `eval_generic.rs`'s `eval_single` had no native `Expr::Try` arm,
+/// so it fell to the wildcard fallback, which materializes the ambient
+/// value via `owned_or_err!` *before* ever reaching `full_eval`'s own
+/// catchability-aware dispatch -- no catchability check at all. A #1194
+/// malformed (non-string) object key raised there uncaught, even though
+/// `?` (which does have a native, catchability-aware `Expr::Optional` arm)
+/// already suppressed the identical error correctly. Confirmed live
+/// against unmodified `main` before this fix: `sort?` on `{123: 1}`
+/// succeeded silently while `try (1+1) catch "x"` raised uncaught, exit 5.
+#[test]
+fn test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812() -> Result<()> {
+    let doc = "{123: 1}";
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "sort?"], Some(doc))?;
+    assert_eq!((stdout.as_str(), code), ("", 0), "stderr: {stderr}");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"try (1+1) catch "x""#], Some(doc))?;
+    assert_eq!((stdout.as_str(), code), ("\"x\"\n", 0), "stderr: {stderr}");
+
+    // Bare `try`, no `catch` handler: suppresses to no output, same as `?`.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "try (1+1)"], Some(doc))?;
+    assert_eq!((stdout.as_str(), code), ("", 0), "stderr: {stderr}");
+
+    Ok(())
+}
+
+/// #1812 companion: the new `Expr::Try` arm's `Partial`-prefix handling
+/// (outputs produced before the error, then the catch handler's own result
+/// spliced in after them) still matches jq exactly for an *ordinary*,
+/// already-catchable error -- not just the newly-fixed #1194 case above.
+/// Oracle-verified against jq 1.7.1.
+#[test]
+fn test_try_catch_prefix_then_catch_result_matches_jq_1812() -> Result<()> {
+    for (filter, want) in [
+        (r#"try (1,2,error("x")) catch "c""#, "1\n2\n\"c\"\n"),
+        (r#"try error("boom") catch ."#, "\"boom\"\n"),
+        // The label must sit *outside* the `try` -- a `break` whose own
+        // enclosing `label` is inside the `try` never escapes it at all
+        // (the label catches its own break first), so `try`/`catch` never
+        // even sees it. Oracle-verified: `try (label $out | break $out)
+        // catch "caught"` is empty/exit-0 in both jq and succinctly, not
+        // `"caught"`.
+        (
+            r#"label $out | try (break $out) catch "caught""#,
+            "\"caught\"\n",
+        ),
+        (
+            r#"[label $out | try (1,2,break $out) catch "c"]"#,
+            "[1,2,\"c\"]\n",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #1812 companion: `try`/`catch` must still never catch a `halt`, matching
+/// `Expr::Optional`'s identical exclusion and `Control::Halt`'s own
+/// pass-through guarantee.
+#[test]
+fn test_try_catch_still_does_not_catch_halt_1812() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"try halt_error(7) catch "x""#], Some("null"))?;
+    assert_eq!(code, 7, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #1812 companion: a `LazySeq` (`map(f)`) that fails only once forced must
+/// still be caught -- mirrors `Expr::Optional`'s identical `LazySeq`-forcing
+/// arm, now exercised through `try`/`catch` too.
+#[test]
+fn test_try_catch_forces_and_catches_a_lazyseq_failure_1812() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"[try (map(.+1) | .[]) catch "c"]"#],
+        Some(r#"[1,"x",3]"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"c\"]\n", 0),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 /// #1194 (the half in #1247's scope): a *structurally* malformed value --
 /// one the semi-index accepted as a span but could not classify as any JSON
 /// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`


### PR DESCRIPTION
## Summary

`eval_generic.rs`'s `eval_single` had no native arm for `Expr::Try`, so it fell to the wildcard fallback, which materializes the ambient value via `owned_or_err!(to_owned_with_cursor(&value, cursor))` *before* ever reaching `full_eval`'s own catchability-aware `try`/`catch` dispatch. `owned_or_err!` is an unconditional early return on `Err` with no catchability check at all — unlike `Expr::Optional`'s own existing native arm, which already gates correctly.

## The issue's own repro is stale — found a fresh one instead

The issue's original repro used a #1642 colliding-display-key collision error. That specific case no longer demonstrates the asymmetry: `#1620`'s own decode-failure exclusion now correctly applies to `?` too, so both `sort?` and `try/catch` already refuse to suppress that error class — by design, matching real jq's own "parse-time rejection no program could ever catch" equivalent.

Verified this live before implementing anything, then found a fresh, still-reproducing example: a **#1194 malformed (non-string) object key** is a genuinely *catchable* error, and `sort?` already suppresses it correctly via `Expr::Optional`'s gated arm — but `try/catch` did not:

```console
$ echo '{123: 1}' | succinctly jq -c 'sort?'
                                                    # suppressed correctly, exit 0
$ echo '{123: 1}' | succinctly jq -c 'try (1+1) catch "x"'
jq: error (at <stdin>:0): Invalid JSON text: expected string key, found '1'
                                                    # NOT caught, exit 5 (the real bug)
```

## Fix

Add a native `Expr::Try { expr, catch }` arm to `eval_single`, mirroring `Expr::Optional`'s existing dispatch exactly:
- Same `#1620` decode-failure exclusion (checked before the ordinary `Error`/`Break` catch, so it still falls through uncaught).
- Same `LazySeq`-forcing arm (a `map(f)` failure not yet materialized needs to be forced now, since a `try`/`catch` boundary needs to know immediately whether it fails).
- Instead of collapsing a caught `Error`/`Break` to `None` (bare `?`'s behavior), runs the `catch` handler (if any) against the raised payload — `null` for `Break` (#562) — via the already-existing `eval_each_owned_collect` primitive.

Also adds `prepend_generic`, the `GenericResult` counterpart of `eval::prepend`, to splice a `Partial` result's already-produced output prefix in front of the catch handler's own result — `try (1,2,error("x")) catch "c"` yields `1`, `2`, `"c"`, matching jq exactly.

This is the cursor-native twin of `eval.rs`'s own `eval_try`/`Expr::Try` handling, which the issue itself names as already correct — the fix ports that same logic into `eval_generic.rs`'s parallel evaluator rather than inventing new semantics.

## Verification

Live-verified against jq 1.7.1 across: an ordinary catchable error (with and without a partial output prefix), `break` correctly escaping to an *outer* label (a `break` whose own `label` sits inside the `try` never escapes at all — jq and succinctly agree), `halt` staying uncaught, and a `LazySeq` (`map(f)`) failure forced and caught. All byte-for-byte identical.

## Test plan

- [x] New tests: the fresh #1194 repro, ordinary-error/break/partial-prefix splicing, halt exclusion, and `LazySeq`-forcing — all oracle-verified.
- [x] Existing `#1620` regression tests (`test_decode_failure_not_caught_by_try_catch_1620`, `test_decode_failure_not_suppressed_by_optional_1620`, `test_ordinary_type_error_still_suppressed_and_caught_1620`) still pass unmodified.
- [x] Full test suite (`cargo test --features cli,simd,regex,serde --no-fail-fast`): 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and CI's second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): both clean.
- [x] `cargo fmt --check`: clean.

Fixes #1812