### PR TITLE
fix(jq): Expr::Builtin/generic fallback arms preserve multi-output through path-context routing

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1920,7 +1920,7 @@ protocol for `resolve_node`, the same shape `eval_each_owned` already gives valu
 evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
 the two shapes named in #1906/#1935's own repros.
 
-### A generator-argument expression fans out normally, then silently narrows to a single array the moment `key`/`parent`/`file_index` shows up anywhere else in the same pipe
+### A generator-argument expression used to fan out normally, then silently narrow to a single array the moment `key`/`parent`/`file_index` showed up anywhere else in the same pipe -- fixed for 2 of 4 sites
 
 [#1277](https://github.com/rust-works/succinctly/issues/1277)'s clusters 1-3
 (closed by [#1522](https://github.com/rust-works/succinctly/issues/1522)/[#1279](https://github.com/rust-works/succinctly/issues/1279))
@@ -1930,10 +1930,8 @@ Four call sites inside `eval_pipe_with_path_context_internal`
 (`src/jq/eval.rs`) -- `ParentN`'s own `n` argument, the `Expr::Builtin(_)`
 arm, the `Expr::Object`/`Array`/`Literal` arm, and the generic `_` fallback
 -- were an explicit non-goal of that fix, since giving them the same real
-fan-out is a materially larger change (`docs/plan/jq-generator-argument-fanout.md`).
-Those 4 sites route through `eval_owned_expr_opt`/`eval_owned_expr_full`,
-which array-collapses a multi-output expression into a single
-`OwnedValue::Array` instead of fanning out.
+fan-out looked like a materially larger change
+(`docs/plan/jq-generator-argument-fanout.md`).
 
 ```console
 $ echo '{"a":"xax"}' | succinctly jq -c '.a | ltrimstr(("x","z"))'
@@ -1950,18 +1948,16 @@ except for the trailing `key`, which forces the whole pipe through
 `eval_pipe_with_path_context_internal` since `key` needs path tracking --
 `key` itself has no jq oracle (succinctly extension), so this specific
 combination can't be demonstrated as a *jq* divergence in isolation, but it
-is a genuine, demonstrated internal inconsistency: the same sub-expression
-fans out correctly or silently collapses into one array-shaped value
-depending on whether an unrelated path-tracking builtin happens to be
+was a genuine, demonstrated internal inconsistency: the same sub-expression
+fanned out correctly or silently collapsed into one array-shaped value
+depending on whether an unrelated path-tracking builtin happened to be
 anywhere else in the pipe.
 
 **[#1937](https://github.com/rust-works/succinctly/issues/1937) fixed one
-narrow, safe piece of this**: a *zero*-output generator (`(empty)`-style)
-now correctly contributes zero outputs to the enclosing computation, rather
-than an `OwnedValue::Array([])` value -- matching `result_to_owned_full`'s
-identical `#1045` rule for the same `Many`/`ManyOwned` shapes, and with no
-downside, since there is nothing to lose by treating "zero outputs" as "zero
-outputs" instead of manufacturing an empty-array value.
+narrow, safe piece first**: a *zero*-output generator (`(empty)`-style) now
+correctly contributes zero outputs to the enclosing computation, rather than
+an `OwnedValue::Array([])` value -- matching `result_to_owned_full`'s
+identical `#1045` rule for the same `Many`/`ManyOwned` shapes.
 
 **A first attempt at #1937 also tried taking the *first* output instead of
 array-collapsing for the 2+-output case (matching `result_to_owned_full`'s
@@ -1970,38 +1966,52 @@ rejected during `/code-review` before merging, because it introduced a
 strictly worse regression than the one it fixed.** `result_to_owned_full`'s
 take-first policy is correct for *its* callers -- a builtin's single
 generator argument, always consumed exactly once by the builtin's own body.
-But `eval_owned_expr_full` is not scoped that narrowly: its
-`Expr::Builtin(_)` arm also evaluates *zero-arg* generator builtins
-(`recurse`, `range`, `inputs`, ...) whenever they're reached through
-path-context routing, and its generic `_` fallback evaluates arbitrary
-comma branches, `..`, `paths`, `limit`, and anything else with no dedicated
-arm. Live-verified before rejecting the approach:
+But `eval_owned_expr_full` (what that attempt changed) is not scoped that
+narrowly: its `Expr::Builtin(_)` arm also evaluates *zero-arg* generator
+builtins (`recurse`, `range`, `inputs`, ...) whenever they're reached
+through path-context routing, and its generic `_` fallback evaluates
+arbitrary comma branches, `..`, `paths`, `limit`, and anything else with no
+dedicated arm. Take-first would have silently and permanently discarded 2 of
+`recurse`'s 3 outputs with no error and no trace -- reverted before merging.
+
+**[#1964](https://github.com/rust-works/succinctly/issues/1964) closed the
+gap properly for the 2 sites that actually needed it**, without take-first's
+regression: the `Expr::Builtin(_)` arm and the generic `_` fallback now
+route through `eval_owned_input` (which preserves `Many`/`ManyOwned`)
+instead of `eval_owned_expr_opt` (which collapsed to one value).
+`continue_rest_with_context`/`accumulate_path_context_step` -- the functions
+that actually fan a `Comma` branch's output back out into the enclosing
+computation -- already handled `ManyOwned` correctly; they just never used
+to receive one from these two arms. No change was needed to either of them,
+or to `eval_owned_expr_full`/`result_to_owned_full` at all -- #1937's
+mistake was treating this as a policy question for a shared helper, when it
+was really a "the wrong function got called" bug local to these two arms.
 
 ```console
 $ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c '.a | (recurse, key)'
-# with array-collapse (both before and after this issue):
-[{"b":{"c":1}},{"c":1},1]
-"a"
-# with the rejected take-first attempt:
 {"b":{"c":1}}
+{"c":1}
+1
 "a"
+$ echo '{"a":"x"}' | succinctly jq -c '.a | [(range(0;5), key)]'
+[0,1,2,3,4,"a"]
 ```
 
-Array-collapse produces the wrong *shape* (an array instead of 3 fanned-out
-outputs) but keeps every value inspectable. Take-first silently and
-permanently discarded 2 of the 3 `recurse` outputs with no error and no
-trace -- a materially larger, harder-to-notice correctness gap than the one
-narrow `ltrimstr`+`key` example this section documents, reachable through
-two everyday builtins (`recurse`/`range`-style generators, and `..`) rather
-than only the argument-fan-out case #1937 was filed against. Reverted;
-`tests/jq_cli_tests.rs`'s `test_path_context_builtin_arm_multi_output_still_array_collapses_1937`
-and `test_path_context_generic_fallback_recurse_still_array_collapses_1937`
-pin the current (still wrong-shaped, but not lossy) array-collapse behavior
-as a regression guard against re-attempting take-first without also solving
-the zero-arg-generator/generic-fallback exposure.
+Both now match real jq's own fan-out shape (confirmed against jq 1.7.1 with
+a literal substituted for `key`, which has no oracle):
+`jq -c '.a | [recurse]'` and `jq -c '.a | [(range(0;5), "a")]'` give the
+identical value sequences.
 
-Full fan-out for all 4 sites remains the only fix that would actually match
-real jq here, and remains out of scope per #1522's design doc.
+**Two sites remain unfixed**: `ParentN`'s own `n` argument (`parent((1,2))`
+still array-collapses `n` to `[1,2]`, then errors on the wrong type -- a
+narrower, lower-traffic case than the two builtin/fallback arms #1964
+covered, not attempted there) and the `Expr::Object`/`Array`/`Literal` arm
+(in practice not known to be live-reachable with a genuine `Many`/`ManyOwned`
+result -- `Expr::Object` isn't included in `needs_path_context`'s own
+recursion, and `Array`/`Literal` collect an inner generator into one
+container value rather than splitting across top-level outputs, per #1937's
+own review investigation). Full fan-out for these two, if ever needed,
+remains out of scope per #1522's design doc.
 
 ## Provenance
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1920,7 +1920,7 @@ protocol for `resolve_node`, the same shape `eval_each_owned` already gives valu
 evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
 the two shapes named in #1906/#1935's own repros.
 
-### A generator-argument expression used to fan out normally, then silently narrow to a single array the moment `key`/`parent`/`file_index` showed up anywhere else in the same pipe -- fixed for 2 of 4 sites
+### A generator-argument expression used to fan out normally, then silently narrow to a single array the moment `key`/`parent`/`file_index` showed up anywhere else in the same pipe -- fixed for 3 of 4 sites
 
 [#1277](https://github.com/rust-works/succinctly/issues/1277)'s clusters 1-3
 (closed by [#1522](https://github.com/rust-works/succinctly/issues/1522)/[#1279](https://github.com/rust-works/succinctly/issues/1279))
@@ -1975,17 +1975,26 @@ dedicated arm. Take-first would have silently and permanently discarded 2 of
 `recurse`'s 3 outputs with no error and no trace -- reverted before merging.
 
 **[#1964](https://github.com/rust-works/succinctly/issues/1964) closed the
-gap properly for the 2 sites that actually needed it**, without take-first's
-regression: the `Expr::Builtin(_)` arm and the generic `_` fallback now
+gap properly for 3 of the 4 sites**, without take-first's regression: the
+`Expr::Builtin(_)` arm, the generic `_` fallback, and (added during that
+issue's own `/code-review`, after a finder disproved the "not known to be
+live-reachable" claim below) the `Expr::Object`/`Array`/`Literal` arm now
 route through `eval_owned_input` (which preserves `Many`/`ManyOwned`)
 instead of `eval_owned_expr_opt` (which collapsed to one value).
 `continue_rest_with_context`/`accumulate_path_context_step` -- the functions
 that actually fan a `Comma` branch's output back out into the enclosing
 computation -- already handled `ManyOwned` correctly; they just never used
-to receive one from these two arms. No change was needed to either of them,
-or to `eval_owned_expr_full`/`result_to_owned_full` at all -- #1937's
+to receive one from these three arms. No change was needed to either of
+them, or to `eval_owned_expr_full`/`result_to_owned_full` at all -- #1937's
 mistake was treating this as a policy question for a shared helper, when it
-was really a "the wrong function got called" bug local to these two arms.
+was really a "the wrong function got called" bug local to a handful of arms.
+The `Expr::Object`/`Array`/`Literal` arm couldn't reuse
+`continue_rest_with_context`'s own `ManyOwned` handling directly, though:
+that shares one `root`/`current_path` across every element, correct for
+`Builtin`/the fallback (whose navigational position never moves) but wrong
+here, where *each* constructed value must become its own root -- so that
+arm loops by hand instead, mirroring how `Expr::Comma` accumulates its own
+branches.
 
 ```console
 $ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c '.a | (recurse, key)'
@@ -1995,23 +2004,46 @@ $ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c '.a | (recurse, key)'
 "a"
 $ echo '{"a":"x"}' | succinctly jq -c '.a | [(range(0;5), key)]'
 [0,1,2,3,4,"a"]
+$ echo '{"a":"x"}' | succinctly jq -c '.a | ({x:(1,2)}, key)'
+{"x":1}
+{"x":2}
+"a"
 ```
 
-Both now match real jq's own fan-out shape (confirmed against jq 1.7.1 with
-a literal substituted for `key`, which has no oracle):
-`jq -c '.a | [recurse]'` and `jq -c '.a | [(range(0;5), "a")]'` give the
-identical value sequences.
+All three now match real jq's own fan-out shape (confirmed against jq 1.7.1
+with a literal substituted for `key`, which has no oracle):
+`jq -c '.a | [recurse]'`, `jq -c '.a | [(range(0;5), "a")]'`, and
+`jq -c '.a | ({x:(1,2)}, "a")'` give the identical value sequences.
 
-**Two sites remain unfixed**: `ParentN`'s own `n` argument (`parent((1,2))`
+**Fixing the `Expr::Builtin(_)`/fallback arms surfaced one further latent
+bug, in shared code neither #1937 nor #1964's first draft touched**:
+`continue_rest_with_context` (and its twin, `continue_rest_with_fresh_root`)
+each have a `Partial` arm that pipes an already-produced prefix through
+`rest` before reattaching the trailing `Control` -- but neither one gated
+that reattachment on their own `optional` parameter, so `?` correctly kept
+the prefix but then failed to suppress the trailing error:
+
+```console
+$ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c \
+    '.a | (recurse(if type=="object" then error("boom") else empty end))? | key'
+# before this fix: "a" printed, then "boom" raised anyway, exit 5 -- `?` didn't suppress it
+# after:           "a"                                                exit 0 -- matches jq (substituting a literal for `key`)
+```
+
+This was unreachable before #1964 gave these two arms a real `Partial` to
+hand `continue_rest_with_context` in the first place (previously,
+`eval_owned_expr_opt` intercepted the shape itself and discarded the prefix
+entirely -- a different, separately-known bug). Fixed by routing both
+functions' `Partial` arms through the existing `catch_error_under_optional`
+helper (the same one `Expr::Iterate`/`Builtin::Map` already use for this
+exact "keep the prefix, gate only the error" policy) instead of a bare
+`partial(...)` call.
+
+**One site remains unfixed**: `ParentN`'s own `n` argument (`parent((1,2))`
 still array-collapses `n` to `[1,2]`, then errors on the wrong type -- a
-narrower, lower-traffic case than the two builtin/fallback arms #1964
-covered, not attempted there) and the `Expr::Object`/`Array`/`Literal` arm
-(in practice not known to be live-reachable with a genuine `Many`/`ManyOwned`
-result -- `Expr::Object` isn't included in `needs_path_context`'s own
-recursion, and `Array`/`Literal` collect an inner generator into one
-container value rather than splitting across top-level outputs, per #1937's
-own review investigation). Full fan-out for these two, if ever needed,
-remains out of scope per #1522's design doc.
+narrower, lower-traffic case than the three arms fixed above, not attempted
+here). Full fan-out for it, if ever needed, remains out of scope per
+#1522's design doc.
 
 ## Provenance
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27366,6 +27366,19 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // have raised (e.g. `(1, error("x")) | file_index` reported the raw
         // `1` instead of `file_index`'s resolved value, and never reported
         // an error for a `rest` that itself fails).
+        //
+        // `catch_error_under_optional(..., atomic: false)` (#1964 code
+        // review): `partial(results, outer_control)` alone reattaches
+        // `outer_control` unconditionally, never consulting this function's
+        // own `optional` parameter -- so `?` failed to suppress a trailing
+        // error once #1964 gave the `Expr::Builtin(_)`/generic-fallback arms
+        // a real `Partial` to hand this function instead of discarding it
+        // themselves beforehand (`(recurse(...if ... then error(...) ...))?`
+        // kept its prefix output correctly but then still raised, where real
+        // jq suppresses the error and keeps the prefix). `atomic: false`
+        // matches this arm's own "keep the prefix, don't discard it" shape
+        // (the same policy `Expr::Iterate`'s identical call already uses),
+        // not the array/object-construction "discard everything" policy.
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
             for v in vs {
@@ -27381,7 +27394,7 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     return stop;
                 }
             }
-            partial(results, outer_control)
+            catch_error_under_optional::<W>(partial(results, outer_control), optional, false)
         }
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
     }
@@ -27517,6 +27530,14 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
+        // `catch_error_under_optional(..., atomic: false)` (#1964 code
+        // review): same gap `continue_rest_with_context`'s identical arm had
+        // -- a bare `partial(results, outer_control)` reattaches
+        // `outer_control` unconditionally, never consulting this function's
+        // own `optional` parameter, so `?` failed to suppress a trailing
+        // error while still correctly keeping the already-produced prefix.
+        // `atomic: false` matches this arm's "keep the prefix" shape, not
+        // an array/object-construction "discard everything" policy.
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
             for v in vs {
@@ -27532,7 +27553,7 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     return stop;
                 }
             }
-            partial(results, outer_control)
+            catch_error_under_optional::<W>(partial(results, outer_control), optional, false)
         }
         QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => unreachable!(
             "eval_pipe_with_path_context_internal only ever produces \
@@ -27954,6 +27975,51 @@ fn eval_bind_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         None => owned_vec_to_result(all_results),
     });
     continue_rest_with_context::<W, S>(combined, rest, root, file_origin, current_path, optional)
+}
+
+/// Shared by `eval_pipe_with_path_context_internal`'s `Expr::Builtin(_)` arm
+/// and its generic `_` fallback (#1964 code review): evaluate `first` via
+/// [`eval_owned_input`] -- which preserves `Many`/`ManyOwned` instead of
+/// collapsing a multi-output expression to one value the way
+/// `eval_owned_expr_opt` used to -- then hand the result to
+/// [`continue_rest_with_context`], applying the same `optional`-swallow
+/// safety net both call sites need. Neither arm moves navigational
+/// position, so both pass `root`/`current_path` through unchanged.
+fn eval_and_continue_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    first: &Expr,
+    value: &OwnedValue,
+    rest: &[Expr],
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
+    match eval_owned_input::<W, S>(first, value, optional) {
+        // #1280: a builtin/expression that legitimately produced nothing (a
+        // `?`-swallowed type mismatch, or its own zero-output result)
+        // contributes zero outputs to this comma/pipe branch, matching real
+        // jq's own `.a?`-style empty-not-null path semantics -- not
+        // `QueryResult::Owned(Null)`.
+        QueryResult::None => QueryResult::None,
+        // `?` swallows only a genuine error; a halt always escapes (#791).
+        // Same gate the old `eval_owned_expr_opt`-based arms applied on
+        // their own `Err(EvalEscape::Error(_))` case, kept here as a
+        // caller-level safety net even though `optional` is already
+        // threaded into `eval_owned_input` itself.
+        QueryResult::Error(_) if optional => QueryResult::None,
+        // `continue_rest_with_context`'s own `rest.is_empty()` fast path
+        // (#1445) and its `ManyOwned`/`Many` arms are what correctly fan a
+        // multi-output result through `rest` (#1964) -- no change needed
+        // there, or in `accumulate_path_context_step`, for either caller.
+        result => continue_rest_with_context::<W, S>(
+            result,
+            rest,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
+    }
 }
 
 /// Internal helper that also tracks the root value for parent navigation,
@@ -28721,58 +28787,27 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // `first` already *is* this `Expr::Builtin`, so evaluate it
             // directly rather than reconstructing an equivalent one.
             //
-            // `eval_owned_input`, not `eval_owned_expr_opt` (#1964): the
-            // latter collapses a genuinely multi-output builtin (`range`,
-            // `splits`, `recurse`, ...) into a single `OwnedValue::Array`
-            // before this arm ever sees it -- wrong whenever this branch
-            // reaches here via `Expr::Comma` (`(range(0;5), key)`), since
+            // `eval_and_continue_with_context` (#1964), not
+            // `eval_owned_expr_opt` directly: the latter collapses a
+            // genuinely multi-output builtin (`range`, `splits`, `recurse`,
+            // ...) into a single `OwnedValue::Array` before this arm ever
+            // saw it -- wrong whenever this branch reaches here via
+            // `Expr::Comma` (`(range(0;5), key)`), since
             // `accumulate_path_context_step`'s caller already knows how to
             // fan a `QueryResult::ManyOwned` out into separate branch
-            // outputs (see its own `ManyOwned` arm) -- it was never given
-            // the chance to, because this arm handed it one collapsed value
-            // instead. `eval_owned_input` preserves `Many`/`ManyOwned`
-            // (`eval.rs`'s own doc comment: "keeps Many/ManyOwned intact"),
-            // and `continue_rest_with_context` below already fans those out
-            // through `rest` per-element (its own `ManyOwned`/`Many` arms) --
-            // no change needed there or in `accumulate_path_context_step`,
-            // both already handle the shape this arm was never producing.
-            match eval_owned_input::<W, S>(first, value, optional) {
-                // #1280: a builtin that legitimately produced nothing (a
-                // `?`-swallowed type mismatch, or its own zero-output
-                // result) contributes zero outputs to this comma/pipe
-                // branch, matching real jq's own `.a?`-style empty-not-null
-                // path semantics -- not `QueryResult::Owned(Null)`.
-                QueryResult::None => QueryResult::None,
-                // `?` swallows only a genuine error; a halt always escapes
-                // (#791). Same gate the old `eval_owned_expr_opt`-based arm
-                // applied on its own `Err(EvalEscape::Error(_))` case, kept
-                // here as the same safety net even though `optional` was
-                // already threaded into `eval_owned_input` itself -- a
-                // caller-level check for whatever slips through unswallowed
-                // rather than trusting every internal call site to have
-                // applied it.
-                QueryResult::Error(_) if optional => QueryResult::None,
-                // #1313: `continue_rest_with_context` (shared with the
-                // `Expr::Object`/`Array`/`Literal` arm below and the
-                // generic fallback further below) replaces the old
-                // hand-rolled "if `rest` is empty, return; else recurse" --
-                // unlike that arm, this one keeps the enclosing `root`/
-                // `current_path` unchanged (a builtin doesn't move
-                // navigational position), so it needs no extra `.clone()`
-                // of its own the way that arm does. The helper's own
-                // `rest.is_empty()` fast path (#1445) is what keeps this
-                // arm's *value* move free too, and its own `ManyOwned`/
-                // `Many` arms are what now correctly fan out a multi-output
-                // builtin's result through `rest` (#1964).
-                result => continue_rest_with_context::<W, S>(
-                    result,
-                    rest,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                ),
-            }
+            // outputs. The shared helper routes through `eval_owned_input`
+            // instead, which preserves that shape, and is shared with the
+            // generic `_` fallback below -- both arms had the identical bug
+            // and the identical fix.
+            eval_and_continue_with_context::<W, S>(
+                first,
+                value,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         // `[key]`/`[parent]`/`[file_index]` (#1302): the generic
         // `Expr::Array` arm below builds the array via `eval_owned_expr_opt`
@@ -29185,13 +29220,28 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         Expr::Object(_) | Expr::Array(_) | Expr::Literal(_) => {
             // Value-constructing expressions reset the path context
             // because we're now at the "root" of a newly constructed value
-            match eval_owned_expr_opt::<S>(first, value, optional) {
+            //
+            // `eval_owned_input`, not `eval_owned_expr_opt` (#1964 code
+            // review): the identical collapse bug the `Expr::Builtin(_)`/
+            // generic-fallback arms above were fixed for also lives here --
+            // `.a | ({x:(1,2)}, key)` collapsed `(1,2)` into `{"x":[1,2]}`
+            // instead of two separate objects (confirmed live; swapping
+            // `key` for a literal, `.a | ({x:(1,2)}, "a")`, matches jq
+            // 1.7.1's own fanned-out shape). This arm can't reuse
+            // `continue_rest_with_context`'s own `ManyOwned` handling
+            // directly, though: that shares one `root`/`current_path`
+            // across every element, correct for `Builtin`/the fallback
+            // (whose navigational position never moves) but wrong here,
+            // where *each* constructed value must become its own root --
+            // so a multi-output result loops by hand below instead,
+            // mirroring how `Expr::Comma` accumulates its own branches.
+            match eval_owned_input::<W, S>(first, value, optional) {
                 // #1280: a zero-output generator inside the construction
                 // (`{(empty): 1}`, `[empty]` behaves differently -- this is
                 // specifically the object-key-generator case) means the
                 // whole construction contributes zero outputs, matching real
                 // jq -- not a spurious `null`.
-                Ok(None) => QueryResult::None,
+                QueryResult::None => QueryResult::None,
                 // #1313: hands off to `continue_rest_with_context` (shared
                 // with the `Expr::Builtin(_)` arm above and the generic
                 // fallback further below) instead of hand-rolling "if
@@ -29205,7 +29255,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // `intermediate` here, and this arm (unlike `Builtin`/the
                 // fallback) needs the *new* value as `root`, not the
                 // enclosing one already in scope.
-                Ok(Some(result)) => {
+                QueryResult::Owned(result) => {
                     let root = result.clone();
                     continue_rest_with_context::<W, S>(
                         QueryResult::Owned(result),
@@ -29216,10 +29266,54 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                         optional,
                     )
                 }
+                // #1964: each constructed value gets its own root/reset
+                // path, then its own `rest` continuation -- see this arm's
+                // own doc comment above for why `continue_rest_with_context`
+                // can't be delegated to wholesale here the way the
+                // `Builtin`/fallback arms do.
+                QueryResult::ManyOwned(vs) => {
+                    let mut results = Vec::new();
+                    for v in vs {
+                        let root = v.clone();
+                        let step = continue_rest_with_context::<W, S>(
+                            QueryResult::Owned(v),
+                            rest,
+                            &root,
+                            file_origin,
+                            &[],
+                            optional,
+                        );
+                        if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                            return stop;
+                        }
+                    }
+                    owned_vec_to_result(results)
+                }
                 // `?` swallows only a genuine error; a halt always escapes
                 // (#791).
-                Err(EvalEscape::Error(_)) if optional => QueryResult::None,
-                Err(escape) => escape.into(),
+                QueryResult::Error(_) if optional => QueryResult::None,
+                QueryResult::Error(e) => QueryResult::Error(e),
+                QueryResult::Break(label) => QueryResult::Break(label),
+                QueryResult::Halt(code) => QueryResult::Halt(code),
+                // A `Partial`'s own trailing control still discards the
+                // already-produced prefix here, matching this arm's
+                // pre-#1964 behavior for the escape case -- unlike the
+                // `Builtin`/fallback arms (#1964 code review), extending
+                // prefix-streaming to this arm would need each
+                // already-produced value to also get its own root/`rest`
+                // treatment before the escape fires, a separate, unverified
+                // extension not attempted here; #1964 scoped this fix to
+                // the reported multi-output-with-no-escape case.
+                QueryResult::Partial(_, control) => match control {
+                    Control::Error(e) => QueryResult::Error(e),
+                    Control::Break(label) => QueryResult::Break(label),
+                    Control::Halt(code) => QueryResult::Halt(code),
+                },
+                QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => {
+                    unreachable!(
+                        "eval_owned_input never returns a borrowed-cursor variant (see its own doc comment)"
+                    )
+                }
             }
         }
         Expr::If {
@@ -29460,44 +29554,24 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // For other expressions, evaluate normally and continue
             // Note: This loses path context for complex expressions
             //
-            // `eval_owned_input`, not `eval_owned_expr_opt` (#1964): this
-            // fallback is what a genuinely multi-output expression with no
-            // dedicated arm -- `Expr::Range` (`range(0;5)`) is the actual
-            // AST node the issue's own repro hits, not `Expr::Builtin(_)`
-            // above, despite the issue's own "root cause" section naming
-            // that arm; same underlying bug, same fix, different arm -- and
-            // `Comma`/arbitrary sub-pipes reach when `needs_path_context`'s
-            // own recursion has no more specific arm for them. Same
-            // rationale as the `Expr::Builtin(_)` arm's identical fix
-            // above: `eval_owned_expr_opt` collapsed every case here into a
-            // single `OwnedValue::Array` before `continue_rest_with_context`/
-            // `accumulate_path_context_step` (both already `ManyOwned`-aware)
-            // ever got a chance to fan it out.
-            match eval_owned_input::<W, S>(first, value, optional) {
-                // #1280: a legitimately-empty result (a `?`-swallowed type
-                // mismatch reached through this generic fallback) is zero
-                // outputs, matching real jq -- not a spurious `null`.
-                QueryResult::None => QueryResult::None,
-                // `?` swallows only a genuine error; a halt always escapes
-                // (#791). Same safety net as the `Expr::Builtin(_)` arm
-                // above.
-                QueryResult::Error(_) if optional => QueryResult::None,
-                // #1313: same `continue_rest_with_context` hand-off as the
-                // `Expr::Builtin(_)` arm above -- root/current_path stay
-                // unchanged (this arm never moves navigational position
-                // either, it just loses further path *tracking* for
-                // whatever it evaluates). Its own `ManyOwned`/`Many` arms
-                // now correctly fan out a multi-output expression's result
-                // through `rest` (#1964).
-                result => continue_rest_with_context::<W, S>(
-                    result,
-                    rest,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                ),
-            }
+            // `eval_and_continue_with_context` (#1964), shared with the
+            // `Expr::Builtin(_)` arm above -- this fallback is what a
+            // genuinely multi-output expression with no dedicated arm hits:
+            // `Expr::Range` (`range(0;5)`) is the actual AST node #1964's
+            // own repro exercised, not `Expr::Builtin(_)` as that issue's
+            // "root cause" section named, despite the identical underlying
+            // bug and fix. `Comma`/arbitrary sub-pipes reach here too,
+            // whenever `needs_path_context`'s own recursion has no more
+            // specific arm for them.
+            eval_and_continue_with_context::<W, S>(
+                first,
+                value,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28720,13 +28720,38 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Handle other builtins that don't need special path handling.
             // `first` already *is* this `Expr::Builtin`, so evaluate it
             // directly rather than reconstructing an equivalent one.
-            match eval_owned_expr_opt::<S>(first, value, optional) {
+            //
+            // `eval_owned_input`, not `eval_owned_expr_opt` (#1964): the
+            // latter collapses a genuinely multi-output builtin (`range`,
+            // `splits`, `recurse`, ...) into a single `OwnedValue::Array`
+            // before this arm ever sees it -- wrong whenever this branch
+            // reaches here via `Expr::Comma` (`(range(0;5), key)`), since
+            // `accumulate_path_context_step`'s caller already knows how to
+            // fan a `QueryResult::ManyOwned` out into separate branch
+            // outputs (see its own `ManyOwned` arm) -- it was never given
+            // the chance to, because this arm handed it one collapsed value
+            // instead. `eval_owned_input` preserves `Many`/`ManyOwned`
+            // (`eval.rs`'s own doc comment: "keeps Many/ManyOwned intact"),
+            // and `continue_rest_with_context` below already fans those out
+            // through `rest` per-element (its own `ManyOwned`/`Many` arms) --
+            // no change needed there or in `accumulate_path_context_step`,
+            // both already handle the shape this arm was never producing.
+            match eval_owned_input::<W, S>(first, value, optional) {
                 // #1280: a builtin that legitimately produced nothing (a
                 // `?`-swallowed type mismatch, or its own zero-output
                 // result) contributes zero outputs to this comma/pipe
                 // branch, matching real jq's own `.a?`-style empty-not-null
                 // path semantics -- not `QueryResult::Owned(Null)`.
-                Ok(None) => QueryResult::None,
+                QueryResult::None => QueryResult::None,
+                // `?` swallows only a genuine error; a halt always escapes
+                // (#791). Same gate the old `eval_owned_expr_opt`-based arm
+                // applied on its own `Err(EvalEscape::Error(_))` case, kept
+                // here as the same safety net even though `optional` was
+                // already threaded into `eval_owned_input` itself -- a
+                // caller-level check for whatever slips through unswallowed
+                // rather than trusting every internal call site to have
+                // applied it.
+                QueryResult::Error(_) if optional => QueryResult::None,
                 // #1313: `continue_rest_with_context` (shared with the
                 // `Expr::Object`/`Array`/`Literal` arm below and the
                 // generic fallback further below) replaces the old
@@ -28736,19 +28761,17 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 // navigational position), so it needs no extra `.clone()`
                 // of its own the way that arm does. The helper's own
                 // `rest.is_empty()` fast path (#1445) is what keeps this
-                // arm's *value* move free too.
-                Ok(Some(result)) => continue_rest_with_context::<W, S>(
-                    QueryResult::Owned(result),
+                // arm's *value* move free too, and its own `ManyOwned`/
+                // `Many` arms are what now correctly fan out a multi-output
+                // builtin's result through `rest` (#1964).
+                result => continue_rest_with_context::<W, S>(
+                    result,
                     rest,
                     root,
                     file_origin,
                     current_path,
                     optional,
                 ),
-                // `?` swallows only a genuine error; a halt always escapes
-                // (#791).
-                Err(EvalEscape::Error(_)) if optional => QueryResult::None,
-                Err(escape) => escape.into(),
             }
         }
         // `[key]`/`[parent]`/`[file_index]` (#1302): the generic
@@ -29436,28 +29459,44 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         _ => {
             // For other expressions, evaluate normally and continue
             // Note: This loses path context for complex expressions
-            match eval_owned_expr_opt::<S>(first, value, optional) {
+            //
+            // `eval_owned_input`, not `eval_owned_expr_opt` (#1964): this
+            // fallback is what a genuinely multi-output expression with no
+            // dedicated arm -- `Expr::Range` (`range(0;5)`) is the actual
+            // AST node the issue's own repro hits, not `Expr::Builtin(_)`
+            // above, despite the issue's own "root cause" section naming
+            // that arm; same underlying bug, same fix, different arm -- and
+            // `Comma`/arbitrary sub-pipes reach when `needs_path_context`'s
+            // own recursion has no more specific arm for them. Same
+            // rationale as the `Expr::Builtin(_)` arm's identical fix
+            // above: `eval_owned_expr_opt` collapsed every case here into a
+            // single `OwnedValue::Array` before `continue_rest_with_context`/
+            // `accumulate_path_context_step` (both already `ManyOwned`-aware)
+            // ever got a chance to fan it out.
+            match eval_owned_input::<W, S>(first, value, optional) {
                 // #1280: a legitimately-empty result (a `?`-swallowed type
                 // mismatch reached through this generic fallback) is zero
                 // outputs, matching real jq -- not a spurious `null`.
-                Ok(None) => QueryResult::None,
+                QueryResult::None => QueryResult::None,
+                // `?` swallows only a genuine error; a halt always escapes
+                // (#791). Same safety net as the `Expr::Builtin(_)` arm
+                // above.
+                QueryResult::Error(_) if optional => QueryResult::None,
                 // #1313: same `continue_rest_with_context` hand-off as the
                 // `Expr::Builtin(_)` arm above -- root/current_path stay
                 // unchanged (this arm never moves navigational position
                 // either, it just loses further path *tracking* for
-                // whatever it evaluates).
-                Ok(Some(result)) => continue_rest_with_context::<W, S>(
-                    QueryResult::Owned(result),
+                // whatever it evaluates). Its own `ManyOwned`/`Many` arms
+                // now correctly fan out a multi-output expression's result
+                // through `rest` (#1964).
+                result => continue_rest_with_context::<W, S>(
+                    result,
                     rest,
                     root,
                     file_origin,
                     current_path,
                     optional,
                 ),
-                // `?` swallows only a genuine error; a halt always escapes
-                // (#791).
-                Err(EvalEscape::Error(_)) if optional => QueryResult::None,
-                Err(escape) => escape.into(),
             }
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20300,20 +20300,25 @@ fn test_path_context_builtin_arm_multi_output_fans_out_1964() -> Result<()> {
     Ok(())
 }
 
-/// #1937/#1964: the generic `_` fallback arm (`eval_pipe_with_path_context_internal`)
-/// backs far more than argument-fan-out builtins -- it's also how a
-/// zero-arg generator (`recurse`, `range`, `..`) or an arbitrary comma
-/// branch gets evaluated whenever a sibling `key`/`parent`/`file_index`
-/// forces the whole pipe through path-context routing. #1937's own
-/// investigation found and rejected a "take first" fix attempt here (it
-/// silently discarded every `recurse` output but the first, with no error
-/// at all -- confirmed live during that PR's `/code-review`). #1964's
-/// `eval_owned_input` fix closes the gap without that regression: `recurse`'s
-/// 3 outputs now each pair with `key`'s own output, matching real jq's own
-/// fan-out (`.a | [recurse]` gives the same 3 values, confirmed against jq
-/// 1.7.1) instead of collapsing them into one array.
+/// #1937/#1964: the `Expr::Builtin(_)` arm (`eval_pipe_with_path_context_internal`)
+/// backs far more than argument-fan-out builtins -- `recurse` (`Builtin::Recurse`)
+/// is a *zero*-arg generator reached through this same arm whenever a
+/// sibling `key`/`parent`/`file_index` forces the whole pipe through
+/// path-context routing (`range`/arbitrary comma branches with no dedicated
+/// arm instead reach the generic `_` fallback further below -- see
+/// `test_comma_range_and_key_fan_out_in_array_1964` for that arm's own
+/// coverage; this test's own name previously called this "the generic
+/// fallback arm," which #1964's own code review caught as inaccurate for
+/// `recurse` specifically). #1937's own investigation found and rejected a
+/// "take first" fix attempt here (it silently discarded every `recurse`
+/// output but the first, with no error at all -- confirmed live during that
+/// PR's `/code-review`). #1964's `eval_owned_input` fix closes the gap
+/// without that regression: `recurse`'s 3 outputs now each pair with `key`'s
+/// own output, matching real jq's own fan-out (`.a | [recurse]` gives the
+/// same 3 values, confirmed against jq 1.7.1) instead of collapsing them
+/// into one array.
 #[test]
-fn test_path_context_generic_fallback_recurse_fans_out_1964() -> Result<()> {
+fn test_path_context_builtin_arm_recurse_fans_out_1964() -> Result<()> {
     let (out, err, code) = run_jq_full(
         &["-c", ".a | (recurse, key)"],
         Some(r#"{"a":{"b":{"c":1}}}"#),
@@ -20357,6 +20362,53 @@ fn test_comma_range_and_key_fan_out_through_limit_1964() -> Result<()> {
     )?;
     assert_eq!(code, 0, "err={err}");
     assert_eq!(out, "[0,1]\n");
+    Ok(())
+}
+
+/// #1964 code review: the `Expr::Object`/`Array`/`Literal` arm has the
+/// identical collapse bug the `Expr::Builtin(_)`/generic-fallback arms were
+/// fixed for -- a `/code-review` finder demonstrated it live even though
+/// this PR's own first draft (incorrectly) documented this arm as "not
+/// known to be live-reachable" with a genuine multi-output result.
+/// `Expr::Object`/`Array`/`Literal` isn't itself in `needs_path_context`'s
+/// own recursion, but that's irrelevant here: routing through this whole
+/// evaluator is decided at the *enclosing* comma/pipe level, so an object
+/// construction with its own internal generator still lands in this arm
+/// whenever a sibling `key` forces the enclosing comma through path-context
+/// routing. Confirmed against jq 1.7.1 with a literal substituted for `key`:
+/// `.a | ({x:(1,2)}, "a")` gives the identical 3-value sequence.
+#[test]
+fn test_path_context_object_arm_multi_output_fans_out_1964() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ".a | ({x:(1,2)}, key)"], Some(r#"{"a":"x"}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "{\"x\":1}\n{\"x\":2}\n\"a\"\n");
+    Ok(())
+}
+
+/// #1964 code review: fixing the `Expr::Builtin(_)`/generic-fallback arms to
+/// hand `continue_rest_with_context` a real `Partial` (instead of
+/// discarding the prefix themselves, as `eval_owned_expr_opt` used to)
+/// exposed a latent gap in `continue_rest_with_context` itself: its own
+/// `Partial` arm reattached the trailing control unconditionally, never
+/// consulting its own `optional` parameter -- so `?` correctly kept a
+/// generator's already-produced prefix but then failed to suppress the
+/// trailing error, where real jq's `?` suppresses it. Fixed by routing
+/// through the existing `catch_error_under_optional` helper (the same one
+/// `Expr::Iterate`/`Builtin::Map` already use for their own "keep the
+/// prefix, gate only the error" policy) instead of a bare `partial(...)`.
+/// The identical fix was also applied to `continue_rest_with_fresh_root`'s
+/// twin `Partial` arm, which had the same gap.
+#[test]
+fn test_path_context_optional_suppresses_trailing_error_after_partial_output_1964() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &[
+            "-c",
+            r#".a | (recurse(if type=="object" then error("boom") else empty end))? | key"#,
+        ],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "\"a\"\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7025,26 +7025,25 @@ fn test_limit_path_context_resolves_1765() -> Result<()> {
     Ok(())
 }
 
-/// #1964 (found in review of this fix): pre-existing, unrelated to `limit`
-/// itself -- `eval_pipe_with_path_context_internal`'s `Expr::Comma` arm
-/// routes every branch through this same evaluator, including a branch that
-/// doesn't need path context at all (`range(0;5)`), which then falls to the
-/// generic `Expr::Builtin(_)` catch-all's single-output `eval_owned_expr_opt`
-/// and collapses the whole multi-output builtin into one array. Reachable on
-/// `main` today without `limit` (`.a | [(range(0;5), key)]` already gives
-/// `[[0,1,2,3,4],"a"]`) -- this fix's own new `Expr::Limit` routing just
-/// makes it reachable through `limit`'s body too, since it evaluates that
-/// body through the identical evaluator. Pinned here rather than fixed,
-/// matching #1964's own scoping (a general fix belongs to that evaluator's
-/// `Comma`/`Builtin` combination, not this narrower `Limit`-specific PR).
+/// #1964 (found in review of the `Expr::Limit` path-context fix above, then
+/// fixed by #1964 itself): `eval_pipe_with_path_context_internal`'s
+/// `Expr::Comma` arm routes every branch through this same evaluator,
+/// including a branch that doesn't need path context at all (`range(0;5)`),
+/// which used to fall to the generic `Expr::Builtin(_)` catch-all's
+/// single-output `eval_owned_expr_opt` and collapse the whole multi-output
+/// builtin into one array before `limit` ever got to truncate it. #1964
+/// fixed the underlying evaluator (`eval_owned_input` in place of
+/// `eval_owned_expr_opt`), so `limit`'s own truncation now sees the real,
+/// fanned-out stream: 2 of the 6 genuine outputs (`range`'s 5 plus `key`'s
+/// 1), not one already-collapsed 5-element array.
 #[test]
-fn test_limit_path_context_inherits_comma_multi_output_collapse_known_gap_1964() -> Result<()> {
+fn test_limit_path_context_comma_multi_output_fans_out_1964() -> Result<()> {
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | [limit(2; (range(0;5), key))]"],
         Some(r#"{"a":"x"}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "[[0,1,2,3,4],\"a\"]");
+    assert_eq!(stdout.trim(), "[0,1]");
 
     Ok(())
 }
@@ -20341,27 +20340,6 @@ fn test_comma_range_and_key_fan_out_in_array_1964() -> Result<()> {
     let (out, err, code) = run_jq_full(&["-c", ".a | [(range(0;5), key)]"], Some(r#"{"a":"x"}"#))?;
     assert_eq!(code, 0, "err={err}");
     assert_eq!(out, "[0,1,2,3,4,\"a\"]\n");
-    Ok(())
-}
-
-/// #1964 sibling: the same shape reached through `limit`'s own body (newly
-/// routed into path-context evaluation by #1961/#1765) instead of a bare
-/// comma. Unlike the issue's own claimed pre-fix repro (`[[0,1,2,3,4],"a"]`),
-/// live-verified against this branch's own pre-#1964 state that this
-/// particular combination already produced the correct `[0,1]` -- `limit`'s
-/// own truncation happens to land on `range`'s first 2 elements before the
-/// path-context evaluator ever reaches `key` in the same branch, so the
-/// array-collapse bug this issue is about doesn't manifest for this exact
-/// `n`/generator-length combination. Kept as a regression guard for the
-/// correct behavior, not evidence #1964 changed this specific case.
-#[test]
-fn test_comma_range_and_key_fan_out_through_limit_1964() -> Result<()> {
-    let (out, err, code) = run_jq_full(
-        &["-c", ".a | [limit(2; (range(0;5), key))]"],
-        Some(r#"{"a":"x"}"#),
-    )?;
-    assert_eq!(code, 0, "err={err}");
-    assert_eq!(out, "[0,1]\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20272,52 +20272,91 @@ fn test_path_context_builtin_arm_non_swallowed_result_unaffected_1280() -> Resul
     Ok(())
 }
 
-/// #1937: `.a | ltrimstr(("xax","x")) | [length, key]` forces the fanned-out
-/// `ltrimstr(("xax","x"))` (two outputs: `""`, then `"ax"`, matching real
-/// jq's own generator-argument fan-out for the isolated `ltrimstr` call,
-/// confirmed against jq 1.7.1) through the `Expr::Builtin(_)` arm's
-/// `eval_owned_expr_opt` call, since the trailing `key` needs path tracking.
-/// That call array-collapses the two outputs into `["", "ax"]` before
-/// continuing, so `length` measures the *array* (2, the comma-branch count)
-/// rather than either individual string's own length. `key` itself has no
-/// jq oracle (succinctly extension) and is content-independent, so it's
-/// included only to force path-context routing.
-///
-/// This is a known, documented gap (`docs/compliance/jq/limitations.md`),
-/// not a fix -- #1937's own investigation found the alternative (take the
-/// *first* output instead of collapsing) is a strictly worse regression for
-/// this helper's other call sites (silently drops every `recurse`/`..`/
-/// `paths` output but the first, with no error), so array-collapse remains.
-/// Pinned here as a regression guard against re-introducing that regression.
+/// #1937/#1964: `.a | ltrimstr(("xax","x")) | [length, key]` forces the
+/// fanned-out `ltrimstr(("xax","x"))` (two outputs: `""`, then `"ax"`,
+/// matching real jq's own generator-argument fan-out for the isolated
+/// `ltrimstr` call, confirmed against jq 1.7.1) through the
+/// `Expr::Builtin(_)` arm, since the trailing `key` needs path tracking.
+/// #1937 found this arm array-collapsed the two outputs into `["", "ax"]`
+/// before continuing (so `length` measured the *array*, 2, rather than
+/// either individual string's own length), and rejected the "take first
+/// instead" fix attempt as a worse regression for this arm's other traffic
+/// (zero-arg generators like `recurse` reached through the *same* arm).
+/// #1964 closed the gap properly instead -- `eval_owned_input` in place of
+/// `eval_owned_expr_opt` preserves the `ManyOwned` shape that
+/// `continue_rest_with_context` already knew how to fan out through `rest` --
+/// so this now produces one `[length, key]` result per `ltrimstr` output,
+/// matching real jq's own fan-out semantics for the first time. `key` itself
+/// has no jq oracle (succinctly extension) and is content-independent, so
+/// it's included only to force path-context routing.
 #[test]
-fn test_path_context_builtin_arm_multi_output_still_array_collapses_1937() -> Result<()> {
+fn test_path_context_builtin_arm_multi_output_fans_out_1964() -> Result<()> {
     let (out, err, code) = run_jq_full(
         &["-c", r#".a | ltrimstr(("xax","x")) | [length, key]"#],
         Some(r#"{"a":"xax"}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out, "[2,\"a\"]\n");
+    assert_eq!(out, "[0,\"a\"]\n[2,\"a\"]\n");
     Ok(())
 }
 
-/// #1937: the generic `_` fallback arm (`eval_pipe_with_path_context_internal`)
+/// #1937/#1964: the generic `_` fallback arm (`eval_pipe_with_path_context_internal`)
 /// backs far more than argument-fan-out builtins -- it's also how a
 /// zero-arg generator (`recurse`, `range`, `..`) or an arbitrary comma
 /// branch gets evaluated whenever a sibling `key`/`parent`/`file_index`
-/// forces the whole pipe through path-context routing. An earlier fix
-/// attempt (round 1, take-first) silently discarded every `recurse` output
-/// but the first here with no error at all -- confirmed live during
-/// `/code-review` before merging. Array-collapse, while still the wrong
-/// shape relative to real jq's own fan-out, at least keeps every value
-/// visible; pinned here as a regression guard.
+/// forces the whole pipe through path-context routing. #1937's own
+/// investigation found and rejected a "take first" fix attempt here (it
+/// silently discarded every `recurse` output but the first, with no error
+/// at all -- confirmed live during that PR's `/code-review`). #1964's
+/// `eval_owned_input` fix closes the gap without that regression: `recurse`'s
+/// 3 outputs now each pair with `key`'s own output, matching real jq's own
+/// fan-out (`.a | [recurse]` gives the same 3 values, confirmed against jq
+/// 1.7.1) instead of collapsing them into one array.
 #[test]
-fn test_path_context_generic_fallback_recurse_still_array_collapses_1937() -> Result<()> {
+fn test_path_context_generic_fallback_recurse_fans_out_1964() -> Result<()> {
     let (out, err, code) = run_jq_full(
         &["-c", ".a | (recurse, key)"],
         Some(r#"{"a":{"b":{"c":1}}}"#),
     )?;
     assert_eq!(code, 0, "err={err}");
-    assert_eq!(out, "[{\"b\":{\"c\":1}},{\"c\":1},1]\n\"a\"\n");
+    assert_eq!(out, "{\"b\":{\"c\":1}}\n{\"c\":1}\n1\n\"a\"\n");
+    Ok(())
+}
+
+/// #1964's own primary repro: `range(0;5)` (parsed as `Expr::Range`, not
+/// `Expr::Builtin` -- it falls into the generic `_` fallback arm, not the
+/// `Expr::Builtin(_)` arm the issue's own "root cause" section named) as one
+/// branch of a `Comma` alongside `key`, inside an array construction.
+/// Confirmed against jq 1.7.1 with a literal substituted for `key` (which
+/// has no oracle, being a succinctly-only extension):
+/// `jq -c '.a | [(range(0;5), "a")]'` on `{"a":"x"}` also gives
+/// `[0,1,2,3,4,"a"]`.
+#[test]
+fn test_comma_range_and_key_fan_out_in_array_1964() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-c", ".a | [(range(0;5), key)]"], Some(r#"{"a":"x"}"#))?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "[0,1,2,3,4,\"a\"]\n");
+    Ok(())
+}
+
+/// #1964 sibling: the same shape reached through `limit`'s own body (newly
+/// routed into path-context evaluation by #1961/#1765) instead of a bare
+/// comma. Unlike the issue's own claimed pre-fix repro (`[[0,1,2,3,4],"a"]`),
+/// live-verified against this branch's own pre-#1964 state that this
+/// particular combination already produced the correct `[0,1]` -- `limit`'s
+/// own truncation happens to land on `range`'s first 2 elements before the
+/// path-context evaluator ever reaches `key` in the same branch, so the
+/// array-collapse bug this issue is about doesn't manifest for this exact
+/// `n`/generator-length combination. Kept as a regression guard for the
+/// correct behavior, not evidence #1964 changed this specific case.
+#[test]
+fn test_comma_range_and_key_fan_out_through_limit_1964() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a | [limit(2; (range(0;5), key))]"],
+        Some(r#"{"a":"x"}"#),
+    )?;
+    assert_eq!(code, 0, "err={err}");
+    assert_eq!(out, "[0,1]\n");
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1964.

## Summary

\`eval_pipe_with_path_context_internal\`'s \`Expr::Builtin(_)\` arm and generic \`_\` fallback both routed through \`eval_owned_expr_opt\`, which collapses a genuinely multi-output expression (\`recurse\`, \`range\`, \`splits\`, \`..\`, or any \`Comma\` branch reaching these catch-alls) into a single \`OwnedValue::Array\` — silently corrupting output whenever a sibling \`key\`/\`parent\`/\`file_index\` forces the whole pipe through path-context routing:

\`\`\`console
$ echo '{"a":"x"}' | succinctly jq -c '.a | [(range(0;5), key)]'
[[0,1,2,3,4],"a"]   # was; should be [0,1,2,3,4,"a"]
\`\`\`

This is the exact bug class #1937 investigated and (correctly) declined to fix with a blanket "take the first output instead of collapsing" policy change to the shared \`eval_owned_expr_full\` helper — that approach regresses \`recurse\`/\`..\`/\`paths\` traffic reached through the *same* two arms. This issue's own suggested fix direction (mirror #1302's \`Expr::Array\` approach) is the actually-correct, surgical fix: \`continue_rest_with_context\`/\`accumulate_path_context_step\` already handle \`QueryResult::ManyOwned\` correctly — they just never received one from these two arms, because \`eval_owned_expr_opt\` collapsed to a single value before they got the chance.

## Changes

- \`Expr::Builtin(_)\` arm and the generic \`_\` fallback in \`eval_pipe_with_path_context_internal\` (\`src/jq/eval.rs\`) now route through \`eval_owned_input\` (preserves \`Many\`/\`ManyOwned\`) instead of \`eval_owned_expr_opt\` (collapses to one value). No changes to \`continue_rest_with_context\`, \`accumulate_path_context_step\`, or \`eval_owned_expr_full\`/\`result_to_owned_full\` — this was a "wrong function called" bug local to two arms, not a shared-helper policy question.
- Corrected a small inaccuracy in the issue's own root-cause note: \`range(0;5)\` parses as \`Expr::Range\`, not \`Expr::Builtin\`, so it actually reaches the generic \`_\` fallback, not the \`Expr::Builtin(_)\` arm. Both needed the identical fix.
- Updated the two \`#1937\` regression-guard tests (which pinned the old array-collapse behavior as "the best available option at the time") to assert the new, correct fan-out instead.
- Added the issue's own \`range\`/\`limit\` repros as new tests. Live-verified the \`limit\` sibling repro already produced the correct output even before this fix on current \`main\` — corrected the test's docstring rather than repeating an unverified claim from the issue.
- Rewrote the relevant \`docs/compliance/jq/limitations.md\` entry to record this closing 2 of the 4 originally-affected sites (\`ParentN\`'s own \`n\` argument and the \`Object\`/\`Array\`/\`Literal\` arm remain open — narrower, and the latter not known to be live-reachable with a genuine multi-output result).

## Test plan

- [x] \`cargo test --features cli,simd,regex,serde\` — 1309 lib tests + all integration suites pass
- [x] \`cargo test\` (default features) — passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` — clean
- [x] \`cargo build --no-default-features\` — builds
- [x] \`cargo fmt --check\` — clean
- [x] Live-verified both fixed repros against jq 1.7.1 with a literal substituted for \`key\` (a succinctly-only extension with no oracle) — output sequences match
- [x] Confirmed the two updated regression-guard tests genuinely exercise the fix (failed with the pre-fix code, verified via manual revert)