### PR TITLE
fix(yq): use real yq's own wording for any/all/flatten/group_by/unique/unique_by/from_entries

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1198,6 +1198,56 @@ through `--arg`/`-P` still silently drops one entry rather than raising. Tracked
 in the `load()` builtin's own separate YAML-mapping conversion, which has no collision
 guard at all.
 
+### `any`/`all`/`flatten`/`group_by`/`unique`/`unique_by`/`from_entries` on a non-array — resolved, real yq has its own wording per builtin, not jq's "Cannot iterate" template
+
+Found during code review of [#1494](https://github.com/rust-works/succinctly/issues/1494)/PR
+#1900 (the `cannot_iterate_with` `EvalTag` threading fix): that PR correctly threads the real
+evaluation mode through to `cannot_iterate_with`'s value-preview formatting, but real yq
+doesn't use this jq-pinned "Cannot iterate over `<type>` (`<value>`)" *template* at all for
+these seven builtins — it has its own, unrelated, per-builtin wording with no value preview,
+confirmed live against pinned Homebrew yq v4.53.3:
+
+```console
+$ printf 'null\n' | yq '5 | any'                          # any only supports arrays, was !!int
+$ printf 'null\n' | yq '5 | all'                          # all only supports arrays, was !!int
+$ printf 'null\n' | yq '5 | flatten'                      # only arrays are supported for flatten
+$ printf 'null\n' | yq '5 | group_by(.)'                  # only arrays are supported for group by
+$ printf 'null\n' | yq '5 | unique'                       # only arrays are supported for unique
+$ printf 'null\n' | yq '5 | unique_by(.)'                 # only arrays are supported for unique (not "unique by")
+$ printf 'null\n' | yq '5 | from_entries'                 # from entries only runs against arrays
+```
+
+[#1901](https://github.com/rust-works/succinctly/issues/1901) also found real yq rejects an
+**object** input the same as a scalar for all seven — a second axis jq disagrees with it on:
+jq's own semantics let `any`/`all`/`flatten` succeed on an object (iterating its
+values/entries) and give `group_by`/`unique`/`unique_by` a different, jq-specific "object and
+array cannot be sorted" pairing error (`{"a":3,"b":1} | group_by(.)` — a quirk of jq's own
+`map([f])`-based definition) — none of that carries over to yq mode, where every one of these
+seven raises the identical wording for an object as for a scalar. Fixed via
+`EvalError::yq_only_supports_arrays`/`yq_only_arrays_supported_for`/
+`yq_from_entries_requires_array` (`src/jq/error.rs`), gated by `S::TAG == EvalTag::Yq` at each
+of the seven builtins' object and scalar arms in `src/jq/eval.rs` — jq mode's own
+`cannot_iterate_with`/`object_pair_type_error` paths are untouched.
+
+**Two related items found but not fixed here, needing materially different implementation
+shapes:**
+
+- **`sort`/`sort_by` on a non-array/map**: real yq's wording is `"node at path <path> is not
+  an array or map (it's a <tag>)"`, where `<path>` genuinely varies with navigation depth
+  (confirmed live: `[]` at the top level, `[a.b]` after `.a.b`, `[[2]]` after `.[2]`) — unlike
+  the seven builtins above, whose wording never names a path. `builtin_sort`/`builtin_sort_by`
+  receive only a bare value with no path context today, so this needs real path-tracking
+  plumbing threaded into these builtins, not just a wording swap.
+- **`.[]`'s own read-side behavior on a scalar**: real yq treats this as a **silent no-op**
+  (exit 0, no output) rather than an error at all (`5 | .[]` prints nothing on real yq).
+  succinctly raises `cannot_iterate_with` here in yq mode too, matching jq's own `.[]`
+  semantics (correct for jq mode, not yq's). Whether this shares one root cause with the seven
+  builtins above or needs its own fix is unresolved — bare `Expr::Iterate` has 20+ dispatch
+  arms across `eval.rs`'s value/path/assignment-mode evaluators, so scoping this properly
+  needs its own investigation.
+
+Both filed together as [#1998](https://github.com/rust-works/succinctly/issues/1998).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1248,6 +1248,21 @@ shapes:**
 
 Both filed together as [#1998](https://github.com/rust-works/succinctly/issues/1998).
 
+**Two more items found reviewing the fix itself, also not fixed here:**
+
+- **`any(cond)`/`all(cond)`/`any(gen; cond)`/`all(gen; cond)`** (the predicate-argument forms,
+  dispatched from `Builtin::AnyF`/`AllF`/`AnyCond`/`AllCond`) still leak jq's own wording and
+  still allow full object iteration, unlike the now-fixed bare forms — and real yq's own lexer
+  rejects this syntax entirely regardless of arity (`bad expression, please check expression
+  syntax`), which `succinctly yq`'s parser doesn't gate behind `--jq-extensions` the way
+  neighboring jq-only builtins like `min_by` do. Filed as
+  [#2005](https://github.com/rust-works/succinctly/issues/2005).
+- **`with_entries(f)` rejects numeric keys** that real yq coerces to strings on reassembly
+  (`[1,2] | with_entries(.)` succeeds on real yq, errors `Cannot use number (0) as object key`
+  on succinctly) — a functional bug on well-formed input, unrelated to this section's
+  malformed-input wording fix. Filed as
+  [#2006](https://github.com/rust-works/succinctly/issues/2006).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -781,8 +781,51 @@ impl EvalError {
     /// The jq-pinned shim this once forwarded from (#1055) is gone: #1494
     /// finished migrating every production call site to pass its own real
     /// `S::TAG` instead of a hardcoded `EvalTag::Jq`.
+    ///
+    /// jq-mode only, despite taking a `tag` parameter for the value-preview
+    /// convention (#1494/#1900): #1901 found real yq doesn't use this
+    /// template at all for `any`/`all`/`flatten`/`group_by`/`unique`/
+    /// `unique_by`/`from_entries` -- see [`Self::yq_only_supports_arrays`],
+    /// [`Self::yq_only_arrays_supported_for`], and
+    /// [`Self::yq_from_entries_requires_array`] for real yq's own wording,
+    /// confirmed live against v4.53.3.
     pub fn cannot_iterate_with(tag: EvalTag, value: &OwnedValue) -> Self {
         Self::new(format!("Cannot iterate over {}", describe_with(tag, value)))
+    }
+
+    /// `<builtin> only supports arrays, was <tag>` (#1901).
+    ///
+    /// Real yq's own wording for `any`/`all` on a non-array (object or
+    /// scalar) -- confirmed live against yq v4.53.3: `5 | any` is `"any only
+    /// supports arrays, was !!int"`, `{"a":1} | any` is `"any only supports
+    /// arrays, was !!map"`. Unlike jq (whose `any`/`all` iterate an object's
+    /// *values*), real yq rejects an object the same as a scalar -- so this
+    /// covers both, not just the scalar case `cannot_iterate_with` was
+    /// reached for.
+    pub fn yq_only_supports_arrays(builtin: &str, tag: &str) -> Self {
+        Self::new(format!("{builtin} only supports arrays, was {tag}"))
+    }
+
+    /// `only arrays are supported for <op>` (#1901).
+    ///
+    /// Real yq's own wording for `flatten`/`group_by`/`unique`/`unique_by`
+    /// on a non-array -- confirmed live against yq v4.53.3: `5 | flatten` is
+    /// `"only arrays are supported for flatten"`, `5 | group_by(.)` is
+    /// `"...for group by"`, and both `5 | unique` and `5 | unique_by(.)` are
+    /// `"...for unique"` (`unique_by` does **not** get its own `"unique
+    /// by"` wording -- confirmed live, not a typo here). No YAML tag in this
+    /// one, unlike [`Self::yq_only_supports_arrays`] -- real yq's own
+    /// message doesn't name the offending type for these four.
+    pub fn yq_only_arrays_supported_for(op: &str) -> Self {
+        Self::new(format!("only arrays are supported for {op}"))
+    }
+
+    /// `from entries only runs against arrays` (#1901).
+    ///
+    /// Real yq's own wording for `from_entries` on a non-array -- confirmed
+    /// live against yq v4.53.3, for both an object and a scalar input.
+    pub fn yq_from_entries_requires_array() -> Self {
+        Self::new("from entries only runs against arrays")
     }
 
     /// `strptime/1 requires string inputs and arguments` (#929).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7301,31 +7301,36 @@ fn any_all_over<'a, W: Clone + AsRef<[u64]> + 'a>(
 /// any is [.[] | .] with an early-exit truthiness check, and .[] over an
 /// object iterates its values, so jq accepts an object here as readily as
 /// an array (#422).
-fn builtin_any<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'_, W>,
+fn builtin_any<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'a, W>,
     optional: bool,
-) -> QueryResult<'_, W> {
+) -> QueryResult<'a, W> {
     let owned_bool = |r: Result<bool, EvalError>| {
         r.map_or_else(QueryResult::Error, |b| {
             QueryResult::Owned(OwnedValue::Bool(b))
         })
     };
+    // #1901: unlike jq (which iterates an object's *values*), real yq
+    // rejects an object the same as a scalar -- confirmed live: `{"a":1} |
+    // any` is `"any only supports arrays, was !!map"` in yq v4.53.3, not a
+    // successful iteration. One closure, called from both the object arm
+    // and the scalar arm below, rather than two copies of the same
+    // `scalar_fallback` call (#1901 review) -- also why this arm now comes
+    // *before* the pre-existing `_ if optional` wildcard: that ordering
+    // used to make this whole branch (and the decode-failure check inside
+    // `scalar_fallback`) unreachable whenever `optional` was `true` (#1901
+    // review, confirmed live via a direct library call).
+    let yq_reject_non_array = |value: &StandardJson<'a, W>| {
+        scalar_fallback(value, optional, || {
+            EvalError::yq_only_supports_arrays("any", yaml_type_tag(value))
+        })
+    };
     match value {
         StandardJson::Array(elements) => owned_bool(any_all_over(elements, true)),
-        // #1901: unlike jq (which iterates an object's *values*), real yq
-        // rejects an object the same as a scalar -- confirmed live:
-        // `{"a":1} | any` is `"any only supports arrays, was !!map"` in
-        // yq v4.53.3, not a successful iteration.
-        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            scalar_fallback(&value, optional, || {
-                EvalError::yq_only_supports_arrays("any", yaml_type_tag(&value))
-            })
-        }
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), true)),
+        _ if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         _ if optional => QueryResult::None,
-        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
-            EvalError::yq_only_supports_arrays("any", yaml_type_tag(&value))
-        }),
         _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
     }
 }
@@ -7333,28 +7338,29 @@ fn builtin_any<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Builtin: all
 ///
 /// Same shape as `any` — see #422.
-fn builtin_all<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'_, W>,
+fn builtin_all<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'a, W>,
     optional: bool,
-) -> QueryResult<'_, W> {
+) -> QueryResult<'a, W> {
     let owned_bool = |r: Result<bool, EvalError>| {
         r.map_or_else(QueryResult::Error, |b| {
             QueryResult::Owned(OwnedValue::Bool(b))
         })
     };
+    // #1901: same yq-only rejection as `any` above, including the same
+    // arm-ordering fix (this arm must precede `_ if optional`, not follow
+    // it -- see `builtin_any`'s identical comment).
+    let yq_reject_non_array = |value: &StandardJson<'a, W>| {
+        scalar_fallback(value, optional, || {
+            EvalError::yq_only_supports_arrays("all", yaml_type_tag(value))
+        })
+    };
     match value {
         StandardJson::Array(elements) => owned_bool(any_all_over(elements, false)),
-        // #1901: same yq-only rejection as `any` above.
-        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            scalar_fallback(&value, optional, || {
-                EvalError::yq_only_supports_arrays("all", yaml_type_tag(&value))
-            })
-        }
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), false)),
+        _ if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         _ if optional => QueryResult::None,
-        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
-            EvalError::yq_only_supports_arrays("all", yaml_type_tag(&value))
-        }),
         _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
     }
 }
@@ -8775,23 +8781,23 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'_, W> {
     // #1755: to_owned_checked, not to_owned -- an undecodable element must
     // raise, not silently flatten in as "".
+    //
+    // #1901: unlike jq (`flatten` is defined over `[.[]]`, and `.[]` on an
+    // object iterates its values, per this function's own doc comment
+    // above), real yq rejects an object the same as a scalar -- confirmed
+    // live: `{"a":1} | flatten` is `"only arrays are supported for
+    // flatten"` in yq v4.53.3. One zero-capture closure (`Copy`, so it can
+    // be passed to `scalar_fallback` at both call sites below) rather than
+    // two copies of the same error literal (#1901 review).
+    let yq_reject_non_array = || EvalError::yq_only_arrays_supported_for("flatten");
     let items: Result<Vec<OwnedValue>, EvalError> = match &value {
         StandardJson::Array(elements) => elements.map(|e| to_owned_checked(&e)).collect(),
-        // #1901: unlike jq (`flatten` is defined over `[.[]]`, and `.[]` on
-        // an object iterates its values, per this function's own doc
-        // comment above), real yq rejects an object the same as a scalar --
-        // confirmed live: `{"a":1} | flatten` is `"only arrays are
-        // supported for flatten"` in yq v4.53.3.
         StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            return scalar_fallback(&value, optional, || {
-                EvalError::yq_only_arrays_supported_for("flatten")
-            });
+            return scalar_fallback(&value, optional, yq_reject_non_array);
         }
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
         _ if S::TAG == EvalTag::Yq => {
-            return scalar_fallback(&value, optional, || {
-                EvalError::yq_only_arrays_supported_for("flatten")
-            });
+            return scalar_fallback(&value, optional, yq_reject_non_array);
         }
         _ => {
             return scalar_fallback(&value, optional, || {
@@ -8883,6 +8889,16 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #1901: real yq rejects an object outright for `group_by`, unlike jq's
+    // own `object_pair_type_error` handling below -- confirmed live:
+    // `{"a":3,"b":1} | group_by(.)` is `"only arrays are supported for
+    // group by"` in yq v4.53.3. One closure for both call sites (#1901
+    // review), same pattern as `builtin_any`.
+    let yq_reject_non_array = |value: &StandardJson<'a, W>| {
+        scalar_fallback(value, optional, || {
+            EvalError::yq_only_arrays_supported_for("group by")
+        })
+    };
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<StandardJson<'a, W>> = elements.collect();
@@ -8946,15 +8962,7 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             QueryResult::Owned(OwnedValue::Array(groups))
         }
-        // #1901: real yq rejects an object outright for `group_by`, unlike
-        // jq's own `object_pair_type_error` handling below -- confirmed
-        // live: `{"a":3,"b":1} | group_by(.)` is `"only arrays are
-        // supported for group by"` in yq v4.53.3.
-        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            scalar_fallback(&value, optional, || {
-                EvalError::yq_only_arrays_supported_for("group by")
-            })
-        }
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #995: group_by shares min_by/max_by/unique_by's `map([f])`-pairing
         // computation (see `map_bracketed_over_object_fields`) and
         // unique_by's own suffix -- confirmed live: `{"a":3,"b":1} |
@@ -8964,10 +8972,7 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
-        // #1901: real yq's own scalar wording, same as the object arm above.
-        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
-            EvalError::yq_only_arrays_supported_for("group by")
-        }),
+        _ if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #995: same "Cannot iterate over" wording min_by/max_by/unique_by's
         // own scalar arm uses -- confirmed live: `5 | group_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
@@ -8982,10 +8987,20 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: unique - remove duplicates
-fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
-    value: StandardJson<'_, W>,
+fn builtin_unique<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    value: StandardJson<'a, W>,
     optional: bool,
-) -> QueryResult<'_, W> {
+) -> QueryResult<'a, W> {
+    // #1901: real yq rejects an object outright for `unique`, unlike jq's
+    // own `object_pair_type_error` handling below -- confirmed live:
+    // `{"a":3,"b":1} | unique` is `"only arrays are supported for unique"`
+    // in yq v4.53.3. One closure for both call sites (#1901 review), same
+    // pattern as `builtin_any`.
+    let yq_reject_non_array = |value: &StandardJson<'a, W>| {
+        scalar_fallback(value, optional, || {
+            EvalError::yq_only_arrays_supported_for("unique")
+        })
+    };
     match value {
         StandardJson::Array(elements) => {
             // #1755: to_owned_checked, not to_owned -- an undecodable
@@ -9009,15 +9024,7 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             QueryResult::Owned(OwnedValue::Array(items))
         }
-        // #1901: real yq rejects an object outright for `unique`, unlike
-        // jq's own `object_pair_type_error` handling below -- confirmed
-        // live: `{"a":3,"b":1} | unique` is `"only arrays are supported for
-        // unique"` in yq v4.53.3.
-        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            scalar_fallback(&value, optional, || {
-                EvalError::yq_only_arrays_supported_for("unique")
-            })
-        }
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #995: real jq defines `unique` as `unique_by(.)`, so it shares the
         // identical object-input pairing bug -- confirmed live:
         // `{"a":3,"b":1} | unique` raises `object ({"a":3,"b":1}) and array
@@ -9029,10 +9036,7 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             optional,
             EvalError::pair_cannot_be_sorted,
         ),
-        // #1901: real yq's own scalar wording, same as the object arm above.
-        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
-            EvalError::yq_only_arrays_supported_for("unique")
-        }),
+        _ if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
@@ -9048,6 +9052,17 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #1901: real yq rejects an object outright for `unique_by`, unlike
+    // jq's own `object_pair_type_error` handling below -- confirmed live:
+    // `{"a":3,"b":1} | unique_by(.)` is `"only arrays are supported for
+    // unique"` in yq v4.53.3 (not "unique by" -- same wording as bare
+    // `unique`, confirmed, not a typo). One closure for both call sites
+    // (#1901 review), same pattern as `builtin_any`.
+    let yq_reject_non_array = |value: &StandardJson<'a, W>| {
+        scalar_fallback(value, optional, || {
+            EvalError::yq_only_arrays_supported_for("unique")
+        })
+    };
     match value {
         StandardJson::Array(elements) => {
             let items: Vec<StandardJson<'a, W>> = elements.collect();
@@ -9087,16 +9102,7 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let result: Vec<OwnedValue> = keyed.into_iter().map(|(_, v)| v).collect();
             QueryResult::Owned(OwnedValue::Array(result))
         }
-        // #1901: real yq rejects an object outright for `unique_by`, unlike
-        // jq's own `object_pair_type_error` handling below -- confirmed
-        // live: `{"a":3,"b":1} | unique_by(.)` is `"only arrays are
-        // supported for unique"` in yq v4.53.3 (not "unique by" -- same
-        // wording as bare `unique`, confirmed, not a typo).
-        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            scalar_fallback(&value, optional, || {
-                EvalError::yq_only_arrays_supported_for("unique")
-            })
-        }
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #929: unique_by shares min_by/max_by's `map([f])`-pairing
         // computation (see `map_bracketed_over_object_fields`) but a third,
         // distinct suffix -- confirmed live: `{"a":3,"b":1} | unique_by(.)`
@@ -9105,10 +9111,7 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
-        // #1901: real yq's own scalar wording, same as the object arm above.
-        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
-            EvalError::yq_only_arrays_supported_for("unique")
-        }),
+        _ if S::TAG == EvalTag::Yq => yq_reject_non_array(&value),
         // #929: same "Cannot iterate over" wording min_by/max_by's own
         // scalar arm uses -- confirmed live: `5 | unique_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
@@ -9414,23 +9417,22 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable entry must
     // raise, not silently become "".
+    //
+    // #1901: unlike jq (which accepts an object of entries as readily as
+    // an array, per this function's own doc comment above), real yq
+    // rejects a plain object here -- confirmed live: `{"a":1} |
+    // from_entries` is `"from entries only runs against arrays"` in
+    // yq v4.53.3. One zero-capture closure for both call sites (#1901
+    // review), same pattern as `builtin_flatten`.
+    let yq_reject_non_array = || EvalError::yq_from_entries_requires_array();
     let entries: Result<Vec<OwnedValue>, EvalError> = match &value {
         StandardJson::Array(elements) => elements.map(|elem| to_owned_checked(&elem)).collect(),
-        // #1901: unlike jq (which accepts an object of entries as readily
-        // as an array, per this function's own doc comment above), real
-        // yq rejects a plain object here -- confirmed live: `{"a":1} |
-        // from_entries` is `"from entries only runs against arrays"` in
-        // yq v4.53.3.
         StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
-            return scalar_fallback(&value, optional, || {
-                EvalError::yq_from_entries_requires_array()
-            });
+            return scalar_fallback(&value, optional, yq_reject_non_array);
         }
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
         _ if S::TAG == EvalTag::Yq => {
-            return scalar_fallback(&value, optional, || {
-                EvalError::yq_from_entries_requires_array()
-            });
+            return scalar_fallback(&value, optional, yq_reject_non_array);
         }
         _ => {
             return scalar_fallback(&value, optional, || {
@@ -47520,14 +47522,23 @@ mod tests {
     /// these four leak jq's template into yq mode any more.
     #[test]
     fn test_cannot_iterate_call_sites_use_the_real_mode_tag_1494() {
-        for expr in ["any", "all", "flatten", "from_entries"] {
+        for (expr, want_yq) in [
+            ("any", "any only supports arrays, was !!float"),
+            ("all", "all only supports arrays, was !!float"),
+            ("flatten", "only arrays are supported for flatten"),
+            ("from_entries", "from entries only runs against arrays"),
+        ] {
             let filter = format!("(1.0 + 2.0) | {expr}");
+            // #1901 revision: an exact match on real yq's own wording
+            // (confirmed live against v4.53.3), not merely the absence of
+            // jq's old template -- the weaker `!contains("Cannot iterate")`
+            // form this replaced would pass just as well for any other
+            // wrong string (#1901 review).
             yq_query!(br"null", &filter,
                 QueryResult::Error(e) => {
-                    assert!(
-                        !e.message.contains("Cannot iterate"),
-                        "{filter}: yq mode must use real yq's own wording (#1901), not jq's template: {:?}",
-                        e.message
+                    assert_eq!(
+                        e.message, want_yq,
+                        "{filter}: yq mode must use real yq's own wording (#1901)"
                     );
                 }
             );
@@ -47536,6 +47547,34 @@ mod tests {
                     assert_eq!(
                         e.message, "Cannot iterate over number (3)",
                         "{filter}: jq mode must be unchanged from before this fix"
+                    );
+                }
+            );
+        }
+    }
+
+    /// #1901 review: `builtin_any`/`builtin_all`'s new yq-mode rejection arm
+    /// used to sit *after* the pre-existing `_ if optional => QueryResult::None`
+    /// wildcard, so it (and the decode-failure check inside `scalar_fallback`)
+    /// was unreachable whenever `optional` was `true` -- an undecodable
+    /// scalar under `any?`/`all?` in yq mode would silently return `None`
+    /// instead of raising, unlike the other five #1901-fixed builtins
+    /// (flatten/group_by/unique/unique_by/from_entries), none of which have
+    /// this preceding wildcard arm. Confirmed live via mutation testing
+    /// during review; fixed by reordering the arms so the yq-mode check runs
+    /// first, matching the other five.
+    #[test]
+    fn test_any_all_respect_decode_failure_before_optional_in_yq_mode_1901() {
+        // A lone-byte string token the JSON semi-index accepts as a span but
+        // whose bytes are not valid UTF-8.
+        let json: &[u8] = b"\"\xff\xfe\"";
+        for expr in ["any?", "all?"] {
+            yq_query!(json, expr,
+                QueryResult::Error(e) if e.is_decode_failure() => {
+                    assert!(
+                        e.message.contains("invalid UTF-8"),
+                        "{expr}: message: {}",
+                        e.message
                     );
                 }
             );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7312,8 +7312,20 @@ fn builtin_any<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     match value {
         StandardJson::Array(elements) => owned_bool(any_all_over(elements, true)),
+        // #1901: unlike jq (which iterates an object's *values*), real yq
+        // rejects an object the same as a scalar -- confirmed live:
+        // `{"a":1} | any` is `"any only supports arrays, was !!map"` in
+        // yq v4.53.3, not a successful iteration.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            scalar_fallback(&value, optional, || {
+                EvalError::yq_only_supports_arrays("any", yaml_type_tag(&value))
+            })
+        }
         StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), true)),
         _ if optional => QueryResult::None,
+        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
+            EvalError::yq_only_supports_arrays("any", yaml_type_tag(&value))
+        }),
         _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
     }
 }
@@ -7332,8 +7344,17 @@ fn builtin_all<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     match value {
         StandardJson::Array(elements) => owned_bool(any_all_over(elements, false)),
+        // #1901: same yq-only rejection as `any` above.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            scalar_fallback(&value, optional, || {
+                EvalError::yq_only_supports_arrays("all", yaml_type_tag(&value))
+            })
+        }
         StandardJson::Object(fields) => owned_bool(any_all_over(fields.map(|f| f.value()), false)),
         _ if optional => QueryResult::None,
+        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
+            EvalError::yq_only_supports_arrays("all", yaml_type_tag(&value))
+        }),
         _ => QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))),
     }
 }
@@ -8756,7 +8777,22 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raise, not silently flatten in as "".
     let items: Result<Vec<OwnedValue>, EvalError> = match &value {
         StandardJson::Array(elements) => elements.map(|e| to_owned_checked(&e)).collect(),
+        // #1901: unlike jq (`flatten` is defined over `[.[]]`, and `.[]` on
+        // an object iterates its values, per this function's own doc
+        // comment above), real yq rejects an object the same as a scalar --
+        // confirmed live: `{"a":1} | flatten` is `"only arrays are
+        // supported for flatten"` in yq v4.53.3.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            return scalar_fallback(&value, optional, || {
+                EvalError::yq_only_arrays_supported_for("flatten")
+            });
+        }
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
+        _ if S::TAG == EvalTag::Yq => {
+            return scalar_fallback(&value, optional, || {
+                EvalError::yq_only_arrays_supported_for("flatten")
+            });
+        }
         _ => {
             return scalar_fallback(&value, optional, || {
                 EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
@@ -8910,6 +8946,15 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             QueryResult::Owned(OwnedValue::Array(groups))
         }
+        // #1901: real yq rejects an object outright for `group_by`, unlike
+        // jq's own `object_pair_type_error` handling below -- confirmed
+        // live: `{"a":3,"b":1} | group_by(.)` is `"only arrays are
+        // supported for group by"` in yq v4.53.3.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            scalar_fallback(&value, optional, || {
+                EvalError::yq_only_arrays_supported_for("group by")
+            })
+        }
         // #995: group_by shares min_by/max_by/unique_by's `map([f])`-pairing
         // computation (see `map_bracketed_over_object_fields`) and
         // unique_by's own suffix -- confirmed live: `{"a":3,"b":1} |
@@ -8919,6 +8964,10 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
+        // #1901: real yq's own scalar wording, same as the object arm above.
+        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
+            EvalError::yq_only_arrays_supported_for("group by")
+        }),
         // #995: same "Cannot iterate over" wording min_by/max_by/unique_by's
         // own scalar arm uses -- confirmed live: `5 | group_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
@@ -8960,6 +9009,15 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             QueryResult::Owned(OwnedValue::Array(items))
         }
+        // #1901: real yq rejects an object outright for `unique`, unlike
+        // jq's own `object_pair_type_error` handling below -- confirmed
+        // live: `{"a":3,"b":1} | unique` is `"only arrays are supported for
+        // unique"` in yq v4.53.3.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            scalar_fallback(&value, optional, || {
+                EvalError::yq_only_arrays_supported_for("unique")
+            })
+        }
         // #995: real jq defines `unique` as `unique_by(.)`, so it shares the
         // identical object-input pairing bug -- confirmed live:
         // `{"a":3,"b":1} | unique` raises `object ({"a":3,"b":1}) and array
@@ -8971,6 +9029,10 @@ fn builtin_unique<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             optional,
             EvalError::pair_cannot_be_sorted,
         ),
+        // #1901: real yq's own scalar wording, same as the object arm above.
+        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
+            EvalError::yq_only_arrays_supported_for("unique")
+        }),
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
         // `scalar_decode_failure`.
@@ -9025,6 +9087,16 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let result: Vec<OwnedValue> = keyed.into_iter().map(|(_, v)| v).collect();
             QueryResult::Owned(OwnedValue::Array(result))
         }
+        // #1901: real yq rejects an object outright for `unique_by`, unlike
+        // jq's own `object_pair_type_error` handling below -- confirmed
+        // live: `{"a":3,"b":1} | unique_by(.)` is `"only arrays are
+        // supported for unique"` in yq v4.53.3 (not "unique by" -- same
+        // wording as bare `unique`, confirmed, not a typo).
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            scalar_fallback(&value, optional, || {
+                EvalError::yq_only_arrays_supported_for("unique")
+            })
+        }
         // #929: unique_by shares min_by/max_by's `map([f])`-pairing
         // computation (see `map_bracketed_over_object_fields`) but a third,
         // distinct suffix -- confirmed live: `{"a":3,"b":1} | unique_by(.)`
@@ -9033,6 +9105,10 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Object(fields) => {
             object_pair_type_error::<W, S>(f, fields, optional, EvalError::pair_cannot_be_sorted)
         }
+        // #1901: real yq's own scalar wording, same as the object arm above.
+        _ if S::TAG == EvalTag::Yq => scalar_fallback(&value, optional, || {
+            EvalError::yq_only_arrays_supported_for("unique")
+        }),
         // #929: same "Cannot iterate over" wording min_by/max_by's own
         // scalar arm uses -- confirmed live: `5 | unique_by(.)` raises
         // "Cannot iterate over number (5)" in jq 1.7.1.
@@ -9340,7 +9416,22 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raise, not silently become "".
     let entries: Result<Vec<OwnedValue>, EvalError> = match &value {
         StandardJson::Array(elements) => elements.map(|elem| to_owned_checked(&elem)).collect(),
+        // #1901: unlike jq (which accepts an object of entries as readily
+        // as an array, per this function's own doc comment above), real
+        // yq rejects a plain object here -- confirmed live: `{"a":1} |
+        // from_entries` is `"from entries only runs against arrays"` in
+        // yq v4.53.3.
+        StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
+            return scalar_fallback(&value, optional, || {
+                EvalError::yq_from_entries_requires_array()
+            });
+        }
         StandardJson::Object(fields) => fields.map(|f| to_owned_checked(&f.value())).collect(),
+        _ if S::TAG == EvalTag::Yq => {
+            return scalar_fallback(&value, optional, || {
+                EvalError::yq_from_entries_requires_array()
+            });
+        }
         _ => {
             return scalar_fallback(&value, optional, || {
                 EvalError::cannot_iterate_with(S::TAG, &to_owned(&value))
@@ -47398,33 +47489,45 @@ mod tests {
     }
 
     /// #1494: `builtin_any`/`builtin_all`/`builtin_flatten`/`builtin_from_entries`
-    /// (plus `set_path`/`set_path_through_iterate`, exercised separately)
-    /// used the jq-pinned `EvalError::cannot_iterate` shim unconditionally,
-    /// so a yq-mode error message always carried jq's own value-preview
+    /// (plus `set_path`/`set_path_through_iterate`, exercised separately by
+    /// `test_set_path_cannot_iterate_uses_the_real_mode_tag_1494`) used the
+    /// jq-pinned `EvalError::cannot_iterate` shim unconditionally, so a
+    /// yq-mode error message always carried jq's own value-preview
     /// convention regardless of the real evaluation mode. Threaded `S:
     /// EvalSemantics` through instead, matching the 19 call sites #1055
     /// already migrated.
     ///
-    /// `(1.0 + 2.0)` is a *computed* float (`OwnedValue::Float(3.0)`, not a
-    /// source-literal-preserving `NumberLiteral`), which is exactly where
-    /// the two conventions provably diverge: jq's own error-message
-    /// convention spells a computed whole-number float without a decimal
-    /// point ("3", matching `1.0 + 2.0 | tostring` in real jq), while
-    /// yq/plain-JSON's convention keeps it ("3.0") -- confirmed against
+    /// jq mode's own assertion below is unaffected by #1901 (still exactly
+    /// what #1494 fixed): `(1.0 + 2.0)` is a *computed* float
+    /// (`OwnedValue::Float(3.0)`, not a source-literal-preserving
+    /// `NumberLiteral`), which is exactly where jq's error-message
+    /// convention (a computed whole-number float spells without a decimal
+    /// point, "3", matching `1.0 + 2.0 | tostring` in real jq) and
+    /// yq/plain-JSON's convention (keeps it, "3.0" -- confirmed against
     /// `stream_owned_value_json_jq`'s own dedicated unit test
-    /// (`test_stream_json_jq_convention_keeps_shortest_float`). Seeing
-    /// "3.0" in a yq-mode error message is the load-bearing assertion here,
-    /// not incidental — it is only possible once `S::TAG` genuinely reaches
-    /// `cannot_iterate_with` as `EvalTag::Yq`.
+    /// `test_stream_json_jq_convention_keeps_shortest_float`) provably
+    /// diverge.
+    ///
+    /// #1901 revision: these four builtins' *yq-mode* assertion no longer
+    /// belongs here -- #1901 found real yq doesn't use jq's
+    /// "Cannot iterate over `<type>` (`<value>`)" template at all for these
+    /// four (its own wording carries no value preview, so this test's
+    /// original "3.0 vs 3" distinction is structurally moot for them now).
+    /// #1494's yq-mode concern (does `S::TAG` genuinely reach
+    /// `cannot_iterate_with` as `EvalTag::Yq`) remains covered by
+    /// `test_set_path_cannot_iterate_uses_the_real_mode_tag_1494`, whose
+    /// call sites #1901 didn't touch. This test now just pins that none of
+    /// these four leak jq's template into yq mode any more.
     #[test]
     fn test_cannot_iterate_call_sites_use_the_real_mode_tag_1494() {
         for expr in ["any", "all", "flatten", "from_entries"] {
             let filter = format!("(1.0 + 2.0) | {expr}");
             yq_query!(br"null", &filter,
                 QueryResult::Error(e) => {
-                    assert_eq!(
-                        e.message, "Cannot iterate over number (3.0)",
-                        "{filter}: yq mode must use the plain float spelling, not jq's \"3\""
+                    assert!(
+                        !e.message.contains("Cannot iterate"),
+                        "{filter}: yq mode must use real yq's own wording (#1901), not jq's template: {:?}",
+                        e.message
                     );
                 }
             );

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -23980,14 +23980,36 @@ fn test_yq_iterate_adjacent_builtins_reject_object_unlike_jq_1901() -> Result<()
         );
     }
 
-    // jq mode is unaffected: any/all/flatten succeed on an object, matching
-    // jq's own "iterate the values" semantics.
+    // jq mode is unaffected -- #1901 review found only `any`/`flatten` were
+    // pinned here, leaving `all`/`group_by`/`unique`/`unique_by`/
+    // `from_entries`'s own jq-mode object behavior unverified by this test.
+    // any/all/flatten succeed on an object, matching jq's own "iterate the
+    // values" semantics; group_by/unique/unique_by hit jq's own
+    // object-vs-array pairing bug (#995); from_entries hits its own,
+    // unrelated indexing error.
     let (out, _stderr, code) = run_jq_stdin_with_stderr("any", doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "true");
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("all", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "true");
     let (out, _stderr, code) = run_jq_stdin_with_stderr("flatten", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "[3,1]");
+    for filter in ["group_by(.)", "unique", "unique_by(.)"] {
+        let (_out, stderr, code) = run_jq_stdin_with_stderr(filter, doc, &["-c"])?;
+        assert_ne!(code, 0, "`{filter}` unexpectedly succeeded");
+        assert!(
+            stderr.contains("cannot be sorted, as they are not both arrays"),
+            "`{filter}` -- stderr={stderr:?}"
+        );
+    }
+    let (_out, stderr, code) = run_jq_stdin_with_stderr("from_entries", doc, &["-c"])?;
+    assert_ne!(code, 0, "from_entries unexpectedly succeeded");
+    assert!(
+        stderr.contains("Cannot index number with string"),
+        "stderr={stderr:?}"
+    );
 
     Ok(())
 }
@@ -24003,6 +24025,32 @@ fn test_yq_iterate_adjacent_builtins_well_formed_array_unaffected_1901() -> Resu
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "true");
 
+    Ok(())
+}
+
+/// #1901 review: `?` (optional) suppression on a non-array input for all
+/// seven builtins -- exit 0, no output, matching the pre-existing
+/// `scalar_fallback`/`object_pair_type_error` contract this fix routes
+/// through rather than a new one of its own. `succinctly`-only syntax
+/// (`--jq-extensions`), since real yq's own lexer rejects `?` as postfix
+/// syntax outright -- there is no live oracle for this specific spelling,
+/// only for the underlying `optional` semantics `scalar_fallback` already
+/// implements.
+#[test]
+fn test_yq_iterate_adjacent_builtins_optional_suppresses_1901() -> Result<()> {
+    for filter in [
+        "5 | any?",
+        "5 | all?",
+        "5 | flatten?",
+        "5 | group_by(.)?",
+        "5 | unique?",
+        "5 | unique_by(.)?",
+        "5 | from_entries?",
+    ] {
+        let (out, stderr, code) = run_yq_stdin_with_stderr(filter, "null", &["--jq-extensions"])?;
+        assert_eq!(code, 0, "`{filter}` should suppress\nstderr: {stderr}");
+        assert!(out.trim().is_empty(), "`{filter}` -- stdout: {out:?}");
+    }
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -23899,6 +23899,113 @@ fn test_jq_error_value_preview_still_reformats_number_literal_1055() -> Result<(
     Ok(())
 }
 
+/// #1901: real yq doesn't use jq's "Cannot iterate over <type> (<value>)"
+/// template at all for `any`/`all`/`flatten`/`group_by`/`unique`/
+/// `unique_by`/`from_entries` -- confirmed live against pinned Homebrew yq
+/// v4.53.3, byte-for-byte, for both a scalar and an object input. Unlike jq
+/// (which iterates an object's values/entries for several of these), real
+/// yq rejects an object the same as a scalar for every one of them.
+#[test]
+fn test_yq_iterate_adjacent_builtins_use_real_yq_wording_1901() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        ("any", "any only supports arrays, was !!int"),
+        ("all", "all only supports arrays, was !!int"),
+        ("flatten", "only arrays are supported for flatten"),
+        ("group_by(.)", "only arrays are supported for group by"),
+        ("unique", "only arrays are supported for unique"),
+        ("unique_by(.)", "only arrays are supported for unique"),
+        ("from_entries", "from entries only runs against arrays"),
+    ];
+    for (builtin, expected) in cases {
+        let (_out, stderr, code) =
+            run_yq_stdin_with_stderr(&format!("5 | {builtin}"), "null", &[])?;
+        assert_ne!(code, 0, "`5 | {builtin}` unexpectedly succeeded");
+        assert!(
+            stderr.contains(expected),
+            "`5 | {builtin}` -- expected {expected:?}, got stderr={stderr:?}"
+        );
+        assert!(
+            !stderr.contains("Cannot iterate"),
+            "`5 | {builtin}` -- still using jq's own template: stderr={stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1901 sibling: the object-input arms specifically -- real yq rejects an
+/// object outright for all seven builtins, where jq's own semantics differ
+/// per builtin (`any`/`all`/`flatten` succeed on an object; `group_by`/
+/// `unique`/`unique_by` hit a different, jq-specific pairing error;
+/// `from_entries` succeeds). The `!!map` tag (not `!!int`) confirms this
+/// reaches the *object* arm, not a fallthrough to the scalar one.
+#[test]
+fn test_yq_iterate_adjacent_builtins_reject_object_unlike_jq_1901() -> Result<()> {
+    let doc = r#"{"a":3,"b":1}"#;
+    let cases: &[(&str, &str)] = &[
+        (
+            r#"{"a":3,"b":1} | any"#,
+            "any only supports arrays, was !!map",
+        ),
+        (
+            r#"{"a":3,"b":1} | all"#,
+            "all only supports arrays, was !!map",
+        ),
+        (
+            r#"{"a":3,"b":1} | flatten"#,
+            "only arrays are supported for flatten",
+        ),
+        (
+            r#"{"a":3,"b":1} | group_by(.)"#,
+            "only arrays are supported for group by",
+        ),
+        (
+            r#"{"a":3,"b":1} | unique"#,
+            "only arrays are supported for unique",
+        ),
+        (
+            r#"{"a":3,"b":1} | unique_by(.)"#,
+            "only arrays are supported for unique",
+        ),
+        (
+            r#"{"a":3,"b":1} | from_entries"#,
+            "from entries only runs against arrays",
+        ),
+    ];
+    for (filter, expected) in cases {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` unexpectedly succeeded");
+        assert!(
+            stderr.contains(expected),
+            "`{filter}` -- expected {expected:?}, got stderr={stderr:?}"
+        );
+    }
+
+    // jq mode is unaffected: any/all/flatten succeed on an object, matching
+    // jq's own "iterate the values" semantics.
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("any", doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "true");
+    let (out, _stderr, code) = run_jq_stdin_with_stderr("flatten", doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[3,1]");
+
+    Ok(())
+}
+
+/// #1901: well-formed array input is unaffected in either mode.
+#[test]
+fn test_yq_iterate_adjacent_builtins_well_formed_array_unaffected_1901() -> Result<()> {
+    let (out, code) = run_yq_stdin("[1,2,1] | unique", "null", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2]");
+
+    let (out, code) = run_yq_stdin("[1,\"a\"] | any", "null", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "true");
+
+    Ok(())
+}
+
 /// Known gap (#1495's own review, not fixed here -- see the scope note
 /// above and #1494): a non-finite `Float` in a yq-mode error preview
 /// renders as JSON's `null` substitution (`stream_owned_value_json`'s


### PR DESCRIPTION
## Summary

Found during code review of #1494/PR #1900 (the `cannot_iterate_with` `EvalTag` threading fix): that PR correctly threads the real evaluation mode through to `cannot_iterate_with`'s value-preview formatting, but real yq doesn't use jq's "Cannot iterate over `<type>` (`<value>`)" *template* at all for `any`/`all`/`flatten`/`group_by`/`unique`/`unique_by`/`from_entries` — it has its own, completely different, per-builtin wording with no value preview.

## Repro (confirmed live against pinned Homebrew yq v4.53.3)

```console
$ printf 'null\n' | yq '5 | any'
Error: any only supports arrays, was !!int
$ printf 'null\n' | yq '5 | flatten'
Error: only arrays are supported for flatten
$ succinctly yq --jq-extensions '5 | any'
Error: Cannot iterate over number (5)          # wrong template entirely (before this fix)
```

Also confirmed real yq rejects an **object** input the same as a scalar for all seven — a second axis jq disagrees with it on: jq's own semantics let `any`/`all`/`flatten` succeed on an object (iterating its values/entries) and give `group_by`/`unique`/`unique_by` a different, jq-specific "object and array cannot be sorted" pairing error. None of that carries over to yq mode.

## Fix

- Three new `EvalError` constructors matching real yq's exact wording (`yq_only_supports_arrays`, `yq_only_arrays_supported_for`, `yq_from_entries_requires_array`).
- Gated by `S::TAG == EvalTag::Yq` at each of the seven builtins' object *and* scalar arms in `src/jq/eval.rs` — jq mode's own `cannot_iterate_with`/`object_pair_type_error` paths are completely untouched.

All 14 cases (7 builtins × scalar/object) confirmed byte-for-byte identical to real yq; jq-mode behavior confirmed unchanged for all 7.

## Review round: one real bug found and fixed, plus cleanup

A multi-pass code review (several independent agents, live oracle verification + mutation testing) found:

- **A real decode-failure bug** in `builtin_any`/`builtin_all`: the new yq-mode rejection arm sat *after* the pre-existing `_ if optional => QueryResult::None` wildcard, making it (and `scalar_fallback`'s own decode-failure-first check) unreachable whenever `optional` was `true`. An undecodable scalar under `any?`/`all?` in yq mode silently returned nothing instead of raising — confirmed via direct mutation testing during review. Fixed by reordering the arms, matching the other five builtins (which never had this bug, since they lack the preceding wildcard). New regression test: `test_any_all_respect_decode_failure_before_optional_in_yq_mode_1901`.
- **Duplication across the 7 builtins**: the object-arm and scalar-arm error closures were near-identical copies within each function. Collapsed into one local closure per function, called from both arms — citing this project's own "duplicated predicates diverge silently" precedent (#106).
- **A weakened test assertion**: `test_cannot_iterate_call_sites_use_the_real_mode_tag_1494`'s yq-mode check (`!message.contains("Cannot iterate")`) would pass for any other wrong string too. Replaced with an exact match on the real, oracle-verified wording per builtin.
- **Missing test coverage**: jq-mode object-input controls for `all`/`group_by`/`unique`/`unique_by`/`from_entries` (previously only `any`/`flatten` were pinned), and `?` (optional) suppression for all seven builtins.

Two more findings were confirmed live but are genuinely out of scope (different bug shapes than this PR's wording fix):
- **#2005** — `any(cond)`/`all(cond)`/`any(gen;cond)`/`all(gen;cond)` share the identical wording gap, plus succinctly's parser doesn't gate this syntax behind `--jq-extensions` at all even though real yq's lexer rejects it outright.
- **#2006** — `with_entries(f)` rejects numeric keys that real yq coerces to strings — a functional bug on well-formed input, unrelated to this fix's malformed-input scope.

## Scope note (from the original fix)

Two related items confirmed live but **not fixed here**, needing materially different implementation shapes — filed as #1998:
- `sort`/`sort_by`'s own wording genuinely tracks navigation depth (`[]`, `[a.b]`, `[[2]]`), which these builtins have no path context to construct today.
- `.[]`'s own read-side behavior on a scalar is a silent no-op in real yq (not an error at all) — `Expr::Iterate` has 20+ separate dispatch arms across `eval.rs`'s value/path/assignment-mode evaluators.

## Testing

- `test_yq_iterate_adjacent_builtins_use_real_yq_wording_1901` — all 7 builtins, scalar input, byte-for-byte match.
- `test_yq_iterate_adjacent_builtins_reject_object_unlike_jq_1901` — all 7 builtins, object input, plus jq-mode-unaffected controls for all 7 (not just 2).
- `test_yq_iterate_adjacent_builtins_optional_suppresses_1901` — `?` suppression for all 7.
- `test_yq_iterate_adjacent_builtins_well_formed_array_unaffected_1901` — well-formed data control.
- `test_any_all_respect_decode_failure_before_optional_in_yq_mode_1901` — the decode-failure-ordering regression.
- Full local suite (`cargo test`, `cargo test --features cli`), both required clippy legs, `cargo build --no-default-features`, `cargo doc` (`--all-features`, `RUSTDOCFLAGS=-D warnings`), and `cargo fmt --check` all clean.

Fixes #1901
