### PR TITLE
fix(yq): |= autovivifies null under a mid-chain Iterate, matching = (#1919)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19077,22 +19077,45 @@ fn update_path<S: EvalSemantics>(
                             )
                         }
                     }
-                    Expr::Iterate => match root {
-                        OwnedValue::Array(arr) => {
-                            for elem in arr.iter_mut() {
-                                update_path::<S>(elem, &rest, filter_expr, optional, scalar_noop)?;
-                            }
-                            Ok(true)
+                    Expr::Iterate => {
+                        // #1919: same yq-only null-to-`[]` autovivify as the
+                        // terminal `Expr::Iterate` arm above (#1181) -- that
+                        // arm runs for `.[] |= f`, this one for a mid-chain
+                        // `.a[].b |= f`, and only the terminal one had the
+                        // call. Gated on `S::TAG`, not `here`/`scalar_noop`,
+                        // matching every other #1181 check in this function.
+                        if S::TAG == EvalTag::Yq {
+                            autovivify_array(root);
                         }
-                        OwnedValue::Object(map) => {
-                            for value in map.values_mut() {
-                                update_path::<S>(value, &rest, filter_expr, optional, scalar_noop)?;
+                        match root {
+                            OwnedValue::Array(arr) => {
+                                for elem in arr.iter_mut() {
+                                    update_path::<S>(
+                                        elem,
+                                        &rest,
+                                        filter_expr,
+                                        optional,
+                                        scalar_noop,
+                                    )?;
+                                }
+                                Ok(true)
                             }
-                            Ok(true)
+                            OwnedValue::Object(map) => {
+                                for value in map.values_mut() {
+                                    update_path::<S>(
+                                        value,
+                                        &rest,
+                                        filter_expr,
+                                        optional,
+                                        scalar_noop,
+                                    )?;
+                                }
+                                Ok(true)
+                            }
+                            _ if here || noop_scalar => Ok(false),
+                            _ => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
                         }
-                        _ if here || noop_scalar => Ok(false),
-                        _ => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
-                    },
+                    }
                     // `resolve_node`'s `?` arm emits `Optional(Pipe([…]))`
                     // when a branch resolved to more than one component, so
                     // unwrapping can expose a nested pipe. Splice it in rather

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18042,6 +18042,51 @@ fn test_yq_iterate_assign_chained_scalar_and_null_is_noop_1181() -> Result<()> {
     Ok(())
 }
 
+/// #1919: unlike `=` and the compound-assign family (`+=`/`-=`/`*=`/`/=`/
+/// `%=`/`//=`), plain `|=` never autovivified a `null` reached through a
+/// *mid-chain* `Iterate` at all -- not "no-op", a hard `Cannot iterate over
+/// null` error, since the mid-chain `Expr::Iterate` arm inside
+/// `update_path`'s `Pipe`-chain dispatch was missing the yq-only
+/// `autovivify_array` call its terminal-`Iterate` sibling arm already had
+/// (added for #1181). `.a[].b |= 5` on `a: null` real yq gives `{"a": []}`
+/// (the write itself is discarded -- there is nothing to iterate over --
+/// but the container still gets built), matching `.a[] |= 5` on the same
+/// input (the terminal-`Iterate` case, which already worked before this
+/// fix).
+#[test]
+fn test_yq_iterate_pipe_chain_null_autovivifies_under_update_assign_1919() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a[].b |= 5", r#"{"a":null}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
+
+    // A deeper chain past the Iterate behaves the same way.
+    let (out, code) = run_yq_stdin(".a[][0] |= 5", r#"{"a":null}"#, &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
+
+    // jq mode is unaffected: no null-autovivify rule for Iterate at all,
+    // matching real jq.
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+    cmd.arg("jq").arg(".a[].b |= 5");
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(br#"{"a":null}"#)?;
+    let output = child.wait_with_output()?;
+    assert!(
+        !output.status.success(),
+        "jq mode should still raise: {output:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Cannot iterate over null"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
 /// Regression guard: a real array/object target still iterates and writes
 /// normally -- the no-op is specific to a genuinely scalar/null target.
 #[test]


### PR DESCRIPTION
## Summary
- `update_path`'s terminal `Expr::Iterate` arm (`.[] |= f`) already autovivified a `null` root to `[]` in yq mode (#1181's gated `autovivify_array` call).
- The separate, smaller `Expr::Iterate` arm inside the `Pipe`-chain dispatch (reached for a mid-chain shape like `.a[].b |= f`) had no such call at all, so it fell straight to the catch-all `Cannot iterate over null` error instead of autovivifying.
- `=`/the compound-assign family (`+=`/`-=`/`*=`/`/=`/`%=`/`//=`) already matched real yq here (per #1857); `|=` was the one operator still missing it, since it's evaluated through the separate `eval_update`/`update_path` machinery rather than `set_path`/`set_path_through_iterate`.
- Fix ports the identical one-line `S::TAG`-gated `autovivify_array` call over, matching the terminal arm's own established #1181 pattern exactly.

## Verification against the pinned oracle
```console
$ echo 'a: null' | yq            -o=json '.a[].b |= 5'   # {"a": []}
$ echo 'a: null' | succinctly yq -o=json '.a[].b |= 5'   # {"a": []} (fixed; was: Error: Cannot iterate over null (null))
```
jq mode unaffected (real jq has no null-autovivify rule for `Iterate` at all):
```console
$ echo '{"a": null}' | jq            -c '.a[].b |= 5'   # Cannot iterate over null (null)
$ echo '{"a": null}' | succinctly jq -c '.a[].b |= 5'   # Cannot iterate over null (null) (unchanged)
```

## Test plan
- [x] New test `test_yq_iterate_pipe_chain_null_autovivifies_under_update_assign_1919` (tests/yq_cli_tests.rs) -- covers `.a[].b |= 5`, a deeper `.a[][0] |= 5` chain, and confirms jq mode is unaffected.
- [x] `cargo test --lib --features cli` (3110 passed)
- [x] `cargo test --features cli --test yq_cli_tests --test yq_golden_tests --test yq_path_consistency_tests --test jq_golden_tests --test yaml_bench_suite_coverage --test dsv_cli_tests --test text_cli_tests --test json_validate_tests --test yaml_validate_tests --test cli_golden_tests --test cli_characterization_tests --test deep_nesting_valid_tests --test jq_cli_tests` (all green)
- [x] `cargo test` (default features, 42 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (no_std)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

Fixes #1919.