### PR TITLE
fix(jq): builtin_skip uses bare to_owned on real output (#1989)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11246,19 +11246,22 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         _ => return QueryResult::Error(EvalError::type_error("number", "null")),
     };
 
-    // Evaluate expr and skip first n results
+    // Evaluate expr and skip first n results. #1989: each of these three
+    // arms used bare `to_owned` -- an undecodable string in a real,
+    // navigated `expr` output silently became "" instead of raising, with
+    // no guard at all (unlike its sibling `n`-classification arms above).
     let result = eval_single::<W, S>(expr, value, optional);
     match result {
         QueryResult::One(v) => {
             if n == 0 {
-                QueryResult::Owned(to_owned(&v))
+                QueryResult::Owned(to_owned_checked_or_suppress!(&v, optional))
             } else {
                 QueryResult::None
             }
         }
         QueryResult::OneCursor(c) => {
             if n == 0 {
-                QueryResult::Owned(to_owned(&c.value()))
+                QueryResult::Owned(to_owned_checked_or_suppress!(&c.value(), optional))
             } else {
                 QueryResult::None
             }
@@ -11271,9 +11274,15 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         QueryResult::Many(results) => {
-            let skipped: Vec<OwnedValue> =
-                results.into_iter().skip(n).map(|v| to_owned(&v)).collect();
-            owned_vec_to_result(skipped)
+            let skipped: Result<Vec<OwnedValue>, EvalError> = results
+                .into_iter()
+                .skip(n)
+                .map(|v| to_owned_checked(&v))
+                .collect();
+            match skipped {
+                Ok(skipped) => owned_vec_to_result(skipped),
+                Err(e) => suppress_or_raise(e, optional),
+            }
         }
         QueryResult::ManyOwned(results) => {
             let skipped: Vec<OwnedValue> = results.into_iter().skip(n).collect();
@@ -67955,6 +67964,39 @@ mod tests {
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "Invalid path expression with result 0");
             }
+        );
+    }
+
+    /// #1989: `builtin_skip`'s three output-conversion arms (`One`,
+    /// `OneCursor`, `Many`) all used bare `to_owned`, with no
+    /// decode-failure guard at all -- unlike its sibling `n`-classification
+    /// arms above, which already error correctly. An undecodable string in
+    /// `expr`'s real output silently became garbage instead of raising.
+    #[test]
+    fn test_builtin_skip_raises_on_output_decode_failure_1989() {
+        // `Many` arm: skip(1; .[]) surfaces the second element.
+        query!(
+            &b"[\"good\",\"\xff\xfe\"]"[..],
+            "skip(1; .[])",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // A genuine decode failure is never suppressed by `optional` (#1620).
+        query!(
+            &b"[\"good\",\"\xff\xfe\"]"[..],
+            "(skip(1; .[]))?",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        // Positive control: valid data is unaffected.
+        query!(
+            br#"["good","also-good"]"#,
+            "skip(1; .[])",
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(&*s, "also-good")
+        );
+        // `One` arm: n == 0 takes expr's single output directly.
+        query!(
+            &b"\"\xff\xfe\""[..],
+            "skip(0; .)",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
         );
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2605,6 +2605,27 @@ macro_rules! to_owned_checked_or_suppress {
     };
 }
 
+/// The collection-level twin of [`to_owned_checked_or_suppress`]: converts
+/// every item of `$iter` with `to_owned_checked`, short-circuiting on the
+/// first error (code review, #1989/#2028) -- was hand-rolled as `match
+/// $iter.map(|v| to_owned_checked(&v)).collect() { Ok(v) => v, Err(e) =>
+/// return suppress_or_raise(e, $optional) }` at three separate call sites
+/// (`builtin_combinations`, `builtin_combinations_n`, `builtin_skip`)
+/// before this consolidation -- the exact "keeps rediscovering missing at
+/// one more call site" pattern [`to_owned_checked_or_suppress`]'s own doc
+/// comment already names for the single-value case.
+macro_rules! to_owned_checked_vec_or_suppress {
+    ($iter:expr, $optional:expr) => {
+        match $iter
+            .map(|v| to_owned_checked(&v))
+            .collect::<Result<Vec<OwnedValue>, EvalError>>()
+        {
+            Ok(v) => v,
+            Err(e) => return suppress_or_raise(e, $optional),
+        }
+    };
+}
+
 /// #1934 item 7: whether `optional == true` is ever actually reachable here
 /// (or at `eval_reduce`/`eval_foreach`/`eval_as`, which route into this same
 /// guard) was left as an open question after #1902/#1927's review -- multiple
@@ -11274,15 +11295,8 @@ fn builtin_skip<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         QueryResult::Many(results) => {
-            let skipped: Result<Vec<OwnedValue>, EvalError> = results
-                .into_iter()
-                .skip(n)
-                .map(|v| to_owned_checked(&v))
-                .collect();
-            match skipped {
-                Ok(skipped) => owned_vec_to_result(skipped),
-                Err(e) => suppress_or_raise(e, optional),
-            }
+            let skipped = to_owned_checked_vec_or_suppress!(results.into_iter().skip(n), optional);
+            owned_vec_to_result(skipped)
         }
         QueryResult::ManyOwned(results) => {
             let skipped: Vec<OwnedValue> = results.into_iter().skip(n).collect();
@@ -35068,10 +35082,7 @@ fn builtin_combinations<W: Clone + AsRef<[u64]>>(
                         // `optional`, the same as the sibling `_ if
                         // optional` arms in this same match.
                         let inner_values: Vec<OwnedValue> =
-                            match inner.map(|v| to_owned_checked(&v)).collect() {
-                                Ok(v) => v,
-                                Err(e) => return suppress_or_raise(e, optional),
-                            };
+                            to_owned_checked_vec_or_suppress!(inner, optional);
                         arrays.push(inner_values);
                     }
                     _ if optional => return QueryResult::None,
@@ -35183,10 +35194,7 @@ fn builtin_combinations_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Array(elements) => {
             // #1953: a non-decode-failure error respects `optional`, the
             // same as the sibling `_ if optional` arm below.
-            match (*elements).map(|v| to_owned_checked(&v)).collect() {
-                Ok(v) => v,
-                Err(e) => return suppress_or_raise(e, optional),
-            }
+            to_owned_checked_vec_or_suppress!(*elements, optional)
         }
         _ if optional => return QueryResult::None,
         _ => return QueryResult::Error(EvalError::type_error("array", type_name(&value))),


### PR DESCRIPTION
## Summary

`skip(n; expr)`'s three output-conversion arms (`One`, `OneCursor`,
`Many`) all used bare `to_owned`, with **no decode-failure guard at
all** — unlike its sibling `n`-classification arms just above, which
already error correctly. An undecodable string in `expr`'s real output
silently became `""` instead of raising.

Uses `to_owned_checked_or_suppress!` for the `One`/`OneCursor` arms and
`to_owned_checked` directly for the `Many` arm's `.collect()`.

## Background

Found during #1989's own classification pass — a fresh census of every
bare `to_owned` call site in `eval.rs` (79 genuine sites; a naive grep
returns 127, mostly false positives from `.into_owned()` and compound
names like `item_to_owned`). 21 of those 79 lines were classified
UNSAFE, collapsing into 8 distinct call-site families. This is the
first and most self-contained of them.

`skip` postdates the pinned jq 1.7.1 oracle (a jq 1.8 builtin), so no
oracle comparison is possible for this one — verified reachability and
correctness via the built `succinctly jq` CLI binary directly instead.

## Scope

The other 6 CLI-reachable UNSAFE families found during the same
classification pass are filed separately, each with its own repro and
suggested next step:

- #2022 — `collect_owned` (object-construction keys/values, string interpolation)
- #2023 — `item_to_owned` (generator-argument builtins via lazy fanout)
- #2024 — `push_owned_values` (`nth`/`flatten`/`limit` fanout)
- #2025 — `Item::into_owned` (`paths()`'s emitted keys, `inputs`)
- #2026 — `accumulate_path_context_step`/`continue_rest_with_context` (`key`/`parent` path-context machinery)
- #2027 — `try_pattern_alternatives` (`as`-binding destructuring)

`builtin_last_stream` (the 8th family) is confirmed CLI-unreachable per
#1986's own finding — not filed as its own issue.

#1989 itself stays open to track the overall initiative (fix each live
bug, then the mechanical `to_owned`/`to_owned_checked` rename once the
remaining bare sites are confirmed safe).

## Test plan

- [x] New test exercising all three fixed arms (`One`/`OneCursor` via
      `n == 0`, `Many` via `n >= 1`), plus a positive control on valid
      data and a confirmation that the raised error is a genuine
      `is_decode_failure()` (never suppressed by `optional`, per #1620).
      Verified independently: reverting the fix makes the test fail
      with the exact silent-corruption shape (`Owned(String(""))`).
- [x] `cargo test --features cli,simd,regex,serde --workspace` (56/56 binaries green)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`

All checks run against a genuinely clean build (`cargo clean -p
succinctly` before the verification pass).
