### PR TITLE
refactor(jq): simplify navigate_read_only, dedup index-normalization idiom

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -906,7 +906,7 @@ RHS-discard predicate tweak like its siblings above):
   $ printf 'a:\n  - 1\n  - 2\n' | yq            -o=json '.a.b[].c = error("boom")'
   Error: cannot index array with 'b' (strconv.ParseInt: parsing "b": invalid syntax)
   $ printf 'a:\n  - 1\n  - 2\n' | succinctly yq -o=json '.a.b[].c = error("boom")'
-  jq: error: boom
+  Error: boom
   ```
 - **An `Index` step mid-chain is out of range on a real `Array`.** Real yq autovivifies the
   array out to that length (padding with `null`), then continues the write into the
@@ -916,7 +916,7 @@ RHS-discard predicate tweak like its siblings above):
   $ printf 'a:\n  - 1\n  - 2\n' | yq            -o=json -I=0 '.a[5][].b = error("boom")'
   {"a":[1,2,null,null,null,[]]}
   $ printf 'a:\n  - 1\n  - 2\n' | succinctly yq -o=json -I=0 '.a[5][].b = error("boom")'
-  jq: error: boom
+  Error: boom
   ```
 - **An `Index` step mid-chain hits a real `Object`.** Real yq coerces the numeric index to a
   string key and inserts it; succinctly has no such coercion and evaluates the RHS instead:
@@ -924,7 +924,7 @@ RHS-discard predicate tweak like its siblings above):
   $ printf 'a: {}\n' | yq            -o=json -I=0 '.a[0][].b = error("boom")'
   {"a":{"0":[]}}
   $ printf 'a: {}\n' | succinctly yq -o=json -I=0 '.a[0][].b = error("boom")'
-  jq: error: boom
+  Error: boom
   ```
 
 Pinned as known-divergent by `test_yq_assign_all_noop_mismatched_element_type_1432`

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -890,6 +890,48 @@ mechanism at all and turned out to have a separate, more severe divergence (a ha
 instead of missing autovivification) — see
 [#1919](https://github.com/rust-works/succinctly/issues/1919).
 
+### A mid-chain `Field`/`Index` step hitting the wrong container type or an out-of-range array index
+
+Found alongside [#1432](https://github.com/rust-works/succinctly/issues/1432)/tracked as
+[#1863](https://github.com/rust-works/succinctly/issues/1863) — three still-open gaps in the
+same mid-chain-`Iterate` write path #1298/#1432/#1857 progressively fixed above, all
+live-verified against v4.53.3, none a quick fix (each needs its own deeper write-path
+change — array bounds-autovivification, index-to-string-key coercion — not just an
+RHS-discard predicate tweak like its siblings above):
+
+- **A `Field` step mid-chain hits a real `Array`.** Real yq raises its own structural error
+  *before* the RHS ever evaluates; succinctly evaluates the RHS first, surfacing its
+  error/side-effect instead of the structural one:
+  ```bash
+  $ printf 'a:\n  - 1\n  - 2\n' | yq            -o=json '.a.b[].c = error("boom")'
+  Error: cannot index array with 'b' (strconv.ParseInt: parsing "b": invalid syntax)
+  $ printf 'a:\n  - 1\n  - 2\n' | succinctly yq -o=json '.a.b[].c = error("boom")'
+  jq: error: boom
+  ```
+- **An `Index` step mid-chain is out of range on a real `Array`.** Real yq autovivifies the
+  array out to that length (padding with `null`), then continues the write into the
+  newly-created tail (empty, so the fan-out RHS never runs) — no error at all; succinctly has
+  no such padding and evaluates the RHS instead:
+  ```bash
+  $ printf 'a:\n  - 1\n  - 2\n' | yq            -o=json -I=0 '.a[5][].b = error("boom")'
+  {"a":[1,2,null,null,null,[]]}
+  $ printf 'a:\n  - 1\n  - 2\n' | succinctly yq -o=json -I=0 '.a[5][].b = error("boom")'
+  jq: error: boom
+  ```
+- **An `Index` step mid-chain hits a real `Object`.** Real yq coerces the numeric index to a
+  string key and inserts it; succinctly has no such coercion and evaluates the RHS instead:
+  ```bash
+  $ printf 'a: {}\n' | yq            -o=json -I=0 '.a[0][].b = error("boom")'
+  {"a":{"0":[]}}
+  $ printf 'a: {}\n' | succinctly yq -o=json -I=0 '.a[0][].b = error("boom")'
+  jq: error: boom
+  ```
+
+Pinned as known-divergent by `test_yq_assign_all_noop_mismatched_element_type_1432`
+(`tests/yq_cli_tests.rs`), which also confirms the one sibling shape that *does* already
+match yq: an `Index` step hitting a genuine scalar mid-chain permanently no-ops the whole
+write (#1232), same as every other position.
+
 ### `=`'s multi-output RHS: real yq takes only the last value, no fan-out
 
 [#1430](https://github.com/rust-works/succinctly/issues/1430) started as a narrower report

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15811,15 +15811,10 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
             }
         }
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
-            OwnedValue::Array(arr) => {
-                let len = arr.len() as i64;
-                let actual = if *idx < 0 { len + idx } else { *idx };
-                if actual >= 0 && (actual as usize) < arr.len() {
-                    classify_yq_assign_prefix(&arr[actual as usize], rest)
-                } else {
-                    PathAssignOutcome::NeedsRhs
-                }
-            }
+            OwnedValue::Array(arr) => match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                Some(i) => classify_yq_assign_prefix(&arr[i], rest),
+                None => PathAssignOutcome::NeedsRhs,
+            },
             _ if is_yq_field_index_noop_scalar(current) => PathAssignOutcome::TotalNoop,
             _ => PathAssignOutcome::NeedsRhs,
         },
@@ -16103,10 +16098,7 @@ fn yq_del_slice_outcome(
     // is the only remaining reason to defer to `delete_at_path`'s own
     // absent-path handling instead.
     let prefix_components: Vec<Expr> = prefix.iter().map(|s| s.component.clone()).collect();
-    if !matches!(
-        navigate_read_only(root, &prefix_components),
-        PrefixNavOutcome::Resolved
-    ) {
+    if !navigate_read_only(root, &prefix_components) {
         return YqDelSliceOutcome::NotApplicable;
     }
     let wrap = |s: &DeleteStep| {
@@ -16122,49 +16114,24 @@ fn yq_del_slice_outcome(
     })
 }
 
-/// Outcome of [`navigate_read_only`]'s prefix walk.
+/// Read-only navigation used by [`yq_del_slice_outcome`]'s prefix peek: does
+/// every step of `steps` resolve, through `root`, to an existing value?
+/// Unlike `get_path_mut`, never autovivifies (a peek must not create
+/// structure the caller's own real walker would otherwise leave untouched).
 ///
-/// Three-way rather than [`navigate_read_only`]'s old binary `Option`
-/// (#1232): a step that can't continue splits into two outcomes real yq
-/// treats completely differently. Hitting a genuine scalar (`is_yq_field_
-/// index_noop_scalar`) while trying to `Field`/`Index` into it is a
-/// transitively-permanent no-op — the scalar never becomes a container no
-/// matter what the rest of the path was going to do, matching
-/// `get_path_mut`'s own post-#1232 `Field`/`Index` arms. A missing object
-/// key, an out-of-range array index, or `Null` (autovivifies), by contrast,
-/// is not settled at all — `get_path_mut` autovivifies straight through
-/// those and keeps going. Collapsing both into one `None` was exactly the
-/// gap #1232 found: `yq_assign_is_total_noop` (the only caller that cares
-/// about the distinction) treated a mid-prefix scalar hit the same as an
-/// unresolved parent, deferring to normal RHS evaluation and letting
-/// `.a.b.c = error("boom")` on `a: 5` raise `boom` where real yq no-ops
-/// silently (RHS never runs) — live-verified against yq v4.53.3.
-enum PrefixNavOutcome {
-    /// Every prefix step navigated an existing value. Carries no payload:
-    /// `yq_assign_is_total_noop` used to read the resolved parent off this
-    /// variant for its own terminal scalar check, but that check now lives
-    /// inside `classify_yq_assign_prefix`'s own base case (#1432), so the only
-    /// remaining reader (`yq_del_slice_outcome`) only ever matches the
-    /// variant itself via `matches!(..., Resolved(_))`.
-    Resolved,
-    /// A step tried to index into a real, non-`Null` scalar.
-    HitScalar,
-    /// Missing key, out-of-range index, `Null`, or a container-type
-    /// mismatch (e.g. `Field` on an `Array`) — the real write either
-    /// autovivifies through it or genuinely errors; either way this isn't
-    /// a settled no-op.
-    Absent,
-}
-
-/// Read-only navigation shared by [`yq_del_slice_outcome`]'s prefix peek and
-/// [`yq_assign_is_total_noop`]'s pre-RHS-evaluation check. Unlike
-/// `get_path_mut`, never autovivifies (a peek must not create structure the
-/// caller's own real walker would otherwise leave untouched) — see
-/// [`PrefixNavOutcome`] for what each non-`Resolved` outcome means and why
-/// there are two of them. `yq_del_slice_outcome` doesn't need the
-/// distinction (`del()`'s own scalar-root behavior is a separate, unscoped
-/// gap — #1411) and folds `HitScalar` back into "this rule doesn't apply",
-/// same as it always treated `None`.
+/// Used to return a three-way `Resolved`/`HitScalar`/`Absent` outcome
+/// (#1232) back when `yq_assign_is_total_noop` was also a caller and
+/// needed to tell a genuine scalar hit (a transitively permanent no-op)
+/// apart from a merely-absent step (autovivifies and keeps going) for its
+/// own pre-RHS-evaluation check. #1920 replaced that function -- and its
+/// own inner twin `assign_path_all_noop` -- with `PathAssignOutcome`/
+/// `yq_assign_classify`, leaving `yq_del_slice_outcome` as the only caller
+/// here. It never needed the distinction to begin with (`del()`'s own
+/// scalar-root behavior is a separate, unscoped gap — #1411): it already
+/// folded `HitScalar` back into "this rule doesn't apply", same as it
+/// always treated a missing/absent step. A plain `bool` is enough now; the
+/// three-way `PrefixNavOutcome` enum this used to return is gone with it
+/// (#1863).
 ///
 /// A second, hand-synchronized walker rather than a shared traversal
 /// `get_path_mut` itself could call — code review flagged this against the
@@ -16174,9 +16141,9 @@ enum PrefixNavOutcome {
 /// mutates and autovivifies), so unifying them is a real redesign, not a
 /// mechanical extraction. If a future `Field`/`Index` arm gains a new
 /// container-mismatch case (or `OwnedValue` gains a variant) in one walker,
-/// mirror it here too — a drift would make `yq_assign_is_total_noop`
-/// disagree with what the real write does.
-fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> PrefixNavOutcome {
+/// mirror it here too — a drift would make `yq_del_slice_outcome` disagree
+/// with what the real write does.
+fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> bool {
     let mut current = root;
     for step in steps {
         let (step, _optional) = unwrap_path_component(step);
@@ -16184,59 +16151,29 @@ fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> PrefixNavOutcome {
             Expr::Field(name) => match current {
                 OwnedValue::Object(map) => match map.get(name) {
                     Some(v) => v,
-                    None => return PrefixNavOutcome::Absent,
+                    None => return false,
                 },
-                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
-                _ => return PrefixNavOutcome::Absent,
+                _ => return false,
             },
             Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
                 OwnedValue::Array(arr) => {
-                    let len = arr.len() as i64;
-                    let actual = if *idx < 0 { len + idx } else { *idx };
-                    if actual >= 0 && (actual as usize) < arr.len() {
-                        &arr[actual as usize]
-                    } else {
-                        return PrefixNavOutcome::Absent;
+                    match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                        Some(i) => &arr[i],
+                        None => return false,
                     }
                 }
-                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
-                _ => return PrefixNavOutcome::Absent,
+                _ => return false,
             },
             // #1298: `Iterate` fans out into every element/value of a real
             // container -- unlike `Field`/`Index`, there is no single next
-            // `current` to continue this loop with, so a real container
-            // here can only ever mean "give up and defer" (`Absent`), same
-            // as this function already does for a component it can't
-            // interpret at all. A genuine scalar, though, is exactly
-            // `set_path_through_iterate`'s own no-op fallback (`.a[].b = v`
-            // on scalar `.a` no-ops the whole write, transitively, whatever
-            // the rest of the path was going to do) -- so that case still
-            // reports `HitScalar`, closing the gap where `yq_assign_is_
-            // total_noop` used to fall through this arm's old absence to
-            // the generic catch-all below and eagerly evaluate an RHS the
-            // real write was always going to discard.
-            //
-            // Deliberately incomplete, not just conservative: live-verified
-            // that real yq's actual rule is broader than "the iterated
-            // value is itself a scalar" -- `a: [1, 2]` (a real container
-            // whose own elements are *all* scalars `.b` would no-op into)
-            // also discards the RHS, and so does an empty or
-            // null-autovivified container (vacuously -- zero elements to
-            // check). Reporting `HitScalar` for those too would need
-            // recursively checking every element against the *rest* of the
-            // path, not just this one step -- effectively a read-only dry
-            // run of `set_path_through_iterate` itself. Left as `Absent`
-            // (correct, just not optimal) rather than attempted here; see
-            // #1432.
-            Expr::Iterate => match current {
-                OwnedValue::Array(_) | OwnedValue::Object(_) => return PrefixNavOutcome::Absent,
-                _ if is_yq_field_index_noop_scalar(current) => return PrefixNavOutcome::HitScalar,
-                _ => return PrefixNavOutcome::Absent,
-            },
-            _ => return PrefixNavOutcome::Absent,
+            // `current` to continue this loop with, so any step here means
+            // "give up", same as every other shape this function can't
+            // interpret.
+            Expr::Iterate => return false,
+            _ => return false,
         };
     }
-    PrefixNavOutcome::Resolved
+    true
 }
 
 /// Apply a resolved slice directly to an owned value.
@@ -18621,43 +18558,43 @@ fn update_path<S: EvalSemantics>(
                     // silently no-ops -- the error exists only on the
                     // write path, never the read/delete one that an
                     // empty update filter takes instead.
-                    let len = arr.len() as i64;
-                    let actual_idx = if *idx < 0 { len + idx } else { *idx };
-                    let in_bounds = actual_idx >= 0 && (actual_idx as usize) < arr.len();
-                    let wrote = if in_bounds {
-                        let wrote = update_path::<S>(
-                            &mut arr[actual_idx as usize],
-                            &Expr::Identity,
-                            filter_expr,
-                            optional,
-                            scalar_noop,
-                        )?;
-                        if !wrote {
-                            arr.remove(actual_idx as usize);
+                    let wrote = match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                        Some(actual_idx) => {
+                            let wrote = update_path::<S>(
+                                &mut arr[actual_idx],
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )?;
+                            if !wrote {
+                                arr.remove(actual_idx);
+                            }
+                            wrote
                         }
-                        wrote
-                    } else {
-                        // Probe once against a detached `null`, the value
-                        // `getpath` would read here -- never run the
-                        // filter twice (#1428: a real write below reuses
-                        // this scratch's already-computed value rather
-                        // than re-invoking `filter_expr`). A `!wrote`
-                        // here is a true no-op: nothing was ever padded
-                        // in, so there is nothing to undo, matching
-                        // `delpaths` silently skipping an out-of-range
-                        // index either direction.
-                        let mut scratch = OwnedValue::Null;
-                        let wrote = update_path::<S>(
-                            &mut scratch,
-                            &Expr::Identity,
-                            filter_expr,
-                            optional,
-                            scalar_noop,
-                        )?;
-                        if wrote {
-                            *write_index(arr, *idx)? = scratch;
+                        None => {
+                            // Probe once against a detached `null`, the
+                            // value `getpath` would read here -- never run
+                            // the filter twice (#1428: a real write below
+                            // reuses this scratch's already-computed value
+                            // rather than re-invoking `filter_expr`). A
+                            // `!wrote` here is a true no-op: nothing was
+                            // ever padded in, so there is nothing to undo,
+                            // matching `delpaths` silently skipping an
+                            // out-of-range index either direction.
+                            let mut scratch = OwnedValue::Null;
+                            let wrote = update_path::<S>(
+                                &mut scratch,
+                                &Expr::Identity,
+                                filter_expr,
+                                optional,
+                                scalar_noop,
+                            )?;
+                            if wrote {
+                                *write_index(arr, *idx)? = scratch;
+                            }
+                            wrote
                         }
-                        wrote
                     };
                     if !wrote && root_was_null {
                         *root = OwnedValue::Null;
@@ -27910,10 +27847,8 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
 
             // Get the element value
             if let OwnedValue::Array(arr) = value {
-                let len = arr.len() as i64;
-                let actual_idx = if *idx < 0 { len + *idx } else { *idx };
-                if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
-                    let v = &arr[actual_idx as usize];
+                if let Some(actual_idx) = resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                    let v = &arr[actual_idx];
                     return continue_rest_with_borrowed_value::<W, S>(
                         v,
                         rest,
@@ -30833,20 +30768,21 @@ fn delete_expr_array_paths(
         for (step, group) in &groups {
             match step {
                 ArrayStep::Index(idx) => {
-                    let len = arr.len() as i64;
-                    let actual = if *idx < 0 { len + idx } else { *idx };
-                    if actual >= 0 && (actual as usize) < arr.len() {
-                        let slot = &mut arr[actual as usize];
-                        let old = core::mem::replace(slot, OwnedValue::Null);
-                        *slot = delete_expr_paths_at(old, group, start + 1)?;
-                    } else {
-                        // An out-of-range index names nothing to delete
-                        // through, so jq's delpaths silently skips the step
-                        // itself, `?` or not (#477) — but the tail still
-                        // decides: `del(.[5].a)` stays a no-op while
-                        // `del(.[5][])` raises `Cannot iterate over null
-                        // (null)` (#527/#529).
-                        delete_expr_paths_through_absent(group, start + 1)?;
+                    match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                        Some(actual) => {
+                            let slot = &mut arr[actual];
+                            let old = core::mem::replace(slot, OwnedValue::Null);
+                            *slot = delete_expr_paths_at(old, group, start + 1)?;
+                        }
+                        None => {
+                            // An out-of-range index names nothing to delete
+                            // through, so jq's delpaths silently skips the
+                            // step itself, `?` or not (#477) — but the tail
+                            // still decides: `del(.[5].a)` stays a no-op
+                            // while `del(.[5][])` raises `Cannot iterate
+                            // over null (null)` (#527/#529).
+                            delete_expr_paths_through_absent(group, start + 1)?;
+                        }
                     }
                 }
                 // Deleting *through* a slice deletes inside the sub-array and
@@ -31253,10 +31189,8 @@ fn delete_at_path(
         },
         Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match root {
             OwnedValue::Array(arr) => {
-                let len = arr.len() as i64;
-                let actual_idx = if *idx < 0 { len + idx } else { *idx };
-                if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
-                    arr.remove(actual_idx as usize);
+                if let Some(actual_idx) = resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                    arr.remove(actual_idx);
                 }
                 // An out-of-range index names nothing to delete — jq's
                 // delpaths silently skips it, `?` or not (#477).
@@ -31359,22 +31293,19 @@ fn delete_at_path(
                     },
                     Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match root {
                         OwnedValue::Array(arr) => {
-                            let len = arr.len() as i64;
-                            let actual_idx = if *idx < 0 { len + idx } else { *idx };
-                            if actual_idx >= 0 && (actual_idx as usize) < arr.len() {
-                                delete_at_path(
-                                    &mut arr[actual_idx as usize],
-                                    &rest,
-                                    optional,
-                                    yq_mode,
-                                )
-                            } else {
-                                // An out-of-range index resolves to null, and
-                                // deleting further into null is a no-op for
-                                // most tails, `?` or not (#477) — but not
-                                // `[]`, which still raises `Cannot iterate
-                                // over null (null)` (#527/#529).
-                                delete_at_path_through_absent(&rest, optional, yq_mode)
+                            match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                                Some(actual_idx) => {
+                                    delete_at_path(&mut arr[actual_idx], &rest, optional, yq_mode)
+                                }
+                                None => {
+                                    // An out-of-range index resolves to
+                                    // null, and deleting further into null
+                                    // is a no-op for most tails, `?` or not
+                                    // (#477) — but not `[]`, which still
+                                    // raises `Cannot iterate over null
+                                    // (null)` (#527/#529).
+                                    delete_at_path_through_absent(&rest, optional, yq_mode)
+                                }
                             }
                         }
                         // Same per-step `null` exemption as the `Field` case


### PR DESCRIPTION
## Summary

Two of #1863's three bundled findings:

1. **`navigate_read_only`/`PrefixNavOutcome` simplification.** This function used to return a three-way `Resolved`/`HitScalar`/`Absent` outcome for two callers that needed the distinction differently. Since this issue was filed, #1920 already replaced the other caller (`yq_assign_is_total_noop`, plus its own inner twin `assign_path_all_noop`) with `PathAssignOutcome`/`yq_assign_classify` — leaving `yq_del_slice_outcome` as the only remaining caller, which already folded `HitScalar` into "doesn't apply" the same as `Absent`. Simplified `navigate_read_only` to a plain `bool`; `PrefixNavOutcome` is gone.

2. **`resolve_read_index` consolidation.** The `let len = arr.len() as i64; let actual = if *idx < 0 { len + idx } else { *idx }; if actual >= 0 && (actual as usize) < arr.len() { ... }` idiom was hand-copied at 7 sites in `eval.rs`. Turns out an existing helper already does exactly this — `resolve_read_index(key: &OwnedValue, len: usize) -> Option<usize>` (used by `getpath`/`delpaths`) — and its `numeric_key_to_index` call passes an `OwnedValue::Int` straight through unchanged, so it's a drop-in replacement rather than a new helper. Applied at all 7 sites: `classify_yq_assign_prefix`, `navigate_read_only`, `update_path`'s `Index` arm, the borrowed-value path-context walker, `delete_expr_paths_at`, and both of `delete_at_path`'s `Index` arms.

   An 8th site (`pick`'s array-key loop) was deliberately **not** touched: its `Float` handling doesn't exclude NaN the way `numeric_key_to_index` does, so swapping it in would be a real behavior change (NaN key handling) needing its own oracle verification, not a mechanical dedup.

The third finding — three deep yq write-path divergences found alongside #1432 (a `Field` mid-chain hit on a real `Array`, an out-of-range `Index` mid-chain on a real `Array`, an `Index` mid-chain hit on a real `Object`) — is explicitly flagged in the issue as "none is a quick fix," each needing its own deeper write-path change (array bounds-autovivification, index-to-string-key coercion). Rather than attempt those here, this PR documents them in `docs/compliance/yq/limitations.md` per this repo's ADR-0018 rule — they were live-verified against yq v4.53.3 and pinned in `test_yq_assign_all_noop_mismatched_element_type_1432`, but never recorded in the limitations doc.

## Test plan

No behavioral change from items 1/2 (pure refactor + doc addition):
- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (3073 lib + 1305 jq_cli_tests + full yq_cli_tests, all green, including the pinned mismatched-element-type test)
- [x] `cargo test` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo build --no-default-features` (no_std)
- [x] All three divergence repros re-verified live against the pinned yq v4.53.3 binary before writing the docs entry

Fixes #1863