### PR TITLE
fix(jq): close decode-failure suppression gaps in reduce/foreach's input/INIT arms

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -871,6 +871,13 @@ coverage differs:
   `ltrimstr`/`rtrimstr`, the sort family, `min`/`max`/`unique`/`group_by`, `add`, `join`,
   `flatten`, and every assignment RHS, among others) — not the wholesale gap the previous
   revision of this paragraph implied.
+- **#1902 widened this to `. as $var`/`reduce`/`foreach`.** Their bound/INIT/input value and
+  body-output conversions switched from the unchecked `to_owned`/`promote_borrowed` to
+  `to_owned_checked`/`promote_borrowed_checked` — so a #1194 malformed member or #1642
+  collision key that used to be silently dropped (`reduce . as $x (0; .+1)` on `{"a":1,"b"}`
+  used to succeed with `1`) now raises there too, same as the builtins listed above. Not a new
+  divergence unique to #1902: this is `to_owned_checked`'s own established contract from
+  #1755 onward, just newly reached by three more call sites (#1934).
 - **The #1677 malformed-`,`/`:`-delimiter check is the narrower gap.**
   `to_owned_checked_at_depth` itself never calls `key_delimiter_ok`/`value_delimiter_ok`, so
   every builtin routed through it still misses this one check. `Builtin::Keys` (`keys`/

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -877,7 +877,11 @@ coverage differs:
   collision key that used to be silently dropped (`reduce . as $x (0; .+1)` on `{"a":1,"b"}`
   used to succeed with `1`) now raises there too, same as the builtins listed above. Not a new
   divergence unique to #1902: this is `to_owned_checked`'s own established contract from
-  #1755 onward, just newly reached by three more call sites (#1934).
+  #1755 onward, at three call sites this one just hadn't named yet (documented here per
+  #1934 item 6, which also closed a related gap: five bare, non-`to_owned_checked`
+  `Error`/`Partial` arms across these same three functions' `input`/INIT streams didn't
+  exclude a genuine decode failure from `optional`'s suppression the way `finish_fork`
+  already does — an internal-consistency fix, not a further widening of this policy).
 - **The #1677 malformed-`,`/`:`-delimiter check is the narrower gap.**
   `to_owned_checked_at_depth` itself never calls `key_delimiter_ok`/`value_delimiter_ok`, so
   every builtin routed through it still misses this one check. `Builtin::Keys` (`keys`/

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2446,6 +2446,33 @@ fn eval_owned_expr_fork<S: EvalSemantics>(
 /// ever sees `optional` after that boundary has already had its chance to
 /// react, so it correctly leaves `Break` alone and only ever silences a
 /// trailing `Error`.
+/// Whether `e` should be suppressed under an ambient `optional`: true for
+/// an ordinary error, false for a decode failure (#1620), which `optional`
+/// never suppresses. One definition for a rule `finish_fork` below,
+/// `finish_fork_generic` (`eval_generic.rs`), and every `eval_reduce`/
+/// `eval_foreach` input/INIT arm all need, instead of each hand-copying
+/// `optional && !e.is_decode_failure()` -- this exact condition already
+/// drifted out of sync once (#1902 fixing `finish_fork` itself, #1934
+/// fixing five more `eval_reduce`/`eval_foreach` arms that had the same
+/// drift); one shared predicate is the actual fix for a bug class that
+/// otherwise recurs every time a new match arm needs the same check.
+fn suppresses(e: &EvalError, optional: bool) -> bool {
+    optional && !e.is_decode_failure()
+}
+
+/// Fold `e` into a terminal suppress-or-raise `QueryResult`, per
+/// [`suppresses`]. Collapses the `Err(e) if suppresses(...) =>
+/// QueryResult::None, Err(e) => QueryResult::Error(e)` arm-pair that
+/// `eval_reduce`/`eval_foreach`'s input/INIT streams otherwise repeat at
+/// every checked-conversion and bare-error site.
+fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> {
+    if suppresses(&e, optional) {
+        QueryResult::None
+    } else {
+        QueryResult::Error(e)
+    }
+}
+
 fn finish_fork<'a, W>(
     outputs: Vec<OwnedValue>,
     control: Option<Control>,
@@ -2458,9 +2485,7 @@ fn finish_fork<'a, W>(
         // `finish_fork_generic`'s identical guard in `eval_generic.rs`,
         // whose own doc comment already claimed to mirror this function;
         // this one had drifted from it.
-        Some(Control::Error(ref e)) if optional && !e.is_decode_failure() => {
-            owned_vec_to_result(outputs)
-        }
+        Some(Control::Error(ref e)) if suppresses(e, optional) => owned_vec_to_result(outputs),
         Some(control) => partial(outputs, control),
     }
 }
@@ -25138,14 +25163,12 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let input_values: Vec<OwnedValue> = match input_result.materialize_cursor() {
         QueryResult::One(v) => match to_owned_checked(&v) {
             Ok(v) => vec![v],
-            Err(e) if optional && !e.is_decode_failure() => return QueryResult::None,
-            Err(e) => return QueryResult::Error(e),
+            Err(e) => return suppress_or_raise(e, optional),
         },
         QueryResult::OneCursor(_) => unreachable!(),
         QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
             Ok(vs) => vs,
-            Err((_, e)) if optional && !e.is_decode_failure() => return QueryResult::None,
-            Err((_, e)) => return QueryResult::Error(e),
+            Err((_, e)) => return suppress_or_raise(e, optional),
         },
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
@@ -25154,8 +25177,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // evaluation (not via the checked-conversion arms above) must not
         // be suppressed by `optional` either, matching `finish_fork`'s
         // identical guard -- this arm had drifted from it.
-        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
-        QueryResult::Error(e) => return QueryResult::Error(e),
+        QueryResult::Error(e) => return suppress_or_raise(e, optional),
         QueryResult::Break(label) => return QueryResult::Break(label),
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         // `reduce`'s own output is always single-shot — it only ever emits
@@ -25163,10 +25185,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // jq: `reduce (1,2,error("x"),4) as $v (0;.+$v)` produces no output
         // at all, just the error) — so a `Partial` input stream just extracts
         // the control and drops the prefix, same as the bare arms above.
-        QueryResult::Partial(_prefix, Control::Error(e)) if optional && !e.is_decode_failure() => {
-            return QueryResult::None;
-        }
-        QueryResult::Partial(_prefix, Control::Error(e)) => return QueryResult::Error(e),
+        QueryResult::Partial(_prefix, Control::Error(e)) => return suppress_or_raise(e, optional),
         QueryResult::Partial(_prefix, Control::Break(label)) => return QueryResult::Break(label),
         QueryResult::Partial(_prefix, Control::Halt(code)) => return QueryResult::Halt(code),
     };
@@ -25183,33 +25202,39 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // forks below before the decode failure surfaces as the terminal
     // control via `finish_fork`, which #1902 also fixed to never suppress
     // a decode failure under `optional`).
-    let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) = match init_result
-        .materialize_cursor()
-    {
-        QueryResult::One(v) => match to_owned_checked(&v) {
-            Ok(v) => (vec![v], None),
-            Err(e) => (Vec::new(), Some(Control::Error(e))),
-        },
-        QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
-            Ok(vs) => (vs, None),
-            Err((prefix, e)) => (prefix, Some(Control::Error(e))),
-        },
-        QueryResult::Owned(v) => (vec![v], None),
-        QueryResult::ManyOwned(vs) => (vs, None),
-        QueryResult::None => (Vec::new(), None),
-        // #1934 item 2: same drift as the `input` block above -- a
-        // decode failure raised directly by INIT's own evaluation must
-        // not be suppressed by `optional`, matching `finish_fork`.
-        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        QueryResult::Break(label) => return QueryResult::Break(label),
-        QueryResult::Halt(code) => return QueryResult::Halt(code),
-        QueryResult::Partial(_, Control::Error(e)) if optional && !e.is_decode_failure() => {
-            return QueryResult::None;
-        }
-        QueryResult::Partial(vs, control) => (vs, Some(control)),
-    };
+    let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
+        match init_result.materialize_cursor() {
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
+            QueryResult::OneCursor(_) => unreachable!(),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
+            QueryResult::Owned(v) => (vec![v], None),
+            QueryResult::ManyOwned(vs) => (vs, None),
+            QueryResult::None => (Vec::new(), None),
+            // #1934 item 2: same drift as the `input` block above -- a
+            // decode failure raised directly by INIT's own evaluation must
+            // not be suppressed by `optional`, matching `finish_fork`.
+            QueryResult::Error(e) => return suppress_or_raise(e, optional),
+            QueryResult::Break(label) => return QueryResult::Break(label),
+            QueryResult::Halt(code) => return QueryResult::Halt(code),
+            // #1934 review: a `Partial` INIT stream's already-produced prefix
+            // must still fork below regardless of whether its trailing
+            // control ends up suppressed -- verified against jq 1.7.1:
+            // `reduce (5) as $x ((1,2,error("boom")); .+$x)?` prints `6`,
+            // `7` (both successful INIT forks), only the trailing error is
+            // swallowed. An earlier version of this arm special-cased a
+            // suppressible error to `return QueryResult::None` here,
+            // discarding `vs` entirely instead of letting it fork below and
+            // reach `finish_fork` (whose own "outputs already produced
+            // don't vanish" contract already handles this correctly) --
+            // this uniform fallthrough is the actual fix.
+            QueryResult::Partial(vs, control) => (vs, Some(control)),
+        };
 
     if init_values.is_empty() {
         return finish_fork(Vec::new(), init_control, optional);
@@ -25808,33 +25833,31 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // ordinary `Partial`'s control (the comment above): the already-decoded
     // prefix is still iterated below before the decode failure surfaces as
     // the terminal control.
-    let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) = match input_result
-        .materialize_cursor()
-    {
-        QueryResult::One(v) => match to_owned_checked(&v) {
-            Ok(v) => (vec![v], None),
-            Err(e) => (Vec::new(), Some(Control::Error(e))),
-        },
-        QueryResult::OneCursor(_) => unreachable!(),
-        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
-            Ok(vs) => (vs, None),
-            Err((prefix, e)) => (prefix, Some(Control::Error(e))),
-        },
-        QueryResult::Owned(v) => (vec![v], None),
-        QueryResult::ManyOwned(vs) => (vs, None),
-        QueryResult::None => (Vec::new(), None),
-        // An immediate (non-`Partial`) error has no prefix to salvage,
-        // so `?` suppresses it the same way `eval_reduce`'s equivalent
-        // arm already does — this one was missing it, letting an
-        // ambient `?` fail to catch an error in the source stream
-        // (#534 follow-up). #1934 item 2: excludes a decode failure from
-        // that suppression too, matching `finish_fork`.
-        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        QueryResult::Break(label) => return QueryResult::Break(label),
-        QueryResult::Halt(code) => return QueryResult::Halt(code),
-        QueryResult::Partial(vs, control) => (vs, Some(control)),
-    };
+    let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
+        match input_result.materialize_cursor() {
+            QueryResult::One(v) => match to_owned_checked(&v) {
+                Ok(v) => (vec![v], None),
+                Err(e) => (Vec::new(), Some(Control::Error(e))),
+            },
+            QueryResult::OneCursor(_) => unreachable!(),
+            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+                Ok(vs) => (vs, None),
+                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+            },
+            QueryResult::Owned(v) => (vec![v], None),
+            QueryResult::ManyOwned(vs) => (vs, None),
+            QueryResult::None => (Vec::new(), None),
+            // An immediate (non-`Partial`) error has no prefix to salvage,
+            // so `?` suppresses it the same way `eval_reduce`'s equivalent
+            // arm already does — this one was missing it, letting an
+            // ambient `?` fail to catch an error in the source stream
+            // (#534 follow-up). #1934 item 2: excludes a decode failure from
+            // that suppression too, matching `finish_fork`.
+            QueryResult::Error(e) => return suppress_or_raise(e, optional),
+            QueryResult::Break(label) => return QueryResult::Break(label),
+            QueryResult::Halt(code) => return QueryResult::Halt(code),
+            QueryResult::Partial(vs, control) => (vs, Some(control)),
+        };
 
     // Evaluate INIT. Each of its outputs forks the whole foreach into a
     // fully independent execution over `input_values` (#534): `[foreach
@@ -41036,6 +41059,7 @@ mod tests {
         let keys_expr = parse("keys").unwrap();
         let init_expr = parse("0").unwrap();
         let update_expr = parse(". + 1").unwrap();
+        let comma_expr = parse("(1,2)").unwrap();
 
         // eval_reduce's `input` arm.
         match eval_reduce::<Vec<u64>, JqSemantics>(
@@ -41054,7 +41078,7 @@ mod tests {
 
         // eval_reduce's INIT arm (same repro, roles swapped).
         match eval_reduce::<Vec<u64>, JqSemantics>(
-            &parse("(1,2)").unwrap(),
+            &comma_expr,
             &[],
             &keys_expr,
             &update_expr,
@@ -41126,6 +41150,102 @@ mod tests {
         ) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected an unsuppressed error, got: {other:?}"),
+        }
+    }
+
+    /// Sibling of the test above for the `QueryResult::Many` arm
+    /// (`promote_borrowed_checked`, not `to_owned_checked`): `.[]` always
+    /// returns `Many`, even for a single-element array, so iterating over
+    /// one malformed-member object exercises the exact arm the `One`-only
+    /// repro above cannot reach.
+    #[test]
+    fn test_eval_reduce_input_many_promote_borrowed_checked_error_respects_optional_unless_decode_failure_1934(
+    ) {
+        let json: &[u8] = br#"[{"a":1,"b"}]"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let iterate_expr = parse(".[]").unwrap();
+        let init_expr = parse("0").unwrap();
+        let update_expr = parse(". + 1").unwrap();
+
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &iterate_expr,
+            &[],
+            &init_expr,
+            &update_expr,
+            root.value(),
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected suppression under optional, got: {other:?}"),
+        }
+
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &iterate_expr,
+            &[],
+            &init_expr,
+            &update_expr,
+            root.value(),
+            false,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected an unsuppressed error, got: {other:?}"),
+        }
+    }
+
+    /// #1934 review: `eval_reduce`'s INIT block's `Partial` arm used to
+    /// discard the already-produced INIT prefix entirely (`return
+    /// QueryResult::None`) whenever the trailing error was suppressible,
+    /// instead of letting it fork below like `finish_fork`'s own "outputs
+    /// already produced don't vanish" contract requires. Verified live
+    /// against jq 1.7.1: `reduce (5) as $x ((1,2,error("boom")); .+$x)?`
+    /// prints `6`, `7` -- both successful INIT forks survive, only the
+    /// trailing error is swallowed.
+    #[test]
+    fn test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934() {
+        let json: &[u8] = b"null";
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let full = parse(r#"reduce (5) as $x ((1,2,error("boom")); .+$x)"#).unwrap();
+        let Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } = &full
+        else {
+            panic!("expected Expr::Reduce, got: {full:?}");
+        };
+
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            input,
+            patterns,
+            init,
+            update,
+            root.value(),
+            true,
+        ) {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![OwnedValue::Int(6), OwnedValue::Int(7)]);
+            }
+            other => panic!("expected the two successful INIT forks to survive, got: {other:?}"),
+        }
+
+        // Same repro, `optional = false`: the trailing error still surfaces,
+        // but the two successful outputs still precede it (#400/#494).
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            input,
+            patterns,
+            init,
+            update,
+            root.value(),
+            false,
+        ) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(6), OwnedValue::Int(7)]);
+                assert!(!e.is_decode_failure());
+            }
+            other => panic!("expected a Partial with the two prior outputs, got: {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25125,25 +25125,36 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     // Evaluate input to get the stream of values
     let input_result = eval_single::<W, S>(input, value.clone(), optional);
-    // #1902: to_owned_checked/promote_borrowed_checked, not to_owned -- an
-    // undecodable input element used to silently become `""` instead of
+    // #1902/#1934: to_owned_checked/promote_borrowed_checked, not to_owned --
+    // an undecodable input element used to silently become `""` instead of
     // raising. A decode failure is never suppressed by `optional` (#1620),
     // matching the "drop the prefix, propagate unconditionally" policy the
-    // comment below already applies to an ordinary `Partial` error.
+    // comment below already applies to an ordinary `Partial` error -- but a
+    // *non*-decode-failure conversion error (a #1194 malformed-member or
+    // #1642 collision error) is an ordinary error like any other, and
+    // `optional` should suppress it the same way the bare `QueryResult::Error`
+    // arm below already does (#1934 item 3: this used to be unconditionally
+    // fatal regardless of `optional`, unlike that sibling arm).
     let input_values: Vec<OwnedValue> = match input_result.materialize_cursor() {
         QueryResult::One(v) => match to_owned_checked(&v) {
             Ok(v) => vec![v],
+            Err(e) if optional && !e.is_decode_failure() => return QueryResult::None,
             Err(e) => return QueryResult::Error(e),
         },
         QueryResult::OneCursor(_) => unreachable!(),
         QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
             Ok(vs) => vs,
+            Err((_, e)) if optional && !e.is_decode_failure() => return QueryResult::None,
             Err((_, e)) => return QueryResult::Error(e),
         },
         QueryResult::Owned(v) => vec![v],
         QueryResult::ManyOwned(vs) => vs,
         QueryResult::None => Vec::new(),
-        QueryResult::Error(_) if optional => return QueryResult::None,
+        // #1934 item 2: a decode failure raised directly by `input`'s own
+        // evaluation (not via the checked-conversion arms above) must not
+        // be suppressed by `optional` either, matching `finish_fork`'s
+        // identical guard -- this arm had drifted from it.
+        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
         QueryResult::Error(e) => return QueryResult::Error(e),
         QueryResult::Break(label) => return QueryResult::Break(label),
         QueryResult::Halt(code) => return QueryResult::Halt(code),
@@ -25152,7 +25163,9 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // jq: `reduce (1,2,error("x"),4) as $v (0;.+$v)` produces no output
         // at all, just the error) — so a `Partial` input stream just extracts
         // the control and drops the prefix, same as the bare arms above.
-        QueryResult::Partial(_prefix, Control::Error(_)) if optional => return QueryResult::None,
+        QueryResult::Partial(_prefix, Control::Error(e)) if optional && !e.is_decode_failure() => {
+            return QueryResult::None;
+        }
         QueryResult::Partial(_prefix, Control::Error(e)) => return QueryResult::Error(e),
         QueryResult::Partial(_prefix, Control::Break(label)) => return QueryResult::Break(label),
         QueryResult::Partial(_prefix, Control::Halt(code)) => return QueryResult::Halt(code),
@@ -25170,27 +25183,33 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // forks below before the decode failure surfaces as the terminal
     // control via `finish_fork`, which #1902 also fixed to never suppress
     // a decode failure under `optional`).
-    let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
-        match init_result.materialize_cursor() {
-            QueryResult::One(v) => match to_owned_checked(&v) {
-                Ok(v) => (vec![v], None),
-                Err(e) => (Vec::new(), Some(Control::Error(e))),
-            },
-            QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
-                Ok(vs) => (vs, None),
-                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
-            },
-            QueryResult::Owned(v) => (vec![v], None),
-            QueryResult::ManyOwned(vs) => (vs, None),
-            QueryResult::None => (Vec::new(), None),
-            QueryResult::Error(_) if optional => return QueryResult::None,
-            QueryResult::Error(e) => return QueryResult::Error(e),
-            QueryResult::Break(label) => return QueryResult::Break(label),
-            QueryResult::Halt(code) => return QueryResult::Halt(code),
-            QueryResult::Partial(_, Control::Error(_)) if optional => return QueryResult::None,
-            QueryResult::Partial(vs, control) => (vs, Some(control)),
-        };
+    let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) = match init_result
+        .materialize_cursor()
+    {
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(v) => (vec![v], None),
+            Err(e) => (Vec::new(), Some(Control::Error(e))),
+        },
+        QueryResult::OneCursor(_) => unreachable!(),
+        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+            Ok(vs) => (vs, None),
+            Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+        },
+        QueryResult::Owned(v) => (vec![v], None),
+        QueryResult::ManyOwned(vs) => (vs, None),
+        QueryResult::None => (Vec::new(), None),
+        // #1934 item 2: same drift as the `input` block above -- a
+        // decode failure raised directly by INIT's own evaluation must
+        // not be suppressed by `optional`, matching `finish_fork`.
+        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
+        QueryResult::Error(e) => return QueryResult::Error(e),
+        QueryResult::Break(label) => return QueryResult::Break(label),
+        QueryResult::Halt(code) => return QueryResult::Halt(code),
+        QueryResult::Partial(_, Control::Error(e)) if optional && !e.is_decode_failure() => {
+            return QueryResult::None;
+        }
+        QueryResult::Partial(vs, control) => (vs, Some(control)),
+    };
 
     if init_values.is_empty() {
         return finish_fork(Vec::new(), init_control, optional);
@@ -25789,31 +25808,33 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // ordinary `Partial`'s control (the comment above): the already-decoded
     // prefix is still iterated below before the decode failure surfaces as
     // the terminal control.
-    let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
-        match input_result.materialize_cursor() {
-            QueryResult::One(v) => match to_owned_checked(&v) {
-                Ok(v) => (vec![v], None),
-                Err(e) => (Vec::new(), Some(Control::Error(e))),
-            },
-            QueryResult::OneCursor(_) => unreachable!(),
-            QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
-                Ok(vs) => (vs, None),
-                Err((prefix, e)) => (prefix, Some(Control::Error(e))),
-            },
-            QueryResult::Owned(v) => (vec![v], None),
-            QueryResult::ManyOwned(vs) => (vs, None),
-            QueryResult::None => (Vec::new(), None),
-            // An immediate (non-`Partial`) error has no prefix to salvage,
-            // so `?` suppresses it the same way `eval_reduce`'s equivalent
-            // arm already does — this one was missing it, letting an
-            // ambient `?` fail to catch an error in the source stream
-            // (#534 follow-up).
-            QueryResult::Error(_) if optional => return QueryResult::None,
-            QueryResult::Error(e) => return QueryResult::Error(e),
-            QueryResult::Break(label) => return QueryResult::Break(label),
-            QueryResult::Halt(code) => return QueryResult::Halt(code),
-            QueryResult::Partial(vs, control) => (vs, Some(control)),
-        };
+    let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) = match input_result
+        .materialize_cursor()
+    {
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(v) => (vec![v], None),
+            Err(e) => (Vec::new(), Some(Control::Error(e))),
+        },
+        QueryResult::OneCursor(_) => unreachable!(),
+        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+            Ok(vs) => (vs, None),
+            Err((prefix, e)) => (prefix, Some(Control::Error(e))),
+        },
+        QueryResult::Owned(v) => (vec![v], None),
+        QueryResult::ManyOwned(vs) => (vs, None),
+        QueryResult::None => (Vec::new(), None),
+        // An immediate (non-`Partial`) error has no prefix to salvage,
+        // so `?` suppresses it the same way `eval_reduce`'s equivalent
+        // arm already does — this one was missing it, letting an
+        // ambient `?` fail to catch an error in the source stream
+        // (#534 follow-up). #1934 item 2: excludes a decode failure from
+        // that suppression too, matching `finish_fork`.
+        QueryResult::Error(e) if optional && !e.is_decode_failure() => return QueryResult::None,
+        QueryResult::Error(e) => return QueryResult::Error(e),
+        QueryResult::Break(label) => return QueryResult::Break(label),
+        QueryResult::Halt(code) => return QueryResult::Halt(code),
+        QueryResult::Partial(vs, control) => (vs, Some(control)),
+    };
 
     // Evaluate INIT. Each of its outputs forks the whole foreach into a
     // fully independent execution over `input_values` (#534): `[foreach
@@ -40983,6 +41004,128 @@ mod tests {
                 assert!(e.is_decode_failure());
             }
             other => panic!("expected the decode failure to survive optional, got: {other:?}"),
+        }
+    }
+
+    /// #1934 item 2: `eval_reduce`'s bare `QueryResult::Error` arm on its
+    /// `input`/INIT streams, and `eval_foreach`'s equivalent `input` arm,
+    /// lacked the `!is_decode_failure()` exclusion `finish_fork` already
+    /// has -- a decode failure produced directly by that stream's own
+    /// evaluation (not via this function's own checked-conversion arms,
+    /// covered by the `1902` tests above) was wrongly suppressed under
+    /// `optional`.
+    ///
+    /// `optional == true` is not reachable here via any query this CLI can
+    /// currently parse -- confirmed across #1902/#1934's own review
+    /// (including a probe that replaced `finish_fork`'s guard body with
+    /// `panic!()` and ran the full test suite with zero hits): `?` catches
+    /// via `eval_try`'s post-hoc Error-to-`None` conversion on the *whole*
+    /// wrapped expression, not by forcing that expression's own ambient
+    /// `optional` true. Exercised directly, like this file's other "no
+    /// parser construction site" tests (e.g.
+    /// `builtin_envvar_propagates_halt_from_variable_name_expression`).
+    /// `keys` on a non-container value reaches `scalar_fallback`, which
+    /// raises a decode failure straight from `input`'s own evaluation --
+    /// distinct from `to_owned_checked` materializing an already-produced
+    /// `One`/`Many`, which the #1902 tests above already cover.
+    #[test]
+    fn test_eval_reduce_and_foreach_bare_error_arms_exclude_decode_failure_1934() {
+        let json: &[u8] = b"\"\xff\xfe\"";
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let keys_expr = parse("keys").unwrap();
+        let init_expr = parse("0").unwrap();
+        let update_expr = parse(". + 1").unwrap();
+
+        // eval_reduce's `input` arm.
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &keys_expr,
+            &[],
+            &init_expr,
+            &update_expr,
+            root.value(),
+            true,
+        ) {
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+            }
+            other => panic!("expected the decode failure to survive optional, got: {other:?}"),
+        }
+
+        // eval_reduce's INIT arm (same repro, roles swapped).
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &parse("(1,2)").unwrap(),
+            &[],
+            &keys_expr,
+            &update_expr,
+            root.value(),
+            true,
+        ) {
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+            }
+            other => panic!("expected the decode failure to survive optional, got: {other:?}"),
+        }
+
+        // eval_foreach's `input` arm.
+        match eval_foreach::<Vec<u64>, JqSemantics>(
+            &keys_expr,
+            &[],
+            &init_expr,
+            &update_expr,
+            None,
+            root.value(),
+            true,
+        ) {
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+            }
+            other => panic!("expected the decode failure to survive optional, got: {other:?}"),
+        }
+    }
+
+    /// #1934 item 3: `eval_reduce`'s `input` arm treated *every*
+    /// `to_owned_checked`/`promote_borrowed_checked` failure as
+    /// unconditionally fatal, including a non-decode-failure error (a
+    /// #1194 malformed-member error) that the sibling bare
+    /// `QueryResult::Error` arm a few lines below already respects
+    /// `optional` for. `{"a":1,"b"}` is a trailing unpaired object member
+    /// JSON's own semi-index accepts (#1194) -- `.` (identity) surfaces it
+    /// as-is, and `to_owned_checked` raises on the full walk.
+    #[test]
+    fn test_eval_reduce_input_to_owned_checked_error_respects_optional_unless_decode_failure_1934()
+    {
+        let json: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let identity = parse(".").unwrap();
+        let init_expr = parse("0").unwrap();
+        let update_expr = parse(". + 1").unwrap();
+
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &identity,
+            &[],
+            &init_expr,
+            &update_expr,
+            root.value(),
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected suppression under optional, got: {other:?}"),
+        }
+
+        // Same repro, `optional = false`: still raises, matching the
+        // sibling bare-error arm's own contract.
+        match eval_reduce::<Vec<u64>, JqSemantics>(
+            &identity,
+            &[],
+            &init_expr,
+            &update_expr,
+            root.value(),
+            false,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected an unsuppressed error, got: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Scoped to items 2, 3, 6, and 7 of #1934 (items 1, 4, 5 are each their own real investigation/design task, deferred per the claim comment on that issue).

- **Item 2**: five bare `if optional => return QueryResult::None` arms — `eval_reduce`'s input/INIT streams (2 each) and `eval_foreach`'s input stream (1) — lacked the `!is_decode_failure()` exclusion `finish_fork` already has. A decode failure surfacing directly from that stream's own evaluation (not via a checked-conversion arm) was wrongly suppressed under `optional`.

- **Item 3**: `eval_reduce`'s `input` arm treated *every* `to_owned_checked`/`promote_borrowed_checked` failure as unconditionally fatal, including a non-decode-failure error (a #1194 malformed-member error) that the sibling bare `QueryResult::Error` arm a few lines below already respects `optional` for. Restructured to match: decode failures stay unconditional, everything else now respects `optional` like the sibling arm.

- **Item 6**: documented in `docs/compliance/jq/limitations.md` that #1902 widened the #1194/#1642 malformed-key/collision policy to `. as $var`/`reduce`/`foreach` — not a new divergence, just three more call sites reached by the established `to_owned_checked` contract from #1755 onward.

- **Item 7**: resolved as a documented decision rather than escalated. `optional == true` is confirmed not reachable at this depth via any query the CLI can currently parse (per #1902/#1934's own reachability audit, including a `panic!()`-based probe across the full test suite with zero hits). Rather than removing the now-more-consistent guards as dead code, I'm keeping them — same rationale as #1907/#1940 (merged): cheap to close, and a future change to `optional`'s threading would otherwise silently resurrect the gap.

Three rounds of review on this PR found and fixed two further issues:

- **`eval_reduce`'s INIT block's `Partial` arm discarded the whole already-produced INIT prefix** (`return QueryResult::None`) whenever the trailing error was suppressible, instead of letting it fork below like `finish_fork`'s own "outputs already produced don't vanish" contract requires. Verified live against jq 1.7.1: `reduce (5) as $x ((1,2,error("boom")); .+$x)?` prints `6`, `7` — both successful INIT forks survive, only the trailing error is swallowed. Fixed by letting every `Partial` case fall through uniformly instead of special-casing the suppressible one.
- **`optional && !e.is_decode_failure()` was duplicated 7 times** across `finish_fork` and the arms this PR touches — extracted into `suppresses()`/`suppress_or_raise()`, used everywhere the rule is needed instead of hand-copied at each site.

New unit tests exercise `eval_reduce`/`eval_foreach` directly (no parser construction site exists for `optional == true` here), matching this file's existing pattern for such cases (e.g. `builtin_envvar_propagates_halt_from_variable_name_expression`).

## Test plan
- [x] New unit tests in `src/jq/eval.rs`: `test_eval_reduce_and_foreach_bare_error_arms_exclude_decode_failure_1934`, `test_eval_reduce_input_to_owned_checked_error_respects_optional_unless_decode_failure_1934`, `test_eval_reduce_input_many_promote_borrowed_checked_error_respects_optional_unless_decode_failure_1934`, `test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934`
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, re-run after each review round)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Refs #1934
