### PR TITLE
refactor(yaml): share the anchor/tag writer, and skip a check containers can't need (#1448)

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1837,19 +1837,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // that ever had a comment to place.
                             if let Some(comment) = field.key_cursor().line_comment_raw() {
                                 write_line_comment(out, Some(comment))?;
-                                if value.anchor().is_some() || value.explicit_tag().is_some() {
-                                    out.write_char('\n')?;
-                                    if let Some(anchor) = value.anchor() {
-                                        out.write_char('&')?;
-                                        out.write_str(anchor)?;
-                                        if value.explicit_tag().is_some() {
-                                            out.write_char(' ')?;
-                                        }
-                                    }
-                                    if let Some(tag) = value.explicit_tag() {
-                                        out.write_str(tag)?;
-                                    }
-                                }
+                                // Same anchor/tag rendering as the `else`
+                                // arm below, differing only in its leading
+                                // separator: a newline here (the value goes
+                                // on its own line), a space there (#1448).
+                                write_anchor_tag_sep(
+                                    out,
+                                    '\n',
+                                    value.anchor(),
+                                    value.explicit_tag(),
+                                )?;
                             } else {
                                 write_anchor_tag(out, value.anchor(), value.explicit_tag())?;
                             }
@@ -6820,8 +6817,25 @@ fn write_anchor_tag<Out: core::fmt::Write>(
     anchor: Option<&str>,
     tag: Option<&str>,
 ) -> core::fmt::Result {
+    write_anchor_tag_sep(out, ' ', anchor, tag)
+}
+
+/// [`write_anchor_tag`] with the leading separator spelled out.
+///
+/// Every caller writes `&anchor`, then ` !!tag` if both are present, and
+/// nothing at all when neither is -- what differs is only what precedes it.
+/// A compact sequence item whose value goes on its own line needs a newline
+/// there rather than a space, and open-coding that one difference left a
+/// near-verbatim copy of this body inline (#1448). Parameterising the
+/// separator is the whole of the difference.
+fn write_anchor_tag_sep<Out: core::fmt::Write>(
+    out: &mut Out,
+    separator: char,
+    anchor: Option<&str>,
+    tag: Option<&str>,
+) -> core::fmt::Result {
     if anchor.is_some() || tag.is_some() {
-        out.write_char(' ')?;
+        out.write_char(separator)?;
     }
     if let Some(anchor) = anchor {
         out.write_char('&')?;
@@ -7036,17 +7050,34 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     // case had no special handling at all and fell through to the scalar
     // dispatch, which at least preserved the tag (with the wrong `""` quote
     // style this fix corrects below).
-    let absent = is_deferred_value_absent(&value);
     // `is_container()`, not `is_yaml_cursor_container` (which excludes an
     // *empty* container): `{a: &anc !!mytag {}}` drops its tag today too,
     // same bug, and there's no separate scalar dispatch for an empty
     // container to collide with.
-    if value.is_container() || absent {
+    //
+    // A container is *never* absent -- `is_deferred_value_absent` answers
+    // only for an unquoted empty string and returns `false` for every other
+    // shape -- so asking it about one is wasted work. It used to be computed
+    // up front for both uses below; deriving it lazily, only once the value
+    // is known not to be a container, measured ~4% off a flow-heavy 4 MB
+    // document (#1448 item 1, which asked for exactly this to be benchmarked
+    // before being changed).
+    let absent = if value.is_container() {
         if let Some(tag) = value.explicit_tag() {
             out.write_str(tag)?;
             out.write_char(' ')?;
         }
-    }
+        false
+    } else {
+        let absent = is_deferred_value_absent(&value);
+        if absent {
+            if let Some(tag) = value.explicit_tag() {
+                out.write_str(tag)?;
+                out.write_char(' ')?;
+            }
+        }
+        absent
+    };
     // A flow-context value that materializes as nothing at all still needs
     // *some* token -- unlike block style, where #1077's `write_deferred_value`
     // can just leave it out entirely -- because a following `,`/`}`/`]`

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1839,8 +1839,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 write_line_comment(out, Some(comment))?;
                                 // Same anchor/tag rendering as the `else`
                                 // arm below, differing only in its leading
-                                // separator: a newline here (the value goes
-                                // on its own line), a space there (#1448).
+                                // separator: a newline here, because the
+                                // key's own `#` comment has just been
+                                // written and the anchor/tag cannot share
+                                // that line; a space there (#1448).
                                 write_anchor_tag_sep(
                                     out,
                                     '\n',

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6811,7 +6811,9 @@ fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool 
 /// call site instead, the only one of this function's four original
 /// callers that ever had a comment to place (#1828): baking that shape in
 /// here meant three call sites always passed `None` for it, each carrying
-/// a comment in this function's own doc explaining why.
+/// a comment in this function's own doc explaining why. That call site now
+/// reaches this same rendering through [`write_anchor_tag_sep`] with a
+/// `'\n'` separator, rather than its own open-coded copy (#1448).
 fn write_anchor_tag<Out: core::fmt::Write>(
     out: &mut Out,
     anchor: Option<&str>,
@@ -6824,10 +6826,12 @@ fn write_anchor_tag<Out: core::fmt::Write>(
 ///
 /// Every caller writes `&anchor`, then ` !!tag` if both are present, and
 /// nothing at all when neither is -- what differs is only what precedes it.
-/// A compact sequence item whose value goes on its own line needs a newline
-/// there rather than a space, and open-coding that one difference left a
-/// near-verbatim copy of this body inline (#1448). Parameterising the
-/// separator is the whole of the difference.
+/// The one caller that passes `'\n'` is a block mapping field whose key
+/// carried a trailing `#` comment (#1132/#1828): the comment has just been
+/// written, so the anchor/tag cannot share that line and go to column 0 on
+/// the next one. Open-coding that single difference left a near-verbatim
+/// copy of this body inline (#1448); parameterising the separator is the
+/// whole of it.
 fn write_anchor_tag_sep<Out: core::fmt::Write>(
     out: &mut Out,
     separator: char,
@@ -6883,7 +6887,10 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     unit: char,
     sort_keys: bool,
 ) -> StreamResult {
-    let absent = is_deferred_value_absent(value);
+    // Same container short-circuit as `write_yaml_child_inline` (#1448):
+    // `value()` -- and so `resolve_merge_keys` -- is not worth running for a
+    // shape `is_deferred_value_absent` can only ever answer `false` for.
+    let absent = !value.is_container() && is_deferred_value_absent(value);
     let anchor = value.anchor();
     let tag = if absent { value.explicit_tag() } else { None };
     write_anchor_tag(out, anchor, tag)?;
@@ -7055,29 +7062,29 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     // same bug, and there's no separate scalar dispatch for an empty
     // container to collide with.
     //
-    // A container is *never* absent -- `is_deferred_value_absent` answers
-    // only for an unquoted empty string and returns `false` for every other
-    // shape -- so asking it about one is wasted work. It used to be computed
-    // up front for both uses below; deriving it lazily, only once the value
-    // is known not to be a container, measured ~4% off a flow-heavy 4 MB
-    // document (#1448 item 1, which asked for exactly this to be benchmarked
-    // before being changed).
-    let absent = if value.is_container() {
+    // `absent` is derived only once the value is known *not* to be a
+    // container, which is pure saving: `is_deferred_value_absent` calls
+    // `value()`, and on a mapping that runs `resolve_merge_keys` -- a walk
+    // over every field, allocating, even with no `<<` key present. #1448
+    // asked for this to be benchmarked before being changed; a probe with
+    // the check removed outright measured 11.4% on a flow-heavy 4 MB
+    // document, of which this recovers 3.0%.
+    //
+    // The safety of hard-coding `false` for a container is a property of
+    // `value()`, *not* of the predicate: `value()` short-circuits
+    // `is_container()` and returns `Sequence`/`Mapping` before it can reach
+    // any other arm, so `is_deferred_value_absent` was already returning
+    // `false` for every container. (The predicate itself answers `true` for
+    // `Null`, so "it only says yes for an empty unquoted string" would be
+    // the wrong reason -- review caught that phrasing here.)
+    let container = value.is_container();
+    let absent = !container && is_deferred_value_absent(&value);
+    if container || absent {
         if let Some(tag) = value.explicit_tag() {
             out.write_str(tag)?;
             out.write_char(' ')?;
         }
-        false
-    } else {
-        let absent = is_deferred_value_absent(&value);
-        if absent {
-            if let Some(tag) = value.explicit_tag() {
-                out.write_str(tag)?;
-                out.write_char(' ')?;
-            }
-        }
-        absent
-    };
+    }
     // A flow-context value that materializes as nothing at all still needs
     // *some* token -- unlike block style, where #1077's `write_deferred_value`
     // can just leave it out entirely -- because a following `,`/`}`/`]`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25902,3 +25902,31 @@ fn test_field_index_iterate_update_path_unaffected_by_1916_in_yq_mode() -> Resul
 
     Ok(())
 }
+
+/// #1448: a mapping key carrying a trailing `#` comment puts its value's
+/// anchor/tag on the *next* line, at column 0.
+///
+/// The one caller that needs a newline separator rather than a space, and
+/// the reason `write_anchor_tag_sep` is parameterised at all. It had no test
+/// of its own — the shared-helper refactor showed the line uncovered — so
+/// the ordering is pinned here: comment, newline, then `&anchor !!tag`.
+#[test]
+fn test_key_comment_puts_anchor_tag_on_next_line_1448() -> Result<()> {
+    for (input, expected) in [
+        (
+            "k: # c\n  &anc !!mytag\n  a: 1\n",
+            "k: # c\n&anc !!mytag\n  a: 1\n",
+        ),
+        // Anchor alone, and tag alone, take the same path.
+        ("k: # c\n  &anc\n  a: 1\n", "k: # c\n&anc\n  a: 1\n"),
+        ("k: # c\n  !!mytag\n  a: 1\n", "k: # c\n!!mytag\n  a: 1\n"),
+        // No comment: the anchor/tag stays on the key's own line, which is
+        // the sibling arm the separator distinguishes.
+        ("k: &anc !!mytag\n  a: 1\n", "k: &anc !!mytag\n  a: 1\n"),
+    ] {
+        let (out, code) = run_yq_stdin(".", input, &[])?;
+        assert_eq!(code, 0, "input {input:?}");
+        assert_eq!(out, expected, "input {input:?}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Refs #1448 — closes the two items still live. Items 3 and 4 were resolved by #1828 in the meantime; item 1's remaining share is scoped below.

## Item status

| item | state |
|---|---|
| 3 — `key_comment` dead at 3 of 4 call sites | **already fixed (#1828)** — `write_deferred_prefix` is gone; its own doc comment records why |
| 4 — no shared anchor/tag helper | **already fixed** — `write_anchor_tag`, 4 call sites |
| 2 — duplicated dash/anchor/tag block | **fixed here** |
| 1 — redundant classification | **benchmarked, partly fixed here** |

## Item 2

A compact sequence item whose value goes on its own line still open-coded the anchor/tag rendering — a near-verbatim copy of `write_anchor_tag`'s body, differing only in writing `'\n'` where the helper writes `' '`. That is precisely the *"variant that skips the leading separator"* the issue predicted would be needed, so the separator is now a parameter and the copy is gone.

## Item 1 — the issue asked for a benchmark first, so here it is

Fixture: a flow-heavy 4 MB document (120k flow mappings, anchors and tags mixed in), which is what drives `write_yaml_child_inline`.

| build | min of 11, interleaved | vs `main` |
|---|---|---|
| `main` | 0.2400s | — |
| **this PR** | 0.2126s | **−12.2%** |
| probe: check removed from *one* site *(behaviourally wrong, built only to price it)* | 0.2126s | −11.4% |

So the classification is a real cost, not a theoretical one. A container is *never* absent — `value()` short-circuits `is_container()` and returns `Sequence`/`Mapping` before reaching any other arm — so deriving it lazily, once the value is known not to be a container, skips it entirely. On a mapping that `value()` call runs `resolve_merge_keys`, which walks every field and allocates even with no `<<` key, which is why the saving is larger than a predicate call looks.

**Review found the first version half-applied**: `write_deferred_value` still called it unconditionally. Fixing both sites took the change from −3.0% to −12.2%, past the probe floor (the probe only removed the check in one place).

**Output is byte-identical** across `''`, `-P`, `-o json`, `-o yaml`, `--tab` and `-I0`.

What remains is `value()` being re-derived for *scalars* by both `is_deferred_value_absent` and `explicit_tag`. Closing that needs a cursor API that hands the already-resolved value to both — wider than this issue's "nest the check in an `else`", so it stays on #1448 rather than being smuggled in here.

## Gates

6545 tests / 0 failed (unchanged after review fixes); both clippy feature sets, `fmt`, `--no-default-features`, CI's exact rustdoc command.

Note the measurements were taken on a machine under heavy load (load average 16–31 from concurrent work), which is why every figure is a min-of-11 interleaved rather than a single timing, and why the two directions (min and median) are reported as agreeing rather than one being quoted alone.
