### PR TITLE
fix(yq): add missing #1194/#1677 checks to the --input-format json DOM bridge

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -324,10 +324,25 @@ $ printf '{"a" 1, "b": 2}' | succinctly yq --input-format json --slurp '.[0] | k
 ```
 
 Fixed by adding the same `key_delimiter_ok`/`value_delimiter_ok` checks (object arm) and
-`preceding_delimiter_ok` check (array arm) `to_owned_at_depth` already had, plus the missing
-`ends_unpaired()` check after the object loop. `key_delimiter_ok`/`value_delimiter_ok`
-(`src/jq/document.rs`) went from `pub(crate)` to `pub` for this — `src/bin/succinctly` is a
-separate crate from the library and had no way to call them otherwise.
+`element_gap_ok` check (array arm, #1597's already-extracted helper) `to_owned_at_depth`
+already had, plus the missing `ends_unpaired()` check after the object loop.
+`key_delimiter_ok`/`value_delimiter_ok` (`src/jq/document.rs`) went from `pub(crate)` to
+`pub` for this — `src/bin/succinctly` is a separate crate from the library and had no way
+to call them otherwise.
+
+Review of that first pass found the "mirrors `to_owned_at_depth` exactly" claim had two more
+exceptions, both the same #1194 class as the delimiter/unpaired-tail gap above and both fixed
+the same way:
+
+- A key JSON's grammar never allowed at all (a bare, non-string key like `{123: 1}` — not a
+  *decode* failure, which is preserved via its raw span rather than raised on, same as
+  `to_owned_at_depth`) used to be silently dropped along with its whole field — the
+  `if let Some(key) = ... {}`-with-no-`else` pattern [#1679](https://github.com/rust-works/succinctly/issues/1679)
+  already fixed at five other call sites, missed here.
+- A structurally malformed value token the semi-index accepted as a span but couldn't
+  classify as any JSON token (`[xyz123]`) used to materialize as `null` instead of raising —
+  `to_owned_at_depth`'s own `string_decode_error()`/`is_error()` arms (#1247) were missing
+  from this function entirely.
 
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478),

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -308,6 +308,27 @@ Four narrower gaps this fix deliberately left alone remain open, each already fi
   needs to reorder/slice entries, not just stream them) — a real representation limit, not a
   missed wiring like the three above.
 
+**[#1975](https://github.com/rust-works/succinctly/issues/1975) found this same `parse_input`/
+`to_owned_canonicalizing_numbers` bridge — #1343's still-open DOM fallback for `--slurp`/
+`--eval-all`, and `--inplace`'s DOM-forcing flags — had neither the #1194 unpaired-tail check
+nor the #1677 malformed-`,`/`:` delimiter check at all, unlike every other route into the
+evaluator.** Its own doc comment already claimed to mirror `eval_generic::to_owned_at_depth`
+"exactly"; this was the one place that claim wasn't true:
+
+```console
+$ printf '{"a" 1, "b": 2}' | succinctly jq -c 'keys_unsorted'
+jq: error (at <stdin>:0): Invalid JSON text: expected ':', found '1'         # correct
+$ printf '{"a" 1, "b": 2}' | succinctly yq --input-format json --slurp '.[0] | keys_unsorted'
+- a
+- b                                                                          # WRONG (before this fix)
+```
+
+Fixed by adding the same `key_delimiter_ok`/`value_delimiter_ok` checks (object arm) and
+`preceding_delimiter_ok` check (array arm) `to_owned_at_depth` already had, plus the missing
+`ends_unpaired()` check after the object loop. `key_delimiter_ok`/`value_delimiter_ok`
+(`src/jq/document.rs`) went from `pub(crate)` to `pub` for this — `src/bin/succinctly` is a
+separate crate from the library and had no way to call them otherwise.
+
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478),
 [#868](https://github.com/rust-works/succinctly/issues/868) and

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9,8 +9,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, resolve_display_key, DisplayKeyGuard, DocumentCursor, DocumentElements,
-    DocumentFields, DocumentValue, IndentSpec,
+    effective_keys, key_delimiter_ok, resolve_display_key, value_delimiter_ok, DisplayKeyGuard,
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
@@ -722,6 +722,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         let mut map = IndexMap::new();
         let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
+        let mut is_first = true;
         while let Some((field, rest)) = f.uncons() {
             // `resolve_display_key`, not `field.key_str()`: a key that will
             // not *decode* (#1247/#1385) is preserved via its raw source
@@ -734,20 +735,55 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             // keys now raise instead of silently overwriting one another
             // (#1642/#1738), matching every other materializer.
             if let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? {
+                // #1975: this walk was missing the #1677 malformed-`,`/`:`
+                // delimiter check entirely -- unlike its
+                // `eval_generic::to_owned_at_depth` sibling it otherwise
+                // mirrors, which has always had it. This is why
+                // `--input-format json --slurp`/`--eval-all`/`--inplace`
+                // (the only callers of `parse_input`, hence of this
+                // function) silently accepted `{"a" 1, "b": 2}` when every
+                // other route into the evaluator correctly raised.
+                if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
+                    || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
+                {
+                    return Err(f.malformed_member_error());
+                }
                 map.insert(
                     key,
                     to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
                 );
             }
             f = rest;
+            is_first = false;
+        }
+        // #1975: the other half of the same gap -- an unpaired trailing
+        // child (#1194) that `resolve_display_key`'s per-field loop above
+        // never sees at all, matching `eval_generic::to_owned_at_depth`'s
+        // identical post-loop check.
+        if f.ends_unpaired() {
+            return Err(f.malformed_member_error());
         }
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
-        while let Some((elem, rest)) = elems.uncons() {
-            items.push(to_owned_canonicalizing_numbers_at_depth(&elem, depth + 1)?);
+        let mut is_first = true;
+        while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            // #1975: matches `eval_generic::to_owned_at_depth`'s array arm --
+            // a missing/doubled `,` between elements was silently accepted
+            // here too.
+            if let Some(pos) = elem_cursor.text_position() {
+                let expected = if is_first { None } else { Some(b',') };
+                if !elem_cursor.preceding_delimiter_ok(pos, expected) {
+                    return Err(elem_cursor.malformed_delimiter_error());
+                }
+            }
+            items.push(to_owned_canonicalizing_numbers_at_depth(
+                &elem_cursor.value(),
+                depth + 1,
+            )?);
             elems = rest;
+            is_first = false;
         }
         OwnedValue::Array(items)
     } else if value.is_null() {
@@ -6073,6 +6109,50 @@ mod tests {
                 map.get("n")
             );
         }
+    }
+
+    /// #1975: `to_owned_canonicalizing_numbers` (the `parse_input` bridge
+    /// behind `--input-format json` under `--slurp`/`--eval-all`) had
+    /// neither the #1677 malformed-`,`/`:` delimiter check nor the #1194
+    /// unpaired-tail check at all -- unlike its `eval_generic::to_owned_at_depth`
+    /// sibling this function's own doc comment claims to mirror. Confirmed
+    /// live before this fix: `yq --input-format json --slurp -o=json '.[0] |
+    /// keys_unsorted'` on `{"a" 1, "b": 2}` silently returned `["a","b"]`
+    /// with exit 0, where every other route into the evaluator (`jq`,
+    /// `jq --slurp`, `yq --input-format json` without `--slurp`) correctly
+    /// raised.
+    #[test]
+    fn to_owned_canonicalizing_numbers_raises_on_malformed_delimiter_1975() {
+        for json in [
+            &br#"{"a" 1, "b": 2}"#[..], // missing ':'
+            &br#"{"a": 1 "b": 2}"#[..], // missing ','
+            &br#"{"a"}"#[..],           // unpaired tail
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            to_owned_canonicalizing_numbers(&cursor.value())
+                .expect_err(&format!("{json:?} is not well-formed JSON"));
+        }
+
+        // Well-formed data is unaffected.
+        let json = br#"{"a": 1, "b": 2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([
+                ("a".to_string(), OwnedValue::Int(1)),
+                ("b".to_string(), OwnedValue::Int(2)),
+            ]))
+        );
+
+        // The array arm has the identical gap for a missing ','.
+        let json = br"[1 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        to_owned_canonicalizing_numbers(&cursor.value())
+            .expect_err("a missing ',' between array elements is not well-formed JSON");
     }
 
     /// `depth` levels of single-child `CommentTree::Array` nesting, mirroring

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -699,6 +699,12 @@ fn gather_input_sources(
 /// `key_display_string` call it used to make (#1738: that gap meant this,
 /// the `--input-format json` bridge, was the one materializer PR #1672 never
 /// reached).
+///
+/// Also raises on a #1194/#1677 structurally malformed document (a bare
+/// non-string key, an unpaired trailing member, a missing/doubled `,`/`:`,
+/// or a value token the semi-index couldn't classify) -- #1975 found this
+/// function missing every one of `to_owned_at_depth`'s checks for these,
+/// despite this doc comment's own "mirrors ... exactly" claim above.
 fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_canonicalizing_numbers_at_depth(value, 0)
 }
@@ -730,29 +736,34 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             // silently drop such a field under `--slurp`/`--eval-all`/
             // `--inplace` (the only callers of `parse_input`, hence of this
             // function), one short of `length`'s real field count. A key
-            // the format's grammar never allowed at all (#1194) is still
-            // dropped, same as before this fix. Two colliding decode-failure
-            // keys now raise instead of silently overwriting one another
-            // (#1642/#1738), matching every other materializer.
-            if let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? {
-                // #1975: this walk was missing the #1677 malformed-`,`/`:`
-                // delimiter check entirely -- unlike its
-                // `eval_generic::to_owned_at_depth` sibling it otherwise
-                // mirrors, which has always had it. This is why
-                // `--input-format json --slurp`/`--eval-all`/`--inplace`
-                // (the only callers of `parse_input`, hence of this
-                // function) silently accepted `{"a" 1, "b": 2}` when every
-                // other route into the evaluator correctly raised.
-                if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
-                    || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
-                {
-                    return Err(f.malformed_member_error());
-                }
-                map.insert(
-                    key,
-                    to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
-                );
+            // that will not *stringify* at all -- a key JSON's grammar never
+            // allowed (`{123: 1}`) -- is a different, structural fault
+            // (#1194) and now raises instead of silently dropping the whole
+            // field (#1975: this used to be an `if let Some(key) = ... {}`
+            // with no `else`, the exact pattern #1679 already fixed at five
+            // other call sites, but missed here). Two colliding
+            // decode-failure keys now raise instead of silently overwriting
+            // one another (#1642/#1738), matching every other materializer.
+            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
+                return Err(f.malformed_member_error());
+            };
+            // #1975: this walk was missing the #1677 malformed-`,`/`:`
+            // delimiter check entirely -- unlike its
+            // `eval_generic::to_owned_at_depth` sibling it otherwise
+            // mirrors, which has always had it. This is why
+            // `--input-format json --slurp`/`--eval-all`/`--inplace`
+            // (the only callers of `parse_input`, hence of this
+            // function) silently accepted `{"a" 1, "b": 2}` when every
+            // other route into the evaluator correctly raised.
+            if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
+                || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
+            {
+                return Err(f.malformed_member_error());
             }
+            map.insert(
+                key,
+                to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
+            );
             f = rest;
             is_first = false;
         }
@@ -771,12 +782,12 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             // #1975: matches `eval_generic::to_owned_at_depth`'s array arm --
             // a missing/doubled `,` between elements was silently accepted
-            // here too.
-            if let Some(pos) = elem_cursor.text_position() {
-                let expected = if is_first { None } else { Some(b',') };
-                if !elem_cursor.preceding_delimiter_ok(pos, expected) {
-                    return Err(elem_cursor.malformed_delimiter_error());
-                }
+            // here too. `element_gap_ok` (`DocumentCursor`, #1597) rather
+            // than re-deriving `text_position()`/`expected` inline, unlike
+            // that sibling's own still-inline copy (pre-dates the
+            // extraction).
+            if !elem_cursor.element_gap_ok(is_first) {
+                return Err(elem_cursor.malformed_delimiter_error());
             }
             items.push(to_owned_canonicalizing_numbers_at_depth(
                 &elem_cursor.value(),
@@ -811,9 +822,29 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         OwnedValue::Float(f)
     } else if let Some(s) = value.as_str() {
         OwnedValue::String(s.into_owned())
+    } else if let Some(reason) = value.string_decode_error() {
+        // #1975: matches `eval_generic::to_owned_at_depth`'s identical arm
+        // (#1247) -- `as_str` above answered `None`, but the value *is* a
+        // string token whose bytes just don't decode. This function used to
+        // fall all the way to the final `else` for this case, materializing
+        // an undecodable string as `null` instead of raising.
+        return Err(EvalError::decode_failure(reason));
+    } else if value.is_error() {
+        // #1975: matches `eval_generic::to_owned_at_depth`'s identical arm
+        // (#1194) -- a structurally malformed value (`[xyz123]`, `[tru]`)
+        // the semi-index accepted as a span but could not classify as any
+        // JSON token. This function used to materialize it as `null`
+        // instead of raising the semi-index's own, more specific message.
+        return Err(EvalError::new(
+            value
+                .error_message()
+                .unwrap_or("malformed value in document")
+                .to_string(),
+        ));
     } else {
-        // Matches `to_owned_at_depth`'s own `else` arm (#1098) --
-        // unaffected by number canonicalization.
+        // Matches `to_owned_at_depth`'s own final `else` arm (#1098) --
+        // a genuinely unknown type no format implements today, unaffected
+        // by number canonicalization.
         OwnedValue::Null
     })
 }
@@ -6153,6 +6184,34 @@ mod tests {
         let cursor = index.root(json);
         to_owned_canonicalizing_numbers(&cursor.value())
             .expect_err("a missing ',' between array elements is not well-formed JSON");
+    }
+
+    /// #1975 review round 1: two more gaps in the same function, found by
+    /// comparing against `eval_generic::to_owned_at_depth` field-by-field
+    /// rather than trusting this function's own "mirrors exactly" doc
+    /// comment. Both used to silently drop or null out a structurally
+    /// invalid document instead of raising, the same #1194 class the
+    /// delimiter-fault fix above addresses.
+    #[test]
+    fn to_owned_canonicalizing_numbers_raises_on_structural_faults_1975() {
+        // A key JSON's grammar never allowed at all (not a decode failure --
+        // a bare, non-string key) used to be silently dropped along with its
+        // value, the exact `if let Some(key) = ... {}`-no-`else` pattern
+        // #1679 already fixed at five other call sites.
+        let json = br#"{"a": 1, 123: 2, "b": 3}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        to_owned_canonicalizing_numbers(&cursor.value())
+            .expect_err("a non-string key is not well-formed JSON");
+
+        // A structurally malformed value token (not a decode failure -- a
+        // span the semi-index could not classify as any JSON token) used to
+        // materialize as `null` instead of raising.
+        let json = br"[xyz123]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        to_owned_canonicalizing_numbers(&cursor.value())
+            .expect_err("an unclassifiable value token is not well-formed JSON");
     }
 
     /// `depth` levels of single-child `CommentTree::Array` nesting, mirroring

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1166,7 +1166,14 @@ pub fn resolve_display_key<V: DocumentValue, T>(
 /// `checked_len`, [`DistinctKeyCursors`], `effective_fields_checked`) has no
 /// way to name that equality -- naming `F` instead sidesteps needing it,
 /// since `key`/`key_cursor` are each used only through their own trait.
-pub(crate) fn key_delimiter_ok<F: DocumentFields>(
+///
+/// `pub`, not `pub(crate)` (#1975): `src/bin/succinctly` is a separate crate
+/// from this library, and its own `to_owned_canonicalizing_numbers_at_depth`
+/// (the `--input-format json --slurp`/`--eval-all`/`--inplace` DOM bridge)
+/// needed this exact check -- it had neither this nor
+/// [`value_delimiter_ok`] at all, unlike its `eval_generic::to_owned_at_depth`
+/// sibling it otherwise mirrors.
+pub fn key_delimiter_ok<F: DocumentFields>(
     key: &F::Value,
     key_cursor: &F::Cursor,
     is_first: bool,
@@ -1187,7 +1194,7 @@ pub(crate) fn key_delimiter_ok<F: DocumentFields>(
 /// not resolved a value at all should use
 /// [`key_only_value_delimiter_ok`] instead, which never touches the value
 /// cursor.
-pub(crate) fn value_delimiter_ok<F: DocumentFields>(
+pub fn value_delimiter_ok<F: DocumentFields>(
     value: Option<&F::Value>,
     value_cursor: &F::Cursor,
 ) -> bool {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1191,9 +1191,9 @@ pub fn key_delimiter_ok<F: DocumentFields>(
 /// Reuses `value`'s own decode (`text_start`) when the caller already has
 /// one -- a full [`DocumentFields::uncons`] walk resolves it regardless, so
 /// this is free for every caller of this function. A key-only walk that has
-/// not resolved a value at all should use
-/// [`key_only_value_delimiter_ok`] instead, which never touches the value
-/// cursor.
+/// not resolved a value at all should use `key_only_value_delimiter_ok`
+/// instead (private to this crate, unlike this function, since every
+/// caller of it lives here), which never touches the value cursor.
 pub fn value_delimiter_ok<F: DocumentFields>(
     value: Option<&F::Value>,
     value_cursor: &F::Cursor,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1668,6 +1668,36 @@ fn test_input_format_json_bridge_raises_on_malformed_delimiter_1975() -> Result<
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"["a","b"]"#);
 
+    // `--inplace` is `parse_input`'s third caller (per
+    // `to_owned_canonicalizing_numbers`'s own doc comment), on its DOM path
+    // only -- an assignment forces that path the same way `-P`/`--arg`
+    // would (#1738's own sibling test), where a plain M2-streamable filter
+    // takes a separate fast path that never calls `parse_input` at all.
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{json}")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .args(["--input-format", "json"])
+        .arg(".a = 5")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        !output.status.success(),
+        "--inplace should raise, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+    let file_contents = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(
+        file_contents, json,
+        "a raised --inplace write must leave the file untouched"
+    );
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1628,6 +1628,49 @@ fn test_input_format_json_bridge_raises_on_colliding_decode_failure_key_1738() -
     Ok(())
 }
 
+/// #1975: the `--input-format json` bridge's `to_owned_canonicalizing_numbers`
+/// had neither the #1677 malformed-`,`/`:` delimiter check nor the #1194
+/// unpaired-tail check at all, unlike every other route into the evaluator.
+/// Confirmed live before this fix: `.[0] | keys_unsorted` here silently
+/// returned `["a","b"]` with exit 0.
+#[test]
+fn test_input_format_json_bridge_raises_on_malformed_delimiter_1975() -> Result<()> {
+    let json = r#"{"a" 1, "b": 2}"#;
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".[0] | keys_unsorted",
+        json,
+        &["--input-format", "json", "--slurp"],
+    )?;
+    assert_eq!(code, 1, "--slurp should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".[0] | keys_unsorted",
+        json,
+        &["--input-format", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 1, "--eval-all should raise, stderr: {stderr}");
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+
+    // Well-formed data is unaffected.
+    let (output, code) = run_yq_stdin(
+        ".[0] | keys_unsorted",
+        r#"{"a":1,"b":2}"#,
+        &["--input-format", "json", "--slurp", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a","b"]"#);
+
+    Ok(())
+}
+
 /// #1749 sibling: `DisplayKeyGuard::check`'s own contract is "a fallback
 /// spelling on *either side* of the collision is refused" (`document.rs`'s
 /// own doc comment) -- not just fallback-vs-fallback. Pins both orders: a


### PR DESCRIPTION
## Summary

`yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth` — the `parse_input` bridge behind `--input-format json`'s `--slurp`/`--eval-all` DOM fallback and `--inplace`'s DOM-forcing flags — never checked for an unpaired trailing member (#1194) or a malformed `,`/`:` delimiter (#1677) at all, despite its own doc comment claiming to mirror `eval_generic::to_owned_at_depth` "exactly." Code review found two more exceptions to that same claim.

This is the actual root cause behind a repro filed as part of #1956/PR #1971's review, which turned out **not** to move with that PR's `DistinctKeyCursors::is_malformed()` fixes:

```console
$ printf '{"a" 1, "b": 2}' | succinctly jq -c 'keys_unsorted'
jq: error (at <stdin>:0): Invalid JSON text: expected ':', found '1'         # correct
$ printf '{"a" 1, "b": 2}' | succinctly yq --input-format json --slurp '.[0] | keys_unsorted'
- a
- b                                                                          # WRONG (before this fix)
```

`--slurp` on a non-identity filter (`is_identity` fails `can_slurp_fast_path`'s gate) converts each source straight to `OwnedValue` via `parse_input`/`to_owned_canonicalizing_numbers` before any lazy, cursor-based walk (and therefore before `DistinctKeyCursors` or any of #1971's fixes) ever runs — so the fault was lost upstream of everywhere #1971 looked.

## Fixes

**First pass:**
- Object arm: added the same `key_delimiter_ok`/`value_delimiter_ok` checks `eval_generic::to_owned_at_depth` already has, plus the missing `ends_unpaired()` check after the loop.
- Array arm: added the same comma-gap check `to_owned_at_depth`'s array arm already has.
- `key_delimiter_ok`/`value_delimiter_ok` (`src/jq/document.rs`) go from `pub(crate)` to `pub` — `src/bin/succinctly` is a separate crate from the library, so this fix's caller had no way to call them otherwise.

**Review found two more exceptions to the same "mirrors exactly" claim:**
- A bare, non-string key (`{123: 1}`) was still silently dropped along with its whole field — the exact `if let Some(key) = ... {}`-with-no-`else` pattern #1679 already fixed at five other call sites, missed here.
- A structurally malformed value token the semi-index accepted as a span but couldn't classify as any JSON token (`[xyz123]`) still materialized as `null` instead of raising — `to_owned_at_depth`'s own `string_decode_error()`/`is_error()` arms (#1247) were missing entirely.

Also simplified the array arm to call the already-extracted `element_gap_ok` helper (#1597) instead of re-deriving `text_position()`/`expected` inline.

**Noted, not actioned:** review also flagged that this function hand-copies `to_owned_at_depth`'s walk instead of sharing one generic implementation — which is exactly why it drifted out of sync in the first place. Left as-is: the function's own existing doc comment explains this duplication is deliberate (a `pub`, `DocumentValue`-generic twin living in the shared library would be reachable by a future YAML/`succinctly jq` call site with no compiler guard, risking reintroducing #918's number-preservation bug). A shared abstraction would need to solve that reachability problem first, which is out of scope here.

## Testing

- `to_owned_canonicalizing_numbers_raises_on_malformed_delimiter_1975` — missing `:`, missing `,`, unpaired-tail, well-formed control, array-arm equivalent.
- `to_owned_canonicalizing_numbers_raises_on_structural_faults_1975` — non-string key, unclassifiable value token.
- `test_input_format_json_bridge_raises_on_malformed_delimiter_1975` (CLI, `yq_cli_tests.rs`) — `--slurp`, `--eval-all`, `--inplace` (verifies the file is left untouched on error), and a well-formed control.
- Full local suite (`cargo test`, `cargo test --features cli`), both required clippy legs, `cargo build --no-default-features`, and `cargo fmt --check` all clean.

Fixes #1975
