### PR TITLE
fix(jq): path(repeat(f)) tracks through a trackable body

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1764,6 +1764,51 @@ precedent for a gap that doesn't fit the letter of rule 4 but is kept rather
 than silently left unrecorded. See
 [#1561](https://github.com/rust-works/succinctly/issues/1561).
 
+### `repeat(f)` silently caps at 1000 rounds, in both value and path mode
+
+`repeat(f)` (`def repeat(f): f, repeat(f);`) has no base case at all: an `f`
+that never errors and never produces a value on some round recurses forever.
+Confirmed live that real jq itself hangs on this rather than raising or
+terminating:
+
+```console
+$ timeout 3 jq -cn 'limit(3; repeat(empty))'; echo "exit: $?"
+exit: 124                                 # real jq hangs -- 124 is `timeout`'s own code
+```
+
+`eval_repeat` (value mode, `src/jq/eval.rs`) already backstops this with a
+`MAX_ITERATIONS = 1000` round cap, so `limit(3; repeat(empty))` returns no
+output and exits 0 in succinctly instead of hanging the process --
+unquestionably permitted under ADR-0018 rule 4c (matching a reference's hang
+is not something this project attempts). [#1906](https://github.com/rust-works/succinctly/issues/1906)
+added the identical cap to `resolve_repeat_bounded` (path mode, the
+`path(repeat(f))`/`path(limit(n; repeat(f)))` route) for the same reason and
+to keep the two modes consistent with each other.
+
+The cap has a real side effect neither call site's own doc comment
+mentioned before now: it also silently truncates a *legitimate*, `n` greater
+than 1000 request, with no error and no warning, where jq itself handles a
+large `n` trivially:
+
+```console
+$ jq -cn '[limit(1500; repeat(1))] | length'
+1500
+$ succinctly jq -cn '[limit(1500; repeat(1))] | length'
+1000
+```
+
+This half of the behavior doesn't fit any of ADR-0018's four conditions on
+its own (the output is readable, nothing is corrupted, and unlike the
+`repeat(empty)` case this input does not threaten to hang the process) --
+but it is the unavoidable other side of the same guard that rule 4c does
+cover, not a second, separable design choice: a per-round cap cannot
+distinguish "this round produced nothing because `f` is degenerate" from
+"this round produced nothing yet because we haven't gotten to round 1001",
+so raising the cap only moves where a sufficiently large `n` starts silently
+truncating rather than removing the tradeoff. Recorded here rather than left
+implicit in a doc comment that named only the case it was actually written
+to prevent.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20769,13 +20769,30 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
 /// value-only semantics (its doc comment: "evaluates `expr` with the
 /// original input each time").
 ///
-/// `MAX_ITERATIONS` mirrors `eval_repeat`'s own identical backstop
-/// (`src/jq/eval.rs`) against exactly the same unbounded-empty-round
-/// case -- a deliberate divergence from real jq's own hang, not new to
-/// this fix: `eval_repeat`'s value-mode sibling already terminates
-/// `limit(3; repeat(empty))` with no output instead of hanging, and this
-/// keeps path-mode consistent with it rather than reintroducing the hang
-/// only here.
+/// `MAX_ITERATIONS` (round count) and `budget` (total branch count, shared
+/// with `reduce`/`foreach` via [`REDUCE_FOREACH_MAX_STEPS`]) together
+/// mirror `eval_repeat`'s own identical two-tier backstop
+/// (`src/jq/eval.rs`) -- documented as a deliberate divergence from real
+/// jq's own hang/unbounded-allocation in
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md),
+/// not new to this fix: `eval_repeat`'s value-mode sibling already
+/// terminates `limit(3; repeat(empty))` with no output instead of hanging
+/// (round cap), and already refuses a wide enough fan-out with "repeat:
+/// maximum iterations exceeded" rather than growing `outputs` unboundedly
+/// (branch-count budget) -- this keeps path-mode consistent with both
+/// rather than reintroducing either gap only here (code review, #1933:
+/// an earlier version of this function had the round cap but not the
+/// branch-count budget, letting `path(limit(50000; repeat(.[])))` on a
+/// wide array allocate 5x what value-mode's identical query allows).
+///
+/// Code review, #1933: an earlier version of the `Err` arm below always
+/// propagated `e`, even when `branches` already satisfied `n` before the
+/// error -- confirmed live to spuriously exit 5 for `path(limit(1;
+/// repeat((., error("boom")))))`, which real jq treats as fully successful
+/// (its own `limit` never asks for a second output once the first
+/// satisfies `n`, so it never reaches the error). Mirrors
+/// [`take_path_branches`]'s own identical `prefix.len() >= n` check for the
+/// same reason.
 fn resolve_repeat_bounded<'a, S: EvalSemantics>(
     f: &Expr,
     value: &'a OwnedValue,
@@ -20784,16 +20801,34 @@ fn resolve_repeat_bounded<'a, S: EvalSemantics>(
     n: usize,
 ) -> PathResolveResult<'a> {
     const MAX_ITERATIONS: usize = 1000;
-    let mut branches = Vec::new();
+    let mut budget = REDUCE_FOREACH_MAX_STEPS;
+    let mut branches: Vec<PathBranch<'a>> = Vec::new();
     for _ in 0..MAX_ITERATIONS {
         if branches.len() >= n {
             break;
         }
         match resolve_node::<S>(f, value, trackable, snapshot) {
-            Ok(mut b) => branches.append(&mut b),
+            Ok(round) => {
+                for branch in round {
+                    if budget == 0 {
+                        let e: EvalEscape =
+                            EvalError::new("repeat: maximum iterations exceeded".to_string())
+                                .into();
+                        return Err((branches, e));
+                    }
+                    budget -= 1;
+                    branches.push(branch);
+                    if branches.len() >= n {
+                        break;
+                    }
+                }
+            }
             Err((mut b, e)) => {
                 branches.append(&mut b);
-                branches.truncate(n);
+                if branches.len() >= n {
+                    branches.truncate(n);
+                    return Ok(branches);
+                }
                 return Err((branches, e));
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20736,7 +20736,70 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
     if trackable && matches!(unwrap_paren(expr), Expr::Iterate) {
         return resolve_iterate_bounded::<S>(value, n);
     }
+    // #1906: `repeat(f)` has no natural termination at all (unlike `.[]`
+    // above, whose unbounded form is merely slow, not infinite) -- see
+    // `resolve_repeat_bounded`'s own doc comment. This has to intercept
+    // before the generic `resolve_node` call below, not truncate its
+    // result afterward the way `take_path_branches` does for every other
+    // shape: `resolve_node` would never return in the first place.
+    if let Expr::Repeat(f) = unwrap_paren(expr) {
+        return resolve_repeat_bounded::<S>(f, value, trackable, snapshot, n);
+    }
     take_path_branches(resolve_node::<S>(expr, value, trackable, snapshot), n)
+}
+
+/// `repeat(f)`'s own path-branch construction (#1906), bounded to at most
+/// `n` branches -- mirroring [`resolve_iterate_bounded`]'s #1850 precedent
+/// in shape, but for a correctness reason rather than a performance one:
+/// `repeat(f)` has no base case at all (real jq's own `def repeat(f): f,
+/// repeat(f);`, unconditional on how many outputs `f` produced), so an `f`
+/// that never errors and never produces a value on some round loops
+/// forever -- confirmed live, `limit(3; repeat(empty))` hangs against
+/// pinned jq 1.7.1 too. `resolve_node`'s other arms all return a fully
+/// materialized `Vec<PathBranch>` for `take_path_branches` to truncate
+/// afterward, which cannot work here: the call would simply never return.
+///
+/// Each cycle re-resolves `f` against the *same* original `value`, never
+/// the previous cycle's own result -- `repeat` has no leading `.,` the way
+/// `recurse`'s `., (f | r)` does, and threads no state between rounds at
+/// all. Confirmed live against jq 1.7.1: `{"a":{"a":2}} | path(limit(2;
+/// repeat(.a)))` is `["a"]`, `["a"]` -- the identical single-level path
+/// twice, not the progressively deepening `["a"]`, `["a","a"]` `recurse(.a)`
+/// gives for the same input -- matching `eval_repeat`'s own identical
+/// value-only semantics (its doc comment: "evaluates `expr` with the
+/// original input each time").
+///
+/// `MAX_ITERATIONS` mirrors `eval_repeat`'s own identical backstop
+/// (`src/jq/eval.rs`) against exactly the same unbounded-empty-round
+/// case -- a deliberate divergence from real jq's own hang, not new to
+/// this fix: `eval_repeat`'s value-mode sibling already terminates
+/// `limit(3; repeat(empty))` with no output instead of hanging, and this
+/// keeps path-mode consistent with it rather than reintroducing the hang
+/// only here.
+fn resolve_repeat_bounded<'a, S: EvalSemantics>(
+    f: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    n: usize,
+) -> PathResolveResult<'a> {
+    const MAX_ITERATIONS: usize = 1000;
+    let mut branches = Vec::new();
+    for _ in 0..MAX_ITERATIONS {
+        if branches.len() >= n {
+            break;
+        }
+        match resolve_node::<S>(f, value, trackable, snapshot) {
+            Ok(mut b) => branches.append(&mut b),
+            Err((mut b, e)) => {
+                branches.append(&mut b);
+                branches.truncate(n);
+                return Err((branches, e));
+            }
+        }
+    }
+    branches.truncate(n);
+    Ok(branches)
 }
 
 /// `.[]`'s own path-branch construction (#1850), bounded to at most `n`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12753,11 +12753,14 @@ fn test_repeat_value_budget_bounds_total_output_independent_of_fan_out() -> Resu
     // budget, a single highly-fanning-out round (`range(20001)` produces
     // 20001 values in one round) could balloon `outputs` far past any
     // reasonable size before the per-round `MAX_ITERATIONS` cap ever had a
-    // chance to matter. `repeat` is a succinctly extension (no upstream jq
-    // builtin to compare against), so this pins succinctly's own contract:
-    // the budget (`REDUCE_FOREACH_MAX_STEPS`, shared with `reduce`/
-    // `foreach`) cuts the stream at exactly 10000 values with a clear
-    // error, not an unbounded allocation.
+    // chance to matter. `repeat` genuinely is a real jq builtin (confirmed
+    // live against jq 1.7.1, #1906 -- an earlier version of this comment
+    // wrongly called it a succinctly extension with no upstream builtin to
+    // compare against), but this specific budget-exceeded contract at this
+    // exact threshold is succinctly's own choice, not something to compare
+    // against jq for: the budget (`REDUCE_FOREACH_MAX_STEPS`, shared with
+    // `reduce`/`foreach`) cuts the stream at exactly 10000 values with a
+    // clear error, not an unbounded allocation.
     let (stdout, stderr, code) = run_jq_full(&["-c", "repeat(range(20001))"], Some("null"))?;
     assert_eq!(code, 5, "stderr: {stderr:?}");
     assert_eq!(stdout.lines().count(), 10000, "stdout: {stdout:?}");
@@ -12766,6 +12769,66 @@ fn test_repeat_value_budget_bounds_total_output_independent_of_fan_out() -> Resu
         stderr.contains("maximum iterations exceeded"),
         "stderr: {stderr:?}"
     );
+    Ok(())
+}
+
+/// #1906: `repeat(f)` inside `path(...)` was treated as an untracked value
+/// even when `f` was itself perfectly path-trackable (e.g. `.`), raising
+/// "Invalid path expression" where real jq tracks through it correctly.
+/// Every case here confirmed live against jq 1.7.1.
+#[test]
+fn test_path_repeat_tracks_through_trackable_body_1906() -> Result<()> {
+    // The issue's own repro.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(limit(3; repeat(.)))"], Some("{\"a\":1}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n[]\n[]\n");
+
+    // `repeat(f)` re-resolves `f` against the *original* value every round,
+    // never the previous round's own result -- unlike `recurse(f)`, which
+    // chains and deepens. Confirmed live: `recurse(.a)` on the same input
+    // gives the progressively deepening `[]`, `["a"]`, `["a","a"]`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "path(limit(3; repeat(.a)))"],
+        Some("{\"a\":{\"a\":2}}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\"]\n[\"a\"]\n[\"a\"]\n");
+
+    // A multi-output body fans out every round, exactly like `eval_repeat`'s
+    // own identical value-mode semantics.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(limit(5; repeat(.[])))"], Some("[1,2]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[0]\n[1]\n[0]\n[1]\n[0]\n");
+
+    // A non-path-shaped body still raises immediately -- unaffected by
+    // this fix, which only closes the false-negative for a genuinely
+    // trackable body.
+    let (_, stderr, code) = run_jq_full(&["-c", "path(limit(3; repeat(1)))"], Some("null"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Invalid path expression with result 1"),
+        "stderr: {stderr}"
+    );
+
+    // A body that errors on its first cycle still raises that error,
+    // rather than retrying further rounds.
+    let (_, stderr, code) = run_jq_full(&["-c", "path(limit(3; repeat(.+1)))"], Some("0"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Invalid path expression with result 1"),
+        "stderr: {stderr}"
+    );
+
+    // `limit(3; repeat(empty))` hangs forever against real jq 1.7.1 itself
+    // (`repeat`'s own recursive definition has no base case at all) --
+    // succinctly's value-mode `repeat` already deliberately diverges from
+    // that hang via a round-count backstop (`eval_repeat`'s own
+    // `MAX_ITERATIONS`), and this fix keeps path-mode consistent with it
+    // rather than reintroducing the hang only here.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(limit(3; repeat(empty)))"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12832,6 +12832,53 @@ fn test_path_repeat_tracks_through_trackable_body_1906() -> Result<()> {
     Ok(())
 }
 
+/// Code review on PR #1933 (fixing #1906): an earlier version of
+/// `resolve_repeat_bounded` always propagated a later round's error, even
+/// when `limit`'s own `n` was already satisfied by branches produced
+/// before it -- something real jq's own lazy `limit` never even reaches.
+/// Confirmed live against jq 1.7.1: exit 0, `[]`, no error at all.
+#[test]
+fn test_path_repeat_error_dropped_once_limit_satisfied_1933() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(limit(1; repeat((., error(\"boom\")))))"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "[]\n");
+    Ok(())
+}
+
+/// Code review on PR #1933: an earlier version of `resolve_repeat_bounded`
+/// had no per-branch budget at all, unlike `eval_repeat`'s value-mode
+/// sibling (`REDUCE_FOREACH_MAX_STEPS`) -- letting a large `limit()`-
+/// supplied `n` combined with a wide-fanning-out body allocate far more
+/// than value-mode allows for the identical query shape. Both modes now
+/// cut at exactly 10000 branches with the same "repeat: maximum
+/// iterations exceeded" message.
+#[test]
+fn test_path_repeat_width_budget_matches_value_mode_1933() -> Result<()> {
+    let input = format!(
+        "[{}]",
+        (0..20001)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let (path_stdout, path_stderr, path_code) =
+        run_jq_full(&["-c", "path(limit(50000; repeat(.[])))"], Some(&input))?;
+    let (value_stdout, value_stderr, value_code) =
+        run_jq_full(&["-c", "limit(50000; repeat(.[]))"], Some(&input))?;
+    assert_eq!(path_code, 5, "stderr: {path_stderr}");
+    assert_eq!(value_code, 5, "stderr: {value_stderr}");
+    assert!(
+        path_stderr.contains("repeat: maximum iterations exceeded"),
+        "stderr: {path_stderr}"
+    );
+    assert_eq!(path_stdout.lines().count(), 10000);
+    assert_eq!(path_stdout.lines().count(), value_stdout.lines().count());
+    Ok(())
+}
+
 #[test]
 fn test_walk_nested_break_reaches_its_enclosing_label() -> Result<()> {
     // Before this fix, a nested `f` application collapsed a `Control::Break`


### PR DESCRIPTION
## Summary

`repeat(f)` inside a `path(...)` expression was treated as an untracked value even when `f` was itself perfectly path-trackable — `path(limit(3; repeat(.)))` raised "Invalid path expression" where real jq returns `[]` three times.

## Root cause

`resolve_node` (the path-context resolver in `src/jq/eval.rs`) has a dedicated arm for `recurse`'s every spelling, but none at all for `Expr::Repeat` — it fell through to the generic non-primitive fallback (`resolve_leaf`), which only probes the *first* output before deferring/erroring. Since `repeat(f)` never terminates on its own, this made even a trivially trackable body report the generic error.

## The surprising part: `repeat` doesn't share `recurse`'s shape

I initially assumed `repeat(f)` could just reuse `resolve_recurse` (the same machinery `Builtin::RecurseF` uses), since jq's docs describe `repeat`'s definition as looking identical to `recurse`'s (`., (f | r)`). Live-testing against jq 1.7.1 disproved that:

```console
$ echo '{"a":{"a":2}}' | jq -c 'path(limit(2; repeat(.a)))'
["a"]
["a"]
$ echo '{"a":{"a":2}}' | jq -c 'path(limit(2; recurse(.a)))'
[]
["a"]
```

`repeat(f)` re-resolves `f` against the *original* value every round, never the previous round's own result — it has no base `.,` case at all. This matches `eval_repeat`'s own existing value-mode implementation exactly (its doc comment: "evaluates expr with the original input each time").

## Fix

Since `repeat(f)` has no natural termination, the fix intercepts in `resolve_limit_one_n` (mirroring #1850's `Expr::Iterate` precedent, but for correctness rather than performance — an unbounded `resolve_node` call for `Expr::Repeat` would simply never return). `resolve_repeat_bounded` loops calling `resolve_node` for the body up to `n` times, stopping as soon as `n` branches are collected or an error occurs. A `MAX_ITERATIONS` backstop (1000, mirroring `eval_repeat`'s own identical guard) keeps an always-empty body from hanging path-mode the way it already doesn't hang value-mode — `limit(3; repeat(empty))` genuinely hangs against real jq 1.7.1 itself (confirmed live, with a timeout), and succinctly's value-mode `repeat` already deliberately diverges from that hang.

Also corrected a stale, adjacent comment that called `repeat` a "succinctly extension" with "no upstream jq builtin to compare against" — confirmed live against jq 1.7.1 that it's a real builtin.

## Verification

- Every case in the issue, plus the `recurse` divergence, multi-output fan-out, non-path-shaped body, first-cycle error, and the `repeat(empty)` hang-avoidance — all confirmed byte-identical to jq 1.7.1 (or its documented-divergence counterpart).
- `cargo test` under default features (3022 passed) and `--features cli,simd,regex,serde` (3070 passed) — 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second leg — clean.
- `cargo build --no-default-features` (no_std) and `cargo fmt --check` — clean.

Fixes #1906