### PR TITLE
fix(jq): five more to_owned_checked sites bypass optional (#1194)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2588,17 +2588,21 @@ fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> 
 /// own suggestion: collapses the `match to_owned_checked(&value) { Ok(v) =>
 /// v, Err(e) => return suppress_or_raise(e, optional) }` four-liner this
 /// issue's whole lineage (#1194→#1953→#1972→#1999→#2001) keeps
-/// rediscovering missing at one more call site, into a two-line `match ...
-/// { Ok(v) => v, Err(early_return) => return early_return }` -- `QueryResult`
-/// has no stable `Try`/`?` impl, so a literal `?` isn't achievable here, but
-/// this still turns "did this site remember `optional`" from a fact a human
-/// has to separately audit for into a call-site choice of which helper to
-/// call.
-fn to_owned_checked_or_suppress<'a, W: Clone + AsRef<[u64]>>(
-    value: &StandardJson<'_, W>,
-    optional: bool,
-) -> Result<OwnedValue, QueryResult<'a, W>> {
-    to_owned_checked(value).map_err(|e| suppress_or_raise(e, optional))
+/// rediscovering missing at one more call site, into a single call. A macro
+/// rather than a function because it has to `return` from the *caller* --
+/// `QueryResult` has no stable `Try`/`?` impl, so a function returning
+/// `Result<_, QueryResult<'_, W>>` still can't be unwrapped with `?` -- the
+/// same reasoning `eval_generic.rs`'s `owned_or_err!`/`push_or_control!`
+/// already establish for the identical "no-`Try`-impl, need-early-return"
+/// shape against `GenericResult`; this is that same idiom's `eval.rs`
+/// twin, not a new one.
+macro_rules! to_owned_checked_or_suppress {
+    ($value:expr, $optional:expr) => {
+        match to_owned_checked($value) {
+            Ok(v) => v,
+            Err(e) => return suppress_or_raise(e, $optional),
+        }
+    };
 }
 
 /// #1934 item 7: whether `optional == true` is ever actually reachable here
@@ -6790,10 +6794,7 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raise, not silently compare as "". #2001: a non-decode-failure error
     // (a #1194 malformed-member shape) respects `optional` the same way
     // this function's own `check_escape`/fanout handling below does.
-    let key_owned = match to_owned_checked_or_suppress(&value, optional) {
-        Ok(v) => v,
-        Err(early_return) => return early_return,
-    };
+    let key_owned = to_owned_checked_or_suppress!(&value, optional);
     let (candidates, xs_escape) = eval_owned_multi_keep_partial::<S>(obj_expr, &key_owned);
     // `key_owned` doesn't change across `candidates`, so this is computed
     // once rather than once per candidate (#909 review). Semantics-aware --
@@ -7534,10 +7535,7 @@ fn any_all_gen_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `suppress_or_raise`'s own doc comment), so treating this entry
     // point's own conversion as unconditional was the actual gap, not a
     // deliberate split.
-    let owned = match to_owned_checked_or_suppress(&value, optional) {
-        Ok(v) => v,
-        Err(early_return) => return early_return,
-    };
+    let owned = to_owned_checked_or_suppress!(&value, optional);
 
     let mut matched = false;
     // `cond`'s own escape is not `gen`'s, so it travels out-of-band rather
@@ -8547,10 +8545,7 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // non-decode-failure error (a #1194 malformed-member shape) respects
     // `optional` the same way the closure's own kind-mismatch check below
     // does.
-    let input = match to_owned_checked_or_suppress(&value, optional) {
-        Ok(v) => v,
-        Err(early_return) => return early_return,
-    };
+    let input = to_owned_checked_or_suppress!(&value, optional);
     fanout_arg::<W, S, _>(
         b_expr,
         value.clone(),
@@ -8659,10 +8654,7 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // non-decode-failure error (a #1194 malformed-member shape) respects
     // `optional` the same way the closure's own kind-mismatch check below
     // does -- mirrors `builtin_contains`'s matching fix.
-    let input = match to_owned_checked_or_suppress(&value, optional) {
-        Ok(v) => v,
-        Err(early_return) => return early_return,
-    };
+    let input = to_owned_checked_or_suppress!(&value, optional);
     fanout_arg::<W, S, _>(
         b_expr,
         value.clone(),
@@ -37172,18 +37164,12 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // sibling `QueryResult::None if optional`/keys-must-be-an-array arms
     // in this same match do.
     let keys_owned = match eval_single::<W, S>(keys_expr, value.clone(), optional) {
-        QueryResult::One(v) => match to_owned_checked_or_suppress(&v, optional) {
-            Ok(v) => v,
-            Err(early_return) => return early_return,
-        },
+        QueryResult::One(v) => to_owned_checked_or_suppress!(&v, optional),
         // Defensive only: `eval_single` (unlike top-level `eval`'s own
         // `Expr::Identity` special case) never actually produces
         // `OneCursor`, so this arm is unreachable in practice today --
         // kept fallible anyway rather than assuming that stays true.
-        QueryResult::OneCursor(c) => match to_owned_checked_or_suppress(&c.value(), optional) {
-            Ok(v) => v,
-            Err(early_return) => return early_return,
-        },
+        QueryResult::OneCursor(c) => to_owned_checked_or_suppress!(&c.value(), optional),
         QueryResult::Owned(v) => v,
         QueryResult::ManyOwned(v) if !v.is_empty() => v.into_iter().next().unwrap(),
         QueryResult::ManyOwned(_) => {
@@ -37197,10 +37183,7 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             return QueryResult::Error(EvalError::new("pick: keys expression produced no output"))
         }
         QueryResult::Many(v) if !v.is_empty() => {
-            match to_owned_checked_or_suppress(&v.into_iter().next().unwrap(), optional) {
-                Ok(v) => v,
-                Err(early_return) => return early_return,
-            }
+            to_owned_checked_or_suppress!(&v.into_iter().next().unwrap(), optional)
         }
         QueryResult::Many(_) => {
             return QueryResult::Error(EvalError::new("pick: keys expression produced no output"))
@@ -40898,6 +40881,40 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Identity;
+        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001 (code review): `builtin_pick`'s keys-expression conversion has
+    /// *three* `to_owned_checked_or_suppress` sites -- `One`, `OneCursor`
+    /// (parser-unreachable, not covered here), and `Many` (reached by a
+    /// multi-output keys expression, which `pick`/`omit` take only the
+    /// first output of). The `One`-arm test above never exercises this one.
+    ///
+    /// `.k1, .k2` (two field accesses, matching
+    /// `test_pick_omit_keys_expression_raises_on_decode_failure_1755`'s own
+    /// established way of reaching this arm) is required rather than `(.,
+    /// [])`: both operands there stay cursor-backed, so `eval_comma`
+    /// aggregates them into `QueryResult::Many` without materializing
+    /// either upfront, letting `builtin_pick`'s own `Many` arm be the first
+    /// place `to_owned_checked` runs on the malformed `.k1`. A literal
+    /// operand like `[]` forces an earlier, unconditional owned-conversion
+    /// inside `eval_comma` itself before `builtin_pick` ever sees a
+    /// `Many`/`ManyOwned` result -- confirmed empirically: that shape
+    /// raises regardless of `optional`, an unrelated site this PR doesn't
+    /// touch, not the bug this test is pinning.
+    #[test]
+    fn test_builtin_pick_many_arm_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"k1":{"x":1,"y"},"k2":["b"]}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = parse("(.k1,.k2)").unwrap();
         match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), true) {
             QueryResult::None => {}
             other => panic!("expected None, got {other:?}"),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2584,6 +2584,23 @@ fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> 
     }
 }
 
+/// [`to_owned_checked`] plus [`suppress_or_raise`] in one call, per #2001's
+/// own suggestion: collapses the `match to_owned_checked(&value) { Ok(v) =>
+/// v, Err(e) => return suppress_or_raise(e, optional) }` four-liner this
+/// issue's whole lineage (#1194→#1953→#1972→#1999→#2001) keeps
+/// rediscovering missing at one more call site, into a two-line `match ...
+/// { Ok(v) => v, Err(early_return) => return early_return }` -- `QueryResult`
+/// has no stable `Try`/`?` impl, so a literal `?` isn't achievable here, but
+/// this still turns "did this site remember `optional`" from a fact a human
+/// has to separately audit for into a call-site choice of which helper to
+/// call.
+fn to_owned_checked_or_suppress<'a, W: Clone + AsRef<[u64]>>(
+    value: &StandardJson<'_, W>,
+    optional: bool,
+) -> Result<OwnedValue, QueryResult<'a, W>> {
+    to_owned_checked(value).map_err(|e| suppress_or_raise(e, optional))
+}
+
 /// #1934 item 7: whether `optional == true` is ever actually reachable here
 /// (or at `eval_reduce`/`eval_foreach`/`eval_as`, which route into this same
 /// guard) was left as an open question after #1902/#1927's review -- multiple
@@ -6770,10 +6787,12 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // doesn't change `.`).
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable key must
-    // raise, not silently compare as "".
-    let key_owned = match to_owned_checked(&value) {
+    // raise, not silently compare as "". #2001: a non-decode-failure error
+    // (a #1194 malformed-member shape) respects `optional` the same way
+    // this function's own `check_escape`/fanout handling below does.
+    let key_owned = match to_owned_checked_or_suppress(&value, optional) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(early_return) => return early_return,
     };
     let (candidates, xs_escape) = eval_owned_multi_keep_partial::<S>(obj_expr, &key_owned);
     // `key_owned` doesn't change across `candidates`, so this is computed
@@ -7506,12 +7525,18 @@ fn any_all_gen_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable root value
     // must raise, not silently become "" and get fed to `gen` as if it
-    // were the real value. Unconditional regardless of `optional`: that
-    // flag governs `gen`'s own generator errors below, never a decode
-    // failure at this entry point.
-    let owned = match to_owned_checked(&value) {
+    // were the real value. #2001: a genuine decode failure still raises
+    // unconditionally either way, but a non-decode-failure error (a #1194
+    // malformed-member shape) now respects `optional` the same way `gen`'s
+    // own generator errors do a few lines below -- `optional` is a live,
+    // used parameter throughout the rest of this function (unlike
+    // `builtin_recurse_f`'s principled exemption, see
+    // `suppress_or_raise`'s own doc comment), so treating this entry
+    // point's own conversion as unconditional was the actual gap, not a
+    // deliberate split.
+    let owned = match to_owned_checked_or_suppress(&value, optional) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(early_return) => return early_return,
     };
 
     let mut matched = false;
@@ -8518,10 +8543,13 @@ fn builtin_contains<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // argument would pay for it N times.
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable input must
-    // raise, not silently be checked for containment as "".
-    let input = match to_owned_checked(&value) {
+    // raise, not silently be checked for containment as "". #2001: a
+    // non-decode-failure error (a #1194 malformed-member shape) respects
+    // `optional` the same way the closure's own kind-mismatch check below
+    // does.
+    let input = match to_owned_checked_or_suppress(&value, optional) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(early_return) => return early_return,
     };
     fanout_arg::<W, S, _>(
         b_expr,
@@ -8627,10 +8655,13 @@ fn builtin_inside<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `builtin_contains`, of which this is the inverse.
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable input must
-    // raise, not silently be checked for containment as "".
-    let input = match to_owned_checked(&value) {
+    // raise, not silently be checked for containment as "". #2001: a
+    // non-decode-failure error (a #1194 malformed-member shape) respects
+    // `optional` the same way the closure's own kind-mismatch check below
+    // does -- mirrors `builtin_contains`'s matching fix.
+    let input = match to_owned_checked_or_suppress(&value, optional) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(early_return) => return early_return,
     };
     fanout_arg::<W, S, _>(
         b_expr,
@@ -37135,18 +37166,23 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // must raise, not silently become "" (and then fail the "must be an
     // array" check with the wrong message, or worse, silently pick/omit
     // nothing correctly-named).
+    // #2001: each `to_owned_checked` below now routes through
+    // `to_owned_checked_or_suppress` -- a non-decode-failure error (a
+    // #1194 malformed-member shape) respects `optional` the same way the
+    // sibling `QueryResult::None if optional`/keys-must-be-an-array arms
+    // in this same match do.
     let keys_owned = match eval_single::<W, S>(keys_expr, value.clone(), optional) {
-        QueryResult::One(v) => match to_owned_checked(&v) {
+        QueryResult::One(v) => match to_owned_checked_or_suppress(&v, optional) {
             Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
+            Err(early_return) => return early_return,
         },
         // Defensive only: `eval_single` (unlike top-level `eval`'s own
         // `Expr::Identity` special case) never actually produces
         // `OneCursor`, so this arm is unreachable in practice today --
         // kept fallible anyway rather than assuming that stays true.
-        QueryResult::OneCursor(c) => match to_owned_checked(&c.value()) {
+        QueryResult::OneCursor(c) => match to_owned_checked_or_suppress(&c.value(), optional) {
             Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
+            Err(early_return) => return early_return,
         },
         QueryResult::Owned(v) => v,
         QueryResult::ManyOwned(v) if !v.is_empty() => v.into_iter().next().unwrap(),
@@ -37161,9 +37197,9 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             return QueryResult::Error(EvalError::new("pick: keys expression produced no output"))
         }
         QueryResult::Many(v) if !v.is_empty() => {
-            match to_owned_checked(&v.into_iter().next().unwrap()) {
+            match to_owned_checked_or_suppress(&v.into_iter().next().unwrap(), optional) {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(early_return) => return early_return,
             }
         }
         QueryResult::Many(_) => {
@@ -40750,6 +40786,125 @@ mod tests {
         match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), df_cursor.value(), true) {
             QueryResult::Error(e) => assert!(e.is_decode_failure()),
             other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+    }
+
+    /// #2001: `builtin_in`'s own root-value conversion had the same
+    /// unconditional-regardless-of-`optional` gap the #1953/#1972/#1999
+    /// sweeps already closed elsewhere. See
+    /// `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for why this is exercised via a direct call rather than
+    /// through the CLI.
+    #[test]
+    fn test_builtin_in_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let obj_expr = parse("[]").unwrap();
+        match builtin_in::<Vec<u64>, JqSemantics>(&obj_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_in::<Vec<u64>, JqSemantics>(&obj_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001: `any_all_gen_cond`'s own root-value conversion was previously
+    /// unconditional by design (its own doc comment claimed `optional`
+    /// only ever governs `gen`'s later generator errors) -- but `optional`
+    /// is a live, used parameter throughout the rest of this function
+    /// (unlike `builtin_recurse_f`'s principled exemption), so that split
+    /// was the actual gap. See
+    /// `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for why this is exercised via a direct call.
+    #[test]
+    fn test_any_all_gen_cond_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let gen_expr = Expr::Identity;
+        let cond_expr = Expr::Literal(Literal::Bool(true));
+        match any_all_gen_cond::<Vec<u64>, JqSemantics>(
+            &gen_expr,
+            &cond_expr,
+            cursor.value(),
+            true,
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match any_all_gen_cond::<Vec<u64>, JqSemantics>(
+            &gen_expr,
+            &cond_expr,
+            cursor.value(),
+            false,
+            true,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001: `builtin_contains`'s own root-value conversion had the same
+    /// gap. See
+    /// `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for why this is exercised via a direct call.
+    #[test]
+    fn test_builtin_contains_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let b_expr = Expr::Literal(Literal::String(String::new()));
+        match builtin_contains::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_contains::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001: `builtin_inside`'s own root-value conversion had the same
+    /// gap, mirroring `builtin_contains`'s matching fix. See
+    /// `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
+    /// doc comment for why this is exercised via a direct call.
+    #[test]
+    fn test_builtin_inside_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let b_expr = Expr::Literal(Literal::String(String::new()));
+        match builtin_inside::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_inside::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001: `builtin_pick`'s own keys-expression-result conversion (the
+    /// `QueryResult::One(v)` arm) had the same gap. Uses `Expr::Identity`
+    /// as the keys expression so its own output is the same malformed
+    /// document under test.
+    #[test]
+    fn test_builtin_pick_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Identity;
+        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

`builtin_in`, `any_all_gen_cond`, `builtin_contains`, `builtin_inside`,
and `builtin_pick` (three sites) all raised unconditionally on a
non-decode-failure `to_owned_checked` error (a #1194 malformed-member
shape), ignoring `optional` — despite each having a live, used `optional`
parameter elsewhere in the same function body. Same gap #1953/#1972/#1999
already closed at other sites in this lineage.

`any_all_gen_cond`'s own doc comment claimed the conversion was
deliberately unconditional ("that flag governs `gen`'s own generator
errors, never a decode failure at this entry point"). But `optional` is
used throughout the rest of the function — unlike `builtin_recurse_f`'s
principled exemption (`optional` unused elsewhere, matching real jq's own
`recurse` having no internal optional-suppression concept; see
`suppress_or_raise`'s doc comment) — so that split was the actual gap,
not a deliberate design choice. Comment updated to match.

## New combinator

Adds `to_owned_checked_or_suppress`, combining `to_owned_checked` with
the existing `suppress_or_raise` helper in one call, per this issue's own
architectural suggestion — collapses the four-line
`match to_owned_checked(&value) { Ok(v) => v, Err(e) => return
suppress_or_raise(e, optional) }` this whole issue lineage
(#1194→#1953→#1972→#1999→#2001) keeps rediscovering missing at one more
site, into a two-line `match to_owned_checked_or_suppress(&value,
optional) { Ok(v) => v, Err(early_return) => return early_return }`.
`QueryResult` has no stable `Try`/`?` impl, so a literal `?` (as the
issue's wording aspired to) isn't achievable on stable Rust — this is the
closest equivalent, matching this file's existing idiom for
`Result<_, QueryResult<'a, W>>`-shaped early returns elsewhere.

## Scope

The remaining ~54 unaudited `to_owned_checked` call sites this issue
names stay out of scope for this pass — this PR only touches the 5
concrete, pre-identified, live-`optional`-parameter sites.

## Test plan

- [x] Five new tests, each calling the target function directly with an
      explicit `optional: true`/`false` (not through the CLI — per this
      lineage's own established finding, none of these builtins forwards
      `optional: true` through any real `?`/`try` syntax today; `eval_try`'s
      generic catch-and-convert wraps them instead). Verified each
      independently fails when its own site's fix is reverted (temporarily
      reverted all 7 call sites — `builtin_pick` has three — confirmed all
      5 tests fail, restored).
- [x] `cargo test --features cli,simd,regex,serde --workspace` (56/56 binaries green)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`

All checks run against a genuinely clean build (`cargo clean -p
succinctly` before the verification pass) — a prior PR this session
(#2003) found local `clippy`/`no_std` checks can falsely pass against
stale incremental artifacts right after an edit.

## Update (code review)

- Converted `to_owned_checked_or_suppress` from a function to a macro,
  matching `eval_generic.rs`'s existing `owned_or_err!`/`push_or_control!`
  idiom for the identical "need early-return from a non-`Try` result type"
  problem -- collapses each call site from a 3-line match to one line.
- Added coverage for `builtin_pick`'s `QueryResult::Many` arm specifically
  (the original test only reached `QueryResult::One`) -- verified
  independently that reverting just that arm's fix makes the new test fail.
- Filed #2015 for `builtin_upper_in`/`builtin_upper_in_src` (found during
  review), which hardcode/ignore `optional` when calling into
  `any_all_gen_cond` -- not folded into this PR since `optional` is unused
  elsewhere in both functions (the `builtin_recurse_f`-style exemption
  shape, not the live-parameter gap this PR's five sites all had) and
  needs verification against real jq before treating as a bug.
