### PR TITLE
fix(yq): -0/--nul-output rejects results whose content contains a raw NUL

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -151,7 +151,7 @@ the raw byte.
 
 One interaction remains open: this check only fires on bytes that are genuinely unescaped in
 the rendered output. `-o=json -0 '.a'` *without* an explicit `-r` should print a properly
-JSON-escaped `"b c"` and succeed (JSON's default unwrap-scalar setting is `false`,
+JSON-escaped `"b\u0000c"` and succeed (JSON's default unwrap-scalar setting is `false`,
 unlike YAML's `true` — real yq needs `-r` explicit to unwrap a JSON scalar), but succinctly's
 own `raw_output` resolution unconditionally ORs in `-0`/`-j` regardless of output format, so
 this one combination instead unwraps (bypassing JSON's own escaping) and correctly triggers

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -153,7 +153,8 @@ Two interactions remain open, neither closed by #1709 itself:
 
 1. This check only fires on bytes that are genuinely unescaped in the rendered output.
    `-o=json -0 '.a'` *without* an explicit `-r` should print a properly JSON-escaped
-   `"b\u0000c"` and succeed (JSON's default unwrap-scalar setting is `false`, unlike YAML's
+   `"b\u0000c"` and succeed (live-verified against the pinned oracle, Homebrew yq
+   v4.53.3: JSON's default unwrap-scalar setting is `false`, unlike YAML's
    `true` — real yq needs `-r` explicit to unwrap a JSON scalar), but succinctly's own
    `raw_output` resolution unconditionally ORs in `-0`/`-j` regardless of output format, so
    this one combination instead unwraps (bypassing JSON's own escaping) and correctly

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -139,11 +139,25 @@ different story — it collides with a real yq flag of the same name but an unre
 own justification doesn't change either way: it's applied to both spellings purely for
 internal consistency between them, not for fidelity to anything real yq does with `-j`.
 
-Scope note: this entry covers only the `---`-boundary corruption. The reparsed value shown
-above still differs from the original once the embedded `\0` itself is considered — succinctly
-performs no embedded-NUL content validation on `-0` output, unlike real yq's own refusal to
-read it back at all. That is a separate, already-filed gap
-([#1709](https://github.com/rust-works/succinctly/issues/1709)), not fixed by this entry.
+Scope note: this entry covers only the `---`-boundary corruption. `-0` output whose *value
+content* itself contains a raw NUL byte is a separate matter, fixed by
+[#1709](https://github.com/rust-works/succinctly/issues/1709): succinctly now rejects such
+a result the same way real yq does (`can't serialise value because it contains NUL char and
+you are using NUL separated output`), matching real yq's own flush-then-error atomicity
+(earlier results in a stream are still flushed; the offending result and everything after it
+are not) rather than either the whole-document-buffering approach an earlier attempt at that
+fix tried and abandoned (PR #1767, +65% peak RSS on a 100MB document) or silently emitting
+the raw byte.
+
+One interaction remains open: this check only fires on bytes that are genuinely unescaped in
+the rendered output. `-o=json -0 '.a'` *without* an explicit `-r` should print a properly
+JSON-escaped `"b c"` and succeed (JSON's default unwrap-scalar setting is `false`,
+unlike YAML's `true` — real yq needs `-r` explicit to unwrap a JSON scalar), but succinctly's
+own `raw_output` resolution unconditionally ORs in `-0`/`-j` regardless of output format, so
+this one combination instead unwraps (bypassing JSON's own escaping) and correctly triggers
+this same NUL check on the resulting raw byte. That's a distinct, pre-existing root cause —
+[#1996](https://github.com/rust-works/succinctly/issues/1996) — not something #1709 itself
+introduced or is scoped to fix.
 
 ### Merge-flag `+` and `d` combined — **no carve-out; this one is out of policy**
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -149,15 +149,31 @@ are not) rather than either the whole-document-buffering approach an earlier att
 fix tried and abandoned (PR #1767, +65% peak RSS on a 100MB document) or silently emitting
 the raw byte.
 
-One interaction remains open: this check only fires on bytes that are genuinely unescaped in
-the rendered output. `-o=json -0 '.a'` *without* an explicit `-r` should print a properly
-JSON-escaped `"b\u0000c"` and succeed (JSON's default unwrap-scalar setting is `false`,
-unlike YAML's `true` — real yq needs `-r` explicit to unwrap a JSON scalar), but succinctly's
-own `raw_output` resolution unconditionally ORs in `-0`/`-j` regardless of output format, so
-this one combination instead unwraps (bypassing JSON's own escaping) and correctly triggers
-this same NUL check on the resulting raw byte. That's a distinct, pre-existing root cause —
-[#1996](https://github.com/rust-works/succinctly/issues/1996) — not something #1709 itself
-introduced or is scoped to fix.
+Two interactions remain open, neither closed by #1709 itself:
+
+1. This check only fires on bytes that are genuinely unescaped in the rendered output.
+   `-o=json -0 '.a'` *without* an explicit `-r` should print a properly JSON-escaped
+   `"b\u0000c"` and succeed (JSON's default unwrap-scalar setting is `false`, unlike YAML's
+   `true` — real yq needs `-r` explicit to unwrap a JSON scalar), but succinctly's own
+   `raw_output` resolution unconditionally ORs in `-0`/`-j` regardless of output format, so
+   this one combination instead unwraps (bypassing JSON's own escaping) and correctly
+   triggers this same NUL check on the resulting raw byte. That's a distinct, pre-existing
+   root cause — [#1996](https://github.com/rust-works/succinctly/issues/1996) — not
+   something #1709 itself introduced or is scoped to fix.
+
+2. **`--color`/`--colors` combined with `-0` loses the flush-then-error atomicity described
+   above.** Real yq's own `--colors -0` still flushes earlier valid results before erroring
+   on a later NUL-containing one — live-verified: `yq --colors -0 '.[]'` on `["hello",
+   "wor\0ld", "x"]` prints `hello\0` to stdout, then errors on the second element, exit 1.
+   succinctly's own `--colors -0` combination instead buffers the *entire* multi-result
+   render into one string (the pre-existing, `--color`-only mechanism `colorize_yaml`/
+   `colorize_json` need to re-lex ANSI spans across result boundaries) and scans that whole
+   buffer once before writing anything — so a NUL anywhere in the stream discards every
+   earlier, already-valid result too, printing nothing at all where real yq printed
+   `hello\0`. Fixing this properly needs the buffered/color rendering path restructured to
+   flush (and re-colorize) per result rather than once for the whole document — a
+   materially larger change than #1709's own scope, filed separately as
+   [#2004](https://github.com/rust-works/succinctly/issues/2004).
 
 ### Merge-flag `+` and `d` combined — **no carve-out; this one is out of policy**
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -386,9 +386,15 @@ macro_rules! json_ascii {
 /// pre-existing cost unrelated to `-0`); a `-0`+`--color` combination is
 /// checked for an embedded NUL over that same already-buffered content
 /// before writing, coarser-grained (whole document, not per-result) than
-/// the no-color path below, but bounded by the same memory this
-/// combination already pays for coloring — see
-/// `docs/compliance/yq/limitations.md` for this scope note.
+/// the no-color path below -- bounded by the same memory this combination
+/// already pays for coloring, but NOT flush-then-error atomic the way the
+/// no-color path is: real yq's own `--colors -0` still flushes earlier
+/// valid results before erroring on a later NUL-containing one
+/// (live-verified), while this whole-buffer check discards every result in
+/// the render, including already-clean earlier ones, on any NUL anywhere
+/// in the stream. A real, currently-open divergence, not a documented
+/// design choice — see `docs/compliance/yq/limitations.md`'s `-0`
+/// multi-document separator entry and #2004.
 fn stream_maybe_colored<W: Write, T>(
     writer: &mut W,
     use_color: bool,
@@ -2464,31 +2470,57 @@ fn write_doc_separator_marker<W: std::io::Write>(
 /// State for tracking split_doc output separators.
 struct SplitDocState {
     has_split_doc: bool,
-    is_first_output: bool,
+    /// Same polarity as `DocSeparatorArgs`/`PendingSeparator`'s own
+    /// `doc_streamed` (`true` once *any* output has happened), not the
+    /// original `is_first_output`'s inverted one -- needed so a `-0` call
+    /// site can hand this field straight to `output_value` as its own
+    /// deferred separator state (#1709 code review) without an extra
+    /// polarity-flipping adapter.
+    any_output: bool,
 }
 
 impl SplitDocState {
     fn new(has_split_doc: bool) -> Self {
         Self {
             has_split_doc,
-            is_first_output: true,
+            any_output: false,
         }
     }
 
-    /// Write a separator if needed for split_doc mode. Returns Ok(()) always.
+    /// Write a separator if needed for split_doc mode -- unless `config`'s
+    /// output is NUL-separated, in which case the separator is deferred
+    /// into the returned `DocSeparatorArgs` for `output_value`'s own
+    /// per-result NUL check to decide instead (#1709 code review): this
+    /// method used to always write eagerly, the same bug class every other
+    /// document-separator call site in this file was fixed for -- verified
+    /// live that a `split_doc`-tagged result whose value contains an
+    /// embedded NUL left a dangling `---` for content that was never
+    /// actually emitted.
     ///
     /// Same `---`-must-start-on-its-own-line fix as `emit_yaml_doc_separator`
-    /// (#1701 code review): the previous document's own terminator might
-    /// have been `\0`/nothing rather than `\n`, and gluing `---` directly
-    /// onto that document's last byte corrupts it on reparse the same way.
-    fn write_separator<W: Write>(&mut self, writer: &mut W, config: &OutputConfig) -> Result<()> {
-        if self.has_split_doc && config.output_format == OutputFormat::Yaml && !config.no_doc {
-            if !self.is_first_output {
-                write_doc_separator_marker(writer, terminator_from_config(config))?;
-            }
-            self.is_first_output = false;
+    /// (#1701 code review) for the eager case: the previous document's own
+    /// terminator might have been `\0`/nothing rather than `\n`, and gluing
+    /// `---` directly onto that document's last byte corrupts it on
+    /// reparse.
+    fn write_separator<W: Write>(
+        &mut self,
+        writer: &mut W,
+        config: &OutputConfig,
+    ) -> Result<Option<DocSeparatorArgs<'_>>> {
+        if !self.has_split_doc || config.output_format != OutputFormat::Yaml || config.no_doc {
+            return Ok(None);
         }
-        Ok(())
+        if config.nul_output {
+            return Ok(Some(DocSeparatorArgs {
+                doc_streamed: &mut self.any_output,
+                no_doc: config.no_doc,
+            }));
+        }
+        if self.any_output {
+            write_doc_separator_marker(writer, terminator_from_config(config))?;
+        }
+        self.any_output = true;
+        Ok(None)
     }
 }
 
@@ -2552,10 +2584,12 @@ fn write_pending_separator<W: Write>(
     terminator: Terminator,
 ) -> Result<()> {
     if let Some(sep) = separator {
-        if *sep.doc_streamed && !sep.no_doc {
-            write_doc_separator_marker(writer, terminator)?;
-        }
-        *sep.doc_streamed = true;
+        // Reuses the same guard/write/set-flag logic every other terminator
+        // mode's separator goes through, rather than hand-duplicating it
+        // here (#1709 code review) -- `true` for `will_output` since
+        // reaching this point already means this result survived
+        // `output_value`'s own NUL check.
+        emit_yaml_doc_separator(writer, sep.doc_streamed, true, sep.no_doc, terminator)?;
     }
     Ok(())
 }
@@ -4831,12 +4865,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 && output_config.output_format == OutputFormat::Yaml
                 && !output_config.no_doc
                 && results.len() > 1;
-            if has_split_doc {
+            let mut doc_streamed = i > 0;
+            let separator = if has_split_doc {
                 // The filter explicitly marks its outputs as separate
                 // documents (`split_doc`); route through the same state
                 // machine every other output path uses for that, or no
-                // separator is ever written here at all.
-                split_doc_state.write_separator(&mut writer, &output_config)?;
+                // separator is ever written here at all. Deferred into
+                // `output_value` under `-0`, same as every other arm here.
+                split_doc_state.write_separator(&mut writer, &output_config)?
             } else if wants_doc_separator && i > 0 && !output_config.nul_output {
                 // `---` BETWEEN results (not before the first) -- deliberately
                 // different from --slurp's no-separator convention, since
@@ -4855,14 +4891,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // to close. `output_value` writes it lazily instead, below,
                 // once its own check has passed.
                 write_doc_separator_marker(&mut writer, terminator_from_config(&output_config))?;
-            }
-            any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
-            let mut doc_streamed = i > 0;
-            let separator =
+                None
+            } else {
                 (wants_doc_separator && output_config.nul_output).then_some(DocSeparatorArgs {
                     doc_streamed: &mut doc_streamed,
                     no_doc: output_config.no_doc,
-                });
+                })
+            };
+            any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
             output_value(
                 &mut writer,
                 result,
@@ -5008,14 +5044,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let mut split_doc_state = SplitDocState::new(has_split_doc);
         let results = evaluate_input(&OwnedValue::Null, &program.expr, &mut sink)?;
         for result in results {
-            split_doc_state.write_separator(&mut writer, &output_config)?;
+            let split_separator = split_doc_state.write_separator(&mut writer, &output_config)?;
             any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
             output_value(
                 &mut writer,
                 &result,
                 &CommentTree::empty(),
                 &output_config,
-                None,
+                split_separator,
             )?;
         }
     } else if args.raw_input {
@@ -5044,14 +5080,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let slurped = OwnedValue::String(input_content);
             let results = evaluate_input(&slurped, &program.expr, &mut sink)?;
             for result in results {
-                split_doc_state.write_separator(&mut writer, &output_config)?;
+                let split_separator =
+                    split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                 output_value(
                     &mut writer,
                     &result,
                     &CommentTree::empty(),
                     &output_config,
-                    None,
+                    split_separator,
                 )?;
             }
         } else {
@@ -5060,14 +5097,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let input = OwnedValue::String(line.to_string());
                 let results = evaluate_input(&input, &program.expr, &mut sink)?;
                 for result in results {
-                    split_doc_state.write_separator(&mut writer, &output_config)?;
+                    let split_separator =
+                        split_doc_state.write_separator(&mut writer, &output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                     output_value(
                         &mut writer,
                         &result,
                         &CommentTree::empty(),
                         &output_config,
-                        None,
+                        split_separator,
                     )?;
                 }
                 // halt/halt_error (#791) outranks evaluating any further lines.
@@ -5260,14 +5298,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             let results = evaluate_input(&slurped, &program.expr, &mut sink)?;
             let mut split_doc_state = SplitDocState::new(has_split_doc);
             for result in results {
-                split_doc_state.write_separator(&mut writer, &output_config)?;
+                let split_separator =
+                    split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
                 output_value(
                     &mut writer,
                     &result,
                     &CommentTree::empty(),
                     &output_config,
-                    None,
+                    split_separator,
                 )?;
             }
         }
@@ -5562,12 +5601,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                             doc_had_output = true;
                             any_doc_output_this_file = true;
                         }
-                        split_doc_state.write_separator(&mut buf_writer, &output_config)?;
+                        // `split_doc` (#1709 code review) takes priority
+                        // over the inter-document separator above when both
+                        // apply -- matches every other call site's own
+                        // has_split_doc-first precedence (e.g. the
+                        // --eval-all arm above).
+                        let split_separator =
+                            split_doc_state.write_separator(&mut buf_writer, &output_config)?;
                         any_truthy |=
                             !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                        let separator = defer_to_nul_check.then_some(DocSeparatorArgs {
-                            doc_streamed: &mut any_doc_output_this_file,
-                            no_doc: output_config.no_doc,
+                        let separator = split_separator.or_else(|| {
+                            defer_to_nul_check.then_some(DocSeparatorArgs {
+                                doc_streamed: &mut any_doc_output_this_file,
+                                no_doc: output_config.no_doc,
+                            })
                         });
                         output_value(
                             &mut buf_writer,
@@ -5822,13 +5869,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // 2's own (unwanted) separator check to fire on it too.
                 let mut first_result_in_doc = true;
                 for (result, comments) in results {
-                    split_doc_state.write_separator(&mut writer, &file_output_config)?;
+                    // `split_doc` (#1709 code review) takes priority over
+                    // the inter-document separator above when both apply --
+                    // matches every other call site's own has_split_doc-
+                    // first precedence.
+                    let split_separator =
+                        split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    let separator =
+                    let separator = split_separator.or_else(|| {
                         (defer_to_nul_check && first_result_in_doc).then_some(DocSeparatorArgs {
                             doc_streamed: &mut any_yaml_doc_output,
                             no_doc: output_config.no_doc,
-                        });
+                        })
+                    });
                     output_value(
                         &mut writer,
                         &result,

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -167,7 +167,6 @@ struct PendingSeparator<'a> {
 struct NulCheckedSink<'a, W: Write> {
     writer: &'a mut W,
     buf: String,
-    terminator: Terminator,
     nul_detected: &'a Cell<bool>,
     separator: Option<PendingSeparator<'a>>,
 }
@@ -190,11 +189,24 @@ impl<W: Write> NulCheckedSink<'_, W> {
         }
         if let Some(sep) = &mut self.separator {
             if !sep.settled {
-                if *sep.doc_streamed && !sep.no_doc {
-                    write_doc_separator_marker(self.writer, self.terminator)
-                        .map_err(|_| core::fmt::Error)?;
-                }
-                *sep.doc_streamed = true;
+                // Reuses the same guard/write/set-flag logic every other
+                // terminator mode's separator goes through, rather than
+                // hand-duplicating it here (#1709 code review) -- `true`
+                // for `will_output` since reaching this point already
+                // means this result survived the NUL check above.
+                // `Terminator::Nul` is a literal, not `self.terminator`:
+                // this sink is only ever constructed for that terminator
+                // (see its one call site in `stream_maybe_colored`), so a
+                // stored field would just be a second name for the same
+                // constant.
+                emit_yaml_doc_separator(
+                    self.writer,
+                    sep.doc_streamed,
+                    true,
+                    sep.no_doc,
+                    Terminator::Nul,
+                )
+                .map_err(|_| core::fmt::Error)?;
                 sep.settled = true;
             }
         }
@@ -408,6 +420,22 @@ fn stream_maybe_colored<W: Write, T>(
         if terminator == Terminator::Nul && separator.is_some() && buf.as_bytes().contains(&0) {
             return Err(anyhow::anyhow!(NUL_OUTPUT_ERROR_MESSAGE));
         }
+        // #1709: `separator` is only ever `Some` for a NUL-checked YAML
+        // call site (its caller skipped its own eager
+        // `emit_yaml_doc_separator` call for exactly this reason -- see
+        // the `NulChecked` branch below), and the NUL scan just above
+        // already gates reaching this point on "the document's own
+        // content survived." Write the separator now, directly to
+        // `writer` -- never colorized, matching every other call site's
+        // own separator write -- before the colorized body. A no-op for
+        // every other `use_color` call (terminator != Nul, or JSON, both
+        // of which pass `None`).
+        if let Some(sep) = separator {
+            if *sep.doc_streamed && !sep.no_doc {
+                write_doc_separator_marker(writer, terminator)?;
+            }
+            *sep.doc_streamed = true;
+        }
         write!(writer, "{}", colorize(&buf, &boundaries))?;
         match rendered {
             Ok(value) => Ok(Ok(value)),
@@ -419,7 +447,6 @@ fn stream_maybe_colored<W: Write, T>(
         let sink_state = NulCheckedSink {
             writer,
             buf: String::new(),
-            terminator,
             nul_detected: &nul_detected,
             separator: separator.map(|s| PendingSeparator {
                 doc_streamed: s.doc_streamed,
@@ -438,7 +465,18 @@ fn stream_maybe_colored<W: Write, T>(
         // terminator`, unlike the evaluated multi-result path, whose own
         // `on_value` calls already drained the buffer via `flush_result`
         // before `render` ever returns. A no-op there.
-        let rendered = if rendered.is_ok() && !sink_state.buf.is_empty() {
+        //
+        // Flushed even on a `StreamFailure::Decode` (#1709 code review):
+        // whatever rendered into the buffer before a mid-stream decode
+        // failure is still real, already-checked content, and this file's
+        // own established keep-the-prefix-and-diagnose trade (#1641/#1679,
+        // this function's own doc comment above) says to write it rather
+        // than silently drop it -- the `Buffered`/color arm above already
+        // does this unconditionally. Only a genuine write failure
+        // (`StreamFailure::Fmt`) means the underlying writer itself is
+        // already broken, with nothing left to safely flush.
+        let rendered = if !matches!(rendered, Err(StreamFailure::Fmt)) && !sink_state.buf.is_empty()
+        {
             match sink_state.flush_body() {
                 Ok(()) => rendered,
                 Err(e) => Err(StreamFailure::from(e)),
@@ -1824,7 +1862,7 @@ fn write_split_result(
     let mut buf = Vec::new();
     let mut no_color_config = output_config.clone();
     no_color_config.use_color = false;
-    output_value(&mut buf, result, comments, &no_color_config)?;
+    output_value(&mut buf, result, comments, &no_color_config, None)?;
 
     std::fs::write(&filename, &buf)
         .with_context(|| format!("failed to write --split-exp output file: {filename}"))
@@ -2498,16 +2536,42 @@ fn reject_nul_output(rendered: &str, config: &OutputConfig) -> Result<()> {
     Ok(())
 }
 
+/// Writes a pending `---` document separator, once its caller's own
+/// [`reject_nul_output`] check has already passed (#1709 code review):
+/// every `output_value` call site that precedes it with an eager
+/// `write_doc_separator_marker` call has the identical bug the M2 path's
+/// own `PendingSeparator` was built to close -- a document whose first
+/// result fails the NUL check still leaves its separator already on the
+/// writer. `None` for a call site with no separator concept of its own
+/// (most of `output_value`'s callers -- `-n`, `--raw-input`, `--slurp`,
+/// `--split-exp`, ...), matching `DocSeparatorArgs`'s own YAML-only use in
+/// `stream_maybe_colored`.
+fn write_pending_separator<W: Write>(
+    writer: &mut W,
+    separator: Option<DocSeparatorArgs<'_>>,
+    terminator: Terminator,
+) -> Result<()> {
+    if let Some(sep) = separator {
+        if *sep.doc_streamed && !sep.no_doc {
+            write_doc_separator_marker(writer, terminator)?;
+        }
+        *sep.doc_streamed = true;
+    }
+    Ok(())
+}
+
 fn output_value<W: Write>(
     writer: &mut W,
     value: &OwnedValue,
     comments: &CommentTree,
     config: &OutputConfig,
+    separator: Option<DocSeparatorArgs<'_>>,
 ) -> Result<()> {
     // Handle raw output for scalars
     if config.raw_output {
         if let OwnedValue::String(s) = value {
             reject_nul_output(s, config)?;
+            write_pending_separator(writer, separator, terminator_from_config(config))?;
             write!(writer, "{s}")?;
             write_terminator(writer, config)?;
             return Ok(());
@@ -2592,6 +2656,7 @@ fn output_value<W: Write>(
             body
         };
         reject_nul_output(&output, config)?;
+        write_pending_separator(writer, separator, terminator_from_config(config))?;
         if config.use_color {
             // No boundary recorded here -- `write_terminator` below writes
             // directly to `writer`, outside this buffer (#1708).
@@ -2630,6 +2695,7 @@ fn output_value<W: Write>(
     );
 
     reject_nul_output(&json_str, config)?;
+    write_pending_separator(writer, separator, terminator_from_config(config))?;
     if config.use_color {
         write!(
             writer,
@@ -4761,17 +4827,17 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
 
         let mut split_doc_state = SplitDocState::new(has_split_doc);
         for (i, result) in results.iter().enumerate() {
+            let wants_doc_separator = !has_split_doc
+                && output_config.output_format == OutputFormat::Yaml
+                && !output_config.no_doc
+                && results.len() > 1;
             if has_split_doc {
                 // The filter explicitly marks its outputs as separate
                 // documents (`split_doc`); route through the same state
                 // machine every other output path uses for that, or no
                 // separator is ever written here at all.
                 split_doc_state.write_separator(&mut writer, &output_config)?;
-            } else if output_config.output_format == OutputFormat::Yaml
-                && !output_config.no_doc
-                && results.len() > 1
-                && i > 0
-            {
+            } else if wants_doc_separator && i > 0 && !output_config.nul_output {
                 // `---` BETWEEN results (not before the first) -- deliberately
                 // different from --slurp's no-separator convention, since
                 // eval-all is explicitly a multi-document-stream feature (#715).
@@ -4780,10 +4846,30 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // (#1701 code review): the previous result's own
                 // `write_terminator` call (inside `output_value` below)
                 // might have written `\0`/nothing rather than `\n`.
+                //
+                // Skipped under `-0` (#1709 code review): a NUL-checked
+                // result can still fail `output_value`'s own check, and
+                // writing this eagerly would leave a stray `---` for a
+                // document whose own content never made it out -- same bug
+                // class the M2 streaming path's `PendingSeparator` exists
+                // to close. `output_value` writes it lazily instead, below,
+                // once its own check has passed.
                 write_doc_separator_marker(&mut writer, terminator_from_config(&output_config))?;
             }
             any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
-            output_value(&mut writer, result, &CommentTree::empty(), &output_config)?;
+            let mut doc_streamed = i > 0;
+            let separator =
+                (wants_doc_separator && output_config.nul_output).then_some(DocSeparatorArgs {
+                    doc_streamed: &mut doc_streamed,
+                    no_doc: output_config.no_doc,
+                });
+            output_value(
+                &mut writer,
+                result,
+                &CommentTree::empty(),
+                &output_config,
+                separator,
+            )?;
         }
     } else if let Some(split_expr) = split_expr.as_ref() {
         // Handle --split-exp: write each result to its own file (named by
@@ -4924,7 +5010,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         for result in results {
             split_doc_state.write_separator(&mut writer, &output_config)?;
             any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-            output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
+            output_value(
+                &mut writer,
+                &result,
+                &CommentTree::empty(),
+                &output_config,
+                None,
+            )?;
         }
     } else if args.raw_input {
         // Handle --raw-input: read each line as a string instead of
@@ -4954,7 +5046,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             for result in results {
                 split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
+                output_value(
+                    &mut writer,
+                    &result,
+                    &CommentTree::empty(),
+                    &output_config,
+                    None,
+                )?;
             }
         } else {
             // Without --slurp, process each line independently
@@ -4964,7 +5062,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 for result in results {
                     split_doc_state.write_separator(&mut writer, &output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
+                    output_value(
+                        &mut writer,
+                        &result,
+                        &CommentTree::empty(),
+                        &output_config,
+                        None,
+                    )?;
                 }
                 // halt/halt_error (#791) outranks evaluating any further lines.
                 if sink.halted().is_some() {
@@ -5158,7 +5262,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             for result in results {
                 split_doc_state.write_separator(&mut writer, &output_config)?;
                 any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                output_value(&mut writer, &result, &CommentTree::empty(), &output_config)?;
+                output_value(
+                    &mut writer,
+                    &result,
+                    &CommentTree::empty(),
+                    &output_config,
+                    None,
+                )?;
             }
         }
     } else if args.inplace {
@@ -5425,14 +5535,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // eagerly left a dangling `---` whenever a doc
                         // produced zero output, whether from an ordinary
                         // empty filter or from a halt partway through (#791).
-                        if !doc_had_output
+                        let wants_doc_separator = !doc_had_output
                             && !has_split_doc
                             && output_config.output_format == OutputFormat::Yaml
                             && !output_config.no_doc
                             && is_multi_doc
                             && front_matter_body.is_none()
-                            && any_doc_output_this_file
-                        {
+                            && any_doc_output_this_file;
+                        // #1709 code review: deferred to `output_value`
+                        // itself under `-0`, same reason as the `--eval-all`
+                        // arm above -- an eager write here can't yet know
+                        // whether this document's own first result will
+                        // survive `output_value`'s NUL check.
+                        let defer_to_nul_check = wants_doc_separator && output_config.nul_output;
+                        if wants_doc_separator && !output_config.nul_output {
                             // #1701 code review: same fix as
                             // `emit_yaml_doc_separator` -- the previous
                             // document's own terminator might not have been
@@ -5442,17 +5558,27 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 terminator_from_config(&output_config),
                             )?;
                         }
-                        doc_had_output = true;
-                        any_doc_output_this_file = true;
+                        if !defer_to_nul_check {
+                            doc_had_output = true;
+                            any_doc_output_this_file = true;
+                        }
                         split_doc_state.write_separator(&mut buf_writer, &output_config)?;
                         any_truthy |=
                             !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
+                        let separator = defer_to_nul_check.then_some(DocSeparatorArgs {
+                            doc_streamed: &mut any_doc_output_this_file,
+                            no_doc: output_config.no_doc,
+                        });
                         output_value(
                             &mut buf_writer,
                             &result,
                             &CommentTree::empty(),
                             &output_config,
+                            separator,
                         )?;
+                        if defer_to_nul_check {
+                            doc_had_output = true;
+                        }
                         any_real_output = true;
                     }
                     // halt/halt_error (#791): still write this file's buffer
@@ -5664,13 +5790,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // YAML document immediately after a JSON one would
                 // wrongly get a leading separator, while the same YAML
                 // document appearing first would not.
-                if !has_split_doc
+                let wants_doc_separator = !has_split_doc
                     && file_output_config.output_format == OutputFormat::Yaml
                     && !output_config.no_doc
                     && is_multi_doc
                     && front_matter_body.is_none()
-                    && any_yaml_doc_output
-                {
+                    && any_yaml_doc_output;
+                // #1709 code review: deferred to `output_value` itself
+                // under `-0`, same reason as the `--eval-all`/`--inplace`
+                // arms above -- an eager write here can't yet know whether
+                // this document's own first result will survive
+                // `output_value`'s NUL check.
+                let defer_to_nul_check = wants_doc_separator && file_output_config.nul_output;
+                if wants_doc_separator && !file_output_config.nul_output {
                     // #1701 code review: same fix as
                     // `emit_yaml_doc_separator` -- the previous document's
                     // own terminator might not have been `\n`.
@@ -5679,13 +5811,32 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         terminator_from_config(&file_output_config),
                     )?;
                 }
-                if file_output_config.output_format == OutputFormat::Yaml {
+                if file_output_config.output_format == OutputFormat::Yaml && !defer_to_nul_check {
                     any_yaml_doc_output = true;
                 }
+                // Only the first result of this document gets a chance at
+                // the deferred separator -- `defer_to_nul_check` alone is
+                // constant across every result in `results`, so without
+                // this, `output_value`'s own successful flush of result 1
+                // would flip `any_yaml_doc_output` true in time for result
+                // 2's own (unwanted) separator check to fire on it too.
+                let mut first_result_in_doc = true;
                 for (result, comments) in results {
                     split_doc_state.write_separator(&mut writer, &file_output_config)?;
                     any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-                    output_value(&mut writer, &result, &comments, &file_output_config)?;
+                    let separator =
+                        (defer_to_nul_check && first_result_in_doc).then_some(DocSeparatorArgs {
+                            doc_streamed: &mut any_yaml_doc_output,
+                            no_doc: output_config.no_doc,
+                        });
+                    output_value(
+                        &mut writer,
+                        &result,
+                        &comments,
+                        &file_output_config,
+                        separator,
+                    )?;
+                    first_result_in_doc = false;
                     any_output_this_file = true;
                 }
             }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
+use std::cell::Cell;
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
@@ -57,6 +58,12 @@ fn absorb_stream_stats(sink: &mut ErrorSink, stats: &succinctly::jq::stream::Str
     }
 }
 
+/// Matches real yq's own message text (Homebrew v4.53.3, live-verified,
+/// #1709) for a `-0`/`--nul-output` result whose rendered bytes contain a
+/// raw NUL character.
+const NUL_OUTPUT_ERROR_MESSAGE: &str =
+    "can't serialise value because it contains NUL char and you are using NUL separated output";
+
 /// Adapter to use `std::io::Write` with `core::fmt::Write` methods.
 /// This enables streaming JSON output without intermediate String allocation.
 struct FmtWriter<W>(W);
@@ -77,6 +84,16 @@ impl<W: Write> core::fmt::Write for FmtWriter<W> {
 enum ColorSink<'a, W: Write> {
     Buffered(String, Vec<usize>),
     Direct(FmtWriter<&'a mut W>),
+    /// Per-result NUL-checked buffering (#1709), used instead of `Direct`
+    /// when `-0`/`--nul-output` is active and `--color` isn't. See
+    /// [`NulCheckedSink`]'s own doc comment for why this needs to buffer
+    /// one result at a time rather than either streaming straight through
+    /// (`Direct`, which would leak an invalid result's own already-rendered
+    /// prefix bytes before detecting its embedded NUL) or buffering the
+    /// whole document like `Buffered` does (which would reintroduce the
+    /// #789-class memory regression a prior attempt at this issue, PR
+    /// #1767, measured and got closed over).
+    NulChecked(NulCheckedSink<'a, W>),
 }
 
 impl<W: Write> core::fmt::Write for ColorSink<'_, W> {
@@ -84,7 +101,118 @@ impl<W: Write> core::fmt::Write for ColorSink<'_, W> {
         match self {
             ColorSink::Buffered(buf, _) => buf.write_str(s),
             ColorSink::Direct(w) => w.write_str(s),
+            ColorSink::NulChecked(sink) => sink.buf.write_str(s),
         }
+    }
+}
+
+/// Threads `stream_cursor!`'s own `$doc_streamed`/`no_doc` state into
+/// [`stream_maybe_colored`] for lazy `---` emission (#1709). `None` for
+/// JSON output call sites, which have no document-separator concept at
+/// all.
+struct DocSeparatorArgs<'a> {
+    doc_streamed: &'a mut bool,
+    no_doc: bool,
+}
+
+/// Lazy `---` document-separator state carried inside [`NulCheckedSink`]
+/// (#1709). `emit_yaml_doc_separator`'s ordinary eager write (before the
+/// body even renders) is wrong for NUL-checked output: verified live
+/// against the pinned oracle (Homebrew yq v4.53.3) that real yq does NOT
+/// write a document's `---` when that document's *first* result fails the
+/// NUL check, even though the document would otherwise structurally
+/// produce output -- but DOES keep the separator once at least one earlier
+/// result in the same document already flushed clean. So the separator has
+/// to be decided at the same per-result granularity as the NUL check
+/// itself, not before it.
+struct PendingSeparator<'a> {
+    /// Mirrors `stream_cursor!`'s own `$doc_streamed`: has any *prior*
+    /// document already produced real output. Only ever set, never
+    /// cleared, so a document that fails outright doesn't un-flag one that
+    /// already succeeded earlier.
+    doc_streamed: &'a mut bool,
+    no_doc: bool,
+    /// Whether this document's own separator question has already been
+    /// settled (written, or correctly skipped for `no_doc`/being first) --
+    /// distinct from `doc_streamed`, which is global: without this, every
+    /// result after the first in the *same* document would see
+    /// `doc_streamed` already `true` (set by the first result's own flush)
+    /// and try to insert another `---` before itself.
+    settled: bool,
+}
+
+/// Per-result buffered writer used when `-0`/`--nul-output` is active and
+/// `--color` isn't (#1709). Buffers ONE streamed result's rendered text at
+/// a time -- not the whole document/stream, unlike `ColorSink::Buffered`
+/// above (which exists for an unrelated reason, color re-lexing, and pays
+/// for materializing every result of a whole document up front as an
+/// accepted, pre-existing cost of `--color` specifically). A per-*result*
+/// buffer keeps bounded, O(one result) memory regardless of document size,
+/// matching this crate's M2 streaming architecture's own memory guarantee.
+///
+/// A prior attempt at this exact issue (PR #1767, closed without merging)
+/// buffered the entire rendered stream instead whenever `-0` was set, and
+/// measured +65% peak RSS on a 100MB document as a result -- buffering the
+/// wrong granularity, not buffering itself, was the regression.
+///
+/// Verified live against the pinned oracle (Homebrew yq v4.53.3) that
+/// per-result is also the *correct* granularity, not just the cheap one:
+/// earlier results in a stream flush with their real terminator even when
+/// a later one fails (`1,2,("a"+NUL+"b"),4` under `-0` prints `1\0002\000`
+/// then errors, producing nothing for the third result and never reaching
+/// the fourth) -- exactly the shape one flush-buffer-per-result gives for
+/// free, with no separate "is this scalar being unwrapped" mode predicate
+/// to derive (see the issue's own second post-mortem comment): the gate is
+/// simply "does this result's rendered buffer contain a raw NUL byte."
+struct NulCheckedSink<'a, W: Write> {
+    writer: &'a mut W,
+    buf: String,
+    terminator: Terminator,
+    nul_detected: &'a Cell<bool>,
+    separator: Option<PendingSeparator<'a>>,
+}
+
+impl<W: Write> NulCheckedSink<'_, W> {
+    /// Checks the current per-result buffer for an embedded NUL byte,
+    /// clearing the buffer either way. On success, writes the pending
+    /// `---` separator first (if this is the document's first surviving
+    /// result), then the buffer's own contents -- but not the terminator,
+    /// which callers add separately: [`Self::flush_result`] for the
+    /// evaluated multi-result path's per-result hook, or
+    /// [`stream_maybe_colored`]'s own post-render step for the identity
+    /// path, whose `stream_yaml_as_document` has no per-result callback to
+    /// hook a flush into.
+    fn flush_body(&mut self) -> core::fmt::Result {
+        if self.buf.as_bytes().contains(&0) {
+            self.nul_detected.set(true);
+            self.buf.clear();
+            return Err(core::fmt::Error);
+        }
+        if let Some(sep) = &mut self.separator {
+            if !sep.settled {
+                if *sep.doc_streamed && !sep.no_doc {
+                    write_doc_separator_marker(self.writer, self.terminator)
+                        .map_err(|_| core::fmt::Error)?;
+                }
+                *sep.doc_streamed = true;
+                sep.settled = true;
+            }
+        }
+        self.writer
+            .write_all(self.buf.as_bytes())
+            .map_err(|_| core::fmt::Error)?;
+        self.buf.clear();
+        Ok(())
+    }
+
+    /// [`Self::flush_body`] plus the real terminator -- the evaluated
+    /// multi-result path's per-result hook, reached through
+    /// [`ColorSink::write_result_terminator`].
+    fn flush_result(&mut self, terminator: Terminator) -> core::fmt::Result {
+        self.flush_body()?;
+        terminator
+            .write_io(self.writer)
+            .map_err(|_| core::fmt::Error)
     }
 }
 
@@ -114,11 +242,13 @@ impl<W: Write> ColorSink<'_, W> {
     /// to the real `$writer`/`OutputConfig` outside any `ColorSink` at all)
     /// to keep the two apart when searching this file.
     fn write_result_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
-        if matches!(self, ColorSink::Buffered(..)) {
-            self.record_boundary();
-            Ok(())
-        } else {
-            terminator.write_fmt(self)
+        match self {
+            ColorSink::Buffered(..) => {
+                self.record_boundary();
+                Ok(())
+            }
+            ColorSink::Direct(_) => terminator.write_fmt(self),
+            ColorSink::NulChecked(sink) => sink.flush_result(terminator),
         }
     }
 }
@@ -203,9 +333,29 @@ macro_rules! json_ascii {
 /// Whatever reached `out` before the failure is still written, colorized path
 /// included — the same keep-the-prefix-and-diagnose trade #1641/#1679 settled
 /// for their own streaming sites.
+///
+/// `terminator`/`separator` (#1709): when `terminator` is `Terminator::Nul`
+/// and `use_color` is false, dispatches to `ColorSink::NulChecked` instead
+/// of `Direct` — see that type's own doc comment for why per-result
+/// buffering, not raw passthrough, is required to match real yq's own
+/// flush-then-error atomicity without regressing this crate's streaming
+/// memory guarantee. `separator` threads `stream_cursor!`'s own
+/// `$doc_streamed`/`no_doc` state through for the YAML call sites' lazy
+/// `---` emission; `None` for JSON, which has no separator concept.
+///
+/// The `use_color` path keeps its existing whole-buffer shape (color
+/// re-lexing already requires materializing the whole rendered document, a
+/// pre-existing cost unrelated to `-0`); a `-0`+`--color` combination is
+/// checked for an embedded NUL over that same already-buffered content
+/// before writing, coarser-grained (whole document, not per-result) than
+/// the no-color path below, but bounded by the same memory this
+/// combination already pays for coloring — see
+/// `docs/compliance/yq/limitations.md` for this scope note.
 fn stream_maybe_colored<W: Write, T>(
     writer: &mut W,
     use_color: bool,
+    terminator: Terminator,
+    separator: Option<DocSeparatorArgs<'_>>,
     colorize: impl FnOnce(&str, &[usize]) -> String,
     render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<T, StreamFailure>,
 ) -> anyhow::Result<Result<T, EvalError>> {
@@ -215,7 +365,64 @@ fn stream_maybe_colored<W: Write, T>(
         let ColorSink::Buffered(buf, boundaries) = sink else {
             unreachable!("stream_maybe_colored always constructs ColorSink::Buffered here")
         };
+        // `separator.is_some()` doubles as "this is a YAML call site"
+        // (#1709): YAML's `Buffered` mode never embeds a raw terminator
+        // character into `buf` itself (`write_result_terminator` records a
+        // boundary offset instead, exactly so `colorize_yaml` can place a
+        // real terminator later, correctly relative to whatever color span
+        // is open there). JSON's own on_value closures write
+        // `terminator.write_fmt(w)` directly, so JSON's buffer *does*
+        // contain raw `\0` terminator bytes between every result when
+        // `-0` is active -- scanning it here would false-positive on the
+        // terminator's own byte, not a value actually containing one.
+        // Narrowing this check to YAML leaves `--color -o=json -0`
+        // unvalidated; that combination already can't be safely consumed
+        // by a NUL-delimited reader once ANSI escapes are mixed in, so
+        // `-0`'s own reason for existing doesn't really apply to it either.
+        if terminator == Terminator::Nul && separator.is_some() && buf.as_bytes().contains(&0) {
+            return Err(anyhow::anyhow!(NUL_OUTPUT_ERROR_MESSAGE));
+        }
         write!(writer, "{}", colorize(&buf, &boundaries))?;
+        match rendered {
+            Ok(value) => Ok(Ok(value)),
+            Err(StreamFailure::Decode(e)) => Ok(Err(e)),
+            Err(StreamFailure::Fmt) => Err(anyhow::anyhow!("Write error")),
+        }
+    } else if terminator == Terminator::Nul {
+        let nul_detected = Cell::new(false);
+        let sink_state = NulCheckedSink {
+            writer,
+            buf: String::new(),
+            terminator,
+            nul_detected: &nul_detected,
+            separator: separator.map(|s| PendingSeparator {
+                doc_streamed: s.doc_streamed,
+                no_doc: s.no_doc,
+                settled: false,
+            }),
+        };
+        let mut sink = ColorSink::NulChecked(sink_state);
+        let rendered = render(&mut sink);
+        let ColorSink::NulChecked(mut sink_state) = sink else {
+            unreachable!("stream_maybe_colored always constructs ColorSink::NulChecked here")
+        };
+        // The identity path leaves exactly one un-flushed result in the
+        // buffer -- `stream_yaml_as_document`/`stream_json_as_document`
+        // have no per-result callback to flush through `write_result_
+        // terminator`, unlike the evaluated multi-result path, whose own
+        // `on_value` calls already drained the buffer via `flush_result`
+        // before `render` ever returns. A no-op there.
+        let rendered = if rendered.is_ok() && !sink_state.buf.is_empty() {
+            match sink_state.flush_body() {
+                Ok(()) => rendered,
+                Err(e) => Err(StreamFailure::from(e)),
+            }
+        } else {
+            rendered
+        };
+        if nul_detected.get() {
+            return Err(anyhow::anyhow!(NUL_OUTPUT_ERROR_MESSAGE));
+        }
         match rendered {
             Ok(value) => Ok(Ok(value)),
             Err(StreamFailure::Decode(e)) => Ok(Err(e)),
@@ -239,11 +446,12 @@ fn stream_maybe_colored<W: Write, T>(
 fn stream_or_report<W: Write>(
     writer: &mut W,
     use_color: bool,
+    terminator: Terminator,
     sink: &mut ErrorSink,
     colorize: impl FnOnce(&str, &[usize]) -> String,
     render: impl FnOnce(&mut ColorSink<'_, W>) -> Result<(), StreamFailure>,
 ) -> anyhow::Result<bool> {
-    match stream_maybe_colored(writer, use_color, colorize, render)? {
+    match stream_maybe_colored(writer, use_color, terminator, None, colorize, render)? {
         Ok(()) => Ok(true),
         Err(e) => {
             report_stream_decode_failure(sink, &e);
@@ -2248,6 +2456,22 @@ fn write_terminator<W: Write>(writer: &mut W, config: &OutputConfig) -> Result<(
 /// (issue #710). Callers with no cursor-derived comment data (JSON input,
 /// `--null-input`, `--raw-input`, `--slurp`, `--inplace`'s slow path) pass
 /// `&CommentTree::empty()`.
+/// DOM-path counterpart to `NulCheckedSink` (#1709) -- `output_value`
+/// already fully materializes its rendered text as an owned `String`
+/// before writing, unlike the M2 streaming path, so the check here needs
+/// no per-result buffering of its own: this isn't a new allocation, only a
+/// new scan over one `output_value` already made. Scans the pre-colorized
+/// text (colorizing only wraps existing content in ANSI codes, never
+/// alters or strips a NUL byte already there), and runs before
+/// `write_terminator`, so a `Terminator::Nul` byte written separately,
+/// after this check, is never mistaken for a rejected value's own content.
+fn reject_nul_output(rendered: &str, config: &OutputConfig) -> Result<()> {
+    if config.nul_output && rendered.contains('\0') {
+        anyhow::bail!(NUL_OUTPUT_ERROR_MESSAGE);
+    }
+    Ok(())
+}
+
 fn output_value<W: Write>(
     writer: &mut W,
     value: &OwnedValue,
@@ -2257,6 +2481,7 @@ fn output_value<W: Write>(
     // Handle raw output for scalars
     if config.raw_output {
         if let OwnedValue::String(s) = value {
+            reject_nul_output(s, config)?;
             write!(writer, "{s}")?;
             write_terminator(writer, config)?;
             return Ok(());
@@ -2340,6 +2565,7 @@ fn output_value<W: Write>(
         } else {
             body
         };
+        reject_nul_output(&output, config)?;
         if config.use_color {
             // No boundary recorded here -- `write_terminator` below writes
             // directly to `writer`, outside this buffer (#1708).
@@ -2377,6 +2603,7 @@ fn output_value<W: Write>(
         },
     );
 
+    reject_nul_output(&json_str, config)?;
     if config.use_color {
         write!(
             writer,
@@ -3940,18 +4167,37 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // `$cursor` here is the whole document being
                     // redisplayed as itself - its own trailing comment,
                     // if any, must be kept (#710).
-                    emit_yaml_doc_separator(
-                        $writer,
-                        $doc_streamed,
-                        true,
-                        $output_config.no_doc,
-                        terminator,
-                    )?;
+                    //
+                    // #1709: when the output is NUL-separated, the
+                    // separator can't be written eagerly here -- real yq
+                    // doesn't emit a document's `---` when that document's
+                    // own (identity mode: only) result fails the NUL
+                    // check, so the decision has to move inside
+                    // `stream_maybe_colored`'s `NulChecked` sink, which
+                    // only learns the outcome after rendering. Every other
+                    // terminator keeps the existing eager write unchanged.
+                    let nul_separator = if terminator == Terminator::Nul {
+                        Some(DocSeparatorArgs {
+                            doc_streamed: $doc_streamed,
+                            no_doc: $output_config.no_doc,
+                        })
+                    } else {
+                        emit_yaml_doc_separator(
+                            $writer,
+                            $doc_streamed,
+                            true,
+                            $output_config.no_doc,
+                            terminator,
+                        )?;
+                        None
+                    };
                     // No boundary recorded here -- the terminator is written
                     // directly to `$writer` below, outside this buffer (#1708).
                     let rendered = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
+                        nul_separator,
                         |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                         |out| $cursor.stream_yaml_as_document(out, yaml_indent, sort_keys),
                     )?;
@@ -3979,13 +4225,26 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // output (`GenericResult::Halt`) answers `false`
                     // there; an output-bearing halt
                     // (`GenericResult::Partial`) answers `true`.
-                    emit_yaml_doc_separator(
-                        $writer,
-                        $doc_streamed,
-                        result.produces_output(),
-                        $output_config.no_doc,
-                        terminator,
-                    )?;
+                    // #1709: see the identity branch's own comment above --
+                    // `result.produces_output()` predicts the STRUCTURE of
+                    // the result, not whether its first NUL-checked result
+                    // will actually survive, so a NUL-separated document's
+                    // separator has to be decided lazily too.
+                    let nul_separator = if terminator == Terminator::Nul {
+                        Some(DocSeparatorArgs {
+                            doc_streamed: $doc_streamed,
+                            no_doc: $output_config.no_doc,
+                        })
+                    } else {
+                        emit_yaml_doc_separator(
+                            $writer,
+                            $doc_streamed,
+                            result.produces_output(),
+                            $output_config.no_doc,
+                            terminator,
+                        )?;
+                        None
+                    };
                     // #1708: the per-result terminator write runs *inside*
                     // this buffered render callback, so a real terminator
                     // byte here would become part of what gets colorized --
@@ -3999,6 +4258,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
+                        nul_separator,
                         |s, boundaries| colorize_yaml(s, terminator, boundaries),
                         |out| {
                             result
@@ -4044,6 +4305,8 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let rendered = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
+                        None,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |sink| {
                             json_ascii!($output_config.ascii_output, sink, |out| {
@@ -4068,12 +4331,34 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let stats = stream_maybe_colored(
                         $writer,
                         $use_color,
+                        terminator,
+                        None,
                         |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                         |sink| {
                             json_ascii!($output_config.ascii_output, sink, |out| {
                                 result
                                     .stream_json(out, json_indent, sort_keys, |w| {
-                                        terminator.write_fmt(w)
+                                        // #1709: `--color`'s `Buffered` mode
+                                        // needs the raw terminator byte
+                                        // written straight into its buffer
+                                        // (JSON's own colorizer re-lexes
+                                        // that unmodified, unlike YAML's
+                                        // boundary-based one -- see
+                                        // `stream_maybe_colored`'s own
+                                        // comment on this). `write_result_
+                                        // terminator` would silently drop
+                                        // it there. Every other mode
+                                        // (`Direct`, `NulChecked`) is
+                                        // unaffected either way -- `Direct`'s
+                                        // own arm is exactly `terminator.
+                                        // write_fmt(self)`, and `NulChecked`
+                                        // needs the dispatch to trigger its
+                                        // per-result flush.
+                                        if $use_color {
+                                            terminator.write_fmt(w)
+                                        } else {
+                                            w.write_result_terminator(terminator)
+                                        }
                                     })
                                     .map_err(StreamFailure::from)
                             })
@@ -4174,6 +4459,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 stream_or_report(
                                     &mut writer,
                                     output_config.use_color,
+                                    terminator_from_config(&output_config),
                                     &mut sink,
                                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                                     |out| root.stream_yaml_document(out, yaml_indent, sort_keys),
@@ -4182,6 +4468,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                 stream_or_report(
                                     &mut writer,
                                     output_config.use_color,
+                                    terminator_from_config(&output_config),
                                     &mut sink,
                                     |s, _boundaries| {
                                         output::colorize_json(s, &ColorScheme::default())
@@ -4311,6 +4598,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     stream_or_report(
                                         &mut writer,
                                         output_config.use_color,
+                                        terminator_from_config(&output_config),
                                         &mut sink,
                                         |s, boundaries| {
                                             colorize_yaml(s, Terminator::None, boundaries)
@@ -4323,6 +4611,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                     stream_or_report(
                                         &mut writer,
                                         output_config.use_color,
+                                        terminator_from_config(&output_config),
                                         &mut sink,
                                         |s, _boundaries| {
                                             output::colorize_json(s, &ColorScheme::default())
@@ -4744,6 +5033,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 stream_or_report(
                     &mut writer,
                     output_config.use_color,
+                    terminator_from_config(&output_config),
                     &mut sink,
                     |s, _boundaries| output::colorize_json(s, &ColorScheme::default()),
                     |sink| {
@@ -4765,6 +5055,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 stream_or_report(
                     &mut writer,
                     output_config.use_color,
+                    terminator_from_config(&output_config),
                     &mut sink,
                     |s, boundaries| colorize_yaml(s, Terminator::None, boundaries),
                     |out| {

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4355,9 +4355,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     // `result.produces_output()` predicts the STRUCTURE of
                     // the result, not whether its first NUL-checked result
                     // will actually survive, so a NUL-separated document's
-                    // separator has to be decided lazily too.
+                    // separator has to be decided lazily too. Still gated
+                    // on `result.produces_output()` itself (#1709 code
+                    // review): a document producing zero results must
+                    // never offer a separator opportunity at all, colored
+                    // or not -- the color/`Buffered` arm of
+                    // `stream_maybe_colored` has no empty-buffer guard of
+                    // its own the way the non-color `NulChecked` arm does,
+                    // so an ungated `Some(..)` here wrote a stray `---`
+                    // around an empty middle document even when nothing
+                    // failed the NUL check at all. Live-verified regression:
+                    // `-0 --colors 'select(.a != 2)'` over three documents
+                    // whose middle one matches nothing.
                     let nul_separator = if terminator == Terminator::Nul {
-                        Some(DocSeparatorArgs {
+                        result.produces_output().then_some(DocSeparatorArgs {
                             doc_streamed: $doc_streamed,
                             no_doc: $output_config.no_doc,
                         })

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -253,6 +253,32 @@ impl<W: Write> ColorSink<'_, W> {
     }
 }
 
+/// Reaches [`ColorSink::write_result_terminator`] through whichever of the
+/// two concrete types a `json_ascii!`-wrapped `on_value` callback actually
+/// holds (#1709): a bare `ColorSink` when `--ascii-output` is off, or an
+/// `AsciiEscapeWriter` around one when it's on. `write_result_terminator`
+/// is a `ColorSink`-specific method, not part of `core::fmt::Write`, so it
+/// isn't reachable through the wrapper's own `Write` impl the way a plain
+/// `terminator.write_fmt(w)` call is -- and going through the wrapper's
+/// escaping for the terminator's own bytes would be a no-op in any case
+/// (every terminator this crate writes is already ASCII), so bypassing it
+/// via [`AsciiEscapeWriter::inner_mut`] is sound, not just convenient.
+trait DispatchResultTerminator {
+    fn dispatch_result_terminator(&mut self, terminator: Terminator) -> core::fmt::Result;
+}
+
+impl<W: Write> DispatchResultTerminator for ColorSink<'_, W> {
+    fn dispatch_result_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
+        self.write_result_terminator(terminator)
+    }
+}
+
+impl<W: Write> DispatchResultTerminator for AsciiEscapeWriter<'_, ColorSink<'_, W>> {
+    fn dispatch_result_terminator(&mut self, terminator: Terminator) -> core::fmt::Result {
+        self.inner_mut().write_result_terminator(terminator)
+    }
+}
+
 /// Apply `--ascii-output` to a JSON render (#1700).
 ///
 /// Wraps `$sink` in [`AsciiEscapeWriter`] when the flag is set and passes it
@@ -4353,11 +4379,18 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                                         // own arm is exactly `terminator.
                                         // write_fmt(self)`, and `NulChecked`
                                         // needs the dispatch to trigger its
-                                        // per-result flush.
+                                        // per-result flush. `dispatch_
+                                        // result_terminator` (not
+                                        // `write_result_terminator`
+                                        // directly) since `--ascii-output`
+                                        // wraps `w` in `AsciiEscapeWriter`
+                                        // here, which has no
+                                        // `ColorSink`-specific methods of
+                                        // its own.
                                         if $use_color {
                                             terminator.write_fmt(w)
                                         } else {
-                                            w.write_result_terminator(terminator)
+                                            w.dispatch_result_terminator(terminator)
                                         }
                                     })
                                     .map_err(StreamFailure::from)

--- a/src/jq/escape.rs
+++ b/src/jq/escape.rs
@@ -254,6 +254,17 @@ impl<'a, W: Write> AsciiEscapeWriter<'a, W> {
     pub fn new(inner: &'a mut W) -> Self {
         Self { inner }
     }
+
+    /// Reborrow the wrapped writer directly, bypassing this wrapper's own
+    /// ASCII-escaping `Write` impl -- for a caller that needs one of the
+    /// inner writer's own non-`Write`-trait methods (`succinctly yq`'s
+    /// `ColorSink::write_result_terminator`, #1709), not a `write_str`
+    /// call. Sound to bypass escaping for: every terminator this crate
+    /// writes (`\0`, `\n`, or nothing) is already ASCII, so routing it
+    /// through this wrapper would be a no-op anyway.
+    pub fn inner_mut(&mut self) -> &mut W {
+        self.inner
+    }
 }
 
 impl<W: Write> Write for AsciiEscapeWriter<'_, W> {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4102,6 +4102,28 @@ fn test_nul_output_colors_multidoc_separator_survives_1709() -> Result<()> {
     Ok(())
 }
 
+/// #1709 code review (4th round, live-verified): the `--colors` branch's
+/// separator write had no empty-buffer guard the way the non-color
+/// `NulChecked` path does, so a zero-result middle document (whose
+/// structural `produces_output()` is false, no NUL involved anywhere)
+/// still got an unwanted `---` written around it, producing a stray
+/// separator pair with nothing between them -- a structural corruption of
+/// the multi-document boundary the non-color `-0` path never had.
+#[test]
+fn test_nul_output_colors_no_stray_separator_around_empty_document_1709() -> Result<()> {
+    let input = "a: 1\n---\na: 2\n---\na: 3\n";
+    let (output, code) = run_yq_stdin("select(.a != 2)", input, &["-0", "--colors"])?;
+    assert_eq!(code, 0);
+    // Exactly one `---`, between the two surviving documents -- not two,
+    // and none around the empty middle one.
+    assert_eq!(output.matches("---").count(), 1, "got: {output:?}");
+    assert_eq!(
+        output,
+        "\u{1b}[36ma\u{1b}[0m: 1\0\u{1b}[0m\n---\n\u{1b}[36ma\u{1b}[0m: 3\0"
+    );
+    Ok(())
+}
+
 /// #1709 code review: the identity (P9) path's leftover-buffer flush was
 /// gated on the render having fully succeeded, so a mid-document decode
 /// failure discarded whatever valid content had already rendered into the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4128,6 +4128,38 @@ fn test_nul_output_identity_keeps_prefix_on_decode_failure_1709() -> Result<()> 
     Ok(())
 }
 
+/// #1709 code review (independently caught by two separate finders): the
+/// `split_doc` builtin's own separator writer, `SplitDocState::
+/// write_separator`, was never updated to defer past `output_value`'s NUL
+/// check the way every *other* document-separator writer in this file was
+/// -- reachable via a plain `split_doc` in the filter itself, not just
+/// `--split-exp`, so this isn't a rare edge branch.
+#[test]
+fn test_nul_output_split_doc_no_separator_leak_on_later_result_failure_1709() -> Result<()> {
+    let input = "- ok1\n- \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".[] | split_doc", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "ok1\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709 counterpart: the separator DOES still appear once an earlier
+/// `split_doc` result already flushed clean.
+#[test]
+fn test_nul_output_split_doc_separator_kept_when_earlier_result_succeeds_1709() -> Result<()> {
+    let input = "- ok1\n- ok2\n- \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".[] | split_doc", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert!(
+        output.contains("---"),
+        "expected the split_doc separator between the two surviving results, got: {output:?}"
+    );
+    assert_eq!(output, "ok1\0\n---\nok2\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
 /// Same fix, `--inplace` (#1701).
 #[test]
 fn test_nul_output_inplace_1701() -> Result<()> {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4044,6 +4044,90 @@ fn test_nul_output_unaffected_when_no_nul_present_1709() -> Result<()> {
     Ok(())
 }
 
+/// #1709 code review: the standard (non-M2, non-`--eval-all`) multi-file
+/// DOM loop wrote its `---` document separator eagerly, before the
+/// document's own first result ever reached `output_value`'s NUL check --
+/// same bug class the M2 streaming path's `PendingSeparator` was built to
+/// close, just unfixed on this loop. `.a + ""` forces the DOM path (same
+/// technique `test_nul_output_multidoc_dom_path_does_not_corrupt_1701`
+/// above uses, adapted to string concatenation since one document's value
+/// here is itself a string); doc2's own (only) result fails the check, so
+/// its `---` must not appear either.
+#[test]
+fn test_nul_output_dom_path_no_separator_leak_on_later_doc_failure_1709() -> Result<()> {
+    let input = "a: \"first\"\n---\na: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".a + \"\"", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "first\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// Same fix, `--eval-all` -- deferred separately from the standard loop
+/// above (own call site, own `results.len() > 1 && i > 0` condition).
+/// `--eval-all` combines every document into one array context, so `.[]`
+/// yields each *whole document* as its own result (`a: 1`, not `1`).
+#[test]
+fn test_nul_output_eval_all_no_separator_leak_on_later_doc_failure_1709() -> Result<()> {
+    let input = "a: 1\n---\nb: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".[]", input, &["--eval-all", "-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "a: 1\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709 code review: `stream_maybe_colored`'s `use_color` (`--colors`)
+/// branch read `separator.is_some()` to gate its own NUL scan but never
+/// consulted `DocSeparatorArgs` to actually *write* the `---` marker,
+/// silently dropping every document separator whenever `--colors` and
+/// `-0` were combined -- regardless of whether the NUL check passed.
+#[test]
+fn test_nul_output_colors_multidoc_separator_survives_1709() -> Result<()> {
+    let input = "a: 1\n---\nb: 2\n";
+    let (output, code) = run_yq_stdin(".", input, &["-0", "--colors"])?;
+    assert_eq!(code, 0);
+    assert!(
+        output.contains("---"),
+        "expected the document separator to survive --colors + -0, got: {output:?}"
+    );
+    // Byte-exact: ANSI-colorized "a: 1" (with its own trailing reset),
+    // NUL terminator, newline-guarded `---`, colorized "b: 2" (own
+    // trailing reset), NUL terminator (#1701's own established divergence
+    // for the newline-before-`---` fix, unaffected by this PR).
+    assert_eq!(
+        output,
+        "\u{1b}[36ma\u{1b}[0m: 1\u{1b}[0m\0\n---\n\u{1b}[36mb\u{1b}[0m: 2\u{1b}[0m\0"
+    );
+    Ok(())
+}
+
+/// #1709 code review: the identity (P9) path's leftover-buffer flush was
+/// gated on the render having fully succeeded, so a mid-document decode
+/// failure discarded whatever valid content had already rendered into the
+/// buffer before it -- violating this file's own established keep-the-
+/// prefix-and-diagnose trade (#1641/#1679), which the exact same query
+/// without `-0` still honors. One YAML document with two fields, the
+/// second undecodable -- no `-0` terminator appears anywhere here, `-0`
+/// or not: the whole document is a single identity-mode stream cut short
+/// mid-way, never reaching its own (would-be single, trailing) terminator
+/// write either way.
+#[test]
+fn test_nul_output_identity_keeps_prefix_on_decode_failure_1709() -> Result<()> {
+    let input = "a: 1\nb: \"\\x\"\n";
+
+    let (output, _, code) = run_yq_stdin_with_stderr(".", input, &[])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "a: 1\nb: ");
+
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "a: 1\nb: ");
+    assert!(stderr.contains("invalid escape"), "got: {stderr}");
+
+    Ok(())
+}
+
 /// Same fix, `--inplace` (#1701).
 #[test]
 fn test_nul_output_inplace_1701() -> Result<()> {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -3905,6 +3905,145 @@ fn test_nul_output_evaluated_1701() -> Result<()> {
     Ok(())
 }
 
+/// #1709: `-0`/`--nul-output` performed no content validation at all --
+/// real yq refuses to emit a result whose rendered bytes contain a raw NUL
+/// byte (ambiguous against the very separator `-0` exists to use), but
+/// succinctly silently emitted it. `\0` inside the YAML double-quoted
+/// scalar below is YAML's own escape spelling (two literal source
+/// characters, not a raw byte -- a raw NUL byte in YAML source is rejected
+/// by the parser itself, regardless of quoting, confirmed live against the
+/// pinned oracle), matching the M2 evaluated (`.a`) fast path.
+#[test]
+fn test_nul_output_rejects_embedded_nul_1709() -> Result<()> {
+    let input = "a: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".a", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(
+        stderr.contains("NUL"),
+        "expected a NUL-content diagnostic, got: {stderr}"
+    );
+    Ok(())
+}
+
+/// Same check, identity (P9) fast path -- a separate code path from the
+/// evaluated one above (`is_identity` in `stream_cursor!`).
+#[test]
+fn test_nul_output_rejects_embedded_nul_identity_1709() -> Result<()> {
+    let input = "\"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709: real yq's own flush-then-error atomicity, not check-then-flush --
+/// live-verified against the pinned oracle. Earlier valid results in a
+/// stream are still flushed with their real terminator; the offending
+/// result and everything after it are not, and the whole run fails. This
+/// is the correctness property a prior, closed attempt at this issue (PR
+/// #1767) got wrong by buffering the *entire* stream before writing
+/// anything, discarding already-good output on a later failure.
+#[test]
+fn test_nul_output_flushes_earlier_results_then_stops_1709() -> Result<()> {
+    let input = "- 1\n- 2\n- \"x\\0y\"\n- 4\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".[]", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "1\u{0}2\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709: the `---` document separator has to be decided at the same
+/// per-result granularity as the NUL check itself, not eagerly before the
+/// body renders -- live-verified against the pinned oracle that real yq
+/// does NOT write a document's `---` when that document's first (here,
+/// only) result fails the NUL check, even though the document would
+/// otherwise structurally produce output.
+#[test]
+fn test_nul_output_no_separator_when_first_result_fails_1709() -> Result<()> {
+    let input = "a: \"first\"\n---\na: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".a", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "first\0");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709 counterpart: the separator DOES still appear once at least one
+/// earlier result in the *same* document has already flushed clean --
+/// live-verified against the pinned oracle (a document whose first result
+/// succeeds keeps its `---`, even though a later result in it then fails).
+#[test]
+fn test_nul_output_separator_kept_when_earlier_result_in_doc_succeeds_1709() -> Result<()> {
+    let input = "b:\n  - ignored\n---\nb:\n  - 1\n  - \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".b[]?", input, &["-0"])?;
+    assert_eq!(code, 1);
+    // Own newline-before-`---` divergence (#1701/ADR-0018 carve-out) is
+    // orthogonal to what this test pins -- only that the separator survives.
+    assert!(
+        output.contains("---"),
+        "expected the second document's separator to survive, got: {output:?}"
+    );
+    assert!(output.starts_with("ignored\0"));
+    assert!(output.ends_with("---\n1\0"), "got: {output:?}");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709: the DOM path (`output_value`) needs the identical check --
+/// `.a + 0` is not M2-eligible (arithmetic forces the DOM path, same
+/// technique #1701's own `test_nul_output_multidoc_dom_path_does_not_
+/// corrupt_1701` uses above).
+#[test]
+fn test_nul_output_rejects_embedded_nul_dom_path_1709() -> Result<()> {
+    let input = "a: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".a + \"\"", input, &["-0"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709: `-P` also forces the DOM path.
+#[test]
+fn test_nul_output_rejects_embedded_nul_pretty_print_1709() -> Result<()> {
+    let input = "a: \"x\\0y\"\n";
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".a", input, &["-0", "-P"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// #1709: `--null-input` (`-n`) always takes the DOM path (nothing to
+/// stream from).
+#[test]
+fn test_nul_output_rejects_embedded_nul_null_input_1709() -> Result<()> {
+    let (output, stderr, code) =
+        run_yq_stdin_with_stderr("\"x\" + \"\\u0000\" + \"y\"", "", &["-0", "-n"])?;
+    assert_eq!(code, 1);
+    assert_eq!(output, "");
+    assert!(stderr.contains("NUL"), "got: {stderr}");
+    Ok(())
+}
+
+/// Regression guard: ordinary `-0` output with no embedded NUL anywhere is
+/// completely unaffected by #1709's check, on both the M2 and DOM paths.
+#[test]
+fn test_nul_output_unaffected_when_no_nul_present_1709() -> Result<()> {
+    let (output, code) = run_yq_stdin(".a", "a: 1\n", &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\0");
+
+    let (output, code) = run_yq_stdin(".a + 0", "a: 1\n", &["-0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\0");
+
+    Ok(())
+}
+
 /// Same fix, `--inplace` (#1701).
 #[test]
 fn test_nul_output_inplace_1701() -> Result<()> {


### PR DESCRIPTION
## Summary

Real yq refuses to emit a `-0`/`--nul-output` result whose rendered bytes contain a raw NUL
character (ambiguous against the very separator `-0` exists to use); succinctly silently
emitted it. Fixes #1709.

A prior attempt at this issue (PR #1767, closed without merging) buffered the *entire*
rendered stream to check it — regressing peak memory +65% on a 100MB document and
discarding already-good output on a later failure. This PR implements the design worked
out in #1709's own post-mortem comments instead: the check is a pure byte-level scan
("does this result's rendered buffer contain a raw NUL"), with no separate "is this scalar
being unwrapped" predicate to derive.

## Design

**M2 streaming path** (`src/bin/succinctly/yq_runner.rs`):
- New `ColorSink::NulChecked` variant + `NulCheckedSink`, used instead of `Direct` when
  `-0` is active and `--color` isn't. Buffers ONE streamed result at a time — not the
  whole document/stream — matching this crate's M2 streaming memory guarantee.
  Live-verified against the pinned oracle (Homebrew yq v4.53.3) that per-result is also
  the *correct* granularity, not just the cheap one: earlier results in a stream flush
  with their real terminator even when a later one fails
  (`1,2,("a"+NUL+"b"),4` under `-0` prints `1\0002\000` then errors, producing nothing
  for the third result and never reaching the fourth).
- The YAML `---` document separator is decided lazily, at the same per-result granularity
  as the NUL check, instead of eagerly before the body renders. Live-verified that real
  yq does NOT write a document's separator when that document's first result fails the
  check, but DOES keep it once an earlier result in the same document already flushed
  clean.
- `--color`'s existing whole-buffer path gets a same-shape check before its final write,
  scoped to YAML call sites only: JSON's own `on_value` embeds the raw terminator
  character directly into its color buffer (unlike YAML's boundary-based one), so scanning
  that buffer would false-positive on the terminator's own NUL byte, not a value that
  actually contains one.

**DOM path** (`output_value`): checks its already-fully-materialized rendered string
before writing — no new buffering, since the value is never streamed there in the first
place. Covers `-n`, `-P`, `--arg`, assignment operators, `--raw-input`, `--slurp`,
`--eval-all`, `--front-matter`, `--inplace`, and any query shape that falls back to DOM
(e.g. `as $x | ...`, arithmetic).

## Deliberately out of scope, filed separately

- **#1996**: `-o=json -0 '.a'` without an explicit `-r` incorrectly unwraps (`raw_output`
  is unconditionally ORed with `nul_output`/`join_output`, wrong for JSON's own default —
  real yq needs `-r` explicit to unwrap a JSON scalar, only YAML defaults to unwrap). A
  pre-existing, independent bug that this fix's new check makes more visible (turns
  silent corruption into a loud error for that one flag combination) but did not
  introduce — confirmed byte-identical on unmodified `main` before this PR.
- **#1973** (already filed from #789's own review): `LazySeq<V>`'s size is ultimately
  driven by `DistinctKeyCursors` — unrelated to this PR, just noting it's still open.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast` — 56/56 binaries, 6636 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings)
- [x] 9 new CLI tests in `tests/yq_cli_tests.rs`, each independently verified to fail
      without the fix (single-result rejection, multi-result flush-then-stop, separator
      laziness both directions, DOM path via `-n`/`-P`/arithmetic-forced-DOM, regression
      guard for unaffected normal output)
- [x] Live-verified against the pinned oracle (Homebrew yq v4.53.3) across the full flag
      matrix from #1709's own post-mortem comments, plus the multi-result/separator edge
      cases — byte-identical except for the pre-existing, intentionally-diverged #1701
      newline-before-`---` fix (ADR-0018 carve-out, unrelated to this change)
- [x] `--ascii-output` + `-0` combination verified byte-identical to unmodified `main`
      (no regression from the `AsciiEscapeWriter` dispatch fixup needed after rebasing
      onto #1700)

Fixes #1709