### PR TITLE
fix(jq): guard eval_as/eval_reduce/eval_foreach's decode-failure sweep

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3216,10 +3216,20 @@ fn each_label<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn materialize_bound_values<W: Clone + AsRef<[u64]>>(
     bound_result: QueryResult<'_, W>,
 ) -> Result<(Vec<OwnedValue>, Option<Control>), Flow> {
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- the
+    // lazy twin of the same bug `eval_as`'s own bound-value conversion had.
+    // A checked-conversion failure folds into the trailing control exactly
+    // like an ordinary `Partial`'s control (the `Partial` arm below).
     match bound_result.materialize_cursor() {
-        QueryResult::One(v) => Ok((vec![to_owned(&v)], None)),
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(v) => Ok((vec![v], None)),
+            Err(e) => Ok((Vec::new(), Some(Control::Error(e)))),
+        },
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
-        QueryResult::Many(vs) => Ok((vs.iter().map(to_owned).collect(), None)),
+        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+            Ok(vs) => Ok((vs, None)),
+            Err((prefix, e)) => Ok((prefix, Some(Control::Error(e)))),
+        },
         QueryResult::Owned(v) => Ok((vec![v], None)),
         QueryResult::ManyOwned(vs) => Ok((vs, None)),
         QueryResult::None => Err(Flow::Exhausted),
@@ -25913,19 +25923,42 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => (Vec::new(), None),
-            // Same missing-guard fix as the source stream above, mirroring
-            // `eval_reduce`'s INIT handling.
-            QueryResult::Error(_) if optional => return QueryResult::None,
-            QueryResult::Error(e) => return QueryResult::Error(e),
-            QueryResult::Break(label) => return QueryResult::Break(label),
+            // #1902 review: routed through `finish_fork` (not a bare
+            // `return`) so `input_control` -- evaluated earlier than INIT,
+            // per the source order above -- isn't silently dropped if it
+            // also holds a control (most importantly a decode failure,
+            // which `finish_fork` never suppresses regardless of
+            // `optional`). Same precedence as the fork loop's own
+            // `aborted.or_else(|| input_control.clone())` below.
+            QueryResult::Error(e) => {
+                return finish_fork(
+                    Vec::new(),
+                    input_control.or(Some(Control::Error(e))),
+                    optional,
+                )
+            }
+            QueryResult::Break(label) => {
+                return finish_fork(
+                    Vec::new(),
+                    input_control.or(Some(Control::Break(label))),
+                    optional,
+                )
+            }
             QueryResult::Halt(code) => return QueryResult::Halt(code),
             QueryResult::Partial(vs, control) => (vs, Some(control)),
         };
 
     // Same hoist as `eval_reduce`: skipped entirely when there are no
     // INIT forks to consume it.
+    //
+    // #1902 review: with zero forks to run, `input_control` (which can now
+    // carry a decode failure, per this function's own checked conversion
+    // above) never gets the chance the loop below gives it via
+    // `aborted.or_else(|| input_control.clone())` -- surface it here
+    // first, same precedence, so a corrupted `input` doesn't go silently
+    // unnoticed just because INIT happened to produce nothing.
     if init_values.is_empty() {
-        return finish_fork(Vec::new(), init_control, optional);
+        return finish_fork(Vec::new(), input_control.clone().or(init_control), optional);
     }
 
     // Every name any alternative could bind (#1365) -- same convention as
@@ -26240,9 +26273,12 @@ fn eval_until<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // #1755: to_owned_checked, not to_owned -- an undecodable starting
-    // value must raise unconditionally, before it ever reaches
-    // `finish_fork`'s own `Some(Control::Error(_)) if optional` arm,
-    // which would otherwise silently suppress it.
+    // value must raise unconditionally, matching this crate's own
+    // "decode failure is never suppressed by `?`" rule directly rather
+    // than relying on ever reaching `finish_fork` (which #1902 also made
+    // exempt decode failures from its own `optional` suppression, but
+    // that's this comment's own sibling function, not a guarantee this
+    // early return depends on).
     let initial = match to_owned_checked(&value) {
         Ok(v) => v,
         Err(e) => return QueryResult::Error(e),
@@ -36850,11 +36886,23 @@ fn eval_as_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // A `Partial` bind expression (#400, #494) still has its produced prefix
     // destructured and run through the body below, same as `eval_as`; the
     // bind's own control is held until that loop has run its course.
+    //
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- the
+    // destructuring twin of the same bug `eval_as`'s own bound-value
+    // conversion had (`. as [$a] | ...`/`. as {k: $a} | ...`, not just
+    // `. as $a | ...`). A checked-conversion failure folds into
+    // `bound_control` exactly like an ordinary `Partial`'s control.
     let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
         match bound_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => return QueryResult::None,
@@ -40685,9 +40733,14 @@ mod tests {
             "reduce .[] as $x (0; . + 1)",
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
+        // Review: `[.]` (array construction) already raises via its own
+        // pre-existing #1755 check before `eval_reduce`'s own INIT
+        // conversion ever sees a `One`/`Many` shape to convert -- bare `.`
+        // (still lazy, not yet decoded) is the genuine repro for this
+        // function's own new `QueryResult::One` arm.
         query!(
             b"\"\xff\xfe\"",
-            "reduce (1,2) as $x ([.]; . + [$x])",
+            "reduce (1,2) as $x (.; . + [$x])",
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
     }
@@ -40704,9 +40757,24 @@ mod tests {
             "[foreach .[] as $x (0; . + 1)]",
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
+        // Review: the `[...]`-wrapped assertion above collapses a
+        // `Partial` prefix into a bare `Error` on its own, which cannot
+        // distinguish "prefix retained" from "prefix dropped". Unwrapped,
+        // this pins the doc comment's actual claim: `1`'s real output
+        // survives ahead of the terminal decode failure.
+        query!(
+            b"[1, \"\xff\xfe\"]",
+            "foreach .[] as $x (0; . + 1)",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.is_decode_failure());
+            }
+        );
+        // Same `[.]` -> bare `.` correction as `eval_reduce`'s equivalent
+        // test above.
         query!(
             b"\"\xff\xfe\"",
-            "[foreach (1,2) as $x ([.]; . + [$x])]",
+            "[foreach (1,2) as $x (.; . + [$x])]",
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
     }
@@ -40716,7 +40784,7 @@ mod tests {
     #[test]
     fn test_eval_as_reduce_foreach_valid_data_unaffected_1902() {
         query!(br#"{"a":"x","b":5}"#, "(.a, .b) as $v | $v",
-            QueryResult::Partial(vs, Control::Halt(_)) | QueryResult::ManyOwned(vs) => {
+            QueryResult::ManyOwned(vs) => {
                 assert_eq!(vs, vec![OwnedValue::String("x".to_string()), OwnedValue::Int(5)]);
             }
         );
@@ -40730,11 +40798,92 @@ mod tests {
         );
     }
 
+    /// #1902 review: `eval_as`'s eager bound-value fix has three siblings
+    /// sharing the identical unpacking shape that were initially missed --
+    /// `materialize_bound_values` (the lazy twin backing `first`/`limit`/
+    /// `isempty` over an `as` bind, via `each_as`) and `eval_as_pattern`
+    /// (the destructuring spelling, `. as [$v] | ...` / `. as {k:$v} | ...`)
+    /// -- confirmed live during review to still silently substitute `""`
+    /// after the initial fix, since `.a as $v | $v` alone doesn't exercise
+    /// either path.
+    #[test]
+    fn test_eval_as_lazy_and_destructuring_siblings_raise_on_decode_failure_1902() {
+        // `each_as`, via `first`'s lazy sink -- `materialize_bound_values`'s
+        // `QueryResult::One` arm.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "first(.a as $v | $v)",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // `each_as`, via `limit`'s lazy sink.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[limit(1; .a as $v | $v)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // `each_as`, via `isempty`'s lazy sink.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "isempty(.a as $v | $v)",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // `eval_as_pattern`: array-destructuring bind.
+        query!(
+            b"{\"arr\": [\"\xff\xfe\"]}",
+            ".arr as [$v] | $v",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // `eval_as_pattern`: object-destructuring bind.
+        query!(
+            b"{\"obj\": {\"k\": \"\xff\xfe\"}}",
+            ".obj as {k: $v} | $v",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
+    /// #1902 review: `eval_foreach`'s `init_values.is_empty()` early return
+    /// used to hand `finish_fork` only `init_control`, dropping
+    /// `input_control` (and the decode failure it can now carry) entirely
+    /// whenever INIT produces nothing -- confirmed live during review:
+    /// `reduce`'s equivalent already raised unconditionally (its `input`
+    /// never depends on INIT), so the two constructs disagreed on the same
+    /// input.
+    #[test]
+    fn test_eval_foreach_input_control_not_dropped_when_init_is_empty_1902() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[foreach .a as $x (empty; . + 1)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // Positive control: a genuinely empty INIT with valid input still
+        // correctly produces no output and no error.
+        query!(
+            br#"{"a": "x"}"#,
+            "[foreach .a as $x (empty; . + 1)]",
+            QueryResult::Owned(OwnedValue::Array(vs)) => assert_eq!(vs, Vec::<OwnedValue>::new())
+        );
+        // Same class of bug, different trigger: INIT's own bare `Error`
+        // (not "produced nothing") used to `return` immediately, dropping
+        // `input_control` the same way -- `try (...) catch "C"` proved it
+        // catchable before this fix, since the decode failure never
+        // reached `finish_fork`'s own uncatchable-for-decode-failure logic.
+        query!(
+            b"{\"arr\": [\"\xff\xfe\"]}",
+            "[foreach .arr[] as $x (error(\"boom\"); . + 1)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        query!(
+            b"{\"arr\": [\"\xff\xfe\"]}",
+            "try ([foreach .arr[] as $x (error(\"boom\"); . + 1)]) catch \"CAUGHT\"",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
     /// #1902: the `QueryResult::One` (single, not multi-output) arms of
     /// each of the three fixed sites, plus the `Many` partial-prefix arms
-    /// -- the sweep test above only ever hit the `Many`-with-empty-prefix
-    /// shape, since the corrupted value was always first in a 2-element
-    /// stream.
+    /// on the *INIT* side specifically -- the sweep test above only
+    /// exercises `input`'s own `Many` arm with a non-empty prefix (the
+    /// corrupted value there is second), but never INIT's.
     #[test]
     fn test_eval_as_reduce_foreach_single_and_partial_prefix_shapes_1902() {
         // eval_as: bound-value conversion, `QueryResult::One` arm.
@@ -40768,16 +40917,20 @@ mod tests {
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
         // eval_reduce: INIT, `QueryResult::Many` arm with a non-empty
-        // prefix -- `.arr[]` (`Expr::Iterate`) reaches `eval_reduce`'s own
-        // `materialize_cursor()` as one un-promoted `Many` of borrowed
-        // cursors (unlike a comma of separate sub-expressions, which
-        // `eval_comma`'s own #1832 promotion would already have converted
-        // -- and already caught the decode failure on -- before it ever
-        // reaches here). INIT's first element (`0`) succeeds before its
-        // second (corrupted) fails; the fork over the successfully
-        // converted `0` still completes and contributes its own real
-        // output (`1`) before the decode failure surfaces as
-        // `finish_fork`'s trailing control.
+        // prefix -- `.arr[]` (`Expr::Iterate`) is a single expression that
+        // reaches `eval_reduce`'s own `materialize_cursor()` directly as
+        // one `Many` of still-borrowed cursors, isolating this function's
+        // own conversion from any other combinator's. (A homogeneous
+        // borrowed comma like `(.a, .b)` would reach here the same
+        // un-promoted way too -- `eval_comma`'s own #1832 promotion only
+        // triggers once an `Owned`/`ManyOwned` sibling forces the whole
+        // batch out of its lazy state, per `push_promoted`'s own doc
+        // comment -- `.arr[]` is just the more direct repro of the same
+        // shape.) INIT's first element (`0`) succeeds before its second
+        // (corrupted) fails; the fork over the successfully converted `0`
+        // still completes and contributes its own real output (`1`)
+        // before the decode failure surfaces as `finish_fork`'s trailing
+        // control.
         query!(
             b"{\"arr\": [0, \"\xff\xfe\"]}",
             "reduce 1 as $x (.arr[]; . + $x)",
@@ -40826,20 +40979,53 @@ mod tests {
         );
     }
 
-    /// #1902: `finish_fork`'s own fix -- an *ordinary* trailing error is
-    /// still suppressed by an ambient `optional`, unlike a decode failure.
-    /// `reduce`/`foreach` don't have direct `EXPR?` surface on their own
-    /// input/INIT sub-expressions, so this drives `optional` in through the
-    /// `?`-suffixed builtin argument path (`limit`'s generator argument),
-    /// which routes through `eval_single(..., optional)` the same way
-    /// `eval_reduce`/`eval_foreach`'s own input/INIT calls do.
+    /// #1902 review: the fixed `finish_fork` guard (`optional &&
+    /// !e.is_decode_failure()`) is exercised here by calling the function
+    /// directly, not through a parsed query -- verified live that no
+    /// current jq/yq syntax reaches `finish_fork` with `optional == true`
+    /// (post-#693, `Expr::Optional` forwards the *ambient* optional rather
+    /// than forcing `true`; the only two call sites that force `true`,
+    /// `.[EXPR]?`/`.[S:E]?`, hard-code `false` for their own sub-expression
+    /// evaluations, so it never reaches this deep). Same "live-unreachable
+    /// today, pinned against the function's own contract regardless"
+    /// precedent as `eval_rs_delpaths_decode_failure_bypasses_optional_1746`
+    /// above. An earlier version of this test used a parsed
+    /// `(reduce ... )?` query and appeared to pass, but its `QueryResult::None`
+    /// actually came from `eval_try`'s own independent catch one layer up
+    /// (with `optional == false` reaching `finish_fork`) -- confirmed by
+    /// reverting the `finish_fork` guard entirely and finding the whole
+    /// suite still green, which is exactly the false-coverage this direct
+    /// call closes.
     #[test]
-    fn test_finish_fork_still_suppresses_ordinary_error_under_optional_1902() {
-        query!(
-            br"0",
-            "(reduce (1, error(\"boom\")) as $x (0; . + $x))?",
-            QueryResult::None => {}
-        );
+    fn test_finish_fork_ordinary_error_suppressed_decode_failure_is_not_1902() {
+        let ordinary = EvalError::new("boom");
+        assert!(!ordinary.is_decode_failure());
+        match finish_fork::<Vec<u64>>(
+            vec![OwnedValue::Int(1)],
+            Some(Control::Error(ordinary)),
+            true,
+        ) {
+            // A single-element `outputs` collapses to `Owned` (not an
+            // `Array`), matching `owned_vec_to_result`'s own collapse rule.
+            QueryResult::Owned(v) => assert_eq!(v, OwnedValue::Int(1)),
+            other => {
+                panic!("expected the ordinary error suppressed under optional, got: {other:?}")
+            }
+        }
+
+        let decode_failure = EvalError::decode_failure("invalid UTF-8 in string");
+        assert!(decode_failure.is_decode_failure());
+        match finish_fork::<Vec<u64>>(
+            vec![OwnedValue::Int(1)],
+            Some(Control::Error(decode_failure)),
+            true,
+        ) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.is_decode_failure());
+            }
+            other => panic!("expected the decode failure to survive optional, got: {other:?}"),
+        }
     }
 
     /// #1755: the "misc bucket" slice -- `INDEX`/`INDEX(stream;...)`,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2425,7 +2425,14 @@ fn finish_fork<'a, W>(
 ) -> QueryResult<'a, W> {
     match control {
         None => owned_vec_to_result(outputs),
-        Some(Control::Error(_)) if optional => owned_vec_to_result(outputs),
+        // #1902: a decode failure (#1620) is never silenced by an ambient
+        // `optional`, unlike an ordinary trailing error -- matches
+        // `finish_fork_generic`'s identical guard in `eval_generic.rs`,
+        // whose own doc comment already claimed to mirror this function;
+        // this one had drifted from it.
+        Some(Control::Error(ref e)) if optional && !e.is_decode_failure() => {
+            owned_vec_to_result(outputs)
+        }
         Some(control) => partial(outputs, control),
     }
 }
@@ -25004,11 +25011,23 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `(1,2,error("x")) as $v | $v + 10` is `11`, `12`, then the error — so
     // the bind expression's own control is held until that loop over its
     // prefix has run its course.
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- an
+    // undecodable bound value used to silently become `""` here instead of
+    // raising. A checked-conversion failure is folded into `bound_control`
+    // exactly like an ordinary `Partial`'s control (the comment above): the
+    // already-converted prefix still runs through the body below before
+    // the decode failure surfaces as the terminal control.
     let (bound_values, bound_control): (Vec<OwnedValue>, Option<Control>) =
         match bound_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => return QueryResult::None,
@@ -25024,9 +25043,27 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for bound_val in bound_values {
         let substituted_body = substitute_bound_var(expr, body, var, &bound_val);
         match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
-            QueryResult::One(v) => all_results.push(to_owned(&v)),
+            // #1902: to_owned_checked/promote_borrowed_checked, not
+            // to_owned -- an undecodable body output used to silently
+            // become `""` and join `all_results` instead of raising,
+            // which also let a *later* bound value's ordinary error
+            // (e.g. `error("boom")`) wrongly win over an *earlier* bound
+            // value's decode failure -- returning here immediately, before
+            // any later bound value's own body ever runs, restores the
+            // "earlier undecodable value preempts a later competing
+            // signal" ordering #1832 already established elsewhere.
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => all_results.push(v),
+                Err(e) => return partial(all_results, Control::Error(e)),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => all_results.extend(vs.iter().map(to_owned)),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => all_results.extend(vs),
+                Err((prefix, e)) => {
+                    all_results.extend(prefix);
+                    return partial(all_results, Control::Error(e));
+                }
+            },
             QueryResult::Owned(v) => all_results.push(v),
             QueryResult::ManyOwned(vs) => all_results.extend(vs),
             QueryResult::None => {}
@@ -25195,10 +25232,21 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate input to get the stream of values
     let input_result = eval_single::<W, S>(input, value.clone(), optional);
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- an
+    // undecodable input element used to silently become `""` instead of
+    // raising. A decode failure is never suppressed by `optional` (#1620),
+    // matching the "drop the prefix, propagate unconditionally" policy the
+    // comment below already applies to an ordinary `Partial` error.
     let input_values: Vec<OwnedValue> = match input_result.materialize_cursor() {
-        QueryResult::One(v) => vec![to_owned(&v)],
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(v) => vec![v],
+            Err(e) => return QueryResult::Error(e),
+        },
         QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => vs.iter().map(to_owned).collect(),
+        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+            Ok(vs) => vs,
+            Err((_, e)) => return QueryResult::Error(e),
+        },
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => Vec::new(),
@@ -25223,11 +25271,23 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // INIT stream still forks over the prefix it did produce, mirroring
     // `eval_reduce`'s own optional-aware policy on its `input` stream above.
     let init_result = eval_single::<W, S>(init, value.clone(), optional);
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- a
+    // checked-conversion failure folds into `init_control` exactly like an
+    // ordinary `Partial`'s control (the already-converted prefix still
+    // forks below before the decode failure surfaces as the terminal
+    // control via `finish_fork`, which #1902 also fixed to never suppress
+    // a decode failure under `optional`).
     let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
         match init_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => (Vec::new(), None),
@@ -25802,11 +25862,22 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // .+$v)` emits `1`, `3` before erroring — the input stream's own control
     // is held until the loop over that prefix has run its course.
     let input_result = eval_single::<W, S>(input, value.clone(), optional);
+    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- a
+    // checked-conversion failure folds into `input_control` exactly like an
+    // ordinary `Partial`'s control (the comment above): the already-decoded
+    // prefix is still iterated below before the decode failure surfaces as
+    // the terminal control.
     let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
         match input_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => (Vec::new(), None),
@@ -25827,11 +25898,18 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (1,2) as $x ((10,20); .+$x)]` is `[11,13,21,23]`, the concatenation of
     // one independent run per INIT output.
     let init_result = eval_single::<W, S>(init, value.clone(), optional);
+    // #1902: same checked-conversion treatment as `input_values` above.
     let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
         match init_result.materialize_cursor() {
-            QueryResult::One(v) => (vec![to_owned(&v)], None),
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
             QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => (vs.iter().map(to_owned).collect(), None),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
             QueryResult::Owned(v) => (vec![v], None),
             QueryResult::ManyOwned(vs) => (vs, None),
             QueryResult::None => (Vec::new(), None),
@@ -40563,6 +40641,93 @@ mod tests {
             QueryResult::Error(e) => assert!(e.is_decode_failure()),
             other => panic!("unexpected result: {other:?}"),
         }
+    }
+
+    /// #1902: `eval_as`'s bound-value conversion used to silently substitute
+    /// `""` for an undecodable bound value instead of raising. The
+    /// corrupted value is the *first* of the two bound values here, so the
+    /// checked-conversion failure's prefix is empty and `partial()` (#400/
+    /// #494) collapses it straight to a bare `Error`.
+    #[test]
+    fn test_eval_as_bound_value_raises_on_decode_failure_1902() {
+        query!(
+            b"{\"a\": \"\xff\xfe\", \"b\": 5}",
+            "(.a, .b) as $v | $v",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
+    /// #1902: `eval_as`'s per-bound-value body output shared the same bug --
+    /// and an earlier bound value's decode failure must preempt a later
+    /// bound value's own, unrelated error (mirroring #1832's identical
+    /// ordering rule): `(1,2) as $v | (if $v==1 then .a else error("boom")
+    /// end)` must report the decode failure from `$v=1`'s output, not
+    /// `$v=2`'s "boom" -- the second bound value's body must never even run.
+    #[test]
+    fn test_eval_as_body_output_decode_failure_preempts_later_error_1902() {
+        query!(
+            b"{\"a\": \"\xff\xfe\", \"b\": 5}",
+            "(1, 2) as $v | (if $v == 1 then .a else error(\"boom\") end)",
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+            }
+        );
+    }
+
+    /// #1902: `eval_reduce`'s `input`/INIT conversions shared the same bug.
+    /// `input` drops any prefix on a decode failure (matching this
+    /// function's own "always single-shot" policy for an ordinary error);
+    /// INIT retains it like an ordinary `Partial`.
+    #[test]
+    fn test_eval_reduce_input_and_init_raise_on_decode_failure_1902() {
+        query!(
+            b"[\"\xff\xfe\", 1]",
+            "reduce .[] as $x (0; . + 1)",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        query!(
+            b"\"\xff\xfe\"",
+            "reduce (1,2) as $x ([.]; . + [$x])",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
+    /// #1902: `eval_foreach`'s `input`/INIT conversions shared the same bug
+    /// -- unlike `reduce`, `foreach` genuinely streams intermediate output,
+    /// so both retain their already-converted prefix rather than dropping
+    /// it (foreach's own doc comment: `foreach (1,2,error(x),4) as $v (0;
+    /// .+$v)` emits `1`, `3` before erroring).
+    #[test]
+    fn test_eval_foreach_input_and_init_raise_on_decode_failure_1902() {
+        query!(
+            b"[1, \"\xff\xfe\"]",
+            "[foreach .[] as $x (0; . + 1)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        query!(
+            b"\"\xff\xfe\"",
+            "[foreach (1,2) as $x ([.]; . + [$x])]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
+    /// #1902 positive control: valid data through `eval_as`/`eval_reduce`/
+    /// `eval_foreach`'s checked conversions is unaffected.
+    #[test]
+    fn test_eval_as_reduce_foreach_valid_data_unaffected_1902() {
+        query!(br#"{"a":"x","b":5}"#, "(.a, .b) as $v | $v",
+            QueryResult::Partial(vs, Control::Halt(_)) | QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::String("x".to_string()), OwnedValue::Int(5)]);
+            }
+        );
+        query!(br#"["x",1]"#, "reduce .[] as $x (0; . + 1)",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 2)
+        );
+        query!(br#"["x",1]"#, "[foreach .[] as $x (0; . + 1)]",
+            QueryResult::Owned(OwnedValue::Array(vs)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
     }
 
     /// #1755: the "misc bucket" slice -- `INDEX`/`INDEX(stream;...)`,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40839,6 +40839,23 @@ mod tests {
             ".obj as {k: $v} | $v",
             QueryResult::Error(e) => assert!(e.is_decode_failure())
         );
+        // `each_as`'s `materialize_bound_values` call, `QueryResult::Many`
+        // arm with a non-empty prefix: `.arr[]` binds two values, the
+        // first (valid) converts before the second (corrupted) fails.
+        query!(
+            b"{\"arr\": [\"ok\", \"\xff\xfe\"]}",
+            "[limit(2; .arr[] as $v | $v)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // `eval_as_pattern`'s own `QueryResult::Many` arm with a non-empty
+        // prefix: `.arrs[]` binds two whole array *values* (`[$v]`
+        // destructures each), the first (valid) converts before the
+        // second (containing a corrupted element) fails.
+        query!(
+            b"{\"arrs\": [[\"ok\"], [\"\xff\xfe\"]]}",
+            "[.arrs[] as [$v] | $v]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
     }
 
     /// #1902 review: `eval_foreach`'s `init_values.is_empty()` early return

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40730,6 +40730,118 @@ mod tests {
         );
     }
 
+    /// #1902: the `QueryResult::One` (single, not multi-output) arms of
+    /// each of the three fixed sites, plus the `Many` partial-prefix arms
+    /// -- the sweep test above only ever hit the `Many`-with-empty-prefix
+    /// shape, since the corrupted value was always first in a 2-element
+    /// stream.
+    #[test]
+    fn test_eval_as_reduce_foreach_single_and_partial_prefix_shapes_1902() {
+        // eval_as: bound-value conversion, `QueryResult::One` arm.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            ".a as $v | $v",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // eval_as: body output, `QueryResult::Many` arm with a non-empty
+        // prefix -- `.b` (valid) is pushed to `all_results` before `.a`
+        // (corrupted) fails within the same body's multi-output.
+        query!(
+            b"{\"a\": \"\xff\xfe\", \"b\": \"ok\"}",
+            "1 as $v | (.b, .a)",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("ok".to_string())]);
+                assert!(e.is_decode_failure());
+            }
+        );
+        // eval_reduce: `input`, `QueryResult::One` arm (a single corrupted
+        // value, not iterated via `.[]`).
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "reduce .a as $x (0; . + 1)",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // eval_reduce: INIT, `QueryResult::One` arm.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "reduce (1,2) as $x (.a; . + [$x])",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // eval_reduce: INIT, `QueryResult::Many` arm with a non-empty
+        // prefix -- `.arr[]` (`Expr::Iterate`) reaches `eval_reduce`'s own
+        // `materialize_cursor()` as one un-promoted `Many` of borrowed
+        // cursors (unlike a comma of separate sub-expressions, which
+        // `eval_comma`'s own #1832 promotion would already have converted
+        // -- and already caught the decode failure on -- before it ever
+        // reaches here). INIT's first element (`0`) succeeds before its
+        // second (corrupted) fails; the fork over the successfully
+        // converted `0` still completes and contributes its own real
+        // output (`1`) before the decode failure surfaces as
+        // `finish_fork`'s trailing control.
+        query!(
+            b"{\"arr\": [0, \"\xff\xfe\"]}",
+            "reduce 1 as $x (.arr[]; . + $x)",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.is_decode_failure());
+            }
+        );
+        // eval_reduce: `input`, `QueryResult::One` arm with a *valid*
+        // single value (the success half of the `One` arm's match).
+        query!(
+            br#"{"a": 5}"#,
+            "reduce .a as $x (0; . + $x)",
+            QueryResult::Owned(OwnedValue::Int(n)) => assert_eq!(n, 5)
+        );
+        // eval_as: body output, `QueryResult::Many` arm's success case --
+        // `.arr[]` (valid, multi-output) reaches this arm directly, the
+        // same un-promoted-cursor shape as the `eval_reduce` INIT case
+        // above.
+        query!(
+            br#"{"arr": [1, 2]}"#,
+            "0 as $v | .arr[]",
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+        // eval_foreach: `input`, `QueryResult::One` arm.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[foreach .a as $x (0; . + 1)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // eval_foreach: INIT, `QueryResult::One` arm.
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "[foreach (1,2) as $x (.a; . + [$x])]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+        // eval_foreach: INIT, `QueryResult::Many` arm with a non-empty
+        // prefix -- same `.arr[]` un-promoted-cursor shape as the
+        // `eval_reduce` INIT case above.
+        query!(
+            b"{\"arr\": [0, \"\xff\xfe\"]}",
+            "[foreach 1 as $x (.arr[]; . + $x)]",
+            QueryResult::Error(e) => assert!(e.is_decode_failure())
+        );
+    }
+
+    /// #1902: `finish_fork`'s own fix -- an *ordinary* trailing error is
+    /// still suppressed by an ambient `optional`, unlike a decode failure.
+    /// `reduce`/`foreach` don't have direct `EXPR?` surface on their own
+    /// input/INIT sub-expressions, so this drives `optional` in through the
+    /// `?`-suffixed builtin argument path (`limit`'s generator argument),
+    /// which routes through `eval_single(..., optional)` the same way
+    /// `eval_reduce`/`eval_foreach`'s own input/INIT calls do.
+    #[test]
+    fn test_finish_fork_still_suppresses_ordinary_error_under_optional_1902() {
+        query!(
+            br"0",
+            "(reduce (1, error(\"boom\")) as $x (0; . + $x))?",
+            QueryResult::None => {}
+        );
+    }
+
     /// #1755: the "misc bucket" slice -- `INDEX`/`INDEX(stream;...)`,
     /// `getpath`, `any`/`all` (bare and `(cond)`/`(gen;cond)` forms),
     /// `eval_pipe`'s path-context entry, `combinations`/`combinations(n)`,


### PR DESCRIPTION
## Summary

`eval_as`'s bound-value conversion, and the equivalent input/INIT
conversions in `eval_reduce`/`eval_foreach`, used unchecked `to_owned` —
an undecodable value silently became `""` instead of raising, and
(worse) let a later bound value's ordinary error win over an earlier
bound value's own decode failure (the exact ordering bug #1832 already
fixed for `eval_comma`/`eval_fanout`/`eval_pipe`).

Routes all three through `to_owned_checked`/`promote_borrowed_checked`,
folding a checked-conversion failure into the existing `Partial`-control
plumbing each function already has (a decode failure preempts a later
bound value/input the same way an ordinary `Partial`'s trailing control
does, and `eval_reduce`'s `input` keeps its established "single-shot,
drop-the-prefix" policy for an ordinary error).

Also fixes `finish_fork` (shared by `eval_reduce`/`eval_foreach`) to
never suppress a decode failure under an ambient `optional`, matching
`finish_fork_generic`'s already-correct guard in `eval_generic.rs` —
whose own doc comment claimed to mirror this function, which had
drifted from it. Without this, a decode failure raised via the fixes
above could be wrongly swallowed by `?`.

Fixes #1902

## Test plan

- [x] New regression tests covering every match arm the fix touched:
      the `One`/`Many` success and failure shapes in
      `eval_as`/`eval_reduce`/`eval_foreach`, the "earlier undecodable
      value preempts a later competing error" ordering rule, and
      `finish_fork`'s own decode-failure-vs-`optional` guard
- [x] `cargo test --lib --features cli,regex jq::eval::tests` — 1148 passed
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo build --no-default-features` (no_std)
- [x] `omni-dev coverage diff` — 98.86% patch coverage (82/83 new lines);
      the one remaining line is exercised by
      `test_finish_fork_still_suppresses_ordinary_error_under_optional_1902`
      (a coverage-instrumentation artifact for a single-expression
      guarded match arm — the test's own passing assertion proves it ran)