### PR TITLE
fix(jq): reduce/foreach's input and INIT resolve key/parent/file_index

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -909,6 +909,21 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // navigation before `limit` already creates the enclosing `Pipe`
         // this arm needs.
         Expr::Limit { expr, .. } => needs_path_context(expr),
+        // `reduce EXPR as PATTERN (INIT; UPDATE)` / `foreach EXPR as
+        // PATTERN (INIT; UPDATE[; EXTRACT])` (#1765, item 3 of #1663's own
+        // remaining-gaps list): `input`/`INIT` both evaluate against the
+        // caller's own ambient position -- `eval_reduce`/`eval_foreach`
+        // evaluate each via `eval_single(_, value.clone(), optional)`, the
+        // same `value` this whole pipe is already at -- so a `key`/
+        // `parent`/`file_index` inside either one needs the same context a
+        // sibling `key` elsewhere in the pipe would get. `UPDATE`/`EXTRACT`
+        // are deliberately excluded: both evaluate against the
+        // accumulator, a synthetic value with no real document position,
+        // so `key` there already (and correctly) answers `null` without
+        // needing path-context routing -- the issue's own investigation
+        // flagged this as likely already correct, not a gap to close.
+        Expr::Reduce { input, init, .. } => needs_path_context(input) || needs_path_context(init),
+        Expr::Foreach { input, init, .. } => needs_path_context(input) || needs_path_context(init),
         _ => false,
     }
 }
@@ -25371,6 +25386,34 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // forks), only the trailing error is swallowed.
     let (init_values, init_control) = stream_outputs_checked(init_result.materialize_cursor());
 
+    eval_reduce_with_values::<W, S>(
+        patterns,
+        update,
+        input_values,
+        init_values,
+        init_control,
+        optional,
+    )
+}
+
+/// The OwnedValue-domain heart of `reduce EXPR as PATTERN (INIT; UPDATE)`,
+/// once `input`/`INIT` have already been reduced to `Vec<OwnedValue>` --
+/// shared by [`eval_reduce`] (cursor-sourced `input`/`INIT`, the ordinary
+/// case) and `eval_pipe_with_path_context_internal`'s own `Expr::Reduce` arm
+/// (#1765: `input`/`INIT` sourced from the path-context evaluator instead,
+/// when either needs `key`/`parent`/`file_index` to resolve correctly).
+/// `update` itself is deliberately never routed through path-context
+/// evaluation by either caller -- it runs against the accumulator, a
+/// synthetic value with no real document position, so `key` there already
+/// answers `null` correctly without needing to change (#1765's own scoping).
+fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    patterns: &[Pattern],
+    update: &Expr,
+    input_values: Vec<OwnedValue>,
+    init_values: Vec<OwnedValue>,
+    init_control: Option<Control>,
+    optional: bool,
+) -> QueryResult<'a, W> {
     if init_values.is_empty() {
         return finish_fork(Vec::new(), init_control, optional);
     }
@@ -26063,6 +26106,40 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Partial(vs, control) => (vs, Some(control)),
         };
 
+    eval_foreach_with_values::<W, S>(
+        patterns,
+        update,
+        extract,
+        input_values,
+        input_control,
+        init_values,
+        init_control,
+        optional,
+    )
+}
+
+/// The OwnedValue-domain heart of `foreach EXPR as PATTERN (INIT; UPDATE[; EXTRACT])`,
+/// once `input`/`INIT` have already been reduced to `Vec<OwnedValue>` (plus
+/// each one's own trailing control, if any) -- shared by [`eval_foreach`]
+/// (cursor-sourced `input`/`INIT`, the ordinary case) and
+/// `eval_pipe_with_path_context_internal`'s own `Expr::Foreach` arm (#1765:
+/// `input`/`INIT` sourced from the path-context evaluator instead, when
+/// either needs `key`/`parent`/`file_index` to resolve correctly). `update`/
+/// `extract` are deliberately never routed through path-context evaluation
+/// by either caller -- both run against the accumulator, a synthetic value
+/// with no real document position, so `key` there already answers `null`
+/// correctly without needing to change (#1765's own scoping).
+#[allow(clippy::too_many_arguments)]
+fn eval_foreach_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    patterns: &[Pattern],
+    update: &Expr,
+    extract: Option<&Expr>,
+    input_values: Vec<OwnedValue>,
+    input_control: Option<Control>,
+    init_values: Vec<OwnedValue>,
+    init_control: Option<Control>,
+    optional: bool,
+) -> QueryResult<'a, W> {
     // Same hoist as `eval_reduce`: skipped entirely when there are no
     // INIT forks to consume it.
     //
@@ -29222,6 +29299,178 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             };
             continue_rest_with_context::<W, S>(
                 limited,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        // `reduce EXPR as PATTERN (INIT; UPDATE)` (#1765, item 3 of #1663's
+        // own remaining-gaps list): `input`/`INIT` are evaluated through
+        // this same path-context evaluator instead of the ordinary one,
+        // whenever either needs it (this arm's own guard), then handed to
+        // `eval_reduce_with_values` -- the OwnedValue-domain core shared
+        // with `eval_reduce`'s own cursor-sourced entry point. `UPDATE` is
+        // deliberately left on the plain evaluator inside that shared core
+        // (see its own doc comment): it runs against the accumulator, a
+        // synthetic value with no document position, so `key` there is
+        // already correctly `null` without needing this routing.
+        //
+        // The `input`/`Partial` arms below mirror `eval_reduce`'s own
+        // cursor-sourced handling exactly (an input-stream error, break, or
+        // halt -- even one arriving after a partial prefix -- returns
+        // immediately, before `INIT` is ever evaluated: `reduce`'s own
+        // output is always single-shot). No `to_owned_checked`/
+        // `promote_borrowed_checked` conversion is needed here the way
+        // `eval_reduce`'s cursor-based version needs it -- this evaluator
+        // already returns checked `OwnedValue`s, never a raw cursor.
+        Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } if needs_path_context(input) || needs_path_context(init) => {
+            let input_values: Vec<OwnedValue> = match eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(input),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            ) {
+                QueryResult::Owned(v) => vec![v],
+                QueryResult::ManyOwned(vs) => vs,
+                QueryResult::None => Vec::new(),
+                QueryResult::Error(e) => return suppress_or_raise(e, optional),
+                QueryResult::Break(label) => return QueryResult::Break(label),
+                QueryResult::Halt(code) => return QueryResult::Halt(code),
+                QueryResult::Partial(_prefix, Control::Error(e)) => {
+                    return suppress_or_raise(e, optional);
+                }
+                QueryResult::Partial(_prefix, Control::Break(label)) => {
+                    return QueryResult::Break(label);
+                }
+                QueryResult::Partial(_prefix, Control::Halt(code)) => {
+                    return QueryResult::Halt(code);
+                }
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!(
+                        "eval_pipe_with_path_context_internal only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Partial"
+                    )
+                }
+            };
+            let init_result = eval_pipe_with_path_context_internal::<W, S>(
+                core::slice::from_ref(init),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let (init_values, init_control) = stream_outputs_checked(init_result);
+            let result = eval_reduce_with_values::<W, S>(
+                patterns,
+                update,
+                input_values,
+                init_values,
+                init_control,
+                optional,
+            );
+            continue_rest_with_context::<W, S>(
+                result,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        // `foreach EXPR as PATTERN (INIT; UPDATE[; EXTRACT])` (#1765): same
+        // reasoning and scoping as `Expr::Reduce` above. Unlike `Reduce`,
+        // an input-stream `Partial` here keeps its already-produced prefix
+        // (`input_control` carried forward, not an immediate return) --
+        // mirroring `eval_foreach`'s own cursor-sourced handling exactly,
+        // since `foreach` (unlike `reduce`) streams one output per input
+        // element as it goes.
+        Expr::Foreach {
+            input,
+            patterns,
+            init,
+            update,
+            extract,
+        } if needs_path_context(input) || needs_path_context(init) => {
+            let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
+                match eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(input),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ) {
+                    QueryResult::Owned(v) => (vec![v], None),
+                    QueryResult::ManyOwned(vs) => (vs, None),
+                    QueryResult::None => (Vec::new(), None),
+                    QueryResult::Error(e) => return suppress_or_raise(e, optional),
+                    QueryResult::Break(label) => return QueryResult::Break(label),
+                    QueryResult::Halt(code) => return QueryResult::Halt(code),
+                    QueryResult::Partial(vs, control) => (vs, Some(control)),
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                };
+            let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
+                match eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(init),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ) {
+                    QueryResult::Owned(v) => (vec![v], None),
+                    QueryResult::ManyOwned(vs) => (vs, None),
+                    QueryResult::None => (Vec::new(), None),
+                    QueryResult::Error(e) => {
+                        return finish_fork(
+                            Vec::new(),
+                            input_control.or(Some(Control::Error(e))),
+                            optional,
+                        );
+                    }
+                    QueryResult::Break(label) => {
+                        return finish_fork(
+                            Vec::new(),
+                            input_control.or(Some(Control::Break(label))),
+                            optional,
+                        );
+                    }
+                    QueryResult::Halt(code) => return QueryResult::Halt(code),
+                    QueryResult::Partial(vs, control) => (vs, Some(control)),
+                    QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                        unreachable!(
+                            "eval_pipe_with_path_context_internal only ever produces \
+                             Owned/ManyOwned/None/Error/Break/Partial"
+                        )
+                    }
+                };
+            let result = eval_foreach_with_values::<W, S>(
+                patterns,
+                update,
+                extract.as_deref(),
+                input_values,
+                input_control,
+                init_values,
+                init_control,
+                optional,
+            );
+            continue_rest_with_context::<W, S>(
+                result,
                 rest,
                 root,
                 file_origin,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -922,6 +922,15 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // so `key` there already (and correctly) answers `null` without
         // needing path-context routing -- the issue's own investigation
         // flagged this as likely already correct, not a gap to close.
+        //
+        // Same standalone-top-level caveat as `Expr::Limit` above (#1978
+        // code review): this arm only fires for the CLI when the
+        // `reduce`/`foreach` sits inside an enclosing `Pipe`/`Array`/etc.
+        // whose own scan is what bridges into `eval.rs`'s path-context
+        // evaluator -- a genuinely standalone top-level `reduce`/`foreach`
+        // still reaches `eval_generic.rs`'s own generic-fallback dispatch
+        // directly. Left unaddressed for the identical reason `Limit`'s
+        // own arm gives: no observably-wrong repro exists for that case.
         Expr::Reduce { input, init, .. } => needs_path_context(input) || needs_path_context(init),
         Expr::Foreach { input, init, .. } => needs_path_context(input) || needs_path_context(init),
         _ => false,
@@ -26129,7 +26138,13 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// by either caller -- both run against the accumulator, a synthetic value
 /// with no real document position, so `key` there already answers `null`
 /// correctly without needing to change (#1765's own scoping).
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // STYLE-0004: `input`'s own trailing
+                                     // control (`input_control`) is a distinct parameter from `init`'s
+                                     // (`init_control`) -- `foreach` (unlike `reduce`, whose shared core has no
+                                     // `input_control` at all) must track the source stream's own control
+                                     // separately, since it can outlive `input_values` being consumed (#534
+                                     // follow-up); collapsing the two into one shared field would lose that
+                                     // distinction, not just shorten the signature.
 fn eval_foreach_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     patterns: &[Pattern],
     update: &Expr,
@@ -28111,6 +28126,45 @@ fn eval_and_continue_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     }
 }
 
+/// Evaluate `expr` against `value`, routing through the eager path-context
+/// evaluator only when `expr` itself needs it (#1978 code review) -- used by
+/// `Expr::Reduce`/`Expr::Foreach`'s own dispatch arms below, whose `input`
+/// and `INIT` are independent sub-expressions with their own separate
+/// `needs_path_context` results. Routing *both* unconditionally once
+/// either one needs it (an earlier version of those arms) forces the side
+/// that doesn't need it to pay for path-context evaluation's per-element
+/// `current_path` bookkeeping (`Expr::Iterate`'s own arm clones and pushes
+/// onto it per element) it never reads -- a real cost proportional to that
+/// side's own output size, e.g. `reduce .large_array[] as $x (key; ...)`
+/// would otherwise clone `current_path` once per array element purely
+/// because `INIT` (a typically-O(1) expression) needed `key`, even though
+/// `input`'s own iteration has no use for it. `eval_owned_input` is the
+/// ordinary evaluator's own ManyOwned-preserving sibling (already used by
+/// several arms in `eval_pipe_with_path_context_internal` below), so this
+/// returns the identical `QueryResult` shape either way -- callers don't
+/// need to know which branch actually ran.
+fn eval_expr_needing_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
+    if needs_path_context(expr) {
+        eval_pipe_with_path_context_internal::<W, S>(
+            core::slice::from_ref(expr),
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        )
+    } else {
+        eval_owned_input::<W, S>(expr, value, optional)
+    }
+}
+
 /// Internal helper that also tracks the root value for parent navigation,
 /// and (for `--eval-all`, #715) an optional origin-file-index side table
 /// keyed by top-level array position, resolving `file_index`/`fileIndex`/`fi`.
@@ -29317,59 +29371,58 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // synthetic value with no document position, so `key` there is
         // already correctly `null` without needing this routing.
         //
-        // The `input`/`Partial` arms below mirror `eval_reduce`'s own
-        // cursor-sourced handling exactly (an input-stream error, break, or
-        // halt -- even one arriving after a partial prefix -- returns
-        // immediately, before `INIT` is ever evaluated: `reduce`'s own
-        // output is always single-shot). No `to_owned_checked`/
-        // `promote_borrowed_checked` conversion is needed here the way
-        // `eval_reduce`'s cursor-based version needs it -- this evaluator
-        // already returns checked `OwnedValue`s, never a raw cursor.
+        // `eval_expr_needing_path_context` (#1978 code review): `input` and
+        // `INIT` are independent sub-expressions, so each is only routed
+        // through the eager path-context evaluator when *it itself* needs
+        // it, not whenever the other one does -- an earlier version of this
+        // arm routed both unconditionally once either needed it, forcing
+        // e.g. `reduce .large_array[] as $x (key; ...)` to pay a
+        // `current_path` clone per array element purely because `INIT`
+        // needed `key`, even though `input`'s own iteration never reads it.
+        //
+        // `stream_outputs_checked`, then discard-and-return-early on any
+        // control (#1978 code review): reproduces `eval_reduce`'s own
+        // cursor-sourced handling exactly -- an input-stream error, break,
+        // or halt, even one arriving after a partial prefix, returns
+        // immediately with the prefix discarded, before `INIT` is ever
+        // evaluated (`reduce`'s own output is always single-shot, so a
+        // partial prefix has nothing to contribute). Safe to fold the bare
+        // and `Partial` cases together this way specifically because
+        // `eval_reduce`'s own code already treats them identically (both
+        // return before touching `init`) -- `eval_foreach`'s sibling arm
+        // below can't take the same shortcut, since it evaluates `INIT`
+        // regardless of a `Partial` input's own control.
         Expr::Reduce {
             input,
             patterns,
             init,
             update,
         } if needs_path_context(input) || needs_path_context(init) => {
-            let input_values: Vec<OwnedValue> = match eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(input),
-                value,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            ) {
-                QueryResult::Owned(v) => vec![v],
-                QueryResult::ManyOwned(vs) => vs,
-                QueryResult::None => Vec::new(),
-                QueryResult::Error(e) => return suppress_or_raise(e, optional),
-                QueryResult::Break(label) => return QueryResult::Break(label),
-                QueryResult::Halt(code) => return QueryResult::Halt(code),
-                QueryResult::Partial(_prefix, Control::Error(e)) => {
-                    return suppress_or_raise(e, optional);
-                }
-                QueryResult::Partial(_prefix, Control::Break(label)) => {
-                    return QueryResult::Break(label);
-                }
-                QueryResult::Partial(_prefix, Control::Halt(code)) => {
-                    return QueryResult::Halt(code);
-                }
-                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
-                    unreachable!(
-                        "eval_pipe_with_path_context_internal only ever produces \
-                         Owned/ManyOwned/None/Error/Break/Partial"
-                    )
-                }
-            };
-            let init_result = eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(init),
-                value,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            );
-            let (init_values, init_control) = stream_outputs_checked(init_result);
+            let (input_values, input_control) =
+                stream_outputs_checked(eval_expr_needing_path_context::<W, S>(
+                    input,
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ));
+            if let Some(control) = input_control {
+                return match control {
+                    Control::Error(e) => suppress_or_raise(e, optional),
+                    Control::Break(label) => QueryResult::Break(label),
+                    Control::Halt(code) => QueryResult::Halt(code),
+                };
+            }
+            let (init_values, init_control) =
+                stream_outputs_checked(eval_expr_needing_path_context::<W, S>(
+                    init,
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ));
             let result = eval_reduce_with_values::<W, S>(
                 patterns,
                 update,
@@ -29388,12 +29441,18 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             )
         }
         // `foreach EXPR as PATTERN (INIT; UPDATE[; EXTRACT])` (#1765): same
-        // reasoning and scoping as `Expr::Reduce` above. Unlike `Reduce`,
+        // reasoning and scoping as `Expr::Reduce` above, including routing
+        // `input`/`INIT` independently via `eval_expr_needing_path_context`
+        // (#1978 code review) rather than unconditionally once either
+        // needs it. Unlike `Reduce`, this can't fold onto
+        // `stream_outputs_checked`'s uniform bare-or-`Partial` handling:
         // an input-stream `Partial` here keeps its already-produced prefix
-        // (`input_control` carried forward, not an immediate return) --
-        // mirroring `eval_foreach`'s own cursor-sourced handling exactly,
-        // since `foreach` (unlike `reduce`) streams one output per input
-        // element as it goes.
+        // and carries the control forward (`input_control`), but a *bare*
+        // (non-`Partial`) error/break/halt still returns immediately,
+        // before `INIT` is ever evaluated -- collapsing that distinction
+        // would evaluate `INIT` (a real side effect, e.g. `debug`/`error`
+        // inside it) in a case where `eval_foreach`'s own cursor-sourced
+        // code never does. Mirrors that code exactly instead.
         Expr::Foreach {
             input,
             patterns,
@@ -29402,8 +29461,8 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             extract,
         } if needs_path_context(input) || needs_path_context(init) => {
             let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
-                match eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(input),
+                match eval_expr_needing_path_context::<W, S>(
+                    input,
                     value,
                     root,
                     file_origin,
@@ -29419,14 +29478,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     QueryResult::Partial(vs, control) => (vs, Some(control)),
                     QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
                         unreachable!(
-                            "eval_pipe_with_path_context_internal only ever produces \
+                            "eval_expr_needing_path_context only ever produces \
                              Owned/ManyOwned/None/Error/Break/Partial"
                         )
                     }
                 };
             let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
-                match eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(init),
+                match eval_expr_needing_path_context::<W, S>(
+                    init,
                     value,
                     root,
                     file_origin,
@@ -29454,7 +29513,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                     QueryResult::Partial(vs, control) => (vs, Some(control)),
                     QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
                         unreachable!(
-                            "eval_pipe_with_path_context_internal only ever produces \
+                            "eval_expr_needing_path_context only ever produces \
                              Owned/ManyOwned/None/Error/Break/Partial"
                         )
                     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6929,52 +6929,74 @@ fn test_as_path_context_builtin_body_loop_arms_1663() -> Result<()> {
     Ok(())
 }
 
-/// Documents two deliberate, narrow gaps #1663 leaves open rather than
-/// silently missing: `needs_path_context` still has no dedicated evaluation
-/// arm for `Expr::Reduce` or `Expr::Foreach`, so a path-context builtin
-/// inside either still falls through to the generic fallback and stubs to
-/// its zero default, exactly as before this fix. `Expr::Object` has the
-/// identical gap but is tracked separately as #1332 (already true before
-/// #1663, per the `Array` arm's own doc comment).
+/// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
+/// open rather than silently missing: a `?//`-chained `AsPattern` (2+
+/// alternatives) still has no dedicated evaluation arm, so a path-context
+/// builtin inside it falls through to the generic fallback and stubs to
+/// its zero default. Its retry-on-failure semantics are real complexity
+/// #1765 didn't attempt to replicate, per that issue's own scoping.
+/// `Expr::Object` has the identical gap but is tracked separately as #1332.
 ///
-/// `Expr::As` (#1663), the single-pattern case of `Expr::AsPattern` (#1765),
-/// and `Expr::Limit` (#1765) -- the most consequential shapes, since the
-/// first two are the ordinary `EXPR as $v | body` / `EXPR as PATTERN | body`
-/// idioms -- are all fixed; see `test_as_pattern_single_pattern_path_context_resolves_1765`
-/// and `test_limit_path_context_resolves_1765` for that coverage. A
-/// `?//`-chained `AsPattern` (2+ alternatives) is intentionally still a known
-/// gap alongside the two below -- its retry-on-failure semantics are real
-/// complexity #1765 didn't attempt to replicate, per that issue's own
-/// scoping.
-///
-/// None of the remaining three shapes (reduce/foreach, plus `?//`) have a
-/// real-yq oracle to verify a fix against (yq's lexer rejects destructuring
-/// `as`, `reduce`, and `foreach` outright), and `Reduce`/`Foreach` in
-/// particular raise a real semantic question (what should `key` mean while
-/// evaluating the fold's own accumulator, which has no document position?)
-/// that #1663's own investigation didn't settle. Filed as a follow-up rather
-/// than guessed at here. Pinned so a future regression or accidental fix is
-/// visible either way, matching #1306's identical "known gap" precedent
+/// `Expr::As` (#1663); the single-pattern case of `Expr::AsPattern`,
+/// `Expr::Limit`, and (`input`/`INIT` only) `Expr::Reduce`/`Expr::Foreach`
+/// (all #1765) are all fixed -- see
+/// `test_as_pattern_single_pattern_path_context_resolves_1765`,
+/// `test_limit_path_context_resolves_1765`, and
+/// `test_reduce_foreach_input_init_path_context_resolves_1765` for that
+/// coverage. No real-yq oracle exists to verify any of this against (yq's
+/// lexer rejects destructuring `as`, `reduce`, and `foreach` outright).
+/// Pinned so a future regression or accidental fix is visible either way,
+/// matching #1306's identical "known gap" precedent
 /// (`test_func_def_path_context_argument_passing_is_a_known_gap_1306`).
 #[test]
-fn test_reduce_foreach_path_context_still_known_gaps_1663() -> Result<()> {
+fn test_as_pattern_alternatives_path_context_still_a_known_gap_1663() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | . as [$x] ?// {b:$x} | key"],
+        Some(r#"{"a":[1]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "null");
+
+    Ok(())
+}
+
+/// #1765 item 3: `Expr::Reduce`/`Expr::Foreach`'s `input`/`INIT` now resolve
+/// `key`/`parent`/`file_index` against the caller's own ambient position,
+/// mirroring `Expr::Limit`'s own hybrid dispatch above -- `input`/`INIT`
+/// route through the path-context evaluator only when either needs it,
+/// then feed `eval_reduce_with_values`/`eval_foreach_with_values` (the
+/// OwnedValue-domain core shared with each function's ordinary,
+/// cursor-sourced entry point) exactly as before. `UPDATE`/`EXTRACT` are
+/// deliberately unchanged: both evaluate against the accumulator, a
+/// synthetic value with no document position, where `key` already
+/// (correctly) answers `null` -- confirmed by the third case below, which
+/// keeps that behavior unchanged even though `input`/`INIT` in the same
+/// expression are now fixed.
+#[test]
+fn test_reduce_foreach_input_init_path_context_resolves_1765() -> Result<()> {
+    // `INIT` is `key` for both -- the exact shape #1663's own investigation
+    // left open. `input`'s own iteration doesn't move position, so `key`
+    // still resolves to the same top-level field name every fold restarts.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | reduce .[] as $x (key; .)"],
         Some(r#"{"a":[1,2]}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "null");
+    assert_eq!(stdout.trim(), r#""a""#);
 
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | [foreach .[] as $x (key; .)]"],
         Some(r#"{"a":[1,2]}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "[null,null]");
+    assert_eq!(stdout.trim(), r#"["a","a"]"#);
 
+    // `UPDATE` unchanged: `key` there means "the accumulator's own
+    // position" (none), so it's still `null` -- not fixed, not attempted,
+    // matching this issue's own scoping.
     let (stdout, _, code) = run_jq_full(
-        &["-c", ".a | . as [$x] ?// {b:$x} | key"],
-        Some(r#"{"a":[1]}"#),
+        &["-c", ".a | reduce .[] as $x (0; key)"],
+        Some(r#"{"a":[1,2]}"#),
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "null");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7004,6 +7004,94 @@ fn test_reduce_foreach_input_init_path_context_resolves_1765() -> Result<()> {
     Ok(())
 }
 
+/// #1978 code review: every case in the test above puts `key` in `INIT`,
+/// never `input` alone -- leaving the `needs_path_context(input) ||
+/// needs_path_context(init)` guard's "only `input` needs it" branch
+/// unexercised by any value-sensitive assertion. Here `input` is
+/// `key,.[]` (so `key` fires the guard) and `INIT` is the path-context-inert
+/// literal `[]` -- the mirror image of the existing test's coverage.
+#[test]
+fn test_reduce_foreach_input_alone_needs_path_context_1765() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | reduce (key,.[]) as $x ([]; . + [$x])"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",1,2]"#);
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [foreach (key,.[]) as $x ([]; . + [$x])]"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"[["a"],["a",1],["a",1,2]]"#);
+
+    Ok(())
+}
+
+/// #1978 code review: pins the error/`Partial`-mid-stream interaction with
+/// path-context routing for both `reduce` and `foreach` -- the new dispatch
+/// arms have substantial control-flow logic specifically for this shape
+/// (`Error`/`Break`/`Halt`/`Partial` coming back from the recursive
+/// path-context call), previously untested. `reduce`'s own single-shot
+/// semantics discard the `1,2` prefix entirely once `input` errors (matches
+/// jq 1.7.1 exactly, confirmed live with a literal substituted for `key`);
+/// `foreach` streams `1,2` before erroring, but only visibly so outside an
+/// atomic array constructor -- `[foreach ...]` swallows the whole partial
+/// array on an interior error the same way `[1,2,error("x")]` would,
+/// unrelated to this fix.
+#[test]
+fn test_reduce_foreach_input_error_mid_stream_path_context_1765() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a | reduce (1,2,error("boom")) as $x (key; .)"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?}, stderr: {stderr:?}");
+    assert!(stdout.trim().is_empty(), "reduce must discard the prefix");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+
+    // `?` suppresses the error entirely -- no partial output to salvage,
+    // matching `reduce`'s own single-shot semantics.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"(.a | reduce (1,2,error("boom")) as $x (key; .))?"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert!(stdout.trim().is_empty());
+
+    // `foreach` streams outputs one at a time (no atomic array wrapper
+    // here, unlike `[foreach ...]`), so `key`'s two resolved outputs print
+    // before the error -- confirms `input_control` still carries the
+    // trailing error forward correctly even when `input` needed
+    // path-context routing.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a | foreach (1,2,error("boom")) as $x (key; .)"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?}, stderr: {stderr:?}");
+    assert_eq!(stdout, "\"a\"\n\"a\"\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #1978 code review: `foreach`'s optional third clause, `EXTRACT`, was
+/// never exercised by this issue's own new test -- only `UPDATE`'s "stays
+/// null" case was. `EXTRACT` shares `UPDATE`'s exact rationale (both
+/// evaluate against the accumulator, a synthetic value with no document
+/// position), so this pins that it's unchanged too.
+#[test]
+fn test_foreach_extract_path_context_unchanged_1765() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [foreach .[] as $x (0; .+$x; key)]"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[null,null]");
+
+    Ok(())
+}
+
 /// #1765 item 2: `Expr::Limit`'s body expression now resolves
 /// `key`/`parent`/`file_index` against the caller's own ambient position,
 /// via a hybrid dispatch (mirrors `eval_binary_fanout_with_path_context`'s


### PR DESCRIPTION
Fixes #1765.

## Summary

Item 3 of #1765's own suggested ordering (items 1-2, \`AsPattern\`/\`Limit\`, already resolved by #1786/#1961). \`needs_path_context\` had no arm for \`Expr::Reduce\`/\`Expr::Foreach\`, so \`key\`/\`parent\`/\`file_index\` inside either's \`input\`/\`INIT\` expression silently stubbed to their zero default instead of resolving against the caller's own ambient position:

\`\`\`console
$ echo '{"a":[1,2]}' | succinctly jq -c '.a | reduce .[] as $x (key; .)'
"a"      # was null
$ echo '{"a":[1,2]}' | succinctly jq -c '.a | [foreach .[] as $x (key; .)]'
["a","a"]  # was [null,null]
\`\`\`

\`UPDATE\`/\`EXTRACT\` are deliberately left unchanged, per the issue's own suggested scoping — both evaluate against the fold's own accumulator, a synthetic value with no document position, where \`key\` already (correctly) answers \`null\`.

## Approach

The bulk of \`eval_reduce\`/\`eval_foreach\`'s own logic is already \`OwnedValue\`-domain once \`input_values\`/\`init_values\` are computed via \`eval_single\` — only that initial conversion is cursor-based. Extracted everything after that point into shared \`eval_reduce_with_values\`/\`eval_foreach_with_values\` cores, then added a hybrid-dispatch arm in \`eval_pipe_with_path_context_internal\` — mirroring \`Expr::Limit\`'s own precedent (#1961) — that sources \`input\`/\`INIT\` from the path-context evaluator instead, only when either actually needs it (this arm's own guard), then feeds the same shared core. \`eval_reduce\`/\`eval_foreach\`'s own cursor-sourced entry points are otherwise unchanged and still handle the common (no path-context builtin) case exactly as before.

The new dispatch arms mirror each function's own error/control-flow precedence exactly (an immediate \`input\`-stream error/break/halt returns before \`INIT\` is ever evaluated for \`reduce\`; \`foreach\`'s own \`Partial\` input keeps its prefix and carries the control forward instead, since \`foreach\` streams per-element).

## Changes

- \`src/jq/eval.rs\`: extracted \`eval_reduce_with_values\`/\`eval_foreach_with_values\`; added \`Expr::Reduce\`/\`Expr::Foreach\` arms to \`needs_path_context\` (guarded on \`input\`/\`init\` only, not \`update\`/\`extract\`) and to \`eval_pipe_with_path_context_internal\`.
- \`tests/jq_cli_tests.rs\`: renamed \`test_reduce_foreach_path_context_still_known_gaps_1663\` to \`test_as_pattern_alternatives_path_context_still_a_known_gap_1663\` (keeping only the still-open \`?//\`-chain \`AsPattern\` case — the reduce/foreach cases it used to pin are now fixed, not gaps); added \`test_reduce_foreach_input_init_path_context_resolves_1765\`, including a case confirming \`UPDATE\`'s own \`key\` handling is unchanged.

## Test plan

- [x] \`cargo test --features cli,simd,regex,serde\` — 1310 lib tests + all integration suites pass
- [x] \`cargo test\` (default features) — passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` — clean
- [x] \`cargo build --no-default-features\` — builds
- [x] \`cargo fmt --check\` — clean
- [x] Confirmed the extraction step alone (before adding the new dispatch arms) is behavior-neutral — full suite passed unchanged
- [x] No jq/yq oracle exists for this (\`key\`/\`parent\`/\`file_index\` are succinctly-only extensions; yq's own lexer rejects destructuring \`as\`/\`reduce\`/\`foreach\` outright) — internal consistency only, matching #1663/#1961's own precedent