### PR TITLE
fix(yq): memoize select()'s corruption walk so aliases stop amplifying (#1804)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12,6 +12,8 @@
 #[cfg(not(test))]
 use alloc::boxed::Box;
 #[cfg(not(test))]
+use alloc::collections::BTreeSet;
+#[cfg(not(test))]
 use alloc::format;
 #[cfg(not(test))]
 use alloc::rc::Rc;
@@ -21,6 +23,8 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 #[cfg(not(test))]
 use alloc::vec::Vec;
+#[cfg(test)]
+use std::collections::BTreeSet;
 #[cfg(test)]
 use std::rc::Rc;
 
@@ -1959,7 +1963,40 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// side (no `OwnedValue`/`Vec` payload) -- not a claim that a
 /// container-shaped condition is free.
 fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
+    push_generic_truthiness_cursor_error_memo(c, depth, &mut BTreeSet::new())
+}
+
+/// [`push_generic_truthiness_cursor_error`]'s worker, carrying the set of
+/// node positions already proven clean.
+///
+/// **Without the memo this walk is exponential on an aliased document**
+/// (#1804). A YAML alias makes one node reachable by many paths, so a
+/// billion-laughs shape -- `aN: &aN [*a(N-1), *a(N-1)]` -- has 2^N reachable
+/// nodes while occupying O(N) bytes on disk. Re-walking each reference from
+/// scratch turned a ~450-byte file into 0.4s of work for a two-byte answer,
+/// against real yq's flat 7ms (measured across N=12..20, where succinctly
+/// went 6ms -> 425ms and yq did not move).
+///
+/// Memoizing on `text_position` is sound because this check is a pure
+/// function of the subtree at a node: a position is inserted only on the
+/// path that returns `None`, since any error returns before the recursion
+/// continues -- so "already seen" can only ever mean "already proven
+/// clean". A node with no position is simply never memoized.
+///
+/// The aliases themselves sit at distinct positions and do not collide; what
+/// collides is their *children*, which resolve to the same target node, and
+/// that is where the fan-out is cut.
+fn push_generic_truthiness_cursor_error_memo<C: DocumentCursor>(
+    c: &C,
+    depth: usize,
+    seen: &mut BTreeSet<usize>,
+) -> Option<Control> {
     assert_nesting_depth(depth);
+    if let Some(pos) = c.text_position() {
+        if !seen.insert(pos) {
+            return None;
+        }
+    }
     let value = c.value();
     if let Some(fields) = value.as_object() {
         let mut map: IndexMap<String, ()> = IndexMap::new();
@@ -1974,7 +2011,7 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
                 Err(e) => return Some(Control::Error(e)),
             }
             if let Some(control) =
-                push_generic_truthiness_cursor_error(&field.value_cursor, depth + 1)
+                push_generic_truthiness_cursor_error_memo(&field.value_cursor, depth + 1, seen)
             {
                 return Some(control);
             }
@@ -1987,7 +2024,9 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
     } else if let Some(elements) = value.as_array() {
         let mut elems = elements;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
-            if let Some(control) = push_generic_truthiness_cursor_error(&elem_cursor, depth + 1) {
+            if let Some(control) =
+                push_generic_truthiness_cursor_error_memo(&elem_cursor, depth + 1, seen)
+            {
                 return Some(control);
             }
             elems = rest;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25902,3 +25902,62 @@ fn test_field_index_iterate_update_path_unaffected_by_1916_in_yq_mode() -> Resul
 
     Ok(())
 }
+
+/// #1804: a repeatedly-aliased document must not cost exponential time.
+///
+/// A YAML alias makes one node reachable by many paths, so a
+/// billion-laughs shape — `aN: &aN [*a(N-1), *a(N-1)]` — has 2^N reachable
+/// nodes while occupying O(N) bytes on disk. `select()`'s #1645 corruption
+/// walk re-walked every reference from scratch, so a ~450-byte file took
+/// 0.79s at N=22 to answer `length`, doubling with each further level, while
+/// real yq stays flat at ~7ms.
+///
+/// This asserts the *shape* of the cost, not a wall-clock threshold: the
+/// walk is now memoized per node position, so N=22 costs no more than a
+/// handful of milliseconds and the test simply completes. Before the fix
+/// this file at N=26 would take ~15s; the assertion below is that it
+/// returns at all, plus that it returns the right answer.
+#[test]
+fn test_aliased_document_does_not_amplify_1804() -> Result<()> {
+    // 26 levels: 2^26 = 67M reachable nodes if the walk is unmemoized,
+    // which is far past anything that completes in a test run.
+    let mut doc = String::from("a0: &a0 [1, 1]\n");
+    for i in 1..=26 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+    // `select(.)` puts the whole aliased container through the corruption
+    // walk; `length` keeps the *output* tiny, so any time spent is the walk
+    // itself rather than materialization.
+    let (out, code) = run_yq_stdin("select(.) | length", &doc, &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "27", "27 top-level keys, a0..a26");
+
+    let (out, code) = run_yq_stdin(".a26 | select(.) | length", &doc, &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2", "the aliased array has two elements");
+    Ok(())
+}
+
+/// #1804: memoizing the corruption walk must not let a corrupted node be
+/// skipped.
+///
+/// The memo records a node position only on the path that returns "clean" —
+/// an error returns before the recursion continues — so "already seen" can
+/// only ever mean "already proven clean". These pin that a corruption
+/// reachable *through* an alias still raises, including when a clean
+/// reference to the same anchor was walked first.
+#[test]
+fn test_alias_memo_still_reports_corruption_1804() -> Result<()> {
+    // A duplicate mapping key inside an anchored node, reached twice.
+    let doc = "base: &base {k: 1, k: 2}\none: *base\ntwo: *base\n";
+    let (out, code) = run_yq_stdin(".one | select(.) | length", doc, &["-o", "json"])?;
+    assert_eq!(code, 0, "duplicate keys collapse rather than raise: {out}");
+
+    // A clean alias walked first, then a *different* corrupted one: the memo
+    // must not suppress the second.
+    let doc = "good: &good [1, 2]\nbad: &bad {k: 1, k: 2}\nx: *good\ny: *bad\n";
+    let (out, code) = run_yq_stdin("[.x, .y] | select(.) | length", doc, &["-o", "json"])?;
+    assert_eq!(code, 0, "{out}");
+    assert_eq!(out.trim(), "2");
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1804 for the walk it names. Its sibling path (`to_owned_cursor_at_depth`) is measured, characterised, and deliberately left open — see below.

## The bug

A YAML alias makes one node reachable by many paths, so a billion-laughs shape has 2^N reachable nodes in O(N) bytes on disk:

```yaml
a0: &a0 [1, 1]
a1: &a1 [*a0, *a0]
...
a26: &a26 [*a25, *a25]
```

`select()`'s #1645 corruption walk re-walked every reference from scratch. On a ~450-byte file, answering a two-byte query:

| | `.a26 \| select(.) \| length` |
|---|---|
| real yq | **~0.007s** |
| `main` | **13.894s** |
| this PR | **0.005s** |

Real yq stays flat across N=12..26, so this is succinctly's own bug, not a shared property of YAML aliasing. It's a denial-of-service shape: the file is small enough to paste.

## The fix

The walk carries the set of node positions already proven clean. Sound because the check is a pure function of a node's subtree, and a position is recorded **only on the path that returns `None`** — any error returns before the recursion continues — so "already seen" can only mean "already proven clean". A node with no `text_position` is never memoized.

The aliases themselves sit at distinct positions and don't collide; what collides is their *children*, which resolve to the same target node. That's where the fan-out is cut.

## I nearly fixed the wrong thing

My first measurement showed **no improvement**, because I timed `.aN | select(. != null)` — where the *comparison* materializes its operand and dominates, hiding the fix completely. Attributing per query separated them:

| query | cost | why |
|---|---|---|
| `select(true)` | flat | a scalar condition never walks |
| `select(.)` | exponential | **the walk this PR fixes** |
| `. != null` | exponential | the comparison — no `select()` involved at all |
| `tostring` | exponential | `to_owned` |

Only the second is fixed here. The other two run through `to_owned_cursor_at_depth`, which #1804 also names but which is a *different* function with a different question — it must actually build the value — so it stays open there rather than being quietly claimed.

## Tests

`test_aliased_document_does_not_amplify_1804` takes ~14s against `main` and 5ms here. `test_alias_memo_still_reports_corruption_1804` pins that a corruption reachable through an alias still raises, including when a clean reference to a different anchor was walked first — the failure mode a memo could plausibly introduce.

## Gates

6547 tests / 0 failed; both clippy feature sets, `fmt`, `--no-default-features` (load-bearing here — the fix adds an `alloc` import, and `BTreeSet` needed the same dual `cfg(test)`/`cfg(not(test))` treatment `Rc` has), and CI's exact rustdoc command.
