### PR TITLE
fix(jq): update_path deletes on `|= empty` instead of writing null

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18461,9 +18461,11 @@ fn get_path_mut<'a>(
 /// elements), reports its own outcome directly. Consumed in three places:
 /// `through_slice`'s `Null`/`Array`/`String` arms (to distinguish `|=
 /// empty` from a literal `null` write), the mid-chain `Pipe` arm's
-/// "stranded" autoviv-undo check, and -- since #1916 -- this function's own
-/// terminal `Field`/`Index`/`Iterate` arms, which delete the key/element
-/// outright on `false` instead of leaving it `null`.
+/// "stranded" autoviv-undo check, and -- since #1916, jq mode only -- this
+/// function's own terminal `Field`/`Index`/`Iterate` arms, which delete the
+/// key/element outright on `false` instead of leaving it `null`. yq mode
+/// keeps its pre-#1916 behavior at those three arms unchanged; see the
+/// `Field` arm's own comment for why.
 fn update_path<S: EvalSemantics>(
     root: &mut OwnedValue,
     path_expr: &Expr,
@@ -18536,16 +18538,36 @@ fn update_path<S: EvalSemantics>(
                 let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
                 let wrote =
                     update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)?;
-                if !wrote {
-                    // #1916: an update filter that produced no output at
-                    // all (`.a |= empty`) deletes the key instead of
-                    // leaving it `null` -- jq's `_modify` falls back to
-                    // `delpaths` here, mirroring `through_slice`'s own
-                    // `|= empty` splice (#1877/#1894). `root_was_null`
-                    // mirrors the mid-chain `Field` arm below: undo the
-                    // autovivification too if nothing ended up in it, so
-                    // `null | .a |= empty` stays `null` rather than
-                    // becoming `{}`.
+                // #1916 is jq-mode only. An update filter that produced no
+                // output at all (`.a |= empty`) deletes the key instead of
+                // leaving it `null` -- jq's `_modify` falls back to
+                // `delpaths` here, mirroring `through_slice`'s own `|=
+                // empty` splice (#1877/#1894). `root_was_null` mirrors the
+                // mid-chain `Field` arm below: undo the autovivification
+                // too if nothing ended up in it, so `null | .a |= empty`
+                // stays `null` rather than becoming `{}`.
+                //
+                // `empty` itself isn't valid yq syntax at all (its lexer
+                // rejects the bare keyword, confirmed live against yq
+                // v4.53.3), but the same zero-output shape is reachable
+                // there via an ordinary filter like `select(false)` -- and
+                // real yq's own behavior for it is neither "delete" nor
+                // this arm's pre-#1916 "always leave `null`": a key that
+                // already existed is left completely untouched (`{"a":1}
+                // | .a |= select(false)` stays `{"a":1}`), while one only
+                // reached through autovivification still lands `null`
+                // (`{} | .a |= select(false)` is `{"a":null}`) -- a
+                // narrower rule than jq's, and not one `wrote` alone is
+                // enough to implement (it would need the pre-update value
+                // preserved before this recursive call even runs, not
+                // just a bool after). Deleting unconditionally regressed
+                // that mode from "wrong in a value" (pre-#1916: always
+                // `null`) to "wrong in a shape" (delete, changing the
+                // key/element set) -- gating this off for yq keeps its
+                // pre-#1916 behavior exactly, rather than trading one
+                // undocumented divergence for a worse one. Closing yq's
+                // own gap is left to a follow-up issue.
+                if !wrote && S::TAG != EvalTag::Yq {
                     map.shift_remove(name);
                     if root_was_null && map.is_empty() {
                         *root = OwnedValue::Null;
@@ -18571,60 +18593,83 @@ fn update_path<S: EvalSemantics>(
             let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
-                // #1916: bounds-checking is deferred behind the filter,
-                // mirroring `delete_at_path`'s own `Expr::Index` arm --
-                // real jq resolves an index leniently for *reading*
-                // (`getpath`-style: any out-of-range position, either
-                // direction, reads as `null` rather than erroring) and
-                // only applies the write-time check (`write_index`,
-                // padding for a positive overshoot / erroring for a
-                // negative one) once a real value is actually about to
-                // land. Confirmed live: `.[-5] |= 99` raises "Out of
-                // bounds negative array index", but `.[-5] |= empty`
-                // silently no-ops -- the error exists only on the write
-                // path, never the read/delete one that an empty update
-                // filter takes instead.
-                let len = arr.len() as i64;
-                let actual_idx = if *idx < 0 { len + idx } else { *idx };
-                let in_bounds = actual_idx >= 0 && (actual_idx as usize) < arr.len();
-                let wrote = if in_bounds {
-                    let wrote = update_path::<S>(
-                        &mut arr[actual_idx as usize],
+                if S::TAG == EvalTag::Yq {
+                    // #1916 is jq-mode only -- see the `Field` arm's
+                    // comment above for why. It also isn't just the
+                    // delete-vs-null choice that would need to change for
+                    // yq here: unlike jq, yq's own bounds behavior is
+                    // *not* deferred behind whether the filter ends up
+                    // writing anything -- confirmed live (yq v4.53.3)
+                    // that `.[-10] |= select(false)` still raises yq's
+                    // own "out of range" error on a 3-element array, and
+                    // `.[10] |= select(false)` still pads all the way to
+                    // index 10. Keep the original eager `write_index`
+                    // call, unconditional on the filter's outcome.
+                    update_path::<S>(
+                        write_index(arr, *idx)?,
                         &Expr::Identity,
                         filter_expr,
                         optional,
                         scalar_noop,
-                    )?;
-                    if !wrote {
-                        arr.remove(actual_idx as usize);
-                    }
-                    wrote
+                    )
                 } else {
-                    // Probe once against a detached `null`, the value
-                    // `getpath` would read here -- never run the filter
-                    // twice (#1428: a real write below reuses this
-                    // scratch's already-computed value rather than
-                    // re-invoking `filter_expr`). A `!wrote` here is a
-                    // true no-op: nothing was ever padded in, so there
-                    // is nothing to undo, matching `delpaths` silently
-                    // skipping an out-of-range index either direction.
-                    let mut scratch = OwnedValue::Null;
-                    let wrote = update_path::<S>(
-                        &mut scratch,
-                        &Expr::Identity,
-                        filter_expr,
-                        optional,
-                        scalar_noop,
-                    )?;
-                    if wrote {
-                        *write_index(arr, *idx)? = scratch;
+                    // #1916: bounds-checking is deferred behind the
+                    // filter, mirroring `delete_at_path`'s own
+                    // `Expr::Index` arm -- real jq resolves an index
+                    // leniently for *reading* (`getpath`-style: any
+                    // out-of-range position, either direction, reads as
+                    // `null` rather than erroring) and only applies the
+                    // write-time check (`write_index`, padding for a
+                    // positive overshoot / erroring for a negative one)
+                    // once a real value is actually about to land.
+                    // Confirmed live: `.[-5] |= 99` raises "Out of bounds
+                    // negative array index", but `.[-5] |= empty`
+                    // silently no-ops -- the error exists only on the
+                    // write path, never the read/delete one that an
+                    // empty update filter takes instead.
+                    let len = arr.len() as i64;
+                    let actual_idx = if *idx < 0 { len + idx } else { *idx };
+                    let in_bounds = actual_idx >= 0 && (actual_idx as usize) < arr.len();
+                    let wrote = if in_bounds {
+                        let wrote = update_path::<S>(
+                            &mut arr[actual_idx as usize],
+                            &Expr::Identity,
+                            filter_expr,
+                            optional,
+                            scalar_noop,
+                        )?;
+                        if !wrote {
+                            arr.remove(actual_idx as usize);
+                        }
+                        wrote
+                    } else {
+                        // Probe once against a detached `null`, the value
+                        // `getpath` would read here -- never run the
+                        // filter twice (#1428: a real write below reuses
+                        // this scratch's already-computed value rather
+                        // than re-invoking `filter_expr`). A `!wrote`
+                        // here is a true no-op: nothing was ever padded
+                        // in, so there is nothing to undo, matching
+                        // `delpaths` silently skipping an out-of-range
+                        // index either direction.
+                        let mut scratch = OwnedValue::Null;
+                        let wrote = update_path::<S>(
+                            &mut scratch,
+                            &Expr::Identity,
+                            filter_expr,
+                            optional,
+                            scalar_noop,
+                        )?;
+                        if wrote {
+                            *write_index(arr, *idx)? = scratch;
+                        }
+                        wrote
+                    };
+                    if !wrote && root_was_null {
+                        *root = OwnedValue::Null;
                     }
-                    wrote
-                };
-                if !wrote && root_was_null {
-                    *root = OwnedValue::Null;
+                    Ok(wrote)
                 }
-                Ok(wrote)
             } else if optional || noop_scalar {
                 Ok(false)
             } else {
@@ -18643,46 +18688,72 @@ fn update_path<S: EvalSemantics>(
             }
             match root {
                 OwnedValue::Array(arr) => {
-                    // #1916: `.[] |= empty` removes every element whose
-                    // update filter produced no output, rather than
-                    // leaving it `null` (mirrors the `Field`/`Index` arms
-                    // above and `through_slice`'s own `|= empty` splice,
-                    // #1877/#1894). No `root_was_null` restore is needed
-                    // here unlike those two: an `Array` root is never
-                    // itself `Null` by the time this arm runs, and a
-                    // freshly yq-autovivified empty array is meant to
-                    // stay (#1181), not revert. Rebuilt in one pass
-                    // rather than removed in place, since a `Vec::remove`
-                    // per dropped element would be quadratic.
-                    let mut retained = vec_with_capacity(arr.len());
-                    for mut elem in core::mem::take(arr) {
-                        if update_path::<S>(
-                            &mut elem,
-                            &Expr::Identity,
-                            filter_expr,
-                            optional,
-                            scalar_noop,
-                        )? {
-                            retained.push(elem);
+                    if S::TAG == EvalTag::Yq {
+                        // #1916 is jq-mode only -- see the `Field` arm's
+                        // comment above.
+                        for elem in arr.iter_mut() {
+                            update_path::<S>(
+                                elem,
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )?;
                         }
+                    } else {
+                        // #1916: `.[] |= empty` removes every element
+                        // whose update filter produced no output, rather
+                        // than leaving it `null` (mirrors the
+                        // `Field`/`Index` arms above and
+                        // `through_slice`'s own `|= empty` splice,
+                        // #1877/#1894). No `root_was_null` restore is
+                        // needed here unlike those two: an `Array` root
+                        // is never itself `Null` by the time this arm
+                        // runs. Rebuilt in one pass rather than removed
+                        // in place, since a `Vec::remove` per dropped
+                        // element would be quadratic.
+                        let mut retained = vec_with_capacity(arr.len());
+                        for mut elem in core::mem::take(arr) {
+                            if update_path::<S>(
+                                &mut elem,
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )? {
+                                retained.push(elem);
+                            }
+                        }
+                        *arr = retained;
                     }
-                    *arr = retained;
                     Ok(true)
                 }
                 OwnedValue::Object(map) => {
-                    let mut retained = IndexMap::with_capacity(map.len());
-                    for (key, mut value) in core::mem::take(map) {
-                        if update_path::<S>(
-                            &mut value,
-                            &Expr::Identity,
-                            filter_expr,
-                            optional,
-                            scalar_noop,
-                        )? {
-                            retained.insert(key, value);
+                    if S::TAG == EvalTag::Yq {
+                        for value in map.values_mut() {
+                            update_path::<S>(
+                                value,
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )?;
                         }
+                    } else {
+                        let mut retained = IndexMap::with_capacity(map.len());
+                        for (key, mut value) in core::mem::take(map) {
+                            if update_path::<S>(
+                                &mut value,
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )? {
+                                retained.insert(key, value);
+                            }
+                        }
+                        *map = retained;
                     }
-                    *map = retained;
                     Ok(true)
                 }
                 _ if optional || noop_scalar => Ok(false),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18458,9 +18458,12 @@ fn get_path_mut<'a>(
 /// either forwards its single recursive call's answer unchanged, or, where
 /// it can suppress a write itself (an `optional`/yq-no-op branch, or an
 /// `Iterate`/mid-chain arm that legitimately touches zero or many
-/// elements), reports its own outcome directly. The only consumer today is
-/// `through_slice`'s `Null`/`Array`/`String` arms, which use it to
-/// distinguish `|= empty` from a literal `null` write.
+/// elements), reports its own outcome directly. Consumed in three places:
+/// `through_slice`'s `Null`/`Array`/`String` arms (to distinguish `|=
+/// empty` from a literal `null` write), the mid-chain `Pipe` arm's
+/// "stranded" autoviv-undo check, and -- since #1916 -- this function's own
+/// terminal `Field`/`Index`/`Iterate` arms, which delete the key/element
+/// outright on `false` instead of leaving it `null`.
 fn update_path<S: EvalSemantics>(
     root: &mut OwnedValue,
     path_expr: &Expr,
@@ -18507,11 +18510,7 @@ fn update_path<S: EvalSemantics>(
             // only the filter's *first* output, never an array of every
             // output (#392) -- `eval_owned_expr` collapsed a multi-output
             // result into exactly that array (`.a |= (1,2)` produced
-            // `{"a":[1,2]}` instead of jq's `{"a":1}`). A zero-output
-            // filter still falls back to `Null` here -- `.a |= empty`
-            // leaves `"a":null` rather than deleting the key the way real
-            // jq does, a separate, pre-existing bug this fix does not
-            // change.
+            // `{"a":[1,2]}` instead of jq's `{"a":1}`).
             //
             // `_first`, not the plain `eval_owned_multi` (#694): jq's
             // `_modify` only ever observes the update filter's first
@@ -18519,23 +18518,40 @@ fn update_path<S: EvalSemantics>(
             // surface -- `.a |= (1, error("x"))` is `{"a":1}` in jq 1.7.1,
             // not an error.
             //
-            // A zero-output filter still falls back to `Null` here -- `.a
-            // |= empty` leaves `"a":null` rather than deleting the key the
-            // way real jq does, a separate, pre-existing bug this fix does
-            // not change (#1877/#1894 are scoped to `through_slice`'s own
-            // arms, not this general field/index case). The `false`
-            // returned alongside it is the one place that signal
-            // originates -- see this function's own doc comment.
+            // A zero-output filter still falls back to `Null` at *this*
+            // level -- the `Field`/`Index`/`Iterate` arms above are what
+            // turn that into a real delete (#1916), by checking the
+            // `wrote` bool returned here rather than inspecting the
+            // resulting value (a legitimate `.a |= null` also leaves
+            // `Null` behind, and must not be deleted).
             let outputs = eval_owned_multi_first::<S>(filter_expr, root)?;
             let wrote = !outputs.is_empty();
             *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
             Ok(wrote)
         }
         Expr::Field(name) => {
+            let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_object(root);
             if let OwnedValue::Object(map) = root {
                 let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)
+                let wrote =
+                    update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)?;
+                if !wrote {
+                    // #1916: an update filter that produced no output at
+                    // all (`.a |= empty`) deletes the key instead of
+                    // leaving it `null` -- jq's `_modify` falls back to
+                    // `delpaths` here, mirroring `through_slice`'s own
+                    // `|= empty` splice (#1877/#1894). `root_was_null`
+                    // mirrors the mid-chain `Field` arm below: undo the
+                    // autovivification too if nothing ended up in it, so
+                    // `null | .a |= empty` stays `null` rather than
+                    // becoming `{}`.
+                    map.shift_remove(name);
+                    if root_was_null && map.is_empty() {
+                        *root = OwnedValue::Null;
+                    }
+                }
+                Ok(wrote)
             } else if optional
                 // #1181: unconditional on the operator, unlike `scalar_noop`
                 // above (which is `container_noop`'s slice-only, #1101
@@ -18552,15 +18568,63 @@ fn update_path<S: EvalSemantics>(
             }
         }
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+            let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
-                update_path::<S>(
-                    write_index(arr, *idx)?,
-                    &Expr::Identity,
-                    filter_expr,
-                    optional,
-                    scalar_noop,
-                )
+                // #1916: bounds-checking is deferred behind the filter,
+                // mirroring `delete_at_path`'s own `Expr::Index` arm --
+                // real jq resolves an index leniently for *reading*
+                // (`getpath`-style: any out-of-range position, either
+                // direction, reads as `null` rather than erroring) and
+                // only applies the write-time check (`write_index`,
+                // padding for a positive overshoot / erroring for a
+                // negative one) once a real value is actually about to
+                // land. Confirmed live: `.[-5] |= 99` raises "Out of
+                // bounds negative array index", but `.[-5] |= empty`
+                // silently no-ops -- the error exists only on the write
+                // path, never the read/delete one that an empty update
+                // filter takes instead.
+                let len = arr.len() as i64;
+                let actual_idx = if *idx < 0 { len + idx } else { *idx };
+                let in_bounds = actual_idx >= 0 && (actual_idx as usize) < arr.len();
+                let wrote = if in_bounds {
+                    let wrote = update_path::<S>(
+                        &mut arr[actual_idx as usize],
+                        &Expr::Identity,
+                        filter_expr,
+                        optional,
+                        scalar_noop,
+                    )?;
+                    if !wrote {
+                        arr.remove(actual_idx as usize);
+                    }
+                    wrote
+                } else {
+                    // Probe once against a detached `null`, the value
+                    // `getpath` would read here -- never run the filter
+                    // twice (#1428: a real write below reuses this
+                    // scratch's already-computed value rather than
+                    // re-invoking `filter_expr`). A `!wrote` here is a
+                    // true no-op: nothing was ever padded in, so there
+                    // is nothing to undo, matching `delpaths` silently
+                    // skipping an out-of-range index either direction.
+                    let mut scratch = OwnedValue::Null;
+                    let wrote = update_path::<S>(
+                        &mut scratch,
+                        &Expr::Identity,
+                        filter_expr,
+                        optional,
+                        scalar_noop,
+                    )?;
+                    if wrote {
+                        *write_index(arr, *idx)? = scratch;
+                    }
+                    wrote
+                };
+                if !wrote && root_was_null {
+                    *root = OwnedValue::Null;
+                }
+                Ok(wrote)
             } else if optional || noop_scalar {
                 Ok(false)
             } else {
@@ -18579,27 +18643,46 @@ fn update_path<S: EvalSemantics>(
             }
             match root {
                 OwnedValue::Array(arr) => {
-                    for elem in arr.iter_mut() {
-                        update_path::<S>(
-                            elem,
+                    // #1916: `.[] |= empty` removes every element whose
+                    // update filter produced no output, rather than
+                    // leaving it `null` (mirrors the `Field`/`Index` arms
+                    // above and `through_slice`'s own `|= empty` splice,
+                    // #1877/#1894). No `root_was_null` restore is needed
+                    // here unlike those two: an `Array` root is never
+                    // itself `Null` by the time this arm runs, and a
+                    // freshly yq-autovivified empty array is meant to
+                    // stay (#1181), not revert. Rebuilt in one pass
+                    // rather than removed in place, since a `Vec::remove`
+                    // per dropped element would be quadratic.
+                    let mut retained = vec_with_capacity(arr.len());
+                    for mut elem in core::mem::take(arr) {
+                        if update_path::<S>(
+                            &mut elem,
                             &Expr::Identity,
                             filter_expr,
                             optional,
                             scalar_noop,
-                        )?;
+                        )? {
+                            retained.push(elem);
+                        }
                     }
+                    *arr = retained;
                     Ok(true)
                 }
                 OwnedValue::Object(map) => {
-                    for value in map.values_mut() {
-                        update_path::<S>(
-                            value,
+                    let mut retained = IndexMap::with_capacity(map.len());
+                    for (key, mut value) in core::mem::take(map) {
+                        if update_path::<S>(
+                            &mut value,
                             &Expr::Identity,
                             filter_expr,
                             optional,
                             scalar_noop,
-                        )?;
+                        )? {
+                            retained.insert(key, value);
+                        }
                     }
+                    *map = retained;
                     Ok(true)
                 }
                 _ if optional || noop_scalar => Ok(false),
@@ -55645,12 +55728,14 @@ mod tests {
     }
 
     #[test]
-    fn test_update_assign_empty_rhs_characterizes_preexisting_null_bug() {
+    fn test_update_assign_empty_rhs_deletes_key_1916() {
         // Real jq deletes the key when the update filter produces no output
-        // (`.a |= empty` on `{}` is `{}`); succinctly currently leaves it
-        // `null`. Pre-existing, out of scope for #392 -- if this is ever
-        // fixed, update this test.
-        assert_eq!(outputs(b"{}", ".a |= empty"), vec![r#"{"a":null}"#]);
+        // (`.a |= empty` on `{}` is `{}`) rather than leaving it `null` --
+        // #1916 closed that gap in the `Field`/`Index`/`Iterate` terminal
+        // arms of `update_path`. This test used to characterize the
+        // pre-existing bug (`{"a":null}`); it now asserts the fixed,
+        // jq-matching answer.
+        assert_eq!(outputs(b"{}", ".a |= empty"), vec![r"{}"]);
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26224,15 +26224,80 @@ fn test_nested_slice_delete_on_empty_update_filter_noops_on_null_1877() -> Resul
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "[2,3,4,5]");
 
-    // Regression guard: a slice followed by a plain `Index` (not another
-    // slice) is a separate, pre-existing, out-of-scope divergence (the
-    // general "`.a |= empty` should delete the key/element, not write
-    // `null`" gap for `Field`/`Index`, #1894's own follow-up territory) --
-    // confirmed unchanged before and after this fix, not newly broken by
-    // it.
+    // A slice followed by a plain `Index` (not another slice) -- #1916
+    // closed the general "`.a |= empty` should delete the key/element, not
+    // write `null`" gap for `Field`/`Index`, so this now deletes the
+    // element too, matching jq's own answer, rather than the `[null,2,3,4]`
+    // this assertion recorded before that fix landed.
     let (stdout, _stderr, code) = run_jq_full(&["-c", ".[0:2][0] |= empty"], Some("[1,2,3,4]"))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "[null,2,3,4]");
+    assert_eq!(stdout.trim(), "[2,3,4]");
+
+    Ok(())
+}
+
+/// #1916: an update filter that produces no output at all deletes the
+/// key/element it targets, rather than leaving it `null` -- jq's `_modify`
+/// falls back to `delpaths` here (the same mechanism #1877/#1894 already
+/// gave `through_slice`'s slice arms). Every expected value below is real
+/// jq 1.7.1's own output, captured live.
+#[test]
+fn test_field_index_iterate_delete_on_empty_update_filter_1916() -> Result<()> {
+    // Field: the key disappears entirely, not `"a":null`.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a |= empty"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"b":2}"#);
+
+    // Index: the element is removed, the array shrinks.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[0] |= empty"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[2,3]");
+
+    // Iterate over an array: every element that updates to nothing is
+    // dropped.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[] |= empty"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
+
+    // Iterate over an object: same, keyed by name.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[] |= empty"], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "{}");
+
+    // Out-of-range positive/negative indices stay a true no-op: nothing
+    // was ever really there to delete, so nothing is padded in either.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[5] |= empty"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1,2,3]");
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[-5] |= empty"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1,2,3]");
+
+    // The bounds check on a *real* write still fires -- it lives on the
+    // write path, not the delete path an empty filter takes instead.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[-5] |= 99"], Some("[1,2,3]"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Out of bounds negative array index"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout, "");
+
+    // An autovivified container that ends up with nothing written into it
+    // reverts to `null` rather than surfacing as an artifact of the
+    // attempt (`{}`/`[]`).
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a |= empty"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".[0] |= empty"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    // Nested: only the reached leaf is deleted, ancestors that already
+    // existed are left in place.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a.b |= empty"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":{}}"#);
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25849,3 +25849,56 @@ fn test_nth_limit_float_classification_matches_jq_mode_1825() -> Result<()> {
 
     Ok(())
 }
+
+/// #1916 is jq-mode only: `.a |= empty`'s "delete when the update filter
+/// wrote nothing" behavior does not apply in yq mode (`empty` itself isn't
+/// even valid yq syntax -- its lexer rejects the bare keyword, confirmed
+/// live against yq v4.53.3). `select(false)` reaches the same
+/// zero-output-filter shape through ordinary yq syntax, and real yq's own
+/// behavior for it is neither "delete" nor "always leave `null`" -- an
+/// already-existing key/element is left completely untouched, while one
+/// only reached through autovivification still lands `null`. This test
+/// locks in that `update_path`'s `Field`/`Index`/`Iterate` arms keep their
+/// pre-#1916 shape (still-`null`, not deleted) for an *existing* target in
+/// yq mode, guarding against the #1916 fix regressing yq the way an
+/// unconditional (non-`S::TAG`-gated) version of it did during review: it
+/// deleted the key/element outright there instead, which real yq does not
+/// do at all.
+#[test]
+fn test_field_index_iterate_update_path_unaffected_by_1916_in_yq_mode() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+
+    // Field: the key stays present (still `null`, matching this arm's
+    // pre-#1916 shape), not deleted.
+    let (out, code) = run_yq_stdin(".a |= select(false)", "a: 1\nb: 2\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":null,"b":2}"#);
+
+    // Index: the array keeps its length, not shrunk.
+    let (out, code) = run_yq_stdin(".[0] |= select(false)", "[1, 2, 3]\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[null,2,3]");
+
+    // Iterate over an array: no element removed.
+    let (out, code) = run_yq_stdin(".[] |= select(. != 2)", "[1, 2, 3]\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,null,3]");
+
+    // Iterate over an object: no key removed.
+    let (out, code) = run_yq_stdin(".[] |= select(. != 2)", "a: 1\nb: 2\nc: 3\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":1,"b":null,"c":3}"#);
+
+    // A negative out-of-range index still raises yq's own eager bounds
+    // error, not jq mode's deferred one -- unaffected by whether the
+    // update filter would have written anything.
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr(".[-10] |= select(false)", "[1, 2, 3]\n", args)?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Out of bounds negative array index"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`.a |= empty`, `.[0] |= empty`, and `.[] |= empty` left the target as `"key":null` / an unchanged-length array of nulls instead of deleting the key/element, the way real jq's `_modify` does (it falls back to `delpaths` whenever the update filter produces no output at all).

`update_path`'s terminal `Identity` arm already computed a `wrote: bool` signal for exactly this case (added by #1877/#1894 for `through_slice`'s slice arms), but the `Field`/`Index`/`Iterate` arms above it never consumed it — they always kept the just-written `Null`. This PR wires that signal through:

- **`Field`**: deletes the key when `wrote` is false, restoring the root to `Null` if autovivifying it created the only content (`null | .a |= empty` stays `null`, not `{}`).
- **`Index`**: bounds-checking is deferred behind the filter, mirroring `delete_at_path`'s own `Index` arm — jq resolves an index leniently for *reading* (`getpath`-style: out of range in either direction reads `null`) and only applies the write-time bounds check once a real value is about to land. Confirmed live: `.[-5] |= 99` raises `"Out of bounds negative array index"`, but `.[-5] |= empty` silently no-ops — the error lives on the write path, never the delete path an empty filter takes instead.
- **`Iterate`**: rebuilt in one pass for both array and object roots (not removed in place, which would be quadratic).

Every case in the description above, plus the full matrix in the new test, is verified live against jq 1.7.1. Also updates two existing tests that had pinned the old, wrong output as an intentional characterization of this exact bug (one flagged "if this is ever fixed, update this test").

Fixes #1916

## Test plan
- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, incl. new `test_field_index_iterate_delete_on_empty_update_filter_1916`)
- [x] `cargo test` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` (no_std)
- [x] Extensive live differential testing against pinned jq 1.7.1 (36+ cases) covering the deferred-bounds-check edge case, nested chains, and object/array iterate