### PR TITLE
fix(yq): --ascii-output keeps duplicate keys, escaping at the sink (#1700)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -366,6 +366,23 @@ what a construct loses, the question to ask is which output route it takes, not 
 implements** — a construct on the DOM route loses everything the DOM cannot carry, all at
 once.
 
+[#1693](https://github.com/rust-works/succinctly/issues/1693) and
+[#1700](https://github.com/rust-works/succinctly/issues/1700) are that lesson arriving again,
+and the cleanest confirmation of it, because the routing change was made deliberately and for
+an unrelated reason. `--ascii-output` was routed to the DOM emitter because that was the only
+renderer implementing `\uXXXX` escaping — and it immediately lost three things that have
+nothing to do with ASCII: duplicate mapping keys (`a: 1 / a: 2` came back as `{"a":2}`), an
+explicit `!!str` tag's typing (`!!str 5` came back as the number `5`, where both real yq and
+succinctly's own streaming path give `"5"`), and `\L`/`\P`'s `\u2028`/`\u2029` escaping.
+#1700 moved the escaping to the output *sink* (`AsciiEscapeWriter`, `src/jq/escape.rs`)
+instead of into the streamers, which returns the flag to the streaming route and recovers all
+three at once. The DOM emitter's own `!!str` and `\L`/`\P` divergences are unaffected by that
+fix and remain live for the routes that genuinely materialize — `-P` without `-I0`, `--arg`/
+`--argjson`, `-r`/`-j`/`-0`, `--eval-all`, `--split-exp` (each verified live against this
+binary; `--slurpfile` is a jq flag `succinctly yq` does not accept, and `-P -I0` streams,
+because `-I0`'s own `compact` already satisfies the gate) —
+[#1982](https://github.com/rust-works/succinctly/issues/1982).
+
 The `-I0` nesting bug that surfaced along the way was *wider* than `map`: any filter
 `can_use_m2_streaming` rejects (`to_entries`, `with_entries`, `walk`, `--arg`-bearing
 queries, ...) reached the DOM emitter with an empty per-level indent string at `-I0`,

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -420,7 +420,7 @@ succinctly yq '.users[]' input.yaml
 - `-N, --no-doc`: Don't print document separators (`---`)
 - `-P, --prettyPrint`: Pretty print, expand flow styles to block style
 - `--tab`: Use tabs for indentation (write-only — see [yq Language Reference § Known Limitations](../reference/yq-language.md#known-limitations))
-- `-a, --ascii-output`: Output ASCII only, escaping non-ASCII as `\uXXXX`
+- `-a, --ascii-output`: Output ASCII only, escaping non-ASCII as `\uXXXX`. **Not a real yq flag** — v4.53.3 rejects it as an unknown flag; this is a succinctly extension borrowed from jq's own `-a` (ADR-0018 rule 5), so it carries no fidelity obligation to yq. JSON output only: `-o yaml --ascii-output` emits raw UTF-8, since YAML has no `\uXXXX` escape convention to borrow. Escaping happens at the output sink (`AsciiEscapeWriter`), so the flag keeps the streaming path and its duplicate mapping keys; the routes that materialize a DOM anyway (`-P` without `-I0`, `--arg`/`--argjson`, `-r`/`-j`/`-0`, `--eval-all`, `--split-exp`) still collapse duplicates and carry the DOM emitter's own divergences (#1700, #1982)
 - `--split-exp <EXPR>`: Split output into one file per result, named by evaluating `EXPR` against it (`.` is the result, `$index` its 0-based output index; `--arg`/`--argjson` values and `$ARGS` are also available, same as the main filter). Suppresses stdout. Long-only, unlike real yq's `-s`/`--split-exp` — succinctly's `-s` is already `--slurp` (#715). Incompatible with `--slurp`, `--inplace`, `--front-matter`; `--raw-input` not yet supported
 
 ### Input Options

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -12,6 +12,7 @@ use succinctly::jq::document::{
     effective_keys, key_delimiter_ok, resolve_display_key, value_delimiter_ok, DisplayKeyGuard,
     DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec,
 };
+use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
     to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
@@ -120,6 +121,68 @@ impl<W: Write> ColorSink<'_, W> {
             terminator.write_fmt(self)
         }
     }
+}
+
+/// Apply `--ascii-output` to a JSON render (#1700).
+///
+/// Wraps `$sink` in [`AsciiEscapeWriter`] when the flag is set and passes it
+/// through untouched when it is not, so the default path keeps exactly the
+/// code it had before — no per-write branch, and no extra layer between the
+/// M2 streamers and the writer (the `if` costs one predictable test per
+/// streaming call, not one per character). `$body` is duplicated across the
+/// two arms for that reason; it is a single streaming call at every use site.
+/// The duplication is not free, and the cost is code size rather than any
+/// branch: it monomorphizes each streamer twice, worth +108 KB (+1.3%) of
+/// release binary on arm64 and +123 KB (+1.1%) on x86_64 across the six use
+/// sites (measured against this commit's parent on the pinned benchmark
+/// hosts). That shows up in time on x86_64. An interleaved A/B of the
+/// *default*, non-`--ascii-output` path — `.` and `.[]` over 1 MB and 10 MB
+/// `users`/`navigation` documents, 7 reps, output identity gated — reads
+/// +0.49% median with **every one of 8 rows slower** on a 7950X, against a
+/// control floor there of −0.00% median / 4-of-8-slower; the same run on an
+/// M4 Pro is −1.21% median, 0 of 8 slower, against a −0.48% floor. Small, but
+/// the sign consistency on x86 makes it a real regression rather than noise,
+/// and it is the effect #965 was sensitive to arriving by a different route
+/// (code size, not a lost inline). It is accepted here because the flag it
+/// buys back was silently dropping duplicate mapping keys; if it ever needs
+/// recovering, the lever is to stop instantiating the streamers a second time
+/// — give the `--ascii-output` arm a `&mut dyn Write` and leave the default
+/// arm concrete, which pays a vtable call only on the branch that is already
+/// doing per-character escaping.
+///
+/// Escaping the *sink* rather than teaching the streamers an `ascii` flag is
+/// sound because of a property of JSON rather than of any particular writer —
+/// see [`AsciiEscapeWriter`]'s own comment for that argument. What it buys is
+/// that the flag cannot be missed at one of the streamers' three separate
+/// string-writing routes (`stream_json_string` and the two quoted-scalar
+/// transcoders); what it costs is that every JSON write route *in this file*
+/// has to go through this macro instead. Since `can_stream_json_output_style`
+/// no longer excludes `--ascii-output`, a route that skipped it would stream
+/// raw UTF-8 under the flag.
+///
+/// Three of the six use sites are reachable — both arms of `stream_cursor!`
+/// and `--slurp`'s `stream_json_sequence` — and
+/// `test_ascii_output_covers_every_live_json_route_1700` in
+/// `tests/yq_cli_tests.rs` pins those against exactly that failure. The other
+/// three (the two `stream_json_document` calls and `--inplace`'s direct
+/// `FmtWriter`) are in `_ =>` arms this file documents as defensive fallbacks
+/// no input reaches, so they carry the wrap without a test to hold it: a
+/// probe at each of the six sites showed every non-`--slurp` invocation —
+/// file, multi-document, `--inplace` and `-C` alike — landing on the identity
+/// arm. Wrap them anyway; #757's lesson in `docs/compliance/yq/limitations.md`
+/// is that routes move, and this is the loss such a move would cause.
+macro_rules! json_ascii {
+    ($ascii:expr, $sink:expr, |$out:ident| $body:expr) => {{
+        let sink = $sink;
+        if $ascii {
+            let mut escaped = AsciiEscapeWriter::new(sink);
+            let $out = &mut escaped;
+            $body
+        } else {
+            let $out = sink;
+            $body
+        }
+    }};
 }
 
 /// Streams through `render` directly when `use_color` is false. When true,
@@ -3687,28 +3750,25 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // falling back to the DOM/IndexMap path that would collapse duplicate
     // mapping keys (#442, #748, #809).
     let can_stream_pretty_or_colored = !args.pretty_print;
-    // `!args.ascii_output` gates the whole disjunction, not just the
-    // pretty-or-colored half (#1693): none of the M2 JSON streamers
-    // implement ASCII escaping, so `compact ||` previously let
-    // `--ascii-output` through unescaped whenever `-I=0`/compact mode was
-    // also requested -- the DOM path (`output_value`) is the only place
-    // that escapes correctly, and it's reached only when this is false.
+    // `--ascii-output` no longer appears here (#1700). It used to gate the
+    // whole disjunction (#1693) because no M2 JSON streamer could escape
+    // non-ASCII, leaving the DOM path (`output_value`) as the only correct
+    // renderer -- which cost the flag its duplicate mapping keys, since an
+    // `OwnedValue::Object`'s `IndexMap` cannot represent them (#442/#748/
+    // #809). That was a real, shipped data loss (`{"a":1,"a":2}` rendered
+    // as `{"a":2}`), not merely a slower path.
     //
-    // Falling back to DOM for `--ascii-output` reopens the duplicate-key
-    // collapse `can_stream_pretty_or_colored`'s own comment above warns
-    // about (#442/#748/#809) -- but only for this one flag, and only in a
-    // way that already shipped: pretty mode's `can_stream_pretty_or_colored
-    // && !ascii_output` had exactly this same DOM fallback (and therefore
-    // the same duplicate-key loss) for `--ascii-output` before #1693 ever
-    // touched this function. This shared local makes compact mode
-    // consistent with that pre-existing behavior instead of leaving the two
-    // output styles to diverge on the same input. #1700 tracks the real fix
-    // (ASCII-escaping support in the M2 streamers themselves, which would
-    // let `--ascii-output` keep both correct escaping and duplicate-key
-    // safety at once) -- not attempted here per #1693's own "Low, cosmetic"
-    // scoping and the same #965 inlining-cost reasoning this file's
-    // `stream_json_string` doc comment records for why that isn't a
-    // drop-in change.
+    // The escaping now happens at the sink instead, via `json_ascii!` at
+    // every JSON write route in this file, so the streamers stay untouched
+    // and `--ascii-output` keeps correct escaping and duplicate-key safety
+    // at once. #1700 itself proposed threading an `ascii` flag into the
+    // streamers; the sink adapter is sound for a stronger reason than any
+    // such flag would be -- outside a string literal JSON's grammar admits
+    // only ASCII, so every non-ASCII character in the stream is string
+    // content by construction. See `AsciiEscapeWriter` (`src/jq/escape.rs`)
+    // for that argument in full, and for why it also leaves
+    // `stream_json_string`'s #965-sensitive SIMD scan compiled exactly as
+    // before.
     //
     // Extracted into one local (rather than repeating the expression at
     // `can_json_fast_path`, `can_inplace_json_fast_path`, and
@@ -3731,9 +3791,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // risk a wrong fix to the streamers. Same reasoning YAML never needed:
     // YAML's own scalar rendering is already unquoted by default (`-r`-like
     // even without `-r`), so `can_yaml_fast_path` never had this gap.
-    let can_stream_json_output_style = !args.ascii_output
-        && !output_config.raw_output
-        && (output_config.compact || can_stream_pretty_or_colored);
+    let can_stream_json_output_style =
+        !output_config.raw_output && (output_config.compact || can_stream_pretty_or_colored);
     let can_json_fast_path = is_m2_streamable
         && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json
@@ -3802,10 +3861,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // from before #1577.
     //
     // The JSON arm shares `can_json_fast_path`'s `can_stream_json_output_style`
-    // above (#1693 fixed all three JSON gates the same way: none of the M2
-    // JSON streamers implement ASCII escaping, so `!args.ascii_output` has to
-    // gate the whole disjunction, not just the pretty-or-colored half, or
-    // compact mode lets `--ascii-output` through unescaped).
+    // above, which is what keeps all three JSON gates in step -- #1693 had to
+    // fix each of them for `--ascii-output` separately before that local
+    // existed, and #1700 then removed the flag from the predicate entirely
+    // once the escaping moved to the sink. This route's own `json_ascii!`
+    // wrap is on its `stream_json_sequence` call below.
     let can_slurp_fast_path = is_identity
         && match output_config.output_format {
             OutputFormat::Json => can_stream_json_output_style,
@@ -3985,7 +4045,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $writer,
                         $use_color,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
-                        |out| $cursor.stream_json(out, json_indent, sort_keys),
+                        |sink| {
+                            json_ascii!($output_config.ascii_output, sink, |out| {
+                                $cursor.stream_json(out, json_indent, sort_keys)
+                            })
+                        },
                     )?;
                     if let Err(e) = rendered {
                         report_stream_decode_failure(&mut sink, &e);
@@ -4005,12 +4069,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         $writer,
                         $use_color,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
-                        |out| {
-                            result
-                                .stream_json(out, json_indent, sort_keys, |w| {
-                                    terminator.write_fmt(w)
-                                })
-                                .map_err(StreamFailure::from)
+                        |sink| {
+                            json_ascii!($output_config.ascii_output, sink, |out| {
+                                result
+                                    .stream_json(out, json_indent, sort_keys, |w| {
+                                        terminator.write_fmt(w)
+                                    })
+                                    .map_err(StreamFailure::from)
+                            })
                         },
                     )?;
                     // See the YAML branch above (#1615).
@@ -4120,7 +4186,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     |s, _boundaries| {
                                         output::colorize_json(s, &ColorScheme::default())
                                     },
-                                    |out| root.stream_json_document(out, json_indent, sort_keys),
+                                    |sink| {
+                                        json_ascii!(output_config.ascii_output, sink, |out| {
+                                            root.stream_json_document(out, json_indent, sort_keys)
+                                        })
+                                    },
                                 )?
                             };
                             if streamed_ok {
@@ -4257,8 +4327,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         |s, _boundaries| {
                                             output::colorize_json(s, &ColorScheme::default())
                                         },
-                                        |out| {
-                                            root.stream_json_document(out, json_indent, sort_keys)
+                                        |sink| {
+                                            json_ascii!(output_config.ascii_output, sink, |out| {
+                                                root.stream_json_document(
+                                                    out,
+                                                    json_indent,
+                                                    sort_keys,
+                                                )
+                                            })
                                         },
                                     )?
                                 };
@@ -4670,15 +4746,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     output_config.use_color,
                     &mut sink,
                     |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
-                    |out| {
-                        stream_json_sequence(
-                            cursors.iter().copied(),
-                            out,
-                            0,
-                            json_indent_spaces,
-                            indent_unit,
-                            sort_keys,
-                        )
+                    |sink| {
+                        json_ascii!(output_config.ascii_output, sink, |out| {
+                            stream_json_sequence(
+                                cursors.iter().copied(),
+                                out,
+                                0,
+                                json_indent_spaces,
+                                indent_unit,
+                                sort_keys,
+                            )
+                        })
                     },
                 )?
             } else {
@@ -4913,10 +4991,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                             sort_keys,
                                         )
                                     } else {
-                                        root.stream_json_document(
+                                        json_ascii!(
+                                            output_config.ascii_output,
                                             &mut FmtWriter(&mut buf_writer),
-                                            json_indent,
-                                            sort_keys,
+                                            |out| root.stream_json_document(
+                                                out,
+                                                json_indent,
+                                                sort_keys
+                                            )
                                         )
                                     };
                                     match streamed {

--- a/src/jq/escape.rs
+++ b/src/jq/escape.rs
@@ -198,6 +198,99 @@ pub fn escape_json_body(write: fn(&mut String, &str) -> core::fmt::Result, s: &s
     out
 }
 
+/// A [`Write`] adapter that rewrites non-ASCII characters as `\uXXXX` escapes.
+///
+/// Surrogate-paired above the BMP, the same convention
+/// [`write_json_body_yq_ascii`] applies inside a string body; every ASCII byte
+/// passes through untouched.
+///
+/// This is `--ascii-output` for a *streamed* JSON document (#1700), applied to
+/// the finished character stream rather than inside the string writers. That
+/// is sound because of a property of JSON itself, not of any particular
+/// writer: **outside a string literal, JSON's grammar admits only ASCII** —
+/// structural punctuation, digits, `true`/`false`/`null`, whitespace — and
+/// every escape sequence a writer emits is ASCII too. So every non-ASCII
+/// character in a well-formed JSON stream is content inside a string body,
+/// which is exactly the set `--ascii-output` has to escape, and escaping at
+/// the sink cannot reach anything else.
+///
+/// Two consequences worth naming:
+///
+/// - It is **idempotent**. Output that is already all-ASCII — the DOM path's
+///   `format_json` with `ascii: true`, say — passes through byte-for-byte, so
+///   wrapping a sink that some values reach by another route is harmless.
+/// - It composes with any downstream stage that is itself ASCII, ANSI color
+///   codes included.
+///
+/// Deliberately **not** an `ascii: bool` threaded through the M2 streamers,
+/// which is the fix direction #1700 itself first proposed. String bytes reach
+/// the sink from three independent writers — `stream_json_string` and the two
+/// `stream_transcode_*_quoted_to_json` scalar transcoders, the latter pair
+/// carrying ~15 inline write sites each — behind a deeper stack of call paths
+/// (`stream_json_value`, `stream_json_sequence`, `stream_resolved_scalar_as_json`,
+/// the mapping-key arm) that would each have to carry the flag. A flag missed
+/// at any one of them is a silently wrong document. The grammar argument above
+/// covers all of them at once, and leaves `stream_json_string`'s hot SIMD scan
+/// untouched — #965 measured that scan's inlining as worth up to 14%, and this
+/// adapter only exists on the `--ascii-output` branch, so the default path is
+/// compiled exactly as before.
+///
+/// ```
+/// use core::fmt::Write;
+/// use succinctly::jq::escape::AsciiEscapeWriter;
+///
+/// let mut out = String::new();
+/// AsciiEscapeWriter::new(&mut out).write_str("{\"k\":\"héllo 😀\"}").unwrap();
+/// // Structure and ASCII content pass through untouched; the two content
+/// // characters are escaped, the astral one as a surrogate pair.
+/// assert_eq!(out, r#"{"k":"h\u00e9llo \ud83d\ude00"}"#);
+/// ```
+pub struct AsciiEscapeWriter<'a, W> {
+    inner: &'a mut W,
+}
+
+impl<'a, W: Write> AsciiEscapeWriter<'a, W> {
+    /// Wrap `inner`, escaping every non-ASCII character written through it.
+    pub fn new(inner: &'a mut W) -> Self {
+        Self { inner }
+    }
+}
+
+impl<W: Write> Write for AsciiEscapeWriter<'_, W> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let mut rest = s;
+        // ASCII runs are forwarded whole; only a non-ASCII character costs a
+        // decode. The scan can only stop on a *leading* byte: a continuation
+        // byte is never the first `>= 0x80` byte of valid UTF-8, so the
+        // `split_at` below always lands on a character boundary.
+        while let Some(pos) = rest.as_bytes().iter().position(|b| !b.is_ascii()) {
+            let (ascii, tail) = rest.split_at(pos);
+            if !ascii.is_empty() {
+                self.inner.write_str(ascii)?;
+            }
+            // `tail` is non-empty by construction, so this always matches;
+            // handled rather than unwrapped to keep the adapter panic-free.
+            let Some(c) = tail.chars().next() else { break };
+            write_u_escape(self.inner, c)?;
+            rest = &tail[c.len_utf8()..];
+        }
+        if !rest.is_empty() {
+            self.inner.write_str(rest)?;
+        }
+        Ok(())
+    }
+
+    /// The streamers write most structural characters one at a time, so the
+    /// default `write_str`-via-stack-buffer route is worth skipping.
+    fn write_char(&mut self, c: char) -> core::fmt::Result {
+        if c.is_ascii() {
+            self.inner.write_char(c)
+        } else {
+            write_u_escape(self.inner, c)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -373,5 +466,78 @@ mod tests {
             assert_eq!(escape_json_body(write_json_body_jq, &s), jq(&s), "jq/{c:?}");
             assert_eq!(escape_json_body(write_json_body_yq, &s), yq(&s), "yq/{c:?}");
         }
+    }
+
+    /// Run a whole string through [`AsciiEscapeWriter`].
+    fn sink(s: &str) -> String {
+        let mut out = String::new();
+        AsciiEscapeWriter::new(&mut out).write_str(s).unwrap();
+        out
+    }
+
+    /// The design invariant behind escaping at the sink (#1700): a body
+    /// written with the *base* convention and then passed through the adapter
+    /// is byte-for-byte what the dedicated ASCII writer produces. This is what
+    /// lets `--ascii-output` reuse the M2 streamers untouched instead of
+    /// threading a flag into all three of their string-writing routes.
+    #[test]
+    fn adapter_over_base_convention_equals_the_ascii_convention() {
+        for c in corpus() {
+            let s = String::from(c);
+            assert_eq!(sink(&yq(&s)), yq_ascii(&s), "yq/{c:?}");
+            assert_eq!(sink(&jq(&s)), jq_ascii(&s), "jq/{c:?}");
+        }
+    }
+
+    /// Structure, punctuation and existing escapes pass through untouched:
+    /// JSON's grammar admits no non-ASCII outside a string literal, which is
+    /// what makes escaping at the sink equivalent to escaping in the writers.
+    #[test]
+    fn adapter_rewrites_only_non_ascii() {
+        let structural = r#"{"a":[1,-2.5,true,false,null],"b":"x\ty"}"#;
+        assert_eq!(sink(structural), structural);
+        assert_eq!(sink("{\"k\":\"héllo\"}"), "{\"k\":\"h\\u00e9llo\"}");
+        assert_eq!(sink("😀"), "\\ud83d\\ude00");
+        assert_eq!(sink("\u{2028}"), "\\u2028");
+    }
+
+    /// Already-ASCII text survives a second pass unchanged, so a sink that
+    /// also carries output from the DOM path (which escapes for itself) can
+    /// never be double-escaped.
+    #[test]
+    fn adapter_is_idempotent() {
+        for c in corpus() {
+            let once = sink(&yq(&String::from(c)));
+            assert_eq!(sink(&once), once, "{c:?}");
+        }
+    }
+
+    /// The streamers write in many small pieces, one structural character at
+    /// a time included. The adapter keeps no state between calls, so every
+    /// chunking of the same text must produce the same bytes -- including the
+    /// `write_char` fast path, which bypasses `write_str` entirely.
+    #[test]
+    fn adapter_is_chunking_independent() {
+        let text = "{\"k\":\"héllo 😀 \u{2028}\",\"n\":1}";
+        let whole = sink(text);
+        assert_ne!(whole, text, "the sample must actually exercise escaping");
+
+        let mut piecewise = String::new();
+        {
+            let mut w = AsciiEscapeWriter::new(&mut piecewise);
+            for c in text.chars() {
+                w.write_str(&String::from(c)).unwrap();
+            }
+        }
+        assert_eq!(piecewise, whole);
+
+        let mut by_char = String::new();
+        {
+            let mut w = AsciiEscapeWriter::new(&mut by_char);
+            for c in text.chars() {
+                w.write_char(c).unwrap();
+            }
+        }
+        assert_eq!(by_char, whole);
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2093,28 +2093,125 @@ fn test_ascii_output_still_escapes_in_compact_inplace_mode_1693() -> Result<()> 
     Ok(())
 }
 
-/// #1693 code review: routing `--ascii-output` to the DOM path (the fix
-/// above) reopens `can_stream_pretty_or_colored`'s duplicate-key collapse
-/// (#442/#748/#809) for compact mode specifically -- but pretty mode already
-/// had this exact tradeoff before #1693 touched this function (its own
-/// `can_stream_pretty_or_colored && !ascii_output` gate already forced DOM
-/// for `--ascii-output`, collapse included), so this pins compact mode as
-/// now *consistent* with that pre-existing behavior, not a new regression
-/// introduced from a clean baseline. See the `can_stream_json_output_style`
-/// comment in `yq_runner.rs` and #1700 for the real fix (ASCII-escaping
-/// support in the M2 streamers themselves, which would keep both correct
-/// escaping and duplicate-key safety at once).
+/// #1700: `--ascii-output` keeps duplicate mapping keys. It used to lose
+/// them: #1693 routed the flag to the DOM path because that was the only
+/// renderer that escaped non-ASCII, and an `OwnedValue::Object`'s `IndexMap`
+/// cannot represent a repeated key (#442/#748/#809), so `a: 1 / a: 2` came
+/// back as `{"a":2}` in both compact and pretty mode. This test pinned that
+/// collapse as an accepted tradeoff; it now pins its removal. The escaping
+/// moved to the sink (`json_ascii!` / `AsciiEscapeWriter`), so the flag no
+/// longer needs the DOM path at all and keeps both properties at once.
 #[test]
-fn test_ascii_output_compact_and_pretty_agree_on_duplicate_key_collapse_1693() -> Result<()> {
+fn test_ascii_output_compact_and_pretty_preserve_duplicate_keys_1700() -> Result<()> {
     let yaml = "a: 1\na: 2\n";
 
     let (compact, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0", "--ascii-output"])?;
     assert_eq!(code, 0);
-    assert_eq!(compact, "{\"a\":2}\n");
+    assert_eq!(compact, "{\"a\":1,\"a\":2}\n");
 
     let (pretty, code) = run_yq_stdin(".", yaml, &["-o", "json", "--ascii-output"])?;
     assert_eq!(code, 0);
-    assert_eq!(pretty, "{\n  \"a\": 2\n}\n");
+    assert_eq!(pretty, "{\n  \"a\": 1,\n  \"a\": 2\n}\n");
+
+    // The two properties have to hold *together*: escaping a duplicated key's
+    // non-ASCII value is exactly the combination the DOM fallback could not
+    // serve.
+    let yaml = "a: \"h\u{e9}llo\"\na: \"w\u{f6}rld\"\n";
+    let (both, code) = run_yq_stdin(".", yaml, &["-o", "json", "-I0", "--ascii-output"])?;
+    assert_eq!(code, 0);
+    assert_eq!(both, "{\"a\":\"h\\u00e9llo\",\"a\":\"w\\u00f6rld\"}\n");
+
+    Ok(())
+}
+
+/// #1700: with `--ascii-output` no longer excluded from
+/// `can_stream_json_output_style`, every JSON write route in `yq_runner.rs`
+/// has to apply the escaping itself, via the `json_ascii!` wrap. A route that
+/// missed the wrap would stream raw UTF-8 under the flag rather than fail
+/// loudly, so this walks the ones a real invocation can actually take.
+///
+/// **That is three of the six `json_ascii!` sites, not all six** -- established
+/// by probing each site under every case below, not inferred from the call
+/// graph. The three live ones are both `stream_cursor!` arms (identity and
+/// evaluated) and `--slurp`'s `stream_json_sequence`. Every non-`--slurp` case
+/// here reaches the identity arm, `--inplace` and `-C` included: the file,
+/// multi-document, in-place and colored cases below pin behaviour that a
+/// future re-routing could break, but they do *not* exercise distinct sites
+/// today.
+///
+/// The other three wraps -- the two `stream_json_document` calls and
+/// `--inplace`'s direct `FmtWriter` -- sit in the `_ =>` arms `yq_runner.rs`
+/// itself labels "Defensive fallback only: the root cursor (bp_pos 0) always
+/// reports the virtual document sequence". No input reaches them, so no test
+/// can pin them; they are wrapped as insurance, which is the right call given
+/// that `docs/compliance/yq/limitations.md`'s standing lesson is that routes
+/// move (#757) -- an arm that is unreachable today going live is exactly what
+/// the wrap is there for.
+#[test]
+fn test_ascii_output_covers_every_live_json_route_1700() -> Result<()> {
+    let yaml = "a: \"h\u{e9}llo\"\n";
+    let ascii = ["-o", "json", "-I0", "--ascii-output"];
+    let escaped = "{\"a\":\"h\\u00e9llo\"}\n";
+
+    // `stream_cursor!`, identity arm (`YamlCursor::stream_json`) -- the site
+    // every case below except `--slurp` also lands on.
+    let (out, code) = run_yq_stdin(".", yaml, &ascii)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, escaped);
+
+    // `stream_cursor!`, evaluated arm (`GenericResult::stream_json`).
+    let (out, code) = run_yq_stdin(".a", yaml, &ascii)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "\"h\\u00e9llo\"\n");
+
+    // File input rather than stdin. Routes to the identity arm above (the
+    // single-document `stream_json_document` fallback is unreachable); pinned
+    // so a change that split the two inputs apart would be caught.
+    let mut file = NamedTempFile::new()?;
+    write!(file, "{yaml}")?;
+    let (out, code) = run_yq_file(".", file.path().to_str().unwrap(), &ascii)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, escaped);
+
+    // Multi-document file: each document streams through the identity arm in
+    // turn, so the per-document wrap has to hold for every one of them.
+    let mut multi = NamedTempFile::new()?;
+    write!(multi, "a: \"h\u{e9}llo\"\n---\nb: \"w\u{f6}rld\"\n")?;
+    let (out, code) = run_yq_file(".", multi.path().to_str().unwrap(), &ascii)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{\"a\":\"h\\u00e9llo\"}\n{\"b\":\"w\\u00f6rld\"}\n");
+
+    // `--slurp`'s `stream_json_sequence`.
+    let (out, code) = run_yq_file(
+        ".",
+        file.path().to_str().unwrap(),
+        &["-o", "json", "-I0", "--slurp", "--ascii-output"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[{\"a\":\"h\\u00e9llo\"}]\n");
+
+    // `--inplace`: writes through its own buffer with no `ColorSink` at all,
+    // but still via `stream_cursor!`'s identity arm -- the direct `FmtWriter`
+    // site is in the same unreachable fallback arm as the two above.
+    let mut inplace = NamedTempFile::new()?;
+    write!(inplace, "{yaml}")?;
+    let status = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .args(["yq", "-i", "-o", "json", "-I0", "--ascii-output", "."])
+        .arg(inplace.path())
+        .stdin(Stdio::null())
+        .status()?;
+    assert!(status.success());
+    assert_eq!(std::fs::read_to_string(inplace.path())?, escaped);
+
+    // The buffered `ColorSink` behind `-C`: ANSI codes are themselves ASCII,
+    // so the payload still has to come out escaped.
+    let (colored, code) = run_yq_stdin(".", yaml, &["-C", "-o", "json", "-I0", "--ascii-output"])?;
+    assert_eq!(code, 0);
+    assert!(colored.contains("h\\u00e9llo"), "colored: {colored:?}");
+    assert!(
+        !colored.contains('\u{e9}'),
+        "raw non-ASCII leaked through the colored route: {colored:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1700.

## The bug

#1693 routed `--ascii-output` to the DOM (`OwnedValue`) path, because that was the only
renderer implementing `\uXXXX` escaping. An `OwnedValue::Object`'s `IndexMap` cannot
represent a repeated key, so the flag silently collapsed duplicate mapping keys
(#442/#748/#809):

```console
$ printf 'a: 1\na: 2\n' | syq -o json -I0 --ascii-output .
{"a":2}                          # the `a: 1` entry was dropped
```

## The approach — and why not the one #1700 proposed

#1700 suggested threading an `ascii` flag into the M2 streamers. This escapes at the output
**sink** instead, via a new `AsciiEscapeWriter`, which is sound for a stronger reason than a
flag would be:

> **Outside a string literal, JSON's grammar admits only ASCII** — structural punctuation,
> digits, `true`/`false`/`null`, whitespace — and every escape sequence a writer emits is
> ASCII too. So every non-ASCII character in a well-formed JSON stream is string content by
> construction.

That is a property of the *format*, not of any particular writer, so it covers all of the
streamers' string-writing routes at once — `stream_json_string` and both
`stream_transcode_*_quoted_to_json` transcoders, the latter pair carrying ~15 inline write
sites each — where a flag missed at any one of them is a silently wrong document.

## Cost: a small, real x86_64 regression on the default path

**This is not free, and an earlier draft of this description wrongly called it neutral.**

The `json_ascii!` macro duplicates its body across both arms so the default path keeps
exactly the code it had before — no per-write branch, no extra layer. The cost is therefore
code size, not a lost inline: each streamer is monomorphized twice, worth **+108 KB (+1.3%)**
of release binary on arm64 and **+123 KB (+1.1%)** on x86_64.

That shows up in time on x86_64. An interleaved A/B of the *default*, non-`--ascii-output`
path (`.` and `.[]` over 1 MB and 10 MB `users`/`navigation` documents, 7 reps, output
identity gated):

| Machine | Median | Rows slower | Control floor |
|---|---|---|---|
| AMD Ryzen 9 7950X (x86_64) | **+0.49%** | **8 of 8** | −0.00% median, 4-of-8 slower |
| Apple M4 Pro (ARM64) | −1.21% | 0 of 8 | −0.48% median |

Small, but the sign consistency on x86 makes it a real regression rather than noise — the
repo's own rule, printed by `ab-cli.py` itself: *a single row inside the control's range is
noise; a consistent sign across every row is not.* It is #965's effect arriving by a
different route (code size, not a lost inline).

It is accepted here because what it buys back is a flag that was **silently dropping
duplicate mapping keys**. If it ever needs recovering, the lever is to stop instantiating the
streamers twice: give the `--ascii-output` arm a `&mut dyn Write` and leave the default arm
concrete, paying a vtable call only on the branch that is already escaping per character.

## Two latent bugs fixed as a side effect

Returning the flag to the streaming route also fixed two divergences it had inherited from
the DOM path, both confirmed live against the pinned `yq` v4.53.3:

- `!!str 5` came back as the **number** `5` under `--ascii-output`, where real yq and
  succinctly's own default path both give `"5"` — the flag was silently changing a value's
  type.
- `\L`/`\P` lost their `\u2028`/`\u2029` escaping.

Both remain live on the DOM path for the routes that genuinely materialize — `-P` without
`-I0`, `--arg`/`--argjson`, `-r`/`-j`/`-0`, `--eval-all`, `--split-exp`, each verified live
(`-P -I0` streams, since `-I0`'s own `compact` already satisfies the gate). Filed as
**#1982**, and recorded in `docs/compliance/yq/limitations.md`.

## Verification

- **154-case differential** (22 YAML documents x 7 output modes) against the DOM renderer,
  which `--arg` still reaches in the same binary — i.e. the pre-fix renderer, live. No
  difference is attributable to this change: the 7 that appear also appear in the `no-ascii`
  control mode, where the adapter is not installed (they are #1982).
- **Unit invariant**: `base convention + adapter ≡ the dedicated ASCII writer`, over the
  module's existing full corpus (all of Latin-1, plus `é`, U+2028, an astral char), for
  **both** the jq and yq conventions — plus idempotence, chunking-independence and
  structure-passthrough tests.
- **Route coverage, honestly scoped**: `test_ascii_output_covers_every_live_json_route_1700`
  walks the three `json_ascii!` sites a real invocation can reach (both `stream_cursor!` arms
  and `--slurp`'s `stream_json_sequence`). That is **three of the six wraps, not all six** —
  established by probing each site under every case, not inferred from the call graph. Every
  non-`--slurp` case reaches the identity arm, `--inplace` and `-C` included. The other three
  wraps sit in `_ =>` arms the file itself labels defensive fallbacks no input reaches; they
  are wrapped anyway because #757's lesson is that routes move, and this is the loss such a
  move would cause.
- The three escaping tests #1693/#1577 left behind still pass unchanged.
  `test_ascii_output_compact_and_pretty_preserve_duplicate_keys_1700` replaces the test that
  pinned the collapse as an accepted tradeoff.
- Full CI-derived gate set green locally, re-run after rebasing onto current `main`: fmt, all
  three clippy legs, `cargo doc`, doctests, `--no-default-features`, default and simd
  `cargo test`, and the full CLI/golden battery.

## Follow-ups filed

- **#1993** — buy back the x86_64 code-size regression documented above (`&mut dyn Write` on
  the `--ascii-output` arm, leaving the default arm concrete).
- **#1982** — the two DOM-emitter divergences this change fixed for `--ascii-output` only.
- **#1994** — promote the streaming-vs-DOM differential harness used to verify this PR into
  `scripts/`, since the routing-divergence class it checks keeps recurring.
