### PR TITLE
perf(jq): grow the duplicate-key table at 3/4 load, not 1/2 (refs #1588)

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1276,15 +1276,25 @@ impl KeyHashes {
         }
     }
 
-    /// A table sized for `keys` insertions without a rehash: capacity is
-    /// the next power of two at or above `2 * keys`, keeping the load
-    /// factor at or below one half.
+    /// A table sized for `keys` insertions without a rehash: capacity is the
+    /// next power of two at or above `4 * keys / 3`, matching
+    /// [`insert`](Self::insert)'s own three-quarter growth threshold.
+    ///
+    /// Kept in step with that threshold deliberately (#1588). It used to
+    /// round up from `2 * keys` for the old one-half factor, and leaving it
+    /// there would have made this constructor allocate a table one power of
+    /// two larger than the growth path reaches for the same key count --
+    /// 2^21 rather than 2^20 slots at 629,881 keys. That matters because
+    /// this is exactly the constructor #1588's "give the table a capacity
+    /// hint" direction points at: wiring it up while it disagreed with
+    /// `insert` would have silently restored the memory this change removes.
     pub fn with_capacity(keys: usize) -> Self {
         if keys == 0 {
             return Self::new();
         }
         let slots = keys
-            .saturating_mul(2)
+            .saturating_mul(4)
+            .div_ceil(3)
             .next_power_of_two()
             .max(Self::MIN_SLOTS);
         Self {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1299,9 +1299,16 @@ impl KeyHashes {
     /// `true` means "these keys may be the same" -- see the type's note on
     /// conservatism.
     pub fn insert(&mut self, hash: u64) -> bool {
-        // Grow before inserting so the load factor never exceeds one half;
-        // past that, linear probing's run lengths climb sharply.
-        if (self.len + 1) * 2 > self.slots.len() {
+        // Grow before inserting so the load factor never exceeds three
+        // quarters. It was one half until #1588: linear probing's run
+        // lengths do climb past that, but the table also halves, and on a
+        // wide object the locality wins outright -- measured on `wide/10mb`
+        // (629,881 keys), `keys_unsorted` went 52.8 -> 36.9 MiB peak RSS and
+        // *also* 0.106 -> 0.099s. A sweep says 3/4 is the point: 7/8 and
+        // 15/16 buy no further memory (the same power-of-two table serves
+        // all three at this key count) and only pay more probing, measuring
+        // 0.114s and 0.115s respectively.
+        if (self.len + 1) * 4 > self.slots.len() * 3 {
             self.grow();
         }
         let hash = if hash == 0 { 1 } else { hash };


### PR DESCRIPTION
Refs #1588 — a partial improvement. **It does not fix that issue's headline case**, and the issue should stay open; see "What this does not fix".

## The change

The streaming duplicate-key detector keeps 16 bytes per key at load 0.5, where the batch paths keep 8. One line: grow at **3/4** load instead of **1/2**.

## Measured on both pinned boxes, idle, `codegen-units=1` (#1587)

**ARM (M4 Pro)**

| workload | keys | `main` | this PR |
|---|---|---|---|
| `wide/10mb` `keys_unsorted` | 629,881 | 89ms, 52 MiB | 87ms, **36 MiB** (−31%) |
| `wide/100mb` `keys_unsorted` | 5,635,780 | 1123ms, 387 MiB | 1057ms, **259 MiB** (−33%) |
| `wide/10mb` `.` | — | 139ms, 55 MiB | 139ms, 55 MiB |
| `wide/100mb` `.` | — | 1556ms, 433 MiB | 1543ms, 433 MiB |

**x86 (7950X)**

| workload | keys | `main` | this PR |
|---|---|---|---|
| `wide/10mb` `keys_unsorted` | 629,881 | 119ms, 42 MiB | 107ms, **30 MiB** (−29%) |
| `wide/100mb` `keys_unsorted` | 5,635,780 | 1431ms, 320 MiB | 1301ms, **225 MiB** (−30%) |
| `wide/7.1M keys` `keys_unsorted` | 7,100,000 | 1736ms, 306 MiB | 1621ms, **306 MiB** (**unchanged**) |

Time is consistently *better* (−7% to −10%), including where memory does not move: at 3/4 each table holds more before growing, so there are fewer rehash passes. Identity never builds the table and is unchanged on both axes.

## What this does not fix — and why the last row matters

Review caught that the benefit is **key-count dependent**, because the table is power-of-two sized. A count benefits only when a power of two falls in `[4k/3, 2k)` — roughly 58% of counts. #1588's own headline case, `wide/100mb` at **7.1M keys / 388.7 MiB**, is in the other 42%: `2^23` holds 4.19M at 1/2 and 6.29M at 3/4, both short of 7.1M, so **both policies pick `2^24` and peak RSS is identical**.

I built a 7.1M-key fixture specifically to confirm that empirically rather than argue it from arithmetic — the last row above. It is unchanged, exactly as predicted.

So this takes most of the memory for most key counts and none for the rest. Closing #1588 properly needs one of its remaining directions (the batch-shape switch above a width threshold), which is a larger change.

## Two of the issue's own directions are hazardous

Worth recording, since both were ranked above this one:

- **Capacity hint (direction 1)** — the only O(1) quantity available is `BalancedParens::subtree_size`, which counts *all* descendants, not direct fields. `{"a": [1M elements]}` is one field with a ~1M subtree; sizing an allocation from it would make RSS worse on nested objects. A loose bound is fine for choosing an *algorithm* (a wrong guess costs a walk), not for sizing memory.
- **Narrower slots (direction 2)** — at 7.1M keys a 32-bit tag gives ~5,900 birthday collisions, each forcing an exact `collapsed_fields` pass, on exactly the workload the issue is about.

## Also in this PR

`with_capacity` was left rounding up from `2 * keys` for the old load factor, so it allocated one power of two more than the growth path now reaches (2^21 vs 2^20 at 629,881 keys). Test-only today, but it is precisely the constructor direction 1 would wire up — leaving it inconsistent would have silently restored the memory this removes.

## Gates

6587 tests / 0 failed; both clippy feature sets, `fmt`, `--no-default-features`, CI's exact rustdoc command.
