### PR TITLE
fix(jq): widen the missing delimiter_fault() check across 6 LazyKeys call sites

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -787,6 +787,14 @@ diagnostic clean; the truncation itself was already the accepted trade, not a ne
 bare `.[]`. Left open by #1641, mirroring the `#1629` precedent above rather than silently
 expanding that PR's scope.
 
+`LazySource::Keys` -- `keys_unsorted | map(f)`, the sibling variant of the same `advance()`
+match, sourcing from a `DistinctKeyCursors` walk rather than raw `uncons` -- is *not* this
+same gap and is not left open: #1956 found it had no check at all (neither
+`ended_unpaired()` nor `delimiter_fault()`, unlike every other `keys_unsorted` consumer,
+which had at least one), confirmed live (`keys_unsorted | map(.)` silently succeeded where
+`keys_unsorted | last` correctly raised), and fixed by threading `is_malformed()` through
+`advance()`'s now-fallible return.
+
 `--preserve-input` is not an exception to any of this: it changes how values are *rendered*
 (number literals and escape sequences kept as written), not whether the document is accepted,
 so a malformed member raises under it exactly as it does without it.
@@ -884,7 +892,8 @@ shared with the CLI printer rather than duplicated) into the object/array walk p
 gets the same protection a CLI user does, not just `sjq -c .`. The residual gaps are exactly
 the ones already named above for the unpaired-member class, since both checks now ride the
 same walks: `obj | map(f)` (`LazySource::Values`, left open by #1641), `keys_unsorted`'s
-positional fast paths (`.[0]`, `first`, `last`, `.[n]`, tracked separately as #1629), and bare
+still-deliberately-unchecked positional fast paths (`.[0]`, `first`, `.[n]`, tracked
+separately as #1629 -- `last` is no longer one of these, see below), and bare
 `keys_unsorted`'s streaming truncation (a partial array can reach stdout beside the exit 5,
 for the same "cannot rewind a byte-at-a-time writer" reason).
 
@@ -922,6 +931,15 @@ coverage differs:
 A library caller who follows the documented `eval()` example and evaluates straight off a
 fresh cursor gets #1677 protection only from `keys`/`keys_unsorted`/`to_entries`; every other
 builtin in this file, checked or not on the decode-failure/#1194 axis, still misses it.
+
+**`keys_unsorted`'s positional fast paths split three ways.** `.[0]`/`first`/`.[n]` (a
+positive index) stay *deliberately* unchecked -- they are the arms built to answer in O(1)
+without walking the rest of the object, and adding this check would cost strictly more than
+the answer itself (#1629's own accounting of that tradeoff, "Option 1"). `last` is not one
+of these: it already walks the whole object regardless (there is no way to find "the last
+field" without reaching the end), so #1956 folded this same check into that arm too, at no
+extra cost -- `keys_unsorted | last` on a malformed `,`/`:` delimiter now raises the same as
+`keys`/`keys_unsorted` themselves.
 
 **#1829 closed the remaining gap** (`map_values` via #1835/#1848/#1854; `with_entries`
 confirmed to inherit `to_entries`'s fix for free, needing no separate change; `paths`,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -843,7 +843,7 @@ fn bail_if_keys_malformed<F: succinctly::jq::document::DocumentFields>(
     keys: &DistinctKeyCursors<F>,
     doc_text: Option<&[u8]>,
 ) -> Result<()> {
-    match (keys.ended_unpaired() || keys.delimiter_fault(), doc_text) {
+    match (keys.is_malformed(), doc_text) {
         (true, Some(text)) => Err(MalformedJsonError(EvalError::malformed_json_text(text)).into()),
         _ => Ok(()),
     }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1746,6 +1746,26 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
     pub fn ended_unpaired(&self) -> bool {
         self.ended_unpaired
     }
+
+    /// Either #1194 fault together: [`ended_unpaired`](Self::ended_unpaired)
+    /// or [`delimiter_fault`](Self::delimiter_fault). One definition of the
+    /// combined check, so a caller can't correctly check one half and
+    /// forget the other -- #1956 was exactly that: two call sites checking
+    /// `ended_unpaired()` alone, missing the `delimiter_fault()` sibling
+    /// three others already had. Same "only meaningful once exhausted"
+    /// contract as both halves individually.
+    pub fn is_malformed(&self) -> bool {
+        self.ended_unpaired() || self.delimiter_fault()
+    }
+
+    /// The error to raise once [`is_malformed`](Self::is_malformed) is
+    /// `true` -- delegates to the whole object's own `all` copy rather than
+    /// `rest` (stale mid-object on one #1194 shape, already exhausted on the
+    /// other), so a caller holding only this walk and no separate `F` of its
+    /// own (`LazySource::Keys`, #1956) can still build the right error.
+    pub fn malformed_member_error(&self) -> EvalError {
+        self.all.malformed_member_error()
+    }
 }
 
 impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
@@ -2019,7 +2039,7 @@ pub fn effective_keys<F: DocumentFields>(
     // (`eval_generic.rs`) applies to its own `DistinctKeyCursors` walk --
     // this one just never got wired to it when #1642 rewrote this function
     // onto `DistinctKeyCursors` on `main`, ahead of this check existing.
-    if cursors.ended_unpaired() || cursors.delimiter_fault() {
+    if cursors.is_malformed() {
         return Err(fields.malformed_member_error());
     }
     Ok(keys)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3677,11 +3677,10 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 }
                 last_cursor = Some(cursor);
             }
-            // Missing `|| cursors.delimiter_fault()` here (unlike this
-            // function's own `distinct_key_cursors_checked`/
-            // `keys_are_well_formed` siblings) is a pre-existing, tracked
-            // gap (#1956), not addressed in this pass.
-            if cursors.ended_unpaired() {
+            // #1956: matches this function's own `distinct_key_cursors_checked`/
+            // `keys_are_well_formed` siblings, which both check
+            // `ended_unpaired() || delimiter_fault()` together.
+            if cursors.ended_unpaired() || cursors.delimiter_fault() {
                 return GenericResult::Error(fields.malformed_member_error());
             }
             match last_cursor {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -994,9 +994,11 @@ fn keys_are_well_formed<V: DocumentValue>(
 /// a no-op for the latter). Pulled out so the check itself has exactly one
 /// definition instead of two copies that could silently drift apart (the
 /// codebase's own precedent for why this matters: `Builtin::Last`'s inline
-/// walk below already diverged from both of these by omitting the
-/// `delimiter_fault()` half of the check -- tracked as #1956, not fixed
-/// here since it predates and is independent of this fix).
+/// walk below once diverged from both of these by omitting the
+/// `delimiter_fault()` half of the check -- #1956 fixed that arm, plus two
+/// more sites found the same way, by adding
+/// [`DistinctKeyCursors::is_malformed`] so a caller can no longer check one
+/// half of the pair and forget the other).
 fn walk_distinct_keys_checked<V: DocumentValue>(
     fields: &V::Fields,
     collapse: bool,
@@ -1009,7 +1011,7 @@ fn walk_distinct_keys_checked<V: DocumentValue>(
         }
         on_cursor(cursor);
     }
-    if cursors.ended_unpaired() || cursors.delimiter_fault() {
+    if cursors.is_malformed() {
         return Err(fields.malformed_member_error());
     }
     Ok(())
@@ -1129,34 +1131,55 @@ impl<V: DocumentValue> LazySource<V> {
     }
     /// Pull one element forward, storing "the rest" back into `self`. Once a
     /// variant's underlying cons-list is empty (or `next == len`), every
-    /// subsequent call returns `None` forever.
-    fn advance(&mut self) -> Option<LazyElem<V>> {
-        match self {
+    /// subsequent call returns `Ok(None)` forever -- except `Keys`, which can
+    /// still raise on that same exhaustion (#1956: a `keys_unsorted | map(f)`
+    /// chain sourced its elements straight from `DistinctKeyCursors::next()`
+    /// without ever asking `is_malformed()`, the exact check every other
+    /// `keys_unsorted` consumer already made -- confirmed live, `keys_unsorted
+    /// | map(.)` over a document with a missing `,`/`:` silently succeeded
+    /// while every sibling spelling correctly raised).
+    fn advance(&mut self) -> Result<Option<LazyElem<V>>, EvalError> {
+        Ok(match self {
             Self::Elements(elements) => {
-                let (cursor, rest) = elements.uncons_cursor()?;
+                let Some((cursor, rest)) = elements.uncons_cursor() else {
+                    return Ok(None);
+                };
                 *elements = rest;
                 Some(LazyElem::Cursor(cursor))
             }
             Self::Values(fields) => {
-                let (field, rest) = fields.uncons()?;
+                let Some((field, rest)) = fields.uncons() else {
+                    return Ok(None);
+                };
                 *fields = rest;
                 Some(LazyElem::Cursor(field.value_cursor))
             }
-            Self::Keys(keys) => Some(LazyElem::Cursor(keys.next()?.1)),
+            Self::Keys(keys) => match keys.next() {
+                Some((key, cursor)) => {
+                    if key_is_malformed(&key) {
+                        return Err(keys.malformed_member_error());
+                    }
+                    Some(LazyElem::Cursor(cursor))
+                }
+                None if keys.is_malformed() => return Err(keys.malformed_member_error()),
+                None => None,
+            },
             Self::IndexRange { next, len } => {
                 if *next >= *len {
-                    return None;
+                    return Ok(None);
                 }
                 let i = *next;
                 *next += 1;
                 Some(LazyElem::Owned(OwnedValue::Int(i as i64)))
             }
             Self::CollapsedValues { cursors, next } => {
-                let cursor = cursors.get(*next).copied()?;
+                let Some(cursor) = cursors.get(*next).copied() else {
+                    return Ok(None);
+                };
                 *next += 1;
                 Some(LazyElem::Cursor(cursor))
             }
-        }
+        })
     }
 }
 
@@ -1354,7 +1377,11 @@ impl<V: DocumentValue> Iterator for LazySeq<V> {
             if let Some(item) = self.pending.pop() {
                 return Some(Ok(item));
             }
-            let elem = self.source.advance()?;
+            let elem = match self.source.advance() {
+                Ok(Some(elem)) => elem,
+                Ok(None) => return None,
+                Err(e) => return Some(Err(Control::Error(e))),
+            };
             match self.fold_one(elem) {
                 Ok(mut items) => {
                     items.reverse();
@@ -3678,9 +3705,9 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
                 last_cursor = Some(cursor);
             }
             // #1956: matches this function's own `distinct_key_cursors_checked`/
-            // `keys_are_well_formed` siblings, which both check
-            // `ended_unpaired() || delimiter_fault()` together.
-            if cursors.ended_unpaired() || cursors.delimiter_fault() {
+            // `keys_are_well_formed` siblings via the same
+            // `DistinctKeyCursors::is_malformed` they use.
+            if cursors.is_malformed() {
                 return GenericResult::Error(fields.malformed_member_error());
             }
             match last_cursor {

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -28,8 +28,8 @@ use std::borrow::Cow;
 use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
-    effective_len, key_display_string, resolve_display_key, DisplayKeyGuard, DistinctKeyCursors,
-    DocumentFields,
+    effective_len, key_delimiter_ok, key_display_string, resolve_display_key, value_delimiter_ok,
+    DisplayKeyGuard, DistinctKeyCursors, DocumentFields,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -664,9 +664,8 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                 }
                 // #1956: matches `eval_generic.rs`'s own
                 // `distinct_key_cursors_checked`/`keys_are_well_formed`,
-                // which both check `ended_unpaired() || delimiter_fault()`
-                // together.
-                if cursors.ended_unpaired() || cursors.delimiter_fault() {
+                // which both check this via `is_malformed()`.
+                if cursors.is_malformed() {
                     return Err(core::fmt::Error);
                 }
                 out.write_char(']')
@@ -693,7 +692,13 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// For materialized values, serializes to JSON.
     pub fn to_json_string(&self) -> String {
         let mut out = String::new();
-        // Ignore error - writing to String can't fail
+        // Writing to a `String` itself can't fail, but `write_json` can --
+        // a `LazyKeysArray` malformed per #1194/#1677 returns `Err` after
+        // `out` already holds a truncated fragment (#1956; see
+        // `write_json_at_depth`'s own doc comment). No caller of this
+        // function today needs to distinguish "well-formed" from
+        // "truncated on error", so the `Err` is intentionally discarded --
+        // just not for the reason the old comment gave.
         let _ = self.write_json(&mut out);
         out
     }
@@ -723,9 +728,8 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
         keys.push(OwnedValue::String(s.into_owned()));
     }
     // #1956: matches `eval_generic.rs`'s own `distinct_key_cursors_checked`/
-    // `keys_are_well_formed`, which both check
-    // `ended_unpaired() || delimiter_fault()` together.
-    if cursors.ended_unpaired() || cursors.delimiter_fault() {
+    // `keys_are_well_formed`, which both check this via `is_malformed()`.
+    if cursors.is_malformed() {
         return Err(fields.malformed_member_error());
     }
     Ok(OwnedValue::Array(keys))
@@ -790,6 +794,7 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // on an unpaired child" (#1194) -- mirrors
             // `eval_generic::to_owned_at_depth`'s identical shape.
             let mut f = fields;
+            let mut is_first = true;
             while let Some((field, rest)) = f.uncons() {
                 // A key that isn't a `String` token at all is *structurally*
                 // malformed (#1194) and now raises, matching
@@ -800,9 +805,24 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 let Some(key) = resolve_display_key(&field.key(), &map, &mut guard)? else {
                     return Err(f.malformed_member_error());
                 };
+                // #1956: this walk (unlike its `eval_generic::to_owned_at_depth`
+                // sibling it otherwise mirrors) never called `key_delimiter_ok`/
+                // `value_delimiter_ok` -- a missing/doubled `,`/`:` (#1677) with
+                // an otherwise-even member count silently succeeded here.
+                if !key_delimiter_ok::<crate::json::light::JsonFields<'_, W>>(
+                    &field.key(),
+                    &field.key_cursor(),
+                    is_first,
+                ) || !value_delimiter_ok::<crate::json::light::JsonFields<'_, W>>(
+                    Some(&field.value()),
+                    &field.value_cursor(),
+                ) {
+                    return Err(f.malformed_member_error());
+                }
                 let value_cursor = field.value_cursor();
                 map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
                 f = rest;
+                is_first = false;
             }
             if f.ends_unpaired() {
                 return Err(f.malformed_member_error());
@@ -1719,35 +1739,39 @@ mod tests {
             fields,
             collapse: true,
         };
+
         let mut out = String::new();
         assert!(
             val.write_json(&mut out).is_err(),
             "a missing delimiter must not be written past silently: {out:?}"
         );
+        val.materialize()
+            .expect_err("a missing delimiter is not well-formed JSON");
+        val.into_owned()
+            .expect_err("a missing delimiter is not well-formed JSON");
+    }
+
+    /// #1956: `cursor_to_owned_at_depth`'s `StandardJson::Object` arm (backing
+    /// `JqValue::Cursor`'s own `materialize`/`into_owned`) walked `uncons()`
+    /// and checked only `ends_unpaired()`, never `key_delimiter_ok`/
+    /// `value_delimiter_ok` -- unlike its `eval_generic::to_owned_at_depth`
+    /// sibling, which checks both. An even member count with a missing `:`
+    /// used to materialize cleanly here.
+    #[test]
+    fn test_cursor_to_owned_raises_on_missing_delimiter_1956() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{\"a\" 1, \"b\": 2}";
 
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let fields = match cursor.value() {
-            StandardJson::Object(fields) => fields,
-            other => panic!("expected object, got {other:?}"),
-        };
-        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
-            fields,
-            collapse: true,
-        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
         val.materialize()
             .expect_err("a missing delimiter is not well-formed JSON");
 
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let fields = match cursor.value() {
-            StandardJson::Object(fields) => fields,
-            other => panic!("expected object, got {other:?}"),
-        };
-        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
-            fields,
-            collapse: true,
-        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
         val.into_owned()
             .expect_err("a missing delimiter is not well-formed JSON");
     }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -662,7 +662,11 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
                         }
                     }
                 }
-                if cursors.ended_unpaired() {
+                // #1956: matches `eval_generic.rs`'s own
+                // `distinct_key_cursors_checked`/`keys_are_well_formed`,
+                // which both check `ended_unpaired() || delimiter_fault()`
+                // together.
+                if cursors.ended_unpaired() || cursors.delimiter_fault() {
                     return Err(core::fmt::Error);
                 }
                 out.write_char(']')
@@ -718,10 +722,10 @@ fn lazy_keys_array_to_owned<W: Clone + AsRef<[u64]>>(
         };
         keys.push(OwnedValue::String(s.into_owned()));
     }
-    // Missing `|| cursors.delimiter_fault()` here (unlike `eval_generic.rs`'s
-    // `distinct_key_cursors_checked`/`keys_are_well_formed`) is a
-    // pre-existing, tracked gap (#1956), not addressed in this pass.
-    if cursors.ended_unpaired() {
+    // #1956: matches `eval_generic.rs`'s own `distinct_key_cursors_checked`/
+    // `keys_are_well_formed`, which both check
+    // `ended_unpaired() || delimiter_fault()` together.
+    if cursors.ended_unpaired() || cursors.delimiter_fault() {
         return Err(fields.malformed_member_error());
     }
     Ok(OwnedValue::Array(keys))
@@ -1690,6 +1694,62 @@ mod tests {
                 OwnedValue::Array(vec![OwnedValue::String("\u{FFFD}\u{FFFD}".to_string())])
             )]))
         );
+    }
+
+    /// #1956: `lazy_keys_array_to_owned` (backing `materialize`/`into_owned`)
+    /// and `write_json`'s own `LazyKeysArray` arm both used to check only
+    /// `cursors.ended_unpaired()`, missing the `delimiter_fault()` half of
+    /// the #1194/#1677 check that `eval_generic.rs`'s
+    /// `distinct_key_cursors_checked`/`keys_are_well_formed` already get
+    /// right. A missing `,`/`:` delimiter (not a non-string key, not an
+    /// unpaired tail) used to silently succeed here.
+    #[test]
+    fn test_lazy_keys_array_raises_on_missing_delimiter_1956() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"{\"a\" 1, \"b\": 2}";
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+            fields,
+            collapse: true,
+        };
+        let mut out = String::new();
+        assert!(
+            val.write_json(&mut out).is_err(),
+            "a missing delimiter must not be written past silently: {out:?}"
+        );
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+            fields,
+            collapse: true,
+        };
+        val.materialize()
+            .expect_err("a missing delimiter is not well-formed JSON");
+
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = match cursor.value() {
+            StandardJson::Object(fields) => fields,
+            other => panic!("expected object, got {other:?}"),
+        };
+        let val: JqValue<'_, Vec<u64>> = JqValue::LazyKeysArray {
+            fields,
+            collapse: true,
+        };
+        val.into_owned()
+            .expect_err("a missing delimiter is not well-formed JSON");
     }
 
     /// #1194: sibling of `jq_runner.rs`'s `standard_json_to_jq_value` and its

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -637,7 +637,9 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
         }
         stream_json_string(out, &key, write_json_body_yq)?;
     }
-    if error.is_none() && cursors.ended_unpaired() {
+    // #1956: `ended_unpaired()` alone missed a malformed `,`/`:` delimiter
+    // -- `is_malformed()` checks both #1194 faults this walk can find.
+    if error.is_none() && cursors.is_malformed() {
         *error = Some(fields.malformed_member_error());
     }
     if indent.width > 0 {
@@ -968,7 +970,9 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
             }
             stream_yaml_string(out, &key)?;
         }
-        if error.is_none() && cursors.ended_unpaired() {
+        // #1956: `ended_unpaired()` alone missed a malformed `,`/`:` delimiter
+        // -- `is_malformed()` checks both #1194 faults this walk can find.
+        if error.is_none() && cursors.is_malformed() {
             *error = Some(fields.malformed_member_error());
         }
         out.write_char(']')
@@ -986,7 +990,9 @@ pub fn stream_lazy_keys_yaml<W: core::fmt::Write, F: DocumentFields>(
             out.write_str("- ")?;
             stream_yaml_string(out, &key)?;
         }
-        if error.is_none() && cursors.ended_unpaired() {
+        // #1956: `ended_unpaired()` alone missed a malformed `,`/`:` delimiter
+        // -- `is_malformed()` checks both #1194 faults this walk can find.
+        if error.is_none() && cursors.is_malformed() {
             *error = Some(fields.malformed_member_error());
         }
         Ok(())
@@ -1369,6 +1375,56 @@ mod tests {
             err.expect("an unpaired member is not JSON");
             assert_eq!(yaml_block, "");
         }
+    }
+
+    /// #1956: sibling of the unpaired-field test above, for the *other* fault
+    /// [`DistinctKeyCursors::is_malformed`] covers -- a missing `,`/`:`
+    /// delimiter (#1677) with an even member count, so the walk yields both
+    /// keys cleanly and only `delimiter_fault()` (not `ended_unpaired()`)
+    /// catches it at exhaustion. All three writers here used to check
+    /// `ended_unpaired()` alone and missed this fault entirely, matching the
+    /// gap `Builtin::Last`'s own arm had (`eval_generic.rs`) before this fix.
+    #[test]
+    fn test_stream_lazy_keys_raises_on_missing_delimiter_1956() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        let json = br#"{"a" 1, "b": 2}"#;
+        let index = JsonIndex::build(json);
+        let StandardJson::Object(fields) = index.root(json).value() else {
+            panic!("expected object");
+        };
+
+        let mut json_out = String::new();
+        let mut err = None;
+        stream_lazy_keys_json(&fields, true, &mut json_out, IndentSpec::COMPACT, &mut err).unwrap();
+        err.expect("a missing ':' delimiter is not JSON");
+        assert_eq!(
+            json_out, r#"["a","b"]"#,
+            "both keys are written before the post-loop fault check fires"
+        );
+
+        let mut yaml_flow = String::new();
+        let mut err = None;
+        stream_lazy_keys_yaml(&fields, true, &mut yaml_flow, IndentSpec::COMPACT, &mut err)
+            .unwrap();
+        err.expect("a missing ':' delimiter is not JSON");
+        assert_eq!(yaml_flow, "[a, b]");
+
+        let mut yaml_block = String::new();
+        let mut err = None;
+        stream_lazy_keys_yaml(
+            &fields,
+            true,
+            &mut yaml_block,
+            IndentSpec {
+                width: 2,
+                unit: ' ',
+            },
+            &mut err,
+        )
+        .unwrap();
+        err.expect("a missing ':' delimiter is not JSON");
+        assert_eq!(yaml_block, "- a\n- b");
     }
 
     /// The `yq` JSON convention (what the M2 fast path for `.field`/`.[0]`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19200,6 +19200,37 @@ fn test_jq_keys_unsorted_last_raises_on_missing_delimiter_1956() -> Result<()> {
     Ok(())
 }
 
+/// #1956: `keys_unsorted | map(f)` (`LazySource::Keys` in `eval_generic.rs`)
+/// never checked `DistinctKeyCursors::is_malformed` at all -- unlike
+/// `keys_unsorted` bare/`length`/`last`, which each had at least the
+/// `ended_unpaired()` half of the check, `map` had neither half. Confirmed
+/// live before this fix: `keys_unsorted | map(.)` silently returned
+/// `["a","b"]` with exit 0 on this same malformed document.
+#[test]
+fn test_jq_keys_unsorted_map_raises_on_missing_delimiter_1956() -> Result<()> {
+    let doc = r#"{"a" 1, "b": 2}"#;
+
+    let (out, stderr, code) = run_jq_full(&["-c", "keys_unsorted | map(.)"], Some(doc))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    let (out, stderr, code) = run_jq_full(
+        &["-c", r#"try (keys_unsorted | map(.)) catch "c""#],
+        Some(doc),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), "\"c\"", "out: {out:?}");
+
+    // Well-formed data is unaffected.
+    let (out, stderr, code) =
+        run_jq_full(&["-c", "keys_unsorted | map(.)"], Some(r#"{"b":1,"a":2}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), r#"["b","a"]"#);
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19167,6 +19167,39 @@ fn test_jq_wellformed_documents_unaffected_by_1677() -> Result<()> {
     Ok(())
 }
 
+/// #1956: `fold_lazy_keys_stage`'s `Builtin::Last if !sorted` arm walks the
+/// whole object regardless (there's no way to find "the last field" without
+/// reaching the end), so the #1194/#1677 check was already meant to ride
+/// along for free -- but it only checked `ended_unpaired()`, missing the
+/// `delimiter_fault()` half every other checked call site in this file
+/// gets right. `keys_unsorted | last` used to silently return the last
+/// well-formed key instead of raising, unlike bare `keys_unsorted` on the
+/// identical document.
+#[test]
+fn test_jq_keys_unsorted_last_raises_on_missing_delimiter_1956() -> Result<()> {
+    let doc = r#"{"a" 1, "b": 2}"#;
+
+    let (out, stderr, code) = run_jq_full(&["-c", "keys_unsorted | last"], Some(doc))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    let (out, stderr, code) = run_jq_full(
+        &["-c", r#"try (keys_unsorted | last) catch "c""#],
+        Some(doc),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), "\"c\"", "out: {out:?}");
+
+    // Well-formed data is unaffected.
+    let (out, stderr, code) =
+        run_jq_full(&["-c", "keys_unsorted | last"], Some(r#"{"b":1,"a":2}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(out.trim(), "\"a\"");
+
+    Ok(())
+}
+
 /// #1116's yq-only "chained scalar-slice-assign no-ops" / "del() deletes
 /// the parent key" rules must not leak into jq mode: real jq errors on
 /// both `.a[0:1] = 99` and `del(.a[0:1])` for a scalar `.a`, matching


### PR DESCRIPTION
## Summary

`eval_generic.rs` has three call sites doing the identical "walk `DistinctKeyCursors`, raise on a #1194 malformed key" check, all correctly checking `cursors.ended_unpaired() || cursors.delimiter_fault()` together: `distinct_key_cursors_checked`, `keys_are_well_formed`/`walk_distinct_keys_checked` (#1936), and `document.rs`'s `effective_keys`.

This PR started narrow (2 named sites missing the `delimiter_fault()` half) and grew through review to 6 real gaps in the same bug family, plus a shared `DistinctKeyCursors::is_malformed()` method so a future call site can no longer check one half of the pair and forget the other.

```console
$ echo '{"a" 1, "b": 2}' | succinctly jq -c 'keys_unsorted'
jq: error (at <stdin>:0): Invalid JSON text: expected ':', found '1'
                                          # correctly raises (delimiter fault)
$ echo '{"a" 1, "b": 2}' | succinctly jq -c 'keys_unsorted | last'
"b"
                                          # did NOT raise -- unfixed (before this fix)
```

## Fixes

**Checked only `ended_unpaired()`, missing `delimiter_fault()`:**
1. `fold_lazy_keys_stage`'s `Expr::Builtin(Builtin::Last) if !sorted` arm.
2. `JqValue`'s `lazy_keys_array_to_owned` (backing `materialize()`/`into_owned()`) — public API.
3. `write_json_at_depth`'s own inline `LazyKeysArray` walk (backing `write_json()`/`to_json_string()`, which never call `lazy_keys_array_to_owned`) — a third site found by checking every match arm in `lazy.rs`, not just the two named in the issue.
4. `stream_lazy_keys_json` and both branches of `stream_lazy_keys_yaml` (`src/jq/stream.rs`) — the M2 streaming writers for `keys_unsorted`.
5. `document.rs`'s `effective_keys` was already correct here but is now expressed via the new shared method too, for consistency.

**Checked *neither* half at all:**
6. `LazySource::Keys::advance()` (`keys_unsorted | map(f)`) — confirmed live: `keys_unsorted | map(.)` silently returned `["a","b"]` with exit 0 on a document every sibling spelling (`keys_unsorted` bare, `| length`, `| last`) correctly rejected. `advance()`'s signature is now fallible (`Result<Option<LazyElem<V>>, EvalError>`) so this variant has a channel to report it; the other four variants (`Elements`/`Values`/`IndexRange`/`CollapsedValues`) are unaffected, just now wrapped in `Ok`.
7. `cursor_to_owned_at_depth`'s `StandardJson::Object` arm (`JqValue::Cursor`'s own `materialize`/`into_owned`) never called `key_delimiter_ok`/`value_delimiter_ok` at all, unlike its `eval_generic::to_owned_at_depth` sibling which checks both.

**New shared method:** `DistinctKeyCursors::is_malformed()` (`document.rs`) = `ended_unpaired() || delimiter_fault()`. All of the above (plus `eval_generic.rs`'s pre-existing correct sites) now go through it.

**Not in scope, filed as follow-ups instead:**
- #1974 — `JqValue::length()` on `LazyKeysArray` has the identical fault but an *infallible* signature (`effective_len`, not `effective_len_checked`); fixing it needs a signature change, not a boolean swap.
- #1975 — `yq --input-format json --slurp` silently accepts the same malformed documents via a seemingly unrelated, unidentified upstream mechanism: confirmed the fixes in this PR make no difference to that specific repro, so its root cause is upstream of `DistinctKeyCursors` entirely.
- `LazySource::Values` (`obj | map(f)`, distinct from `LazySource::Keys` above) has a related but pre-existing, already-documented gap (#1641) — untouched here.
- `jq_runner.rs`'s `print_json`/`bail_if_keys_malformed` was already correct (checks both halves) — no change needed.

## Testing

- `test_jq_keys_unsorted_last_raises_on_missing_delimiter_1956` (CLI) — `keys_unsorted | last`, bare/`try`-`catch`/well-formed control.
- `test_jq_keys_unsorted_map_raises_on_missing_delimiter_1956` (CLI) — same shape for `keys_unsorted | map(.)`.
- `test_lazy_keys_array_raises_on_missing_delimiter_1956` (library, `lazy.rs`) — `write_json()`/`materialize()`/`into_owned()` on `JqValue::LazyKeysArray`.
- `test_cursor_to_owned_raises_on_missing_delimiter_1956` (library, `lazy.rs`) — `materialize()`/`into_owned()` on `JqValue::Cursor`.
- `test_stream_lazy_keys_raises_on_missing_delimiter_1956` (library, `stream.rs`) — all three writers (JSON, YAML flow, YAML block).
- Full local suite (`cargo test`, `cargo test --features cli`), both required clippy legs, `cargo build --no-default-features`, and `cargo fmt --check` all clean.

Fixes #1956
