### PR TITLE
fix(jq): array slice raises on element decode failure instead of substituting ""

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -910,23 +910,22 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     return QueryResult::One(value);
                 }
                 // jq array slicing yields a single sub-array, not a stream of
-                // elements. #1932: `promote_borrowed_checked`, not an
-                // unchecked `to_owned` per element -- an undecodable
-                // element's string content must raise `decode_failure`, not
-                // silently become `""` (the same #1755 shape the adjacent
-                // `StandardJson::Object` arm below already guards against;
-                // this arm was apparently missed when #1755 patched that
-                // one). The partial prefix `promote_borrowed_checked`'s
-                // `Err` carries is discarded, not threaded into a `Partial`
-                // result: unlike a fan-out stream, this arm always produces
-                // exactly one aggregate `Array` value, so there is nothing
-                // for a caller to consume before the failure -- matching
-                // the `Object` arm's own `to_owned_checked` call just below,
-                // which discards its own error's prefix the same way.
+                // elements. #1932: `to_owned_checked`, not an unchecked
+                // `to_owned`, per element -- an undecodable element's string
+                // content must raise `decode_failure`, not silently become
+                // `""` (the same #1755 shape the adjacent `StandardJson::
+                // Object` arm below already guards against; this arm was
+                // apparently missed when #1755 patched that one). Mirrors
+                // that `Object` arm's own single `to_owned_checked` call
+                // (code review, #1941: an earlier version of this fix used
+                // `promote_borrowed_checked` instead, built for a different
+                // shape -- accumulating a partial prefix for a fan-out
+                // stream to report on error -- that this single-aggregate-
+                // value arm has no use for and was discarding unconditionally).
                 let sliced = slice_elements::<W>(elements, *start, *end);
-                match promote_borrowed_checked(sliced) {
+                match sliced.iter().map(to_owned_checked).collect() {
                     Ok(items) => QueryResult::Owned(OwnedValue::Array(items)),
-                    Err((_, e)) => QueryResult::Error(e),
+                    Err(e) => QueryResult::Error(e),
                 }
             }
             // yq treats a null/number/boolean target as an empty container
@@ -39280,9 +39279,9 @@ mod tests {
                 assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
             }
         );
-        // Fails on the second element of the (post-slice) range, not just
-        // the first -- confirms the whole sliced range is checked, not only
-        // the initial element.
+        // The undecodable element is at index 1 here (vs. index 2 above) --
+        // confirms every position in the sliced range is checked, not only
+        // the first or the last.
         query!(
             &b"[1,\"\xff\xfe\",3,4]"[..],
             ".[0:3]",

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -909,12 +909,25 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 if matches!(start, None | Some(0)) && end.is_none() {
                     return QueryResult::One(value);
                 }
-                // jq array slicing yields a single sub-array, not a stream of elements
-                let items: Vec<OwnedValue> = slice_elements::<W>(elements, *start, *end)
-                    .iter()
-                    .map(to_owned)
-                    .collect();
-                QueryResult::Owned(OwnedValue::Array(items))
+                // jq array slicing yields a single sub-array, not a stream of
+                // elements. #1932: `promote_borrowed_checked`, not an
+                // unchecked `to_owned` per element -- an undecodable
+                // element's string content must raise `decode_failure`, not
+                // silently become `""` (the same #1755 shape the adjacent
+                // `StandardJson::Object` arm below already guards against;
+                // this arm was apparently missed when #1755 patched that
+                // one). The partial prefix `promote_borrowed_checked`'s
+                // `Err` carries is discarded, not threaded into a `Partial`
+                // result: unlike a fan-out stream, this arm always produces
+                // exactly one aggregate `Array` value, so there is nothing
+                // for a caller to consume before the failure -- matching
+                // the `Object` arm's own `to_owned_checked` call just below,
+                // which discards its own error's prefix the same way.
+                let sliced = slice_elements::<W>(elements, *start, *end);
+                match promote_borrowed_checked(sliced) {
+                    Ok(items) => QueryResult::Owned(OwnedValue::Array(items)),
+                    Err((_, e)) => QueryResult::Error(e),
+                }
             }
             // yq treats a null/number/boolean target as an empty container
             // for slicing purposes (#1065, verified live against real yq
@@ -39240,6 +39253,53 @@ mod tests {
             br#"[{"a":2},{"a":1}]"#,
             "max_by(.a)",
             QueryResult::Owned(OwnedValue::Object(_)) => {}
+        );
+    }
+
+    /// #1932: `eval_single`'s `Expr::Slice`/`Expr::SliceNumber` arm, in the
+    /// `StandardJson::Array` case, used an unchecked `to_owned` per element
+    /// instead of `promote_borrowed_checked` -- the same #1755 bug shape
+    /// already fixed for the adjacent `StandardJson::Object` arm a few
+    /// lines below, missed on the array arm at the time. Exercised via
+    /// `eval.rs`'s own library-API dispatch (`query!`), not the CLI, same as
+    /// #1755's sort/unique family above (see that test's own comment) --
+    /// `eval_generic.rs` has no native arm for a bare `Expr::Slice`/
+    /// `Expr::SliceNumber` either, so its own catch-all fallback reaches
+    /// this exact function too, but only *after* first materializing the
+    /// whole target via its own already-checked `to_owned_with_cursor` and
+    /// re-serializing it to fresh JSON bytes (`eval_generic.rs`'s `_ =>` arm
+    /// in its own `eval_single`) -- so any undecodable element in the
+    /// *original* document is already caught upstream of this arm on that
+    /// route, never reaching it with malformed bytes to reproduce the bug.
+    #[test]
+    fn test_array_slice_raises_on_element_decode_failure_1932() {
+        query!(
+            &b"[1,2,\"\xff\xfe\",4]"[..],
+            ".[0:3]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        // Fails on the second element of the (post-slice) range, not just
+        // the first -- confirms the whole sliced range is checked, not only
+        // the initial element.
+        query!(
+            &b"[1,\"\xff\xfe\",3,4]"[..],
+            ".[0:3]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        // Positive control: valid data through the same arm is unaffected.
+        query!(
+            br#"[1,2,"ok",4]"#,
+            ".[0:3]",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(
+                    v,
+                    vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::String("ok".into())]
+                );
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

`eval_single`'s `Expr::Slice`/`Expr::SliceNumber` arm, in the `StandardJson::Array` case, used an unchecked `to_owned` per element instead of `promote_borrowed_checked` — the same #1755 bug shape already fixed for the adjacent `StandardJson::Object` arm a few lines below (that arm's own comment cites #1755), apparently missed on the array arm at the time.

## Fix

`promote_borrowed_checked` already exists for exactly this shape (a `Vec<StandardJson>` needing a checked, first-error-wins conversion to `Vec<OwnedValue>`), and `slice_elements` already returns that exact type — this is a straight swap, no new helper needed.

## A note on verification (the issue's own CLI repro doesn't actually reach this code)

The issue's suggested repro (`printf '[1,2,"\xff\xfe",4]' | succinctly jq '.[0:3]'`) doesn't reproduce via the CLI, on either the old or new code — I verified this directly. The reason: `eval_generic.rs` (what the CLI actually dispatches through) has no native arm for a bare `Expr::Slice`/`Expr::SliceNumber` either, so its own catch-all fallback reaches this same `eval.rs` function too — but only *after* first materializing the whole target via its own already-checked `to_owned_with_cursor` and re-serializing to fresh JSON bytes. Any undecodable element in the *original* document is already caught upstream on that route.

This is the exact same situation this file's own `test_sort_family_valid_data_unaffected_1755` test already documents for the sort/unique/min/max family: "reachable only through the public `succinctly::jq::eval` library API, not the CLI's `eval_generic.rs` bridge." Verified via the same `query!`-macro unit-test methodology that test uses, not CLI testing.

## Verification

- New unit test confirmed to fail on the pre-fix code with exactly the described bug (`String("")` substitution), and pass on the fix.
- `cargo test` under default features (3026 passed) and `--features cli,simd,regex,serde` (3074 passed) — 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and the CI's second leg — clean.
- `cargo build --no-default-features` (no_std) and `cargo fmt --check` — clean.

Fixes #1932