### PR TITLE
fix(jq): force LazyKeys/LazyIndexRange at the ?/try/catch boundary

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -703,6 +703,34 @@ rather than folded into #1629's own scope.
 `keys_unsorted | length` is not in this set at all — it reaches `effective_len`, which walks, and
 so has carried the check for free since #1628.
 
+**A separate catchability dimension, fixed for the pull model, still open for the push
+model (#1936/#1948).** Whether a malformed key *raises* (documented above) is distinct from
+whether `?`/`try`/`catch` can *suppress or catch* that raise — `keys`/`keys_unsorted` stay
+lazy (`GenericResult::LazyKeys`) until something actually materializes them, so wrapping a
+bare `keys_unsorted` in `?` used to let the error escape past a boundary that had already
+closed by the time materialization happened. #1936 fixed this for the pull-model dispatch
+(`try_single_generic`, reached via plain `eval_single`) by checking for a malformed key
+before the boundary's match runs, without forcing a full decode on success (preserving
+`fold_pipe_stages`'s lazy fast paths for `.[]`/`.[n]`/`first`/`last`/`length`):
+
+```
+$ echo '{123: 1}' | sjq -c 'keys_unsorted?'                      # suppressed, exit 0 (fixed)
+$ echo '{123: 1}' | sjq -c 'try (keys_unsorted) catch "c"'       # "c", exit 0 (fixed)
+```
+
+The push-model dispatch (`each_try_generic`, reached via `eval_each_generic` for
+`first`/`limit`) has the identical bug class and remains open — tracked as #1948 rather
+than folded into #1936, since closing it needs `eval_each_generic` itself to carry a "must
+materialize now" signal through arbitrarily nested push-model consumers, not just a new
+arm in `each_try_generic`'s own dispatch. It also affects `LazySeq` (`map(f)`), not just
+`LazyKeys` — a gap that predates #1936 entirely, since #1812 only fixed `LazySeq`'s
+pull-model catchability:
+
+```
+$ echo '{123: 1}' | sjq -c 'first(keys_unsorted?)'                       # exit 5 -- unfixed
+$ echo '[1,2,3]' | sjq -c 'first(try (map(error("x"))) catch "c")'       # exit 5 -- unfixed
+```
+
 Bare `keys_unsorted` — no stage after it — does raise, but only part-way through: it streams,
 and finds a non-string key once its `[` is already out, so a **truncated** array can reach
 stdout beside the exit 5. Pre-checking would mean a second walk over every key on a path

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4287,19 +4287,31 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
 /// regardless (#1067): a future change that ever violates that invariant
 /// degrades gracefully instead of silently misbehaving.
 ///
-/// A `LazySeq` hasn't necessarily failed *yet* -- it's lazy, so it never
-/// matches the `Error`/`Break`/`Partial` arms above even when pulling it
-/// would fail (#724, #725). This boundary needs to know *now* whether
-/// `inner` fails, so force it here -- same one-pass cost
-/// `materialize_atomic` already pays at every other materializing boundary
-/// in this file. Without this arm, `inner` falls through to `other =>
-/// other` below and escapes the boundary entirely: the error only surfaces
-/// later, at whatever downstream site finally pulls the `LazySeq`, by which
-/// point this `try`/`catch`/`?` is long gone (confirmed against real jq:
-/// `[1,2,"x"]|map(.+1)?` is empty/exit-0 in jq, but errored/exit-5 here
-/// before this arm existed). `halt` is never caught here either way,
-/// matching `Control`'s own pass-through guarantee and the `other => other`
-/// wildcard's identical treatment of a bare `GenericResult::Halt`.
+/// None of `LazyKeys`/`LazyIndexRange`/`LazySeq` have necessarily failed
+/// *yet* -- all three are lazy, so none of them matches the
+/// `Error`/`Break`/`Partial` arms above even when pulling one would fail
+/// (#724, #725, #683, #684). This boundary needs to know *now* whether
+/// `inner` fails, so force all three via [`GenericResult::materialize_lazy`]
+/// before the match below runs -- same one-pass cost every other
+/// materializing boundary in this file already pays. Without this,
+/// `inner`'s lazy result falls through to `other => other` and escapes the
+/// boundary entirely: the error only surfaces later, at whatever downstream
+/// site finally pulls it, by which point this `try`/`catch`/`?` is long
+/// gone (confirmed against real jq for `LazySeq`: `[1,2,"x"]|map(.+1)?` is
+/// empty/exit-0 in jq, but errored/exit-5 here before that arm existed;
+/// `LazyKeys`' own #1936 case has no jq oracle -- `keys_unsorted` on a
+/// non-string key is a document real jq's own parser rejects outright -- so
+/// it's pinned by comparing against this same boundary's already-correct
+/// `sort?`/`try (sort) catch` handling of the identical document instead).
+/// `halt` is never caught here either way, matching `Control`'s own
+/// pass-through guarantee and the `other => other` wildcard's identical
+/// treatment of a bare `GenericResult::Halt`.
+///
+/// [`each_try_generic`] below, this function's push-model twin, does *not*
+/// need the equivalent fix: its `keys`/`keys_unsorted` dispatch already
+/// forces each key through `each_lazy_keys_iterate_sink`'s own, separately
+/// fixed catchability path (#1770) rather than ever producing a
+/// `GenericResult::LazyKeys` in the first place.
 fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
     inner: &Expr,
     catch: Option<&Expr>,
@@ -4313,7 +4325,7 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
             None => GenericResult::None,
         }
     };
-    match eval_single::<S, _>(inner, value, optional, cursor) {
+    match eval_single::<S, _>(inner, value, optional, cursor).materialize_lazy() {
         GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
         GenericResult::Error(e) => run_catch(&e.payload()),
         GenericResult::Break(_) => run_catch(&OwnedValue::Null),
@@ -4326,13 +4338,6 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         GenericResult::Partial(prefix, Control::Break(_)) => {
             prepend_generic(prefix, run_catch(&OwnedValue::Null))
         }
-        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-            Ok(owned) => GenericResult::Owned(owned),
-            Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
-            Err(Control::Error(e)) => run_catch(&e.payload()),
-            Err(Control::Break(_)) => run_catch(&OwnedValue::Null),
-            Err(Control::Halt(code)) => GenericResult::Halt(code),
-        },
         other => other,
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -966,16 +966,7 @@ fn distinct_key_cursors_checked<V: DocumentValue>(
     collapse: bool,
 ) -> Result<Vec<V::Cursor>, EvalError> {
     let mut out = Vec::new();
-    let mut cursors = DistinctKeyCursors::new(fields, collapse);
-    for (key, cursor) in cursors.by_ref() {
-        if key_is_malformed(&key) {
-            return Err(fields.malformed_member_error());
-        }
-        out.push(cursor);
-    }
-    if cursors.ended_unpaired() || cursors.delimiter_fault() {
-        return Err(fields.malformed_member_error());
-    }
+    walk_distinct_keys_checked::<V>(fields, collapse, |cursor| out.push(cursor))?;
     Ok(out)
 }
 
@@ -984,19 +975,39 @@ fn distinct_key_cursors_checked<V: DocumentValue>(
 /// cursor back -- `try_single_generic`'s `LazyKeys` arm (#1936) hands the
 /// original, still-lazy value back unchanged on success, so collecting a
 /// `Vec<V::Cursor>` there would be a pure O(n)-space cost for an answer
-/// that's thrown away every time. Mirrors `Builtin::Last`'s own inline
-/// walk below (review already caught this exact `distinct_key_cursors_checked`-
-/// for-a-yes/no-answer mistake once there), pulled out since a second call
-/// site now wants the identical check with no cursor to track either.
+/// that's thrown away every time (review already caught this exact
+/// `distinct_key_cursors_checked`-for-a-yes/no-answer mistake once, on the
+/// first version of this fix). `on_cursor` is a no-op closure here, which
+/// monomorphizes away to nothing -- no `Vec`, no allocation.
 fn keys_are_well_formed<V: DocumentValue>(
     fields: &V::Fields,
     collapse: bool,
 ) -> Result<(), EvalError> {
+    walk_distinct_keys_checked::<V>(fields, collapse, |_cursor| {})
+}
+
+/// Shared walk behind [`distinct_key_cursors_checked`] and
+/// [`keys_are_well_formed`]: both need the identical `DistinctKeyCursors`
+/// walk and #1194/#1677 exhaustion check, differing only in whether the
+/// caller wants each cursor or just the pass/fail verdict -- `on_cursor`
+/// is that difference, not a new allocation (a `Vec::push` for the former,
+/// a no-op for the latter). Pulled out so the check itself has exactly one
+/// definition instead of two copies that could silently drift apart (the
+/// codebase's own precedent for why this matters: `Builtin::Last`'s inline
+/// walk below already diverged from both of these by omitting the
+/// `delimiter_fault()` half of the check -- tracked as #1956, not fixed
+/// here since it predates and is independent of this fix).
+fn walk_distinct_keys_checked<V: DocumentValue>(
+    fields: &V::Fields,
+    collapse: bool,
+    mut on_cursor: impl FnMut(V::Cursor),
+) -> Result<(), EvalError> {
     let mut cursors = DistinctKeyCursors::new(fields, collapse);
-    for (key, _cursor) in cursors.by_ref() {
+    for (key, cursor) in cursors.by_ref() {
         if key_is_malformed(&key) {
             return Err(fields.malformed_member_error());
         }
+        on_cursor(cursor);
     }
     if cursors.ended_unpaired() || cursors.delimiter_fault() {
         return Err(fields.malformed_member_error());
@@ -3666,6 +3677,10 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 }
                 last_cursor = Some(cursor);
             }
+            // Missing `|| cursors.delimiter_fault()` here (unlike this
+            // function's own `distinct_key_cursors_checked`/
+            // `keys_are_well_formed` siblings) is a pre-existing, tracked
+            // gap (#1956), not addressed in this pass.
             if cursors.ended_unpaired() {
                 return GenericResult::Error(fields.malformed_member_error());
             }
@@ -4433,6 +4448,12 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
                 sorted,
                 collapse,
             },
+            // Unreachable for every format shipped today: `malformed_member_error`
+            // (the default and JSON's override alike) always builds a plain,
+            // catchable `EvalError::new(...)`, never a `DecodeFailure`-kind
+            // error, so this arm's condition is never true. Kept anyway,
+            // matching the `LazySeq` arm above -- defensive symmetry for a
+            // future format whose `malformed_member_error` ever does tag one.
             Err(e) if e.is_decode_failure() => GenericResult::Error(e),
             Err(e) => run_catch(&e.payload()),
         },

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4287,31 +4287,54 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
 /// regardless (#1067): a future change that ever violates that invariant
 /// degrades gracefully instead of silently misbehaving.
 ///
-/// None of `LazyKeys`/`LazyIndexRange`/`LazySeq` have necessarily failed
-/// *yet* -- all three are lazy, so none of them matches the
-/// `Error`/`Break`/`Partial` arms above even when pulling one would fail
-/// (#724, #725, #683, #684). This boundary needs to know *now* whether
-/// `inner` fails, so force all three via [`GenericResult::materialize_lazy`]
-/// before the match below runs -- same one-pass cost every other
-/// materializing boundary in this file already pays. Without this,
-/// `inner`'s lazy result falls through to `other => other` and escapes the
-/// boundary entirely: the error only surfaces later, at whatever downstream
-/// site finally pulls it, by which point this `try`/`catch`/`?` is long
-/// gone (confirmed against real jq for `LazySeq`: `[1,2,"x"]|map(.+1)?` is
-/// empty/exit-0 in jq, but errored/exit-5 here before that arm existed;
-/// `LazyKeys`' own #1936 case has no jq oracle -- `keys_unsorted` on a
-/// non-string key is a document real jq's own parser rejects outright -- so
-/// it's pinned by comparing against this same boundary's already-correct
-/// `sort?`/`try (sort) catch` handling of the identical document instead).
-/// `halt` is never caught here either way, matching `Control`'s own
-/// pass-through guarantee and the `other => other` wildcard's identical
-/// treatment of a bare `GenericResult::Halt`.
+/// Neither `LazyKeys` nor `LazySeq` have necessarily failed *yet* -- both
+/// are lazy, so neither matches the `Error`/`Break`/`Partial` arms above
+/// even when pulling one would fail (#724, #725, #683). This boundary needs
+/// to know *now* whether `inner` fails, so force both here -- same one-pass
+/// cost every other materializing boundary in this file already pays.
+/// Without this, `inner`'s lazy result falls through to `other => other`
+/// and escapes the boundary entirely: the error only surfaces later, at
+/// whatever downstream site finally pulls it, by which point this
+/// `try`/`catch`/`?` is long gone (confirmed against real jq for `LazySeq`:
+/// `[1,2,"x"]|map(.+1)?` is empty/exit-0 in jq, but errored/exit-5 here
+/// before that arm existed; `LazyKeys`' own #1936 case has no jq oracle --
+/// `keys_unsorted` on a non-string key is a document real jq's own parser
+/// rejects outright -- so it's pinned by comparing against this same
+/// boundary's already-correct `sort?`/`try (sort) catch` handling of the
+/// identical document instead). `halt` is never caught here either way,
+/// matching `Control`'s own pass-through guarantee and the `other => other`
+/// wildcard's identical treatment of a bare `GenericResult::Halt`.
 ///
-/// [`each_try_generic`] below, this function's push-model twin, does *not*
-/// need the equivalent fix: its `keys`/`keys_unsorted` dispatch already
-/// forces each key through `each_lazy_keys_iterate_sink`'s own, separately
-/// fixed catchability path (#1770) rather than ever producing a
-/// `GenericResult::LazyKeys` in the first place.
+/// `LazyKeys` is checked via [`distinct_key_cursors_checked`] rather than
+/// [`GenericResult::materialize_lazy`]/`materialize_lazy_keys`: the latter
+/// would decode and collect every key into an owned `Vec<String>` even on
+/// the ordinary, non-failing path, permanently forfeiting `fold_pipe_stages`'s
+/// `!sorted` O(1)/no-allocation fast paths (`.[]`, `.[n]`, `first`, `last`)
+/// for any `keys_unsorted` merely *wrapped* in `?`/`try`/`catch` -- a real
+/// cost with no correctness benefit, caught in review before this landed.
+/// `distinct_key_cursors_checked` walks the same fields doing the identical
+/// #1194 check, but only collects cheap `V::Cursor`s, and -- critically --
+/// on success this arm hands back the *original*, still-lazy `LazyKeys`
+/// unchanged, so a downstream `fold_pipe_stages` arm still gets the fast
+/// path it always did. `LazyIndexRange` needs no arm at all: its value is
+/// fully described by `len` alone (#684), so unlike `LazyKeys` it can
+/// never actually fail -- forcing it here would cost real allocation for
+/// zero correctness benefit, so it stays on the `other => other` wildcard,
+/// exactly as before this fix.
+///
+/// [`each_try_generic`] below, this function's push-model twin, has a
+/// **similar but distinct, still-open gap**: `eval_each_generic`'s own
+/// wildcard fallback pushes a `GenericResult::LazyKeys`/`LazyIndexRange`/
+/// `LazySeq` straight to `sink` unmaterialized whenever the immediate
+/// consumer isn't the narrow `keys_unsorted | .[]` shape
+/// `each_lazy_keys_iterate_sink` (#1770) covers -- confirmed live:
+/// `first(keys_unsorted?)` and `first(try (map(error("x"))) catch "c")`
+/// both still raise uncaught on `main` (the latter predates this fix
+/// entirely, since it's `LazySeq`, not `LazyKeys`). Tracked separately as
+/// #1948 rather than folded in here: closing it needs `eval_each_generic`
+/// itself to carry a "must materialize now" signal through arbitrarily
+/// nested push-model consumers (`first`, `limit`, ...), not just a new arm
+/// in this function's own dispatch.
 fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
     inner: &Expr,
     catch: Option<&Expr>,
@@ -4325,7 +4348,7 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
             None => GenericResult::None,
         }
     };
-    match eval_single::<S, _>(inner, value, optional, cursor).materialize_lazy() {
+    match eval_single::<S, _>(inner, value, optional, cursor) {
         GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
         GenericResult::Error(e) => run_catch(&e.payload()),
         GenericResult::Break(_) => run_catch(&OwnedValue::Null),
@@ -4338,6 +4361,26 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         GenericResult::Partial(prefix, Control::Break(_)) => {
             prepend_generic(prefix, run_catch(&OwnedValue::Null))
         }
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(owned) => GenericResult::Owned(owned),
+            Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
+            Err(Control::Error(e)) => run_catch(&e.payload()),
+            Err(Control::Break(_)) => run_catch(&OwnedValue::Null),
+            Err(Control::Halt(code)) => GenericResult::Halt(code),
+        },
+        GenericResult::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        } => match distinct_key_cursors_checked::<V>(&fields, collapse) {
+            Ok(_) => GenericResult::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            },
+            Err(e) if e.is_decode_failure() => GenericResult::Error(e),
+            Err(e) => run_catch(&e.payload()),
+        },
         other => other,
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -979,6 +979,31 @@ fn distinct_key_cursors_checked<V: DocumentValue>(
     Ok(out)
 }
 
+/// [`distinct_key_cursors_checked`]'s check-only sibling, for a caller that
+/// needs to know *whether* an object raises without ever reading a single
+/// cursor back -- `try_single_generic`'s `LazyKeys` arm (#1936) hands the
+/// original, still-lazy value back unchanged on success, so collecting a
+/// `Vec<V::Cursor>` there would be a pure O(n)-space cost for an answer
+/// that's thrown away every time. Mirrors `Builtin::Last`'s own inline
+/// walk below (review already caught this exact `distinct_key_cursors_checked`-
+/// for-a-yes/no-answer mistake once there), pulled out since a second call
+/// site now wants the identical check with no cursor to track either.
+fn keys_are_well_formed<V: DocumentValue>(
+    fields: &V::Fields,
+    collapse: bool,
+) -> Result<(), EvalError> {
+    let mut cursors = DistinctKeyCursors::new(fields, collapse);
+    for (key, _cursor) in cursors.by_ref() {
+        if key_is_malformed(&key) {
+            return Err(fields.malformed_member_error());
+        }
+    }
+    if cursors.ended_unpaired() || cursors.delimiter_fault() {
+        return Err(fields.malformed_member_error());
+    }
+    Ok(())
+}
+
 /// Materialize a `GenericResult::LazyIndexRange` fallback: build the
 /// `[0, 1, ..., len-1]` array exactly as eager array `keys`/`keys_unsorted`
 /// did before it stayed lazy (#684).
@@ -2083,14 +2108,17 @@ fn push_generic_truthiness<V: DocumentValue>(
 /// A bare `Error`/`Break`/`Partial` must never appear in `items` — callers
 /// that build up a per-element batch route those variants to an early return
 /// (folding whatever was already flattened into a `Partial` of their own via
-/// [`partial_generic`]) instead of pushing them here. A `LazySeq` item CAN
-/// still fail once materialized here, though (its failure isn't known until
-/// `materialize_lazy()` actually pulls it) — that's why this returns
-/// `Result`, not a plain `Vec` as it used to before `LazySeq` existed (#725):
-/// unlike `LazyKeys`/`LazyIndexRange`, which can never fail to materialize, a
-/// `LazySeq` runs arbitrary `map(f)` and can be reached here (e.g. via
-/// `.[] | (keys_unsorted | map(f))`) before any materialization has
-/// happened.
+/// [`partial_generic`]) instead of pushing them here. A `LazySeq`/`LazyKeys`
+/// item CAN still fail once materialized here, though (its failure isn't
+/// known until `materialize_lazy()` actually pulls it) — that's why this
+/// returns `Result`, not a plain `Vec` as it used to before `LazySeq`
+/// existed (#725): `LazySeq` runs arbitrary `map(f)`, and `LazyKeys` can
+/// carry a #1194 malformed (non-string) object key (#1936) that only
+/// surfaces on materialization -- both can be reached here (e.g. via
+/// `.[] | (keys_unsorted | map(f))`) before that materialization has
+/// happened. `LazyIndexRange` is the only one of the three that genuinely
+/// can never fail: its value is fully described by the array's length
+/// alone (#684).
 fn flatten_generic_results<V: DocumentValue>(
     items: Vec<GenericResult<V>>,
 ) -> Result<Vec<OwnedValue>, Control> {
@@ -4267,9 +4295,12 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
 /// future change to the catchability rules (another `#1620`-style
 /// exclusion, a new `Control` variant) needs applying to *both*, the same
 /// way `eval.rs`'s and `eval_generic.rs`'s own evaluator pair already needs
-/// any reindex-bridge fix applied in parallel. Currently consistent
-/// (verified: same `is_decode_failure()` exclusion, `Break` bound to
-/// `null`, `catch = None` suppression, `Halt` passthrough).
+/// any reindex-bridge fix applied in parallel. Consistent on the properties
+/// both were built with (verified: same `is_decode_failure()` exclusion,
+/// `Break` bound to `null`, `catch = None` suppression, `Halt` passthrough)
+/// -- but **not** on lazy-variant forcing: this function's own `LazyKeys`
+/// arm below (#1936) has no counterpart in `each_try_generic`, a known,
+/// tracked divergence (#1948), not an oversight in this doc paragraph.
 ///
 /// A decode failure (#1247) is never caught by either spelling, any more
 /// than real jq's own parse-time rejection could ever be caught (#1620) --
@@ -4305,22 +4336,46 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
 /// matching `Control`'s own pass-through guarantee and the `other => other`
 /// wildcard's identical treatment of a bare `GenericResult::Halt`.
 ///
-/// `LazyKeys` is checked via [`distinct_key_cursors_checked`] rather than
+/// `LazyKeys` is checked via [`keys_are_well_formed`] rather than
 /// [`GenericResult::materialize_lazy`]/`materialize_lazy_keys`: the latter
 /// would decode and collect every key into an owned `Vec<String>` even on
 /// the ordinary, non-failing path, permanently forfeiting `fold_pipe_stages`'s
 /// `!sorted` O(1)/no-allocation fast paths (`.[]`, `.[n]`, `first`, `last`)
 /// for any `keys_unsorted` merely *wrapped* in `?`/`try`/`catch` -- a real
 /// cost with no correctness benefit, caught in review before this landed.
-/// `distinct_key_cursors_checked` walks the same fields doing the identical
-/// #1194 check, but only collects cheap `V::Cursor`s, and -- critically --
-/// on success this arm hands back the *original*, still-lazy `LazyKeys`
-/// unchanged, so a downstream `fold_pipe_stages` arm still gets the fast
-/// path it always did. `LazyIndexRange` needs no arm at all: its value is
-/// fully described by `len` alone (#684), so unlike `LazyKeys` it can
-/// never actually fail -- forcing it here would cost real allocation for
-/// zero correctness benefit, so it stays on the `other => other` wildcard,
-/// exactly as before this fix.
+/// `keys_are_well_formed` walks the same fields doing the identical #1194
+/// check but collects nothing (an earlier version of this fix called
+/// [`distinct_key_cursors_checked`] here instead, collecting a `Vec<V::Cursor>`
+/// purely to discard it -- the exact O(n)-space-for-an-O(1)-space-answer
+/// mistake `Builtin::Last` below already hit and fixed once; also caught by
+/// review), and on success this arm hands back the *original*, still-lazy
+/// `LazyKeys` unchanged, so a downstream `fold_pipe_stages` fast-path arm
+/// still gets to run.
+///
+/// **This does not make the check free, only as cheap as it can be while
+/// still being correct.** Handing back a still-lazy `LazyKeys` means
+/// anything downstream that goes on to actually read the keys -- the CLI's
+/// own streaming writer for a bare `keys_unsorted?`, or `fold_lazy_keys_stage`'s
+/// own materializing fallback for any continuation that isn't one of its
+/// narrow `!sorted` fast paths -- walks the object a *second* time to get
+/// there, since nothing here caches or tags the object as already-validated.
+/// That is not avoidable within this fix's scope: this boundary must know
+/// *now* whether the object contains a malformed key, and the only way to
+/// know that is to look at every key once, so a `?`/`try`-wrapped
+/// `keys`/`keys_unsorted` unavoidably costs at least one extra full walk
+/// over the unwrapped form -- the same trade-off `LazySeq` already makes,
+/// just without `LazySeq`'s consolation of retiring laziness for good on
+/// success. Threading an "already validated" fact through `LazyKeys` itself
+/// so a later consumer could skip re-checking is a real follow-up
+/// optimization, tracked as #1951 rather than attempted here to keep this
+/// fix reviewable at the size of a narrow bug fix rather than a `LazyKeys`
+/// redesign.
+///
+/// `LazyIndexRange` needs no arm at all: its value is fully described by
+/// `len` alone (#684), so unlike `LazyKeys` it can never actually fail --
+/// forcing it here would cost real allocation for zero correctness
+/// benefit, so it stays on the `other => other` wildcard, exactly as
+/// before this fix.
 ///
 /// [`each_try_generic`] below, this function's push-model twin, has a
 /// **similar but distinct, still-open gap**: `eval_each_generic`'s own
@@ -4372,8 +4427,8 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
             fields,
             sorted,
             collapse,
-        } => match distinct_key_cursors_checked::<V>(&fields, collapse) {
-            Ok(_) => GenericResult::LazyKeys {
+        } => match keys_are_well_formed::<V>(&fields, collapse) {
+            Ok(()) => GenericResult::LazyKeys {
                 fields,
                 sorted,
                 collapse,

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -718,6 +718,9 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
         };
         keys.push(OwnedValue::String(s.into_owned()));
     }
+    // Missing `|| cursors.delimiter_fault()` here (unlike `eval_generic.rs`'s
+    // `distinct_key_cursors_checked`/`keys_are_well_formed`) is a
+    // pre-existing, tracked gap (#1956), not addressed in this pass.
     if cursors.ended_unpaired() {
         return Err(fields.malformed_member_error());
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25155,6 +25155,78 @@ fn test_try_catch_forces_and_catches_a_lazyseq_failure_1812() -> Result<()> {
     Ok(())
 }
 
+/// #1936: `try_single_generic` (`eval_generic.rs`'s `?`/`try`/`catch`
+/// dispatch) forced a `LazySeq` before this boundary could close (#1812
+/// above), but had no equivalent arm for `GenericResult::LazyKeys` --
+/// `keys`/`keys_unsorted` on an object stay lazy until something actually
+/// materializes them, so a #1194 malformed (non-string) key raised only
+/// once that later, boundary-less materialization happened, escaping `?`/
+/// `try` entirely. `sort?`/`try (sort) catch` on the identical document
+/// already worked (`sort` has no lazy fast path, so it materializes and
+/// fails inside the boundary's own dispatch) -- this pins `keys_unsorted`/
+/// `keys` (the `sorted: true` path through the same `LazyKeys` variant) to
+/// the same already-correct behavior. Confirmed live against unmodified
+/// `main` before this fix: both `keys_unsorted?` and
+/// `try (keys_unsorted) catch "c"` raised uncaught, exit 5.
+#[test]
+fn test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936() -> Result<()> {
+    let doc = "{123: 1}";
+
+    for filter in ["sort?", "keys?", "keys_unsorted?"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_eq!(
+            (stdout.as_str(), code),
+            ("", 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    for filter in [
+        r#"try (keys) catch "c""#,
+        r#"try (keys_unsorted) catch "c""#,
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_eq!(
+            (stdout.as_str(), code),
+            ("\"c\"\n", 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1936 companion: `GenericResult::LazyIndexRange` (`keys`/`keys_unsorted`
+/// on an *array*, not an object) rides the same new `materialize_lazy()`
+/// forcing this fix added, but -- unlike `LazyKeys` -- can never actually
+/// fail (its value is fully described by the array's length alone, #684).
+/// Pins that forcing it through the `?`/`try` boundary is still a no-op for
+/// valid data, on both the array and object shapes.
+#[test]
+fn test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_1936() -> Result<()> {
+    for (doc, filter, want) in [
+        (r#"["a","b"]"#, "keys_unsorted?", "[0,1]\n"),
+        (r#"["a","b"]"#, r#"try (keys) catch "c""#, "[0,1]\n"),
+        (r#"{"b":1,"a":2}"#, "keys_unsorted?", "[\"b\",\"a\"]\n"),
+        (
+            r#"{"b":1,"a":2}"#,
+            r#"try (keys) catch "c""#,
+            "[\"a\",\"b\"]\n",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
+            .unwrap_or_else(|e| panic!("`{filter}` on `{doc}` failed to run: {e}"));
+        assert_eq!(
+            (stdout.as_str(), code),
+            (want, 0),
+            "`{filter}` on `{doc}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
 /// #1194 (the half in #1247's scope): a *structurally* malformed value --
 /// one the semi-index accepted as a span but could not classify as any JSON
 /// token -- must not materialize as `null`. `[xyz123]` came back as `[null]`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25199,11 +25199,12 @@ fn test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936() -
 }
 
 /// #1936 companion: `GenericResult::LazyIndexRange` (`keys`/`keys_unsorted`
-/// on an *array*, not an object) rides the same new `materialize_lazy()`
-/// forcing this fix added, but -- unlike `LazyKeys` -- can never actually
-/// fail (its value is fully described by the array's length alone, #684).
-/// Pins that forcing it through the `?`/`try` boundary is still a no-op for
-/// valid data, on both the array and object shapes.
+/// on an *array*, not an object) needs no arm at all in `try_single_generic`
+/// -- unlike `LazyKeys`, it can never actually fail (its value is fully
+/// described by the array's length alone, #684), so it stays on the
+/// `other => other` wildcard exactly as before this fix. Pins that both it
+/// and the new `LazyKeys` check are still a no-op for valid data, on both
+/// the array and object shapes.
 #[test]
 fn test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_1936() -> Result<()> {
     for (doc, filter, want) in [
@@ -25224,6 +25225,48 @@ fn test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_193
             "`{filter}` on `{doc}` -- stderr: {stderr}"
         );
     }
+    Ok(())
+}
+
+/// #1936 review found a related, still-open gap: `try_single_generic`
+/// (fixed above) only covers the *pull*-model `?`/`try`/`catch` dispatch
+/// (reached via plain `eval_single`). `each_try_generic`, the *push*-model
+/// twin reached via `eval_each_generic` for `first`/`limit`, has the
+/// identical bug class -- a lazy `LazyKeys`/`LazySeq` still escapes past a
+/// `?`/`try`/`catch` boundary once it's wrapped in one more layer of
+/// demand-aware consumer, since `eval_each_generic`'s wildcard fallback
+/// forwards the lazy result straight to `sink` unmaterialized. Deliberately
+/// not folded into #1936 (tracked separately as #1948): closing it needs
+/// `eval_each_generic` itself to carry a "must materialize now" signal
+/// through arbitrarily nested push-model consumers, not just a new arm in
+/// `each_try_generic`'s own dispatch. Pinned as a known, documented
+/// divergence (`docs/compliance/jq/limitations.md`) -- if this starts
+/// suppressing/catching correctly, that is a deliberate future fix (closing
+/// #1948), not a regression, and this test should be updated alongside it.
+#[test]
+fn test_first_limit_wrapped_optional_try_catch_still_known_gap_1948() -> Result<()> {
+    // LazyKeys (#1936's own target), one push-model layer further out.
+    for filter in ["first(keys_unsorted?)", r#"first(try (keys) catch "c")"#] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_ne!(code, 0, "`{filter}` should still fail\nstdout: {stdout}");
+        assert!(
+            !stdout.contains('c'),
+            "`{filter}` should not have run the catch handler\nstdout: {stdout}"
+        );
+        assert!(!stderr.is_empty(), "`{filter}` should carry a diagnostic");
+    }
+
+    // LazySeq (#1812's own target), predating #1936 entirely.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"first(try (map(error("x"))) catch "c")"#],
+        Some("[1,2,3]"),
+    )
+    .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_ne!(code, 0, "should still fail\nstdout: {stdout}");
+    assert!(!stdout.contains('c'), "stdout: {stdout}");
+    assert!(!stderr.is_empty());
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`try_single_generic` (`eval_generic.rs`'s shared `?`/`try`/`catch` dispatch) already forced a `GenericResult::LazySeq` (`map(f)`) before this boundary could close (#1812), so a failure inside a lazy `map` chain surfaces *now*, while the boundary can still suppress/catch it. But `GenericResult::LazyKeys` — the lazy representation `keys`/`keys_unsorted` produce for an object — had no equivalent arm, falling straight through to the wildcard fallback unmaterialized.

A #1194-class malformed (non-string) object key is only detected once the `LazyKeys` is eventually materialized, by which point `?`/`try`/`catch` is long gone:

```console
$ echo '{123: 1}' | succinctly jq -c 'sort?'
                                          # suppressed correctly, exit 0
$ echo '{123: 1}' | succinctly jq -c 'keys_unsorted?'
jq: error (at <stdin>:0): Invalid JSON text: expected string key, found '1'
                                          # NOT suppressed, exit 5 (before this fix)
```

## Fix

`try_single_generic` now checks `LazyKeys` via `keys_are_well_formed`/`walk_distinct_keys_checked` (a zero-allocation cursor-only walk, shared with the pre-existing `distinct_key_cursors_checked` via a callback so the #1194/#1677 check has one definition, not two) *before* the boundary's match runs. On success it hands back the **original, still-lazy** `LazyKeys` unchanged — so a downstream `fold_pipe_stages` arm still gets its documented O(1)/no-allocation fast path for `.[]`/`.[n]`/`first`/`last`/`length`. Only on a genuine malformed key does it route through the existing `is_decode_failure()`/`run_catch` dispatch.

`GenericResult::LazyIndexRange` (array `keys`/`keys_unsorted`) needs no arm at all: its value is fully described by the array's length alone, so it can never actually fail — it's left on the `other => other` wildcard exactly as before.

## Review history (3 rounds)

- **Round 1** caught a false doc-comment claim that `each_try_generic` (the push-model twin reached via `first`/`limit`) needed no equivalent fix — it does; tracked as **#1948** (a materially larger fix needing `eval_each_generic` itself to carry a "materialize now" signal through nested push-model consumers), not folded into this PR.
- **Round 2** caught that the first fix called `GenericResult::materialize_lazy()` unconditionally, forcing full key decoding even on success and defeating `fold_pipe_stages`'s fast paths — live-measured 10x/2.7x regressions on a 2M-key object. Fixed by checking-without-materializing instead; the residual, *inherent* cost (some extra walk is unavoidable to know "would this fail" before the boundary closes) is tracked as **#1951**.
- **Round 3** caught that the check-without-materializing helper still needlessly collected a `Vec<V::Cursor>` on every call — unified it with the existing `distinct_key_cursors_checked` via a shared callback-based walk, and found (pre-existing, unrelated to this fix) that `Builtin::Last`'s own fast path and `JqValue::materialize()`/`into_owned()` both skip half of the same #1194/#1677 check — tracked as **#1956**.

## Testing

- `test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936` — pins the repro: `sort?`/`keys?`/`keys_unsorted?` all suppress correctly, and `try (keys) catch`/`try (keys_unsorted) catch` both now run the catch handler.
- `test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_1936` — valid-data sanity check across both array (`LazyIndexRange`) and object (`LazyKeys`) shapes, through both `?` and `try`/`catch`.
- `test_first_limit_wrapped_optional_try_catch_still_known_gap_1948` — pins the still-open push-model gap as a documented, deliberate divergence (not a silent regression).
- Full local suite (`cargo test --features cli`), both required clippy legs, and `cargo fmt --check` all clean.

Fixes #1936