### PR TITLE
fix(jq): box LazySeq in GenericResult to fix select(true) x86_64 regression

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1212,15 +1212,26 @@ impl<V: DocumentValue> LazySeq<V> {
         }
     }
 
-    /// Push one more `map(f)` stage onto this chain. `f` is cloned once per
-    /// *stage* (not per element) into a fresh `Rc` — `Builtin::Map` only ever
-    /// hands us a borrowed `&Expr` (from `unwrap_paren` in the `Pipe` fold, or
-    /// `&Builtin` in `eval_builtin`), so there is nothing to move out of.
-    fn push_map(mut self, f: &Expr, tag: EvalTag) -> Self {
+    /// Push one more `map(f)` stage onto this chain, in place. `f` is cloned
+    /// once per *stage* (not per element) into a fresh `Rc` — `Builtin::Map`
+    /// only ever hands us a borrowed `&Expr` (from `unwrap_paren` in the
+    /// `Pipe` fold, or `&Builtin` in `eval_builtin`), so there is nothing to
+    /// move out of. Split out from [`Self::push_map`] (#789 code review
+    /// follow-up) so `fold_lazy_seq_stage`'s `Map` arm can mutate an
+    /// already-boxed `LazySeq` through `&mut` instead of moving it out of
+    /// its `Box` (freeing the allocation) only to immediately `Box::new` a
+    /// same-size replacement.
+    fn push_map_in_place(&mut self, f: &Expr, tag: EvalTag) {
         Rc::make_mut(&mut self.instructions).push(Instruction {
             f: Rc::new(f.clone()),
             tag,
         });
+    }
+
+    /// Builder-style wrapper around [`Self::push_map_in_place`], for the
+    /// fresh-construction call sites that chain straight off `LazySeq::new`.
+    fn push_map(mut self, f: &Expr, tag: EvalTag) -> Self {
+        self.push_map_in_place(f, tag);
         self
     }
 
@@ -3493,7 +3504,7 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // materializes once (`materialize_atomic`) and hands off
             // to the full evaluator — still one pass, not the
             // original four-pass round trip.
-            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(*seq, expr, optional),
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => return GenericResult::Error(e),
             GenericResult::Owned(o) => {
@@ -3794,12 +3805,19 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
 /// demand-aware callers, since none of them fan out beyond the single `seq`
 /// they were already holding.
 fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
-    mut seq: LazySeq<V>,
+    mut seq: Box<LazySeq<V>>,
     expr: &Expr,
     optional: bool,
 ) -> GenericResult<V> {
     match unwrap_paren(expr) {
-        Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(Box::new(seq.push_map(h, S::TAG))),
+        // In place (#789 code review follow-up): reuses the `Box`'s
+        // existing heap slot instead of freeing it and allocating a
+        // same-size replacement -- the hot path for a chained
+        // `map(f) | map(g) | map(h)`, where this arm runs once per stage.
+        Expr::Builtin(Builtin::Map(h)) => {
+            seq.push_map_in_place(h, S::TAG);
+            GenericResult::LazySeq(seq)
+        }
 
         // Count-and-discard: every element still runs (so a
         // `map(f)` that errors partway still errors), but no
@@ -4239,7 +4257,7 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
             GenericResult::LazySeq(seq) if is_iterate => {
                 return each_lazy_seq_iterate_sink::<S, V>(*seq, rest, optional, sink);
             }
-            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(*seq, expr, optional),
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
             // Resolved to a genuinely single value/cursor -- hand off to the
             // already-correct, arbitrary-length-pipe-aware demand driver
             // rather than re-deriving its cursor-threading logic here
@@ -5005,12 +5023,11 @@ enum GenericItem<V: DocumentValue> {
         collapse: bool,
     },
     LazyIndexRange(usize),
-    /// Boxed for the same reason as `GenericResult::LazySeq` (#789): this is
-    /// the sibling enum pushed once per *item* through every sink in the
-    /// streaming/demand-driven path (`push_one_generic`,
-    /// `each_*_iterate_sink`, `drain_result_generic`), so an unboxed
-    /// `LazySeq<V>` here pays the same flat oversized-copy tax on an even
-    /// hotter path than `GenericResult`'s own per-stage one.
+    /// Boxed for the same reason as `GenericResult::LazySeq` (#789) -- see
+    /// that variant's doc comment for the mechanism. This sibling enum is
+    /// pushed once per *item* through every sink in the streaming path
+    /// (`push_one_generic`, `each_*_iterate_sink`), an even hotter path than
+    /// `GenericResult`'s own per-stage one.
     LazySeq(Box<LazySeq<V>>),
 }
 
@@ -8629,14 +8646,18 @@ mod tests {
     /// Boxing the variant recovered the original 120 bytes. Pinned here as a
     /// permanent regression guard against a future variant doing the same
     /// thing silently -- Rust enum size is easy to grow by accident one
-    /// field at a time with no compiler warning.
+    /// field at a time with no compiler warning. Exact-value assertion,
+    /// gated to 64-bit, matches this crate's existing size-guard convention
+    /// (`error::tests::eval_error_size_is_pinned_for_the_1021_stack_overflow_fix`);
+    /// 32-bit targets shrink pointer-sized fields, so this exact count
+    /// doesn't hold there.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_generic_result_size_stays_bounded_789() {
-        let size =
-            core::mem::size_of::<GenericResult<crate::json::light::StandardJson<'_, Vec<u64>>>>();
-        assert!(
-            size <= 128,
-            "GenericResult<V> grew to {size} bytes (was 120 pre-#740, 184 with the #789 \
+        assert_eq!(
+            core::mem::size_of::<GenericResult<crate::json::light::StandardJson<'_, Vec<u64>>>>(),
+            120,
+            "GenericResult<V>'s size regressed (was 120 pre-#740, 184 with the #789 \
              regression, 120 again after boxing LazySeq) -- every variant now pays this on \
              every return; investigate before accepting a bigger enum"
         );
@@ -8649,14 +8670,15 @@ mod tests {
     /// (`push_one_generic`, `each_*_iterate_sink`), not once per pipe
     /// stage. Measured at 184 bytes pre-fix (identical to raw `LazySeq<V>`
     /// itself), 80 bytes after boxing. Pinned as the `GenericItem` twin of
-    /// [`test_generic_result_size_stays_bounded_789`] above.
+    /// [`test_generic_result_size_stays_bounded_789`] above, same
+    /// exact-value-plus-64-bit-gate convention.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_generic_item_size_stays_bounded_789() {
-        let size =
-            core::mem::size_of::<GenericItem<crate::json::light::StandardJson<'_, Vec<u64>>>>();
-        assert!(
-            size <= 96,
-            "GenericItem<V> grew to {size} bytes (was 184 with the #789 defect, 80 after \
+        assert_eq!(
+            core::mem::size_of::<GenericItem<crate::json::light::StandardJson<'_, Vec<u64>>>>(),
+            80,
+            "GenericItem<V>'s size regressed (was 184 with the #789 defect, 80 after \
              boxing LazySeq) -- every variant now pays this on every push; investigate \
              before accepting a bigger enum"
         );

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5005,7 +5005,13 @@ enum GenericItem<V: DocumentValue> {
         collapse: bool,
     },
     LazyIndexRange(usize),
-    LazySeq(LazySeq<V>),
+    /// Boxed for the same reason as `GenericResult::LazySeq` (#789): this is
+    /// the sibling enum pushed once per *item* through every sink in the
+    /// streaming/demand-driven path (`push_one_generic`,
+    /// `each_*_iterate_sink`, `drain_result_generic`), so an unboxed
+    /// `LazySeq<V>` here pays the same flat oversized-copy tax on an even
+    /// hotter path than `GenericResult`'s own per-stage one.
+    LazySeq(Box<LazySeq<V>>),
 }
 
 /// Push one item to `sink`, translating its `Demand` into a terminal `Flow`.
@@ -5072,7 +5078,7 @@ fn drain_result_generic<V: DocumentValue>(
         GenericResult::LazyIndexRange(len) => {
             push_one_generic(GenericItem::LazyIndexRange(len), sink)
         }
-        GenericResult::LazySeq(seq) => push_one_generic(GenericItem::LazySeq(*seq), sink),
+        GenericResult::LazySeq(seq) => push_one_generic(GenericItem::LazySeq(seq), sink),
         GenericResult::Many(vs) => push_many_generic(vs.into_iter().map(GenericItem::One), sink),
         GenericResult::ManyCursor(cs) => {
             push_many_generic(cs.into_iter().map(GenericItem::OneCursor), sink)
@@ -5994,7 +6000,7 @@ fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResu
             collapse,
         },
         GenericItem::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
-        GenericItem::LazySeq(seq) => GenericResult::LazySeq(Box::new(seq)),
+        GenericItem::LazySeq(seq) => GenericResult::LazySeq(seq),
     }
 }
 
@@ -8633,6 +8639,26 @@ mod tests {
             "GenericResult<V> grew to {size} bytes (was 120 pre-#740, 184 with the #789 \
              regression, 120 again after boxing LazySeq) -- every variant now pays this on \
              every return; investigate before accepting a bigger enum"
+        );
+    }
+
+    /// #789 (code review follow-up): `GenericItem<V>`'s own `LazySeq`
+    /// variant had the identical unboxed-widest-variant defect as
+    /// `GenericResult`'s -- and on a hotter path, since `GenericItem` is
+    /// pushed once per *item* through every sink in the streaming path
+    /// (`push_one_generic`, `each_*_iterate_sink`), not once per pipe
+    /// stage. Measured at 184 bytes pre-fix (identical to raw `LazySeq<V>`
+    /// itself), 80 bytes after boxing. Pinned as the `GenericItem` twin of
+    /// [`test_generic_result_size_stays_bounded_789`] above.
+    #[test]
+    fn test_generic_item_size_stays_bounded_789() {
+        let size =
+            core::mem::size_of::<GenericItem<crate::json::light::StandardJson<'_, Vec<u64>>>>();
+        assert!(
+            size <= 96,
+            "GenericItem<V> grew to {size} bytes (was 184 with the #789 defect, 80 after \
+             boxing LazySeq) -- every variant now pays this on every push; investigate \
+             before accepting a bigger enum"
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2275,7 +2275,21 @@ pub enum GenericResult<V: DocumentValue> {
     /// further `| map(g)` stages pushed onto the same chain by the `Pipe`
     /// fold's composability arm below. See `LazySeq`'s own docs for the
     /// mechanism and `docs/plan/jq-lazy-map-select.md` for the design.
-    LazySeq(LazySeq<V>),
+    ///
+    /// Boxed (#789): `LazySeq<V>` embedded directly grew `GenericResult<V>`
+    /// from 120 to 184 bytes (measured via `size_of_val`, x86_64), and every
+    /// arm of this enum -- `select`'s own trivial boolean-test result
+    /// included -- pays that larger copy on every return, since Rust enum
+    /// size is the discriminant plus the *widest* variant regardless of
+    /// which one is active. That extra copying is flat per call, not
+    /// size-scaling, matching the issue's own "flat ~6-7% slower across
+    /// 100kb-100mb" measurement on AMD Ryzen 9 7950X exactly (Apple M4 Pro
+    /// showed no effect, consistent with #106's precedent that small
+    /// constant-factor costs don't always port between architectures).
+    /// Boxing this one variant is the minimal fix: every other variant's own
+    /// size is unaffected, and `LazySeq<V>` itself only grows a single
+    /// pointer wherever it's already handled by reference/move.
+    LazySeq(Box<LazySeq<V>>),
 
     /// No result (optional that was missing).
     None,
@@ -3479,7 +3493,7 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // materializes once (`materialize_atomic`) and hands off
             // to the full evaluator — still one pass, not the
             // original four-pass round trip.
-            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(*seq, expr, optional),
             GenericResult::None => GenericResult::None,
             GenericResult::Error(e) => return GenericResult::Error(e),
             GenericResult::Owned(o) => {
@@ -3698,9 +3712,9 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // first. `LazySource::keys` carries the collapse rule
         // into the pull itself (#1514), so no probe runs here
         // either.
-        Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(
+        Expr::Builtin(Builtin::Map(f)) if !sorted => GenericResult::LazySeq(Box::new(
             LazySeq::new(LazySource::keys(fields, collapse)).push_map(f, S::TAG),
-        ),
+        )),
         // No probe: `materialize_lazy_keys` applies the
         // collapse rule itself, through `effective_keys`.
         _ => match materialize_lazy_keys::<V>(&fields, sorted, collapse) {
@@ -3763,9 +3777,9 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
         // Slice 1 (#724), array counterpart of `LazyKeys`'s
         // own `Builtin::Map` arm above. No `!sorted` guard —
         // array "keys" are never sorted.
-        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(
+        Expr::Builtin(Builtin::Map(f)) => GenericResult::LazySeq(Box::new(
             LazySeq::new(LazySource::IndexRange { next: 0, len }).push_map(f, S::TAG),
-        ),
+        )),
         _ => eval_on_owned::<S, _>(expr, materialize_lazy_index_range(len), optional),
     }
 }
@@ -3785,7 +3799,7 @@ fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
 ) -> GenericResult<V> {
     match unwrap_paren(expr) {
-        Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(seq.push_map(h, S::TAG)),
+        Expr::Builtin(Builtin::Map(h)) => GenericResult::LazySeq(Box::new(seq.push_map(h, S::TAG))),
 
         // Count-and-discard: every element still runs (so a
         // `map(f)` that errors partway still errors), but no
@@ -4223,9 +4237,9 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
                 fold_lazy_index_range_stage::<S, V>(len, expr, optional)
             }
             GenericResult::LazySeq(seq) if is_iterate => {
-                return each_lazy_seq_iterate_sink::<S, V>(seq, rest, optional, sink);
+                return each_lazy_seq_iterate_sink::<S, V>(*seq, rest, optional, sink);
             }
-            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(seq, expr, optional),
+            GenericResult::LazySeq(seq) => fold_lazy_seq_stage::<S, V>(*seq, expr, optional),
             // Resolved to a genuinely single value/cursor -- hand off to the
             // already-correct, arbitrary-length-pipe-aware demand driver
             // rather than re-deriving its cursor-threading logic here
@@ -5058,7 +5072,7 @@ fn drain_result_generic<V: DocumentValue>(
         GenericResult::LazyIndexRange(len) => {
             push_one_generic(GenericItem::LazyIndexRange(len), sink)
         }
-        GenericResult::LazySeq(seq) => push_one_generic(GenericItem::LazySeq(seq), sink),
+        GenericResult::LazySeq(seq) => push_one_generic(GenericItem::LazySeq(*seq), sink),
         GenericResult::Many(vs) => push_many_generic(vs.into_iter().map(GenericItem::One), sink),
         GenericResult::ManyCursor(cs) => {
             push_many_generic(cs.into_iter().map(GenericItem::OneCursor), sink)
@@ -5980,7 +5994,7 @@ fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResu
             collapse,
         },
         GenericItem::LazyIndexRange(len) => GenericResult::LazyIndexRange(len),
-        GenericItem::LazySeq(seq) => GenericResult::LazySeq(seq),
+        GenericItem::LazySeq(seq) => GenericResult::LazySeq(Box::new(seq)),
     }
 }
 
@@ -7536,9 +7550,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // non-goal and stays on the wildcard fallback below.
         Builtin::Map(f) => {
             if let Some(elements) = value.as_array() {
-                GenericResult::LazySeq(
+                GenericResult::LazySeq(Box::new(
                     LazySeq::new(LazySource::Elements(elements)).push_map(f, S::TAG),
-                )
+                ))
             } else if let Some(fields) = value.as_object() {
                 // `.[]` collapses a repeated key to its first position but
                 // last-seen value in both modes (#1398), which needs every
@@ -7558,7 +7572,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     },
                     None => LazySource::Values(fields),
                 };
-                GenericResult::LazySeq(LazySeq::new(source).push_map(f, S::TAG))
+                GenericResult::LazySeq(Box::new(LazySeq::new(source).push_map(f, S::TAG)))
             } else if S::TAG == EvalTag::Yq && value.is_null() {
                 // #1907: real yq no-ops a scalar target for `map` entirely
                 // -- `f` never even runs (confirmed live, v4.53.3: `5 |
@@ -8597,6 +8611,28 @@ mod tests {
         assert_eq!(
             empty_result.collect_owned().unwrap(),
             vec![OwnedValue::Array(vec![])]
+        );
+    }
+
+    /// #789: embedding `LazySeq<V>` directly in `GenericResult::LazySeq`
+    /// grew the enum from 120 to 184 bytes (`size_of_val`, x86_64) -- every
+    /// arm pays the widest variant's size on every return, so `select`'s own
+    /// trivial boolean-test result got 64 bytes heavier to copy on every
+    /// call, a flat per-call cost matching the issue's measured "flat ~6-7%
+    /// slower across all sizes on AMD Ryzen 9 7950X" regression exactly.
+    /// Boxing the variant recovered the original 120 bytes. Pinned here as a
+    /// permanent regression guard against a future variant doing the same
+    /// thing silently -- Rust enum size is easy to grow by accident one
+    /// field at a time with no compiler warning.
+    #[test]
+    fn test_generic_result_size_stays_bounded_789() {
+        let size =
+            core::mem::size_of::<GenericResult<crate::json::light::StandardJson<'_, Vec<u64>>>>();
+        assert!(
+            size <= 128,
+            "GenericResult<V> grew to {size} bytes (was 120 pre-#740, 184 with the #789 \
+             regression, 120 again after boxing LazySeq) -- every variant now pays this on \
+             every return; investigate before accepting a bigger enum"
         );
     }
 


### PR DESCRIPTION
## Summary

PR #740 added `GenericResult::LazySeq(LazySeq<V>)` unboxed to `eval_generic.rs`'s
result enum. Since Rust enum size is the discriminant plus the *widest* variant, this
grew `GenericResult<V>` from 120 to 184 bytes (`size_of_val`, x86_64) — every return of
`GenericResult`, `select`'s own trivial boolean-test result included, now pays that
larger copy. It's a flat per-call cost, not size-scaling, matching #789's own measured
"flat ~6-7% slower across 100kb-100mb" regression on AMD Ryzen 9 7950X exactly. Apple
M4 Pro never showed the regression, consistent with #106's precedent that small
constant-factor costs don't always port across architectures.

## Fix

Box the variant: `LazySeq(Box<LazySeq<V>>)`, recovering the enum to exactly 120 bytes.
Ten call sites updated to box on construction / deref on consumption.
`GenericItem<V>`'s own (separate) `LazySeq` variant is deliberately left unboxed — out
of scope for this minimal fix.

Added a permanent `size_of` regression-guard test so a future variant growing the enum
silently gets caught by CI rather than requiring another benchmark investigation.

## Measurements (interleaved A/B, output-identity gated, `scripts/ab-cli.py`)

**x86_64 (AMD Ryzen 9 7950X, `terminus`):** `select(true)` regression drops from
+6.0%/+7.3% to roughly +1% or less across all four sizes (100kb/1mb/10mb/100mb);
`map(.)` gives back ~1.5-2.5% of its own speedup at 3 of 4 sizes but stays vastly
net-positive vs. the pre-#740 baseline (-5% to -29% there, vs. the +14% to +51% the
original unboxed-enum regression had erased).

**ARM64 (Apple M4 Pro, `johns-mac-mini`):** no new regression on either query — median
of medians +0.75%, mean +0.60%, range -1.1%..+1.7%, well within noise. Consistent with
M4 Pro never having shown the original x86_64-specific regression either.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast` — 56/56 binaries, 6588 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings)
- [x] New `test_generic_result_size_stays_bounded_789` pins the enum at ≤128 bytes
- [x] A/B benchmarked on both x86_64 and ARM64 with output-identity gating (0 differences)

Fixes #789