### PR TITLE
docs(jq): close #1934 items 6 and 7 with fresh audit findings

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2570,6 +2570,26 @@ fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> 
     }
 }
 
+/// #1934 item 7: whether `optional == true` is ever actually reachable here
+/// (or at `eval_reduce`/`eval_foreach`/`eval_as`, which route into this same
+/// guard) was left as an open question after #1902/#1927's review -- multiple
+/// independent audits found it unreachable via any live jq/yq syntax, but
+/// flagged "worth a deliberate decision" rather than continuing to patch
+/// branches nothing can reach. Re-verified fresh here (not just re-read):
+/// `debug_assert!(!optional, ..)` at the top of all four functions, full
+/// `cargo test --workspace` run (only the deliberate white-box unit tests
+/// that call these functions directly with a hard-coded `true` tripped it --
+/// e.g. `test_finish_fork_ordinary_error_suppressed_decode_failure_is_not_1902`
+/// -- zero hits from any parsed-syntax-driven test), plus a battery of
+/// `?`-suffixed `reduce`/`foreach`/optional-chain CLI queries. Also confirmed
+/// `eval_generic.rs` has no native `Expr::Reduce`/`Expr::Foreach` arm at all --
+/// every `reduce`/`foreach` query, path-context or not, bridges to this
+/// module's own `eval_reduce`/`eval_foreach`, so this isn't a case of testing
+/// a rarely-reached evaluator; it is the *only* one, for every CLI query.
+/// Conclusion: kept as intentional defensive code (option (b) from the
+/// original finding), not simplified away -- removing it would mean deleting
+/// the existing white-box tests that exercise it, for a branch that costs
+/// nothing to keep and matches `finish_fork_generic`'s own identical guard.
 fn finish_fork<'a, W>(
     outputs: Vec<OwnedValue>,
     control: Option<Control>,
@@ -25410,7 +25430,14 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1642 collision error) is an ordinary error like any other, and
     // `optional` should suppress it the same way the bare `QueryResult::Error`
     // arm below already does (#1934 item 3: this used to be unconditionally
-    // fatal regardless of `optional`, unlike that sibling arm).
+    // fatal regardless of `optional`, unlike that sibling arm). #1934 item 6:
+    // this widening -- a malformed key/collision now raises here where the
+    // pre-#1902 unchecked `to_owned` silently dropped the offending member --
+    // is `to_owned_checked`'s own already-established contract from #1755
+    // onward, not new scope creep specific to `reduce`; #1907 tracks the
+    // general "`to_owned_checked`'s `Err` can carry a non-decode-failure
+    // error" question this arm (and its `eval_foreach`/`eval_as` siblings)
+    // are instances of.
     let input_values: Vec<OwnedValue> = match input_result.materialize_cursor() {
         QueryResult::One(v) => match to_owned_checked(&v) {
             Ok(v) => vec![v],


### PR DESCRIPTION
## Summary

Closes out the remaining scope of #1934 (items 6 and 7), which Dimitri's earlier PRs #1955/#1963 left open after resolving items 1-4. Item 5 (the `to_owned`/`to_owned_checked` naming inversion) is a substantially larger, riskier rename requiring per-site verification of ~78 call sites — split into its own issue, #1989.

## Item 6: documentation gap

`eval_reduce`'s `input` arm already cited #1194/#1642 for the malformed-key/collision widening #1902 introduced. Added the missing cross-reference to #1907, the general tracking issue for "`to_owned_checked`'s `Err` can carry a non-decode-failure error," and noted explicitly that this widening is `to_owned_checked`'s own established contract from #1755 onward — not scope creep specific to `reduce`.

## Item 7: is `optional == true` reachable at this depth?

Re-verified fresh rather than trusting the original text (per Dimitri's own note that items 1-3 turned out to already be stale by the time they were re-checked):

- Added temporary `debug_assert!(!optional, ...)` probes to `finish_fork`/`eval_reduce`/`eval_foreach`/`eval_as`, ran the full `cargo test --features cli,simd,regex,serde --workspace` — only 5 deliberate white-box unit tests that call these functions directly with a hard-coded `true` (e.g. `test_finish_fork_ordinary_error_suppressed_decode_failure_is_not_1902`) tripped the assert. Excluding those 5, zero hits across the remaining ~3100 tests.
- Ran a battery of `?`-suffixed `reduce`/`foreach`/optional-chain CLI queries directly against a debug build with the probes still in place — none panicked.
- Confirmed `eval_generic.rs` has **no** native `Expr::Reduce`/`Expr::Foreach` arm at all (`grep` returns zero matches) — every `reduce`/`foreach` query, path-context or not, bridges into `eval.rs`'s own `eval_reduce`/`eval_foreach`. This isn't a rarely-reached evaluator being tested in isolation; it's the sole implementation for every CLI query of this shape.

Conclusion: the finding still holds. Resolved via documentation rather than a code change — recorded the conclusion in a new doc comment on `finish_fork` (kept as intentional defensive code, matching `finish_fork_generic`'s own identical guard) rather than adding a permanent `debug_assert!`, since that would break the existing legitimate unit tests that exercise the `true` branch on purpose. Reverted the temporary probes before committing.

## Item 5: split into #1989

The rename's "make `to_owned_checked` the bare `to_owned`" half is mechanical, but the "rename the old infallible `to_owned` to something honest" half requires individually verifying all ~78 current bare-`to_owned` call sites first — #1934's own estimate was "~30 real result-materialization sites still unchecked" among them, which could include live bugs (the same family #1972 found one of, in a sibling function). Not attempted here; #1989 tracks it with a proposed classify-then-rename approach.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Refs #1934