### PR TITLE
fix(jq): resolve key/parent/file_index inside limit's body expression

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -894,6 +894,19 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // `key`/`parent`/`file_index` inside `n` is a narrower, rarer gap
         // left unaddressed, same scoping precedent as `AsPattern`'s own
         // `?//`-chain exclusion above.
+        //
+        // Review: this arm only takes effect for the CLI (`eval_generic.rs`)
+        // when `limit(...)` sits inside an enclosing `Pipe`/`Array`, whose
+        // own `needs_path_context` scan is what actually triggers the
+        // bridge into `eval.rs`'s path-context evaluator -- a genuinely
+        // standalone top-level `limit(n; expr)` still reaches
+        // `eval_generic.rs`'s own `each_limit_generic`/`eval_limit_generic`
+        // directly, which has no equivalent check of its own. Left
+        // unaddressed: no observably-wrong repro was found for this case
+        // (a `key`/`parent`/`file_index` with no prior navigation is
+        // legitimately `null`/root-equivalent either way), and any real
+        // navigation before `limit` already creates the enclosing `Pipe`
+        // this arm needs.
         Expr::Limit { expr, .. } => needs_path_context(expr),
         _ => false,
     }
@@ -29024,24 +29037,27 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 Ok(None) => return QueryResult::None,
                 Err(escape) => return escape.into(),
             };
-            let limited = match classify_limit_n(n_value) {
-                Ok(LimitN::Unlimited) => eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(expr),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                ),
-                Ok(LimitN::Take(0)) => QueryResult::None,
-                Ok(LimitN::Take(n)) => match eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(expr),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                ) {
+            // `Take(0)` must skip evaluating `expr` entirely (jq's own
+            // `elif $n==0 then empty` -- no side effects), so this has to
+            // be peeled off before the single shared eval call below runs,
+            // not folded into a branch that also has to run it.
+            let n = match classify_limit_n(n_value) {
+                Ok(LimitN::Unlimited) => None,
+                Ok(LimitN::Take(0)) => return QueryResult::None,
+                Ok(LimitN::Take(n)) => Some(n),
+                Err(e) => return QueryResult::Error(e),
+            };
+            let body_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(expr),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let limited = match n {
+                None => body_result,
+                Some(n) => match body_result {
                     QueryResult::Owned(v) => QueryResult::Owned(v),
                     QueryResult::ManyOwned(mut vs) => {
                         vs.truncate(n);
@@ -29071,7 +29087,6 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         )
                     }
                 },
-                Err(e) => return QueryResult::Error(e),
             };
             continue_rest_with_context::<W, S>(
                 limited,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -884,6 +884,17 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
             patterns,
             body,
         } => patterns.len() == 1 && (needs_path_context(expr) || needs_path_context(body)),
+        // `limit(n; expr)` (#1765, item 2 of #1663's own remaining-gaps
+        // list): `expr` doesn't navigate away from the caller's own
+        // position (`eval_limit` evaluates it against the same `value`
+        // `n` was), so a `key`/`parent`/`file_index` inside it needs the
+        // same ambient context. `n` itself is deliberately excluded here,
+        // matching the dedicated eval arm below exactly (its own `n`
+        // evaluation always goes through the ordinary evaluator) -- a
+        // `key`/`parent`/`file_index` inside `n` is a narrower, rarer gap
+        // left unaddressed, same scoping precedent as `AsPattern`'s own
+        // `?//`-chain exclusion above.
+        Expr::Limit { expr, .. } => needs_path_context(expr),
         _ => false,
     }
 }
@@ -28987,6 +28998,88 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     let bindings = extract_pattern_bindings(&patterns[0], bound_val, false)?;
                     Ok(substitute_vars(body, as_var_refs(&bindings)))
                 },
+            )
+        }
+        // `limit(n; expr)` (#1765, item 2 of #1663's own remaining-gaps
+        // list): `n` is evaluated through the ordinary evaluator, exactly
+        // like `eval_limit` itself -- only `expr` (this arm's own guard,
+        // via `needs_path_context`) is threaded through this eager
+        // evaluator instead. `n` producing more than one output isn't
+        // handled here (mirrors `eval_owned_expr_opt`'s own single-value
+        // contract, already relied on by the `Object`/`Array`/`Literal`
+        // arm below) -- a narrower, rarer gap than this fix's own repro
+        // (`limit(1; key)`), left unaddressed like the `?//`-chain
+        // exclusion above.
+        //
+        // This evaluator is fully eager, unlike `each_take_n`'s lazy "pull
+        // at most n, then stop" generator (#820's own fix) -- but this arm
+        // only runs when `expr` needs path context (rare), so the common
+        // case stays on `eval_limit`'s existing lazy path, untouched.
+        // Trading #820's stop-early optimization for correctness in the
+        // one shape that needs it is the accepted cost here, not a
+        // regression of the common case.
+        Expr::Limit { n, expr } if needs_path_context(expr) => {
+            let n_value = match eval_owned_expr_opt::<S>(n, value, optional) {
+                Ok(Some(v)) => v,
+                Ok(None) => return QueryResult::None,
+                Err(escape) => return escape.into(),
+            };
+            let limited = match classify_limit_n(n_value) {
+                Ok(LimitN::Unlimited) => eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(expr),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ),
+                Ok(LimitN::Take(0)) => QueryResult::None,
+                Ok(LimitN::Take(n)) => match eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(expr),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ) {
+                    QueryResult::Owned(v) => QueryResult::Owned(v),
+                    QueryResult::ManyOwned(mut vs) => {
+                        vs.truncate(n);
+                        owned_vec_to_result(vs)
+                    }
+                    QueryResult::None => QueryResult::None,
+                    QueryResult::Error(e) => QueryResult::Error(e),
+                    QueryResult::Break(label) => QueryResult::Break(label),
+                    QueryResult::Halt(code) => QueryResult::Halt(code),
+                    // Enough outputs arrived before the trailing control
+                    // fired: drop it, matching `limit_with_n`'s own
+                    // `Flow::Stopped`/`Flow::Exhausted` arms. Otherwise the
+                    // terminator is what `limit` actually reaches, matching
+                    // `limit_with_n`'s own `Flow::Escaped` arm.
+                    QueryResult::Partial(mut vs, control) => {
+                        if vs.len() >= n {
+                            vs.truncate(n);
+                            owned_vec_to_result(vs)
+                        } else {
+                            partial(vs, control)
+                        }
+                    }
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                },
+                Err(e) => return QueryResult::Error(e),
+            };
+            continue_rest_with_context::<W, S>(
+                limited,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
             )
         }
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6863,34 +6863,35 @@ fn test_as_path_context_builtin_body_loop_arms_1663() -> Result<()> {
     Ok(())
 }
 
-/// Documents three deliberate, narrow gaps #1663 leaves open rather than
+/// Documents two deliberate, narrow gaps #1663 leaves open rather than
 /// silently missing: `needs_path_context` still has no dedicated evaluation
-/// arm for `Expr::Reduce`, `Expr::Foreach`, or `Expr::Limit`, so a
-/// path-context builtin inside any of these three still falls through to the
-/// generic fallback and stubs to its zero default, exactly as before this
-/// fix. `Expr::Object` has the identical gap but is tracked separately as
-/// #1332 (already true before #1663, per the `Array` arm's own doc comment).
+/// arm for `Expr::Reduce` or `Expr::Foreach`, so a path-context builtin
+/// inside either still falls through to the generic fallback and stubs to
+/// its zero default, exactly as before this fix. `Expr::Object` has the
+/// identical gap but is tracked separately as #1332 (already true before
+/// #1663, per the `Array` arm's own doc comment).
 ///
-/// `Expr::As` (#1663) and the single-pattern case of `Expr::AsPattern`
-/// (#1765) -- the two most consequential shapes, since they're the ordinary
-/// `EXPR as $v | body` / `EXPR as PATTERN | body` idioms -- are both fixed;
-/// see `test_as_pattern_single_pattern_path_context_resolves_1765` for that
-/// coverage. A `?//`-chained `AsPattern` (2+ alternatives) is intentionally
-/// still a known gap alongside the three below -- its retry-on-failure
-/// semantics are real complexity #1765 didn't attempt to replicate, per that
-/// issue's own scoping.
+/// `Expr::As` (#1663), the single-pattern case of `Expr::AsPattern` (#1765),
+/// and `Expr::Limit` (#1765) -- the most consequential shapes, since the
+/// first two are the ordinary `EXPR as $v | body` / `EXPR as PATTERN | body`
+/// idioms -- are all fixed; see `test_as_pattern_single_pattern_path_context_resolves_1765`
+/// and `test_limit_path_context_resolves_1765` for that coverage. A
+/// `?//`-chained `AsPattern` (2+ alternatives) is intentionally still a known
+/// gap alongside the two below -- its retry-on-failure semantics are real
+/// complexity #1765 didn't attempt to replicate, per that issue's own
+/// scoping.
 ///
-/// None of the remaining four shapes (reduce/foreach/limit, plus `?//`) have
-/// a real-yq oracle to verify a fix against (yq's lexer rejects destructuring
-/// `as`, `reduce`, `foreach`, and `limit` outright), and `Reduce`/`Foreach`
-/// in particular raise a real semantic question (what should `key` mean
-/// while evaluating the fold's own accumulator, which has no document
-/// position?) that #1663's own investigation didn't settle. Filed as a
-/// follow-up rather than guessed at here. Pinned so a future regression or
-/// accidental fix is visible either way, matching #1306's identical "known
-/// gap" precedent (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
+/// None of the remaining three shapes (reduce/foreach, plus `?//`) have a
+/// real-yq oracle to verify a fix against (yq's lexer rejects destructuring
+/// `as`, `reduce`, and `foreach` outright), and `Reduce`/`Foreach` in
+/// particular raise a real semantic question (what should `key` mean while
+/// evaluating the fold's own accumulator, which has no document position?)
+/// that #1663's own investigation didn't settle. Filed as a follow-up rather
+/// than guessed at here. Pinned so a future regression or accidental fix is
+/// visible either way, matching #1306's identical "known gap" precedent
+/// (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
 #[test]
-fn test_reduce_foreach_limit_path_context_still_known_gaps_1663() -> Result<()> {
+fn test_reduce_foreach_path_context_still_known_gaps_1663() -> Result<()> {
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | reduce .[] as $x (key; .)"],
         Some(r#"{"a":[1,2]}"#),
@@ -6905,16 +6906,55 @@ fn test_reduce_foreach_limit_path_context_still_known_gaps_1663() -> Result<()> 
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "[null,null]");
 
-    let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(1; key)]"], Some(r#"{"a":1}"#))?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "[null]");
-
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | . as [$x] ?// {b:$x} | key"],
         Some(r#"{"a":[1]}"#),
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "null");
+
+    Ok(())
+}
+
+/// #1765 item 2: `Expr::Limit`'s body expression now resolves
+/// `key`/`parent`/`file_index` against the caller's own ambient position,
+/// via a hybrid dispatch (mirrors `eval_binary_fanout_with_path_context`'s
+/// existing per-operand hybrid) that only routes through the eager
+/// path-context evaluator when the body actually needs it -- the common
+/// case (no path-context builtin in the body) stays on `each_take_n`'s
+/// existing lazy "pull at most n, then stop" path (#820), untouched.
+#[test]
+fn test_limit_path_context_resolves_1765() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(1; key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[\"a\"]");
+
+    // Multiple outputs: only the first `n` are taken, matching `limit`'s
+    // own established semantics.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [limit(2; .[] | key)]"],
+        Some(r#"{"a":[10,20,30]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[0,1]");
+
+    // `limit(0; ...)` still short-circuits to no output at all, even with a
+    // path-context body.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(0; key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
+
+    // A negative/`null` `n` means "no limit at all" (#983) -- still resolves
+    // through the path-context arm's `LimitN::Unlimited` case.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [limit(-1; key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[\"a\"]");
+
+    // The common case (no path-context builtin in the body) is unaffected --
+    // still routes through the existing lazy `each_take_n` path.
+    let (stdout, _, code) = run_jq_full(&["-c", "[limit(2; .[])]"], Some(r"[1,2,3,4,5]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1,2]");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6959,6 +6959,30 @@ fn test_limit_path_context_resolves_1765() -> Result<()> {
     Ok(())
 }
 
+/// #1964 (found in review of this fix): pre-existing, unrelated to `limit`
+/// itself -- `eval_pipe_with_path_context_internal`'s `Expr::Comma` arm
+/// routes every branch through this same evaluator, including a branch that
+/// doesn't need path context at all (`range(0;5)`), which then falls to the
+/// generic `Expr::Builtin(_)` catch-all's single-output `eval_owned_expr_opt`
+/// and collapses the whole multi-output builtin into one array. Reachable on
+/// `main` today without `limit` (`.a | [(range(0;5), key)]` already gives
+/// `[[0,1,2,3,4],"a"]`) -- this fix's own new `Expr::Limit` routing just
+/// makes it reachable through `limit`'s body too, since it evaluates that
+/// body through the identical evaluator. Pinned here rather than fixed,
+/// matching #1964's own scoping (a general fix belongs to that evaluator's
+/// `Comma`/`Builtin` combination, not this narrower `Limit`-specific PR).
+#[test]
+fn test_limit_path_context_inherits_comma_multi_output_collapse_known_gap_1964() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [limit(2; (range(0;5), key))]"],
+        Some(r#"{"a":"x"}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[[0,1,2,3,4],\"a\"]");
+
+    Ok(())
+}
+
 /// #1765: `Expr::AsPattern`'s single-pattern case (no `?//` alternatives)
 /// now resolves `key`/`parent`/`file_index` against the caller's own ambient
 /// position, mirroring #1663's `Expr::As` fix -- both array and object


### PR DESCRIPTION
## Summary

Item 2 of #1765's own suggested ordering (item 1, `Expr::AsPattern`, was already fixed in #1786).

`needs_path_context` had no arm for `Expr::Limit`, so `key`/`parent`/`file_index` inside `limit(n; expr)`'s body silently stubbed to their zero defaults instead of resolving against the caller's own ambient position:

```console
$ echo '{"a":1}' | succinctly jq -c '.a | [limit(1; key)]'
[null]     # before this fix
["a"]      # after
```

## Fix

Hybrid dispatch, mirroring `eval_binary_fanout_with_path_context`'s existing per-operand hybrid:
- `n` is evaluated through the ordinary evaluator (unchanged).
- `expr` (the body) only routes through the eager path-context evaluator when `needs_path_context(expr)` is true, then gets truncated to `n` outputs afterward.
- The common case (no path-context builtin in the body) stays on `each_take_n`'s existing lazy "pull at most n, then stop" path (#820), completely untouched.

This does trade #820's stop-early optimization for correctness in the one (rare) shape that needs it, but only for queries that actually reference `key`/`parent`/`file_index` inside a `limit(...)` body, which were already broken (silently wrong output) before this fix.

**Scope**: `n` itself needing path context (e.g. `limit(key; ...)`), and `Expr::Reduce`/`Expr::Foreach` (items 3-4 of #1765's own ordering), remain open — left for a follow-up, per that issue's own "each shape is independently shippable" framing.

## Review findings addressed

Three rounds of review found and addressed:
- A duplicate `eval_pipe_with_path_context_internal` call (identical args in both the `Unlimited` and `Take(n)` branches) — collapsed to one, made after peeling off `Take(0)` first (which must still skip evaluating `expr` at all, per jq's own `elif $n==0 then empty`).
- A pre-existing, unrelated bug this fix's own routing makes newly reachable through `limit`: `eval_pipe_with_path_context_internal`'s `Expr::Comma` arm collapses a multi-output builtin like `range()` mixed with a path-context builtin into one array. Reachable on `main` today without `limit` at all (`.a | [(range(0;5), key)]` already gives the wrong `[[0,1,2,3,4],"a"]`) — filed as #1964, pinned here with a test documenting it as a known gap rather than attempted in this PR.
- This fix only reaches the CLI (`eval_generic.rs`) when `limit(...)` sits inside an enclosing `Pipe`/`Array`, whose own `needs_path_context` scan triggers the bridge — a genuinely standalone top-level `limit(n; expr)` still bypasses it. No observably-wrong repro was found for that case (`key`/`parent`/`file_index` with no prior navigation are legitimately null/root-equivalent either way), so documented as a caveat rather than fixed.

## Test plan
- [x] New/updated tests in `tests/jq_cli_tests.rs`: `test_limit_path_context_resolves_1765` (new), `test_limit_path_context_inherits_comma_multi_output_collapse_known_gap_1964` (new, pins #1964), `test_reduce_foreach_path_context_still_known_gaps_1663` (renamed from `test_reduce_foreach_limit_path_context_still_known_gaps_1663`, `limit` case removed since it's now fixed)
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, re-run after each review round)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Refs #1765
