### PR TITLE
fix(test): reap child before propagating a stdin write failure

### DIFF
--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -220,13 +220,32 @@ pub fn spawn_with_signal_retry(
             }
             Err(e) => return Err(e.into()),
         };
-        if let Some(input) = stdin_input {
+        // Write, but don't propagate a failure yet (#1891): if the child
+        // exits or closes stdin early (e.g. an argv-parse error before it
+        // ever reads stdin), `write_all` can fail before the child has been
+        // waited on. Returning via `?` at that point would drop `child`
+        // without reaping it -- `Child`'s `Drop` does not wait() the OS
+        // process, so the early return would leak a zombie for the rest of
+        // this test binary's run. `wait_with_output()` below doesn't care
+        // whether the write succeeded; call it unconditionally first so the
+        // child is always reaped, then surface the write error if there was
+        // one.
+        //
+        // Ordering invariant: this write runs to completion (blocking on a
+        // full pipe buffer) *before* `wait_with_output()`'s own concurrent
+        // stdout/stderr draining starts, which is the classic double-pipe
+        // deadlock shape if the child fills its stdout/stderr buffer while
+        // waiting on stdin. Currently safe only because every binary this
+        // helper spawns reads stdin to completion before writing any
+        // output, and the small inputs/outputs these tests use never fill
+        // an OS pipe buffer either way -- not an invariant this function
+        // enforces itself.
+        let write_result = stdin_input.and_then(|input| {
             use std::io::Write;
-            if let Some(mut sin) = child.stdin.take() {
-                sin.write_all(input)?;
-            }
-        }
+            child.stdin.take().map(|mut sin| sin.write_all(input))
+        });
         let output = child.wait_with_output()?;
+        write_result.transpose()?;
         if let Some(code) = output.status.code() {
             return Ok((output, code));
         }
@@ -241,4 +260,82 @@ pub fn spawn_with_signal_retry(
         std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
     }
     unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spawn_with_signal_retry;
+
+    /// #1891: a `write_all` failure used to `?` out of
+    /// `spawn_with_signal_retry` before the child was ever waited on,
+    /// leaking a zombie process for the rest of this test binary's run.
+    /// Reproduces the failure condition -- a large stdin payload to a
+    /// child that closes its own stdin (and so its own read end of the
+    /// pipe) almost immediately, reliably forcing `write_all` to observe
+    /// a broken pipe (a small write can silently land in the kernel pipe
+    /// buffer even after the reader has gone away, so this needs to be
+    /// large enough to exceed that buffer) -- and verifies via a
+    /// process-table check that the *specific* child process is not left
+    /// as a zombie either way.
+    ///
+    /// Checks one targeted PID, not a system-wide zombie count: this
+    /// crate's own test suite runs many test binaries and threads
+    /// concurrently, each spawning its own short-lived subprocesses, so a
+    /// broad "any zombie owned by this process" scan sees transient noise
+    /// from unrelated sibling tests under load and is not reliable here
+    /// (this shape of flake was caught live during this issue's own
+    /// verification). The child writes its own PID to a temp file as its
+    /// first action -- independent of whatever happens to its stdin --
+    /// so the PID is known even on the failure path, where
+    /// `spawn_with_signal_retry`'s own `Output` (whose stdout would
+    /// otherwise carry it) is never returned.
+    ///
+    /// Skips the assertion (not the exercise of the code path itself) if
+    /// `ps` isn't available in this environment, rather than failing on
+    /// an environment limitation.
+    #[test]
+    #[cfg(unix)]
+    fn reaps_child_on_stdin_write_failure_1891() {
+        let pid_file = tempfile::NamedTempFile::new().expect("create temp file");
+        let pid_path = pid_file.path().to_path_buf();
+
+        let big_input = vec![0u8; 8 * 1024 * 1024];
+        // The write failing (or not -- the OS's exact timing isn't
+        // guaranteed) is the path under test here, not a test failure in
+        // itself; what matters is that this doesn't panic and doesn't
+        // leave a zombie either way.
+        let _ = spawn_with_signal_retry(
+            || {
+                let mut cmd = std::process::Command::new("sh");
+                cmd.args(["-c", &format!("echo $$ > {}", pid_path.display())]);
+                cmd
+            },
+            Some(&big_input),
+        );
+
+        // The child writing its PID file and exiting isn't necessarily
+        // synchronous with this function returning; give it a moment.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let Ok(pid_text) = std::fs::read_to_string(&pid_path) else {
+            eprintln!("skipping zombie assertion: child never wrote its PID file");
+            return;
+        };
+        let Ok(pid) = pid_text.trim().parse::<u32>() else {
+            eprintln!("skipping zombie assertion: unparseable PID {pid_text:?}");
+            return;
+        };
+
+        let Ok(output) = std::process::Command::new("ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output()
+        else {
+            eprintln!("skipping zombie assertion: `ps` unavailable in this environment");
+            return;
+        };
+        let stat = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stat.contains('Z'),
+            "child pid {pid} is a zombie (stat: {stat:?}) -- not reaped"
+        );
+    }
 }

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -1,10 +1,19 @@
 //! Shared exit-code classification for `cargo run`-spawned CLI test helpers.
 //!
-//! Included by `tests/jq_cli_tests.rs`, `tests/cli_golden_tests.rs`,
-//! `tests/cli_characterization_tests.rs`, `tests/deep_nesting_valid_tests.rs`
-//! and `tests/json_validate_tests.rs` via `#[path = ...] mod`, per the
-//! `tests/common/` convention `json_oracle.rs` established. #1516 fixed the
-//! signal-death misdiagnosis
+//! Included via `#[path = "common/cargo_run_exit.rs"] mod ...` by 11
+//! integration-test crates as of #1891's own code review (this list drifts
+//! independently of this comment -- `grep -rl '#\[path = "common/
+//! cargo_run_exit.rs"\]' tests/*.rs` is the source of truth, not this
+//! prose): `cli_characterization_tests.rs`, `cli_golden_tests.rs`,
+//! `deep_nesting_valid_tests.rs`, `dsv_cli_tests.rs`, `jq_cli_tests.rs`,
+//! `json_validate_tests.rs`, `locate_cli_tests.rs`,
+//! `orchestrate_cli_tests.rs`, `text_cli_tests.rs`,
+//! `yaml_validate_tests.rs`, `yq_cli_tests.rs` -- per the `tests/common/`
+//! convention `json_oracle.rs` established. Since `#[path]` textually
+//! inlines the whole file, anything added here (including this file's own
+//! `#[cfg(test)]` module) compiles and runs independently in *every* one of
+//! those crates, not just the ones that call this file's own functions.
+//! #1516 fixed the signal-death misdiagnosis
 //! (`.code().unwrap_or(-1)` silently coercing a killed child to a fake exit
 //! code) in `jq_cli_tests.rs` alone; its own `/code-review` found the
 //! identical pattern hand-rolled in three more files (#1546). Sharing one
@@ -240,12 +249,31 @@ pub fn spawn_with_signal_retry(
         // output, and the small inputs/outputs these tests use never fill
         // an OS pipe buffer either way -- not an invariant this function
         // enforces itself.
-        let write_result = stdin_input.and_then(|input| {
-            use std::io::Write;
-            child.stdin.take().map(|mut sin| sin.write_all(input))
-        });
-        let output = child.wait_with_output()?;
-        write_result.transpose()?;
+        let write_result: std::io::Result<()> =
+            if let (Some(input), Some(mut sin)) = (stdin_input, child.stdin.take()) {
+                use std::io::Write;
+                sin.write_all(input)
+            } else {
+                Ok(())
+            };
+        // Prefer the write error's own diagnostic over `wait_with_output`'s
+        // (#1891 code review): on the rare double failure -- the child is
+        // also reaped or killed by something else (an OOM kill, another
+        // session's `pkill`, `cargo-guard.sh`'s stall guard, all named
+        // above) between the write failing and this wait running --
+        // `wait_with_output` erroring first would otherwise mask *why* the
+        // write itself failed with a more generic wait/I-O error.
+        let output = match child.wait_with_output() {
+            Ok(output) => output,
+            Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
+        };
+        // A write failure returns here unconditionally, same as it always
+        // has (#1891 code review): only exit-status classification below
+        // gets this loop's own retry-on-signal-death treatment, not a
+        // failed write -- unchanged by this fix, which only moved *when*
+        // the child gets reaped relative to this return, not *whether* a
+        // write failure skips the retry path.
+        write_result?;
         if let Some(code) = output.status.code() {
             return Ok((output, code));
         }
@@ -290,16 +318,34 @@ mod tests {
     /// `spawn_with_signal_retry`'s own `Output` (whose stdout would
     /// otherwise carry it) is never returned.
     ///
-    /// Skips the assertion (not the exercise of the code path itself) if
-    /// `ps` isn't available in this environment, rather than failing on
-    /// an environment limitation.
+    /// No sleep between `spawn_with_signal_retry` returning and reading the
+    /// PID file: that call already blocks on `wait_with_output()` before
+    /// returning at all (on every path, success or the write-failure path
+    /// this test exercises -- that's the fix), so the child's PID-file
+    /// write and exit already happened, synchronously, before this
+    /// function got its `_` back.
+    ///
+    /// Skips the final assertion (not the exercise of the code path
+    /// itself) only for the one condition genuinely outside this test's
+    /// own control -- `ps` unavailable in this environment. The PID file
+    /// existing and parsing are asserted, not skipped, on failure: this
+    /// test wrote that `sh` command itself, so either failing indicates a
+    /// real regression in the spawn/write path, not an environment
+    /// limitation, and silently passing over it would let that regression
+    /// through as a quiet stderr line on an otherwise-green run.
     #[test]
     #[cfg(unix)]
     fn reaps_child_on_stdin_write_failure_1891() {
         let pid_file = tempfile::NamedTempFile::new().expect("create temp file");
         let pid_path = pid_file.path().to_path_buf();
 
-        let big_input = vec![0u8; 8 * 1024 * 1024];
+        // A few multiples of the largest common OS pipe buffer (64 KiB on
+        // Linux, historically 16 KiB on macOS) is enough to guarantee the
+        // write blocks against a child that never reads it; the child
+        // closing its own stdin (it never reads at all) is what turns
+        // that block into the broken-pipe failure this test exercises,
+        // not the buffer's own size past that point.
+        let big_input = vec![0u8; 1024 * 1024];
         // The write failing (or not -- the OS's exact timing isn't
         // guaranteed) is the path under test here, not a test failure in
         // itself; what matters is that this doesn't panic and doesn't
@@ -313,17 +359,13 @@ mod tests {
             Some(&big_input),
         );
 
-        // The child writing its PID file and exiting isn't necessarily
-        // synchronous with this function returning; give it a moment.
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        let Ok(pid_text) = std::fs::read_to_string(&pid_path) else {
-            eprintln!("skipping zombie assertion: child never wrote its PID file");
-            return;
-        };
-        let Ok(pid) = pid_text.trim().parse::<u32>() else {
-            eprintln!("skipping zombie assertion: unparseable PID {pid_text:?}");
-            return;
-        };
+        let pid_text = std::fs::read_to_string(&pid_path).expect(
+            "child should have written its PID file before spawn_with_signal_retry returned",
+        );
+        let pid: u32 = pid_text
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("unparseable PID {pid_text:?}: {e}"));
 
         let Ok(output) = std::process::Command::new("ps")
             .args(["-o", "stat=", "-p", &pid.to_string()])


### PR DESCRIPTION
## Summary

`tests/common/cargo_run_exit.rs`'s `spawn_with_signal_retry` wrote `stdin_input` to the
spawned child before calling `wait_with_output()`. If `write_all` failed (the child exits
or closes stdin early -- e.g. an argv-parse error before it ever reads stdin), the `?`
propagated immediately and `child` was dropped without ever being waited on. `Child`'s
`Drop` does not reap the OS process, so the child was leaked as a zombie for the remainder
of the test binary's own run.

Fixes #1891.

`wait_with_output()` doesn't care whether the write succeeded, so it's now called
unconditionally first (reaping the child either way), with the write error surfaced
afterward if there was one.

## Scope decision: documented, not fixed, the adjacent dormant deadlock risk

The same code review pass that found this issue also flagged the classic `Command`
pipe-deadlock shape (the stdin write runs to completion, blocking on a full pipe buffer,
*before* `wait_with_output()`'s own concurrent stdout/stderr draining starts) as
currently dormant -- safe only because every binary this helper spawns reads stdin to
completion before writing output, and the small inputs/outputs these tests use never fill
an OS pipe buffer either way. That's now documented as an invariant this function doesn't
itself enforce, rather than restructured into a fuller thread-based fix (spawning a
concurrent stdin-writer thread) -- a materially larger change than this issue's own
**Severity: Low** framing calls for.

## Test

New regression test targets one *specific* child PID (via a temp file the child writes
its own PID to, independent of whatever happens to its stdin) rather than a system-wide
zombie count. First attempt used a broad "any zombie owned by this process" scan, which
turned out to be flaky itself under this crate's own `cargo test --workspace`: many test
binaries and threads run concurrently, each spawning short-lived subprocesses of their
own, so the scan saw transient noise from unrelated sibling tests under load (caught live
during this fix's own verification -- 2 of 56 test binaries failed on the first full-suite
run). The PID-targeted redesign eliminates that noise entirely and passed 2/2 full-suite
runs afterward.

Verified to fail against the pre-fix code twice: once with the original count-based
design (a real zombie, not just noise -- count grew 0→1 in an isolated single-test run),
and again with the redesigned PID-targeted check after replacing the flaky design.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace --no-fail-fast` — 56/56 binaries, 6667 passed, 0 failed (run twice, both clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings)

Fixes #1891