### PR TITLE
fix(jq): eval_owned_expr_opt/full take first output instead of array-collapsing

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1881,7 +1881,7 @@ protocol for `resolve_node`, the same shape `eval_each_owned` already gives valu
 evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
 the two shapes named in #1906/#1935's own repros.
 
-### A generator-argument expression fans out normally, then silently narrows to its first output the moment `key`/`parent`/`file_index` shows up anywhere else in the same pipe
+### A generator-argument expression fans out normally, then silently narrows to a single array the moment `key`/`parent`/`file_index` shows up anywhere else in the same pipe
 
 [#1277](https://github.com/rust-works/succinctly/issues/1277)'s clusters 1-3
 (closed by [#1522](https://github.com/rust-works/succinctly/issues/1522)/[#1279](https://github.com/rust-works/succinctly/issues/1279))
@@ -1893,9 +1893,8 @@ arm, the `Expr::Object`/`Array`/`Literal` arm, and the generic `_` fallback
 -- were an explicit non-goal of that fix, since giving them the same real
 fan-out is a materially larger change (`docs/plan/jq-generator-argument-fanout.md`).
 Those 4 sites route through `eval_owned_expr_opt`/`eval_owned_expr_full`,
-which -- until [#1937](https://github.com/rust-works/succinctly/issues/1937)
--- array-collapsed a multi-output expression into a single
-`OwnedValue::Array` instead of fanning out or taking the first output.
+which array-collapses a multi-output expression into a single
+`OwnedValue::Array` instead of fanning out.
 
 ```console
 $ echo '{"a":"xax"}' | succinctly jq -c '.a | ltrimstr(("x","z"))'
@@ -1913,19 +1912,57 @@ except for the trailing `key`, which forces the whole pipe through
 `key` itself has no jq oracle (succinctly extension), so this specific
 combination can't be demonstrated as a *jq* divergence in isolation, but it
 is a genuine, demonstrated internal inconsistency: the same sub-expression
-fans out correctly or silently narrows to one value depending on whether an
-unrelated path-tracking builtin happens to be anywhere else in the pipe.
+fans out correctly or silently collapses into one array-shaped value
+depending on whether an unrelated path-tracking builtin happens to be
+anywhere else in the pipe.
 
-#1937 changed the narrowing from array-collapse to take-first (matching
-`result_to_owned_full`'s identical policy for the same shapes, and its
-`x as $b | ...` rationale for why real jq's own generator-argument
-desugaring only ever drives the rest of a computation off the *first*
-output) -- internally consistent with that sibling function's behavior now,
-rather than being a second, differently-wrong answer. This is **not** a fix
-to full fidelity: real jq still produces every output here, and neither
-take-first nor array-collapse matches that. Left as a known, documented gap
-rather than the larger fan-out rework #1522's design doc already declined
-for these 4 sites.
+**[#1937](https://github.com/rust-works/succinctly/issues/1937) fixed one
+narrow, safe piece of this**: a *zero*-output generator (`(empty)`-style)
+now correctly contributes zero outputs to the enclosing computation, rather
+than an `OwnedValue::Array([])` value -- matching `result_to_owned_full`'s
+identical `#1045` rule for the same `Many`/`ManyOwned` shapes, and with no
+downside, since there is nothing to lose by treating "zero outputs" as "zero
+outputs" instead of manufacturing an empty-array value.
+
+**A first attempt at #1937 also tried taking the *first* output instead of
+array-collapsing for the 2+-output case (matching `result_to_owned_full`'s
+policy for that shape too) -- this was implemented, tested, and then
+rejected during `/code-review` before merging, because it introduced a
+strictly worse regression than the one it fixed.** `result_to_owned_full`'s
+take-first policy is correct for *its* callers -- a builtin's single
+generator argument, always consumed exactly once by the builtin's own body.
+But `eval_owned_expr_full` is not scoped that narrowly: its
+`Expr::Builtin(_)` arm also evaluates *zero-arg* generator builtins
+(`recurse`, `range`, `inputs`, ...) whenever they're reached through
+path-context routing, and its generic `_` fallback evaluates arbitrary
+comma branches, `..`, `paths`, `limit`, and anything else with no dedicated
+arm. Live-verified before rejecting the approach:
+
+```console
+$ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c '.a | (recurse, key)'
+# with array-collapse (both before and after this issue):
+[{"b":{"c":1}},{"c":1},1]
+"a"
+# with the rejected take-first attempt:
+{"b":{"c":1}}
+"a"
+```
+
+Array-collapse produces the wrong *shape* (an array instead of 3 fanned-out
+outputs) but keeps every value inspectable. Take-first silently and
+permanently discarded 2 of the 3 `recurse` outputs with no error and no
+trace -- a materially larger, harder-to-notice correctness gap than the one
+narrow `ltrimstr`+`key` example this section documents, reachable through
+two everyday builtins (`recurse`/`range`-style generators, and `..`) rather
+than only the argument-fan-out case #1937 was filed against. Reverted;
+`tests/jq_cli_tests.rs`'s `test_path_context_builtin_arm_multi_output_still_array_collapses_1937`
+and `test_path_context_generic_fallback_recurse_still_array_collapses_1937`
+pin the current (still wrong-shaped, but not lossy) array-collapse behavior
+as a regression guard against re-attempting take-first without also solving
+the zero-arg-generator/generic-fallback exposure.
+
+Full fan-out for all 4 sites remains the only fix that would actually match
+real jq here, and remains out of scope per #1522's design doc.
 
 ## Provenance
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1881,6 +1881,52 @@ protocol for `resolve_node`, the same shape `eval_each_owned` already gives valu
 evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
 the two shapes named in #1906/#1935's own repros.
 
+### A generator-argument expression fans out normally, then silently narrows to its first output the moment `key`/`parent`/`file_index` shows up anywhere else in the same pipe
+
+[#1277](https://github.com/rust-works/succinctly/issues/1277)'s clusters 1-3
+(closed by [#1522](https://github.com/rust-works/succinctly/issues/1522)/[#1279](https://github.com/rust-works/succinctly/issues/1279))
+gave generator-argument builtins real fan-out: a builtin whose argument is a
+generator now produces one output per argument output, matching real jq.
+Four call sites inside `eval_pipe_with_path_context_internal`
+(`src/jq/eval.rs`) -- `ParentN`'s own `n` argument, the `Expr::Builtin(_)`
+arm, the `Expr::Object`/`Array`/`Literal` arm, and the generic `_` fallback
+-- were an explicit non-goal of that fix, since giving them the same real
+fan-out is a materially larger change (`docs/plan/jq-generator-argument-fanout.md`).
+Those 4 sites route through `eval_owned_expr_opt`/`eval_owned_expr_full`,
+which -- until [#1937](https://github.com/rust-works/succinctly/issues/1937)
+-- array-collapsed a multi-output expression into a single
+`OwnedValue::Array` instead of fanning out or taking the first output.
+
+```console
+$ echo '{"a":"xax"}' | succinctly jq -c '.a | ltrimstr(("x","z"))'
+"ax"
+"xax"
+$ echo '{"a":"xax"}' | succinctly jq -c '.a | ltrimstr(("x","z")) | key'
+"a"
+```
+
+The first query (no `key`, so the ordinary fan-out-aware evaluator handles
+it) correctly produces 2 outputs, matching real jq's own fan-out for this
+exact query (confirmed against jq 1.7.1). The second query is identical
+except for the trailing `key`, which forces the whole pipe through
+`eval_pipe_with_path_context_internal` since `key` needs path tracking --
+`key` itself has no jq oracle (succinctly extension), so this specific
+combination can't be demonstrated as a *jq* divergence in isolation, but it
+is a genuine, demonstrated internal inconsistency: the same sub-expression
+fans out correctly or silently narrows to one value depending on whether an
+unrelated path-tracking builtin happens to be anywhere else in the pipe.
+
+#1937 changed the narrowing from array-collapse to take-first (matching
+`result_to_owned_full`'s identical policy for the same shapes, and its
+`x as $b | ...` rationale for why real jq's own generator-argument
+desugaring only ever drives the rest of a computation off the *first*
+output) -- internally consistent with that sibling function's behavior now,
+rather than being a second, differently-wrong answer. This is **not** a fix
+to full fidelity: real jq still produces every output here, and neither
+take-first nor array-collapse matches that. Left as a known, documented gap
+rather than the larger fan-out rework #1522's design doc already declined
+for these 4 sites.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25481,23 +25481,28 @@ fn eval_owned_expr_full<S: EvalSemantics>(
         QueryResult::One(v) => Ok(Some((to_owned(&v), None))),
         QueryResult::OneCursor(_) => unreachable!(),
         QueryResult::Owned(v) => Ok(Some((v, None))),
-        QueryResult::Many(vs) => {
-            if vs.len() == 1 {
-                Ok(Some((to_owned(&vs[0]), None)))
-            } else {
-                Ok(Some((
-                    OwnedValue::Array(vs.iter().map(to_owned).collect()),
-                    None,
-                )))
-            }
-        }
-        QueryResult::ManyOwned(vs) => {
-            if vs.len() == 1 {
-                Ok(Some((vs.into_iter().next().unwrap(), None)))
-            } else {
-                Ok(Some((OwnedValue::Array(vs), None)))
-            }
-        }
+        // Take-first, not array-collapse (#1937): real jq's generator-argument
+        // desugaring (`f(x)` ~= `x as $b | ...`) runs the caller's computation
+        // against `x`'s *first* output only -- see `result_to_owned_full`'s
+        // identical policy and doc comment, which this now matches instead of
+        // diverging from it. An empty `Many`/`ManyOwned` is the same
+        // "zero outputs" case as a bare `QueryResult::None`, not an empty
+        // array (same reasoning as `result_to_owned_full`).
+        //
+        // This is a deliberate simplification, not full fan-out: giving these
+        // 4 call sites (`ParentN`'s `n`, `Builtin`, `Object`/`Array`/`Literal`,
+        // the generic fallback -- all inside
+        // `eval_pipe_with_path_context_internal`) real one-output-per-argument-
+        // output fan-out is the "materially larger, too invasive" fix #1522's
+        // design doc (`docs/plan/jq-generator-argument-fanout.md`) explicitly
+        // declined for this exact helper. Taking the first output instead of
+        // array-collapsing it is *not* a correct match for real jq either --
+        // jq still produces every output -- but it is at least internally
+        // consistent with `result_to_owned`'s sibling policy, rather than the
+        // previous array-collapse being a second, different wrong answer.
+        // Residual gap documented in `docs/compliance/jq/limitations.md`.
+        QueryResult::Many(vs) => Ok(vs.first().map(|v| (to_owned(v), None))),
+        QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().map(|v| (v, None))),
         // The one behavior change from `eval_owned_expr_ctrl_full`'s own
         // slow path (#1280): `None`, not `Ok(Some((Null, None)))`.
         QueryResult::None => Ok(None),
@@ -25511,17 +25516,15 @@ fn eval_owned_expr_full<S: EvalSemantics>(
         // after some values were already produced, not have it silently
         // discarded (#791).
         QueryResult::Partial(_, Control::Halt(code)) => Err(Control::Halt(code)),
-        // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
-        // above; the trailing `Error`/`Break` is now exposed via the second
-        // tuple element instead of silently dropped (#1164) -- a caller
-        // using this function (rather than the plain `eval_owned_expr_ctrl`
-        // above) is expected to apply it to its own final result.
+        // Same take-first policy as `Many`/`ManyOwned` above (a `Partial`
+        // prefix is never empty, per `partial`'s own contract -- same
+        // assumption `result_to_owned_full` relies on for its identical arm);
+        // the trailing `Error`/`Break` is still exposed via the second tuple
+        // element instead of silently dropped (#1164) -- a caller using this
+        // function (rather than the plain `eval_owned_expr_ctrl` above) is
+        // expected to apply it to its own final result.
         QueryResult::Partial(vs, control) => {
-            if vs.len() == 1 {
-                Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
-            } else {
-                Ok(Some((OwnedValue::Array(vs), Some(control))))
-            }
+            Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
         }
     }
 }
@@ -63223,13 +63226,18 @@ mod tests {
     /// the owned equivalent (`ManyOwned`), and a `Partial` with 2+ prior
     /// values -- are covered directly here instead of hunting for CLI
     /// syntax that happens to produce each borrowed/owned distinction.
+    ///
+    /// #1937 changed both of these from array-collapse to take-first (see
+    /// `eval_owned_expr_full`'s own doc comment) -- updated in place here
+    /// rather than left pinning the old, now-removed collapse behavior.
     #[test]
     fn eval_owned_expr_ctrl_full_many_shapes_and_multi_value_partial_1164() {
         // Many (borrowed, 2+ outputs, no escape): `eval_owned_expr_ctrl_full`
         // reindexes `input` into its own internal JsonIndex/cursor before
         // evaluating, so a comma of two field accesses against an object
         // input reaches `eval_single`'s `Many` arm (borrowed cursor values),
-        // not already-owned ones.
+        // not already-owned ones. Takes the first output (#1937), not an
+        // array of both.
         let expr = parse(".a, .b").unwrap();
         match eval_owned_expr_ctrl_full::<JqSemantics>(
             &expr,
@@ -63239,19 +63247,19 @@ mod tests {
             ])),
             false,
         ) {
-            Ok((OwnedValue::Array(vs), None)) => {
-                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
-            }
+            Ok((v, None)) => assert_eq!(v.to_json(), "1"),
             other => panic!("unexpected result: {other:?}"),
         }
 
         // Multi-value Partial (2+ values, then a break): the `else` branch
-        // of the `vs.len() == 1` check inside the `Partial` arm.
+        // of the `vs.len() == 1` check inside the old `Partial` arm --
+        // now takes the first value (#1937), with the trailing break still
+        // exposed rather than dropped (#1164).
         let expr = parse("(1, 2, break $out)").unwrap();
         match eval_owned_expr_ctrl_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
-            Ok((OwnedValue::Array(vs), Some(Control::Break(label)))) => {
+            Ok((v, Some(Control::Break(label)))) => {
+                assert_eq!(v.to_json(), "1");
                 assert_eq!(label, "out");
-                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
             }
             other => panic!("unexpected result: {other:?}"),
         }
@@ -63292,6 +63300,46 @@ mod tests {
         let expr = parse("[1,2,3] | .[0:1][]").unwrap();
         match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
             Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// #1937: a genuinely multi-output expression takes its *first* output
+    /// instead of array-collapsing every output into one `OwnedValue::Array`
+    /// -- consistent with `result_to_owned_full`'s identical policy for the
+    /// same shapes (see that function's own doc comment for why: real jq's
+    /// generator-argument desugaring uses only the first output to drive the
+    /// rest of the computation). Not full fan-out -- #1522's design doc
+    /// explicitly declined that as too invasive for this helper -- just no
+    /// longer manufacturing a second, differently-wrong answer.
+    #[test]
+    fn eval_owned_expr_full_takes_first_not_array_collapse_1937() {
+        // QueryResult::Many, len() > 1: `.[]` over a two-key object.
+        let input = OwnedValue::Object(IndexMap::from([
+            ("a".to_string(), OwnedValue::Int(1)),
+            ("b".to_string(), OwnedValue::Int(2)),
+        ]));
+        let expr = parse(".[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
+            Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // QueryResult::ManyOwned, len() > 1: a constructed array's own `.[]`.
+        let expr = parse("[10,20,30] | .[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
+            Ok(Some((v, None))) => assert_eq!(v.to_json(), "10"),
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // QueryResult::Many, len() == 0: same "zero outputs" case as a bare
+        // `QueryResult::None`, not an empty array -- `.[]` over `{}` produces
+        // nothing at all, matching `result_to_owned_full`'s identical
+        // "an empty Many/ManyOwned is the same zero-outputs case" rule.
+        let empty_obj = OwnedValue::Object(IndexMap::new());
+        let expr = parse(".[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &empty_obj, false) {
+            Ok(None) => {}
             other => panic!("unexpected result: {other:?}"),
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25481,28 +25481,46 @@ fn eval_owned_expr_full<S: EvalSemantics>(
         QueryResult::One(v) => Ok(Some((to_owned(&v), None))),
         QueryResult::OneCursor(_) => unreachable!(),
         QueryResult::Owned(v) => Ok(Some((v, None))),
-        // Take-first, not array-collapse (#1937): real jq's generator-argument
-        // desugaring (`f(x)` ~= `x as $b | ...`) runs the caller's computation
-        // against `x`'s *first* output only -- see `result_to_owned_full`'s
-        // identical policy and doc comment, which this now matches instead of
-        // diverging from it. An empty `Many`/`ManyOwned` is the same
-        // "zero outputs" case as a bare `QueryResult::None`, not an empty
-        // array (same reasoning as `result_to_owned_full`).
+        // #1937 (round 2, after `/code-review` caught a worse regression in
+        // an earlier version of this fix -- see the "Rejected" note in
+        // `docs/compliance/jq/limitations.md` for the full account): a
+        // *zero*-output `Many`/`ManyOwned` is the same "zero outputs" case as
+        // a bare `QueryResult::None` below, not an empty-array value -- same
+        // reasoning as `result_to_owned_full`'s identical `#1045` fix, and
+        // safe here because there is nothing to lose: no value competes with
+        // "no output."
         //
-        // This is a deliberate simplification, not full fan-out: giving these
-        // 4 call sites (`ParentN`'s `n`, `Builtin`, `Object`/`Array`/`Literal`,
-        // the generic fallback -- all inside
-        // `eval_pipe_with_path_context_internal`) real one-output-per-argument-
-        // output fan-out is the "materially larger, too invasive" fix #1522's
-        // design doc (`docs/plan/jq-generator-argument-fanout.md`) explicitly
-        // declined for this exact helper. Taking the first output instead of
-        // array-collapsing it is *not* a correct match for real jq either --
-        // jq still produces every output -- but it is at least internally
-        // consistent with `result_to_owned`'s sibling policy, rather than the
-        // previous array-collapse being a second, different wrong answer.
-        // Residual gap documented in `docs/compliance/jq/limitations.md`.
-        QueryResult::Many(vs) => Ok(vs.first().map(|v| (to_owned(v), None))),
-        QueryResult::ManyOwned(vs) => Ok(vs.into_iter().next().map(|v| (v, None))),
+        // A `Many`/`ManyOwned` with 2+ outputs, by contrast, still
+        // array-collapses (unchanged from before this issue). An earlier
+        // version of this fix took the *first* output instead, matching
+        // `result_to_owned_full`'s policy for the same shapes -- correct for
+        // that function's own callers (a builtin's single generator
+        // argument), but wrong here: this helper also backs the
+        // `Expr::Builtin(_)` arm for *zero*-arg generator builtins
+        // (`recurse`, `range`, ...) and the generic `_` fallback (`..`,
+        // `paths`, `limit`, arbitrary comma branches) whenever a sibling
+        // `key`/`parent`/`file_index` forces path-context routing --
+        // reachable, common builtins, not just the narrow argument-fan-out
+        // case. Taking the first output there silently and permanently
+        // discards every other output with no error and no trace (`.a |
+        // (recurse, key)` went from 3 recurse values collapsed into one wrong
+        // array, to 2 of the 3 vanishing outright) -- a strictly worse
+        // failure mode than array-collapse, which at least keeps every value
+        // inspectable. Reverted; full fan-out remains the only correct fix,
+        // still out of scope per #1522's design doc.
+        QueryResult::Many(vs) => match vs.len() {
+            0 => Ok(None),
+            1 => Ok(Some((to_owned(&vs[0]), None))),
+            _ => Ok(Some((
+                OwnedValue::Array(vs.iter().map(to_owned).collect()),
+                None,
+            ))),
+        },
+        QueryResult::ManyOwned(vs) => match vs.len() {
+            0 => Ok(None),
+            1 => Ok(Some((vs.into_iter().next().unwrap(), None))),
+            _ => Ok(Some((OwnedValue::Array(vs), None))),
+        },
         // The one behavior change from `eval_owned_expr_ctrl_full`'s own
         // slow path (#1280): `None`, not `Ok(Some((Null, None)))`.
         QueryResult::None => Ok(None),
@@ -25516,15 +25534,18 @@ fn eval_owned_expr_full<S: EvalSemantics>(
         // after some values were already produced, not have it silently
         // discarded (#791).
         QueryResult::Partial(_, Control::Halt(code)) => Err(Control::Halt(code)),
-        // Same take-first policy as `Many`/`ManyOwned` above (a `Partial`
-        // prefix is never empty, per `partial`'s own contract -- same
-        // assumption `result_to_owned_full` relies on for its identical arm);
-        // the trailing `Error`/`Break` is still exposed via the second tuple
-        // element instead of silently dropped (#1164) -- a caller using this
-        // function (rather than the plain `eval_owned_expr_ctrl` above) is
-        // expected to apply it to its own final result.
+        // Same collapse-to-single-or-array policy as `Many`/`ManyOwned`
+        // above (unchanged, #1937 round 2); the trailing `Error`/`Break` is
+        // exposed via the second tuple element instead of silently dropped
+        // (#1164) -- a caller using this function (rather than the plain
+        // `eval_owned_expr_ctrl` above) is expected to apply it to its own
+        // final result.
         QueryResult::Partial(vs, control) => {
-            Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
+            if vs.len() == 1 {
+                Ok(Some((vs.into_iter().next().unwrap(), Some(control))))
+            } else {
+                Ok(Some((OwnedValue::Array(vs), Some(control))))
+            }
         }
     }
 }
@@ -63227,17 +63248,18 @@ mod tests {
     /// values -- are covered directly here instead of hunting for CLI
     /// syntax that happens to produce each borrowed/owned distinction.
     ///
-    /// #1937 changed both of these from array-collapse to take-first (see
-    /// `eval_owned_expr_full`'s own doc comment) -- updated in place here
-    /// rather than left pinning the old, now-removed collapse behavior.
+    /// #1937 round 1 briefly changed both of these from array-collapse to
+    /// take-first; round 2 reverted that (see `eval_owned_expr_full`'s own
+    /// doc comment for why -- take-first turned out to silently drop
+    /// `recurse`/`..`/`paths`-style outputs, worse than the collapse it
+    /// replaced), so this test is unchanged from its original #1164 form.
     #[test]
     fn eval_owned_expr_ctrl_full_many_shapes_and_multi_value_partial_1164() {
         // Many (borrowed, 2+ outputs, no escape): `eval_owned_expr_ctrl_full`
         // reindexes `input` into its own internal JsonIndex/cursor before
         // evaluating, so a comma of two field accesses against an object
         // input reaches `eval_single`'s `Many` arm (borrowed cursor values),
-        // not already-owned ones. Takes the first output (#1937), not an
-        // array of both.
+        // not already-owned ones.
         let expr = parse(".a, .b").unwrap();
         match eval_owned_expr_ctrl_full::<JqSemantics>(
             &expr,
@@ -63247,19 +63269,19 @@ mod tests {
             ])),
             false,
         ) {
-            Ok((v, None)) => assert_eq!(v.to_json(), "1"),
+            Ok((OwnedValue::Array(vs), None)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
             other => panic!("unexpected result: {other:?}"),
         }
 
         // Multi-value Partial (2+ values, then a break): the `else` branch
-        // of the `vs.len() == 1` check inside the old `Partial` arm --
-        // now takes the first value (#1937), with the trailing break still
-        // exposed rather than dropped (#1164).
+        // of the `vs.len() == 1` check inside the `Partial` arm.
         let expr = parse("(1, 2, break $out)").unwrap();
         match eval_owned_expr_ctrl_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
-            Ok((v, Some(Control::Break(label)))) => {
-                assert_eq!(v.to_json(), "1");
+            Ok((OwnedValue::Array(vs), Some(Control::Break(label)))) => {
                 assert_eq!(label, "out");
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
             }
             other => panic!("unexpected result: {other:?}"),
         }
@@ -63304,42 +63326,48 @@ mod tests {
         }
     }
 
-    /// #1937: a genuinely multi-output expression takes its *first* output
-    /// instead of array-collapsing every output into one `OwnedValue::Array`
-    /// -- consistent with `result_to_owned_full`'s identical policy for the
-    /// same shapes (see that function's own doc comment for why: real jq's
-    /// generator-argument desugaring uses only the first output to drive the
-    /// rest of the computation). Not full fan-out -- #1522's design doc
-    /// explicitly declined that as too invasive for this helper -- just no
-    /// longer manufacturing a second, differently-wrong answer.
+    /// #1937 (round 2, after `/code-review` rejected round 1's take-first
+    /// approach -- see `eval_owned_expr_full`'s own doc comment): a
+    /// genuinely *empty* `Many`/`ManyOwned` is the same "zero outputs" case
+    /// as a bare `QueryResult::None`, not an empty-array value -- matching
+    /// `result_to_owned_full`'s identical `#1045` rule for the same shapes.
+    /// A 2+-output `Many`/`ManyOwned`/`Partial` still array-collapses,
+    /// unchanged from before this issue -- round 1's take-first for that
+    /// case silently discarded every output but the first for `recurse`,
+    /// `..`, `paths`, and arbitrary comma branches reached through this
+    /// helper's `Expr::Builtin(_)`/generic-fallback call sites, which is
+    /// strictly worse than collapsing them into a (still wrong-shaped, but
+    /// at least fully visible) array.
     #[test]
-    fn eval_owned_expr_full_takes_first_not_array_collapse_1937() {
-        // QueryResult::Many, len() > 1: `.[]` over a two-key object.
+    fn eval_owned_expr_full_empty_many_is_no_output_not_empty_array_1937() {
+        // QueryResult::Many, len() == 0: `.[]` over `{}` produces nothing at
+        // all, matching `result_to_owned_full`'s identical rule -- not
+        // `Ok(Some((OwnedValue::Array(vec![]), None)))`.
+        let empty_obj = OwnedValue::Object(IndexMap::new());
+        let expr = parse(".[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &empty_obj, false) {
+            Ok(None) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // QueryResult::ManyOwned, len() == 0: same rule for the owned
+        // variant -- an empty constructed array's own `.[]`.
+        let expr = parse("[] | .[]").unwrap();
+        match eval_owned_expr_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
+            Ok(None) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // Positive control: 2+ outputs still array-collapse (unchanged).
         let input = OwnedValue::Object(IndexMap::from([
             ("a".to_string(), OwnedValue::Int(1)),
             ("b".to_string(), OwnedValue::Int(2)),
         ]));
         let expr = parse(".[]").unwrap();
         match eval_owned_expr_full::<JqSemantics>(&expr, &input, false) {
-            Ok(Some((v, None))) => assert_eq!(v.to_json(), "1"),
-            other => panic!("unexpected result: {other:?}"),
-        }
-
-        // QueryResult::ManyOwned, len() > 1: a constructed array's own `.[]`.
-        let expr = parse("[10,20,30] | .[]").unwrap();
-        match eval_owned_expr_full::<JqSemantics>(&expr, &OwnedValue::Null, false) {
-            Ok(Some((v, None))) => assert_eq!(v.to_json(), "10"),
-            other => panic!("unexpected result: {other:?}"),
-        }
-
-        // QueryResult::Many, len() == 0: same "zero outputs" case as a bare
-        // `QueryResult::None`, not an empty array -- `.[]` over `{}` produces
-        // nothing at all, matching `result_to_owned_full`'s identical
-        // "an empty Many/ManyOwned is the same zero-outputs case" rule.
-        let empty_obj = OwnedValue::Object(IndexMap::new());
-        let expr = parse(".[]").unwrap();
-        match eval_owned_expr_full::<JqSemantics>(&expr, &empty_obj, false) {
-            Ok(None) => {}
+            Ok(Some((OwnedValue::Array(vs), None))) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
             other => panic!("unexpected result: {other:?}"),
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20147,21 +20147,47 @@ fn test_path_context_builtin_arm_non_swallowed_result_unaffected_1280() -> Resul
 /// jq's own generator-argument fan-out for the isolated `ltrimstr` call,
 /// confirmed against jq 1.7.1) through the `Expr::Builtin(_)` arm's
 /// `eval_owned_expr_opt` call, since the trailing `key` needs path tracking.
-/// Before this fix, that call array-collapsed the two outputs into
-/// `["", "ax"]` before continuing, so `length` measured the *array* (always
-/// 2, matching the fixed comma-branch count regardless of the actual string
-/// values) rather than the real first string's own length (0). `key` itself
-/// has no jq oracle (succinctly extension) and is content-independent, so
-/// it's included only to force path-context routing -- `length`'s value is
-/// what actually distinguishes take-first from array-collapse here.
+/// That call array-collapses the two outputs into `["", "ax"]` before
+/// continuing, so `length` measures the *array* (2, the comma-branch count)
+/// rather than either individual string's own length. `key` itself has no
+/// jq oracle (succinctly extension) and is content-independent, so it's
+/// included only to force path-context routing.
+///
+/// This is a known, documented gap (`docs/compliance/jq/limitations.md`),
+/// not a fix -- #1937's own investigation found the alternative (take the
+/// *first* output instead of collapsing) is a strictly worse regression for
+/// this helper's other call sites (silently drops every `recurse`/`..`/
+/// `paths` output but the first, with no error), so array-collapse remains.
+/// Pinned here as a regression guard against re-introducing that regression.
 #[test]
-fn test_path_context_builtin_arm_multi_output_takes_first_not_array_collapse_1937() -> Result<()> {
+fn test_path_context_builtin_arm_multi_output_still_array_collapses_1937() -> Result<()> {
     let (out, err, code) = run_jq_full(
         &["-c", r#".a | ltrimstr(("xax","x")) | [length, key]"#],
         Some(r#"{"a":"xax"}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out, "[0,\"a\"]\n");
+    assert_eq!(out, "[2,\"a\"]\n");
+    Ok(())
+}
+
+/// #1937: the generic `_` fallback arm (`eval_pipe_with_path_context_internal`)
+/// backs far more than argument-fan-out builtins -- it's also how a
+/// zero-arg generator (`recurse`, `range`, `..`) or an arbitrary comma
+/// branch gets evaluated whenever a sibling `key`/`parent`/`file_index`
+/// forces the whole pipe through path-context routing. An earlier fix
+/// attempt (round 1, take-first) silently discarded every `recurse` output
+/// but the first here with no error at all -- confirmed live during
+/// `/code-review` before merging. Array-collapse, while still the wrong
+/// shape relative to real jq's own fan-out, at least keeps every value
+/// visible; pinned here as a regression guard.
+#[test]
+fn test_path_context_generic_fallback_recurse_still_array_collapses_1937() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a | (recurse, key)"],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "[{\"b\":{\"c\":1}},{\"c\":1},1]\n\"a\"\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20142,6 +20142,29 @@ fn test_path_context_builtin_arm_non_swallowed_result_unaffected_1280() -> Resul
     Ok(())
 }
 
+/// #1937: `.a | ltrimstr(("xax","x")) | [length, key]` forces the fanned-out
+/// `ltrimstr(("xax","x"))` (two outputs: `""`, then `"ax"`, matching real
+/// jq's own generator-argument fan-out for the isolated `ltrimstr` call,
+/// confirmed against jq 1.7.1) through the `Expr::Builtin(_)` arm's
+/// `eval_owned_expr_opt` call, since the trailing `key` needs path tracking.
+/// Before this fix, that call array-collapsed the two outputs into
+/// `["", "ax"]` before continuing, so `length` measured the *array* (always
+/// 2, matching the fixed comma-branch count regardless of the actual string
+/// values) rather than the real first string's own length (0). `key` itself
+/// has no jq oracle (succinctly extension) and is content-independent, so
+/// it's included only to force path-context routing -- `length`'s value is
+/// what actually distinguishes take-first from array-collapse here.
+#[test]
+fn test_path_context_builtin_arm_multi_output_takes_first_not_array_collapse_1937() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", r#".a | ltrimstr(("xax","x")) | [length, key]"#],
+        Some(r#"{"a":"xax"}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "[0,\"a\"]\n");
+    Ok(())
+}
+
 /// #1280's `Expr::Object`/`Array`/`Literal` arm: an object-construction key
 /// generator that produces zero outputs (`{(empty): 1}`) means the whole
 /// construction contributes zero outputs, matching real jq


### PR DESCRIPTION
Fixes #1937.

## Summary

`eval_pipe_with_path_context_internal`'s 4 non-fan-out-aware call sites (`ParentN`'s `n`, the `Expr::Builtin(_)` arm, the `Expr::Object`/`Array`/`Literal` arm, and the generic `_` fallback) route through `eval_owned_expr_opt`/`eval_owned_expr_full`. When the evaluated expression itself produced 2+ outputs, these array-collapsed them into a single `OwnedValue::Array` — a second, different wrong answer, since the exact same sub-expression fans out correctly when no path-tracking builtin (`key`/`parent`/`file_index`) happens to be elsewhere in the pipe.

Full fan-out for these 4 sites is the "materially larger, too invasive" fix #1522's own design doc (`docs/plan/jq-generator-argument-fanout.md`) explicitly declined — per the issue's own suggested next step, this PR takes the smaller, scoped fix instead: switch the collapse policy to take-first, matching `result_to_owned_full`'s identical policy for the same `Many`/`ManyOwned`/`Partial` shapes (real jq's own generator-argument desugaring, `f(x)` ~= `x as $b | ...`, drives the rest of a computation off only `x`'s first output). Not a full fidelity fix — documented as a residual, known gap in `docs/compliance/jq/limitations.md` rather than left implicit.

An empty `Many`/`ManyOwned` now also matches `result_to_owned_full`'s "zero outputs" treatment (no output at all, not an empty-array value), for the same consistency reason.

## Changes

- `eval_owned_expr_full`'s `Many`/`ManyOwned`/`Partial` arms: take-first instead of collapse-to-array-when-len-is-not-1.
- New unit test `eval_owned_expr_full_takes_first_not_array_collapse_1937` pinning the `Many`(len>1)/`ManyOwned`(len>1)/empty-`Many` shapes directly.
- New CLI test `test_path_context_builtin_arm_multi_output_takes_first_not_array_collapse_1937`, a content-sensitive repro (`length` after the fanned-out value, since `key` alone is path-only and can't show the difference).
- Updated `eval_owned_expr_ctrl_full_many_shapes_and_multi_value_partial_1164`, which pinned the old collapse behavior for both its `Many` and multi-value `Partial` shapes, to assert take-first instead.
- New `docs/compliance/jq/limitations.md` entry recording the residual gap.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 3094 lib tests + all integration suites pass
- [x] `cargo test` (default features) — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (avoids the `scalar-yaml` blind spot)
- [x] `cargo build --no-default-features` — builds
- [x] `cargo fmt --check` — clean
- [x] Confirmed the new unit test fails against the pre-fix code (temporarily reverted, reran, reverted back) before trusting it as a real regression pin
- [x] Live-verified the underlying `ltrimstr(("x","z"))` fan-out (without `key`) against jq 1.7.1 to confirm it already matches real jq — this PR only touches the path-context-forced narrowing, not that fan-out itself