### PR TITLE
fix(jq): guard error(msg)'s decode failure, extract scalar_fallback helper

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5701,26 +5701,37 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // ones) would otherwise silently resurrect it.
         Some(msg_expr) => {
             let msg_result = eval_single::<W, S>(msg_expr, value, optional).materialize_cursor();
-            let owned = match msg_result {
-                QueryResult::One(v) => to_owned_checked(&v).map_err(EvalEscape::from),
-                QueryResult::Many(vs) => match vs.first() {
-                    Some(v) => to_owned_checked(v).map_err(EvalEscape::from),
-                    None => result_to_owned(QueryResult::Many(vs)),
-                },
-                other => result_to_owned(other),
+            // `to_owned_checked`'s own materialization errors (a decode
+            // failure, or a #1194 malformed-member error -- neither is
+            // `is_decode_failure()`-tagged, but `to_owned_checked` raises
+            // both unconditionally at every other call site in this file,
+            // including this function's own `None` arm below) are never
+            // suppressed by `optional`. That's a different, narrower
+            // question than whether `optional` should suppress an ordinary
+            // error surfacing from `msg_expr`'s *own* evaluation (handled
+            // in the `else` branch below) -- conflating the two by gating
+            // only on `is_decode_failure()` here would wrongly let
+            // `optional` swallow a malformed-member error too.
+            let checked = match &msg_result {
+                QueryResult::One(v) => Some(to_owned_checked(v)),
+                QueryResult::Many(vs) => vs.first().map(to_owned_checked),
+                _ => None,
             };
-            match owned {
-                Ok(v) => v,
-                // `?` swallows only a genuine, catchable error in the message
-                // expression; a halt inside it always escapes (#791) --
-                // `isvalid(error(halt_error(3)))` must still halt, not report
-                // `false` -- and, per #1247/#1620, a decode failure is never
-                // suppressed by `?` either, matching the `None` arm below's
-                // own unconditional-return contract.
-                Err(EvalEscape::Error(e)) if optional && !e.is_decode_failure() => {
-                    return QueryResult::None;
+            if let Some(checked) = checked {
+                match checked {
+                    Ok(v) => v,
+                    Err(e) => return QueryResult::Error(e),
                 }
-                Err(escape) => return escape.into(),
+            } else {
+                match result_to_owned(msg_result) {
+                    Ok(v) => v,
+                    // `?` swallows only a genuine, catchable error in the
+                    // message expression; a halt inside it always escapes
+                    // (#791) -- `isvalid(error(halt_error(3)))` must still
+                    // halt, not report `false`.
+                    Err(EvalEscape::Error(_)) if optional => return QueryResult::None,
+                    Err(escape) => return escape.into(),
+                }
             }
         }
         // #1820: to_owned_checked, not to_owned -- bare `error` raises the
@@ -44127,6 +44138,53 @@ mod tests {
         query!(br#"{"a": "\uXXXX", "b": "ok"}"#, "error((.a, .b))?",
             QueryResult::Error(e) => {
                 assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
+            }
+        );
+    }
+
+    #[test]
+    fn eval_error_msg_expr_malformed_member_reaches_an_enclosing_catch_1907() {
+        // A more discriminating sibling of the plain-raise test below: `?`
+        // and `try`/`catch` suppression is `eval_try`'s own decision, made
+        // *after* inspecting whatever this function returns -- for a bare
+        // `?` (no catch handler), `eval_try` discards any non-decode-failure
+        // `Error` to `None` regardless of how it got there, so that shape
+        // can't tell an internally-self-suppressing `eval_error` apart from
+        // one that raises and lets `eval_try` decide. Wrapping a *real*
+        // catch handler inside the `?` can: with `optional` forced `true` by
+        // the outer `?`, the inner `eval_try`'s `catch = Some(...)` arm only
+        // ever runs if this function actually returns `Error(e)` rather than
+        // self-suppressing to `None` first. Confirmed this reaches the
+        // handler with the fix, and would return bare `None` (skipping the
+        // handler entirely) without it.
+        query!(br#"{"a":1,"b"}"#, r#"(try error(.) catch "caught")?"#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "caught");
+            }
+        );
+    }
+
+    #[test]
+    fn eval_error_msg_expr_malformed_member_raised_1907() {
+        // Sibling to the decode-failure tests above, for the *other* error
+        // class `to_owned_checked` can raise: a #1194 malformed-member error
+        // (a trailing unpaired object member JSON's own semi-index accepts,
+        // e.g. `{"a":1,"b"}`) is not `is_decode_failure()`-tagged, but
+        // `to_owned_checked` raises it unconditionally at every other call
+        // site in this file, including this function's own `None` arm below
+        // -- so `error(.)` must raise it here too, not silently swallow it
+        // into `""` via an unchecked `to_owned`.
+        //
+        // This does *not* assert anything about a *wrapping* `?`/`try`:
+        // that suppression/catch decision belongs to `eval_try`, one level
+        // up, whose own `is_decode_failure()`-only exclusion is a separate,
+        // pre-existing gap (closely related to #1907's own item 3) outside
+        // this fix's scope -- `eval_try` re-decides uniformly from the
+        // `Error` this function returns, regardless of *how* this function
+        // arrived at it.
+        query!(br#"{"a":1,"b"}"#, "error(.)",
+            QueryResult::Error(e) => {
+                assert!(!e.is_decode_failure());
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1019,37 +1019,32 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             )),
         },
 
-        // #1820: `scalar_decode_failure` before the `optional`/type-error
-        // fallback -- an undecodable-string scalar must raise its own
-        // decode failure, not the generic `cannot_iterate_with` message
-        // built from an unchecked `to_owned` (which silently substitutes
-        // `""` into the message and, worse, would still report "cannot
-        // iterate" instead of the real reason, even under `?`, where a
-        // decode failure must never be suppressed, #1247/#1620).
-        Expr::Iterate => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
+        // #1820/#1907: `scalar_fallback` -- an undecodable-string scalar must
+        // raise its own decode failure, not the generic `cannot_iterate_with`
+        // message built from an unchecked `to_owned` (which silently
+        // substitutes `""` into the message and, worse, would still report
+        // "cannot iterate" instead of the real reason, even under `?`, where
+        // a decode failure must never be suppressed, #1247/#1620).
+        Expr::Iterate => match value {
+            StandardJson::Array(elements) => {
+                let results: Vec<_> = elements.collect();
+                QueryResult::Many(results)
             }
-            match value {
-                StandardJson::Array(elements) => {
-                    let results: Vec<_> = elements.collect();
-                    QueryResult::Many(results)
-                }
-                // Duplicate keys collapse here in jq mode (#1385): the object
-                // jq iterates has already had a repeated key reduced to one
-                // member. yq keeps every occurrence, so `effective_fields`
-                // degenerates to the plain walk this used to do inline.
-                StandardJson::Object(fields) => {
-                    let results: Vec<_> = effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS)
-                        .into_iter()
-                        .map(|f| f.value)
-                        .collect();
-                    QueryResult::Many(results)
-                }
-                _ if optional => QueryResult::None,
-                _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
+            // Duplicate keys collapse here in jq mode (#1385): the object
+            // jq iterates has already had a repeated key reduced to one
+            // member. yq keeps every occurrence, so `effective_fields`
+            // degenerates to the plain walk this used to do inline.
+            StandardJson::Object(fields) => {
+                let results: Vec<_> = effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS)
+                    .into_iter()
+                    .map(|f| f.value)
+                    .collect();
+                QueryResult::Many(results)
             }
-        }
+            _ => scalar_fallback(&value, optional, || {
+                EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+            }),
+        },
 
         // `.[EXPR]?`/`.[S:E]?`: jq's `?` here guards only the *final*
         // indexing/slicing operation, not evaluation of the bracket's own
@@ -5676,17 +5671,22 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `{"x":1}`, not `null`.
     let payload = match msg {
         // #1907: `to_owned_checked` on the materialized `One`/`OneCursor`
-        // case, not the plain `to_owned` `result_to_owned` uses internally --
-        // the same asymmetry the `None` arm below was already fixed for by
-        // #1820. `result_to_owned`/`result_to_owned_ctrl`/`result_to_owned_full`
+        // case and on `Many`'s first element, not the plain `to_owned`
+        // `result_to_owned` uses internally -- the same asymmetry the `None`
+        // arm below was already fixed for by #1820.
+        // `result_to_owned`/`result_to_owned_ctrl`/`result_to_owned_full`
         // back ~47 other call sites across this file, each with its own
         // optional/catchability contract, so this fixes only `error(msg)`'s
         // own materialization here rather than touching the shared helper
-        // (#1907's own "Category 2 territory" scope note). `Owned`/`ManyOwned`/
-        // `Many` arms of `result_to_owned` need no equivalent guard: a
-        // computed/collected `OwnedValue` is already valid UTF-8 by
-        // construction, so only the still-lazy `One`/`OneCursor` case can
-        // carry an undecoded string through to here.
+        // (#1907's own "Category 2 territory" scope note). `Owned`/`ManyOwned`
+        // need no equivalent guard: a computed/collected `OwnedValue` is
+        // already valid UTF-8 by construction. `Many` does need one --
+        // unlike `ManyOwned`, it holds still-lazy, undecoded `StandardJson`
+        // values (e.g. `error((.a, .b))`'s comma keeps both operands
+        // borrowed when neither forces owned promotion), so only its first
+        // element (the one a generator-argument caller actually consumes,
+        // per `result_to_owned_ctrl`'s own doc comment) is checked here,
+        // mirroring `result_to_owned_full`'s own `vs.first()` semantics.
         //
         // Not reachable via any query this CLI can currently parse:
         // `Expr::Error` has no native arm in `eval_generic::eval_single`, so
@@ -5703,6 +5703,10 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let msg_result = eval_single::<W, S>(msg_expr, value, optional).materialize_cursor();
             let owned = match msg_result {
                 QueryResult::One(v) => to_owned_checked(&v).map_err(EvalEscape::from),
+                QueryResult::Many(vs) => match vs.first() {
+                    Some(v) => to_owned_checked(v).map_err(EvalEscape::from),
+                    None => result_to_owned(QueryResult::Many(vs)),
+                },
                 other => result_to_owned(other),
             };
             match owned {
@@ -44097,6 +44101,30 @@ mod tests {
         // suppressed by `?` -- `error(.a)?` must still raise uncaught, the
         // same rule bare `error?` on an undecodable value already follows.
         query!(br#"{"a": "\uXXXX"}"#, "error(.a)?",
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
+            }
+        );
+    }
+
+    #[test]
+    fn eval_error_msg_expr_raises_decode_failure_through_comma_1907() {
+        // A comma expression (`(.a, .b)`) keeps both operands lazily
+        // borrowed when neither forces owned promotion (`eval_comma`'s
+        // `borrowed_vec_to_result`), so `msg_result` here is
+        // `QueryResult::Many`, not `One` -- a case the initial version of
+        // this fix missed (only special-casing `One`), letting a `Many`
+        // whose first element is undecodable fall through to
+        // `result_to_owned`'s own unchecked `to_owned` (#1907 review).
+        // `error`'s generator-argument semantics only ever consume the
+        // *first* output (see `result_to_owned_ctrl`'s doc comment), so
+        // checking `Many`'s first element is the correct, matching fix.
+        query!(br#"{"a": "\uXXXX", "b": "ok"}"#, "error((.a, .b))",
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
+            }
+        );
+        query!(br#"{"a": "\uXXXX", "b": "ok"}"#, "error((.a, .b))?",
             QueryResult::Error(e) => {
                 assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -694,6 +694,27 @@ fn scalar_decode_failure<W: Clone + AsRef<[u64]>>(
     None
 }
 
+/// Collapse the `scalar_decode_failure` / `optional` / type-error triplet
+/// that `#1820`'s scalar-fallback arms duplicated across this file (#1907
+/// item 5): decode failure wins unconditionally, `optional` suppresses the
+/// remaining type error, and otherwise `err()` builds it. `err` is called at
+/// most once and only in the final, un-suppressed case, so a caller whose
+/// constructor itself does real work (`to_owned`, formatting) pays nothing
+/// extra on the two earlier-return paths.
+fn scalar_fallback<'a, W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'a, W>,
+    optional: bool,
+    err: impl FnOnce() -> EvalError,
+) -> QueryResult<'a, W> {
+    if let Some(e) = scalar_decode_failure(value) {
+        return QueryResult::Error(e);
+    }
+    if optional {
+        return QueryResult::None;
+    }
+    QueryResult::Error(err())
+}
+
 /// Materialize a key/slice-bound candidate just enough to classify it.
 ///
 /// `index_one`/[`EvalError::cannot_index`] and `SliceBounds::resolved_bound`
@@ -5654,15 +5675,47 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `error` raises the input value, as jq does — `{"x":1} | error` reports
     // `{"x":1}`, not `null`.
     let payload = match msg {
+        // #1907: `to_owned_checked` on the materialized `One`/`OneCursor`
+        // case, not the plain `to_owned` `result_to_owned` uses internally --
+        // the same asymmetry the `None` arm below was already fixed for by
+        // #1820. `result_to_owned`/`result_to_owned_ctrl`/`result_to_owned_full`
+        // back ~47 other call sites across this file, each with its own
+        // optional/catchability contract, so this fixes only `error(msg)`'s
+        // own materialization here rather than touching the shared helper
+        // (#1907's own "Category 2 territory" scope note). `Owned`/`ManyOwned`/
+        // `Many` arms of `result_to_owned` need no equivalent guard: a
+        // computed/collected `OwnedValue` is already valid UTF-8 by
+        // construction, so only the still-lazy `One`/`OneCursor` case can
+        // carry an undecoded string through to here.
+        //
+        // Not reachable via any query this CLI can currently parse:
+        // `Expr::Error` has no native arm in `eval_generic::eval_single`, so
+        // every `error(msg)` call — the only parser construction site for
+        // this function's `Some` branch — falls to that file's wildcard
+        // bridge, which already decode-checks the whole ambient value via
+        // `to_owned_with_cursor`/`owned_or_err!` before `eval::eval` (this
+        // function's caller) ever runs, exactly like the already-documented
+        // `Expr::Try`/`Expr::Optional` case in `eval_generic.rs`. Fixed
+        // anyway since the asymmetry is real and cheap to close, and a
+        // future native `Expr::Error` arm (mirroring #1812's `Try`/`Optional`
+        // ones) would otherwise silently resurrect it.
         Some(msg_expr) => {
-            let msg_result = eval_single::<W, S>(msg_expr, value, optional);
-            match result_to_owned(msg_result) {
+            let msg_result = eval_single::<W, S>(msg_expr, value, optional).materialize_cursor();
+            let owned = match msg_result {
+                QueryResult::One(v) => to_owned_checked(&v).map_err(EvalEscape::from),
+                other => result_to_owned(other),
+            };
+            match owned {
                 Ok(v) => v,
-                // `?` swallows only a genuine error in the message
-                // expression; a halt inside it always escapes (#791) —
-                // `isvalid(error(halt_error(3)))` must still halt, not
-                // report `false`.
-                Err(EvalEscape::Error(_)) if optional => return QueryResult::None,
+                // `?` swallows only a genuine, catchable error in the message
+                // expression; a halt inside it always escapes (#791) --
+                // `isvalid(error(halt_error(3)))` must still halt, not report
+                // `false` -- and, per #1247/#1620, a decode failure is never
+                // suppressed by `?` either, matching the `None` arm below's
+                // own unconditional-return contract.
+                Err(EvalEscape::Error(e)) if optional && !e.is_decode_failure() => {
+                    return QueryResult::None;
+                }
                 Err(escape) => return escape.into(),
             }
         }
@@ -6271,13 +6324,9 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
             // decode failure, never suppressed by `?` (#1247/#1620),
             // instead of the generic `has_no_keys` message built from an
             // unchecked `to_owned`.
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::has_no_keys(&to_owned(&value)))
+            scalar_fallback(&value, optional, || {
+                EvalError::has_no_keys(&to_owned(&value))
+            })
         }
     }
 }
@@ -6706,13 +6755,9 @@ fn builtin_map<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // must raise its own decode failure, never suppressed by `?`
             // (#1247/#1620), instead of the generic message built from an
             // unchecked `to_owned`.
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
+            scalar_fallback(&value, optional, || {
+                EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+            })
         }
     }
 }
@@ -6883,15 +6928,9 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         //
         // #1820: scalar_decode_failure first -- same gap as builtin_map's
         // sibling fallback above.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -6909,13 +6948,9 @@ fn builtin_add<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Array(elements) => elements.map(|e| to_owned_checked(&e)).collect(),
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
         _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)));
+            return scalar_fallback(&value, optional, || {
+                EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+            });
         }
     };
     let items = match items {
@@ -7226,18 +7261,9 @@ fn builtin_min<W: Clone + AsRef<[u64]>>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, never be suppressed by `optional`/`?` (the
         // #1247/#1620 rule) or misreported as an ordinary type error.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::pair_cannot_be_iterated(
-                &to_owned(&value),
-                &to_owned(&value),
-            ))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::pair_cannot_be_iterated(&to_owned(&value), &to_owned(&value))
+        }),
     }
 }
 
@@ -7264,18 +7290,9 @@ fn builtin_max<W: Clone + AsRef<[u64]>>(
             QueryResult::Owned(max)
         }
         // #1755: same reasoning as builtin_min's own scalar arm above.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::pair_cannot_be_iterated(
-                &to_owned(&value),
-                &to_owned(&value),
-            ))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::pair_cannot_be_iterated(&to_owned(&value), &to_owned(&value))
+        }),
     }
 }
 
@@ -7405,15 +7422,9 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: but a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -7471,15 +7482,9 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         //
         // #1755: same decode-failure precedence as min_by's own scalar arm
         // above.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -8328,18 +8333,9 @@ fn builtin_first<W: Clone + AsRef<[u64]>>(
         // `scalar_decode_failure`. Found alongside `last`'s identical
         // fallback arm, though `first` was not itself in scope for this
         // sweep (its own Array arm never materializes at all).
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_index_with_type(
-                type_name(&value),
-                "number",
-            ))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_index_with_type(type_name(&value), "number")
+        }),
     }
 }
 
@@ -8368,18 +8364,9 @@ fn builtin_last<W: Clone + AsRef<[u64]>>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_index_with_type(
-                type_name(&value),
-                "number",
-            ))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_index_with_type(type_name(&value), "number")
+        }),
     }
 }
 
@@ -8465,13 +8452,9 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Array(elements) => elements.map(|e| to_owned_checked(&e)).collect(),
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
         _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)));
+            return scalar_fallback(&value, optional, || {
+                EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+            });
         }
     };
     let items = match items {
@@ -8637,15 +8620,9 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: but a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -8691,15 +8668,9 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -8763,15 +8734,9 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: but a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -8796,15 +8761,9 @@ fn builtin_sort<W: Clone + AsRef<[u64]>>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_be_sorted(&to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_be_sorted(&to_owned(&value))
+        }),
     }
 }
 
@@ -8864,15 +8823,9 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: but a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+        }),
     }
 }
 
@@ -8979,13 +8932,9 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
             // `to_owned_checked`'s own "primary" call site); the residual
             // scalar fallback was missed. Same guard as builtin_keys'
             // sibling fallback.
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::has_no_keys(&to_owned(&value)))
+            scalar_fallback(&value, optional, || {
+                EvalError::has_no_keys(&to_owned(&value))
+            })
         }
     }
 }
@@ -9087,13 +9036,9 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Array(elements) => elements.map(|elem| to_owned_checked(&elem)).collect(),
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
         _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value)));
+            return scalar_fallback(&value, optional, || {
+                EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
+            });
         }
     };
     let entries = match entries {
@@ -11936,15 +11881,9 @@ fn builtin_fromjsonstream<W: Clone + AsRef<[u64]>>(
         // `scalar_decode_failure` guard so a corrupted top-level scalar
         // raises an uncatchable decode failure (#1247/#1620) instead of
         // an ordinary, `?`-suppressible "not an array" type error.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::type_error("array", type_name(&value)))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::type_error("array", type_name(&value))
+        }),
     }
 }
 
@@ -36049,15 +35988,9 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::new("pick: input must be an object or array"))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::new("pick: input must be an object or array")
+        }),
     }
 }
 
@@ -36213,15 +36146,9 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
-        _ => {
-            if let Some(e) = scalar_decode_failure(&value) {
-                return QueryResult::Error(e);
-            }
-            if optional {
-                return QueryResult::None;
-            }
-            QueryResult::Error(EvalError::new("omit: input must be an object or array"))
-        }
+        _ => scalar_fallback(&value, optional, || {
+            EvalError::new("omit: input must be an object or array")
+        }),
     }
 }
 
@@ -44137,6 +44064,41 @@ mod tests {
         query!(br#"{"msg": "custom error"}"#, "error(.msg)",
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "custom error");
+            }
+        );
+    }
+
+    #[test]
+    fn eval_error_msg_expr_raises_decode_failure_1907() {
+        // #1907 item 1: `error(msg)`'s `Some(msg_expr)` branch used to
+        // materialize `msg` via the unchecked `to_owned`, silently
+        // substituting `""` for an undecodable string instead of raising its
+        // own decode failure -- asymmetric with bare `error` (this file's
+        // `None` arm, fixed by #1820), which already used `to_owned_checked`.
+        //
+        // Exercised directly through this macro's own `eval::eval` dispatch,
+        // not the CLI: `Expr::Error` has no native `eval_generic::eval_single`
+        // arm, so every CLI-parsed `error(msg)` query is decode-checked
+        // earlier, by that file's wildcard bridge (`to_owned_with_cursor` /
+        // `owned_or_err!`), before this function ever runs -- confirmed live
+        // against the built CLI binary with the identical `{"a": "\uXXXX"}` /
+        // `error(.a)` repro, which already raised correctly before this fix.
+        query!(br#"{"a": "\uXXXX"}"#, "error(.a)",
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
+                assert_eq!(e.message, "invalid unicode escape sequence");
+            }
+        );
+    }
+
+    #[test]
+    fn eval_error_msg_expr_decode_failure_not_suppressed_by_optional_1907() {
+        // Sibling of the above: per #1247/#1620, a decode failure is never
+        // suppressed by `?` -- `error(.a)?` must still raise uncaught, the
+        // same rule bare `error?` on an undecodable value already follows.
+        query!(br#"{"a": "\uXXXX"}"#, "error(.a)?",
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
             }
         );
     }


### PR DESCRIPTION
## Summary

Scoped to items 1 and 5 of #1907 (items 2/3/4 need their own separate look, per the claim comment on that issue).

- **Item 1**: `error(msg)`'s `Some(msg_expr)` branch materialized `msg` via the unchecked `to_owned`, silently substituting `""` for an undecodable string instead of raising its own decode failure — asymmetric with bare `error` (the `None` arm, already fixed by #1820) and with `error(msg)?` incorrectly suppressing what should be an uncatchable decode failure.

  **Not reachable via any query the CLI can currently parse**: `Expr::Error` has no native arm in `eval_generic::eval_single`, so every parsed `error(msg)` call falls to that file's wildcard bridge, which already decode-checks the whole ambient value (`to_owned_with_cursor`/`owned_or_err!`) before `eval::eval` (this function's caller) ever runs — the same mechanism already documented for the `Expr::Try`/`Expr::Optional` case fixed in #1812. Fixed anyway since the asymmetry is real and cheap to close at this one call site, and a future native `Expr::Error` arm in `eval_generic.rs` (mirroring #1812's `Try`/`Optional` ones) would otherwise silently resurrect it.

  Three rounds of review on this PR found and fixed two further gaps in the initial version of this fix:
  - It only special-cased `QueryResult::One`; a comma expression (`error((.a, .b))`) keeps both operands lazily borrowed as `QueryResult::Many` when neither forces owned promotion, so an undecodable string in that position still fell through to the unchecked path. Now checks `Many`'s first element too (the one a generator-argument caller actually consumes).
  - The suppression check (`optional && !e.is_decode_failure()`) only excluded decode failures, but `to_owned_checked` can also raise a #1194 malformed-member error (not `is_decode_failure()`-tagged) that every other `to_owned_checked` call site in this file raises unconditionally regardless of `optional`. Restructured so `to_owned_checked`'s own materialization errors always return `Error` directly, never routed through the `optional`-aware suppression check — that check now applies only to an ordinary error surfacing from `msg_expr`'s own evaluation, which `optional` should still legitimately suppress.

  New unit tests exercise all of this directly via `eval::eval` (the same way this file's other "no parser construction site" tests, e.g. `builtin_envvar_propagates_halt_from_variable_name_expression`, already do).

- **Item 5**: extracted the `scalar_decode_failure` / `optional` / type-error triplet that #1820 duplicated ~20 times across `eval.rs` into a single `scalar_fallback` helper (as proposed in the issue), collapsing each call site to one line, including a leftover instance in `Expr::Iterate` a review round found.

## Test plan
- [x] New unit tests in `src/jq/eval.rs`: `eval_error_msg_expr_raises_decode_failure_1907`, `eval_error_msg_expr_decode_failure_not_suppressed_by_optional_1907`, `eval_error_msg_expr_raises_decode_failure_through_comma_1907`, `eval_error_msg_expr_malformed_member_raised_1907`, `eval_error_msg_expr_malformed_member_reaches_an_enclosing_catch_1907`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, re-run after each review round)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Refs #1907
