### PR TITLE
fix(jq): force lazy items past push-model try/catch and ?// boundaries

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -703,32 +703,53 @@ rather than folded into #1629's own scope.
 `keys_unsorted | length` is not in this set at all — it reaches `effective_len`, which walks, and
 so has carried the check for free since #1628.
 
-**A separate catchability dimension, fixed for the pull model, still open for the push
-model (#1936/#1948).** Whether a malformed key *raises* (documented above) is distinct from
+**A separate catchability dimension, now fixed for both the pull model and the push model
+(#1936, #1948).** Whether a malformed key *raises* (documented above) is distinct from
 whether `?`/`try`/`catch` can *suppress or catch* that raise — `keys`/`keys_unsorted` stay
-lazy (`GenericResult::LazyKeys`) until something actually materializes them, so wrapping a
-bare `keys_unsorted` in `?` used to let the error escape past a boundary that had already
-closed by the time materialization happened. #1936 fixed this for the pull-model dispatch
-(`try_single_generic`, reached via plain `eval_single`) by checking for a malformed key
-before the boundary's match runs, without forcing a full decode on success (preserving
+lazy (`GenericResult`/`GenericItem::LazyKeys`) until something actually materializes them,
+so wrapping a bare `keys_unsorted` in `?` used to let the error escape past a boundary that
+had already closed by the time materialization happened. #1936 fixed this for the pull-model
+dispatch (`try_single_generic`, reached via plain `eval_single`) by checking for a malformed
+key before the boundary's match runs, without forcing a full decode on success (preserving
 `fold_pipe_stages`'s lazy fast paths for `.[]`/`.[n]`/`first`/`last`/`length`):
 
 ```
-$ echo '{123: 1}' | sjq -c 'keys_unsorted?'                      # suppressed, exit 0 (fixed)
-$ echo '{123: 1}' | sjq -c 'try (keys_unsorted) catch "c"'       # "c", exit 0 (fixed)
+$ echo '{123: 1}' | sjq -c 'keys_unsorted?'                      # suppressed, exit 0
+$ echo '{123: 1}' | sjq -c 'try (keys_unsorted) catch "c"'       # "c", exit 0
 ```
 
 The push-model dispatch (`each_try_generic`, reached via `eval_each_generic` for
-`first`/`limit`) has the identical bug class and remains open — tracked as #1948 rather
-than folded into #1936, since closing it needs `eval_each_generic` itself to carry a "must
-materialize now" signal through arbitrarily nested push-model consumers, not just a new
-arm in `each_try_generic`'s own dispatch. It also affects `LazySeq` (`map(f)`), not just
-`LazyKeys` — a gap that predates #1936 entirely, since #1812 only fixed `LazySeq`'s
-pull-model catchability:
+`first`/`limit`) had the identical bug class, plus a wider one: it also affected `LazySeq`
+(`map(f)`), a gap that predated #1936 entirely, since #1812 only fixed `LazySeq`'s
+pull-model catchability. #1948 closed both by wrapping `sink` itself inside
+`each_try_generic` — `check_lazy_item_for_try` runs the identical `keys_are_well_formed`
+check (staying lazy on success, same as `try_single_generic`) or, for `LazySeq`, the
+identical `materialize_atomic` call `try_single_generic` already made, capturing any fault
+via a side channel checked once the push loop returns (`Demand` has no error channel of its
+own to carry it through directly):
 
 ```
-$ echo '{123: 1}' | sjq -c 'first(keys_unsorted?)'                       # exit 5 -- unfixed
-$ echo '[1,2,3]' | sjq -c 'first(try (map(error("x"))) catch "c")'       # exit 5 -- unfixed
+$ echo '{123: 1}' | sjq -c 'first(keys_unsorted?)'                       # suppressed, exit 0
+$ echo '[1,2,3]' | sjq -c 'first(try (map(error("x"))) catch "c")'       # "c", exit 0
+```
+
+**`?//`'s own push-model fallthrough decision had the identical gap** (found reviewing #1948):
+`each_pattern_alternatives_generic` — the sink-based dispatch for a `?//`-chain, reached via
+`first`/`limit` wrapping one — decided whether the *taken* alternative "succeeded" purely from
+the `Flow` `eval_each_generic` returned, and a still-lazy item forwarded to `sink` unmaterialized
+answers `Flow::Exhausted` regardless of whether it would later raise. So a malformed
+`keys_unsorted`/`map(f)` tail on the taken alternative's body made this loop believe that
+alternative succeeded and never try the next one — the exact boundary-closes-too-soon bug
+`each_try_generic` closed for `try`/`catch`/`?`, just for `?//`'s fallthrough rule instead. Fixed
+the same way, reusing `check_lazy_item_for_try` unchanged:
+
+```
+$ echo '[1,2,3]' | sjq -c 'first(. as [$a] ?// $b |
+    (if $a == 1
+     then (. | map(if . == 2 then error("boom") else . + 10 end))
+     else (. | map(. + 100))
+     end))'
+[101,102,103]                                                            # falls through, exit 0
 ```
 
 Bare `keys_unsorted` — no stage after it — does raise, but only part-way through: it streams,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5506,6 +5506,17 @@ fn each_if_generic<S: EvalSemantics, V: DocumentValue>(
 /// this function propagates it verbatim without ever running `catch` --
 /// matching jq exactly: `first(try (1, error("x")) catch "c")` is `1`, and
 /// jq never even reaches `error`, let alone `catch`.
+///
+/// **#1948: a still-lazy `GenericItem` pushed to `sink` must be checked
+/// *here*, before this boundary can close.** `eval_each_generic`'s wildcard
+/// fallback (`drain_result_generic`) forwards `LazyKeys`/`LazySeq` items
+/// opaque and unmaterialized -- the same #1194-class escape #1936/#1812
+/// already closed for the pull-model `try_single_generic`, reached through a
+/// different dispatch path here. `sink`'s own `Demand` return has no error
+/// channel, so [`check_lazy_item_for_try`] reports a fault via the
+/// `lazy_fault` side channel below instead (the same "capture, then check
+/// once the driver returns" idiom `stream.rs`'s own writers use for a
+/// mid-push fault) rather than plumbing one through `Demand` itself.
 fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     catch: Option<&Expr>,
@@ -5514,7 +5525,21 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    match eval_each_generic::<S, V>(expr, value, optional, cursor, sink) {
+    let mut lazy_fault: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        match check_lazy_item_for_try(item) {
+            Ok(item) => sink(item),
+            Err(control) => {
+                lazy_fault = Some(control);
+                Demand::Stop
+            }
+        }
+    });
+    let flow = match lazy_fault {
+        Some(control) => Flow::Escaped(control),
+        None => flow,
+    };
+    match flow {
         Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
             Flow::Escaped(Control::Error(e))
         }
@@ -5537,6 +5562,50 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
         // Halt is never caught (`Control`'s own guarantee); other terminal
         // shapes (`Exhausted`, `Stopped`) pass straight through.
         other => other,
+    }
+}
+
+/// Forces a #1194-class check on a still-lazy [`GenericItem`] *before* it
+/// reaches a push-model sink guarded by `try`/`catch`/`?` (#1948) -- the
+/// push-model twin of [`try_single_generic`]'s identical per-variant switch
+/// for `GenericResult` (#1936/#1812).
+///
+/// `LazyKeys` keeps its laziness on success: [`keys_are_well_formed`] only
+/// walks and checks, never collects, so a well-formed object still reaches
+/// `sink` as a live `LazyKeys` item -- collapsing it to `Owned` here
+/// regardless of outcome would be the exact regression #1503's review found
+/// and reverted (see [`GenericItem`]'s own doc comment). `LazySeq` cannot be
+/// checked without running its buffered `map(f)` closures, so it fully
+/// materializes via `materialize_atomic` -- matching `try_single_generic`'s
+/// own `LazySeq` arm, and sound for the same reason that one is: a
+/// `try`/`catch`/`?` boundary must know *now* whether its body raised, so
+/// laziness cannot survive past it regardless of push or pull. `LazyIndexRange`
+/// can never fail (`0..len`, pure arithmetic) and passes through unchanged.
+///
+/// Nested `try`/`catch` boundaries each re-walk the same still-forwarded
+/// `LazyKeys` item once per boundary (`try (try (keys_unsorted) catch empty)
+/// catch "c"` walks it twice) -- inherited from, not introduced by, this
+/// function: `try_single_generic`'s own pull-model `LazyKeys` arm has the
+/// identical per-boundary cost already, tracked as a future optimization
+/// under #1951 (cache an "already validated" fact on `LazyKeys` itself)
+/// rather than fixed at either call site.
+fn check_lazy_item_for_try<V: DocumentValue>(
+    item: GenericItem<V>,
+) -> Result<GenericItem<V>, Control> {
+    match item {
+        GenericItem::LazyKeys {
+            fields,
+            sorted,
+            collapse,
+        } => keys_are_well_formed::<V>(&fields, collapse)
+            .map(|()| GenericItem::LazyKeys {
+                fields,
+                sorted,
+                collapse,
+            })
+            .map_err(Control::Error),
+        GenericItem::LazySeq(seq) => seq.materialize_atomic().map(GenericItem::Owned),
+        other => Ok(other),
     }
 }
 
@@ -5691,6 +5760,20 @@ fn each_as_pattern_generic<S: EvalSemantics, V: DocumentValue>(
 /// next alternative -- once the consumer has what it wants, no further
 /// alternative is ever tried, matching [`each_try_generic`]'s identical
 /// reasoning.
+///
+/// **Wraps `sink` the same way `each_try_generic` does (#1948 review):**
+/// `eval_each_generic`'s wildcard fallback forwards a still-lazy
+/// `GenericItem::LazyKeys`/`LazySeq` to `sink` opaque, which returns
+/// `Flow::Exhausted` regardless of whether the item is actually
+/// well-formed -- so this loop would otherwise treat a malformed
+/// `keys_unsorted`/`map(f)` tail as "this alternative succeeded" and never
+/// try the next one, the identical boundary-closes-too-soon bug
+/// `each_try_generic` closed for `try`/`catch`/`?`, just for `?//`'s own
+/// fallthrough decision instead. [`check_lazy_item_for_try`] runs the same
+/// check; a fault it finds is folded into this loop's own
+/// `Flow::Escaped(Control::Error/Break/Halt)` handling below via the same
+/// side-channel idiom, so it participates in the *same* `is_last`
+/// fallthrough/decode-failure-exclusion rules as an ordinary error.
 #[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors `eval::each_pattern_alternatives`'s
                                      // own 7-argument shape plus this module's `cursor` --
                                      // every param is threaded straight through to the
@@ -5736,7 +5819,26 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
             ),
         );
 
-        match eval_each_generic::<S, V>(&substituted_body, value.clone(), optional, cursor, sink) {
+        let mut lazy_fault: Option<Control> = None;
+        let flow = eval_each_generic::<S, V>(
+            &substituted_body,
+            value.clone(),
+            optional,
+            cursor,
+            &mut |item| match check_lazy_item_for_try(item) {
+                Ok(item) => sink(item),
+                Err(control) => {
+                    lazy_fault = Some(control);
+                    Demand::Stop
+                }
+            },
+        );
+        let flow = match lazy_fault {
+            Some(control) => Flow::Escaped(control),
+            None => flow,
+        };
+
+        match flow {
             Flow::Exhausted => return Flow::Exhausted,
             Flow::Stopped { pending } => return Flow::Stopped { pending },
             // #1620/#1660: same decode-failure exclusion as

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25750,44 +25750,84 @@ fn test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_193
     Ok(())
 }
 
-/// #1936 review found a related, still-open gap: `try_single_generic`
-/// (fixed above) only covers the *pull*-model `?`/`try`/`catch` dispatch
-/// (reached via plain `eval_single`). `each_try_generic`, the *push*-model
-/// twin reached via `eval_each_generic` for `first`/`limit`, has the
-/// identical bug class -- a lazy `LazyKeys`/`LazySeq` still escapes past a
-/// `?`/`try`/`catch` boundary once it's wrapped in one more layer of
-/// demand-aware consumer, since `eval_each_generic`'s wildcard fallback
-/// forwards the lazy result straight to `sink` unmaterialized. Deliberately
-/// not folded into #1936 (tracked separately as #1948): closing it needs
-/// `eval_each_generic` itself to carry a "must materialize now" signal
-/// through arbitrarily nested push-model consumers, not just a new arm in
-/// `each_try_generic`'s own dispatch. Pinned as a known, documented
-/// divergence (`docs/compliance/jq/limitations.md`) -- if this starts
-/// suppressing/catching correctly, that is a deliberate future fix (closing
-/// #1948), not a regression, and this test should be updated alongside it.
+/// #1936 review found a related gap, tracked separately as #1948:
+/// `try_single_generic` (fixed above) only covers the *pull*-model
+/// `?`/`try`/`catch` dispatch (reached via plain `eval_single`).
+/// `each_try_generic`, the *push*-model twin reached via `eval_each_generic`
+/// for `first`/`limit`, had the identical bug class -- a lazy
+/// `LazyKeys`/`LazySeq` escaped past a `?`/`try`/`catch` boundary once it was
+/// wrapped in one more layer of demand-aware consumer, since
+/// `eval_each_generic`'s wildcard fallback forwarded the lazy result straight
+/// to `sink` unmaterialized. #1948 closed it by wrapping `sink` itself inside
+/// `each_try_generic` to force the identical `try_single_generic` check
+/// synchronously, before the boundary can close, via a side-channel `Control`
+/// captured across the push (`check_lazy_item_for_try`).
 #[test]
-fn test_first_limit_wrapped_optional_try_catch_still_known_gap_1948() -> Result<()> {
-    // LazyKeys (#1936's own target), one push-model layer further out.
-    for filter in ["first(keys_unsorted?)", r#"first(try (keys) catch "c")"#] {
+fn test_first_limit_wrapped_optional_try_catch_suppresses_and_catches_1948() -> Result<()> {
+    // LazyKeys (#1936's own target), one push-model layer further out --
+    // `?`-suppression: exit 0, empty stdout, no catch handler runs.
+    for filter in ["first(keys_unsorted?)", "limit(1; keys_unsorted?)"] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))
             .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
-        assert_ne!(code, 0, "`{filter}` should still fail\nstdout: {stdout}");
-        assert!(
-            !stdout.contains('c'),
-            "`{filter}` should not have run the catch handler\nstdout: {stdout}"
-        );
-        assert!(!stderr.is_empty(), "`{filter}` should carry a diagnostic");
+        assert_eq!(code, 0, "`{filter}` should suppress\nstderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout}");
     }
 
-    // LazySeq (#1812's own target), predating #1936 entirely.
+    // Same LazyKeys fault, `try`/`catch` this time: exit 0, catch handler's
+    // own output reaches stdout.
+    for filter in [
+        r#"first(try (keys) catch "c")"#,
+        r#"first(try (keys_unsorted) catch "c")"#,
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))
+            .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
+        assert_eq!(code, 0, "`{filter}` should catch\nstderr: {stderr}");
+        assert_eq!(stdout.trim(), "\"c\"", "`{filter}` -- stdout: {stdout}");
+    }
+
+    // LazySeq (#1812's own target), predating #1936/#1948 entirely.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", r#"first(try (map(error("x"))) catch "c")"#],
         Some("[1,2,3]"),
     )
     .unwrap_or_else(|e| panic!("failed to run: {e}"));
-    assert_ne!(code, 0, "should still fail\nstdout: {stdout}");
-    assert!(!stdout.contains('c'), "stdout: {stdout}");
-    assert!(!stderr.is_empty());
+    assert_eq!(code, 0, "should catch\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"c\"");
+
+    // `LazyIndexRange` (`keys_unsorted` on a well-formed array): unaffected
+    // by this fix, same as `try_single_generic`'s own `other => other`
+    // wildcard for this variant -- it can never fail, so `check_lazy_item_for_try`
+    // passes it through unchecked.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "first(keys_unsorted?)"], Some("[1,2,3]"))
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "well-formed array is unaffected\nstderr: {stderr}");
+    assert_eq!(stdout.trim(), "[0,1,2]");
+
+    Ok(())
+}
+
+/// #1948 review found a sibling gap in `each_pattern_alternatives_generic`
+/// (`?//`'s own push-model fallthrough decision, reached via `first`/`limit`
+/// wrapping an `?//`-chain): the identical unwrapped-`sink` bug, just
+/// deciding "try the next alternative" instead of "run the catch handler".
+/// A still-lazy `LazySeq` from the taken alternative's body used to make
+/// this loop believe that alternative succeeded, so it never fell through to
+/// the next one when the lazy item's later materialization would have
+/// raised. Fixed the same way, reusing `check_lazy_item_for_try` unchanged.
+#[test]
+fn test_pattern_alternatives_wrapped_in_first_falls_through_on_lazy_fault_1948() -> Result<()> {
+    let filter = r#"first(. as [$a] ?// $b |
+        (if $a == 1
+         then (. | map(if . == 2 then error("boom") else . + 10 end))
+         else (. | map(. + 100))
+         end))"#;
+    let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("[1,2,3]"))
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(
+        code, 0,
+        "should fall through to the second alternative\nstderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "[101,102,103]");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`each_try_generic` (the push-model twin of #1936's `try_single_generic`, reached via `eval_each_generic` for `first()`/`limit()`) let a still-lazy `GenericItem::LazyKeys`/`LazySeq` item escape past a `?`/`try`/`catch` boundary unmaterialized: `eval_each_generic`'s wildcard fallback pushes these items opaque, so a downstream consumer forcing them later surfaces the error after the boundary already closed.

```console
$ echo '{123: 1}' | succinctly jq -c 'keys_unsorted?'                # suppressed correctly (#1936)
$ echo '{123: 1}' | succinctly jq -c 'first(keys_unsorted?)'         # NOT suppressed, exit 5 (before this fix)
$ echo '[1,2,3]' | succinctly jq -c 'first(try (map(error("x"))) catch "c")'  # NOT caught, exit 5 (before this fix)
```

## Fix

Wraps `sink` inside `each_try_generic` with a new `check_lazy_item_for_try` helper that forces the identical `try_single_generic` check synchronously before forwarding:
- `LazyKeys` stays lazy on success (`keys_are_well_formed`, no collection — avoiding the #1503 regression class where collapsing a lazy variant unconditionally broke `fold_pipe_stages`'s composability fast paths).
- `LazySeq` fully materializes (`materialize_atomic`, matching `try_single_generic`'s own arm) since an individual element can fail.
- `LazyIndexRange` passes through unchanged (can never fail).

A fault is captured via a side-channel `Option<Control>` and checked once `eval_each_generic` returns, since `Demand` has no error channel of its own.

## Found during review: `?//`'s identical gap

Multiple independent code-review passes found `each_pattern_alternatives_generic` (`?//`'s own push-model fallthrough decision) has the identical bug: it decides whether the taken alternative "succeeded" purely from the `Flow` `eval_each_generic` returns, so a still-lazy item made it believe a failing alternative had succeeded and never tried the next one:

```console
$ echo '[1,2,3]' | succinctly jq -c 'first(. as [$a] ?// $b |
    (if $a == 1 then (. | map(if . == 2 then error("boom") else . + 10 end))
     else (. | map(. + 100)) end))'
[101,102,103]   # falls through correctly now, matching real jq 1.7.1
```

Fixed the same way, reusing `check_lazy_item_for_try` unchanged.

## Also fixed: a test anti-pattern

Review caught that the updated regression test's original OR-assertion (`stdout.is_empty() || stdout.trim() == "\"c\""`) couldn't distinguish `?`-suppression from `try`/`catch`, so it wouldn't have caught a regression that swapped the two behaviors. Split into per-behavior assertions.

## Testing

- `test_first_limit_wrapped_optional_try_catch_suppresses_and_catches_1948` (renamed from the pre-existing `..._still_known_gap_1948`, which documented this as an open gap before this fix) — `?`-suppression, `try`/`catch`, `LazySeq`, and `LazyIndexRange`-unaffected cases.
- `test_pattern_alternatives_wrapped_in_first_falls_through_on_lazy_fault_1948` (new) — the `?//` fallthrough repro above.
- Full local suite (`cargo test`, `cargo test --features cli`), both required clippy legs, `cargo build --no-default-features`, `cargo doc` (`--all-features`, `RUSTDOCFLAGS=-D warnings`), and `cargo fmt --check` all clean.

Fixes #1948