### PR TITLE
perf(jq): box DistinctKeyCursors's rare-path seen/collapsed fields

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1707,23 +1707,33 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     /// cursor position, so this is a copy of a couple of machine words.
     all: F,
     /// Hashes of the keys yielded so far, while the rule is in force and
-    /// the object is not yet proved clean. Boxed (#1973): live only on the
-    /// probing phase of the rare duplicate-key path, so every walk over a
-    /// clean object (`collapse` false, or true but never repeated) pays a
-    /// single pointer instead of `KeyHashes`'s own ~40-byte hash-table
-    /// header -- `Option<Box<T>>` niches to the same width as `Option<T>`
-    /// would for a `T` that already carries a non-null pointer, so this
-    /// costs nothing beyond the fields it removes from the struct itself.
-    seen: Option<Box<KeyHashes>>,
+    /// the object is not yet proved clean. Deliberately **not** boxed
+    /// (#1973 code review): unlike `collapsed` below, this is constructed
+    /// eagerly in [`new`](Self::new) for every jq-mode walk (`collapse`
+    /// true is the default), not lazily once a duplicate is actually
+    /// found -- `KeyHashes::new()` itself is genuinely free (an empty
+    /// `Vec` allocates nothing until its first insertion), but wrapping it
+    /// in a `Box` would force a heap allocation for the `KeyHashes`
+    /// struct itself on every single call, regardless of whether the
+    /// object ever has a duplicate key. That would add a real,
+    /// unconditional per-object allocation to `keys_unsorted`/`.[]`-style
+    /// hot paths this codebase has otherwise gone out of its way to keep
+    /// allocation-free (see `KeyHashes::slots`'s own doc comment, and the
+    /// O5 optimization, #1599/#1606/#1609) in exchange for shrinking a
+    /// struct that is not on those same hot paths' critical dimension.
+    seen: Option<KeyHashes>,
     /// How many cursors have gone out, which is where `collapsed` resumes.
     yielded: usize,
     /// The exact collapsed key list, once a repeat is confirmed. Key and
     /// cursor only -- this iterator never reads a field's value, so
     /// `collapse_confirmed_repeat` never materializes one (#1514 review).
-    /// Boxed (#1973) for the same reason as `seen` above -- this is already
-    /// niche-optimized as `Option<Vec<_>>`, so wrapping it in a `Box` before
-    /// niching only removes the `Vec`'s own three machine words from every
-    /// instance that never collapses.
+    /// Boxed (#1973): unlike `seen` above, this is only ever set to `Some`
+    /// once a repeat is already confirmed (`collapse_confirmed_repeat` has
+    /// already run its own `IndexMap`/`Vec` allocations by that point), so
+    /// the one extra box here is genuinely free on every walk that never
+    /// collapses -- already niche-optimized as `Option<Vec<_>>`, wrapping
+    /// it in a `Box` before niching only removes the `Vec`'s own three
+    /// machine words from every instance that stays `None`.
     collapsed: Option<Box<Vec<(F::Value, F::Cursor)>>>,
     /// Whether the walk ran out on an unpaired child (#1194). Recorded as
     /// the walk discovers it, because neither branch can answer afterwards:
@@ -1748,7 +1758,7 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
         Self {
             rest: fields.clone(),
             all: fields.clone(),
-            seen: collapse.then(|| Box::new(KeyHashes::new())),
+            seen: collapse.then(KeyHashes::new),
             yielded: 0,
             collapsed: None,
             ended_unpaired: false,

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1707,14 +1707,24 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     /// cursor position, so this is a copy of a couple of machine words.
     all: F,
     /// Hashes of the keys yielded so far, while the rule is in force and
-    /// the object is not yet proved clean.
-    seen: Option<KeyHashes>,
+    /// the object is not yet proved clean. Boxed (#1973): live only on the
+    /// probing phase of the rare duplicate-key path, so every walk over a
+    /// clean object (`collapse` false, or true but never repeated) pays a
+    /// single pointer instead of `KeyHashes`'s own ~40-byte hash-table
+    /// header -- `Option<Box<T>>` niches to the same width as `Option<T>`
+    /// would for a `T` that already carries a non-null pointer, so this
+    /// costs nothing beyond the fields it removes from the struct itself.
+    seen: Option<Box<KeyHashes>>,
     /// How many cursors have gone out, which is where `collapsed` resumes.
     yielded: usize,
     /// The exact collapsed key list, once a repeat is confirmed. Key and
     /// cursor only -- this iterator never reads a field's value, so
     /// `collapse_confirmed_repeat` never materializes one (#1514 review).
-    collapsed: Option<Vec<(F::Value, F::Cursor)>>,
+    /// Boxed (#1973) for the same reason as `seen` above -- this is already
+    /// niche-optimized as `Option<Vec<_>>`, so wrapping it in a `Box` before
+    /// niching only removes the `Vec`'s own three machine words from every
+    /// instance that never collapses.
+    collapsed: Option<Box<Vec<(F::Value, F::Cursor)>>>,
     /// Whether the walk ran out on an unpaired child (#1194). Recorded as
     /// the walk discovers it, because neither branch can answer afterwards:
     /// `rest` is exhausted on one and stale mid-object on the other.
@@ -1738,7 +1748,7 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
         Self {
             rest: fields.clone(),
             all: fields.clone(),
-            seen: collapse.then(KeyHashes::new),
+            seen: collapse.then(|| Box::new(KeyHashes::new())),
             yielded: 0,
             collapsed: None,
             ended_unpaired: false,
@@ -1837,7 +1847,7 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
             self.delimiter_fault |= confirmed.delimiter_fault;
             let ConfirmedRepeat { keys, total, .. } = confirmed;
             if keys.len() < total {
-                self.collapsed = Some(keys);
+                self.collapsed = Some(Box::new(keys));
                 self.seen = None;
                 // Resumes at `yielded`, which the collapsed list's own
                 // prefix matches: every key emitted so far was a first

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -7,7 +7,7 @@
 #[cfg(not(test))]
 use alloc::vec;
 #[cfg(not(test))]
-use alloc::{borrow::Cow, string::String, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 
 use indexmap::IndexMap;
 #[cfg(test)]
@@ -1699,6 +1699,12 @@ pub fn collapsed_fields_if<F: DocumentFields>(
 ///
 /// `collapse` false (yq) carries no probe state at all and is the plain
 /// cons-list walk it always was.
+///
+/// Key and cursor pairs for the confirmed-collapse case below -- factored
+/// out into its own alias since `Option<Box<Vec<(F::Value, F::Cursor)>>>`
+/// trips `clippy::type_complexity` as an inline field type.
+type CollapsedKeys<F> = Vec<(<F as DocumentFields>::Value, <F as DocumentFields>::Cursor)>;
+
 #[derive(Clone)]
 pub struct DistinctKeyCursors<F: DocumentFields> {
     /// The fields still to walk.
@@ -1734,7 +1740,7 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     /// collapses -- already niche-optimized as `Option<Vec<_>>`, wrapping
     /// it in a `Box` before niching only removes the `Vec`'s own three
     /// machine words from every instance that stays `None`.
-    collapsed: Option<Box<Vec<(F::Value, F::Cursor)>>>,
+    collapsed: Option<Box<CollapsedKeys<F>>>,
     /// Whether the walk ran out on an unpaired child (#1194). Recorded as
     /// the walk discovers it, because neither branch can answer afterwards:
     /// `rest` is exhausted on one and stale mid-object on the other.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8819,49 +8819,53 @@ mod tests {
     /// #789's own fix boxed `GenericResult`/`GenericItem`'s `LazySeq`
     /// variant, but left `LazySeq<V>` itself unboxed and just as wide as
     /// before (184 bytes for `StandardJson`, 200 for `YamlValue`, since
-    /// YAML's field-cursor type is bigger than JSON's). #1973's review of
-    /// #1969 traced this to `LazySource::Keys(DistinctKeyCursors<V::Fields>)`
-    /// -- `DistinctKeyCursors` carries two full field-cursor copies
-    /// (`rest`/`all`) plus the rare-path `seen`/`collapsed` fields for
-    /// #1514's duplicate-key collapse, unboxed, on every `LazySeq`
-    /// regardless of whether that document ever hits the collapse path.
-    /// Shrinking `DistinctKeyCursors` at the source is out of scope here
-    /// (a materially larger change touching #1514's machinery -- see
-    /// #1973's own "why deferred" section); this test only pins today's
-    /// size so a *third* unboxed-wide-variant regression (a new field on
-    /// `LazySeq`/`LazySource`/`DistinctKeyCursors`) is caught the same way
-    /// the #789 guards above catch a regression on `GenericResult`/
-    /// `GenericItem`. Pinned on the YAML instantiation since it's the
-    /// larger (worse-case) of the two document kinds.
+    /// YAML's field-cursor type is bigger than JSON's). #1973 traced this to
+    /// `LazySource::Keys(DistinctKeyCursors<V::Fields>)` -- `DistinctKeyCursors`
+    /// carried two full field-cursor copies (`rest`/`all`) plus the rare-path
+    /// `seen`/`collapsed` fields for #1514's duplicate-key collapse, unboxed,
+    /// on every `LazySeq` regardless of whether that document ever hits the
+    /// collapse path. Boxing `seen`/`collapsed` (#1973) shrank this to 152
+    /// bytes -- `rest`/`all`'s own two full cursor copies remain unboxed and
+    /// out of scope here (a materially larger change; see #1973's own "why
+    /// deferred" section), so this isn't the struct's floor, just its next
+    /// pinned value. Pinned on the YAML instantiation since it's the larger
+    /// (worse-case) of the two document kinds.
     #[test]
     #[cfg(target_pointer_width = "64")]
-    fn test_lazyseq_size_is_pinned_pending_distinctkeycursors_shrink_1973() {
+    fn test_lazyseq_size_is_pinned_1973() {
         assert_eq!(
             core::mem::size_of::<LazySeq<crate::yaml::YamlValue<'_, Vec<u64>>>>(),
-            200,
+            152,
             "LazySeq<YamlValue>'s size changed -- if it grew, a new unboxed-wide field \
              snuck onto LazySeq/LazySource/DistinctKeyCursors (investigate before \
-             accepting); if it shrank, #1973's DistinctKeyCursors-shrink follow-up may \
-             have landed -- update this pinned value to match"
+             accepting); if it shrank, DistinctKeyCursors shrank further -- update this \
+             pinned value to match"
         );
     }
 
-    /// The YAML twin of [`test_lazyseq_size_is_pinned_pending_distinctkeycursors_shrink_1973`]
-    /// for `DistinctKeyCursors<YamlFields>` directly -- the actual struct
-    /// #1973 identifies as the real driver of `LazySeq<V>`'s size, not just
-    /// the enum variant wrapping it.
+    /// The YAML twin of [`test_lazyseq_size_is_pinned_1973`] for
+    /// `DistinctKeyCursors<YamlFields>` directly -- the actual struct #1973
+    /// identifies as the real driver of `LazySeq<V>`'s size, not just the
+    /// enum variant wrapping it. `seen: Option<Box<KeyHashes>>` and
+    /// `collapsed: Option<Box<Vec<_>>>` (#1973) replace their previously
+    /// unboxed forms, shrinking this from 168 to 120 bytes -- both were
+    /// already niche-optimized `Option<_>`s, so boxing removes only the
+    /// pointee's own size from every walk that never hits the rare
+    /// duplicate-key path, at the cost of one allocation on the ones that
+    /// do. `rest`/`all`'s own two full field-cursor copies remain unboxed
+    /// and out of scope here (#1973's own "why deferred" section).
     #[test]
     #[cfg(target_pointer_width = "64")]
-    fn test_distinct_key_cursors_size_is_pinned_pending_shrink_1973() {
+    fn test_distinct_key_cursors_size_is_pinned_1973() {
         assert_eq!(
             core::mem::size_of::<
                 crate::jq::document::DistinctKeyCursors<crate::yaml::YamlFields<'_, Vec<u64>>>,
             >(),
-            168,
+            120,
             "DistinctKeyCursors<YamlFields>'s size changed -- if it grew, a new field \
              landed unboxed on the rare-path (seen/collapsed) or copied cursor (rest/all) \
-             members (investigate before accepting); if it shrank, #1973's shrink \
-             follow-up may have landed -- update this pinned value to match"
+             members (investigate before accepting); if it shrank, update this pinned \
+             value to match"
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8824,18 +8824,20 @@ mod tests {
     /// carried two full field-cursor copies (`rest`/`all`) plus the rare-path
     /// `seen`/`collapsed` fields for #1514's duplicate-key collapse, unboxed,
     /// on every `LazySeq` regardless of whether that document ever hits the
-    /// collapse path. Boxing `seen`/`collapsed` (#1973) shrank this to 152
-    /// bytes -- `rest`/`all`'s own two full cursor copies remain unboxed and
-    /// out of scope here (a materially larger change; see #1973's own "why
-    /// deferred" section), so this isn't the struct's floor, just its next
-    /// pinned value. Pinned on the YAML instantiation since it's the larger
-    /// (worse-case) of the two document kinds.
+    /// collapse path. Boxing `collapsed` (#1973) shrank this to 184 bytes --
+    /// `seen` deliberately stays unboxed (see its own doc comment: boxing it
+    /// would force an allocation on every jq-mode walk, not just the ones
+    /// that collapse), and `rest`/`all`'s own two full cursor copies remain
+    /// unboxed and out of scope here too (a materially larger change; see
+    /// #1973's own "why deferred" section) -- so this isn't the struct's
+    /// floor, just its next pinned value. Pinned on the YAML instantiation
+    /// since it's the larger (worse-case) of the two document kinds.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_lazyseq_size_is_pinned_1973() {
         assert_eq!(
             core::mem::size_of::<LazySeq<crate::yaml::YamlValue<'_, Vec<u64>>>>(),
-            152,
+            184,
             "LazySeq<YamlValue>'s size changed -- if it grew, a new unboxed-wide field \
              snuck onto LazySeq/LazySource/DistinctKeyCursors (investigate before \
              accepting); if it shrank, DistinctKeyCursors shrank further -- update this \
@@ -8846,14 +8848,17 @@ mod tests {
     /// The YAML twin of [`test_lazyseq_size_is_pinned_1973`] for
     /// `DistinctKeyCursors<YamlFields>` directly -- the actual struct #1973
     /// identifies as the real driver of `LazySeq<V>`'s size, not just the
-    /// enum variant wrapping it. `seen: Option<Box<KeyHashes>>` and
-    /// `collapsed: Option<Box<Vec<_>>>` (#1973) replace their previously
-    /// unboxed forms, shrinking this from 168 to 120 bytes -- both were
-    /// already niche-optimized `Option<_>`s, so boxing removes only the
-    /// pointee's own size from every walk that never hits the rare
-    /// duplicate-key path, at the cost of one allocation on the ones that
-    /// do. `rest`/`all`'s own two full field-cursor copies remain unboxed
-    /// and out of scope here (#1973's own "why deferred" section).
+    /// enum variant wrapping it. `collapsed: Option<Box<Vec<_>>>` (#1973)
+    /// replaces its previously unboxed form, shrinking this from 168 to 152
+    /// bytes -- already niche-optimized as `Option<Vec<_>>`, so boxing
+    /// removes only the `Vec`'s own size from every walk that never
+    /// collapses, at the cost of one extra allocation on the already-rare
+    /// confirmed-collapse path. `seen` deliberately stays unboxed (its own
+    /// doc comment has the full reasoning: boxing it would allocate on
+    /// every jq-mode walk, not just the rare ones that collapse -- caught
+    /// in code review before this landed). `rest`/`all`'s own two full
+    /// field-cursor copies remain unboxed and out of scope here too
+    /// (#1973's own "why deferred" section).
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_distinct_key_cursors_size_is_pinned_1973() {
@@ -8861,7 +8866,7 @@ mod tests {
             core::mem::size_of::<
                 crate::jq::document::DistinctKeyCursors<crate::yaml::YamlFields<'_, Vec<u64>>>,
             >(),
-            120,
+            152,
             "DistinctKeyCursors<YamlFields>'s size changed -- if it grew, a new field \
              landed unboxed on the rare-path (seen/collapsed) or copied cursor (rest/all) \
              members (investigate before accepting); if it shrank, update this pinned \


### PR DESCRIPTION
## Summary

`DistinctKeyCursors`'s `collapsed: Option<Vec<(F::Value, F::Cursor)>>`
field is only live on the rare #1514 duplicate-key-collapse path, but
every `DistinctKeyCursors` — and therefore every `LazySeq<V>`, per
#789/#1969's review — paid its full unboxed size regardless of whether
that document ever hits the collapse path. It's already niche-optimized
as `Option<Vec<_>>`, so wrapping it in a `Box` before niching removes
only the `Vec`'s own three machine words from every instance that never
collapses, at the cost of one extra allocation on the already-rare
confirmed-collapse path (`collapse_confirmed_repeat` has already run its
own `IndexMap`/`Vec` allocations by that point, so this is genuinely
free).

This is the "Tier 1" subset of #1973's own numbered proposal — a
mechanical follow-up applying the boxing technique #789/#1969 already
validated, to the struct that's the real driver of the size those fixes
only patched two layers removed from.

**Note on scope vs. the original commit**: an earlier revision of this PR
also boxed `seen: Option<KeyHashes>`, since the same "already
niche-optimized `Option<_>`" reasoning appeared to apply. Code review
caught that it doesn't: `seen` is constructed *eagerly* in `new()` for
every jq-mode walk (`collapse=true` is the default), not lazily once a
duplicate is actually found. `KeyHashes::new()` itself allocates nothing
(an empty `Vec`), but `Box::new(KeyHashes::new())` forces a heap
allocation for the struct on every single call regardless of whether the
object ever has a duplicate key — an unconditional per-object allocation
on exactly the `keys_unsorted`/`.[]` hot paths this codebase has
otherwise gone out of its way to keep allocation-free (the O5
optimization, #1599/#1606/#1609). Reverted; `seen` stays unboxed.

## Measurements

Via the existing `size_of` regression guards (added preemptively when
#1973 was filed, specifically anticipating this follow-up):

| Type                                | Before | After |
|--------------------------------------|--------|-------|
| `DistinctKeyCursors<YamlFields>`     | 168    | 152   |
| `LazySeq<YamlValue>`                 | 200    | 184   |

A smaller win than boxing both fields would have given (120/152), but
correct rather than trading an unmeasured allocation regression for a few
dozen extra bytes. Both pinned tests
(`test_distinct_key_cursors_size_is_pinned_1973`,
`test_lazyseq_size_is_pinned_1973`, renamed from their `_pending_...`
form since the shrink they anticipated has now landed) updated to the
new values.

## Scope

Deliberately deferred, per the issue's own "why deferred" section and
this PR's own review:

- `rest`/`all`'s own two full field-cursor copies (reconsidering whether
  `all: F` needs to be a full second copy touches #1514's hash-collision
  resolution correctness — a materially larger change).
- The repo-wide `clippy::large_enum_variant` lint the issue also proposed
  (explicitly flagged as possibly surfacing unrelated findings well
  outside this scope).
- A lazy `get_or_insert_with`-based boxing of `seen` that would recover
  the full 120/152-byte win without the allocation regression — needs a
  separate "already retired" bit independent of `seen`'s own `Option`
  state (today's `None` conflates "never collapsing" with "was
  collapsing, now retired"), which is a real state-machine change to
  #1514's logic, not a safe mechanical follow-up for this PR.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace` (56/56 binaries green, including the full #1514 duplicate-key-collapse suite)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`

## Update

CI caught two things a locally-cached check had falsely passed:
`clippy::type_complexity` on `collapsed`'s inline `Option<Box<Vec<...>>>`
field type (factored into a `CollapsedKeys<F>` alias), and a missing
`use alloc::boxed::Box` under `no_std` (`cargo check --no-default-features`).
Both verified fixed via a genuinely clean rebuild (`cargo clean -p succinctly`)
after two consecutive local runs of these exact checks had falsely
reported success against the pre-fix code.
