### PR TITLE
test(jq): cross-site consistency test for #1803's 5 duplicated traversal functions

### DIFF
--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1877,6 +1877,36 @@ fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<(
     Ok(())
 }
 
+/// Runs `succinctly jq <extra_args> <filter>` over `doc` and asserts it
+/// raises with `code` and a stderr containing `expect_stderr` -- shared by
+/// [`test_select_and_materialize_agree_on_corruption_1645`]'s three
+/// comparison arms so each one asserts on the *message*, not just the exit
+/// code (#1803 code review: an exit-code-only check can't tell "the expected
+/// corruption was caught" from "an unrelated bug in this arm's own code path
+/// happened to raise the same code").
+fn assert_jq_raises(
+    label: &str,
+    op_label: &str,
+    extra_args: &[&str],
+    filter: &str,
+    doc: &str,
+    code: i32,
+    expect_stderr: &str,
+) {
+    let mut args: Vec<&str> = extra_args.to_vec();
+    args.push(filter);
+    let (out, err, actual_code) = run_jq_full(&args, Some(doc))
+        .unwrap_or_else(|e| panic!("[{label}] {op_label} run failed: {e}"));
+    assert_eq!(
+        actual_code, code,
+        "[{label}] {op_label} must raise\nstdout: {out:?}\nstderr: {err:?}"
+    );
+    assert!(
+        err.contains(expect_stderr),
+        "[{label}] {op_label} stderr must contain {expect_stderr:?}\nstderr: {err:?}"
+    );
+}
+
 /// #1645 code review: `push_generic_truthiness_cursor_error` is a second,
 /// hand-copied implementation of the same "walk and raise on corruption"
 /// predicate `to_owned_at_depth`/`to_owned_cursor_at_depth`/
@@ -1896,59 +1926,78 @@ fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<(
 /// for a genuine cross-site divergence and found none here -- the real bug
 /// that investigation surfaced (#1960) turned out to be an unrelated YAML
 /// flow-scalar parser bug, not a traversal-function disagreement.
+///
+/// **Known scope limit** (#1803 code review): this is example-based
+/// coverage over a hand-picked case list, not an exhaustive or randomized
+/// check -- see `.claude/skills/testing/SKILL.md`'s "Invariant Tests Over
+/// Duplicated Logic" section for why a corpus-wide or fuzzed cross-check
+/// catches more of this bug class than a fixed list ever can. A differential
+/// fuzzer varying nesting depth/format/malformation kind across these same
+/// three CLI paths would close that gap; not attempted here to keep this PR
+/// to the scope it actually verified (see #1803's own comment thread).
 #[test]
 fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
+    let decode_failure_err = "invalid escape sequence";
+    let structural_err = "unexpected character";
+    let collision_err = "ambiguous";
+
     let cases = [
-        ("decode failure, top level", r#"{"bad": "\x", "keep": 5}"#),
+        (
+            "decode failure, top level",
+            r#"{"bad": "\x", "keep": 5}"#,
+            decode_failure_err,
+        ),
         (
             "decode failure, nested in array",
             r#"{"bad": ["\x"], "keep": 5}"#,
+            decode_failure_err,
         ),
         (
             "decode failure, nested in object",
             r#"{"bad": {"x": "\x"}, "keep": 5}"#,
+            decode_failure_err,
         ),
         (
             "structural error, top level",
             r#"{"bad": xyz123, "keep": 5}"#,
+            structural_err,
         ),
         (
             "structural error, nested in array",
             r#"{"bad": [xyz123], "keep": 5}"#,
+            structural_err,
         ),
         (
             "structural error, nested in object",
             r#"{"bad": {"x": xyz123}, "keep": 5}"#,
+            structural_err,
         ),
         (
             "#1642 colliding decode-failure keys",
             r#"{"bad": {"\ud800":1,"\ud800":2}, "keep": 5}"#,
+            collision_err,
         ),
     ];
 
-    for (label, doc) in cases {
-        let (select_out, select_err, select_code) =
-            run_jq_full(&["select(.bad) | .keep"], Some(doc))
-                .unwrap_or_else(|e| panic!("[{label}] select run failed: {e}"));
-        assert_eq!(
-            select_code, 5,
-            "[{label}] select(.bad) must raise\nstdout: {select_out:?}\nstderr: {select_err:?}"
+    for (label, doc, expect_stderr) in cases {
+        assert_jq_raises(
+            label,
+            "select(.bad)",
+            &[],
+            "select(.bad) | .keep",
+            doc,
+            5,
+            expect_stderr,
         );
-
-        let (materialize_out, materialize_err, materialize_code) =
-            run_jq_full(&["-Sc", ".bad"], Some(doc))
-                .unwrap_or_else(|e| panic!("[{label}] materialize run failed: {e}"));
-        assert_eq!(
-            materialize_code, 5,
-            "[{label}] -Sc .bad must raise the same way select's condition walk does\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
-        );
-
-        let (exit_status_out, exit_status_err, exit_status_code) =
-            run_jq_full(&["-e", ".bad"], Some(doc))
-                .unwrap_or_else(|e| panic!("[{label}] -e run failed: {e}"));
-        assert_eq!(
-            exit_status_code, 5,
-            "[{label}] -e .bad must raise the same way select/-Sc do (cursor_to_owned_at_depth, lazy.rs)\nstdout: {exit_status_out:?}\nstderr: {exit_status_err:?}"
+        assert_jq_raises(label, "-Sc .bad", &["-Sc"], ".bad", doc, 5, expect_stderr);
+        assert_jq_raises(
+            label,
+            "-e .bad (cursor_to_owned_at_depth, lazy.rs)",
+            &["-e"],
+            ".bad",
+            doc,
+            5,
+            expect_stderr,
         );
     }
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1879,14 +1879,23 @@ fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<(
 
 /// #1645 code review: `push_generic_truthiness_cursor_error` is a second,
 /// hand-copied implementation of the same "walk and raise on corruption"
-/// predicate `to_owned_cursor_at_depth` already implements for
-/// materialization (`-S`, `-s`, `.,.`) -- the exact "duplicated predicate"
-/// shape this repo's own testing guidance warns diverges silently unless a
-/// test pins that every site agrees, not just that each is individually
-/// correct (see the `testing` skill and CLAUDE.md's "Duplicated predicates
-/// diverge silently" note, #106). For each malformed shape below, checks
-/// that `select(.bad) | .keep` (the new walk) and `-Sc .` on the bare `.bad`
-/// value (the pre-existing materializing walk) raise on the *same* input.
+/// predicate `to_owned_at_depth`/`to_owned_cursor_at_depth`/
+/// `cursor_to_owned_at_depth` (`lazy.rs`) already implement for
+/// materialization -- the exact "duplicated predicate" shape this repo's own
+/// testing guidance warns diverges silently unless a test pins that every
+/// site agrees, not just that each is individually correct (see the
+/// `testing` skill and CLAUDE.md's "Duplicated predicates diverge silently"
+/// note, #106). #1803 extended this from 2 sites to 3: `select(.bad) | .keep`
+/// (`push_generic_truthiness_cursor_error`), `-Sc .bad` (`to_owned_at_depth`,
+/// confirmed live via temporary tracing -- `-S` does *not* route through the
+/// cursor-aware sibling despite the name resemblance), and `-e .bad`
+/// (`cursor_to_owned_at_depth`, `lazy.rs` -- a JSON-only fourth
+/// implementation with no `DocumentValue`/`DocumentCursor` generic bound,
+/// reached only via `--exit-status`'s `JqValue::materialize()` path, #1098's
+/// own doc comment). All three agree on every case below; #1803 also probed
+/// for a genuine cross-site divergence and found none here -- the real bug
+/// that investigation surfaced (#1960) turned out to be an unrelated YAML
+/// flow-scalar parser bug, not a traversal-function disagreement.
 #[test]
 fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
     let cases = [
@@ -1932,6 +1941,14 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
         assert_eq!(
             materialize_code, 5,
             "[{label}] -Sc .bad must raise the same way select's condition walk does\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
+        );
+
+        let (exit_status_out, exit_status_err, exit_status_code) =
+            run_jq_full(&["-e", ".bad"], Some(doc))
+                .unwrap_or_else(|e| panic!("[{label}] -e run failed: {e}"));
+        assert_eq!(
+            exit_status_code, 5,
+            "[{label}] -e .bad must raise the same way select/-Sc do (cursor_to_owned_at_depth, lazy.rs)\nstdout: {exit_status_out:?}\nstderr: {exit_status_err:?}"
         );
     }
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1762,6 +1762,29 @@ fn test_yaml_native_dom_ordinary_repeated_key_still_overwrites_1749() -> Result<
     Ok(())
 }
 
+/// Runs a yq filter over `yaml` with `extra_args` and asserts it raises with
+/// a stderr containing `expect_stderr` -- shared by
+/// [`test_select_and_write_agree_on_corruption_1803`]'s comparison arms so
+/// each one asserts on the *message*, not just a nonzero exit code (#1803
+/// code review: exit-code-only can't distinguish "the expected corruption
+/// was caught" from an unrelated bug that happens to also raise).
+fn assert_yq_raises(
+    label: &str,
+    op_label: &str,
+    filter: &str,
+    yaml: &str,
+    extra_args: &[&str],
+    expect_stderr: &str,
+) {
+    let (_out, err, code) = run_yq_stdin_with_stderr(filter, yaml, extra_args)
+        .unwrap_or_else(|e| panic!("[{label}] {op_label} run failed: {e}"));
+    assert_eq!(code, 1, "[{label}] {op_label} must raise, stderr: {err}");
+    assert!(
+        err.contains(expect_stderr),
+        "[{label}] {op_label} stderr must contain {expect_stderr:?}, stderr: {err}"
+    );
+}
+
 /// #1803: `select(.bad) | .keep` (`push_generic_truthiness_cursor_error`)
 /// and a write op (`.keep = 9`, which forces the YAML DOM path per ADR-0017
 /// -- `to_owned_with_comments_at_depth`/`to_owned_at_depth`/
@@ -1773,31 +1796,81 @@ fn test_yaml_native_dom_ordinary_repeated_key_still_overwrites_1749() -> Result<
 /// bareword like `xyz123`) has no YAML analog (it's a perfectly valid plain
 /// scalar there), so only the two malformation classes meaningful in both
 /// formats -- a decode failure and a #1642 colliding-key collision -- are
-/// covered here.
+/// covered here, at the same three nesting depths (top/array/object) the
+/// JSON test uses.
+///
+/// A third, pre-existing comparison route for a *nested* YAML decode failure
+/// (`select` vs. `.bad,.bad`, yq's multi-output materializing path) already
+/// lives in `test_select_raises_on_yaml_decode_failure_nested_in_container_1645`
+/// above -- this test adds a third arm of its own (`.keep = 9 -o=json`) to
+/// every case, confirming the DOM-write path agrees under `-o=json` output
+/// too, not just the default YAML output the rest of this test (and that
+/// pre-existing one) exercise.
+///
+/// **Known scope limits** (#1803 code review, same caveat as the JSON test's
+/// own doc comment): example-based coverage over a hand-picked case list,
+/// not exhaustive or randomized. Additionally, the write op exercises three
+/// functions together (`to_owned_with_comments_at_depth`/`to_owned_at_depth`/
+/// `to_owned_cursor_at_depth`) and can only tell "the write path as a whole
+/// raised," not "all three functions individually agree" -- a regression
+/// isolated to just one of the three, masked by another still raising
+/// downstream, would not be caught here.
 #[test]
 fn test_select_and_write_agree_on_corruption_1803() -> Result<()> {
+    let decode_failure_err = "invalid escape sequence";
+    let collision_err = "ambiguous";
+
     let cases = [
-        ("decode failure", "bad: \"a\\qb\"\nkeep: 5\n"),
+        (
+            "decode failure, top level",
+            r#"bad: "a\qb"
+keep: 5
+"#,
+            decode_failure_err,
+        ),
+        (
+            "decode failure, nested in array",
+            r#"bad: ["a\qb"]
+keep: 5
+"#,
+            decode_failure_err,
+        ),
+        (
+            "decode failure, nested in object",
+            r#"bad:
+  x: "a\qb"
+keep: 5
+"#,
+            decode_failure_err,
+        ),
         (
             "#1642 colliding decode-failure keys",
-            "bad:\n  \"a\\qb\": 1\n  \"a\\zc\": 2\nkeep: 5\n",
+            r#"bad:
+  "a\qb": 1
+  "a\zc": 2
+keep: 5
+"#,
+            collision_err,
         ),
     ];
 
-    for (label, yaml) in cases {
-        let (_select_out, select_err, select_code) =
-            run_yq_stdin_with_stderr("select(.bad) | .keep", yaml, &[])
-                .unwrap_or_else(|e| panic!("[{label}] select run failed: {e}"));
-        assert_eq!(
-            select_code, 1,
-            "[{label}] select(.bad) must raise, stderr: {select_err}"
+    for (label, yaml, expect_stderr) in cases {
+        assert_yq_raises(
+            label,
+            "select(.bad)",
+            "select(.bad) | .keep",
+            yaml,
+            &[],
+            expect_stderr,
         );
-
-        let (_write_out, write_err, write_code) = run_yq_stdin_with_stderr(".keep = 9", yaml, &[])
-            .unwrap_or_else(|e| panic!("[{label}] write run failed: {e}"));
-        assert_eq!(
-            write_code, 1,
-            "[{label}] .keep = 9 must raise the same way select's condition walk does, stderr: {write_err}"
+        assert_yq_raises(label, ".keep = 9", ".keep = 9", yaml, &[], expect_stderr);
+        assert_yq_raises(
+            label,
+            ".keep = 9 -o=json",
+            ".keep = 9",
+            yaml,
+            &["-o=json"],
+            expect_stderr,
         );
     }
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1762,6 +1762,47 @@ fn test_yaml_native_dom_ordinary_repeated_key_still_overwrites_1749() -> Result<
     Ok(())
 }
 
+/// #1803: `select(.bad) | .keep` (`push_generic_truthiness_cursor_error`)
+/// and a write op (`.keep = 9`, which forces the YAML DOM path per ADR-0017
+/// -- `to_owned_with_comments_at_depth`/`to_owned_at_depth`/
+/// `to_owned_cursor_at_depth` all get exercised together building it,
+/// confirmed live via temporary tracing) must agree on whether a malformed
+/// `.bad` sibling raises. JSON's equivalent 3-way comparison lives in
+/// `test_select_and_materialize_agree_on_corruption_1645`
+/// (`tests/jq_cli_tests.rs`) -- JSON's own "structural error" (an unquoted
+/// bareword like `xyz123`) has no YAML analog (it's a perfectly valid plain
+/// scalar there), so only the two malformation classes meaningful in both
+/// formats -- a decode failure and a #1642 colliding-key collision -- are
+/// covered here.
+#[test]
+fn test_select_and_write_agree_on_corruption_1803() -> Result<()> {
+    let cases = [
+        ("decode failure", "bad: \"a\\qb\"\nkeep: 5\n"),
+        (
+            "#1642 colliding decode-failure keys",
+            "bad:\n  \"a\\qb\": 1\n  \"a\\zc\": 2\nkeep: 5\n",
+        ),
+    ];
+
+    for (label, yaml) in cases {
+        let (_select_out, select_err, select_code) =
+            run_yq_stdin_with_stderr("select(.bad) | .keep", yaml, &[])
+                .unwrap_or_else(|e| panic!("[{label}] select run failed: {e}"));
+        assert_eq!(
+            select_code, 1,
+            "[{label}] select(.bad) must raise, stderr: {select_err}"
+        );
+
+        let (_write_out, write_err, write_code) = run_yq_stdin_with_stderr(".keep = 9", yaml, &[])
+            .unwrap_or_else(|e| panic!("[{label}] write run failed: {e}"));
+        assert_eq!(
+            write_code, 1,
+            "[{label}] .keep = 9 must raise the same way select's condition walk does, stderr: {write_err}"
+        );
+    }
+    Ok(())
+}
+
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion
 /// (`yaml_to_owned_value`) #442 didn't touch, so it kept collapsing
 /// duplicate keys within each slurped element even after plain `yq '.'`


### PR DESCRIPTION
Partial progress on #1803 — does not close it (the full generic-unification refactor remains open, see below).

## Summary

#1803 asked to unify 5 duplicated object/array traversal functions (`to_owned_at_depth`, `to_owned_cursor_at_depth`, `to_owned_with_comments_at_depth`, `cursor_to_owned_at_depth` in `lazy.rs`, `push_generic_truthiness_cursor_error`) behind one generic core, and separately suggested a cross-site consistency test as a concrete, safe deliverable regardless of the refactor's shape.

**Investigated all 5 sites in depth before deciding scope.** Two findings changed the plan from a full unification to a test-only PR:

1. `cursor_to_owned_at_depth` (`lazy.rs`) is **JSON-only** (`JsonCursor<'_, W>`, not generic over `DocumentValue`/`DocumentCursor` like the other 4) — reached via `-e`/`--exit-status`. It's a structurally different function, not a 5th instance of the same generic shape, so folding it into one core with the other 4 is a bigger design question than the issue's framing suggested.
2. The `#1677`-style delimiter checks that differ between `to_owned_with_comments_at_depth` and its siblings are actually **no-ops for YAML** — confirmed via the trait's own doc comment ("every format but JSON validates delimiters while parsing") and the missing override in `yaml/light.rs`. While probing for a real cross-site divergence to justify the unification's value, I found a genuine, live, silent-data-loss bug — but its root cause turned out to be an unrelated YAML flow-scalar *parser* bug, not a traversal-function disagreement. Filed separately as #1960.

Given the full unification spans genuinely different generic bounds (plus the JSON-only outlier) and the issue's own "not prescribing the exact shape — worth a design pass" language, this PR scopes to the one deliverable that's unambiguously safe and valuable regardless of how that design pass concludes: the consistency test.

## Changes

- Extended `test_select_and_materialize_agree_on_corruption_1645` (`tests/jq_cli_tests.rs`) from 2-way (`select` vs `-Sc`) to 3-way, adding `-e` (reaches `cursor_to_owned_at_depth`).
- Added `test_select_and_write_agree_on_corruption_1803` (`tests/yq_cli_tests.rs`), comparing `select` against a write op (which exercises `to_owned_with_comments_at_depth`/`to_owned_at_depth`/`to_owned_cursor_at_depth` together) for the two malformation classes meaningful in both JSON and YAML (decode failure, #1642 colliding keys — JSON's "structural error" bareword concept has no YAML analog).

All cases agree today — this is a regression net for the eventual unification, not a behavior change. Confirmed which function each CLI incantation reaches via temporary tracing (removed before commit) rather than assuming from static reading, given `-S`/`-Sc` turned out **not** to route through the cursor-aware sibling despite the name resemblance.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 1309 lib tests + all integration suites pass
- [x] `cargo test` (default features) — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo build --no-default-features` — builds
- [x] `cargo fmt --check` — clean