### PR TITLE
fix(jq): scope non-UTF-8 document substitution per JSON string (#1743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`jq`: U+FFFD substitution in a non-UTF-8 JSON document is now scoped per
+  JSON string, matching jq 1.7.1** (#1743). jq substitutes inside
+  `jv_string_sized`, which its lexer calls once per string with that
+  string's own decoded bytes; succinctly substituted over the whole file
+  instead, so #1717's end-of-buffer drop quirk almost never fired where jq
+  fires it. `printf '{"a":"\xe1\x41"}' | sjq -c .a` printed `"\u{fffd}A"`
+  and now prints `"\u{fffd}"`, as jq does.
+
+  The scope is the *escape-decoded* string, not the raw source span —
+  escapes only shrink a string, so they can push a lead byte over the
+  `len - pos < seq_len` line its raw span would clear (`"\xe1A"` is
+  seven raw bytes but two decoded, and real jq collapses it). A string
+  carrying escapes is therefore decoded, substituted and re-escaped; one
+  without them takes a direct path, and a valid string is copied verbatim.
+
+  Four routes were affected — the lazy and non-lazy document paths,
+  `--slurp` and `--seq`. `--raw-input --slurp` keeps whole-buffer scope
+  because real jq is whole-buffer there too (the entire input is one
+  string), and `--input-dsv` keeps it because DSV is not JSON; both are now
+  pinned by tests. Valid documents are untouched and pay nothing: both
+  callers still gate on the existing whole-input SIMD `validate_utf8`.
+
 - **`jq`: four architectural gaps in `input`/`inputs`/`input_line_number`**
   (#1309), all four verified against pinned jq 1.7.1 before and after.
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -197,7 +197,7 @@ This case is deliberately **absent from the probe corpus**: the captured table i
 file read with `include_str!`, so jq's byte-exact output here is not representable. It is
 recorded in prose instead rather than dropped silently.
 
-## jq's own UTF-8 replacement-character substitution: fixed at function granularity, open at document granularity
+## jq's own UTF-8 replacement-character substitution: matched, at each caller's own granularity
 
 `substitute_invalid_utf8_jq_style` ([src/text/utf8/mod.rs](../../../src/text/utf8/mod.rs),
 #1617) matches jq 1.7.1's maximal-subpart substitution rule for document/raw-input decode,
@@ -231,40 +231,58 @@ $ printf '"8EFC"' | sjq -c '@base64d | explode'
 [65533]
 ```
 
-**The fix only reaches call sites where `input` is already scoped to one string's own
-bytes** — `@base64d`/`@urid`, via `owned_string_from_decoded_bytes`
-([src/jq/eval.rs](../../../src/jq/eval.rs)). It does *not* reach whole-document/whole-file
-callers (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`), because those substitute
-an entire file's bytes in one pass before JSON structure is even parsed. Real jq's own
-trigger is scoped to *each JSON string's own closing quote* (document mode) or *each
-line* (`--raw-input`, confirmed live: `printf 'a\xe1\x41\n' | jq -R '.'` drops the byte
-even though the file's own trailing newline follows) — neither of which is "the whole
-buffer's own end" in a realistic multi-field document or multi-line file. jq's own
-trigger condition is not rare (it fires on *any* string/line ending in the right byte
-shape, however much more content follows elsewhere in the file); only succinctly's
-whole-buffer reproduction of it essentially never activates:
+**The algorithm is granularity-independent — it only asks how many bytes remain in the
+slice it was handed — so what a caller passes decides where the quirk fires.** Real jq's
+own trigger is scoped to *each JSON string's own decoded bytes* (document mode, inside
+`jv_string_sized`) or *each line* (`--raw-input`, confirmed live: `printf 'a\xe1\x41\n' |
+jq -R '.'` drops the byte even though the file's own trailing newline follows). Neither is
+"the whole buffer's own end" in a realistic multi-field document or multi-line file, and
+jq's trigger is not rare — it fires on *any* string/line ending in the right byte shape,
+however much more content follows elsewhere in the file — so a whole-file caller would
+essentially never reproduce it. Every caller is now scoped the way jq scopes it:
+
+| Caller                                                 | Scope                                                          | Issue |
+|--------------------------------------------------------|----------------------------------------------------------------|-------|
+| `@base64d`/`@urid` (`owned_string_from_decoded_bytes`) | One decoded string, already                                    | #1719 |
+| `--raw-input` (non-slurp)                              | Per line, split before substituting                            | #1742 |
+| JSON document / `--slurp` / `--seq`                    | Per JSON string                                                | #1743 |
+| `--raw-input --slurp`                                  | Whole buffer — **matching real jq**, which has one string here | —     |
+
+`--input-dsv` also stays whole-buffer: DSV is not JSON (its fields are `""`-doubled, not
+backslash-escaped), and neither oracle reads DSV at all.
 
 ```bash
-$ printf '{"a":"\xe1\x41"}' | jq -c '.a'              # jq drops the 'A'
+$ printf '{"a":"\xe1\x41","b":1}' | jq -c '.a'         # jq drops the 'A'
 "�"
-$ printf '{"a":"\xe1\x41"}' | sjq -c '.a'              # unfixed: still whole-document-scoped
-"�A"
+$ printf '{"a":"\xe1\x41","b":1}' | sjq -c '.a'        # since #1743: matches
+"�"
 ```
 
-Reproducing this quirk for `.a`-style document access would need per-JSON-string
-substitution timing — a bigger architectural change than this issue's own "Low severity,
-narrow trigger" framing anticipated, and not attempted here; tracked separately as
-[#1743](https://github.com/rust-works/succinctly/issues/1743). `--raw-input`'s own gap is
-narrower and more tractable (a caller-side reorder: split into lines before
-substituting, instead of after — the algorithm itself needs no further change), tracked
-separately as [#1742](https://github.com/rust-works/succinctly/issues/1742). Likely an
-off-by-one in jq's own end-of-buffer lookahead rather than a designed rule either way;
-per ADR-0018 rule 4 the correct resolution, where reached, is bug-for-bug replication
-rather than "fixing" the substitution into the more sensible WHATWG-consistent shape. See
+Two things about #1743 are worth recording, because its own issue text got both wrong:
+
+- **The scope is the escape-*decoded* string, not the raw source span.** Escapes only ever
+  shrink a string, so they can push a lead byte over the `len - pos < seq_len` line that
+  its raw span would clear. `"\xe1A"` is seven raw bytes but two decoded — one short
+  of the three the `0xE1` lead declares — and real jq collapses it to a bare U+FFFD,
+  dropping the `A` (oracle-verified, as is the 4-byte analogue `"\xf0\x90A"`). A
+  repair scoped to the raw span keeps the `A` and is wrong.
+- **It needed no per-string substitution *timing*, and did not touch semi-indexing.** The
+  issue assumed decoding had to move to after structural parsing. It did not: both callers
+  already gate on a whole-input SIMD `validate_utf8`, so a valid document never enters the
+  repair at all, and the repair still produces a valid-UTF-8 buffer — preserving the
+  invariant ([docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md))
+  that after the input-boundary pass, `as_str()` can only fail on an *escape* problem,
+  which is what lets the cursor borrow and the printer echo raw spans. Locating string
+  boundaries in non-UTF-8 text needs only a byte-level quote/backslash scan, which is sound
+  because UTF-8 is self-synchronising: `"` and `\` can never occur inside a multi-byte
+  sequence, so the scan agrees with jq's own byte-oriented lexer by construction.
+
+Likely an off-by-one in jq's own end-of-buffer lookahead rather than a designed rule; per
+ADR-0018 rule 4 the correct resolution is bug-for-bug replication rather than "fixing" the
+substitution into the more sensible WHATWG-consistent shape. See
 [docs/plan/decode-failure-routing.md](../../plan/decode-failure-routing.md) for the fuller
-substitution-mechanism history, [#1717](https://github.com/rust-works/succinctly/issues/1717)
-for the algorithm fix itself, and #1743/#1742 above for the two granularity gaps it leaves
-open.
+substitution-mechanism history and
+[#1717](https://github.com/rust-works/succinctly/issues/1717) for the algorithm fix itself.
 
 ## Conversion diagnostics beyond a single token
 

--- a/docs/plan/decode-failure-routing.md
+++ b/docs/plan/decode-failure-routing.md
@@ -543,16 +543,28 @@ otherwise already correct, and it can be reverted independently if the perf gate
   `String::from_utf8_lossy`'s own answer). Filed and later fixed *in the algorithm
   itself* as [#1717](https://github.com/rust-works/succinctly/issues/1717) -- likely an
   off-by-one in jq's own end-of-buffer lookahead rather than a designed rule, reproduced
-  bug-for-bug per ADR-0018 rule 4. The fix reaches `@base64d`/`@urid` (#1719, whose own
-  `input` is already scoped to one decoded string) but not this whole-document decode
-  path: `utf8_lossy_document` substitutes the entire file's bytes in one pass before
-  JSON structure is parsed, so jq's own per-string trigger point essentially never
-  coincides with "end of the whole buffer" the way it does for a base64/percent-decoded
-  buffer -- the example above is still accurate post-#1717, even though jq's own trigger
-  is not rare (it fires on any string ending in the right byte shape, however much more
-  content follows in the rest of the file). Closing this gap would need per-JSON-string
-  substitution timing, tracked separately as
-  [#1743](https://github.com/rust-works/succinctly/issues/1743).
+  bug-for-bug per ADR-0018 rule 4. The fix reached `@base64d`/`@urid` immediately (#1719,
+  whose own `input` is already scoped to one decoded string) but not this whole-document
+  decode path, which substituted the entire file's bytes in one pass, so jq's own
+  per-string trigger point essentially never coincided with "end of the whole buffer" --
+  the `"\u{fffd}A"` example above was accurate right up to
+  [#1743](https://github.com/rust-works/succinctly/issues/1743), which closed it.
+  **#1743 needed no change to substitution *timing*, and this document's invariants are
+  why.** The prediction recorded here -- that closing it would require deferring the
+  decode until after structural parsing -- was wrong: `utf8_lossy_document` and
+  `get_inputs` both gate on a whole-input SIMD `validate_utf8`, so a valid document never
+  enters the repair at all, and the repair still emits a valid-UTF-8 buffer, preserving
+  the invariant this whole document is built around (after the input boundary's pass,
+  `as_str()` can only fail on an *escape* problem -- what lets `StandardJson::as_str`
+  borrow out of the document, lets the printer echo a raw string span, and lets the
+  raw-identity fast path exist). Locating string boundaries in non-UTF-8 text needs only
+  a byte-level quote/backslash scan, sound because UTF-8 is self-synchronising: `"` and
+  `\` can never occur inside a multi-byte sequence, so the scan agrees with jq's own
+  byte-oriented lexer by construction. Only *how* the replacement buffer is built
+  changed; see `src/jq/utf8_document.rs`. One subtlety the issue also got wrong: the
+  scope is the escape-*decoded* string, not the raw source span, since escapes only
+  shrink a string and so can push a lead byte over the `len - pos < seq_len` line its raw
+  span would clear.
 - Scope was document input only until #1719 also routed `@base64d`/`@urid`'s jq-mode
   output through this same `substitute_invalid_utf8_jq_style` call (for the
   overlong/surrogate/out-of-range case). At the time, this inherited the #1717 quirk
@@ -560,13 +572,15 @@ otherwise already correct, and it can be reverted independently if the perf gate
   identical wrong answer for #1717's specific shape before #1719 (byte-identical output
   pre/post, confirmed live). #1717's later fix changed that: `@base64d`/`@urid` now match
   jq exactly for this quirk too, since the function's own `input` is naturally scoped to
-  one decoded string already. `--raw-input` shares the jq path too, but real jq's own
+  one decoded string already. `--raw-input` shares the jq path too, and real jq's own
   `-R` (non-slurp) trigger is scoped *per line*, not per whole file (live-verified:
   `printf 'a\xe1\x41\n' | jq -R '.'` drops the byte on a single-line file with an
-  ordinary trailing newline) -- `get_inputs` substitutes the whole raw buffer before
-  splitting into lines, so this is unfixed for a different, more tractable reason than
-  `utf8_lossy_document`'s genuine per-JSON-string granularity gap, tracked separately as
-  [#1742](https://github.com/rust-works/succinctly/issues/1742); DSV input,
+  ordinary trailing newline); `get_inputs` originally substituted the whole raw buffer
+  before splitting into lines, fixed by
+  [#1742](https://github.com/rust-works/succinctly/issues/1742) as a caller-side reorder
+  (split on `\n`, then substitute each line). `--raw-input --slurp` deliberately stays
+  whole-buffer, because real jq is whole-buffer there too -- the entire input is one
+  string, so the buffer's own end genuinely *is* that string's end. DSV input,
   `--arg`/`--argjson` and `--rawfile` remain untouched.
 - **`--validate` is excluded, and getting that wrong was a live regression** caught in
   review. The substitution originally ran at read time, before `validate_json_input`, so

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1895,7 +1895,24 @@ fn get_inputs(
                         .map(succinctly::text::utf8::substitute_invalid_utf8_jq_style)
                         .collect::<Vec<_>>()
                         .join("\n")
+                } else if args.input_dsv.is_none() && !args.raw_input {
+                    // #1743: JSON-shaped input (plain documents, `--slurp`
+                    // and `--seq` alike) gets jq's own per-JSON-string
+                    // substitution scope. Deliberately *not* gated on
+                    // `json_input_mode`, which excludes `--seq` -- `--seq`
+                    // input is still JSON text, just RS-separated, and real
+                    // jq scopes the substitution to each string there too
+                    // (oracle-verified). The two cases this branch must not
+                    // capture are the ones left in the `else` below.
+                    succinctly::jq::utf8_document::substitute_invalid_utf8_jq_document(e.as_bytes())
                 } else {
+                    // `--raw-input --slurp` (the non-slurp `-R` took the
+                    // per-line branch above) is genuinely whole-buffer in
+                    // real jq -- the entire input is one string, so the
+                    // buffer's own end *is* that string's end
+                    // (oracle-verified). DSV input is not JSON at all: its
+                    // strings are `""`-escaped, not backslash-escaped, so a
+                    // JSON string scanner would mis-segment it.
                     succinctly::text::utf8::substitute_invalid_utf8_jq_style(e.as_bytes())
                 }
             }
@@ -2369,8 +2386,12 @@ impl ErrorAt<'_> {
 /// Valid input is returned untouched and unallocated -- the check is a
 /// whole-input SIMD pass (~1.1 ms on 8.4 MB) and only a document that
 /// actually fails it pays for a copy, via
-/// [`substitute_invalid_utf8_jq_style`](succinctly::text::utf8::substitute_invalid_utf8_jq_style),
-/// whose own docs cover the substitution rule itself (#1617).
+/// [`substitute_invalid_utf8_jq_document`](succinctly::jq::utf8_document::substitute_invalid_utf8_jq_document),
+/// which scopes
+/// [`substitute_invalid_utf8_jq_style`](succinctly::text::utf8::substitute_invalid_utf8_jq_style)'s
+/// rule (#1617/#1717) to each JSON string the way real jq's own lexer does
+/// (#1743) rather than to the whole file. Both of those carry the
+/// substitution rule and the scoping rationale respectively.
 ///
 /// Document input only, and only when `--validate` is off: the strict
 /// validator has to see the original bytes, or the substitution repairs the
@@ -2381,7 +2402,9 @@ impl ErrorAt<'_> {
 fn utf8_lossy_document(raw: Vec<u8>) -> Vec<u8> {
     match succinctly::text::utf8::validate_utf8(&raw) {
         Ok(()) => raw,
-        Err(_) => succinctly::text::utf8::substitute_invalid_utf8_jq_style(&raw).into_bytes(),
+        Err(_) => {
+            succinctly::jq::utf8_document::substitute_invalid_utf8_jq_document(&raw).into_bytes()
+        }
     }
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -224,19 +224,19 @@ pub trait EvalSemantics: Copy + Default {
     /// `substitute_invalid_utf8_jq_style` also matches jq's separate
     /// end-of-buffer drop quirk (#1717) at this function's own granularity
     /// -- one already-isolated string's bytes, which is exactly what
-    /// `@base64d`/`@urid` decode to. `jq_runner.rs`'s document/raw-input
-    /// callers do *not* gain that particular match: they substitute a
-    /// whole file/document buffer in one pass, before real jq's own
-    /// per-string (document mode) or per-line (`--raw-input`, live-
-    /// verified) scoping ever applies -- "last byte of the whole buffer"
-    /// essentially never coincides with jq's own trigger point in a
-    /// realistic multi-field document or multi-line file, even though
-    /// jq's own trigger itself is not rare at all (it fires on *any*
-    /// string/line ending in the right byte shape, however much more
-    /// content follows). See docs/compliance/jq/limitations.md's "jq's
-    /// own UTF-8 replacement-character substitution: fixed at function
-    /// granularity, open at document granularity" and #1742 for the
-    /// separate, more tractable raw-input caller-ordering gap.
+    /// `@base64d`/`@urid` decode to. That rule is granularity-independent
+    /// (it only asks how many bytes remain in the slice it was handed), so
+    /// *what a caller passes* decides where the quirk fires, and every
+    /// caller now passes what real jq passes: `jq_runner.rs`'s
+    /// `--raw-input` decode splits on `\n` first (#1742), and its JSON
+    /// document/`--slurp`/`--seq` decode goes through
+    /// `jq::utf8_document::substitute_invalid_utf8_jq_document`, which
+    /// segments the buffer and substitutes per JSON string (#1743).
+    /// `--raw-input --slurp` stays whole-buffer because real jq is
+    /// whole-buffer there too (the entire input is one string). See
+    /// docs/compliance/jq/limitations.md's "jq's own UTF-8
+    /// replacement-character substitution: matched, at each caller's own
+    /// granularity" section for the live-verified detail.
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool;
 }
 
@@ -10658,9 +10658,9 @@ fn format_base64d<S: EvalSemantics>(
     // In jq mode this now round-trips the oracle exactly, including the
     // #1717 end-of-buffer drop quirk (`"null"`'s decoded bytes happen to
     // hit that exact shape) -- see docs/compliance/jq/limitations.md's
-    // "fixed at function granularity, open at document granularity"
-    // section for the one place that quirk is still open (document/
-    // raw-input decode, a different granularity).
+    // "matched, at each caller's own granularity" section for how the
+    // other callers of that rule (document, `--slurp`/`--seq`,
+    // `--raw-input`) reach the same match at their own granularity.
     Ok(owned_string_from_decoded_bytes::<S>(result))
 }
 

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -80,6 +80,7 @@ mod lazy;
 mod parser;
 mod slice;
 pub mod stream;
+pub mod utf8_document;
 mod value;
 pub mod walk;
 

--- a/src/jq/utf8_document.rs
+++ b/src/jq/utf8_document.rs
@@ -1,0 +1,373 @@
+//! jq's own *timing* for U+FFFD substitution in a non-UTF-8 JSON document
+//! (#1743).
+//!
+//! [`crate::text::utf8::substitute_invalid_utf8_jq_style`] reproduces jq
+//! 1.7.1's substitution *algorithm*, including the end-of-buffer drop quirk
+//! #1717 found: when a multi-byte lead byte cannot be completed before its
+//! buffer ends (`len - pos < seq_len`), jq collapses the entire remaining
+//! tail into one U+FFFD, dropping every byte in it.
+//!
+//! That algorithm is granularity-independent -- it only ever asks how many
+//! bytes remain in the slice it was handed -- so *what* you hand it decides
+//! whether the quirk fires where jq fires it. Real jq substitutes inside
+//! `jv_string_sized`, which its lexer calls once per JSON string with that
+//! string's own decoded bytes. Handing the function a whole file instead
+//! makes "the buffer's own end" the file's last byte, which in a realistic
+//! multi-field document essentially never coincides with jq's actual
+//! trigger point:
+//!
+//! ```text
+//! $ printf '{"a":"\xe1\x41"}' | jq -c '.a'      # jq scopes to the string: "\u{fffd}"
+//! $ printf '{"a":"\xe1\x41"}' | sjq -c '.a'     # whole-file scope, pre-#1743: "\u{fffd}A"
+//! ```
+//!
+//! [`substitute_invalid_utf8_jq_document`] closes that by segmenting the
+//! document into JSON strings and everything else, and scoping the
+//! substitution to each string.
+//!
+//! # Why this stays a buffer rewrite
+//!
+//! The obvious alternative -- defer substitution to string materialisation,
+//! where jq does it -- would cost the invariant
+//! [docs/plan/decode-failure-routing.md] was built around: *after the input
+//! boundary's pass, `as_str()` can only fail on an escape problem*. That is
+//! what lets `StandardJson::as_str` borrow out of the document, lets the
+//! printer echo a raw string span verbatim, and lets the raw-identity fast
+//! path exist. Keeping the rewrite preserves all of it; only *how* the
+//! replacement buffer is built changes.
+//!
+//! It also costs nothing on valid input. Both callers reach this function
+//! only after a whole-input `validate_utf8` (a SIMD pass, ~1.1 ms on 8.4 MB)
+//! has already failed, so a well-formed document never enters the scanner
+//! below.
+//!
+//! # Why a byte scanner is sound here
+//!
+//! Finding string boundaries in text that is *not* valid UTF-8 sounds
+//! fragile and is not: UTF-8 is self-synchronising, so `"` (0x22) and `\`
+//! (0x5C) can never occur inside a multi-byte sequence, valid or otherwise.
+//! A byte-level quote/backslash scan therefore agrees with jq's own
+//! byte-oriented lexer by construction, whatever garbage the document
+//! carries. No semi-index, and no JSON structure beyond string boundaries,
+//! is needed -- so nothing here interacts with the parse-lazily design.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::jq::escape::{escape_json_body, write_json_body_jq};
+use crate::json::light::decode_escapes_into;
+use crate::text::utf8::substitute_invalid_utf8_jq_style;
+
+/// Lossily decode a JSON *document* as UTF-8 the way jq 1.7.1 does, scoping
+/// [`substitute_invalid_utf8_jq_style`] to each JSON string rather than to
+/// the whole buffer (#1743).
+///
+/// Bytes outside any string are substituted too, per contiguous segment:
+/// the result has to be valid UTF-8 for the rest of the pipeline to treat
+/// it as text at all. Real jq rejects a document with a bad byte outside a
+/// string (`printf '{"a":\xe1\x41 1}' | jq .` is a parse error), and so
+/// does succinctly, so the exact replacement chosen there is only ever
+/// visible in an error message.
+///
+/// Only for JSON-shaped input. `--raw-input` is line-scoped (#1742, handled
+/// by its own caller), `--raw-input --slurp` is genuinely whole-buffer in
+/// real jq, and DSV input is not JSON at all -- see `jq_runner`'s call
+/// sites for the gate.
+///
+/// # Examples
+///
+/// ```
+/// use succinctly::jq::utf8_document::substitute_invalid_utf8_jq_document;
+///
+/// // Scoped to the string, so the trailing 'A' is dropped -- as in real jq --
+/// // even though the document continues past it.
+/// assert_eq!(
+///     substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41\",\"b\":1}"),
+///     "{\"a\":\"\u{fffd}\",\"b\":1}",
+/// );
+///
+/// // A string with enough bytes left to judge the lead byte on its own
+/// // merits keeps the rescanned byte, exactly as before.
+/// assert_eq!(
+///     substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41x\"}"),
+///     "{\"a\":\"\u{fffd}Ax\"}",
+/// );
+/// ```
+pub fn substitute_invalid_utf8_jq_document(raw: &[u8]) -> String {
+    let mut out = String::with_capacity(raw.len());
+    // Start of the current run of bytes outside any string.
+    let mut segment_start = 0;
+    let mut i = 0;
+
+    while i < raw.len() {
+        if raw[i] != b'"' {
+            i += 1;
+            continue;
+        }
+
+        out.push_str(&substitute_invalid_utf8_jq_style(&raw[segment_start..i]));
+        out.push('"');
+
+        let body_start = i + 1;
+        let (body_end, has_escape) = scan_string_body(raw, body_start);
+        out.push_str(&repair_string_body(&raw[body_start..body_end], has_escape));
+
+        if body_end < raw.len() {
+            // The closing quote, consumed here so the scan resumes outside
+            // the string rather than re-entering it on the same byte.
+            out.push('"');
+            i = body_end + 1;
+        } else {
+            // Unterminated string: the document is a parse error either way,
+            // and there is no closing quote to emit.
+            i = raw.len();
+        }
+        segment_start = i;
+    }
+
+    out.push_str(&substitute_invalid_utf8_jq_style(&raw[segment_start..]));
+    out
+}
+
+/// The offset of the string's closing quote (or `raw.len()` if it is
+/// unterminated) and whether the body contains a backslash escape, in one
+/// scan -- the quote scan has to recognise every backslash anyway in order
+/// to skip what it escapes, so reporting it is free.
+fn scan_string_body(raw: &[u8], body_start: usize) -> (usize, bool) {
+    let mut i = body_start;
+    let mut has_escape = false;
+    while i < raw.len() {
+        match raw[i] {
+            b'"' => return (i, has_escape),
+            b'\\' => {
+                has_escape = true;
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    (raw.len(), has_escape)
+}
+
+/// Rewrite one JSON string's body (between the quotes, escapes still in
+/// their source spelling) so that decoding it yields what real jq's
+/// `jv_string_sized` would have produced for the same string.
+///
+/// Three cases, in decreasing order of how often they run:
+///
+/// 1. **Already valid UTF-8** -- copied verbatim. Most strings in a document
+///    with one bad byte are fine, and copying keeps their escape spelling
+///    untouched.
+/// 2. **Invalid, no escapes** -- substituted directly. Raw body and decoded
+///    string are the same bytes here, so this is exact, and it needs no
+///    re-escaping: the body provably contains no `"` (the scan stopped at
+///    one) and no `\`, and substitution only ever replaces non-ASCII bytes
+///    with U+FFFD, so it cannot introduce either.
+/// 3. **Invalid, with escapes** -- decoded to bytes, substituted, re-escaped.
+///    Required for exactness because jq's rule is scoped to the *decoded*
+///    string, and escapes only ever shrink it: `"\xe1\u0041"` decodes to two
+///    bytes, one short of the three the `0xE1` lead declares, so real jq
+///    collapses it to a bare `"\u{fffd}"` where the seven-byte raw span
+///    would not have. Re-escaping via [`write_json_body_jq`] normalises the
+///    spelling of any *other* escape in that string (`\u0041` becomes `A`),
+///    which is what succinctly's own printer does to every string on output
+///    anyway.
+///
+/// A body whose escapes cannot be decoded at all (a bad escape character, a
+/// lone surrogate) falls back to case 2's raw-span substitution rather than
+/// inventing a decoding: such a document is a parse error downstream, and
+/// this keeps the bytes that error is reported against unchanged.
+fn repair_string_body(body: &[u8], has_escape: bool) -> String {
+    if let Ok(s) = core::str::from_utf8(body) {
+        return String::from(s);
+    }
+
+    if has_escape {
+        let mut decoded = Vec::with_capacity(body.len());
+        if decode_escapes_into::<false>(body, &mut decoded).is_ok() {
+            return escape_json_body(
+                write_json_body_jq,
+                &substitute_invalid_utf8_jq_style(&decoded),
+            );
+        }
+    }
+
+    substitute_invalid_utf8_jq_style(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    /// The gap #1743 names: jq scopes the #1717 drop to the string, not the
+    /// file, so content after the string does not rescue the dropped byte.
+    #[test]
+    fn drop_quirk_is_scoped_to_the_string_not_the_document_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41\"}"),
+            "{\"a\":\"\u{fffd}\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41\",\"b\":[1,2,3],\"c\":\"x\"}"),
+            "{\"a\":\"\u{fffd}\",\"b\":[1,2,3],\"c\":\"x\"}"
+        );
+    }
+
+    /// Every string is judged on its own bytes, so two identically-corrupt
+    /// strings collapse identically regardless of position in the document.
+    #[test]
+    fn each_string_is_scoped_independently_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41\",\"b\":\"\xf0\x90\x41\"}"),
+            "{\"a\":\"\u{fffd}\",\"b\":\"\u{fffd}\"}"
+        );
+    }
+
+    /// Object keys go through the same lexer path in jq, so they collapse too.
+    #[test]
+    fn object_keys_are_scoped_like_values_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"\xe1\x41\":1,\"b\":2}"),
+            "{\"\u{fffd}\":1,\"b\":2}"
+        );
+    }
+
+    /// With `seq_len` bytes actually present inside the string, jq falls back
+    /// to WHATWG-style rescan-at-the-bad-byte -- the rescanned byte is kept.
+    /// This is the half of the rule the document-scoped version already got
+    /// right, and must not regress into an over-eager collapse.
+    #[test]
+    fn headroom_inside_the_string_still_keeps_the_rescanned_byte_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41x\"}"),
+            "{\"a\":\"\u{fffd}Ax\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"X\xe1\x41Y\"}"),
+            "{\"a\":\"X\u{fffd}AY\"}"
+        );
+    }
+
+    /// jq substitutes over the *decoded* string, so an escape -- which is
+    /// always shorter decoded than spelled -- can push a lead byte over the
+    /// `len - pos < seq_len` line that its raw span would clear.
+    /// `"\xe1\u0041"` is 7 raw bytes but 2 decoded, one short of the three
+    /// the `0xE1` lead declares.
+    #[test]
+    fn substitution_is_scoped_to_the_decoded_string_not_the_raw_span_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\\u0041\"}"),
+            "{\"a\":\"\u{fffd}\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xf0\x90\\u0041\"}"),
+            "{\"a\":\"\u{fffd}\"}"
+        );
+        // Same shape via a non-`\u` escape: `\n` is two bytes spelled, one
+        // decoded.
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\\n\"}"),
+            "{\"a\":\"\u{fffd}\"}"
+        );
+    }
+
+    /// Re-escaping a repaired string must keep it readable as the same JSON
+    /// string -- a surviving quote/backslash has to come back out escaped.
+    #[test]
+    fn repaired_string_with_escapes_is_re_escaped_1743() {
+        // `\"` survives the substitution and must not terminate the string.
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"x\\\"y\xe1\x41z\"}"),
+            "{\"a\":\"x\\\"y\u{fffd}Az\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"x\\\\y\xe1\x41z\"}"),
+            "{\"a\":\"x\\\\y\u{fffd}Az\"}"
+        );
+    }
+
+    /// A body whose escapes cannot be decoded keeps today's raw-span
+    /// substitution: the document is a parse error either way, and inventing
+    /// a decoding would change the bytes that error names. A lone surrogate
+    /// is the live example -- succinctly currently echoes it rather than
+    /// rejecting it as jq does, and that separate divergence must not shift
+    /// here.
+    #[test]
+    fn undecodable_escapes_fall_back_to_raw_span_substitution_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\\ud800\xe1\x41\"}"),
+            "{\"a\":\"\\ud800\u{fffd}\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\\q\xe1\x41\"}"),
+            "{\"a\":\"\\q\u{fffd}\"}"
+        );
+    }
+
+    /// Strings that are already valid UTF-8 are copied through untouched,
+    /// escape spelling included -- only the corrupt one is rewritten.
+    #[test]
+    fn valid_strings_keep_their_escape_spelling_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\\u0041\\/\",\"b\":\"\xe1\x41\"}"),
+            "{\"a\":\"\\u0041\\/\",\"b\":\"\u{fffd}\"}"
+        );
+    }
+
+    /// The already-agreeing shapes from #1617 are unchanged by re-scoping:
+    /// a never-valid lead stays one U+FFFD per byte, a structurally valid
+    /// overlong collapses to one for the whole sequence.
+    #[test]
+    fn existing_1617_shapes_are_unchanged_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xff\xfe\"}"),
+            "{\"a\":\"\u{fffd}\u{fffd}\"}"
+        );
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe0\x80\x80\"}"),
+            "{\"a\":\"\u{fffd}\"}"
+        );
+    }
+
+    /// Bytes outside any string are still substituted -- the result has to
+    /// be valid UTF-8 for the rest of the pipeline. Both tools reject such a
+    /// document, so only the error message ever sees this.
+    #[test]
+    fn bytes_outside_a_string_are_still_substituted_1743() {
+        let out = substitute_invalid_utf8_jq_document(b"{\"a\":\xff 1}");
+        assert!(out.contains('\u{fffd}'), "{out}");
+        assert!(!out.contains('\u{0}'), "{out}");
+    }
+
+    /// A valid document is returned byte-identical: the scanner must be a
+    /// pure pass-through when there is nothing to repair. (Callers gate on
+    /// `validate_utf8` first, so this is a safety net, not the hot path.)
+    #[test]
+    fn valid_document_round_trips_unchanged_1743() {
+        for doc in [
+            &br#"{"a":"hi","b":[1,2,{"c":null}],"d":"\u00e9\t\\"}"#[..],
+            &br#"["\"quoted\"","tab\there"]"#[..],
+            &b"{}"[..],
+            &b""[..],
+            "\u{65e5}\u{672c}\u{8a9e}".as_bytes(),
+        ] {
+            assert_eq!(
+                substitute_invalid_utf8_jq_document(doc),
+                String::from_utf8(doc.to_vec()).unwrap(),
+                "{}",
+                String::from_utf8_lossy(doc)
+            );
+        }
+    }
+
+    /// An unterminated string must not lose its content or emit a closing
+    /// quote it never saw.
+    #[test]
+    fn unterminated_string_is_repaired_without_inventing_a_quote_1743() {
+        assert_eq!(
+            substitute_invalid_utf8_jq_document(b"{\"a\":\"\xe1\x41"),
+            "{\"a\":\"\u{fffd}".to_string()
+        );
+    }
+}

--- a/src/jq/utf8_document.rs
+++ b/src/jq/utf8_document.rs
@@ -105,12 +105,12 @@ pub fn substitute_invalid_utf8_jq_document(raw: &[u8]) -> String {
             continue;
         }
 
-        out.push_str(&substitute_invalid_utf8_jq_style(&raw[segment_start..i]));
+        push_segment(&mut out, &raw[segment_start..i]);
         out.push('"');
 
         let body_start = i + 1;
         let (body_end, has_escape) = scan_string_body(raw, body_start);
-        out.push_str(&repair_string_body(&raw[body_start..body_end], has_escape));
+        repair_string_body(&mut out, &raw[body_start..body_end], has_escape);
 
         if body_end < raw.len() {
             // The closing quote, consumed here so the scan resumes outside
@@ -125,8 +125,26 @@ pub fn substitute_invalid_utf8_jq_document(raw: &[u8]) -> String {
         segment_start = i;
     }
 
-    out.push_str(&substitute_invalid_utf8_jq_style(&raw[segment_start..]));
+    push_segment(&mut out, &raw[segment_start..]);
     out
+}
+
+/// Append one run of bytes from *outside* any string, substituting only if
+/// it is not already valid UTF-8.
+///
+/// The check is not an optimisation on top of a different answer -- it *is*
+/// the same answer: [`substitute_invalid_utf8_jq_style`] returns valid input
+/// byte-for-byte unchanged, pinned by #1247's own guard test. Skipping it
+/// skips an allocation and a second scan, and that is worth having because
+/// segment count scales with the document, not with the corruption in it: a
+/// file with one bad byte still has one segment per JSON string, so building
+/// a `String` for each is millions of short-lived allocations on a large
+/// input where a borrow would do.
+fn push_segment(out: &mut String, bytes: &[u8]) {
+    match core::str::from_utf8(bytes) {
+        Ok(s) => out.push_str(s),
+        Err(_) => out.push_str(&substitute_invalid_utf8_jq_style(bytes)),
+    }
 }
 
 /// The offset of the string's closing quote (or `raw.len()` if it is
@@ -161,8 +179,9 @@ fn scan_string_body(raw: &[u8], body_start: usize) -> (usize, bool) {
 /// 2. **Invalid, no escapes** -- substituted directly. Raw body and decoded
 ///    string are the same bytes here, so this is exact, and it needs no
 ///    re-escaping: the body provably contains no `"` (the scan stopped at
-///    one) and no `\`, and substitution only ever replaces non-ASCII bytes
-///    with U+FFFD, so it cannot introduce either.
+///    one) and no `\` (that is what `has_escape` being false means), and
+///    substitution only ever replaces non-ASCII bytes with U+FFFD, so it
+///    cannot introduce either.
 /// 3. **Invalid, with escapes** -- decoded to bytes, substituted, re-escaped.
 ///    Required for exactness because jq's rule is scoped to the *decoded*
 ///    string, and escapes only ever shrink it: `"\xe1\u0041"` decodes to two
@@ -176,23 +195,31 @@ fn scan_string_body(raw: &[u8], body_start: usize) -> (usize, bool) {
 /// A body whose escapes cannot be decoded at all (a bad escape character, a
 /// lone surrogate) falls back to case 2's raw-span substitution rather than
 /// inventing a decoding: such a document is a parse error downstream, and
-/// this keeps the bytes that error is reported against unchanged.
-fn repair_string_body(body: &[u8], has_escape: bool) -> String {
+/// this keeps the bytes that error is reported against unchanged. That
+/// fallback is the one route into case 2 whose body *does* carry a `\`, so
+/// case 2's own proof does not cover it -- but the string still cannot be
+/// broken open: substitution never emits a `"`, and the byte after a
+/// surviving `\` is either a U+FFFD or a byte copied from a body the scan
+/// already proved holds no unescaped quote. The result is an invalid escape
+/// either way, which is exactly the error the caller wants reported.
+fn repair_string_body(out: &mut String, body: &[u8], has_escape: bool) {
     if let Ok(s) = core::str::from_utf8(body) {
-        return String::from(s);
+        out.push_str(s);
+        return;
     }
 
     if has_escape {
         let mut decoded = Vec::with_capacity(body.len());
         if decode_escapes_into::<false>(body, &mut decoded).is_ok() {
-            return escape_json_body(
+            out.push_str(&escape_json_body(
                 write_json_body_jq,
                 &substitute_invalid_utf8_jq_style(&decoded),
-            );
+            ));
+            return;
         }
     }
 
-    substitute_invalid_utf8_jq_style(body)
+    out.push_str(&substitute_invalid_utf8_jq_style(body));
 }
 
 #[cfg(test)]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1496,7 +1496,52 @@ impl<'a> JsonString<'a> {
 ///
 /// Handles: \\, \", \/, \b, \f, \n, \r, \t, and \uXXXX (including surrogate pairs)
 fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
-    let mut result = String::with_capacity(bytes.len());
+    let mut out = Vec::with_capacity(bytes.len());
+    decode_escapes_into::<true>(bytes, &mut out)?;
+    // Unreachable in practice: with `VALIDATE_UTF8 = true` every literal
+    // chunk was already checked and every escape contributes a `char`'s own
+    // encoding, so the concatenation is valid UTF-8 by construction (a `\`
+    // is ASCII and so can never split a multi-byte sequence). Mapped rather
+    // than `expect`ed to keep this path panic-free regardless.
+    String::from_utf8(out).map_err(|_| JsonError::InvalidUtf8)
+}
+
+/// The shared core of [`decode_escapes`], writing *bytes* rather than a
+/// `String` so a caller holding text that is not (yet) valid UTF-8 can still
+/// use it.
+///
+/// `VALIDATE_UTF8` selects between the two callers' differing needs, without
+/// a second copy of this escape table -- three independent copies of one
+/// predicate is the drift trap #106 records:
+///
+/// - `true` ([`decode_escapes`], the hot `as_str` path): a literal run that
+///   is not valid UTF-8 fails immediately with [`JsonError::InvalidUtf8`],
+///   exactly where it did when this loop pushed `&str` chunks into a
+///   `String`. Preserving the *position* of that check, rather than deferring
+///   it to one `String::from_utf8` at the end, keeps the reported error kind
+///   unchanged for a string carrying both a bad literal byte and a later bad
+///   escape.
+/// - `false` (`jq::utf8_document`'s per-string repair, #1743): invalid bytes
+///   pass through verbatim, because reproducing jq's own substitution timing
+///   requires running the substitution over the *decoded* bytes -- jq
+///   substitutes inside `jv_string_sized`, after its lexer has decoded the
+///   escapes, not over the raw source span.
+///
+/// The escape errors themselves are reported identically under both, so a
+/// string the `false` caller cannot decode is exactly one the parser will
+/// reject anyway.
+pub(crate) fn decode_escapes_into<const VALIDATE_UTF8: bool>(
+    bytes: &[u8],
+    out: &mut Vec<u8>,
+) -> Result<(), JsonError> {
+    /// Append `c`'s UTF-8 encoding. `char::encode_utf8` needs a scratch
+    /// buffer; `String::push`'s own byte-level equivalent is not public.
+    fn push_char(out: &mut Vec<u8>, c: char) {
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+    }
+
+    let result = &mut *out;
     let mut i = 0;
 
     while i < bytes.len() {
@@ -1506,14 +1551,14 @@ fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
             }
             i += 1;
             match bytes[i] {
-                b'"' => result.push('"'),
-                b'\\' => result.push('\\'),
-                b'/' => result.push('/'),
-                b'b' => result.push('\u{0008}'), // backspace
-                b'f' => result.push('\u{000C}'), // form feed
-                b'n' => result.push('\n'),
-                b'r' => result.push('\r'),
-                b't' => result.push('\t'),
+                b'"' => result.push(b'"'),
+                b'\\' => result.push(b'\\'),
+                b'/' => result.push(b'/'),
+                b'b' => result.push(0x08), // backspace
+                b'f' => result.push(0x0C), // form feed
+                b'n' => result.push(b'\n'),
+                b'r' => result.push(b'\r'),
+                b't' => result.push(b'\t'),
                 b'u' => {
                     // Unicode escape: \uXXXX
                     if i + 4 >= bytes.len() {
@@ -1535,7 +1580,7 @@ fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
                                     + ((codepoint as u32 - 0xD800) << 10)
                                     + (low as u32 - 0xDC00);
                                 if let Some(c) = char::from_u32(cp) {
-                                    result.push(c);
+                                    push_char(result, c);
                                     i += 6; // Skip \uXXXX for low surrogate
                                 } else {
                                     return Err(JsonError::InvalidUnicodeEscape);
@@ -1552,7 +1597,7 @@ fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
                     } else {
                         // Regular BMP character
                         if let Some(c) = char::from_u32(codepoint as u32) {
-                            result.push(c);
+                            push_char(result, c);
                         } else {
                             return Err(JsonError::InvalidUnicodeEscape);
                         }
@@ -1567,13 +1612,15 @@ fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
             while i < bytes.len() && bytes[i] != b'\\' {
                 i += 1;
             }
-            let chunk =
-                core::str::from_utf8(&bytes[start..i]).map_err(|_| JsonError::InvalidUtf8)?;
-            result.push_str(chunk);
+            let chunk = &bytes[start..i];
+            if VALIDATE_UTF8 && core::str::from_utf8(chunk).is_err() {
+                return Err(JsonError::InvalidUtf8);
+            }
+            result.extend_from_slice(chunk);
         }
     }
 
-    Ok(result)
+    Ok(())
 }
 
 /// Parse 4 hex digits into a u16.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1503,6 +1503,18 @@ fn decode_escapes(bytes: &[u8]) -> Result<String, JsonError> {
     // encoding, so the concatenation is valid UTF-8 by construction (a `\`
     // is ASCII and so can never split a multi-byte sequence). Mapped rather
     // than `expect`ed to keep this path panic-free regardless.
+    //
+    // It is therefore a second validation pass over bytes already known to
+    // be valid, and `from_utf8_unchecked` would skip it -- measured (A/B,
+    // interleaved, 400k escaped strings in a 28 MB document) at -1.3% to
+    // -3.7% on the two workloads that decode every string, `-r '.[].s'` and
+    // `-S -c '.'`. Not taken: that is too small a win to introduce `unsafe`
+    // into this module for, and the obvious safe alternative -- dropping the
+    // per-chunk check and relying on this one -- is not equivalent, because
+    // it would report `InvalidEscape` where a string carrying both a bad
+    // literal byte and a later bad escape reports `InvalidUtf8` today. A
+    // sink trait letting `VALIDATE_UTF8 = true` build a `String` directly
+    // would get it safely, if the cost ever justifies the machinery.
     String::from_utf8(out).map_err(|_| JsonError::InvalidUtf8)
 }
 

--- a/src/text/utf8/mod.rs
+++ b/src/text/utf8/mod.rs
@@ -742,23 +742,28 @@ pub fn format_byte(byte: u8) -> String {
 ///
 /// This function's own fix is granularity-independent -- it only cares
 /// about how many bytes remain in `input` from the lead's own position --
-/// so it correctly reaches every caller where `input` is already scoped
-/// to one decoded JSON string (`@base64d`/`@urid`, #1719). It does *not*
-/// reach `jq_runner.rs`'s document/raw-input callers (`utf8_lossy_document`,
-/// `get_inputs`), which substitute a whole file/document buffer in one
-/// pass before JSON structure is parsed: real jq's own condition is
-/// scoped to *each JSON string's own closing quote* (document mode) or
-/// *each line* (raw-input mode, confirmed live: `printf 'a\xe1\x41\n' |
-/// jq -R '.'` drops the byte even though it's followed by the file's own
-/// trailing newline) -- neither of which is "the whole buffer's own end"
-/// in a realistic multi-field document or multi-line file, so this fix
-/// essentially never activates there, even though jq's own trigger
-/// condition is not rare at all (it fires on *any* string/line ending in
-/// the right byte shape, however much more content follows in the rest
-/// of the file). See `docs/compliance/jq/limitations.md`'s "fixed at
-/// function granularity, open at document granularity" section for the
-/// live-verified detail, #1743 for the document-mode gap, and #1742 for
-/// the separate, more tractable raw-input caller-ordering gap.
+/// so *what a caller passes as `input` is what decides where the quirk
+/// fires*. Real jq's own condition is scoped to each JSON string's own
+/// decoded bytes (document mode, inside `jv_string_sized`) or to each line
+/// (raw-input mode, confirmed live: `printf 'a\xe1\x41\n' | jq -R '.'`
+/// drops the byte even though it's followed by the file's own trailing
+/// newline). Neither is "the whole buffer's own end" in a realistic
+/// multi-field document or multi-line file, and jq's trigger is not rare
+/// at all -- it fires on *any* string/line ending in the right byte shape,
+/// however much more content follows in the rest of the file -- so a
+/// whole-file caller would essentially never reproduce it.
+///
+/// Every caller is therefore scoped the way jq scopes it:
+/// `@base64d`/`@urid` are already handed one decoded string (#1719),
+/// `jq_runner.rs`'s `--raw-input` decode splits on `\n` first (#1742),
+/// and JSON document input goes through
+/// [`substitute_invalid_utf8_jq_document`](crate::jq::utf8_document::substitute_invalid_utf8_jq_document),
+/// which segments the document and calls this function once per JSON
+/// string (#1743). `--raw-input --slurp` is the one caller that stays
+/// whole-buffer, because real jq is whole-buffer there too: the entire
+/// input is a single string, so the buffer's own end genuinely *is* that
+/// string's end. See `docs/compliance/jq/limitations.md` for the
+/// live-verified detail.
 ///
 /// A single left-to-right scan, not a loop over [`validate_utf8`]: that
 /// function's AVX2 path has no early exit (it scans every 32-byte block of

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26108,32 +26108,120 @@ fn test_utf8_never_valid_lead_stays_one_fffd_per_byte_1617() -> Result<()> {
     Ok(())
 }
 
-/// #1717's fix reaches `@base64d`/`@urid` (#1719, see `yq_cli_tests.rs`'s
-/// own `test_jq_base64d_drops_*_1717` tests) but *not* this whole-document
-/// decode path (`utf8_lossy_document`) -- real jq's own trigger is scoped
-/// to each JSON string's own closing quote, but `utf8_lossy_document`
-/// substitutes the entire file's bytes in one pass before JSON structure
-/// is even parsed, so "last byte of the whole file" essentially never
-/// coincides with jq's actual trigger point. Pins the CURRENT (still
-/// divergent from jq) behavior as a deliberate regression guard, not a
-/// target to match -- see docs/compliance/jq/limitations.md's "fixed at
-/// function granularity, open at document granularity" section and #1743,
-/// which tracks closing this specific gap.
+/// #1743: #1717's end-of-buffer drop quirk now fires where real jq fires
+/// it -- at each JSON *string*'s own end, not the whole file's. This test
+/// previously pinned the divergence (`"\u{fffd}A"`) as a known gap; it now
+/// pins the match.
+///
+/// The 'A' is dropped even though the document plainly continues past it,
+/// because `substitute_invalid_utf8_jq_document` scopes the substitution
+/// per string the way jq's lexer does before calling `jv_string_sized`.
+/// Both the lazy and the non-lazy (`-S`) document routes are checked: they
+/// substitute at two separate call sites and would otherwise be free to
+/// drift apart.
 #[test]
-fn test_invalid_utf8_document_drop_quirk_still_diverges_from_jq_1717() -> Result<()> {
+fn test_invalid_utf8_document_drop_quirk_matches_jq_1743() -> Result<()> {
     let mut file = NamedTempFile::new()?;
-    file.write_all(b"{\"a\":\"\xe1\x41\"}")?;
+    // Content after the corrupt string, so a whole-file scope provably
+    // cannot be what produced the drop.
+    file.write_all(b"{\"a\":\"\xe1\x41\",\"b\":[1,2,3],\"c\":\"more\"}")?;
     file.flush()?;
     let path = file.path().to_str().unwrap();
 
     // Real jq 1.7.1 drops the 'A' entirely (confirmed live): `"\u{fffd}"`.
-    // succinctly keeps it -- `utf8_lossy_document` substitutes the whole
-    // file, and 'A' is not that whole file's own last byte (the closing
-    // `"}"` still follows it), so #1717's fix never activates here.
     let (stdout, stderr, code) =
         run_jq_full(&["-c", ".a", path], None).unwrap_or_else(|e| panic!("failed to run: {e}"));
     assert_eq!(code, 0, "stderr: {stderr}");
-    assert_eq!(stdout.trim(), "\"\u{fffd}A\"");
+    assert_eq!(stdout.trim(), "\"\u{fffd}\"");
+
+    // `-S` forces the non-lazy path, whose substitution lives in
+    // `get_inputs` rather than `utf8_lossy_document`.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-S", ".", path], None)
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stdout.trim(),
+        "{\"a\":\"\u{fffd}\",\"b\":[1,2,3],\"c\":\"more\"}"
+    );
+    Ok(())
+}
+
+/// #1743: jq substitutes inside `jv_string_sized`, i.e. over the string's
+/// *escape-decoded* bytes, so an escape -- always shorter decoded than
+/// spelled -- can push a lead byte over the `len - pos < seq_len` line that
+/// its raw source span would clear.
+///
+/// `"\xe1A"` is seven raw bytes but two decoded, one short of the three
+/// the `0xE1` lead declares, so real jq collapses it to a bare U+FFFD and
+/// drops the `A` (confirmed live against jq 1.7.1). A repair scoped to the
+/// raw span would keep the `A`; this is the case that forces the decode.
+#[test]
+fn test_invalid_utf8_substitution_scoped_to_decoded_string_1743() -> Result<()> {
+    for (body, expected, label) in [
+        (&b"\xe1\\u0041"[..], "\u{fffd}", "3-byte lead, \\u escape"),
+        (
+            &b"\xf0\x90\\u0041"[..],
+            "\u{fffd}",
+            "4-byte lead, \\u escape",
+        ),
+        (&b"\xe1\\n"[..], "\u{fffd}", "3-byte lead, short escape"),
+        // Same document without the escape: two raw bytes still present
+        // after the lead, so nothing collapses and the 'A' survives.
+        (&b"\xe1\x41x"[..], "\u{fffd}Ax", "enough headroom, kept"),
+    ] {
+        let mut file = NamedTempFile::new()?;
+        file.write_all(b"{\"a\":\"")?;
+        file.write_all(body)?;
+        file.write_all(b"\",\"z\":1}")?;
+        file.flush()?;
+        let path = file.path().to_str().unwrap();
+
+        let (stdout, stderr, code) = run_jq_full(&["-c", ".a", path], None)
+            .unwrap_or_else(|e| panic!("{label}: failed to run: {e}"));
+        assert_eq!(code, 0, "{label}: stderr: {stderr}");
+        assert_eq!(stdout.trim(), format!("\"{expected}\""), "{label}");
+    }
+    Ok(())
+}
+
+/// #1743: every JSON-shaped input route gets the per-string scope, not just
+/// the plain document one -- `--slurp` and `--seq` reach the substitution
+/// through `get_inputs`' own branch, and each was verified against jq 1.7.1
+/// separately. Object keys go through the same lexer path in jq, so they
+/// collapse too.
+#[test]
+fn test_invalid_utf8_per_string_scope_across_json_input_modes_1743() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"{\"a\":\"\xe1\x41\"} {\"b\":\"\xe1\x41\"}")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    // `jq -s -c .` => [{"a":"<fffd>"},{"b":"<fffd>"}]
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-s", ".", path], None)
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "[{\"a\":\"\u{fffd}\"},{\"b\":\"\u{fffd}\"}]");
+
+    // `--seq` input is still JSON text, just RS-separated -- the gate is
+    // deliberately wider than `json_input_mode`, which excludes it.
+    let mut seq_file = NamedTempFile::new()?;
+    seq_file.write_all(b"\x1e{\"a\":\"\xe1\x41\"}\n")?;
+    seq_file.flush()?;
+    let seq_path = seq_file.path().to_str().unwrap();
+    let (stdout, stderr, code) = run_jq_full(&["-c", "--seq", ".", seq_path], None)
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("{\"a\":\"\u{fffd}\"}"), "--seq: {stdout:?}");
+
+    // Keys, not just values.
+    let mut key_file = NamedTempFile::new()?;
+    key_file.write_all(b"{\"\xe1\x41\":1,\"b\":2}")?;
+    key_file.flush()?;
+    let key_path = key_file.path().to_str().unwrap();
+    let (stdout, stderr, code) = run_jq_full(&["-c", "keys", key_path], None)
+        .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "[\"b\",\"\u{fffd}\"]");
     Ok(())
 }
 
@@ -26225,6 +26313,31 @@ fn test_raw_input_slurp_still_whole_buffer_substitution_1742() -> Result<()> {
         run_jq_full(&["-R", "-s", "-c", ".", path], None).unwrap_or_else(|e| panic!("failed: {e}"));
     assert_eq!(code, 0, "stderr: {stderr}");
     assert_eq!(stdout.trim(), "\"a\u{fffd}A\\nsecond\\nthird\\n\"");
+    Ok(())
+}
+
+/// #1743's per-JSON-string scope must not reach DSV input. DSV is not JSON:
+/// its fields are quoted with `""` doubling, not backslash escaping, so a
+/// JSON string scanner would mis-segment the document -- and there is no
+/// oracle to match anyway, since neither jq nor yq reads DSV. Whole-buffer
+/// substitution (the behaviour before #1743) is what this route keeps.
+///
+/// The `A` surviving is the tell: under the per-string scope it would be
+/// dropped, since it ends the field.
+#[test]
+fn test_input_dsv_keeps_whole_buffer_substitution_1743() -> Result<()> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(b"n,v\na\xe1\x41,1\n")?;
+    file.flush()?;
+    let path = file.path().to_str().unwrap();
+
+    let (stdout, stderr, code) = run_jq_full(&["--input-dsv", ",", "-c", ".", path], None)
+        .unwrap_or_else(|e| panic!("failed: {e}"));
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        ["[\"n\",\"v\"]", "[\"a\u{fffd}A\",\"1\"]"]
+    );
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21955,21 +21955,16 @@ fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
 /// ('A'), with no bytes at all remaining after it -- `len - pos == 2 <
 /// seq_len == 3`. Real jq 1.7.1 drops that trailing byte entirely
 /// (`echo '"4UE="' | jq -c '@base64d|explode'` -> `[65533]`), and
-/// `succinctly` now matches exactly, via `owned_string_from_decoded_bytes`
+/// `succinctly` matches exactly, via `owned_string_from_decoded_bytes`
 /// (`src/jq/eval.rs`) calling the fixed `substitute_invalid_utf8_jq_style`
-/// (`src/text/utf8/mod.rs`). Document/raw-input decode
-/// (`jq_runner.rs`'s `utf8_lossy_document`/`get_inputs`) does *not* gain
-/// this fix -- it substitutes a whole file/document buffer at once,
-/// before real jq's own per-string (document mode) or per-line
-/// (`--raw-input`) trigger point ever applies, so "last byte of input"
-/// almost never coincides with jq's own trigger the way it naturally
-/// does here, where `input` already *is* one decoded string's bytes
-/// (jq's own trigger is not rare -- it fires on any string/line ending
-/// in the right byte shape, however much more content follows; only
-/// succinctly's whole-buffer reproduction of it is). See #1742 for the
-/// separate, more tractable raw-input caller-ordering gap, and
-/// docs/compliance/jq/limitations.md's "fixed at function granularity,
-/// open at document granularity" section for the full detail.
+/// (`src/text/utf8/mod.rs`), whose `input` already *is* one decoded
+/// string's bytes. That rule is granularity-independent, so the other
+/// callers reach the same match by being handed what jq hands it:
+/// `--raw-input` splits on `\n` first (#1742) and JSON document /
+/// `--slurp` / `--seq` decode segments per JSON string via
+/// `jq::utf8_document::substitute_invalid_utf8_jq_document` (#1743).
+/// See docs/compliance/jq/limitations.md's "matched, at each caller's
+/// own granularity" section for the full detail.
 #[test]
 fn test_jq_base64d_drops_trailing_byte_quirk_fixed_1717() -> Result<()> {
     let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"4UE=\"", &["-c"])?;


### PR DESCRIPTION
## Description

Closes #1743: jq's U+FFFD substitution for a non-UTF-8 JSON document is now scoped **per JSON string**, the way real jq scopes it, instead of over the whole file.

`substitute_invalid_utf8_jq_style` (#1617/#1717) already reproduces jq 1.7.1's algorithm, including the end-of-buffer drop quirk (`len - pos < seq_len` collapses the whole remaining tail into one U+FFFD). That algorithm is granularity-independent — it only asks how many bytes remain in the slice it was handed — so *what a caller passes it* decides where the quirk fires. Real jq substitutes inside `jv_string_sized`, which its lexer calls once per JSON string; succinctly handed it the entire file, making "the buffer's own end" the file's last byte, which in a realistic multi-field document essentially never coincides with jq's trigger:

```console
$ printf '{"a":"\xe1\x41","b":1}' | jq -c '.a'
"<U+FFFD>"
$ printf '{"a":"\xe1\x41","b":1}' | sjq -c '.a'     # before
"<U+FFFD>A"
$ printf '{"a":"\xe1\x41","b":1}' | sjq -c '.a'     # after
"<U+FFFD>"
```

### The issue's premise was wrong in two ways, and the fix is smaller for it

#1743 assumed this needed per-string substitution **timing** — deferring the decode until after structural parsing — and called that a conflict with semi-indexing. It is not:

- Both callers already gate on a whole-input SIMD `validate_utf8`, so a valid document never enters the repair, and the repair still emits a valid-UTF-8 buffer. That preserves the invariant `docs/plan/decode-failure-routing.md` is built around (*after the input boundary's pass, `as_str()` can only fail on an escape problem*) — which is what lets `StandardJson::as_str` borrow out of the document, lets the printer echo a raw string span, and lets the raw-identity fast path exist. Only *how* the replacement buffer is built changed.
- Locating string boundaries in non-UTF-8 text needs only a byte-level quote/backslash scan, sound because UTF-8 is self-synchronising: `"` (0x22) and `\` (0x5C) can never occur inside a multi-byte sequence, valid or otherwise, so the scan agrees with jq's own byte-oriented lexer by construction. No semi-index and no JSON structure beyond string boundaries is involved.

The issue was also wrong about the scope itself: it is the escape-**decoded** string, not the raw source span. Escapes only shrink a string, so they can push a lead byte over the `len - pos < seq_len` line its raw span would clear — `"\xe1A"` is 7 raw bytes but 2 decoded, one short of the 3 the `0xE1` lead declares, and real jq collapses it (oracle-verified, as is the 4-byte analogue). A raw-span-scoped repair keeps the `A` and is wrong.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Documentation update

## Related Issue

Fixes #1743

Downstream of #1617 (substitution mechanism), #1717 (the algorithm fix), #1719 (`@base64d`/`@urid` routing). Sibling #1742 (`--raw-input`) was already fixed; with this, every caller is scoped the way jq scopes it.

## Changes Made

- **`src/jq/utf8_document.rs` (new)** — `substitute_invalid_utf8_jq_document` segments the buffer into JSON strings and everything else, and scopes the substitution to each. A string body is copied verbatim if already valid UTF-8; substituted directly if invalid without escapes; and decoded, substituted, re-escaped if invalid with escapes (required for the decoded-scope rule above). An undecodable body falls back to raw-span substitution rather than inventing a decoding — such a document is a parse error downstream either way.
- **`src/json/light.rs`** — `decode_escapes` gains a shared `decode_escapes_into::<VALIDATE_UTF8>` core writing bytes rather than a `String`, so the repair can decode escapes in text that is not (yet) valid UTF-8. `VALIDATE_UTF8 = true` keeps the existing `as_str` behaviour, including *where* the UTF-8 check fires, so a string carrying both a bad literal byte and a later bad escape reports the same error kind as before.
- **`src/bin/succinctly/jq_runner.rs`** — routes JSON document, `--slurp` and `--seq` input to the new function. Deliberately not gated on `json_input_mode` (which excludes `--seq`): `--seq` input is still JSON text, just RS-separated, and real jq scopes per string there too. `--raw-input --slurp` stays whole-buffer because real jq is whole-buffer there too (the whole input is one string); `--input-dsv` stays whole-buffer because DSV is not JSON — its fields are `""`-doubled, not backslash-escaped, so a JSON string scanner would mis-segment it. Both are pinned by tests.
- **Docs** — `docs/compliance/jq/limitations.md`'s section becomes a per-caller scope table; four places that still asserted the gap was open (two in `src/jq/eval.rs`, one in `tests/yq_cli_tests.rs`, one in `docs/plan/decode-failure-routing.md`) are corrected, three of which also cited the renamed section title.

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

11 unit tests in the new module and 3 new CLI tests. `test_invalid_utf8_document_drop_quirk_still_diverges_from_jq_1717`, which pinned the divergence as a known gap, now pins the match. Both the lazy and the non-lazy (`-S`) document routes are asserted — they substitute at two separate call sites and would otherwise be free to drift.

**Differential verification against pinned jq 1.7.1** — ~5,800 cases, zero diffs:

| Sweep | Cases | Result |
|---|---:|---|
| Random corrupt documents (`-c .`, 4 seeds) | 2,600 | 0 diffs |
| Exhaustive lead byte x truncated tail x prefix x suffix | 384 | 0 diffs |
| Random documents x 7 arg sets (`-c`/`-s`/`-S`/`-a`/`--seq`/`tostring`/`[..]`) | 2,800 | 0 diffs |

The only divergences the sweeps surfaced (`\ud800`, `\q`, literal control characters, `-c --tab` precedence) reproduce on **valid** UTF-8 input on `main` — pre-existing and unrelated.

### Test Commands

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo check --no-default-features
cargo test --features cli,simd,regex,serde --no-fail-fast   # 56 suites
cargo test                                                   # 55 suites
```

All green. Patch coverage 96.51% (166/172 new lines).

## Performance Impact

- [x] No performance impact (valid input)
- [x] Performance improvement (the repair path itself)

**Valid documents pay nothing.** Both callers still gate on the existing whole-input SIMD `validate_utf8`, so a well-formed document never reaches the scanner.

For the repair path, the first cut allocated an owned `String` per JSON string *and* per run of bytes between them, then copied each into the output — including the overwhelmingly common case of a segment that needs no repair at all. Segment count scales with the document, not with the corruption in it: a 42 MB file with a single bad byte still has ~3.4M segments. `repair_string_body` now writes into the output buffer, and `push_segment` borrows a clean segment straight out of the source (not a different answer — the substitution returns valid input byte-for-byte unchanged, pinned by #1247's guard test).

Interleaved A/B, 42 MB single-bad-byte document, `sjq -c '.'`:

| | min | median |
|---|---:|---:|
| per-segment `String` | 0.958s | 0.994s |
| borrow clean segments | **0.896s** | **0.927s** |

One optimisation was measured and **rejected**, recorded in `decode_escapes`: replacing its closing `String::from_utf8` (a second pass over bytes the loop already validated) with `from_utf8_unchecked` is worth -1.3% to -3.7% on the two workloads that decode every string (interleaved A/B, 400k escaped strings in a 28 MB document) — too small to introduce `unsafe` into that module for. The obvious safe shortcut, dropping the per-chunk check instead, is not equivalent: it would change which error a string with both a bad literal byte and a bad escape reports.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

Benchmark numbers above were taken on a busy dev machine, so they are interleaved A/B deltas rather than absolute throughput claims; the direction and the mechanism (allocation count) are the load-bearing part, not the wall-clock.
