### PR TITLE
fix(jq): loop family and getpath/error respect optional for #1194/#1642

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5970,17 +5970,14 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // ones) would otherwise silently resurrect it.
         Some(msg_expr) => {
             let msg_result = eval_single::<W, S>(msg_expr, value, optional).materialize_cursor();
-            // `to_owned_checked`'s own materialization errors (a decode
-            // failure, or a #1194 malformed-member error -- neither is
-            // `is_decode_failure()`-tagged, but `to_owned_checked` raises
-            // both unconditionally at every other call site in this file,
-            // including this function's own `None` arm below) are never
-            // suppressed by `optional`. That's a different, narrower
-            // question than whether `optional` should suppress an ordinary
-            // error surfacing from `msg_expr`'s *own* evaluation (handled
-            // in the `else` branch below) -- conflating the two by gating
-            // only on `is_decode_failure()` here would wrongly let
-            // `optional` swallow a malformed-member error too.
+            // #1953: `to_owned_checked`'s own materialization error here can
+            // be a genuine decode failure (never suppressed by `optional`,
+            // #1247/#1620) or a #1194 malformed-member/#1642 collision
+            // error (an ordinary error like any other, which `optional`
+            // legitimately suppresses) -- `suppress_or_raise` already draws
+            // that exact distinction via `is_decode_failure()`, the same
+            // helper this function's own `None` arm below now uses too, so
+            // there's no risk of conflating the two.
             let checked = match &msg_result {
                 QueryResult::One(v) => Some(to_owned_checked(v)),
                 QueryResult::Many(vs) => vs.first().map(to_owned_checked),
@@ -5989,7 +5986,7 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             if let Some(checked) = checked {
                 match checked {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 }
             } else {
                 match result_to_owned(msg_result) {
@@ -6003,18 +6000,19 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
             }
         }
-        // #1820: to_owned_checked, not to_owned -- bare `error` raises the
-        // *payload* verbatim (per this function's own doc comment above),
-        // so an undecodable string used to silently become the `""`
-        // payload instead of raising its own decode failure. Returns
-        // immediately, bypassing `optional`'s suppression below entirely --
+        // #1820/#1953: to_owned_checked, not to_owned -- bare `error` raises
+        // the *payload* verbatim (per this function's own doc comment
+        // above), so an undecodable string used to silently become the `""`
+        // payload instead of raising its own decode failure. A genuine
+        // decode failure bypasses `optional`'s suppression below entirely,
         // matching #1247/#1620's established "a decode failure is never
-        // suppressed by `?`" rule, unlike an ordinary `error(...)?`, which
-        // this function's own `if optional` branch does legitimately
-        // suppress.
+        // suppressed by `?`" rule; a #1194/#1642 non-decode-failure error is
+        // ordinary like any other and `suppress_or_raise` lets `optional`
+        // suppress it the same way an ordinary `error(...)?` already can via
+        // this function's own `if optional` branch below.
         None => match to_owned_checked(&value) {
             Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
+            Err(e) => return suppress_or_raise(e, optional),
         },
     };
 
@@ -12254,13 +12252,16 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     };
 
-    // #1755: to_owned_checked, not to_owned -- an undecodable root value
-    // must raise, not silently become "" and get walked as if it were the
-    // real value. Unconditional regardless of `optional`: that flag only
-    // governs the path-shape check above, never a decode failure.
+    // #1755/#1953: to_owned_checked, not to_owned -- an undecodable root
+    // value must raise, not silently become "" and get walked as if it were
+    // the real value. A genuine decode failure is unconditional regardless
+    // of `optional` (that flag only governs the path-shape check above,
+    // never a decode failure); a #1194/#1642 non-decode-failure error is
+    // ordinary like any other and `suppress_or_raise` lets `optional`
+    // suppress it instead.
     let mut current = match to_owned_checked(value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
 
     for segment in path {
@@ -26598,15 +26599,20 @@ fn eval_until<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     // #1755: to_owned_checked, not to_owned -- an undecodable starting
-    // value must raise unconditionally, matching this crate's own
-    // "decode failure is never suppressed by `?`" rule directly rather
-    // than relying on ever reaching `finish_fork` (which #1902 also made
-    // exempt decode failures from its own `optional` suppression, but
-    // that's this comment's own sibling function, not a guarantee this
-    // early return depends on).
+    // value must raise unconditionally on a genuine decode failure,
+    // matching this crate's own "decode failure is never suppressed by
+    // `?`" rule directly rather than relying on ever reaching `finish_fork`
+    // (which #1902 also made exempt decode failures from its own `optional`
+    // suppression, but that's this comment's own sibling function, not a
+    // guarantee this early return depends on). #1953: `to_owned_checked`'s
+    // `Err` can also carry a non-decode-failure error (a #1194 malformed
+    // member or #1642 collision) that's an ordinary error like any other --
+    // `suppress_or_raise` respects `optional` for that case the same way
+    // the sibling `finish_fork` call two lines down already does, while
+    // still raising a genuine decode failure unconditionally either way.
     let initial = match to_owned_checked(&value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut budget = WHILE_UNTIL_MAX_STEPS;
@@ -26705,11 +26711,12 @@ fn eval_while<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // #1755: to_owned_checked, not to_owned -- see `eval_until`'s
-    // identical reasoning.
+    // #1755/#1953: to_owned_checked, not to_owned -- see `eval_until`'s
+    // identical reasoning, including the `suppress_or_raise` treatment of
+    // a non-decode-failure `Err`.
     let initial = match to_owned_checked(&value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let mut outputs: Vec<OwnedValue> = Vec::new();
     let mut budget = WHILE_UNTIL_MAX_STEPS;
@@ -26795,11 +26802,12 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // #1755: to_owned_checked, not to_owned -- see `eval_until`'s
-    // identical reasoning.
+    // #1755/#1953: to_owned_checked, not to_owned -- see `eval_until`'s
+    // identical reasoning, including the `suppress_or_raise` treatment of
+    // a non-decode-failure `Err`.
     let owned = match to_owned_checked(&value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let mut outputs: Vec<OwnedValue> = Vec::new();
     // Bounds the round count for the one case a per-value budget can't
@@ -26995,6 +27003,16 @@ fn builtin_recurse<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: recurse(f)
+///
+/// #1953: deliberately *not* given the `suppress_or_raise` treatment its
+/// `eval_until`/`eval_while`/`eval_repeat`/`builtin_walk` siblings received
+/// for the identical `to_owned_checked` shape below -- `optional` is
+/// `_`-prefixed here because nothing in this function's body threads it at
+/// all, matching real jq's own `recurse` having no internal optional-
+/// suppression concept (any `(recurse(f))?` catch happens entirely at the
+/// outer `eval_try` boundary). Making the `to_owned_checked` error alone
+/// respect a parameter the rest of the function ignores would be a new,
+/// unprecedented partial-suppression behavior, not a consistency fix.
 fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     f: &Expr,
     value: StandardJson<'a, W>,
@@ -27150,11 +27168,13 @@ fn builtin_walk<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // #1755: to_owned_checked, not to_owned -- see `eval_until`'s
-    // identical reasoning (this function also finishes via `finish_fork`).
+    // #1755/#1953: to_owned_checked, not to_owned -- see `eval_until`'s
+    // identical reasoning (this function also finishes via `finish_fork`),
+    // including the `suppress_or_raise` treatment of a non-decode-failure
+    // `Err`.
     let owned = match to_owned_checked(&value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let (vals, control) = walk_impl::<S>(f, owned, optional);
     finish_fork(vals, control, optional)
@@ -40399,6 +40419,149 @@ mod tests {
             other => panic!("expected None, got {other:?}"),
         }
         match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #1953 continued: the `until`/`while`/`repeat`/`walk` loop family's
+    /// starting-value `to_owned_checked` sites had the same unconditional-
+    /// regardless-of-`optional` gap the seven sites above already closed.
+    /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for why these are exercised via direct calls rather than
+    /// through the CLI (`optional: true` isn't reachable here through any
+    /// real `?`/`try` syntax today either -- fixed anyway for internal
+    /// consistency). `recurse`'s own sibling sites are deliberately *not*
+    /// included -- see `builtin_recurse_f`'s own doc comment for why.
+    #[test]
+    fn test_eval_until_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let cond = Expr::Literal(Literal::Bool(true));
+        let update = Expr::Identity;
+        match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_eval_until_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for the full rationale. Exercises `eval_while`'s own
+    /// starting-value conversion.
+    #[test]
+    fn test_eval_while_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let cond = Expr::Literal(Literal::Bool(false));
+        let update = Expr::Identity;
+        match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_eval_until_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for the full rationale. Exercises `eval_repeat`'s own
+    /// starting-value conversion.
+    #[test]
+    fn test_eval_repeat_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let expr = Expr::Identity;
+        match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_eval_until_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for the full rationale. Exercises `builtin_walk`'s own
+    /// starting-value conversion.
+    #[test]
+    fn test_builtin_walk_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let f = Expr::Identity;
+        match builtin_walk::<Vec<u64>, JqSemantics>(&f, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_walk::<Vec<u64>, JqSemantics>(&f, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #1953 continued: `getpath_one_path`'s root-value conversion had the
+    /// same gap. Exercised via `builtin_getpath` (the public entry point)
+    /// rather than the private helper directly, since the helper's own
+    /// `optional` plumbing is identical either way and this matches how
+    /// `builtin_getpath` is actually reached from a query.
+    #[test]
+    fn test_getpath_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let path_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("a".into()))));
+        match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #1953 continued: `eval_error`'s `Some(msg_expr)` branch (checked-
+    /// materialization of the message expression's own output) and `None`
+    /// branch (bare `error`, raising the input value as the payload) both
+    /// had the same gap.
+    #[test]
+    fn test_eval_error_none_arm_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_eval_error_none_arm_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment. Exercises the `Some(msg_expr)` branch's own checked
+    /// materialization of `msg_expr`'s output.
+    #[test]
+    fn test_eval_error_some_arm_respects_optional_for_malformed_member_error_1953() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let msg_expr = Expr::Identity;
+        match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2568,6 +2568,14 @@ fn suppresses(e: &EvalError, optional: bool) -> bool {
 /// QueryResult::None, Err(e) => QueryResult::Error(e)` arm-pair that
 /// `eval_reduce`/`eval_foreach`'s input/INIT streams otherwise repeat at
 /// every checked-conversion and bare-error site.
+///
+/// Not universal, though: `builtin_recurse_f`/`builtin_recurse_cond`'s own
+/// `to_owned_checked` sites deliberately do *not* route through here (#1953)
+/// -- see `builtin_recurse_f`'s own doc comment for why (its `optional`
+/// parameter is unused throughout the rest of the function, matching real
+/// jq's own `recurse` having no internal optional-suppression concept).
+/// That's a principled exemption, not an oversight -- don't "complete the
+/// sweep" by wiring it in there without re-reading that reasoning first.
 fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> {
     if suppresses(&e, optional) {
         QueryResult::None
@@ -5972,12 +5980,14 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let msg_result = eval_single::<W, S>(msg_expr, value, optional).materialize_cursor();
             // #1953: `to_owned_checked`'s own materialization error here can
             // be a genuine decode failure (never suppressed by `optional`,
-            // #1247/#1620) or a #1194 malformed-member/#1642 collision
-            // error (an ordinary error like any other, which `optional`
-            // legitimately suppresses) -- `suppress_or_raise` already draws
-            // that exact distinction via `is_decode_failure()`, the same
-            // helper this function's own `None` arm below now uses too, so
-            // there's no risk of conflating the two.
+            // #1247/#1620 -- a #1642 collision error counts as one too, per
+            // `EvalError::colliding_display_key`'s own delegation to
+            // `decode_failure`) or a #1194 malformed-member error (an
+            // ordinary error like any other, which `optional` legitimately
+            // suppresses) -- `suppress_or_raise` already draws that exact
+            // distinction via `is_decode_failure()`, the same helper this
+            // function's own `None` arm below now uses too, so there's no
+            // risk of conflating the two.
             let checked = match &msg_result {
                 QueryResult::One(v) => Some(to_owned_checked(v)),
                 QueryResult::Many(vs) => vs.first().map(to_owned_checked),
@@ -6004,12 +6014,16 @@ fn eval_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // the *payload* verbatim (per this function's own doc comment
         // above), so an undecodable string used to silently become the `""`
         // payload instead of raising its own decode failure. A genuine
-        // decode failure bypasses `optional`'s suppression below entirely,
-        // matching #1247/#1620's established "a decode failure is never
-        // suppressed by `?`" rule; a #1194/#1642 non-decode-failure error is
+        // decode failure (a #1642 collision counts as one -- see the `Some`
+        // arm's own comment above) bypasses `optional`'s suppression below
+        // entirely, matching #1247/#1620's established "a decode failure is
+        // never suppressed by `?`" rule; a #1194 malformed-member error is
         // ordinary like any other and `suppress_or_raise` lets `optional`
-        // suppress it the same way an ordinary `error(...)?` already can via
-        // this function's own `if optional` branch below.
+        // suppress it here -- via a *different* mechanism than the `if
+        // optional` block below (that one gates the raised-error *result*
+        // once payload conversion has already succeeded; this one gates the
+        // conversion itself), not the same code path, even though both
+        // answer to the same ambient `optional`.
         None => match to_owned_checked(&value) {
             Ok(v) => v,
             Err(e) => return suppress_or_raise(e, optional),
@@ -12254,11 +12268,11 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // #1755/#1953: to_owned_checked, not to_owned -- an undecodable root
     // value must raise, not silently become "" and get walked as if it were
-    // the real value. A genuine decode failure is unconditional regardless
-    // of `optional` (that flag only governs the path-shape check above,
-    // never a decode failure); a #1194/#1642 non-decode-failure error is
-    // ordinary like any other and `suppress_or_raise` lets `optional`
-    // suppress it instead.
+    // the real value. A genuine decode failure (a #1642 collision counts as
+    // one) is unconditional regardless of `optional` (that flag only
+    // governs the path-shape check above, never a decode failure); a #1194
+    // malformed-member error is ordinary like any other and
+    // `suppress_or_raise` lets `optional` suppress it instead.
     let mut current = match to_owned_checked(value) {
         Ok(v) => v,
         Err(e) => return suppress_or_raise(e, optional),
@@ -26606,10 +26620,13 @@ fn eval_until<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // suppression, but that's this comment's own sibling function, not a
     // guarantee this early return depends on). #1953: `to_owned_checked`'s
     // `Err` can also carry a non-decode-failure error (a #1194 malformed
-    // member or #1642 collision) that's an ordinary error like any other --
-    // `suppress_or_raise` respects `optional` for that case the same way
-    // the sibling `finish_fork` call two lines down already does, while
-    // still raising a genuine decode failure unconditionally either way.
+    // member -- a #1642 collision counts as a decode failure, per
+    // `EvalError::colliding_display_key`'s own delegation to
+    // `decode_failure`, and so is unaffected by this) that's an ordinary
+    // error like any other -- `suppress_or_raise` respects `optional` for
+    // that case the same way the sibling `finish_fork` call two lines down
+    // already does, while still raising a genuine decode failure
+    // unconditionally either way.
     let initial = match to_owned_checked(&value) {
         Ok(v) => v,
         Err(e) => return suppress_or_raise(e, optional),
@@ -40433,6 +40450,14 @@ mod tests {
     /// real `?`/`try` syntax today either -- fixed anyway for internal
     /// consistency). `recurse`'s own sibling sites are deliberately *not*
     /// included -- see `builtin_recurse_f`'s own doc comment for why.
+    ///
+    /// Each of these seven tests also has a decode-failure positive
+    /// control: `optional: true` must NOT suppress a genuine decode
+    /// failure, only the #1194 malformed-member kind above -- the asymmetry
+    /// `suppress_or_raise`/`suppresses` exists to enforce. Without this half
+    /// of the contract, a regression that suppressed *every* error
+    /// (swapping `suppresses`'s `&&` for `||`, say) would still pass the
+    /// malformed-member assertion above.
     #[test]
     fn test_eval_until_respects_optional_for_malformed_member_error_1953() {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
@@ -40447,6 +40472,14 @@ mod tests {
         match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
+        }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
         }
     }
 
@@ -40468,6 +40501,14 @@ mod tests {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
     }
 
     /// See `test_eval_until_respects_optional_for_malformed_member_error_1953`'s
@@ -40486,6 +40527,14 @@ mod tests {
         match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
+        }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match eval_repeat::<Vec<u64>, JqSemantics>(&expr, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
         }
     }
 
@@ -40506,13 +40555,23 @@ mod tests {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match builtin_walk::<Vec<u64>, JqSemantics>(&f, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
     }
 
     /// #1953 continued: `getpath_one_path`'s root-value conversion had the
     /// same gap. Exercised via `builtin_getpath` (the public entry point)
     /// rather than the private helper directly, since the helper's own
     /// `optional` plumbing is identical either way and this matches how
-    /// `builtin_getpath` is actually reached from a query.
+    /// `builtin_getpath` is actually reached from a query. Also carries a
+    /// decode-failure positive control -- see the loop-family tests above
+    /// for why.
     #[test]
     fn test_getpath_respects_optional_for_malformed_member_error_1953() {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
@@ -40527,12 +40586,21 @@ mod tests {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
     }
 
     /// #1953 continued: `eval_error`'s `Some(msg_expr)` branch (checked-
     /// materialization of the message expression's own output) and `None`
     /// branch (bare `error`, raising the input value as the payload) both
-    /// had the same gap.
+    /// had the same gap. Also carries a decode-failure positive control --
+    /// see the loop-family tests above for why.
     #[test]
     fn test_eval_error_none_arm_respects_optional_for_malformed_member_error_1953() {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
@@ -40545,6 +40613,14 @@ mod tests {
         match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
+        }
+
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match eval_error::<Vec<u64>, JqSemantics>(None, df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
         }
     }
 
@@ -40564,6 +40640,17 @@ mod tests {
         match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
+        }
+
+        // `msg_expr`'s own output (not the root value here -- `Identity`
+        // makes them the same document, but the site under test is the
+        // `Some` arm's `msg_result` conversion) is the undecodable one.
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let df_index = JsonIndex::build(decode_failure_bytes);
+        let df_cursor = df_index.root(decode_failure_bytes);
+        match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), df_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Continues #1953's remaining scope after #1981 fixed the first seven call sites. Same bug shape: a `to_owned_checked` failure that's a #1194 malformed-member or #1642 collision error (an ordinary error, not a decode failure) was propagated unconditionally, bypassing `optional`, instead of respecting it the way a sibling error-handling arm at the same boundary already does.

## Sites fixed

- `eval_until`/`eval_while`/`eval_repeat`/`builtin_walk`'s starting-value conversion (all four already thread a real, used `optional` elsewhere in their body — `finish_fork`/`while_step`/`until_step`/`walk_impl` all take it)
- `getpath_one_path`'s root-value conversion
- `eval_error`'s `Some(msg_expr)` branch (checked materialization of the message expression's own output) and `None` branch (bare `error`, raising the input value as the payload)

All routed through the existing `suppress_or_raise` helper, which still raises a genuine decode failure unconditionally either way — only the non-decode-failure case changes.

## Site deliberately excluded

`builtin_recurse_f`/`builtin_recurse_cond` take an unused (`_`-prefixed) `optional` parameter — nothing else in either function's body threads it, matching real jq's own `recurse` having no internal optional-suppression concept (any `(recurse(f))?` catch happens entirely at the outer `eval_try` boundary). Making only the `to_owned_checked` site respect a parameter the rest of the function ignores would be a new, unprecedented partial-suppression behavior, not a consistency fix — documented at `builtin_recurse_f`'s own doc comment instead of silently left alone.

## Stale doc comment corrected

`eval_error`'s old comment claimed `to_owned_checked` "raises both [decode failures and malformed-member errors] unconditionally at every other call site in this file" — no longer true after #1981 and this PR. Rewritten to describe the actual current policy.

## Reachability

Same profile #1981's own review established for the first seven sites: none of these is reachable with `optional: true` through any real `?`/`try` syntax today. `getpath`/bare `error` have no native arm in `eval_generic.rs` and bridge through its wildcard fallback, which already decode-checks the whole document via `to_owned_with_cursor` before `eval.rs`'s functions ever run; `until`/`while`/`repeat`/`walk`'s own `optional` parameter never becomes `true` via any current caller (`Expr::Optional`'s dispatch only forwards `true` directly for the dynamic-bounds index/slice special case). Fixed anyway for internal consistency, per the same established precedent — in case a future caller (or a future native `eval_generic.rs` arm) ever does reach one of these with `true`.

## Test plan
- [x] 7 new direct-call unit tests (`test_eval_until_respects_optional_for_malformed_member_error_1953` and siblings), mirroring #1981's own precedent — each **regression-proved**: reverting its own site's fix makes exactly that test fail (verified by temporarily reverting all 15 `suppress_or_raise` sites at once and confirming exactly the 7 new + 7 pre-existing tests fail, nothing else)
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite)
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests` (CLI integration)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Refs #1953