### PR TITLE
perf(jq): inline single-output replacement cell; correct the input-bridge cost

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1375,21 +1375,41 @@ raises once per top-level document, matching jq — see
 the mechanism.
 
 **The bridge is not free, and it is not universal.** It re-serialises and re-indexes each
-document on top of the index `evaluate_input` already built, so its cost scales with
-document size. An interleaved wall-clock spot check with
-`[.[] | select(.id != null) | .id], (input | [.[] | .id])` over two copies of one generated
-file, outputs byte-identical either way, put the penalty near **1.7x** and growing linearly:
-1 MB 0.06 s → 0.10 s, 2 MB 0.12 s → 0.23 s, 4 MB 0.24 s → 0.43 s. A filter with no input
-builtin is untouched (0.01 s on both), so the guard itself is free — only the programs it
-fires for pay.
+document on top of the index `evaluate_input` already built, so its cost scales with document
+size.
 
-Treat that ratio as indicative, not as a benchmark result: it is `/usr/bin/time` over three
-interleaved repetitions on an Apple M5 Max **laptop running on battery**, which
-[the benchmarking guide](../../guides/benchmarking.md#ab-benchmarking-method) rules out for
-a number worth quoting, and x86_64 was not measured at all. What the check does establish is
-the shape — a per-document, size-proportional penalty, matching the mechanism — and that it
-is confined to filters using an input builtin. Re-measure on pinned hardware before treating
-1.7x as the figure.
+Measured on both pinned boxes, idle, interleaved within each repetition, medians of 5, with an
+output-identity gate (#1603). Isolating the bridge needs **four** variants over one corpus, not
+two, because a naive "with `input`" vs "without `input`" pairing varies document count, pipeline
+count *and* the bridge all at once:
+
+| | variant | docs | pipelines | bridge |
+|---|---|---|---|---|
+| **A** | `[.users[] \| select(.id != null) \| .id]`, 1-doc file | 1 | 1 | no |
+| **C** | that filter plus `, ([.users[] \| .id])`, 1-doc file | 1 | 2 | no |
+| **D** | the same two-pipeline filter, 2-doc file | 2 | 2 | no |
+| **B** | `..., (input \| [.users[] \| .id])`, 2-doc file | 2 | 2 | **yes** |
+
+14 MB `-p users`:
+
+| box | A | C | D | B | C/A | D/C | **B/D — the bridge** |
+|---|---|---|---|---|---|---|---|
+| M4 Pro | 125 ms | 176 ms | 340 ms | 929 ms | 1.41x | 1.93x | **2.73x** |
+| 7950X | 158 ms | 223 ms | 439 ms | 1407 ms | 1.41x | 1.97x | **3.21x** |
+
+`D/C ≈ 1.95` is just "two documents cost about twice one document" — the term a two-variant
+comparison folds into the bridge. The bridge itself is **2.7x on ARM, 3.2x on x86_64**, not the
+~1.7x recorded here previously; that figure came from a battery-powered laptop run whose
+comparison was not work-matched, and it understated the cost. Comparing whole commands (B/A)
+instead gives 7.4x/8.9x, which overstates it by the same conflation in the other direction.
+
+The multiplier is **stable across document size**, not growing: 7950X B/D measures 3.14x at
+4 MB, 3.25x at 14 MB and 3.36x at 40 MB, with both D and B themselves growing linearly. So the
+overhead is proportional to document size — the earlier "growing linearly" wording described the
+absolute cost, which is true but says nothing the multiplier does not.
+
+A filter with no input builtin is untouched, so the guard itself is free — only the programs it
+fires for pay.
 
 It is also **carved back out for cursor-metadata builtins**. `eval.rs` has no cursor to
 answer position questions from: `line`/`column`/`document_index`/`anchor`/`style`/

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13523,6 +13523,43 @@ fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     Ok(values)
 }
 
+/// One match's replacement text: the single-output case inline, generator
+/// replacements behind a `Vec`.
+///
+/// `sub`/`gsub` accept a generator replacement, so a match can produce more
+/// than one row -- but a literal or any other non-generator replacement
+/// produces exactly one, which is the case essentially every real call
+/// takes. Giving that case its own `Vec` cost one heap allocation per match
+/// on top of the string it holds: at half a million matches in a single
+/// `gsub`, 108.7 -> 75.6 MiB of peak RSS (#1834, measured against a probe
+/// that removed the per-match `Vec` outright).
+#[cfg(feature = "regex")]
+enum ReplacementCell {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[cfg(feature = "regex")]
+impl ReplacementCell {
+    /// How many rows this match contributes.
+    fn len(&self) -> usize {
+        match self {
+            Self::One(_) => 1,
+            Self::Many(rows) => rows.len(),
+        }
+    }
+
+    /// This match's text for `row`, or `None` when it has no such row --
+    /// a shorter generator among longer siblings contributes nothing to the
+    /// later rows, exactly as the previous `Vec::get` did.
+    fn row(&self, row: usize) -> Option<&str> {
+        match self {
+            Self::One(one) => (row == 0).then_some(one.as_str()),
+            Self::Many(rows) => rows.get(row).map(String::as_str),
+        }
+    }
+}
+
 /// Apply `replacement_expr` at every match and produce **one output string per
 /// transposed row** (#1279).
 ///
@@ -13557,23 +13594,35 @@ fn stitch_replacement_rows<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     matches: &[regex::Captures],
     optional: bool,
 ) -> Result<Vec<String>, QueryResult<'a, W>> {
-    let mut cells: Vec<Vec<String>> = vec_with_capacity(matches.len());
+    let mut cells: Vec<ReplacementCell> = vec_with_capacity(matches.len());
     let mut last_end = 0;
     for caps in matches {
         let m = caps
             .get(0)
             .expect("capture group 0 is always present on a match");
-        let outputs = eval_sub_replacement::<W, S>(replacement_expr, re, caps, optional)?;
+        let mut outputs = eval_sub_replacement::<W, S>(replacement_expr, re, caps, optional)?;
         let gap = &input[last_end..m.start()];
-        let mut cell = vec_with_capacity(outputs.len());
-        for replacement in outputs {
-            cell.push(combine_sub_gap::<W, S>(gap, replacement)?);
-        }
+        // One output is the overwhelmingly common case -- a literal or any
+        // other non-generator replacement -- and it is stored inline rather
+        // than behind its own `Vec` (#1834). Half a million matches in one
+        // `gsub` call held half a million one-element `Vec`s alongside their
+        // strings, which measured 108.7 -> 75.6 MiB peak RSS against a probe
+        // that removed them.
+        let cell = if outputs.len() == 1 {
+            let replacement = outputs.pop().expect("len checked");
+            ReplacementCell::One(combine_sub_gap::<W, S>(gap, replacement)?)
+        } else {
+            let mut many = vec_with_capacity(outputs.len());
+            for replacement in outputs {
+                many.push(combine_sub_gap::<W, S>(gap, replacement)?);
+            }
+            ReplacementCell::Many(many)
+        };
         cells.push(cell);
         last_end = m.end();
     }
 
-    let rows = cells.iter().map(Vec::len).max().unwrap_or(0);
+    let rows = cells.iter().map(ReplacementCell::len).max().unwrap_or(0);
     if rows == 0 {
         return Ok(vec![input.to_string()]);
     }
@@ -13582,7 +13631,7 @@ fn stitch_replacement_rows<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         .map(|row| {
             let mut out = string_with_capacity(input.len());
             for cell in &cells {
-                if let Some(piece) = cell.get(row) {
+                if let Some(piece) = cell.row(row) {
                     out.push_str(piece);
                 }
             }


### PR DESCRIPTION
Three measurement issues sharing one investigation and one methodology. All
numbers below: both pinned boxes, idle, interleaved within each repetition,
medians of 5, `codegen-units=1` (#1587), output-identity gated on every variant.

Two of the three are **refutations** — the measurement says the proposed work
isn't worth doing. Recording that is the deliverable; it's the same outcome
shape as P2.6/P2.8/P3/P5 in `CLAUDE.md`.

## #1834 — refuted on its own workload; one small fix kept

The issue proposes removing the per-match `Vec<String>` in
`stitch_replacement_rows`, citing `gsub` over logs. I priced the **ceiling**
first — a probe deleting the allocation outright, accepting wrong output for
generator replacements — so the proposal is judged against the most it could
possibly buy.

`[.[] | gsub("[0-9]+"; "N")] | length`, realistic log corpus:

| box | main | fix | ceiling |
|---|---|---|---|
| M4 Pro | 1435 ms / 55 MiB | 1422 ms / 55 MiB | 1418 ms / 55 MiB |
| 7950X | 1798 ms / 54 MiB | 1770 ms / 54 MiB | 1730 ms / 54 MiB |

**1–4% on time, 0 MiB on memory** for deleting the thing entirely. The reason is
structural: many short strings with few matches each, so the per-match `Vec`s
are created and dropped inside one `gsub` call and never coexist.

Where it is real — one string, ~500k matches:

| box | main | fix | ceiling |
|---|---|---|---|
| M4 Pro | 182 ms / 108 MiB | 172 ms / 95 MiB | 161 ms / 72 MiB |
| 7950X | 260 ms / 116 MiB | 238 ms / 105 MiB | 225 ms / 74 MiB |

This PR keeps the honest third of that: `ReplacementCell::One(String)` inline,
`Many(Vec<String>)` for generator replacements. `Many` is exactly the previous
representation, so #1279's ragged-row transposition, #1050's error ordering and
#840's zero-row rule are untouched — verified against jq 1.7.1. Not pursuing
the remaining two-thirds: that means not materialising replacement strings at
all, a much larger change to a function carrying three issues' semantics, for a
win only visible on single-string/half-million-match input.

## #1580 (sites 2, 3) — refuted by bounding

Rather than micro-benchmark the fan-out, bound it: measure builtins that use it
against ones that don't, 1M calls, 7950X.

| filter | time |
|---|---|
| `[.[]] \| length` (bare loop) | 278 ms |
| `[.[] \| floor] \| length` (no fanout) | 577 ms |
| `[.[] \| range(0;1)] \| length` (site 2) | 632 ms |
| `[.[] \| sqrt] \| length` (no fanout) | 716 ms |
| `[.[] \| pow(2;3)] \| length` (site 3) | 752 ms |
| `[.[] \| atan2(1;2)] \| length` (site 3) | 805 ms |

Fan-out sites sit inside the spread of non-fan-out builtins, so whatever it
costs is within a **≤36 ns/call** envelope against builtins costing ~450 ns.
A fast path can't recover a cost this size. No code change.

## #1603 — the recorded ~1.7x was wrong

`limitations.md` put the `input` bridge at ~1.7x, self-flagged as measured on a
laptop on battery. It was also **not work-matched**: comparing a filter with
`input` against one without moves document count, pipeline count *and* the
bridge simultaneously. Four variants over one corpus separate them:

| | docs | pipelines | bridge |
|---|---|---|---|
| **A** | 1 | 1 | no |
| **C** | 1 | 2 | no |
| **D** | 2 | 2 | no |
| **B** | 2 | 2 | **yes** |

14 MB `-p users`:

| box | A | C | D | B | C/A | D/C | **B/D — the bridge** | B/A |
|---|---|---|---|---|---|---|---|---|
| M4 Pro | 125 ms | 176 ms | 340 ms | 929 ms | 1.41x | 1.93x | **2.73x** | 7.43x |
| 7950X | 158 ms | 223 ms | 439 ms | 1407 ms | 1.41x | 1.97x | **3.21x** | 8.91x |

`D/C ≈ 1.95` is "two documents cost twice one document" — exactly the term the
old comparison folded into the bridge, which is how it landed under the truth.
`B/A` conflates the same terms the other way and overstates it.

The doc also claimed the penalty grows linearly with size. The *multiplier* is
flat (7950X): 3.14x at 4 MB, 3.25x at 14 MB, 3.36x at 40 MB. Absolute cost
grows because both sides do. Corrected accordingly.

## Incidental

Chasing a 47-second outlier in the #1580 table found an unrelated live bug:
`limit(n; repeat(f))` silently returns 1000 values for any n > 1000, exit 0,
where jq returns n. Filed as #2014, not fixed here.

## Verification

fmt, `cargo test --features cli,simd,regex,serde` (6641 pass), default-features
`cargo test` (3733 pass), both CI clippy legs, `RUSTDOCFLAGS="-D warnings" cargo
doc --no-deps --all-features`, and `--no-default-features` — all green. The last
of those caught a real defect pre-push: the new enum had been inserted directly
beneath a `#[cfg(feature = "regex")]` attribute, silently stealing the gate from
the function below it.

Fixes #1834
Fixes #1580
Fixes #1603
