### PR TITLE
fix(jq): first(repeat(f)) tracks through path() the same as limit(1; repeat(f))

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1843,6 +1843,42 @@ truncating rather than removing the tradeoff. Recorded here rather than left
 implicit in a doc comment that named only the case it was actually written
 to prevent.
 
+### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
+
+[#1906](https://github.com/rust-works/succinctly/issues/1906)/PR #1933 added `Expr::Repeat`
+interception for `path(limit(n; repeat(f)))` (`resolve_limit_one_n`);
+[#1935](https://github.com/rust-works/succinctly/issues/1935) extended the identical
+interception to `path(first(repeat(f)))` (`first(f)` being `limit(1; f)` for this purpose).
+Both fixes only fire when `Expr::Repeat` is the *direct* (paren-unwrapped) child of the
+bounded consumer's own body expression:
+
+```console
+$ echo '{"a":{"a":2}}' | jq -c 'path(nth(2; repeat(.a)))'
+["a"]
+$ echo '{"a":{"a":2}}' | succinctly jq -c 'path(nth(2; repeat(.a)))'
+jq: error (at <stdin>:1): Invalid path expression with result {"a":2}
+
+$ echo '{"a":1}' | jq -c 'path(limit(2; if true then repeat(.) else 1 end))'
+[]
+[]
+$ echo '{"a":1}' | succinctly jq -c 'path(limit(2; if true then repeat(.) else 1 end))'
+jq: error (at <stdin>:1): Invalid path expression with result {"a":1}
+```
+
+`nth(n; f)` (`Builtin::NthStream`) has no `resolve_node` arm at all today -- a pre-existing
+gap independent of `repeat` (`path(nth(1; .a,.b))` on an ordinary, non-`repeat` generator
+already diverges the same way). Extending `repeat`-specific interception to `nth` has
+nothing to attach to until `nth` has *any* path-context support to extend. `Expr::If`/
+`Expr::Alternative`/(likely) `Expr::Comma` all recurse into `resolve_node` directly on
+their branches rather than through a bounded consumer, so a `repeat` reached only after
+passing through one of these has no way to know, at that point, how many outputs will
+actually be needed -- closing this generally would need a bound threaded *through*
+arbitrary combinator nesting before ever calling `resolve_node` on the `repeat` itself,
+which its current single `(expr, value, trackable, snapshot) -> Vec<PathBranch>` signature
+has no parameter for. Tracked as an open scoping question in #1935 rather than attempted
+here; the narrow `first`/`limit` fixes already close the two shapes named in #1906/#1935's
+own repros.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1875,9 +1875,11 @@ passing through one of these has no way to know, at that point, how many outputs
 actually be needed -- closing this generally would need a bound threaded *through*
 arbitrary combinator nesting before ever calling `resolve_node` on the `repeat` itself,
 which its current single `(expr, value, trackable, snapshot) -> Vec<PathBranch>` signature
-has no parameter for. Tracked as an open scoping question in #1935 rather than attempted
-here; the narrow `first`/`limit` fixes already close the two shapes named in #1906/#1935's
-own repros.
+has no parameter for. Tracked as its own standalone design question in
+[#1952](https://github.com/rust-works/succinctly/issues/1952) (a general sink/early-stop
+protocol for `resolve_node`, the same shape `eval_each_owned` already gives value-mode
+evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
+the two shapes named in #1906/#1935's own repros.
 
 ## Provenance
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20182,19 +20182,28 @@ fn resolve_node<'a, S: EvalSemantics>(
         // parser path. Keeping both arms means it does not matter which one
         // a given call site produces.
         //
-        // #1935: `repeat(f)` needs the same interception `resolve_limit_one_n`
-        // already applies for `limit` -- `resolve_node` on a bare
-        // `Expr::Repeat` never returns (no natural termination, #1906), so
-        // `take_path_branches`'s truncate-after-the-fact shape cannot work
-        // here either. `resolve_repeat_bounded` is already generic over its
-        // bound; `first(f)` is exactly `limit(1; f)` for this purpose.
-        // Live-verified against jq 1.7.1: `{"a":1} | path(first(repeat(.)))`
-        // is `[]`.
+        // #1935: `first(f)` is exactly `limit(1; f)` for path-tracking
+        // purposes, so it needs the same two fast paths
+        // `resolve_limit_one_n` already applies for `limit`, not just
+        // `take_path_branches`'s generic truncate-after-the-fact shape:
+        //
+        // - `repeat(f)` has no natural termination (#1906) -- `resolve_node`
+        //   on a bare `Expr::Repeat` never returns, so truncating its result
+        //   afterward cannot work; `resolve_repeat_bounded` (already generic
+        //   over its bound) must intercept before that call. Live-verified
+        //   against jq 1.7.1: `{"a":1} | path(first(repeat(.)))` is `[]`.
+        // - `.[]` (#1850) is merely slow unbounded, not infinite, but
+        //   `resolve_node`'s `Expr::Iterate` arm still fully materializes
+        //   every element into a `PathBranch` before truncation -- an O(N)
+        //   allocation for what `resolve_iterate_bounded`'s own `.take(n)`
+        //   makes O(1). Same `trackable` gate `resolve_limit_one_n` uses:
+        //   when untracked, falls through to the generic path below, which
+        //   raises the correct error on its own.
         Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
-            if let Expr::Repeat(f) = unwrap_paren(inner) {
-                resolve_repeat_bounded::<S>(f, value, trackable, snapshot, 1)
-            } else {
-                take_path_branches(resolve_node::<S>(inner, value, trackable, snapshot), 1)
+            match unwrap_paren(inner) {
+                Expr::Repeat(f) => resolve_repeat_bounded::<S>(f, value, trackable, snapshot, 1),
+                Expr::Iterate if trackable => resolve_iterate_bounded::<S>(value, 1),
+                _ => take_path_branches(resolve_node::<S>(inner, value, trackable, snapshot), 1),
             }
         }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20181,8 +20181,21 @@ fn resolve_node<'a, S: EvalSemantics>(
         // is a second, older representation reachable from a different
         // parser path. Keeping both arms means it does not matter which one
         // a given call site produces.
+        //
+        // #1935: `repeat(f)` needs the same interception `resolve_limit_one_n`
+        // already applies for `limit` -- `resolve_node` on a bare
+        // `Expr::Repeat` never returns (no natural termination, #1906), so
+        // `take_path_branches`'s truncate-after-the-fact shape cannot work
+        // here either. `resolve_repeat_bounded` is already generic over its
+        // bound; `first(f)` is exactly `limit(1; f)` for this purpose.
+        // Live-verified against jq 1.7.1: `{"a":1} | path(first(repeat(.)))`
+        // is `[]`.
         Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
-            take_path_branches(resolve_node::<S>(inner, value, trackable, snapshot), 1)
+            if let Expr::Repeat(f) = unwrap_paren(inner) {
+                resolve_repeat_bounded::<S>(f, value, trackable, snapshot, 1)
+            } else {
+                take_path_branches(resolve_node::<S>(inner, value, trackable, snapshot), 1)
+            }
         }
 
         // `if cond then a else b end`: only the branch the runtime actually

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20183,28 +20183,13 @@ fn resolve_node<'a, S: EvalSemantics>(
         // a given call site produces.
         //
         // #1935: `first(f)` is exactly `limit(1; f)` for path-tracking
-        // purposes, so it needs the same two fast paths
-        // `resolve_limit_one_n` already applies for `limit`, not just
-        // `take_path_branches`'s generic truncate-after-the-fact shape:
-        //
-        // - `repeat(f)` has no natural termination (#1906) -- `resolve_node`
-        //   on a bare `Expr::Repeat` never returns, so truncating its result
-        //   afterward cannot work; `resolve_repeat_bounded` (already generic
-        //   over its bound) must intercept before that call. Live-verified
-        //   against jq 1.7.1: `{"a":1} | path(first(repeat(.)))` is `[]`.
-        // - `.[]` (#1850) is merely slow unbounded, not infinite, but
-        //   `resolve_node`'s `Expr::Iterate` arm still fully materializes
-        //   every element into a `PathBranch` before truncation -- an O(N)
-        //   allocation for what `resolve_iterate_bounded`'s own `.take(n)`
-        //   makes O(1). Same `trackable` gate `resolve_limit_one_n` uses:
-        //   when untracked, falls through to the generic path below, which
-        //   raises the correct error on its own.
+        // purposes, so it shares `resolve_limit_one_n`'s own bounded
+        // dispatch (`resolve_node_bounded`, which fast-paths `repeat`/`.[]`
+        // the same way `limit` does) rather than `take_path_branches`'s
+        // generic truncate-after-the-fact shape alone. Live-verified against
+        // jq 1.7.1: `{"a":1} | path(first(repeat(.)))` is `[]`.
         Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
-            match unwrap_paren(inner) {
-                Expr::Repeat(f) => resolve_repeat_bounded::<S>(f, value, trackable, snapshot, 1),
-                Expr::Iterate if trackable => resolve_iterate_bounded::<S>(value, 1),
-                _ => take_path_branches(resolve_node::<S>(inner, value, trackable, snapshot), 1),
-            }
+            resolve_node_bounded::<S>(inner, value, trackable, snapshot, 1)
         }
 
         // `if cond then a else b end`: only the branch the runtime actually
@@ -20791,6 +20776,56 @@ fn resolve_limit<'a, S: EvalSemantics>(
     }
 }
 
+/// Shared "resolve `expr`, capped at `n` branches" dispatch for every
+/// bounded consumer of a generator (`limit(n; expr)` and, since #1935,
+/// `first(f)` == `limit(1; f)` for path-tracking purposes) -- extracted from
+/// two independent, drifting copies of this same three-way match (#1935's
+/// own code review, echoing the "duplicated predicates diverge silently"
+/// lesson #106 already burned this file on once).
+///
+/// - #1850: bare `.[]` is bounded directly via `.take(n)` on the same
+///   iterator `resolve_node`'s own `Expr::Iterate` arm builds, making
+///   `path(limit(n; .[]))`/`path(first(.[]))` O(n) instead of O(document
+///   size) -- see [`resolve_iterate_bounded`]'s own doc comment for why this
+///   is scoped to exactly this shape rather than `resolve_node`'s generator
+///   path in general: every other arm there returns a fully materialized
+///   `Vec<PathBranch>` with no sink/early-stop protocol to plug into, so a
+///   fully general fix is a separate, much wider design question that
+///   issue itself left open.
+/// - #1906: `repeat(f)` needs the same interception, for a correctness
+///   reason rather than a performance one -- see [`resolve_repeat_bounded`]'s
+///   own doc comment. This has to intercept *before* the generic
+///   `resolve_node` call below, not truncate its result afterward the way
+///   `take_path_branches` does for every other shape: an un-intercepted
+///   `Expr::Repeat` falls through to `resolve_leaf`'s general case, which
+///   evaluates it via the ordinary (value-mode) evaluator -- bounded by
+///   `eval_repeat`'s own `MAX_ITERATIONS = 1000` round cap, so it *does*
+///   still return, just slowly and with the wrong answer for a `repeat`
+///   whose body is otherwise perfectly path-trackable (confirmed live: the
+///   pre-#1906 code returned "Invalid path expression" for `path(limit(3;
+///   repeat(.)))` after computing, not hanging on, up to 1000 rounds).
+///   Only a body that never produces *any* output (`repeat(empty)`) comes
+///   close to a true hang, and even that is bounded by the same cap.
+///
+/// Both fast paths are gated the same way their originals were: `Iterate`
+/// requires `trackable` (an untracked value falls through to the generic
+/// path below, which raises the correct error on its own); `Repeat` has no
+/// such gate because `resolve_repeat_bounded` re-threads `trackable` through
+/// its own per-round `resolve_node` call instead.
+fn resolve_node_bounded<'a, S: EvalSemantics>(
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    n: usize,
+) -> PathResolveResult<'a> {
+    match unwrap_paren(expr) {
+        Expr::Repeat(f) => resolve_repeat_bounded::<S>(f, value, trackable, snapshot, n),
+        Expr::Iterate if trackable => resolve_iterate_bounded::<S>(value, n),
+        _ => take_path_branches(resolve_node::<S>(expr, value, trackable, snapshot), n),
+    }
+}
+
 /// `path(limit(n; expr))`'s resolution for one already-resolved `n` — the body
 /// of [`resolve_limit`], run once per output of its `n` generator (#1279).
 fn resolve_limit_one_n<'a, S: EvalSemantics>(
@@ -20814,28 +20849,7 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
     if n == 0 {
         return Ok(Vec::new());
     }
-    // #1850: bare `.[]` (the shape the issue itself measures) is bounded
-    // directly via `.take(n)` on the same iterator `resolve_node`'s own
-    // `Expr::Iterate` arm builds, making `path(limit(n; .[]))` O(n)
-    // instead of O(document size) -- see `resolve_iterate_bounded`'s own
-    // doc comment for why this is scoped to exactly this shape rather than
-    // `resolve_node`'s generator path in general: every other arm there
-    // returns a fully materialized `Vec<PathBranch>` with no
-    // sink/early-stop protocol to plug into, so a fully general fix is a
-    // separate, much wider design question this issue itself left open.
-    if trackable && matches!(unwrap_paren(expr), Expr::Iterate) {
-        return resolve_iterate_bounded::<S>(value, n);
-    }
-    // #1906: `repeat(f)` has no natural termination at all (unlike `.[]`
-    // above, whose unbounded form is merely slow, not infinite) -- see
-    // `resolve_repeat_bounded`'s own doc comment. This has to intercept
-    // before the generic `resolve_node` call below, not truncate its
-    // result afterward the way `take_path_branches` does for every other
-    // shape: `resolve_node` would never return in the first place.
-    if let Expr::Repeat(f) = unwrap_paren(expr) {
-        return resolve_repeat_bounded::<S>(f, value, trackable, snapshot, n);
-    }
-    take_path_branches(resolve_node::<S>(expr, value, trackable, snapshot), n)
+    resolve_node_bounded::<S>(expr, value, trackable, snapshot, n)
 }
 
 /// `repeat(f)`'s own path-branch construction (#1906), bounded to at most

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20784,14 +20784,15 @@ fn resolve_limit<'a, S: EvalSemantics>(
 /// lesson #106 already burned this file on once).
 ///
 /// - #1850: bare `.[]` is bounded directly via `.take(n)` on the same
-///   iterator `resolve_node`'s own `Expr::Iterate` arm builds, making
-///   `path(limit(n; .[]))`/`path(first(.[]))` O(n) instead of O(document
-///   size) -- see [`resolve_iterate_bounded`]'s own doc comment for why this
-///   is scoped to exactly this shape rather than `resolve_node`'s generator
-///   path in general: every other arm there returns a fully materialized
-///   `Vec<PathBranch>` with no sink/early-stop protocol to plug into, so a
-///   fully general fix is a separate, much wider design question that
-///   issue itself left open.
+///   iterator `resolve_node`'s own `Expr::Iterate` arm builds (see
+///   [`resolve_iterate_bounded`]'s own doc comment for the implementation),
+///   making `path(limit(n; .[]))`/`path(first(.[]))` O(n) instead of
+///   O(document size). Scoped to exactly this shape rather than
+///   `resolve_node`'s generator path in general because every other arm
+///   there returns a fully materialized `Vec<PathBranch>` with no
+///   sink/early-stop protocol to plug into -- a fully general fix needs
+///   that protocol threaded through `resolve_node` itself, tracked as its
+///   own open design question in #1952 rather than attempted here.
 /// - #1906: `repeat(f)` needs the same interception, for a correctness
 ///   reason rather than a performance one -- see [`resolve_repeat_bounded`]'s
 ///   own doc comment. This has to intercept *before* the generic

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12879,15 +12879,19 @@ fn test_path_repeat_width_budget_matches_value_mode_1933() -> Result<()> {
     Ok(())
 }
 
-/// #1935: `first(f)` needs the identical `Expr::Repeat` interception #1906
-/// gave `limit` -- `first(repeat(f))` is exactly `limit(1; repeat(f))` for
-/// path-tracking purposes, but was routing through the generic (would-never-
-/// return) `resolve_node` call instead. Confirmed live against jq 1.7.1.
-/// `nth(n; repeat(f))` and a `repeat` reached only through an intervening
-/// `if`/`Alternative`/other combinator remain a documented, deliberately
-/// out-of-scope gap (issue #1935's own suggested disposition -- `nth` has no
-/// path-context support at all yet to extend, and the general combinator-
-/// nesting case needs a materially bigger design change).
+/// #1935: `first(f)` needs the same `resolve_node_bounded` dispatch #1906/
+/// #1850 gave `limit` -- `first(f)` is exactly `limit(1; f)` for
+/// path-tracking purposes, but was routing through the generic
+/// `take_path_branches(resolve_node(...), 1)` shape instead, which cannot
+/// fast-path either `repeat` or `.[]` (an un-intercepted `Expr::Repeat`
+/// falls through to `resolve_leaf`'s general case, itself bounded by
+/// `eval_repeat`'s own 1000-round cap -- so it still returns, just slowly
+/// and with the wrong answer, not a true hang). Confirmed live against jq
+/// 1.7.1. `nth(n; repeat(f))` and a `repeat` reached only through an
+/// intervening `if`/`Alternative`/other combinator remain a documented,
+/// deliberately out-of-scope gap (issue #1935's own suggested disposition --
+/// `nth` has no path-context support at all yet to extend, and the general
+/// combinator-nesting case needs a materially bigger design change).
 #[test]
 fn test_path_first_repeat_tracks_through_trackable_body_1935() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-c", "path(first(repeat(.)))"], Some("{\"a\":1}"))?;
@@ -12913,6 +12917,45 @@ fn test_path_first_repeat_tracks_through_trackable_body_1935() -> Result<()> {
     let (stdout, _, code) = run_jq_full(&["-c", "path(first(.a,.b))"], Some("{\"a\":1,\"b\":2}"))?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "[\"a\"]\n");
+
+    Ok(())
+}
+
+/// #1935 (code review): the `Expr::Iterate` fast path (#1850) is the other
+/// half of `resolve_node_bounded`'s dispatch, reused by `first(f)` alongside
+/// `Expr::Repeat` -- covered separately from the `repeat`-focused test above
+/// since it went unpinned by any of this issue's own tests despite being
+/// live-verified during review. `path(limit(1; .[]))`'s already-established
+/// #1850 behavior is the parity baseline `first(.[])` must match, since the
+/// two are the same bound expressed two ways.
+#[test]
+fn test_path_first_iterate_uses_bounded_fast_path_1935() -> Result<()> {
+    let (first_stdout, _, first_code) = run_jq_full(&["-c", "path(first(.[]))"], Some("[1,2,3]"))?;
+    let (limit_stdout, _, limit_code) =
+        run_jq_full(&["-c", "path(limit(1; .[]))"], Some("[1,2,3]"))?;
+    assert_eq!(first_code, 0);
+    assert_eq!(first_stdout, "[0]\n");
+    assert_eq!(first_stdout, limit_stdout);
+    assert_eq!(first_code, limit_code);
+
+    let (stdout, _, code) = run_jq_full(&["-c", "path(first(.[]))"], Some("{\"a\":1,\"b\":2}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\"]\n");
+
+    // Empty container: no branch to keep, not an error.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(first(.[]))"], Some("[]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // Untracked value still raises the correct error rather than silently
+    // taking the fast path (the same `trackable` gate `limit` uses).
+    let (_, stderr, code) =
+        run_jq_full(&["-c", "path(try error(1) catch first(.[]))"], Some("null"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Invalid path expression"),
+        "stderr: {stderr}"
+    );
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12879,6 +12879,63 @@ fn test_path_repeat_width_budget_matches_value_mode_1933() -> Result<()> {
     Ok(())
 }
 
+/// #1935: `first(f)` needs the identical `Expr::Repeat` interception #1906
+/// gave `limit` -- `first(repeat(f))` is exactly `limit(1; repeat(f))` for
+/// path-tracking purposes, but was routing through the generic (would-never-
+/// return) `resolve_node` call instead. Confirmed live against jq 1.7.1.
+/// `nth(n; repeat(f))` and a `repeat` reached only through an intervening
+/// `if`/`Alternative`/other combinator remain a documented, deliberately
+/// out-of-scope gap (issue #1935's own suggested disposition -- `nth` has no
+/// path-context support at all yet to extend, and the general combinator-
+/// nesting case needs a materially bigger design change).
+#[test]
+fn test_path_first_repeat_tracks_through_trackable_body_1935() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "path(first(repeat(.)))"], Some("{\"a\":1}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "path(first(repeat(.a)))"],
+        Some("{\"a\":{\"a\":2}}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\"]\n");
+
+    // A non-path-shaped body still raises immediately.
+    let (_, stderr, code) = run_jq_full(&["-c", "path(first(repeat(1)))"], Some("null"))?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Invalid path expression with result 1"),
+        "stderr: {stderr}"
+    );
+
+    // Regression guard: ordinary (non-`repeat`) `first(f)` is unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(first(.a,.b))"], Some("{\"a\":1,\"b\":2}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\"]\n");
+
+    Ok(())
+}
+
+/// #1935: `nth(n; repeat(f))` is a documented, deliberately unfixed gap --
+/// `nth` has no `resolve_node` arm at all yet (a pre-existing gap
+/// independent of `repeat`), so `repeat`-specific interception there has
+/// nothing to extend. Pins the current (wrong) behavior as a known-gap
+/// regression guard rather than leaving it silently unverified.
+#[test]
+fn test_path_nth_repeat_known_gap_1935() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(
+        &["-c", "path(nth(2; repeat(.a)))"],
+        Some("{\"a\":{\"a\":2}}"),
+    )?;
+    assert_ne!(code, 0, "known gap: nth has no path-context support yet");
+    assert!(
+        stderr.contains("Invalid path expression"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_walk_nested_break_reaches_its_enclosing_label() -> Result<()> {
     // Before this fix, a nested `f` application collapsed a `Control::Break`


### PR DESCRIPTION
## Summary
- `resolve_node`'s `Expr::FirstExpr`/`Builtin::FirstStream` arm called `resolve_node` directly on its inner expression, then truncated to 1 output via `take_path_branches` — the same "would never return" shape #1906 already fixed for `limit`, since `repeat(f)` has no natural termination and `resolve_node`'s other arms all fully materialize before truncating.
- `first(f)` is exactly `limit(1; f)` for path-tracking purposes, so this reuses #1906/PR #1933's own `resolve_repeat_bounded` with `n=1`: intercept `Expr::Repeat` before the generic `resolve_node` call, not after.
- `nth(n; repeat(f))` and a `repeat` reached only through an intervening `if`/`Alternative`/other combinator remain a documented, deliberately out-of-scope gap — `nth` has no path-context support at all yet to extend, and the general combinator-nesting case needs a materially bigger design change, per the issue's own suggested disposition.

## Test plan
- [x] New CLI tests: `first(repeat(.))`/`first(repeat(.a))` track correctly, a non-path-shaped body still raises, ordinary (non-`repeat`) `first(f)` is unaffected; a known-gap regression guard pins `nth(n; repeat(f))`'s current (still-broken) behavior.
- [x] Live-verified against jq 1.7.1: all repros from the issue body, plus regression checks on #1906's own `limit(n; repeat(f))` shape.
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Fixes #1935