### PR TITLE
docs(jq): correct stale FirstStream/LastStream reachability comments

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20477,12 +20477,15 @@ fn resolve_node<'a, S: EvalSemantics>(
             }
         }
 
-        // `first(f)` keeps only the first branch `f` resolves to. Both
-        // internal spellings reach here: `Expr::FirstExpr` is what the
-        // dedicated `first(...)` parse path builds; `Builtin::FirstStream`
-        // is a second, older representation reachable from a different
-        // parser path. Keeping both arms means it does not matter which one
-        // a given call site produces.
+        // `first(f)` keeps only the first branch `f` resolves to.
+        // `Expr::FirstExpr` is what the dedicated `first(...)` parse path
+        // builds; `Builtin::FirstStream` is never constructed by the parser
+        // (#1986) -- `parse_first_expr` intercepts `first(...)` before
+        // `try_parse_builtin` ever runs, so this second arm is dead from any
+        // parseable query. Kept anyway as defensive symmetry, the same way
+        // `builtin_first_stream_propagates_bare_halt`'s own doc comment
+        // documents and tests `Builtin::FirstStream` directly rather than
+        // relying on a (nonexistent) parser path to reach it.
         //
         // #1935: `first(f)` is exactly `limit(1; f)` for path-tracking
         // purposes, so it shares `resolve_limit_one_n`'s own bounded

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -35482,14 +35482,17 @@ fn builtin_limit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: first(expr) - output only the first value from expr (stream version)
+///
+/// Unlike `eval_first_expr`, this function is never actually reached from
+/// parsed `succinctly jq`/`succinctly yq` filter text (#1986) -- `first(expr)`
+/// always parses to `Expr::FirstExpr`, not `Builtin::FirstStream` (see
+/// `builtin_first_stream_propagates_bare_halt`) -- so this update exists
+/// purely to keep the two implementations in sync.
 fn builtin_first_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // `Builtin::FirstStream` is the internal spelling of the same `first(f)`;
-    // it differs from `eval_first_expr` only in always materializing its
-    // answer, which is preserved here.
     match each_take_first::<W, S>(expr, value, optional) {
         Ok(Some(item)) => QueryResult::Owned(item.into_owned()),
         Ok(None) => QueryResult::None,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6238,9 +6238,12 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
     finish_fork_generic(out, control.or(stray), optional)
 }
 
-/// Evaluate `first(inner)`/`last(inner)` (and the `Builtin::FirstStream`/
-/// `LastStream` spelling the parser sometimes produces for the same syntax --
-/// see the call sites in `eval_single`/`eval_builtin`), preserving a cursor
+/// Evaluate `first(inner)`/`last(inner)`. `Expr::FirstExpr`/`Expr::LastExpr`
+/// are the only spellings any parseable query produces -- `Builtin::
+/// FirstStream`/`LastStream` are never constructed by the parser (#1986;
+/// see `builtin_first_stream_propagates_bare_halt`), so the call sites in
+/// `eval_single`/`eval_builtin` that also route here for those two variants
+/// are defensive symmetry, not a second live production. Preserves a cursor
 /// through the extraction when `inner`'s stream carries one.
 ///
 /// Mirrors `eval::eval_first_expr`/`eval::eval_last_expr`'s control-flow
@@ -8098,10 +8101,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
-        // `first(f)`/`last(f)`: the parser's `parse_call` builtin-name path
-        // produces this spelling for the same syntax `Expr::FirstExpr`/
-        // `LastExpr` cover (see their arms in `eval_single`) -- both must
-        // stay cursor-preserving for the same reason (#607).
+        // `first(f)`/`last(f)`: never produced by the parser (#1986) --
+        // `parse_first_expr`/`parse_last_expr` intercept this syntax before
+        // `try_parse_builtin` ever runs, always producing `Expr::FirstExpr`/
+        // `LastExpr` instead (see their arms in `eval_single`). Kept as
+        // defensive symmetry, cursor-preserving for the same reason (#607).
         Builtin::FirstStream(inner) => {
             eval_first_or_last_generic::<S, _>(inner, value, optional, cursor, false)
         }
@@ -12376,13 +12380,15 @@ mod tests {
 
     #[test]
     fn test_json_first_stream_builtin_preserves_duplicate_keys() {
-        // `Builtin::FirstStream`/`LastStream` is the second, older internal
-        // spelling of `first(f)`/`last(f)` that `eval::resolve_node` already
-        // treats as equivalent to `Expr::FirstExpr` (see its comment at
-        // eval.rs's `Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner))`
-        // arm) -- not reachable from `crate::jq::parse` for top-level user
-        // syntax, so built directly here, mirroring how the `IndexExpr` test
-        // above bypasses the parser's own folding.
+        // `Builtin::FirstStream`/`LastStream` is never constructed by the
+        // parser (#1986): `first(f)`/`last(f)` always parse to
+        // `Expr::FirstExpr`/`Expr::LastExpr` instead (see
+        // `builtin_first_stream_propagates_bare_halt` in eval.rs) -- not
+        // reachable from `crate::jq::parse` for any top-level user syntax,
+        // so built directly here, mirroring how the `IndexExpr` test above
+        // bypasses the parser's own folding. `eval::resolve_node`'s matching
+        // `Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner))`
+        // arm still handles this variant, purely as defensive symmetry.
         let json = br#"[{"a":1,"a":2},{"b":3,"b":4}]"#;
         let index = JsonIndex::build(json);
         let expr = Expr::Builtin(Builtin::FirstStream(Box::new(Expr::Iterate)));


### PR DESCRIPTION
## Summary

Corrects three stale comments that claimed `Builtin::FirstStream`/`LastStream`
are a second, genuinely reachable parser production alongside the dedicated
`Expr::FirstExpr`/`Expr::LastExpr` lazy AST nodes.

They aren't: `src/jq/parser.rs`'s atom-chain intercepts `first(...)`/
`last(...)` via `parse_first_expr`/`parse_last_expr` before
`try_parse_builtin()` is ever invoked, so `try_parse_builtin`'s own
`Builtin::FirstStream`/`LastStream` construction arms are dead from any
parseable query. This already matched what
`builtin_first_stream_propagates_bare_halt`'s own doc comment (`eval.rs`)
correctly stated — the two were inconsistent with each other, and per
#1972's code review, exactly the kind of comment that could mislead a
future audit.

## Locations fixed

- `src/jq/eval.rs`'s `resolve_node` (the `Expr::FirstExpr(inner) |
  Expr::Builtin(Builtin::FirstStream(inner))` arm's doc comment)
- `src/jq/eval_generic.rs`'s `eval_first_or_last_generic` doc comment
- `src/jq/eval_generic.rs`'s `eval_builtin` match arm (the `Builtin::
  FirstStream`/`LastStream` arms' doc comment)

Each now states the arm is dead code kept as defensive symmetry, matching
`builtin_first_stream_propagates_bare_halt`'s existing correct wording.
Documentation-only — no functional change.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace` (56/56 binaries green)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`
