### PR TITLE
test(jq): pin LazySeq/DistinctKeyCursors size, guard #1973's unboxed widest-variant defect

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8710,6 +8710,55 @@ mod tests {
         );
     }
 
+    /// #789's own fix boxed `GenericResult`/`GenericItem`'s `LazySeq`
+    /// variant, but left `LazySeq<V>` itself unboxed and just as wide as
+    /// before (184 bytes for `StandardJson`, 200 for `YamlValue`, since
+    /// YAML's field-cursor type is bigger than JSON's). #1973's review of
+    /// #1969 traced this to `LazySource::Keys(DistinctKeyCursors<V::Fields>)`
+    /// -- `DistinctKeyCursors` carries two full field-cursor copies
+    /// (`rest`/`all`) plus the rare-path `seen`/`collapsed` fields for
+    /// #1514's duplicate-key collapse, unboxed, on every `LazySeq`
+    /// regardless of whether that document ever hits the collapse path.
+    /// Shrinking `DistinctKeyCursors` at the source is out of scope here
+    /// (a materially larger change touching #1514's machinery -- see
+    /// #1973's own "why deferred" section); this test only pins today's
+    /// size so a *third* unboxed-wide-variant regression (a new field on
+    /// `LazySeq`/`LazySource`/`DistinctKeyCursors`) is caught the same way
+    /// the #789 guards above catch a regression on `GenericResult`/
+    /// `GenericItem`. Pinned on the YAML instantiation since it's the
+    /// larger (worse-case) of the two document kinds.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_lazyseq_size_is_pinned_pending_distinctkeycursors_shrink_1973() {
+        assert_eq!(
+            core::mem::size_of::<LazySeq<crate::yaml::YamlValue<'_, Vec<u64>>>>(),
+            200,
+            "LazySeq<YamlValue>'s size changed -- if it grew, a new unboxed-wide field \
+             snuck onto LazySeq/LazySource/DistinctKeyCursors (investigate before \
+             accepting); if it shrank, #1973's DistinctKeyCursors-shrink follow-up may \
+             have landed -- update this pinned value to match"
+        );
+    }
+
+    /// The YAML twin of [`test_lazyseq_size_is_pinned_pending_distinctkeycursors_shrink_1973`]
+    /// for `DistinctKeyCursors<YamlFields>` directly -- the actual struct
+    /// #1973 identifies as the real driver of `LazySeq<V>`'s size, not just
+    /// the enum variant wrapping it.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_distinct_key_cursors_size_is_pinned_pending_shrink_1973() {
+        assert_eq!(
+            core::mem::size_of::<
+                crate::jq::document::DistinctKeyCursors<crate::yaml::YamlFields<'_, Vec<u64>>>,
+            >(),
+            168,
+            "DistinctKeyCursors<YamlFields>'s size changed -- if it grew, a new field \
+             landed unboxed on the rare-path (seen/collapsed) or copied cursor (rest/all) \
+             members (investigate before accepting); if it shrank, #1973's shrink \
+             follow-up may have landed -- update this pinned value to match"
+        );
+    }
+
     /// `GenericResult::produces_output()`'s exhaustive match (added after
     /// #791's `Halt` variant was once missed by a hand-maintained exclusion
     /// list, see the method's own doc comment): four of its `true` arms —


### PR DESCRIPTION
## Summary
- #1969 boxed `GenericResult`/`GenericItem`'s `LazySeq` variant to fix #789's measured regression, but `LazySeq<V>` itself -- and the `DistinctKeyCursors<F>` struct actually driving its width -- stayed just as wide as before.
- Adds two `size_of` regression-guard tests (mirroring #1969's own `GenericResult`/`GenericItem` guards, same exact-value-plus-64-bit-gate convention) pinning `LazySeq<YamlValue>` at 200 bytes and `DistinctKeyCursors<YamlFields>` at 168 bytes today, so a future field added anywhere in that chain is caught automatically instead of requiring another benchmark investigation to notice.

## Scope
This lands only #1973's item 3 (regression guard). Item 1 (actually shrinking `DistinctKeyCursors` by boxing the rare-path `seen`/`collapsed` fields) is left open on the issue -- it touches #1514's duplicate-key-collapse machinery and is a materially larger change per the issue's own "why deferred" section. Item 2 (repo-wide `clippy::large_enum_variant` threshold change) is dropped from scope: the current default threshold (200) doesn't trip on this gap (168 vs ~16 bytes for `LazySource`'s smallest variant), and lowering it crate-wide risks surfacing unrelated findings well outside this issue, exactly the concern the issue itself raised -- the `size_of` guards accomplish the same "catch it automatically" goal without that blast radius.

Fixes #1973 (item 3 only; issue stays open for item 1 -- see comment).

## Test plan
- [x] `cargo test --lib --features cli` (3107 passed)
- [x] `cargo test` (default features, 42 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`