### PR TITLE
test(jq,yq): add differential fuzzer for cross-site corruption consistency

### DIFF
--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2054,8 +2054,11 @@ impl FuzzMalformation {
 /// Wrap `leaf` in `path`'s containers, outermost first -- `path = []` leaves
 /// `leaf` unwrapped (depth-0, matching the existing "top level" case);
 /// `path = [Array]`/`[Object]` reproduce the existing "nested in
-/// array"/"nested in object" cases exactly; longer paths generate depths the
-/// hand-picked list never covered.
+/// array"/"nested in object" cases exactly for `DecodeFailure`/
+/// `StructuralError` (the only two the hand-picked list ever nested); the
+/// hand-picked list's `Collision` case was top-level only, so any nested
+/// `Collision` path here is new coverage, not a reproduction. Longer paths
+/// generate depths the hand-picked list never covered for any kind.
 fn fuzz_wrap_json(path: &[FuzzContainer], leaf: &str) -> String {
     match path.split_first() {
         None => leaf.to_string(),
@@ -2101,13 +2104,12 @@ proptest! {
             prop_oneof![Just(FuzzContainer::Array), Just(FuzzContainer::Object)],
             0..=4,
         ),
-        malformation_index in 0..3u8,
+        malformation in prop_oneof![
+            Just(FuzzMalformation::DecodeFailure),
+            Just(FuzzMalformation::StructuralError),
+            Just(FuzzMalformation::Collision),
+        ],
     ) {
-        let malformation = match malformation_index {
-            0 => FuzzMalformation::DecodeFailure,
-            1 => FuzzMalformation::StructuralError,
-            _ => FuzzMalformation::Collision,
-        };
         let doc = fuzz_build_json_doc(&path, malformation);
         let expect_stderr = malformation.expect_stderr();
         let label = format!("{path:?}/{malformation:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8,6 +8,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use anyhow::Result;
+use proptest::prelude::*;
 use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
@@ -2001,6 +2002,128 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// One level of container nesting between `.bad` and the malformed leaf, for
+/// [`fuzz_select_and_materialize_agree_on_corruption_1965`]'s generated
+/// documents -- `Array`/`Object` mirror the two shapes
+/// [`test_select_and_materialize_agree_on_corruption_1645`]'s hand-picked
+/// cases already cover at depth 1, generalized here to an arbitrary,
+/// generated depth and mix.
+#[derive(Debug, Clone, Copy)]
+enum FuzzContainer {
+    Array,
+    Object,
+}
+
+/// The three malformation kinds [`test_select_and_materialize_agree_on_corruption_1645`]'s
+/// fixed case list covers, as a generatable enum.
+#[derive(Debug, Clone, Copy)]
+enum FuzzMalformation {
+    DecodeFailure,
+    StructuralError,
+    Collision,
+}
+
+impl FuzzMalformation {
+    /// The JSON text substituted at the leaf position -- a raw malformed
+    /// *value* for the first two kinds, a whole malformed *object* (two
+    /// colliding decode-failure keys, #1642) for the third, since a
+    /// collision isn't expressible as a single scalar value.
+    fn leaf_json(self) -> &'static str {
+        match self {
+            Self::DecodeFailure => r#""\x""#,
+            Self::StructuralError => "xyz123",
+            Self::Collision => r#"{"\ud800":1,"\ud800":2}"#,
+        }
+    }
+
+    /// The stderr substring every one of the three CLI paths must raise,
+    /// matching [`test_select_and_materialize_agree_on_corruption_1645`]'s
+    /// own three constants -- stable across nesting depth/shape, since the
+    /// underlying `EvalError`'s message never mentions its own position.
+    fn expect_stderr(self) -> &'static str {
+        match self {
+            Self::DecodeFailure => "invalid escape sequence",
+            Self::StructuralError => "unexpected character",
+            Self::Collision => "ambiguous",
+        }
+    }
+}
+
+/// Wrap `leaf` in `path`'s containers, outermost first -- `path = []` leaves
+/// `leaf` unwrapped (depth-0, matching the existing "top level" case);
+/// `path = [Array]`/`[Object]` reproduce the existing "nested in
+/// array"/"nested in object" cases exactly; longer paths generate depths the
+/// hand-picked list never covered.
+fn fuzz_wrap_json(path: &[FuzzContainer], leaf: &str) -> String {
+    match path.split_first() {
+        None => leaf.to_string(),
+        Some((FuzzContainer::Array, rest)) => format!("[{}]", fuzz_wrap_json(rest, leaf)),
+        Some((FuzzContainer::Object, rest)) => {
+            format!(r#"{{"x": {}}}"#, fuzz_wrap_json(rest, leaf))
+        }
+    }
+}
+
+fn fuzz_build_json_doc(path: &[FuzzContainer], malformation: FuzzMalformation) -> String {
+    format!(
+        r#"{{"bad": {}, "keep": 5}}"#,
+        fuzz_wrap_json(path, malformation.leaf_json())
+    )
+}
+
+// Differential fuzzer for #1965: generalizes
+// `test_select_and_materialize_agree_on_corruption_1645`'s hand-picked
+// 7-case list (3 malformation kinds x up to 2 nesting depths) to
+// proptest-generated nesting paths of 0-4 arbitrary `Array`/`Object`
+// containers, crossed with all 3 malformation kinds -- the same "generate
+// nesting depth/shape, run the same CLI battery, assert consistency" design
+// the issue asked for, so a divergence at a depth/shape combination the
+// fixed list never happened to hit still gets caught. Kept alongside
+// (rather than replacing) the fixed-case test: the fixed list's exact case
+// labels are easier to read in a failure message, and losing that
+// human-readable coverage while adding generated coverage would be a
+// regression in debuggability, not just redundant.
+//
+// `ProptestConfig::with_cases` is turned down from proptest's own default
+// (256) because this drives three real subprocess spawns per case (a
+// `Command::new(env!("CARGO_BIN_EXE_succinctly"))` per
+// `run_jq_full`/`assert_jq_raises` call, unlike proptest's usual in-process
+// property) -- 48 cases x 3 spawns is already ~3x this file's entire
+// pre-existing corruption-consistency coverage in one property.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    #[test]
+    fn fuzz_select_and_materialize_agree_on_corruption_1965(
+        path in prop::collection::vec(
+            prop_oneof![Just(FuzzContainer::Array), Just(FuzzContainer::Object)],
+            0..=4,
+        ),
+        malformation_index in 0..3u8,
+    ) {
+        let malformation = match malformation_index {
+            0 => FuzzMalformation::DecodeFailure,
+            1 => FuzzMalformation::StructuralError,
+            _ => FuzzMalformation::Collision,
+        };
+        let doc = fuzz_build_json_doc(&path, malformation);
+        let expect_stderr = malformation.expect_stderr();
+        let label = format!("{path:?}/{malformation:?}");
+
+        assert_jq_raises(&label, "select(.bad)", &[], "select(.bad) | .keep", &doc, 5, expect_stderr);
+        assert_jq_raises(&label, "-Sc .bad", &["-Sc"], ".bad", &doc, 5, expect_stderr);
+        assert_jq_raises(
+            &label,
+            "-e .bad (cursor_to_owned_at_depth, lazy.rs)",
+            &["-e"],
+            ".bad",
+            &doc,
+            5,
+            expect_stderr,
+        );
+    }
 }
 
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1995,25 +1995,80 @@ impl FuzzYamlMalformation {
     }
 }
 
-/// Wrap `leaf` in `path`'s containers using YAML flow style (`[...]`/
-/// `{x: ...}`), outermost first -- flow style nests recursively as easily as
-/// JSON's brace/bracket syntax does, unlike YAML's indentation-sensitive
-/// block style, and is valid mixed into an otherwise block-style document
-/// (`test_select_and_write_agree_on_corruption_1803`'s own "nested in
-/// array" case already does exactly this: `bad: ["a\qb"]`).
-fn fuzz_wrap_yaml(path: &[FuzzYamlContainer], leaf: &str) -> String {
+/// Whether a generated case nests its containers with YAML flow syntax
+/// (`[...]`/`{x: ...}`) or block syntax (indentation-based `- `/`x:` on
+/// their own lines). Added after code review on #1965 found the first
+/// version of this fuzzer only ever generated flow style, silently never
+/// exercising the indentation-sensitive block-mapping/block-sequence
+/// parsing path at all -- despite
+/// `test_select_and_write_agree_on_corruption_1803`'s own "nested in
+/// object" and "colliding decode-failure keys" cases specifically using
+/// block style. A regression reachable only through block-style nesting
+/// (e.g. a divergence between block- and flow-mapping key/value boundary
+/// tracking) would have passed every generated case forever.
+#[derive(Debug, Clone, Copy)]
+enum FuzzYamlStyle {
+    Flow,
+    Block,
+}
+
+/// Wrap `leaf` in `path`'s containers, outermost first, in the chosen
+/// `style` throughout (never mixed: a block collection can hold a flow
+/// child, but not the reverse, so picking one style per generated case
+/// avoids ever generating invalid YAML). `indent` is the block-nesting
+/// depth already consumed by the caller -- 0 at the top (`bad:`'s own
+/// level) -- used only when `style` is `Block`, to indent each level two
+/// spaces deeper than its parent.
+fn fuzz_wrap_yaml(
+    path: &[FuzzYamlContainer],
+    leaf: &str,
+    style: FuzzYamlStyle,
+    indent: usize,
+) -> String {
     match path.split_first() {
         None => leaf.to_string(),
-        Some((FuzzYamlContainer::Array, rest)) => format!("[{}]", fuzz_wrap_yaml(rest, leaf)),
-        Some((FuzzYamlContainer::Object, rest)) => format!("{{x: {}}}", fuzz_wrap_yaml(rest, leaf)),
+        Some((container, rest)) => {
+            let inner = fuzz_wrap_yaml(rest, leaf, style, indent + 1);
+            match (style, container) {
+                (FuzzYamlStyle::Flow, FuzzYamlContainer::Array) => format!("[{inner}]"),
+                (FuzzYamlStyle::Flow, FuzzYamlContainer::Object) => format!("{{x: {inner}}}"),
+                (FuzzYamlStyle::Block, FuzzYamlContainer::Array) => {
+                    format!("\n{}- {inner}", "  ".repeat(indent + 1))
+                }
+                (FuzzYamlStyle::Block, FuzzYamlContainer::Object) => {
+                    format!("\n{}x: {inner}", "  ".repeat(indent + 1))
+                }
+            }
+        }
     }
 }
 
-fn fuzz_build_yaml_doc(path: &[FuzzYamlContainer], malformation: FuzzYamlMalformation) -> String {
-    format!(
-        "bad: {}\nkeep: 5\n",
-        fuzz_wrap_yaml(path, malformation.leaf_yaml())
-    )
+fn fuzz_build_yaml_doc(
+    path: &[FuzzYamlContainer],
+    malformation: FuzzYamlMalformation,
+    style: FuzzYamlStyle,
+) -> String {
+    // The leaf sits one level deeper than the deepest container -- same
+    // depth `fuzz_wrap_yaml`'s own recursion would reach it at -- so a
+    // block-style `Collision` leaf (itself a two-key mapping, needing its
+    // own indentation) lines up with its container siblings.
+    let leaf = match (malformation, style) {
+        (FuzzYamlMalformation::DecodeFailure, _) => malformation.leaf_yaml(),
+        (FuzzYamlMalformation::Collision, FuzzYamlStyle::Flow) => malformation.leaf_yaml(),
+        (FuzzYamlMalformation::Collision, FuzzYamlStyle::Block) => {
+            let pad = "  ".repeat(path.len() + 1);
+            return format!(
+                "bad: {}\nkeep: 5\n",
+                fuzz_wrap_yaml(
+                    path,
+                    &format!("\n{pad}\"a\\qb\": 1\n{pad}\"a\\zc\": 2"),
+                    style,
+                    0
+                )
+            );
+        }
+    };
+    format!("bad: {}\nkeep: 5\n", fuzz_wrap_yaml(path, leaf, style, 0))
 }
 
 // The YAML twin of `jq_cli_tests.rs`'s `fuzz_select_and_materialize_agree_on_corruption_1965`
@@ -2034,15 +2089,15 @@ proptest! {
             prop_oneof![Just(FuzzYamlContainer::Array), Just(FuzzYamlContainer::Object)],
             0..=4,
         ),
-        malformation_index in 0..2u8,
+        malformation in prop_oneof![
+            Just(FuzzYamlMalformation::DecodeFailure),
+            Just(FuzzYamlMalformation::Collision),
+        ],
+        style in prop_oneof![Just(FuzzYamlStyle::Flow), Just(FuzzYamlStyle::Block)],
     ) {
-        let malformation = match malformation_index {
-            0 => FuzzYamlMalformation::DecodeFailure,
-            _ => FuzzYamlMalformation::Collision,
-        };
-        let yaml = fuzz_build_yaml_doc(&path, malformation);
+        let yaml = fuzz_build_yaml_doc(&path, malformation, style);
         let expect_stderr = malformation.expect_stderr();
-        let label = format!("{path:?}/{malformation:?}");
+        let label = format!("{path:?}/{malformation:?}/{style:?}");
 
         assert_yq_raises(&label, "select(.bad)", "select(.bad) | .keep", &yaml, &[], expect_stderr);
         assert_yq_raises(&label, ".keep = 9", ".keep = 9", &yaml, &[], expect_stderr);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 use anyhow::Result;
+use proptest::prelude::*;
 use tempfile::{NamedTempFile, TempDir};
 
 #[path = "common/cargo_run_exit.rs"]
@@ -1953,6 +1954,107 @@ keep: 5
         );
     }
     Ok(())
+}
+
+/// One level of container nesting for
+/// [`fuzz_select_and_write_agree_on_corruption_1965`]'s generated documents
+/// -- mirrors `jq_cli_tests.rs`'s own `FuzzContainer`, kept as a separate
+/// type since the two files don't share a common module.
+#[derive(Debug, Clone, Copy)]
+enum FuzzYamlContainer {
+    Array,
+    Object,
+}
+
+/// The two malformation kinds meaningful in YAML (no analog to JSON's
+/// "structural error" -- an unquoted bareword like `xyz123` is a perfectly
+/// valid plain scalar in YAML, per
+/// `test_select_and_write_agree_on_corruption_1803`'s own doc comment).
+#[derive(Debug, Clone, Copy)]
+enum FuzzYamlMalformation {
+    DecodeFailure,
+    Collision,
+}
+
+impl FuzzYamlMalformation {
+    /// The YAML flow-style text substituted at the leaf position.
+    fn leaf_yaml(self) -> &'static str {
+        match self {
+            Self::DecodeFailure => r#""a\qb""#,
+            Self::Collision => r#"{"a\qb": 1, "a\zc": 2}"#,
+        }
+    }
+
+    /// Matches `test_select_and_write_agree_on_corruption_1803`'s own two
+    /// constants.
+    fn expect_stderr(self) -> &'static str {
+        match self {
+            Self::DecodeFailure => "invalid escape sequence",
+            Self::Collision => "ambiguous",
+        }
+    }
+}
+
+/// Wrap `leaf` in `path`'s containers using YAML flow style (`[...]`/
+/// `{x: ...}`), outermost first -- flow style nests recursively as easily as
+/// JSON's brace/bracket syntax does, unlike YAML's indentation-sensitive
+/// block style, and is valid mixed into an otherwise block-style document
+/// (`test_select_and_write_agree_on_corruption_1803`'s own "nested in
+/// array" case already does exactly this: `bad: ["a\qb"]`).
+fn fuzz_wrap_yaml(path: &[FuzzYamlContainer], leaf: &str) -> String {
+    match path.split_first() {
+        None => leaf.to_string(),
+        Some((FuzzYamlContainer::Array, rest)) => format!("[{}]", fuzz_wrap_yaml(rest, leaf)),
+        Some((FuzzYamlContainer::Object, rest)) => format!("{{x: {}}}", fuzz_wrap_yaml(rest, leaf)),
+    }
+}
+
+fn fuzz_build_yaml_doc(path: &[FuzzYamlContainer], malformation: FuzzYamlMalformation) -> String {
+    format!(
+        "bad: {}\nkeep: 5\n",
+        fuzz_wrap_yaml(path, malformation.leaf_yaml())
+    )
+}
+
+// The YAML twin of `jq_cli_tests.rs`'s `fuzz_select_and_materialize_agree_on_corruption_1965`
+// -- see that test's own doc comment for the full #1965 rationale (why this
+// generalizes the fixed-case test above rather than replacing it, and why
+// `ProptestConfig::with_cases` is turned down from proptest's default).
+// Cases are lower here (32 vs. 48) since each one drives *three* real
+// subprocess spawns exactly like the JSON side, and the YAML CLI path is
+// measurably slower per invocation than JSON's (per this repo's own
+// benchmarks) -- keeping this property's wall-clock roughly comparable
+// rather than strictly matching the JSON side's case count.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn fuzz_select_and_write_agree_on_corruption_1965(
+        path in prop::collection::vec(
+            prop_oneof![Just(FuzzYamlContainer::Array), Just(FuzzYamlContainer::Object)],
+            0..=4,
+        ),
+        malformation_index in 0..2u8,
+    ) {
+        let malformation = match malformation_index {
+            0 => FuzzYamlMalformation::DecodeFailure,
+            _ => FuzzYamlMalformation::Collision,
+        };
+        let yaml = fuzz_build_yaml_doc(&path, malformation);
+        let expect_stderr = malformation.expect_stderr();
+        let label = format!("{path:?}/{malformation:?}");
+
+        assert_yq_raises(&label, "select(.bad)", "select(.bad) | .keep", &yaml, &[], expect_stderr);
+        assert_yq_raises(&label, ".keep = 9", ".keep = 9", &yaml, &[], expect_stderr);
+        assert_yq_raises(
+            &label,
+            ".keep = 9 -o=json",
+            ".keep = 9",
+            &yaml,
+            &["-o=json"],
+            expect_stderr,
+        );
+    }
 }
 
 /// #478: `--slurp '.'` shares the same `IndexMap`-backed conversion


### PR DESCRIPTION
## Summary

#1803/#1962's code review flagged the cross-site consistency test (comparing `select`/`-Sc`/`-e` for JSON, `select`/write for YAML, on whether they agree that a malformed sibling field raises) as a fixed, hand-picked case list — exactly the shape `.claude/skills/testing/SKILL.md`'s "Invariant Tests Over Duplicated Logic" section and a prior hand-picked-oracle-matrix-is-biased incident (#106) both warn under-catches this bug class.

## What this adds

A proptest-based property alongside each existing fixed-case test (kept, not replaced — the fixed list's readable per-case labels stay useful for debugging a failure):

- Generates a nesting path of 0-4 arbitrary `Array`/`Object` containers.
- Crosses it with each malformation kind: decode failure, structural error (JSON only — a bareword like `xyz123` is a valid plain scalar in YAML), #1642 collision.
- Builds the document and runs the same CLI battery each existing fixed-case test already uses (`select(.bad) | .keep`, `-Sc .bad`, `-e .bad` for JSON; `select(.bad) | .keep`, `.keep = 9`, `.keep = 9 -o=json` for YAML).
- Asserts all three agree on whether/how it raises.

Case counts (48 JSON, 32 YAML) are turned down from proptest's own default of 256, since each case drives 3 real subprocess spawns rather than an in-process property check.

## Regression-proved

Deliberately broke one CLI arm's expected exit code/stderr substring in each fuzzer and confirmed proptest catches and shrinks the failure to the minimal case (`path = [], malformation_index = 0`) before reverting.

## Test plan
- [x] Both new fuzz tests pass, each in well under 1s
- [x] `cargo test --features cli,simd,regex,serde --workspace` (full suite, includes both `jq_cli_tests`/`yq_cli_tests` at their new counts: 1168/1314)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo test --verbose` (default features)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Fixes #1965