### PR TITLE
fix(jq,yq): substitute U+FFFD for a lone low surrogate escape instead of erroring

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -839,10 +839,13 @@ which had at least one), confirmed live (`keys_unsorted | map(.)` silently succe
 so a malformed member raises under it exactly as it does without it.
 
 **A key that will not decode is never a duplicate.** succinctly semi-indexes rather than
-validates, so a key carrying an invalid escape or a lone surrogate — input real jq rejects
-outright with `Invalid escape` / `Invalid \uXXXX\uXXXX surrogate pair escape` — still
-reaches the evaluator. Such a key has no decoded name to compare, so it participates in no
-collapse and is echoed verbatim from its source span:
+validates, so a key carrying an invalid escape or a lone *high* surrogate — input real jq
+rejects outright with `Invalid escape` / `Invalid \uXXXX\uXXXX surrogate pair escape` —
+still reaches the evaluator. (A lone *low* surrogate is not this case since #2008: real jq
+accepts it and substitutes U+FFFD, and so does succinctly, so such a key decodes normally
+and participates in collapse like any other.) A key that genuinely won't decode has no
+name to compare, so it participates in no collapse and is echoed verbatim from its source
+span:
 
 ```
 $ echo '{"a\q":1,"b":2,"b":3}' | jq -c  .        # parse error: Invalid escape

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1294,6 +1294,37 @@ Both filed together as [#1998](https://github.com/rust-works/succinctly/issues/1
   malformed-input wording fix. Filed as
   [#2006](https://github.com/rust-works/succinctly/issues/2006).
 
+### `fromjson`/`tonumber`'s shared decoder is jq-modeled, only narrowly gated for yq mode
+
+`Builtin::FromJson`/`Builtin::ToNumber` dispatch to `builtin_fromjson`/`tonumber_from_str`
+in `src/jq/eval.rs` with no mode split at all -- the same hand-rolled JSON-string decoder
+(`parse_json_string_value`) backs `fromjson`/`tonumber` in both `succinctly jq` and
+`succinctly yq`. [#2008](https://github.com/rust-works/succinctly/issues/2008) (a lone
+*low* surrogate escape, `\uDC00`-`\uDFFF`, should substitute U+FFFD rather than error,
+matching real jq) initially applied that fix unconditionally, which broke yq-mode fidelity
+here: real yq's `fromjson` doesn't use jq's JSON string grammar at all -- it decodes
+through go-yaml's own quoted-scalar scanner, which rejects *any* `\u` escape encoding a
+surrogate codepoint outright (confirmed live against yq v4.53.3, including a **valid**,
+correctly-paired surrogate escape, not just a lone one). Fixed during that PR's own review
+by gating the new low-surrogate arm behind `S::TAG == EvalTag::Yq` (threaded as a plain
+`yq_mode: bool` through `parse_complete_json`/`parse_json_value`/`parse_json_array`/
+`parse_json_object`/`parse_json_string_value`, since none of those carried an
+`EvalSemantics` type parameter before): yq mode keeps erroring on a lone low surrogate,
+unchanged from before #2008; only jq mode gained the new leniency.
+
+That gate is deliberately narrow -- it does not make yq-mode `fromjson` match real yq's
+actual model, which rejects the entire surrogate-pairing mechanism, not just the lone-low
+case. A **valid** surrogate pair still silently decodes successfully in yq mode today
+(`succinctly yq -n '"\"\\ud83d\\ude00\"" | fromjson'` → the emoji, real yq → a parse
+error), and a lone **high** surrogate is wrongly *accepted* (substitutes U+FFFD) in both
+jq and yq mode alike -- a separate, pre-existing bug unrelated to #2008's own scope, filed
+as [#2013](https://github.com/rust-works/succinctly/issues/2013) (also documents a real
+data-loss case: two `fromjson`-parsed object keys differing only by an unpaired high
+surrogate silently collapse, last-value-wins). Fully aligning yq-mode `fromjson` with real
+yq's stricter, non-pairing model is filed separately as
+[#2018](https://github.com/rust-works/succinctly/issues/2018), since it needs its own
+yq-mode branch checked ahead of all of jq's pairing logic, not an arm-by-arm patch.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11465,6 +11465,14 @@ fn parse_json_string_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, 
                                 result.push('\u{FFFD}');
                                 *pos -= 1;
                             }
+                        } else if (0xDC00..=0xDFFF).contains(&codepoint) {
+                            // #2008: a lone low surrogate isn't a valid Rust
+                            // `char` (falls through `char::from_u32` below),
+                            // but real jq accepts it and substitutes U+FFFD --
+                            // matches the high-surrogate arm above and
+                            // `json::light::decode_escapes`.
+                            result.push('\u{FFFD}');
+                            *pos += 3;
                         } else if let Some(c) = char::from_u32(codepoint) {
                             result.push(c);
                             *pos += 3; // Move past the hex digits (will be incremented again below)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6222,7 +6222,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::ToString => builtin_tostring::<W, S>(value, optional),
         Builtin::ToNumber => builtin_tonumber::<W>(value, optional),
         Builtin::ToJson => builtin_tojson::<W, S>(value, optional),
-        Builtin::FromJson => builtin_fromjson::<W>(value, optional),
+        Builtin::FromJson => builtin_fromjson::<W, S>(value, optional),
 
         // Phase 6: Additional String Functions
         Builtin::Explode => builtin_explode::<W>(value, optional),
@@ -11137,7 +11137,11 @@ pub(super) fn tonumber_from_str(s: &str) -> Result<OwnedValue, EvalError> {
     if let Ok(f) = trimmed.parse::<f64>() {
         return Ok(OwnedValue::Float(f));
     }
-    if parse_complete_json(trimmed).is_ok() {
+    // Mode-blind on purpose: this call only distinguishes "valid JSON but
+    // not a number" from "not valid JSON at all" for a nicer error message,
+    // never returns the parsed value, so `fromjson`'s jq/yq surrogate-mode
+    // split (#2008) has nothing to plumb through here.
+    if parse_complete_json(trimmed, false).is_ok() {
         Err(EvalError::cannot_parse_as_number(&OwnedValue::String(
             s.to_string(),
         )))
@@ -11285,7 +11289,7 @@ fn builtin_tojson<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: fromjson - parse JSON string to value
-fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
+fn builtin_fromjson<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
@@ -11296,7 +11300,7 @@ fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
                 // The whole string must be one JSON value: jq rejects `"0x10"`
                 // and `"1 2"` rather than reading the first value and dropping
                 // the rest, which is what the old prefix parse did here.
-                match parse_complete_json(json_str) {
+                match parse_complete_json(json_str, S::TAG == EvalTag::Yq) {
                     Ok(owned) => QueryResult::Owned(owned),
                     Err(_) if optional => QueryResult::None,
                     Err(_) => QueryResult::Error(EvalError::invalid_numeric_literal(json_str)),
@@ -11317,10 +11321,10 @@ fn builtin_fromjson<W: Clone + AsRef<[u64]>>(
 /// `x10` silently dropped and `"1 2"` as `1`. `tonumber` needs it to tell
 /// "this is valid JSON but not a number" (`"null"`) from "this is not valid
 /// JSON at all" (`"0x10"`), which jq words differently.
-fn parse_complete_json(s: &str) -> Result<OwnedValue, String> {
+fn parse_complete_json(s: &str, yq_mode: bool) -> Result<OwnedValue, String> {
     let bytes = s.as_bytes();
     let mut pos = 0;
-    let value = parse_json_value(bytes, &mut pos)?;
+    let value = parse_json_value(bytes, &mut pos, yq_mode)?;
     while pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t' | b'\n' | b'\r') {
         pos += 1;
     }
@@ -11331,7 +11335,7 @@ fn parse_complete_json(s: &str) -> Result<OwnedValue, String> {
 }
 
 /// Parse a JSON value starting at the given position
-fn parse_json_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String> {
+fn parse_json_value(bytes: &[u8], pos: &mut usize, yq_mode: bool) -> Result<OwnedValue, String> {
     // Skip whitespace
     while *pos < bytes.len() && matches!(bytes[*pos], b' ' | b'\t' | b'\n' | b'\r') {
         *pos += 1;
@@ -11371,15 +11375,15 @@ fn parse_json_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String>
         }
         b'"' => {
             // string
-            parse_json_string_value(bytes, pos)
+            parse_json_string_value(bytes, pos, yq_mode)
         }
         b'[' => {
             // array
-            parse_json_array(bytes, pos)
+            parse_json_array(bytes, pos, yq_mode)
         }
         b'{' => {
             // object
-            parse_json_object(bytes, pos)
+            parse_json_object(bytes, pos, yq_mode)
         }
         b'-' | b'0'..=b'9' => {
             // number
@@ -11394,7 +11398,11 @@ fn parse_json_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String>
 /// The bounds check is not redundant with [`parse_json_value`]'s: an object's
 /// key position is reached from [`parse_json_object`] directly, so `"{"` and
 /// `{"a":1,` arrive here at end of input.
-fn parse_json_string_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String> {
+fn parse_json_string_value(
+    bytes: &[u8],
+    pos: &mut usize,
+    yq_mode: bool,
+) -> Result<OwnedValue, String> {
     if *pos >= bytes.len() {
         return Err("unexpected end of input".to_string());
     }
@@ -11467,17 +11475,33 @@ fn parse_json_string_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, 
                             }
                         } else if (0xDC00..=0xDFFF).contains(&codepoint) {
                             // #2008: a lone low surrogate isn't a valid Rust
-                            // `char` (falls through `char::from_u32` below),
-                            // but real jq accepts it and substitutes U+FFFD --
-                            // matches the high-surrogate arm above and
-                            // `json::light::decode_escapes`.
+                            // `char` (falls through `char::from_u32` below).
+                            // Real jq accepts it and substitutes U+FFFD, but
+                            // real yq's `fromjson` doesn't use jq's JSON
+                            // string grammar at all -- it decodes through
+                            // go-yaml's own quoted-scalar scanner, which
+                            // rejects *any* `\u` escape encoding a surrogate
+                            // codepoint outright, lone or (even) validly
+                            // paired (confirmed live against yq v4.53.3, incl.
+                            // a valid astral-plane pair). Matching that fully
+                            // is a larger, separate gap (#2013); this only
+                            // keeps yq's pre-#2008 behavior for the lone-low
+                            // case unchanged (error) rather than silently
+                            // picking up jq's leniency here too.
+                            if yq_mode {
+                                return Err("invalid unicode codepoint".to_string());
+                            }
                             result.push('\u{FFFD}');
                             *pos += 3;
-                        } else if let Some(c) = char::from_u32(codepoint) {
-                            result.push(c);
-                            *pos += 3; // Move past the hex digits (will be incremented again below)
                         } else {
-                            return Err("invalid unicode codepoint".to_string());
+                            // codepoint is <= 0xFFFF (4 hex digits) and
+                            // outside 0xD800-0xDFFF (both arms above already
+                            // cover that whole range), so it's always a
+                            // valid char and this can't fail.
+                            result.push(char::from_u32(codepoint).expect(
+                                "non-surrogate u16-range codepoint is always a valid char",
+                            ));
+                            *pos += 3; // Move past the hex digits (will be incremented again below)
                         }
                     }
                     c => return Err(format!("invalid escape sequence: \\{}", c as char)),
@@ -11506,7 +11530,7 @@ fn parse_json_string_value(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, 
 }
 
 /// Parse a JSON array
-fn parse_json_array(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String> {
+fn parse_json_array(bytes: &[u8], pos: &mut usize, yq_mode: bool) -> Result<OwnedValue, String> {
     if *pos >= bytes.len() || bytes[*pos] != b'[' {
         return Err("expected '['".to_string());
     }
@@ -11526,7 +11550,7 @@ fn parse_json_array(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String>
     }
 
     loop {
-        let value = parse_json_value(bytes, pos)?;
+        let value = parse_json_value(bytes, pos, yq_mode)?;
         elements.push(value);
 
         // Skip whitespace
@@ -11552,7 +11576,7 @@ fn parse_json_array(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String>
 }
 
 /// Parse a JSON object
-fn parse_json_object(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String> {
+fn parse_json_object(bytes: &[u8], pos: &mut usize, yq_mode: bool) -> Result<OwnedValue, String> {
     if *pos >= bytes.len() || bytes[*pos] != b'{' {
         return Err("expected '{{'".to_string());
     }
@@ -11578,7 +11602,7 @@ fn parse_json_object(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String
         }
 
         // Parse key (must be a string)
-        let key = match parse_json_string_value(bytes, pos)? {
+        let key = match parse_json_string_value(bytes, pos, yq_mode)? {
             OwnedValue::String(s) => s,
             _ => return Err("object key must be a string".to_string()),
         };
@@ -11595,7 +11619,7 @@ fn parse_json_object(bytes: &[u8], pos: &mut usize) -> Result<OwnedValue, String
         *pos += 1;
 
         // Parse value
-        let value = parse_json_value(bytes, pos)?;
+        let value = parse_json_value(bytes, pos, yq_mode)?;
         entries.insert(key, value);
 
         // Skip whitespace

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1614,14 +1614,17 @@ pub(crate) fn decode_escapes_into<const VALIDATE_UTF8: bool>(
                         // high-surrogate arm's `Err` (falling back to the raw
                         // span) remains the already-documented leniency for
                         // the case jq genuinely does reject.
-                        result.push('\u{FFFD}');
+                        push_char(result, '\u{FFFD}');
                     } else {
-                        // Regular BMP character
-                        if let Some(c) = char::from_u32(codepoint as u32) {
-                            push_char(result, c);
-                        } else {
-                            return Err(JsonError::InvalidUnicodeEscape);
-                        }
+                        // Regular BMP character: codepoint is a u16 (from
+                        // parse_hex4) outside 0xD800-0xDFFF (both arms above
+                        // already cover that whole range), so it's always a
+                        // valid char and this can't fail.
+                        push_char(
+                            result,
+                            char::from_u32(codepoint as u32)
+                                .expect("non-surrogate u16 is always a valid char"),
+                        );
                     }
                 }
                 _ => return Err(JsonError::InvalidEscape),

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1604,8 +1604,17 @@ pub(crate) fn decode_escapes_into<const VALIDATE_UTF8: bool>(
                             return Err(JsonError::InvalidUnicodeEscape);
                         }
                     } else if (0xDC00..=0xDFFF).contains(&codepoint) {
-                        // Lone low surrogate
-                        return Err(JsonError::InvalidUnicodeEscape);
+                        // #2008: an unpaired *low* surrogate (`\uDC00`-`\uDFFF`)
+                        // is a different case from the unpaired *high*
+                        // surrogate arm above -- real jq 1.7.1 doesn't reject
+                        // this one at all: it accepts the document and
+                        // substitutes U+FFFD (confirmed live: `{"a":"\udc00"}`
+                        // decodes to `{"a":"�"}`, exit 0). Substituting
+                        // here rather than erroring matches that, where the
+                        // high-surrogate arm's `Err` (falling back to the raw
+                        // span) remains the already-documented leniency for
+                        // the case jq genuinely does reject.
+                        result.push('\u{FFFD}');
                     } else {
                         // Regular BMP character
                         if let Some(c) = char::from_u32(codepoint as u32) {
@@ -3671,6 +3680,13 @@ mod tests {
         }
     }
 
+    /// #2008: a lone low surrogate is a different case from the lone high
+    /// surrogate above -- real jq 1.7.1 doesn't reject it at all, it
+    /// substitutes U+FFFD and accepts the document (confirmed live:
+    /// `{"a":"\udc00"}` decodes to `{"a":"\u{FFFD}"}`, exit 0). Matches that
+    /// instead of erroring, unlike the high-surrogate case, which stays the
+    /// already-documented "echo the raw span" leniency since jq genuinely
+    /// rejects it.
     #[test]
     fn test_string_lone_low_surrogate() {
         // Lone low surrogate
@@ -3680,9 +3696,31 @@ mod tests {
 
         match root.value() {
             StandardJson::String(s) => {
-                assert_eq!(s.as_str(), Err(JsonError::InvalidUnicodeEscape));
+                let result = s.as_str().unwrap();
+                assert_eq!(&*result, "\u{FFFD}");
             }
             _ => panic!("expected string"),
+        }
+    }
+
+    /// #2008: pins the exact range boundary and mid-string/multiple-escape
+    /// cases the issue's own repro covers.
+    #[test]
+    fn test_string_lone_low_surrogate_range_and_mid_string_2008() {
+        for (json, want) in [
+            (&br#""\uDC00""#[..], "\u{FFFD}"),
+            (&br#""\uDFFF""#[..], "\u{FFFD}"),
+            (&br#""x\uDC00y""#[..], "x\u{FFFD}y"),
+        ] {
+            let index = JsonIndex::build(json);
+            let root = index.root(json);
+            match root.value() {
+                StandardJson::String(s) => {
+                    let result = s.as_str().unwrap();
+                    assert_eq!(&*result, want, "json={json:?}");
+                }
+                _ => panic!("expected string for json={json:?}"),
+            }
         }
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25612,6 +25612,42 @@ fn test_low_surrogate_substitutes_replacement_character_2008() {
     assert!(stderr.contains("invalid unicode escape sequence"));
 }
 
+/// #2008 (code review): a lone low surrogate in an object *key* decodes the
+/// same way as one in a value, so a pair of keys differing only by a lone
+/// low surrogate now collapses like any other duplicate (confirmed live
+/// against the pinned oracle) -- see the updated
+/// `docs/compliance/jq/limitations.md` "A key that will not decode is never
+/// a duplicate" section, which scopes that rule to the *high* surrogate case
+/// only as of this fix.
+#[test]
+fn test_low_surrogate_key_participates_in_duplicate_collapse_2008() {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "."], Some(r#"{"a\udc00":1,"a\udc00":2}"#)).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "{\"a\u{FFFD}\":2}");
+}
+
+/// #2008 (code review): `fromjson`/`tonumber`'s own hand-rolled JSON string
+/// decoder (`parse_json_string_value` in `eval.rs`) is a second,
+/// independent implementation of surrogate handling from
+/// `json::light::decode_escapes` and had the identical gap -- erroring
+/// instead of substituting U+FFFD for a lone low surrogate. Confirmed live
+/// against the pinned oracle before the fix (succinctly errored, real jq
+/// substituted); a valid surrogate pair is an unaffected control.
+#[test]
+fn test_fromjson_low_surrogate_substitutes_replacement_character_2008() {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "-r", r#""\"\\udc00\"" | fromjson"#], None).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\u{FFFD}");
+
+    // Control: a valid surrogate pair is unaffected.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "-r", r#""\"\\ud83d\\ude00\"" | fromjson"#], None).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "😀");
+}
+
 /// #1642 (was #1247): an undecodable *key* does not silently shrink the
 /// object -- `to_entries` used to return one entry fewer than the document
 /// had, because `effective_fields`' dedup walk dropped any field whose key

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25574,6 +25574,44 @@ fn test_decode_failure_surfaces_as_error_1247() {
     }
 }
 
+/// #2008: an unpaired *low* surrogate (`\uDC00`-`\uDFFF`) is a different
+/// case from the unpaired *high* surrogate `test_decode_failure_surfaces_as_error_1247`
+/// pins above -- real jq 1.7.1 doesn't reject it at all, it substitutes
+/// U+FFFD and accepts the document (confirmed live against the pinned
+/// oracle: `{"a":"\udc00"}` decodes to `{"a":"\u{FFFD}"}`, exit 0). Holds
+/// mid-string and across the whole low-surrogate range; a valid surrogate
+/// pair and the high-surrogate case are both unaffected controls.
+#[test]
+fn test_low_surrogate_substitutes_replacement_character_2008() {
+    for (doc, want) in [
+        (r#"{"a":"\udc00"}"#, "{\"a\":\"\u{FFFD}\"}"),
+        (r#"{"a":"\udfff"}"#, "{\"a\":\"\u{FFFD}\"}"),
+        (r#"{"a":"x\udc00y"}"#, "{\"a\":\"x\u{FFFD}y\"}"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", "."], Some(doc))
+            .unwrap_or_else(|e| panic!("doc={doc:?} failed to run: {e}"));
+        assert_eq!(code, 0, "doc={doc:?}\nstderr: {stderr}");
+        assert_eq!(stdout.trim(), want, "doc={doc:?}");
+    }
+
+    // Controls: unaffected by this fix.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", "."], Some(r#"{"a":"𐀀"}"#)).unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "{\"a\":\"\u{10000}\"}");
+
+    // A materializing filter (bare `.` is a streaming passthrough that
+    // never decodes the string at all, unlike `to_entries`/`.a | length`
+    // above) still raises for a lone *high* surrogate, unaffected by this
+    // fix -- matching `test_decode_failure_surfaces_as_error_1247`.
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | length"], Some(r#"{"a":"\ud800"}"#)).unwrap();
+    assert_ne!(
+        code, 0,
+        "lone high surrogate should still be rejected (#1247)"
+    );
+    assert!(stderr.contains("invalid unicode escape sequence"));
+}
+
 /// #1642 (was #1247): an undecodable *key* does not silently shrink the
 /// object -- `to_entries` used to return one entry fewer than the document
 /// had, because `effective_fields`' dedup walk dropped any field whose key

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -26978,3 +26978,32 @@ fn test_jq_only_date_builtins_gated_behind_jq_extensions_1907() -> Result<()> {
 
     Ok(())
 }
+
+/// #2008 (code review): `fromjson`/`tonumber`'s shared decoder
+/// (`parse_json_string_value` in `eval.rs`, reachable from both jq and yq
+/// mode via the same unparameterized `Builtin::FromJson` dispatch) is not
+/// jq-only -- #2008's own low-surrogate fix initially applied jq's leniency
+/// (substitute U+FFFD) unconditionally, which broke `succinctly yq`'s own
+/// fidelity: real yq's `fromjson` doesn't use jq's JSON string grammar at
+/// all, it decodes through go-yaml's quoted-scalar scanner, which rejects
+/// *any* `\u` escape encoding a surrogate codepoint outright -- lone or even
+/// validly paired (confirmed live against yq v4.53.3). This pins that
+/// `succinctly yq`'s `fromjson` keeps rejecting a lone low surrogate
+/// (ADR-0018: mode decides, never format), unlike jq mode's
+/// `test_fromjson_low_surrogate_substitutes_replacement_character_2008`.
+#[test]
+fn test_yq_fromjson_low_surrogate_still_rejected_2008() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(r#""\"x\\udc00y\"" | fromjson"#, "", &["-n"])?;
+    assert_ne!(code, 0, "stderr: {stderr}");
+
+    // A valid surrogate pair is an unaffected control -- still decodes to
+    // the emoji in yq mode too (real yq itself actually rejects even valid
+    // pairs, a separate, pre-existing, much larger divergence tracked
+    // separately; this control only pins that #2008 didn't newly break it).
+    let (out, code) = run_yq_stdin(r#""\"\\ud83d\\ude00\"" | fromjson"#, "", &["-n"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "😀");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real jq 1.7.1 accepts an unpaired *low* surrogate escape (`\uDC00`-`\uDFFF`)
and substitutes the Unicode replacement character (U+FFFD); succinctly was
rejecting it outright, treating it the same as the unpaired *high* surrogate
case jq genuinely does reject. Confirmed live against the pinned oracle.

```
$ printf '{"a":"\udc00"}' | jq -c .
{"a":"�"}
$ printf '{"a":"\udc00"}' | succinctly jq -c .   # before this fix
jq: error (...): invalid unicode escape sequence
```

- `json::light::decode_escapes`/`decode_escapes_into` (the primary document
  decoder): added the missing low-surrogate arm.
- `eval.rs::parse_json_string_value` (`fromjson`/`tonumber`'s own,
  independent hand-rolled decoder): found during code review to have the
  identical gap, fixed the same way -- but gated behind `S::TAG !=
  EvalTag::Yq`, since real yq's `fromjson` doesn't use jq's JSON string
  grammar at all (it decodes through go-yaml's own quoted-scalar scanner,
  which rejects *any* `\u` surrogate escape outright). An initial
  unconditional fix broke yq-mode fidelity here; this was caught and fixed
  in the same PR before merge (see review notes below).
- Cleaned up a small piece of now-provably-unreachable dead code in both
  decoders' "regular BMP character" fallback, found by the same review.

## Follow-ups filed (different bug shape / larger scope, out of this PR)

- [#2012](https://github.com/rust-works/succinctly/issues/2012):
  `--argjson`/`--jsonargs` still reject the same lone low surrogate (routes
  through `serde_json` validation, a structurally different fix).
- [#2013](https://github.com/rust-works/succinctly/issues/2013):
  `fromjson` wrongly *accepts* a lone high surrogate (pre-existing, opposite
  direction from this PR's fix); includes a real data-loss case via
  object-key collapse.
- [#2018](https://github.com/rust-works/succinctly/issues/2018): yq-mode
  `fromjson` still doesn't fully match real yq's stricter surrogate model
  (a *valid* pair should also be rejected in yq mode; this PR's mode gate
  only restores the lone-low-surrogate case to its pre-existing, correct
  yq behavior).

## Test plan

- [x] `cargo test` (default features)
- [x] `cargo test --features cli` across all CLI-gated integration test
      binaries (jq_cli_tests, yq_cli_tests, golden tests, etc.)
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` (CI's simd-feature leg)
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --all -- --check`
- [x] Live-verified against the pinned oracles (`/usr/bin/jq` 1.7.1,
      Homebrew `yq` v4.53.3) for every behavior change and control case
- [x] Two rounds of `/code-review` (7 parallel finders in round 2), all
      actionable findings fixed or filed as scoped follow-ups above

Fixes #2008