### PR TITLE
fix(jq): prepend raises on a catch handler's decode failure instead of substituting ""

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14444,8 +14444,10 @@ fn push_promoted<'a, W: Clone + AsRef<[u64]>>(
 /// `Owned`/`ManyOwned` sibling in `eval_pipe`'s `Many`-branch loop (or
 /// `eval_comma`'s identical shape, #1790) forces the whole batch out of
 /// its lazy borrowed state for the first time (see [`push_promoted`]'s
-/// identical #1755 reasoning). Returns whatever converted successfully so
-/// far as the `Err` payload's own prefix.
+/// identical #1755 reasoning). Also used directly by [`prepend`]'s own
+/// `Many` arm (#1908), whose catch-handler result has no `Owned`/`ManyOwned`
+/// sibling to wait for. Returns whatever converted successfully so far as
+/// the `Err` payload's own prefix.
 fn promote_borrowed_checked<W: Clone + AsRef<[u64]>>(
     borrowed: Vec<StandardJson<'_, W>>,
 ) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalError)> {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2480,18 +2480,33 @@ fn prepend<W: Clone + AsRef<[u64]>>(
     match result.materialize_cursor() {
         QueryResult::None => owned_vec_to_result(prefix),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
-        QueryResult::One(v) => {
-            prefix.push(to_owned(&v));
-            owned_vec_to_result(prefix)
-        }
+        // #1908 (Category 2 of #1820's audit): `to_owned_checked`, not
+        // `to_owned` -- the catch handler's own result can hold an
+        // undecodable string (e.g. `try (.a, (.b | error({x: .}))) catch
+        // .x` on a `.b` whose bytes don't decode), and this splice must
+        // raise `EvalError::decode_failure` instead of silently
+        // substituting `""`, matching #1755's established rule.
+        QueryResult::One(v) => match to_owned_checked(&v) {
+            Ok(owned) => {
+                prefix.push(owned);
+                owned_vec_to_result(prefix)
+            }
+            Err(e) => partial(prefix, Control::Error(e)),
+        },
         QueryResult::Owned(v) => {
             prefix.push(v);
             owned_vec_to_result(prefix)
         }
-        QueryResult::Many(vs) => {
-            prefix.extend(vs.iter().map(to_owned));
-            owned_vec_to_result(prefix)
-        }
+        QueryResult::Many(vs) => match promote_borrowed_checked(vs) {
+            Ok(owned) => {
+                prefix.extend(owned);
+                owned_vec_to_result(prefix)
+            }
+            Err((partial_owned, e)) => {
+                prefix.extend(partial_owned);
+                partial(prefix, Control::Error(e))
+            }
+        },
         QueryResult::ManyOwned(vs) => {
             prefix.extend(vs);
             owned_vec_to_result(prefix)
@@ -44536,6 +44551,69 @@ mod tests {
                 assert_eq!(label, "out");
             }
         );
+    }
+
+    /// #1908 (#1820 Category 2): `prepend` -- the function backing
+    /// `try`/`catch`'s output-prefix splicing -- used unchecked `to_owned`
+    /// on the catch handler's own result, silently substituting `""` for an
+    /// undecodable string instead of raising `EvalError::decode_failure`.
+    ///
+    /// Exercised directly against `prepend` rather than through a full
+    /// `try`/`catch` query: every path that could hand `prepend` an
+    /// undecodable *borrowed* cursor turns out to be intercepted upstream
+    /// today (`error(msg)`'s own payload materialization already raises a
+    /// decode failure unconditionally per #1907's fix, before `prepend` is
+    /// ever reached; `break`'s catch input is hardcoded `Null`; a variable
+    /// bound before `try` resolves through a separate, already-owned path
+    /// that never reaches `prepend`'s cursor arms at all). Matching #1897's
+    /// own `eval_index_expr` precedent for this same situation, this
+    /// white-box test still pins the fix directly against the function
+    /// (and was confirmed to fail without it, by temporarily reverting the
+    /// fix and re-running).
+    #[test]
+    fn prepend_raises_on_handler_decode_failure_1908() {
+        let json: &[u8] = b"{\"a\": \"\xff\xfe\", \"b\": \"ok\"}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+
+        // `One` arm.
+        let expr = parse(".a").unwrap();
+        let result = eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false);
+        match prepend(vec![OwnedValue::Int(1)], result) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.is_decode_failure());
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // `Many` arm: a decodable value ahead of the undecodable one.
+        let expr = parse(".b, .a").unwrap();
+        let result = eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false);
+        match prepend(vec![OwnedValue::Int(1)], result) {
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(
+                    vs,
+                    vec![OwnedValue::Int(1), OwnedValue::String("ok".to_string())]
+                );
+                assert!(e.is_decode_failure());
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+
+        // Positive control: a fully decodable handler result still splices
+        // normally.
+        let expr = parse(".b").unwrap();
+        let result = eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false);
+        match prepend(vec![OwnedValue::Int(1)], result) {
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(
+                    vs,
+                    vec![OwnedValue::Int(1), OwnedValue::String("ok".to_string())]
+                );
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `prepend` — the function backing `try`/`catch`'s output-prefix splicing — used unchecked `to_owned` on the catch handler's own materialized result, silently substituting `""` for an undecodable string instead of raising `EvalError::decode_failure`. Category 2 of #1820's audit (#1908) named this as its own concrete starting point.
- Fixed with the established `to_owned_checked`/`promote_borrowed_checked` pair, same pattern as every other #1755-lineage fix.
- Exercised directly against `prepend` rather than through a full `try`/`catch` query: every route that could hand it an undecodable *borrowed* cursor turns out to be intercepted upstream today (`error(msg)`'s own payload materialization already raises unconditionally per #1907's fix; `break`'s catch input is hardcoded `Null`; a variable bound before `try` resolves through an already-owned path that never reaches `prepend`'s cursor arms). Confirmed the new white-box test fails without the fix (temporarily reverted, reran, restored) before trusting it.
- Also investigated a CLI-visible oddity found along the way — `.b | error({x: .})` on undecodable `.b` prints a mangled payload rather than raising — but confirmed live against `/usr/bin/jq` that real jq produces the byte-identical mangled output for the same query, so this is jq's own lossy behavior here, not a divergence to fix.
- #1908's remaining ~46 `to_owned(&...)` sites are still untriaged; left open for further incremental work rather than attempting the full sweep in one PR (not closing #1908 with this PR).

## Test plan
- [x] New white-box unit test exercising `prepend` directly (`One`/`Many` arms + positive control), confirmed to fail without the fix and pass with it.
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, before and after rebase onto latest main)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Part of #1908 (not closing it — the rest of the ~47-site sweep remains open).