### PR TITLE
fix(jq): respect optional for non-decode-failure to_owned_checked errors

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1061,10 +1061,14 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
                 // #1755: to_owned_checked, not to_owned -- an undecodable
                 // field value must raise, not silently become "" and get
-                // sliced as if it were the real value.
+                // sliced as if it were the real value. #1953: a non-decode-
+                // failure to_owned_checked error (a #1194 malformed-member
+                // or #1642 collision error) respects `optional` the same
+                // way the sibling `_ if optional` arm below does -- only a
+                // genuine decode failure is unconditional.
                 let owned = match to_owned_checked(&value) {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
                 let OwnedValue::Object(map) = owned else {
                     unreachable!("StandardJson::Object always materializes to OwnedValue::Object")
@@ -16919,9 +16923,14 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         YqAssignNoopCheck::Continue { pristine, paths } => (pristine, paths),
         YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
         YqAssignNoopCheck::NotChecked => {
+            // #1953: a non-decode-failure to_owned_checked error (#1194
+            // malformed-member/#1642 collision) respects `optional` like
+            // every other fallible step at this boundary (per this
+            // function's own doc comment above) -- only a genuine decode
+            // failure is unconditional.
             let pristine = match to_owned_checked(&input) {
                 Ok(pristine) => pristine,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
                 Ok(paths) => paths,
@@ -16995,10 +17004,14 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     scalar_slice_noop: bool,
 ) -> QueryResult<'a, W> {
-    // Convert input to owned for modification
+    // Convert input to owned for modification. #1953: a non-decode-failure
+    // to_owned_checked error respects `optional` like every other fallible
+    // step at this boundary (see this function's own `resolve_dynamic_indexes`
+    // arm and `eval_assign`'s matching comment below) -- only a genuine
+    // decode failure is unconditional.
     let mut result = match to_owned_checked(&input) {
         Ok(result) => result,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
 
     // Computed keys resolve against the original document, before any update.
@@ -17215,9 +17228,13 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Err(early_return) => return early_return,
         };
 
+    // #1953: a non-decode-failure to_owned_checked error respects `optional`
+    // like the sibling `resolve_dynamic_indexes` arm just below (and
+    // `eval_assign`/`eval_update`'s matching sites) -- only a genuine
+    // decode failure is unconditional.
     let pristine = match to_owned_checked(&input) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false, false) {
         Ok(paths) => paths,
@@ -31026,9 +31043,11 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(EvalError::path_must_be_array())
                 };
             };
+            // #1953: a non-decode-failure to_owned_checked error respects
+            // `optional`, the same as every other builtin refusal here.
             let owned = match to_owned_checked(&value) {
                 Ok(owned) => owned,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             match set_value_at_path(owned, &path, new_val) {
                 Ok(result) => QueryResult::Owned(result),
@@ -34826,10 +34845,13 @@ fn builtin_combinations<W: Clone + AsRef<[u64]>>(
                         // #1755: to_owned_checked, not to_owned -- an
                         // undecodable element must raise, not silently
                         // become "" and take part in the product.
+                        // #1953: a non-decode-failure error respects
+                        // `optional`, the same as the sibling `_ if
+                        // optional` arms in this same match.
                         let inner_values: Vec<OwnedValue> =
                             match inner.map(|v| to_owned_checked(&v)).collect() {
                                 Ok(v) => v,
-                                Err(e) => return QueryResult::Error(e),
+                                Err(e) => return suppress_or_raise(e, optional),
                             };
                         arrays.push(inner_values);
                     }
@@ -34940,9 +34962,11 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raise, not silently become "" and take part in the product.
     let base_array: Vec<OwnedValue> = match &value {
         StandardJson::Array(elements) => {
+            // #1953: a non-decode-failure error respects `optional`, the
+            // same as the sibling `_ if optional` arm below.
             match (*elements).map(|v| to_owned_checked(&v)).collect() {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             }
         }
         _ if optional => return QueryResult::None,
@@ -40104,6 +40128,44 @@ mod tests {
                 );
             }
         );
+    }
+
+    /// #1953: `to_owned_checked`'s `Err` can carry a #1194 malformed-member
+    /// error (a trailing unpaired object member, e.g. `{"a":1,"b"}`), which
+    /// is not `is_decode_failure()`-tagged -- unlike a genuine decode
+    /// failure, `optional` should suppress it the same way it suppresses
+    /// any other ordinary error, at the six sites this fix scoped to (each
+    /// already had an adjacent, established "ordinary error respects
+    /// `optional`" sibling to mirror). Before this fix, all six propagated
+    /// unconditionally regardless of `optional`.
+    #[test]
+    fn test_six_sites_respect_optional_for_malformed_member_error_1953() {
+        // eval_assign: unsuppressed still raises...
+        query!(
+            br#"{"a":1,"b"}"#,
+            ".c = 5",
+            QueryResult::Error(e) => assert!(!e.is_decode_failure())
+        );
+        // ...and `optional` now suppresses it.
+        query!(br#"{"a":1,"b"}"#, "(.c = 5)?", QueryResult::None => {});
+
+        // eval_update
+        query!(br#"{"a":1,"b"}"#, "(.c |= . + 1)?", QueryResult::None => {});
+
+        // eval_update_multi (via compound assign)
+        query!(br#"{"a":1,"b"}"#, "(.c += 1)?", QueryResult::None => {});
+
+        // builtin_setpath
+        query!(br#"{"a":1,"b"}"#, r#"setpath(["c"]; 5)?"#, QueryResult::None => {});
+
+        // builtin_combinations
+        query!(br#"{"a":1,"b"}"#, "[combinations]?", QueryResult::None => {});
+
+        // builtin_combinations_n
+        query!(br#"{"a":1,"b"}"#, "[combinations(1)]?", QueryResult::None => {});
+
+        // eval_single's yq Object-slice arm
+        yq_query!(br#"{"a":1,"b"}"#, ".[0:1]?", QueryResult::None => {});
     }
 
     /// #1972: `eval_single`'s fully-open `Expr::Slice` fast path (the same

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1063,9 +1063,11 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // field value must raise, not silently become "" and get
                 // sliced as if it were the real value. #1953: a non-decode-
                 // failure to_owned_checked error (a #1194 malformed-member
-                // or #1642 collision error) respects `optional` the same
-                // way the sibling `_ if optional` arm below does -- only a
-                // genuine decode failure is unconditional.
+                // error -- a #1642 collision error is itself tagged as a
+                // decode failure and so is unaffected by this) respects
+                // `optional` the same way the sibling `_ if optional` arm
+                // below does -- only a genuine decode failure is
+                // unconditional.
                 let owned = match to_owned_checked(&value) {
                     Ok(v) => v,
                     Err(e) => return suppress_or_raise(e, optional),
@@ -16923,11 +16925,12 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         YqAssignNoopCheck::Continue { pristine, paths } => (pristine, paths),
         YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
         YqAssignNoopCheck::NotChecked => {
-            // #1953: a non-decode-failure to_owned_checked error (#1194
-            // malformed-member/#1642 collision) respects `optional` like
-            // every other fallible step at this boundary (per this
-            // function's own doc comment above) -- only a genuine decode
-            // failure is unconditional.
+            // #1953: a non-decode-failure to_owned_checked error (a #1194
+            // malformed-member error -- a #1642 collision error is itself
+            // tagged as a decode failure and so is unaffected by this)
+            // respects `optional` like every other fallible step at this
+            // boundary (per this function's own doc comment above) -- only
+            // a genuine decode failure is unconditional.
             let pristine = match to_owned_checked(&input) {
                 Ok(pristine) => pristine,
                 Err(e) => return suppress_or_raise(e, optional),
@@ -25400,8 +25403,9 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raising. A decode failure is never suppressed by `optional` (#1620),
     // matching the "drop the prefix, propagate unconditionally" policy the
     // comment below already applies to an ordinary `Partial` error -- but a
-    // *non*-decode-failure conversion error (a #1194 malformed-member or
-    // #1642 collision error) is an ordinary error like any other, and
+    // *non*-decode-failure conversion error (a #1194 malformed-member error
+    // -- a #1642 collision error is itself tagged as a decode failure and
+    // so is unaffected by this) is an ordinary error like any other, and
     // `optional` should suppress it the same way the bare `QueryResult::Error`
     // arm below already does (#1934 item 3: this used to be unconditionally
     // fatal regardless of `optional`, unlike that sibling arm).
@@ -40132,40 +40136,212 @@ mod tests {
 
     /// #1953: `to_owned_checked`'s `Err` can carry a #1194 malformed-member
     /// error (a trailing unpaired object member, e.g. `{"a":1,"b"}`), which
-    /// is not `is_decode_failure()`-tagged -- unlike a genuine decode
-    /// failure, `optional` should suppress it the same way it suppresses
-    /// any other ordinary error, at the six sites this fix scoped to (each
-    /// already had an adjacent, established "ordinary error respects
-    /// `optional`" sibling to mirror). Before this fix, all six propagated
-    /// unconditionally regardless of `optional`.
+    /// is not `is_decode_failure()`-tagged. Confirmed here (via a plain,
+    /// un-suppressed `.c = 5` reachable straight through the CLI) that the
+    /// raised error is indeed not a decode failure -- the premise the rest
+    /// of this fix rests on.
     #[test]
-    fn test_six_sites_respect_optional_for_malformed_member_error_1953() {
-        // eval_assign: unsuppressed still raises...
+    fn test_malformed_member_error_is_not_a_decode_failure_1953() {
         query!(
             br#"{"a":1,"b"}"#,
             ".c = 5",
             QueryResult::Error(e) => assert!(!e.is_decode_failure())
         );
-        // ...and `optional` now suppresses it.
-        query!(br#"{"a":1,"b"}"#, "(.c = 5)?", QueryResult::None => {});
+    }
 
-        // eval_update
-        query!(br#"{"a":1,"b"}"#, "(.c |= . + 1)?", QueryResult::None => {});
+    /// #1953: the seven `to_owned_checked` call sites tested individually
+    /// below all propagated this non-decode-failure error unconditionally,
+    /// ignoring `optional`, before this fix -- diverging from an adjacent
+    /// sibling arm at the very same boundary in every case.
+    ///
+    /// None of the seven is reachable with `optional: true` through any
+    /// real `?`/`try` syntax today (code review, #1953): `Expr::Optional`'s
+    /// dispatch (see the doc comment on `eval_single`'s own `Expr::Optional
+    /// (inner) if matches!(**inner, Expr::IndexExpr{..}|Expr::SliceExpr{..})`
+    /// arm) only ever forwards `optional: true` *directly* into a callee for
+    /// that one dynamic-bounds index/slice shape. Every other spelling of
+    /// `?` -- including a literal-bounds slice like `.[0:1]?` (which folds
+    /// to `Expr::Slice`/`Expr::SliceNumber`, not `Expr::SliceExpr`, so it
+    /// doesn't take that bypass either) and Assign/Update/SetPath/
+    /// Combinations, none of which are Index/Slice at all -- instead
+    /// evaluates its inner expression with the *ambient* `optional` and
+    /// lets `eval_try`'s own catch-and-convert machinery decide the
+    /// aggregate outcome afterward, independent of what the callee did
+    /// internally. So each site is exercised directly here, the same way
+    /// this file's own pre-existing `eval_assign_optional_swallows_
+    /// ordinary_path_error_called_directly` and its siblings already test
+    /// `optional`-gated behavior with no reachable `?` spelling of its own.
+    /// Fixing it anyway keeps every one of these functions' own `optional`
+    /// parameter internally consistent with what its doc comment already
+    /// promises, in case a future caller (or a future widening of the
+    /// `Expr::Optional` bypass above) ever does reach it with `true`.
+    /// Split one function per site (rather than one function with seven
+    /// blocks) so a regression at any single site fails its own test
+    /// instead of hiding behind an earlier block's panic.
+    #[test]
+    fn test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let slice_expr = Expr::Slice {
+            start: None,
+            end: None,
+        };
+        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
 
-        // eval_update_multi (via compound assign)
-        query!(br#"{"a":1,"b"}"#, "(.c += 1)?", QueryResult::None => {});
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale shared by all seven of
+    /// these per-site tests. `eval_assign`'s `YqAssignNoopCheck::NotChecked`
+    /// branch is reached under `JqSemantics`, which never takes the
+    /// yq-only no-op fast path (see `eval_assign_optional_swallows_ordinary_
+    /// path_error_called_directly` above for the same convention).
+    #[test]
+    fn test_eval_assign_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let path_expr = Expr::Identity;
+        let value_expr = Expr::Literal(Literal::Int(5));
+        match eval_assign::<Vec<u64>, JqSemantics>(&path_expr, &value_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_assign::<Vec<u64>, JqSemantics>(&path_expr, &value_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
 
-        // builtin_setpath
-        query!(br#"{"a":1,"b"}"#, r#"setpath(["c"]; 5)?"#, QueryResult::None => {});
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale. Exercises `eval_update`'s
+    /// own input-conversion step.
+    #[test]
+    fn test_eval_update_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        match eval_update::<Vec<u64>, JqSemantics>(
+            &Expr::Identity,
+            &Expr::Identity,
+            cursor.value(),
+            true,
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_update::<Vec<u64>, JqSemantics>(
+            &Expr::Identity,
+            &Expr::Identity,
+            cursor.value(),
+            false,
+            true,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
 
-        // builtin_combinations
-        query!(br#"{"a":1,"b"}"#, "[combinations]?", QueryResult::None => {});
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale. Exercises
+    /// `eval_update_multi`'s own input-conversion step, reached via
+    /// `eval_compound_assign` (`+=`), which just forwards its own
+    /// `optional` straight through.
+    #[test]
+    fn test_eval_update_multi_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let path_expr = Expr::Identity;
+        let value_expr = Expr::Literal(Literal::Int(1));
+        match eval_compound_assign::<Vec<u64>, JqSemantics>(
+            AssignOp::Add,
+            &path_expr,
+            &value_expr,
+            cursor.value(),
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_compound_assign::<Vec<u64>, JqSemantics>(
+            AssignOp::Add,
+            &path_expr,
+            &value_expr,
+            cursor.value(),
+            false,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
 
-        // builtin_combinations_n
-        query!(br#"{"a":1,"b"}"#, "[combinations(1)]?", QueryResult::None => {});
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale. Exercises
+    /// `builtin_setpath`'s `fanout_two_args` closure.
+    #[test]
+    fn test_builtin_setpath_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let path_expr = parse(r#"["c"]"#).unwrap();
+        let val_expr = Expr::Literal(Literal::Int(5));
+        match builtin_setpath::<Vec<u64>, JqSemantics>(&path_expr, &val_expr, cursor.value(), true)
+        {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_setpath::<Vec<u64>, JqSemantics>(&path_expr, &val_expr, cursor.value(), false)
+        {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
 
-        // eval_single's yq Object-slice arm
-        yq_query!(br#"{"a":1,"b"}"#, ".[0:1]?", QueryResult::None => {});
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale. Exercises
+    /// `builtin_combinations`'s per-element inner-array loop -- needs an
+    /// array of arrays, so the malformed object sits one level deeper.
+    #[test]
+    fn test_builtin_combinations_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"[[{"a":1,"b"}]]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        match builtin_combinations::<Vec<u64>>(cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_combinations::<Vec<u64>>(cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment above for the full rationale. Exercises
+    /// `builtin_combinations_n`'s array-conversion step.
+    #[test]
+    fn test_builtin_combinations_n_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"[{"a":1,"b"}]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let n_expr = Expr::Literal(Literal::Int(1));
+        match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 
     /// #1972: `eval_single`'s fully-open `Expr::Slice` fast path (the same


### PR DESCRIPTION
## Summary

`to_owned_checked`'s `Err` can carry a #1194 malformed-member error (a
trailing unpaired object member, e.g. `{"a":1,"b"}`), which is not
`is_decode_failure()`-tagged. Per this codebase's established rule, only a
genuine decode failure is supposed to bypass `optional` unconditionally —
an ordinary error (including this one) should respect it like any other.

Seven call sites did not: they returned `QueryResult::Error(e)`
unconditionally from a `to_owned_checked` failure, regardless of
`optional`, diverging from an adjacent sibling arm at the very same
boundary in every case:

- `eval_single`'s yq `Object`-slice arm
- `eval_assign`'s `YqAssignNoopCheck::NotChecked` branch
- `eval_update`'s input-conversion step
- `eval_update_multi`'s input-conversion step
- `builtin_setpath`'s `fanout_two_args` closure
- `builtin_combinations`'s per-element inner-array loop
- `builtin_combinations_n`'s array-conversion step

All seven now go through the existing `suppress_or_raise(e, optional)`
helper (added in #1934) instead of a bare `return QueryResult::Error(e)`.

## Reachability

None of the seven is reachable with `optional: true` through any real
`?`/`try` syntax today. `Expr::Optional`'s dispatch only ever forwards
`optional: true` *directly* into a callee for one specific shape — a
dynamic-bounds index/slice (`Expr::IndexExpr`/`Expr::SliceExpr`). Every
other spelling of `?` — including a literal-bounds slice like `.[0:1]?`
(which folds to `Expr::Slice`/`Expr::SliceNumber`, not `Expr::SliceExpr`)
and Assign/Update/SetPath/Combinations, none of which are Index/Slice at
all — evaluates its inner expression with the *ambient* `optional` and
lets `eval_try`'s own catch-and-convert machinery decide the aggregate
outcome afterward, independent of what the callee did internally.

This matches an existing, already-accepted pattern in this same file (see
`eval_assign_optional_swallows_ordinary_path_error_called_directly` and
its siblings): several functions' own `optional` parameter has no
reachable `?` spelling today, and are tested by calling the function
directly rather than through the CLI. The value of this fix is internal
consistency — every one of these functions' own `optional` parameter now
matches what its doc comment already promised, and it's the correct
implementation if a future caller (or a future widening of the
`Expr::Optional` bypass) ever does reach one of these sites with `true`.

(An earlier revision of this PR tested via `(expr)?` at the top level,
which — per the above — doesn't actually exercise the fix. Caught in code
review; replaced with seven direct-call tests, each verified to fail when
its own site's fix is reverted.)

## Scope

This is the "Tier 1" subset of a wider ~30+-call-site audit (see the
claim comment on #1953). Deliberately deferred to follow-up work:

- The `until`/`while`/`repeat`/`recurse`/`walk` family (loop-shaped
  control flow, higher risk of subtly changing fork/early-exit behavior).
- `getpath_one_path` and `eval_error`'s own doc comment, which currently
  overstate "unconditional" in a way that's stale after #1907/#1953.

## Test plan

- [x] Seven per-site tests (one per fixed call site), each calling the
      function directly via `eval.rs`'s own evaluator with an explicit
      `optional: true`/`false`, asserting `None`/`!is_decode_failure()`
      respectively — verified each independently fails when its own site's
      fix is reverted (temporarily reverted all 7, confirmed all 7 tests
      fail, restored).
- [x] `cargo test --features cli,simd,regex,serde --workspace` (56/56 binaries green)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`
