### PR TITLE
fix(jq): reject input/inputs/input_line_number unconditionally in yq mode

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -392,7 +392,7 @@ otherwise-verified fix (which is strictly more correct than what it replaced: it
 real regression at `-I=4` introduced mid-fix and two cases pre-#1485 `main` never got right
 at all, `-I=5`/`-I=6`).
 
-### `input`, `inputs`, `input_line_number` — parse-time gated behind `--jq-extensions`, still not functional
+### `input`, `inputs`, `input_line_number` — resolved, rejected unconditionally like real yq
 
 Real yq has no such builtins at any arity — its lexer rejects the identifiers exactly as it
 rejects a name that does not exist
@@ -404,39 +404,43 @@ $ printf 'a: 1\n' | yq 'inputs'      # Error: 1:1: lexer: invalid input text "in
 $ printf 'a: 1\n' | yq 'no_such_fn'  # Error: 1:1: lexer: invalid input text "no_such_fn"
 ```
 
-**By default, succinctly now matches this unconditionally** — #1507 gated all three behind
-`--jq-extensions` in the parser, the same treatment as the ~65 other jq-only builtins already
-gated that way, closing the one divergence this section used to record (a call site that was
-never reached, e.g. `if false then input else . end`, used to be silently accepted rather
-than rejected — pinned by `test_yq_unreached_input_builtin_now_rejected_1507`,
-[tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)):
+succinctly now matches this unconditionally, in the parser (`reject_in_yq_mode`,
+[src/jq/parser.rs](../../../src/jq/parser.rs)) rather than at dispatch
+(`input_builtins_unsupported_in_yq_mode`, [src/jq/eval.rs](../../../src/jq/eval.rs), added by
+#723):
 
 ```bash
 $ printf 'a: 1\n' | succinctly yq 'input'
-Error: parse error: parse error at position 0: "input" is not part of yq's syntax; pass --jq-extensions to enable succinctly's jq-compatible builtin surface
+Error: parse error: parse error at position 0: input is not supported in yq mode
 ```
 
-**Unlike every other name in that gated class, passing `--jq-extensions` does not make these
-three work.** They still error, now from `input_builtins_unsupported_in_yq_mode`
-([src/jq/eval.rs](../../../src/jq/eval.rs)) at dispatch:
+This closes the one divergence this section used to record: dispatch only fires for a call
+site that's actually *reached*, so `if false then input else . end` used to be silently
+accepted instead of rejected — pinned by
+`test_yq_unreached_input_builtin_now_rejected_1507`
+([tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)).
 
-```bash
-$ printf 'a: 1\n' | succinctly yq --jq-extensions 'input'
-Error: input is not supported in yq mode
-```
-
-This isn't a divergence to fix — there's no oracle to match, since real yq has no
-`--jq-extensions` equivalent to compare against at all. It's a deliberate two-layer gate: the
-parser change only lifts the *syntax* restriction; the *architectural* one underneath is real
-and unaddressed. yq mode's document loop is cursor-native (`YamlValue::Sequence(docs)` walked
-by `uncons_cursor`, [src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs))
+**Deliberately *not* routed through the `--jq-extensions` gate** the ~65 other jq-only
+builtins use, even though real yq lacks all of them the same way. That flag's contract
+elsewhere is "pass this and the builtin becomes usable" — but no flag value makes these three
+usable, since yq mode's document loop is cursor-native (`YamlValue::Sequence(docs)` walked by
+`uncons_cursor`, [src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs))
 precisely so duplicate mapping keys (#1398) and ADR-0017's comment/anchor side-trees survive;
 jq's queue is `Vec<(OwnedValue, u32, u32)>`. Reusing jq's queue would push YAML documents
 through `OwnedValue` and silently lose all three, so real support needs a second,
-cursor-native queue — tracked as its own follow-up, not attempted here. Deleting the dispatch
-check instead would reopen the exact bug it was added to fix (#723), just reachable via
-`--jq-extensions` instead of unconditionally: `input` reporting a spurious "break" on every
-document, `inputs` silently producing no output at all.
+cursor-native queue — tracked as its own follow-up, not attempted here (#1507's own "Option
+A"). An earlier version of this fix *did* route them through `--jq-extensions`, and that
+reopened the exact divergence above one layer down: the flag let the keyword parse, so the
+dispatch-time check's reachability-dependence came right back for the unreached-branch case,
+just gated behind an opt-in flag instead of the unconditional default. Rejecting in the
+parser regardless of the flag closes it for good, and matches real yq's own behavior more
+precisely besides -- there is no `--jq-extensions`-shaped escape hatch in real yq either.
+
+`input_builtins_unsupported_in_yq_mode` stays in `eval.rs` even though the parser now catches
+every CLI-reachable case: `Expr`, `Builtin`, `eval`, and `YqSemantics` are public API
+(`succinctly::jq`), so a library consumer can construct `Expr::Builtin(Builtin::Input)`
+directly and evaluate it with `YqSemantics`, bypassing the parser (and any CLI flag) entirely
+— deleting the check would reopen #723's bug for that surface specifically.
 
 ### 3-argument `sub(re; s; flags)` — resolved, real yq ignores everything past the pattern
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -392,7 +392,7 @@ otherwise-verified fix (which is strictly more correct than what it replaced: it
 real regression at `-I=4` introduced mid-fix and two cases pre-#1485 `main` never got right
 at all, `-I=5`/`-I=6`).
 
-### `input`, `inputs`, `input_line_number` — resolved, rejected unconditionally like real yq
+### `input`, `inputs`, `input_line_number` — resolved as a call target, matching real yq's lexer
 
 Real yq has no such builtins at any arity — its lexer rejects the identifiers exactly as it
 rejects a name that does not exist
@@ -404,8 +404,8 @@ $ printf 'a: 1\n' | yq 'inputs'      # Error: 1:1: lexer: invalid input text "in
 $ printf 'a: 1\n' | yq 'no_such_fn'  # Error: 1:1: lexer: invalid input text "no_such_fn"
 ```
 
-succinctly now matches this unconditionally, in the parser (`reject_in_yq_mode`,
-[src/jq/parser.rs](../../../src/jq/parser.rs)) rather than at dispatch
+succinctly now matches this unconditionally *as a call target*, in the parser
+(`reject_in_yq_mode`, [src/jq/parser.rs](../../../src/jq/parser.rs)) rather than at dispatch
 (`input_builtins_unsupported_in_yq_mode`, [src/jq/eval.rs](../../../src/jq/eval.rs), added by
 #723):
 
@@ -414,11 +414,20 @@ $ printf 'a: 1\n' | succinctly yq 'input'
 Error: parse error: parse error at position 0: input is not supported in yq mode
 ```
 
-This closes the one divergence this section used to record: dispatch only fires for a call
-site that's actually *reached*, so `if false then input else . end` used to be silently
+This closes the call-target divergence this section used to record: dispatch only fires for a
+call site that's actually *reached*, so `if false then input else . end` used to be silently
 accepted instead of rejected — pinned by
 `test_yq_unreached_input_builtin_now_rejected_1507`
-([tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)).
+([tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)). It does **not** close every route to
+these three names: a bare object-construction key (`{input: 5}`) bypasses `reject_in_yq_mode`
+entirely, since that parses through a different code path
+(`parse_object_construction`'s bare-identifier-key branch) that never reaches
+`try_parse_builtin`. That's one instance of a wider, pre-existing, undocumented divergence —
+succinctly's object-key grammar accepts jq's permissive bare identifiers unconditionally,
+with no yq-mode restriction, for *any* name (`{foo: 5}` succeeds the same way) — tracked
+separately as [#1966](https://github.com/rust-works/succinctly/issues/1966) rather than folded
+into this fix, since properly closing it means deciding how strict `succinctly yq`'s
+object-key grammar should be relative to jq's, not a small patch scoped to 3 names.
 
 **Deliberately *not* routed through the `--jq-extensions` gate** the ~65 other jq-only
 builtins use, even though real yq lacks all of them the same way. That flag's contract

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -392,7 +392,7 @@ otherwise-verified fix (which is strictly more correct than what it replaced: it
 real regression at `-I=4` introduced mid-fix and two cases pre-#1485 `main` never got right
 at all, `-I=5`/`-I=6`).
 
-### `input`, `inputs`, `input_line_number` are rejected, but at runtime rather than parse time
+### `input`, `inputs`, `input_line_number` — parse-time gated behind `--jq-extensions`, still not functional
 
 Real yq has no such builtins at any arity — its lexer rejects the identifiers exactly as it
 rejects a name that does not exist
@@ -404,36 +404,39 @@ $ printf 'a: 1\n' | yq 'inputs'      # Error: 1:1: lexer: invalid input text "in
 $ printf 'a: 1\n' | yq 'no_such_fn'  # Error: 1:1: lexer: invalid input text "no_such_fn"
 ```
 
-succinctly also rejects all three in yq mode, but from
-`input_builtins_unsupported_in_yq_mode` ([src/jq/eval.rs](../../../src/jq/eval.rs)), which
-runs at *dispatch*. yq fails at *lex*, so its rejection is unconditional where succinctly's
-is reachability-dependent:
+**By default, succinctly now matches this unconditionally** — #1507 gated all three behind
+`--jq-extensions` in the parser, the same treatment as the ~65 other jq-only builtins already
+gated that way, closing the one divergence this section used to record (a call site that was
+never reached, e.g. `if false then input else . end`, used to be silently accepted rather
+than rejected — pinned by `test_yq_unreached_input_builtin_now_rejected_1507`,
+[tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)):
 
-| Filter on `a: 1` | real yq | succinctly |
-|---|---|---|
-| `input` | `Error: 1:1: lexer: invalid input text "input"`, exit 1 | `Error: input is not supported in yq mode`, exit 1 |
-| `., input` | lexer error at 1:4, exit 1 | runtime error, exit 1 |
-| `if false then input else . end` | lexer error, exit 1 | **exit 0, prints `a: 1`** |
+```bash
+$ printf 'a: 1\n' | succinctly yq 'input'
+Error: parse error: parse error at position 0: "input" is not part of yq's syntax; pass --jq-extensions to enable succinctly's jq-compatible builtin surface
+```
 
-Only the third row differs in outcome rather than wording. It is the same shape as jq mode's
-[undefined-function gap](../jq/limitations.md) (#1473): this codebase has no per-mode keyword
-gating in the parser anywhere, so a "not supported" verdict cannot be reached before
-evaluation. Pinned by `test_yq_unreached_input_builtin_is_not_rejected_1507`
-([tests/yq_cli_tests.rs](../../../tests/yq_cli_tests.rs)) so it cannot drift unnoticed.
+**Unlike every other name in that gated class, passing `--jq-extensions` does not make these
+three work.** They still error, now from `input_builtins_unsupported_in_yq_mode`
+([src/jq/eval.rs](../../../src/jq/eval.rs)) at dispatch:
 
-No ADR-0018 rule 4 condition applies — the output is readable, nothing is corrupted, no
-process dies — so like the `*+d` merge-flag case above, this is recorded as a divergence to
-be fixed or re-justified, not a settled decision.
+```bash
+$ printf 'a: 1\n' | succinctly yq --jq-extensions 'input'
+Error: input is not supported in yq mode
+```
 
-**Implementing the three in yq mode is a separate question, and is not blocked on an
-oracle**, because there is none to match: it would be a rule-5 extension, which rule 5
-permits without a carve-out. The cost is the reason it has not been done, not the category.
-yq mode's document loop is cursor-native (`YamlValue::Sequence(docs)` walked by
-`uncons_cursor`, [src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs))
+This isn't a divergence to fix — there's no oracle to match, since real yq has no
+`--jq-extensions` equivalent to compare against at all. It's a deliberate two-layer gate: the
+parser change only lifts the *syntax* restriction; the *architectural* one underneath is real
+and unaddressed. yq mode's document loop is cursor-native (`YamlValue::Sequence(docs)` walked
+by `uncons_cursor`, [src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs))
 precisely so duplicate mapping keys (#1398) and ADR-0017's comment/anchor side-trees survive;
 jq's queue is `Vec<(OwnedValue, u32, u32)>`. Reusing jq's queue would push YAML documents
 through `OwnedValue` and silently lose all three, so real support needs a second,
-cursor-native queue. See #1507.
+cursor-native queue — tracked as its own follow-up, not attempted here. Deleting the dispatch
+check instead would reopen the exact bug it was added to fix (#723), just reachable via
+`--jq-extensions` instead of unconditionally: `input` reporting a spurious "break" on every
+document, `inputs` silently producing no output at all.
 
 ### 3-argument `sub(re; s; flags)` — resolved, real yq ignores everything past the pattern
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31964,21 +31964,28 @@ pub const fn input_queue_is_active() -> bool {
 /// Code review's own doc-comment-vs-doc-comment cross-check catch (#723):
 /// `jq_runner.rs` is the only CLI driver that calls
 /// [`seed_remaining_inputs`]/[`pop_remaining_input`] before evaluating a
-/// filter -- `yq_runner.rs` never does. #1507 gave the parser per-mode
-/// keyword gating (`--jq-extensions`) for these three, matching the ~65
-/// other jq-only builtins already gated that way, so the *default* yq
-/// dispatch path this function guards is unreachable now (the parser
-/// rejects `input`/`inputs`/`input_line_number` before evaluation ever
-/// starts). This check stays anyway, because `--jq-extensions` only lifts
-/// the *parse*-time gate, not the underlying architectural gap #1507's own
-/// cost analysis identified: yq's document loop is cursor-native
-/// specifically to preserve duplicate mapping keys and ADR-0017's
-/// comment/anchor side-trees, so it cannot share jq's `Vec<(OwnedValue, u32,
-/// u32)>` queue without silently losing all three. Deleting this check
-/// would reopen the exact bug #723 fixed -- `break` on every document for
-/// `input`, silent empty output for `inputs` -- just gated behind an opt-in
-/// flag instead of being the unconditional default. Real cursor-native
-/// queue support remains its own, larger follow-up (#1507's "Option A").
+/// filter -- `yq_runner.rs` never does. #1507 moved the *CLI-reachable*
+/// rejection into the parser (`reject_in_yq_mode`, `src/jq/parser.rs`),
+/// unconditionally and regardless of `--jq-extensions` -- unlike the ~65
+/// other jq-only builtins that flag *does* unlock, these three still need
+/// real per-document driver-loop coordination yq mode's cursor-native
+/// document loop doesn't have (it exists specifically to preserve
+/// duplicate mapping keys and ADR-0017's comment/anchor side-trees, so it
+/// cannot share jq's `Vec<(OwnedValue, u32, u32)>` queue without silently
+/// losing all three), so no flag value would ever make them work.
+///
+/// This function itself is therefore unreachable through `succinctly yq`
+/// today -- the parser now rejects the keyword before evaluation starts,
+/// flag or no flag. It stays anyway because `Expr`, `Builtin`, `eval`, and
+/// `YqSemantics` are all public (`succinctly::jq`, `src/jq/mod.rs`): a
+/// downstream Rust crate can construct `Expr::Builtin(Builtin::Input)`
+/// directly and evaluate it with `YqSemantics`, bypassing the parser (and
+/// any CLI flag) entirely. Deleting this function would reopen the exact
+/// bug #723 fixed -- `break` on every document for `input`, silent empty
+/// output for `inputs` -- for that API surface specifically, with no
+/// parser standing between the caller and evaluation to catch it. Real
+/// cursor-native queue support remains its own, larger follow-up (#1507's
+/// "Option A").
 fn input_builtins_unsupported_in_yq_mode<S: EvalSemantics>(name: &str) -> Option<EvalError> {
     if S::TAG == EvalTag::Yq {
         Some(EvalError::new(format!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31964,17 +31964,21 @@ pub const fn input_queue_is_active() -> bool {
 /// Code review's own doc-comment-vs-doc-comment cross-check catch (#723):
 /// `jq_runner.rs` is the only CLI driver that calls
 /// [`seed_remaining_inputs`]/[`pop_remaining_input`] before evaluating a
-/// filter -- `yq_runner.rs` never does, yet these three builtins parse and
-/// dispatch unconditionally for `YqSemantics` too (the parser has no
-/// per-mode keyword gating anywhere in this codebase to lean on instead).
-/// Without this check, `succinctly yq` would silently accept `input`/
-/// `inputs`/`input_line_number` syntax that can never produce a correct
-/// result -- confirmed live: `break` on every document for `input`, and
-/// silent empty output for `inputs`, instead of the "undefined function"
-/// parse-time-ish error real yq (and this codebase, pre-#723) gives for a
-/// genuinely unimplemented builtin. Wiring `yq_runner.rs` up to the same
-/// queue for real support is a larger, separate piece of work -- tracked as
-/// a follow-up; this keeps yq mode's failure mode honest in the meantime.
+/// filter -- `yq_runner.rs` never does. #1507 gave the parser per-mode
+/// keyword gating (`--jq-extensions`) for these three, matching the ~65
+/// other jq-only builtins already gated that way, so the *default* yq
+/// dispatch path this function guards is unreachable now (the parser
+/// rejects `input`/`inputs`/`input_line_number` before evaluation ever
+/// starts). This check stays anyway, because `--jq-extensions` only lifts
+/// the *parse*-time gate, not the underlying architectural gap #1507's own
+/// cost analysis identified: yq's document loop is cursor-native
+/// specifically to preserve duplicate mapping keys and ADR-0017's
+/// comment/anchor side-trees, so it cannot share jq's `Vec<(OwnedValue, u32,
+/// u32)>` queue without silently losing all three. Deleting this check
+/// would reopen the exact bug #723 fixed -- `break` on every document for
+/// `input`, silent empty output for `inputs` -- just gated behind an opt-in
+/// flag instead of being the unconditional default. Real cursor-native
+/// queue support remains its own, larger follow-up (#1507's "Option A").
 fn input_builtins_unsupported_in_yq_mode<S: EvalSemantics>(name: &str) -> Option<EvalError> {
     if S::TAG == EvalTag::Yq {
         Some(EvalError::new(format!(

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3583,14 +3583,17 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Builtins));
         }
         if self.matches_keyword("inputs") {
+            self.reject_unless_jq_extensions("inputs")?;
             self.consume_keyword("inputs");
             return Ok(Some(Builtin::Inputs));
         }
         if self.matches_keyword("input_line_number") {
+            self.reject_unless_jq_extensions("input_line_number")?;
             self.consume_keyword("input_line_number");
             return Ok(Some(Builtin::InputLineNumber));
         }
         if self.matches_keyword("input") {
+            self.reject_unless_jq_extensions("input")?;
             self.consume_keyword("input");
             return Ok(Some(Builtin::Input));
         }
@@ -6707,6 +6710,13 @@ mod tests {
     /// (the `--jq-extensions` CLI flag's parser-level counterpart) accepts
     /// them. jq mode is unaffected either way -- it already accepts this
     /// whole surface unconditionally, gate or no gate.
+    ///
+    /// #1507 adds `input`/`inputs`/`input_line_number` -- this test only
+    /// covers parsing, so it doesn't distinguish them from the rest here:
+    /// unlike every other name in this list, they still error once
+    /// evaluated even with the gate open (see
+    /// `input_builtins_unsupported_in_yq_mode`, `src/jq/eval.rs`), since
+    /// yq mode's document loop has no real support for them yet.
     #[test]
     fn test_yq_mode_rejects_jq_only_builtins_unless_jq_extensions_1512() {
         let cases: &[(&str, &str)] = &[
@@ -6733,6 +6743,9 @@ mod tests {
             ("trunc", "1.5 | trunc"),
             ("isinfinite", "1 | isinfinite"),
             ("nan", "nan"),
+            ("input", "input"),
+            ("inputs", "inputs"),
+            ("input_line_number", "input_line_number"),
         ];
 
         for (name, filter) in cases {

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -343,6 +343,31 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    /// Unlike [`reject_unless_jq_extensions`], `--jq-extensions` never
+    /// rescues this rejection: `input`/`inputs`/`input_line_number` (#1507)
+    /// need real per-document driver-loop coordination yq mode's
+    /// cursor-native document loop doesn't have (see
+    /// `input_builtins_unsupported_in_yq_mode`, `src/jq/eval.rs`), unlike
+    /// every other jq-only builtin the flag actually unlocks. Routing them
+    /// through `reject_unless_jq_extensions` instead of this function once
+    /// reopened the exact bug #1507 fixed, one layer down: passing the flag
+    /// let the keyword parse, so an *unreached* branch (`if false then
+    /// input else . end`) went right back to silently succeeding, since the
+    /// eval-time-only dispatch check in `eval.rs` never runs for a branch
+    /// that's never evaluated. Rejecting unconditionally here, regardless
+    /// of the flag, is reachability-independent by construction -- the same
+    /// property that made the flag-gated fix work for every *other* jq-only
+    /// builtin in the first place.
+    fn reject_in_yq_mode(&self, name: &str) -> Result<(), ParseError> {
+        if self.mode == ParserMode::Yq {
+            return Err(ParseError::new(
+                format!("{name} is not supported in yq mode"),
+                self.pos,
+            ));
+        }
+        Ok(())
+    }
+
     /// Scan a run of yq merge-flag characters (`+ ? n d c`, any order,
     /// repeats allowed) starting at the current position. Matches real yq's
     /// lexer, which greedily consumes these characters with no regard for
@@ -3583,17 +3608,17 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Builtins));
         }
         if self.matches_keyword("inputs") {
-            self.reject_unless_jq_extensions("inputs")?;
+            self.reject_in_yq_mode("inputs")?;
             self.consume_keyword("inputs");
             return Ok(Some(Builtin::Inputs));
         }
         if self.matches_keyword("input_line_number") {
-            self.reject_unless_jq_extensions("input_line_number")?;
+            self.reject_in_yq_mode("input_line_number")?;
             self.consume_keyword("input_line_number");
             return Ok(Some(Builtin::InputLineNumber));
         }
         if self.matches_keyword("input") {
-            self.reject_unless_jq_extensions("input")?;
+            self.reject_in_yq_mode("input")?;
             self.consume_keyword("input");
             return Ok(Some(Builtin::Input));
         }
@@ -6711,12 +6736,11 @@ mod tests {
     /// them. jq mode is unaffected either way -- it already accepts this
     /// whole surface unconditionally, gate or no gate.
     ///
-    /// #1507 adds `input`/`inputs`/`input_line_number` -- this test only
-    /// covers parsing, so it doesn't distinguish them from the rest here:
-    /// unlike every other name in this list, they still error once
-    /// evaluated even with the gate open (see
-    /// `input_builtins_unsupported_in_yq_mode`, `src/jq/eval.rs`), since
-    /// yq mode's document loop has no real support for them yet.
+    /// `input`/`inputs`/`input_line_number` (#1507) are deliberately *not*
+    /// in this list: unlike everything here, `--jq-extensions` never makes
+    /// them parse in yq mode -- see
+    /// `test_yq_input_builtins_rejected_in_yq_mode_regardless_of_extensions_1507`
+    /// below.
     #[test]
     fn test_yq_mode_rejects_jq_only_builtins_unless_jq_extensions_1512() {
         let cases: &[(&str, &str)] = &[
@@ -6743,9 +6767,6 @@ mod tests {
             ("trunc", "1.5 | trunc"),
             ("isinfinite", "1 | isinfinite"),
             ("nan", "nan"),
-            ("input", "input"),
-            ("inputs", "inputs"),
-            ("input_line_number", "input_line_number"),
         ];
 
         for (name, filter) in cases {
@@ -6768,6 +6789,48 @@ mod tests {
             assert!(
                 parse_program_with_mode(filter, ParserMode::Jq).is_ok(),
                 "`{name}` should parse in jq mode regardless of the yq-only gate"
+            );
+        }
+    }
+
+    /// #1507: `input`/`inputs`/`input_line_number` are the one jq-only
+    /// class `--jq-extensions` does not unlock, unlike every name in
+    /// [`test_yq_mode_rejects_jq_only_builtins_unless_jq_extensions_1512`]
+    /// above. Routing them through that same flag-gated mechanism once
+    /// reopened #1507's own bug one layer down: passing the flag let the
+    /// keyword parse, so an *unreached* branch went right back to silently
+    /// succeeding, since `input_builtins_unsupported_in_yq_mode`
+    /// (`src/jq/eval.rs`) only fires when the builtin is actually
+    /// evaluated. Rejecting in the parser unconditionally, regardless of
+    /// the flag, closes that gap by construction.
+    #[test]
+    fn test_yq_input_builtins_rejected_in_yq_mode_regardless_of_extensions_1507() {
+        for (name, filter) in [
+            ("input", "input"),
+            ("inputs", "inputs"),
+            ("input_line_number", "input_line_number"),
+        ] {
+            for extensions in [false, true] {
+                let rejected =
+                    parse_program_with_mode_and_extensions(filter, ParserMode::Yq, extensions);
+                assert!(
+                    rejected.is_err(),
+                    "`{name}` should be rejected in yq mode (extensions={extensions}), got: {rejected:?}"
+                );
+                let message = &rejected.unwrap_err().message;
+                assert!(
+                    message.contains("not supported in yq mode"),
+                    "`{name}`'s rejection message should say it's not supported in yq mode, got: {message}"
+                );
+                assert!(
+                    !message.contains("--jq-extensions"),
+                    "`{name}`'s rejection should not suggest --jq-extensions, since it never helps: {message}"
+                );
+            }
+
+            assert!(
+                parse_program_with_mode(filter, ParserMode::Jq).is_ok(),
+                "`{name}` should still parse in jq mode"
             );
         }
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1341,6 +1341,11 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 /// `nan`) found by
 /// #1885's own code review tracing this same "Phase 10"/"Phase 12" gap
 /// further -- see #1887 for the still-unaudited remainder of this surface.
+/// #1507 adds `input`/`inputs`/`input_line_number` -- unlike every other
+/// name here, these three still error even once gated open (see
+/// `test_yq_input_not_supported_723` and friends below), since gating only
+/// lifts the parse-time refusal, not the separate architectural gap that
+/// keeps them from actually working in yq mode.
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     for filter in [
@@ -1398,6 +1403,9 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "isnormal",
         "isfinite",
         "nan",
+        "input",
+        "inputs",
+        "input_line_number",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -21701,17 +21709,21 @@ fn test_destructuring_pattern_null_propagates_through_nested_object_1239() -> Re
 // #723 review round: input/inputs/input_line_number are jq-only -- the
 // CLI driver behind `succinctly yq` (yq_runner.rs) never seeds their shared
 // document queue, since they need real per-document loop coordination that
-// yq mode doesn't have. Before this fix, the parser/dispatch accepted them
-// unconditionally (no per-mode gating exists for any keyword in this
-// codebase), so `succinctly yq` silently misbehaved -- `input` reported a
-// spurious "break" on every document instead of only true exhaustion, and
-// `inputs` silently produced no output at all. Now they report a clear
-// "not supported in yq mode" error instead, restoring the pre-#723
-// "undefined function"-equivalent failure mode.
+// yq mode doesn't have. #1507 later gave the parser per-mode keyword gating
+// (`--jq-extensions`), so by default these three are now rejected at parse
+// time before dispatch ever runs (see `test_yq_default_rejects_jq_only_builtins_1512`
+// and `test_yq_unreached_input_builtin_now_rejected_1507` below) -- these
+// three tests now cover what happens once `--jq-extensions` lifts that
+// parse-time gate: dispatch still refuses them with a clear "not supported
+// in yq mode" error rather than silently misbehaving (`input` reporting a
+// spurious "break" on every document instead of only true exhaustion,
+// `inputs` silently producing no output at all) -- restoring the pre-#723
+// "undefined function"-equivalent failure mode for the one case
+// (`--jq-extensions`) where the parser still lets the syntax through.
 
 #[test]
 fn test_yq_input_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr("input", "a: 1\n", &[])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("input", "a: 1\n", &["--jq-extensions"])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("input is not supported in yq mode"),
@@ -21722,7 +21734,7 @@ fn test_yq_input_not_supported_723() -> Result<()> {
 
 #[test]
 fn test_yq_inputs_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr("inputs", "a: 1\n", &[])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("inputs", "a: 1\n", &["--jq-extensions"])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("inputs is not supported in yq mode"),
@@ -21733,7 +21745,8 @@ fn test_yq_inputs_not_supported_723() -> Result<()> {
 
 #[test]
 fn test_yq_input_line_number_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr("input_line_number", "a: 1\n", &[])?;
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("input_line_number", "a: 1\n", &["--jq-extensions"])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("input_line_number is not supported in yq mode"),
@@ -21742,28 +21755,28 @@ fn test_yq_input_line_number_not_supported_723() -> Result<()> {
     Ok(())
 }
 
-/// #1507: the gate above fires at *dispatch*, so a call site that is never
-/// reached is silently accepted. Real yq rejects at *lex* time and so is
-/// unconditional -- `yq 'if false then input else . end'` is
-/// `Error: 1:1: lexer: invalid input text`, exit 1, captured live from
-/// v4.53.3.
-///
-/// This is the one row of the three where the *outcome* differs rather than
-/// just the wording, and it is a divergence with no ADR-0018 rule 4 condition
-/// behind it. Closing it needs per-mode keyword gating in the parser, which
-/// this codebase has for no keyword anywhere. Pinned here so it cannot drift
-/// unnoticed while it stays open; see
+/// #1507: the dispatch-time gate above used to fire too late to catch a call
+/// site that's never reached (`if false then input else . end` used to exit
+/// 0, printing `a: 1`, where real yq's lexer rejects unconditionally). Now
+/// fixed the same way the other ~65 jq-only builtins already are: `input`/
+/// `inputs`/`input_line_number` are gated in the parser behind
+/// `--jq-extensions`, so this shape is rejected before evaluation starts
+/// regardless of whether the branch would ever run, matching real yq's own
+/// unconditional lex-time rejection. See
 /// `docs/compliance/yq/limitations.md`.
 #[test]
-fn test_yq_unreached_input_builtin_is_not_rejected_1507() -> Result<()> {
+fn test_yq_unreached_input_builtin_now_rejected_1507() -> Result<()> {
     for filter in [
         "if false then input else . end",
         "if false then inputs else . end",
         "if false then input_line_number else . end",
     ] {
-        let (out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
-        assert_eq!(code, 0, "{filter}: stderr: {stderr}");
-        assert_eq!(out, "a: 1\n", "{filter}");
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_ne!(code, 0, "{filter} should now be rejected");
+        assert!(
+            stderr.contains("--jq-extensions"),
+            "{filter} stderr should mention --jq-extensions, got: {stderr}"
+        );
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1341,11 +1341,12 @@ fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
 /// `nan`) found by
 /// #1885's own code review tracing this same "Phase 10"/"Phase 12" gap
 /// further -- see #1887 for the still-unaudited remainder of this surface.
-/// #1507 adds `input`/`inputs`/`input_line_number` -- unlike every other
-/// name here, these three still error even once gated open (see
-/// `test_yq_input_not_supported_723` and friends below), since gating only
-/// lifts the parse-time refusal, not the separate architectural gap that
-/// keeps them from actually working in yq mode.
+///
+/// `input`/`inputs`/`input_line_number` (#1507) are deliberately *not* in
+/// this list, even though real yq's lexer lacks them too: unlike every name
+/// here, `--jq-extensions` never makes them work in yq mode, so they're
+/// rejected unconditionally instead of through this flag-gated mechanism --
+/// see `test_yq_input_not_supported_723` and friends below.
 #[test]
 fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     for filter in [
@@ -1403,9 +1404,6 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "isnormal",
         "isfinite",
         "nan",
-        "input",
-        "inputs",
-        "input_line_number",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -21709,21 +21707,20 @@ fn test_destructuring_pattern_null_propagates_through_nested_object_1239() -> Re
 // #723 review round: input/inputs/input_line_number are jq-only -- the
 // CLI driver behind `succinctly yq` (yq_runner.rs) never seeds their shared
 // document queue, since they need real per-document loop coordination that
-// yq mode doesn't have. #1507 later gave the parser per-mode keyword gating
-// (`--jq-extensions`), so by default these three are now rejected at parse
-// time before dispatch ever runs (see `test_yq_default_rejects_jq_only_builtins_1512`
-// and `test_yq_unreached_input_builtin_now_rejected_1507` below) -- these
-// three tests now cover what happens once `--jq-extensions` lifts that
-// parse-time gate: dispatch still refuses them with a clear "not supported
-// in yq mode" error rather than silently misbehaving (`input` reporting a
-// spurious "break" on every document instead of only true exhaustion,
-// `inputs` silently producing no output at all) -- restoring the pre-#723
-// "undefined function"-equivalent failure mode for the one case
-// (`--jq-extensions`) where the parser still lets the syntax through.
+// yq mode doesn't have. #1507 moved this rejection from eval.rs's dispatch
+// (which only fired for a *reached* call site -- see the divergence
+// `test_yq_unreached_input_builtin_now_rejected_1507` below used to pin)
+// into the parser's `reject_in_yq_mode`, unconditionally and regardless of
+// `--jq-extensions` (unlike every other jq-only builtin that flag *does*
+// unlock -- these three still need real per-document driver-loop
+// coordination yq mode doesn't have, so the flag would never make them
+// work). These three tests now exercise the parse-time rejection directly
+// (message text carried over verbatim from the original dispatch-time
+// check) rather than the CLI ever reaching evaluation at all.
 
 #[test]
 fn test_yq_input_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr("input", "a: 1\n", &["--jq-extensions"])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("input", "a: 1\n", &[])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("input is not supported in yq mode"),
@@ -21734,7 +21731,7 @@ fn test_yq_input_not_supported_723() -> Result<()> {
 
 #[test]
 fn test_yq_inputs_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) = run_yq_stdin_with_stderr("inputs", "a: 1\n", &["--jq-extensions"])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("inputs", "a: 1\n", &[])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("inputs is not supported in yq mode"),
@@ -21745,8 +21742,7 @@ fn test_yq_inputs_not_supported_723() -> Result<()> {
 
 #[test]
 fn test_yq_input_line_number_not_supported_723() -> Result<()> {
-    let (_out, stderr, code) =
-        run_yq_stdin_with_stderr("input_line_number", "a: 1\n", &["--jq-extensions"])?;
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("input_line_number", "a: 1\n", &[])?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(
         stderr.contains("input_line_number is not supported in yq mode"),
@@ -21755,14 +21751,18 @@ fn test_yq_input_line_number_not_supported_723() -> Result<()> {
     Ok(())
 }
 
-/// #1507: the dispatch-time gate above used to fire too late to catch a call
-/// site that's never reached (`if false then input else . end` used to exit
-/// 0, printing `a: 1`, where real yq's lexer rejects unconditionally). Now
-/// fixed the same way the other ~65 jq-only builtins already are: `input`/
-/// `inputs`/`input_line_number` are gated in the parser behind
-/// `--jq-extensions`, so this shape is rejected before evaluation starts
-/// regardless of whether the branch would ever run, matching real yq's own
-/// unconditional lex-time rejection. See
+/// #1507: the dispatch-time gate these three used to go through only fired
+/// for a call site that's actually *reached* -- `if false then input else .
+/// end` used to exit 0, printing `a: 1`, where real yq's lexer rejects
+/// unconditionally. Fixed by rejecting in the parser instead (`reject_in_yq_mode`),
+/// which runs before evaluation regardless of which branch would ever run,
+/// matching real yq's own unconditional lex-time rejection. Also confirms
+/// this holds under `--jq-extensions` too: an earlier version of this fix
+/// routed these three through the same flag-gated mechanism as every other
+/// jq-only builtin, which reopened this exact divergence one layer down --
+/// the flag let the keyword parse, so the still-reachability-dependent
+/// dispatch-time check went right back to missing the unreached branch.
+/// Rejecting unconditionally, flag or no flag, closes it for good. See
 /// `docs/compliance/yq/limitations.md`.
 #[test]
 fn test_yq_unreached_input_builtin_now_rejected_1507() -> Result<()> {
@@ -21771,13 +21771,33 @@ fn test_yq_unreached_input_builtin_now_rejected_1507() -> Result<()> {
         "if false then inputs else . end",
         "if false then input_line_number else . end",
     ] {
-        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
-        assert_ne!(code, 0, "{filter} should now be rejected");
-        assert!(
-            stderr.contains("--jq-extensions"),
-            "{filter} stderr should mention --jq-extensions, got: {stderr}"
-        );
+        for extra_args in [[].as_slice(), ["--jq-extensions"].as_slice()] {
+            let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", extra_args)?;
+            assert_eq!(code, 1, "{filter} ({extra_args:?}) stderr: {stderr}");
+            assert!(
+                stderr.contains("is not supported in yq mode"),
+                "{filter} ({extra_args:?}) stderr: {stderr}"
+            );
+        }
     }
+    Ok(())
+}
+
+/// Companion to the fix above, for a builtin `--jq-extensions` *does*
+/// unlock: an unreached branch containing one still parses and evaluates
+/// fine once the flag is on, exactly like before `input`/`inputs`/
+/// `input_line_number` needed the stricter, unconditional treatment. Pins
+/// that `reject_in_yq_mode`'s addition didn't change `reject_unless_jq_extensions`'s
+/// own, correctly flag-gated behavior for everything else in that class.
+#[test]
+fn test_yq_unreached_jq_extensions_builtin_still_works_with_flag() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "if false then paths else . end",
+        "a: 1\n",
+        &["--jq-extensions"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a: 1\n");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21772,8 +21772,9 @@ fn test_yq_unreached_input_builtin_now_rejected_1507() -> Result<()> {
         "if false then input_line_number else . end",
     ] {
         for extra_args in [[].as_slice(), ["--jq-extensions"].as_slice()] {
-            let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", extra_args)?;
+            let (out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", extra_args)?;
             assert_eq!(code, 1, "{filter} ({extra_args:?}) stderr: {stderr}");
+            assert_eq!(out, "", "{filter} ({extra_args:?}) should write no stdout");
             assert!(
                 stderr.contains("is not supported in yq mode"),
                 "{filter} ({extra_args:?}) stderr: {stderr}"


### PR DESCRIPTION
## Summary

Real yq's lexer rejects `input`/`inputs`/`input_line_number` unconditionally — it doesn't have these builtins at any arity. succinctly only rejected them at dispatch time (`input_builtins_unsupported_in_yq_mode`, added by #723), which meant an unreached call site was silently accepted:

```console
$ printf 'a: 1\n' | succinctly yq 'if false then input else . end'
a: 1
                                          # should be rejected, matching real yq's lex-time error (before this fix)
```

## Fix

Adds a new `reject_in_yq_mode` parser check that rejects these three unconditionally, as a call target, regardless of `--jq-extensions` — since no flag value makes them actually work (yq's document loop is cursor-native to preserve duplicate mapping keys and anchors/comments; jq's queue is `Vec<(OwnedValue, u32, u32)>` and can't share it without silently losing all three). This is deliberately different from the other ~65 jq-only builtins already gated behind `--jq-extensions`.

## Review history (3 rounds)

- **Round 1** caught that an earlier version routed these three through the same `--jq-extensions` gate as everything else (matching #1507's own initial suggestion) — which reopened the exact divergence one layer down: passing the flag let the keyword parse, so `if false then input else . end` went right back to silently succeeding, since the dispatch-time check only fires for a call site that's actually evaluated. Fixed by rejecting unconditionally in the parser instead, which is reachability-independent by construction.
- **Round 2** confirmed the redesign and tightened test assertions.
- **Round 3** found the "unconditional" framing overclaimed: a bare object-construction key (`{input: 5}`) still bypasses the new check, since that parses through a different code path. Confirmed this is one instance of a much broader, pre-existing, undocumented divergence (succinctly's object-key grammar accepts jq's permissive bare identifiers for *any* name, not just these three) — filed as **#1966** rather than expanding this fix's scope, along with a related `matches_keyword` hyphen-boundary gap found in the same pass. Docs now scope the "resolved" claim accurately to call-target position.

`input_builtins_unsupported_in_yq_mode` stays in `eval.rs`, justified by a reason review surfaced: `Expr`/`Builtin`/`eval`/`YqSemantics` are public API (`succinctly::jq`), so a library consumer can construct the AST directly and evaluate it with `YqSemantics`, bypassing the parser (and any CLI flag) entirely.

## Testing

- `test_yq_unreached_input_builtin_now_rejected_1507` — confirms the divergence is closed both with and without `--jq-extensions`, and that no stdout leaks before the error.
- `test_yq_input_builtins_rejected_in_yq_mode_regardless_of_extensions_1507` (parser unit test) — same, at the parser level.
- `test_yq_unreached_jq_extensions_builtin_still_works_with_flag` — companion confirming the new check doesn't affect builtins `--jq-extensions` *does* unlock.
- Updated the three `test_yq_*_not_supported_723` tests (no longer need `--jq-extensions`, since rejection is unconditional).
- `docs/compliance/yq/limitations.md` updated, scoped accurately to call-target position; these three are correctly **not** added to `docs/reference/yq-language.md`'s gated-builtins table, since they were never part of that class.
- Full local suite (`cargo test --features cli`), both required clippy legs, and `cargo fmt --check` all clean.

Fixes #1507