### PR TITLE
fix(jq): guard eval_slice_expr's per-target to_owned against decode failure

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15588,7 +15588,18 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     let slice_expr = Expr::Slice { start: *s, end: *e };
                     for t in ts {
                         match eval_single::<W, S>(&slice_expr, t.clone(), optional) {
-                            QueryResult::One(v) => out.push(to_owned(&v)),
+                            // #1943: to_owned_checked, not to_owned -- the
+                            // `Expr::Slice` fast path for a fully-open
+                            // bound (`matches!(start, None|Some(0)) &&
+                            // end.is_none()`) returns the target's original
+                            // borrowed, undecoded value unchanged (#1932's
+                            // own finding for `eval_single`'s array arm),
+                            // so an undecodable string here used to
+                            // silently become `""` instead of raising.
+                            QueryResult::One(v) => match to_owned_checked(&v) {
+                                Ok(v) => out.push(v),
+                                Err(e) => return QueryResult::Error(e),
+                            },
                             QueryResult::Owned(v) => out.push(v),
                             QueryResult::None => {}
                             QueryResult::Error(e) => return QueryResult::Error(e),
@@ -39573,6 +39584,49 @@ mod tests {
                 assert_eq!(
                     v,
                     vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::String("ok".into())]
+                );
+            }
+        );
+    }
+
+    /// #1943: `eval_slice_expr` (computed slice bounds, e.g. `.[$a:$b]`) has
+    /// the identical bug shape #1932 fixed above, via a different call path.
+    /// A bound that resolves to `null` folds to `None` ("open"), and this
+    /// function builds an internal `Expr::Slice{start:None,end:None}` per
+    /// borrowed target -- `eval_single`'s own fast path for that exact shape
+    /// (`matches!(start, None|Some(0)) && end.is_none()`) returns the
+    /// target's original borrowed, undecoded array unchanged, so this
+    /// function's own consumer of that `QueryResult::One(v)` used the
+    /// unchecked `to_owned` instead of `to_owned_checked`.
+    ///
+    /// Exercised via `eval.rs`'s own library-API dispatch (`query!`), not
+    /// the CLI -- `succinctly jq`/`yq`'s real dynamic-slice dispatch is
+    /// `eval_generic.rs`'s own, separately-implemented `eval_slice_expr`,
+    /// which converts via already-checked helpers and doesn't share this
+    /// bug, same CLI-unreachability shape #1932/#1755 established for this
+    /// bug family already.
+    #[test]
+    fn test_slice_expr_raises_on_element_decode_failure_1943() {
+        query!(
+            &b"[1,2,\"\xff\xfe\",4]"[..],
+            ".[null:null]",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        // Positive control: valid data through the same arm is unaffected.
+        query!(
+            br#"[1,2,"ok",4]"#,
+            ".[null:null]",
+            QueryResult::Owned(OwnedValue::Array(v)) => {
+                assert_eq!(
+                    v,
+                    vec![
+                        OwnedValue::Int(1),
+                        OwnedValue::Int(2),
+                        OwnedValue::String("ok".into()),
+                        OwnedValue::Int(4)
+                    ]
                 );
             }
         );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -584,8 +584,9 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
 /// Used only at this file's primary result-value materialization points
 /// (`builtin_path`, `eval_assign`, `eval_update`, `yq_assign_noop_check`,
 /// `builtin_setpath`, `builtin_del`, `delpaths_one`,
-/// `map_over`/`builtin_map_values`, `builtin_to_entries`) rather than
-/// replacing [`to_owned`] everywhere: this file has on the order of 150
+/// `map_over`/`builtin_map_values`, `builtin_to_entries`, `eval_slice_expr`
+/// (#1943) -- not exhaustive, see #1908/#1953 for the remaining audit)
+/// rather than replacing [`to_owned`] everywhere: this file has on the order of 150
 /// other `to_owned` call sites, roughly 50 of them a real instance of the
 /// same #1746 bug shape (filed as #1755) and the rest `QueryResult`
 /// collector boilerplate or error-message rendering -- changing the
@@ -39599,11 +39600,16 @@ mod tests {
     /// function's own consumer of that `QueryResult::One(v)` used the
     /// unchecked `to_owned` instead of `to_owned_checked`.
     ///
-    /// Exercised via `eval.rs`'s own library-API dispatch (`query!`), not
-    /// the CLI -- `succinctly jq`/`yq`'s real dynamic-slice dispatch is
+    /// Exercised via `eval.rs`'s own library-API dispatch (`query!`).
+    /// `succinctly jq`/`yq`'s primary dynamic-slice dispatch is
     /// `eval_generic.rs`'s own, separately-implemented `eval_slice_expr`,
     /// which converts via already-checked helpers and doesn't share this
-    /// bug, same CLI-unreachability shape #1932/#1755 established for this
+    /// bug -- `yq_runner.rs`'s `--slurp`/`--null-input`/`--eval-all`/
+    /// multi-file paths do call into *this* file's `jq::eval` directly, but
+    /// always on an already-materialized `OwnedValue` re-serialized to
+    /// fresh, valid-UTF8 JSON first (`to_json_for_reindex`), so this
+    /// function's own new `Err` branch can't actually fire through that
+    /// bridge in practice -- same shape #1932/#1755 established for this
     /// bug family already.
     #[test]
     fn test_slice_expr_raises_on_element_decode_failure_1943() {


### PR DESCRIPTION
## Summary

`eval_slice_expr` (computed slice bounds, e.g. `.[$a:$b]`) has the identical unchecked-`to_owned` bug shape #1932 fixed for `eval_single`'s own `Expr::Slice` array arm, via a different call path.

When a bound resolves to `null`, it folds to `None` (an "open" bound), and `eval_slice_expr` builds an internal `Expr::Slice{start:None,end:None}` per borrowed target. `eval_single`'s own fast path for that exact shape (`matches!(start, None|Some(0)) && end.is_none()`) returns the target's original borrowed, undecoded array unchanged — which is safe for the callers #1932 checked, but `eval_slice_expr`'s own consumer of that `QueryResult::One(v)` result called the plain unchecked `to_owned`, not `to_owned_checked`, to materialize it.

```
document: [1,2,"\xff\xfe",4]  (an array with an invalid-UTF-8 string)
query:    .[null:null]

before: QueryResult::Owned(Array([Int(1), Int(2), String(""), Int(4)]))  -- silently corrupted
after:  EvalError::decode_failure
```

## Fix

Swap the unchecked `to_owned(&v)` for `to_owned_checked(&v)` at that one call site, propagating its `Err`, mirroring #1932's own fix.

## Review findings

Three rounds of review confirmed the fix is correct and scoped properly, and surfaced:
- A minor doc-comment wording issue (the "not reachable via the CLI" framing was imprecise — `yq_runner.rs`'s `--slurp`/`--null-input`/`--eval-all` paths do call into this file's `eval()` directly, but always on an already-materialized `OwnedValue` re-serialized to fresh, valid-UTF8 JSON first, so the new `Err` branch still can't fire through that bridge in practice, just for a narrower reason). Corrected.
- `to_owned_checked`'s own doc comment listing its call sites was missing `eval_slice_expr`. Added.
- A confirmed-live, **more severe** sibling bug: `eval_single`'s fully-open `Expr::Slice` fast path (the root cause this fix and #1932 each patch at one consumer) is itself unguarded, and at least two more consumers (`push_owned_values` via `eval_binary_fanout`, `eval_string_interpolation_single_value`) inherit it — but produce **no error signal at all** rather than a masked one (e.g. `.[:] == .[:]` on corrupted data silently returns `true`). Filed as #1972 rather than expanding this PR's scope.

## Test plan
- [x] New unit test in `src/jq/eval.rs`: `test_slice_expr_raises_on_element_decode_failure_1943` (exercised via `eval.rs`'s own library-API dispatch, same as `test_array_slice_raises_on_element_decode_failure_1932` right above it)
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, re-run after each review round)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Fixes #1943
