### PR TITLE
fix(jq): pick/omit and eval_single's array slice respect optional for malformed members

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -992,10 +992,17 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // shape -- accumulating a partial prefix for a fan-out
                 // stream to report on error -- that this single-aggregate-
                 // value arm has no use for and was discarding unconditionally).
+                // #2001: `suppress_or_raise`, not an unconditional `Error`
+                // -- a #1194 malformed-member error nested inside a sliced
+                // element respects `optional` the same way the sibling
+                // `Object` arm below already does (#1953); can't use the
+                // `to_owned_checked_or_suppress!` macro directly inside
+                // `.map()` here since its `return` would return from the
+                // closure, not this function.
                 let sliced = slice_elements::<W>(elements, *start, *end);
                 match sliced.iter().map(to_owned_checked).collect() {
                     Ok(items) => QueryResult::Owned(OwnedValue::Array(items)),
-                    Err(e) => QueryResult::Error(e),
+                    Err(e) => suppress_or_raise(e, optional),
                 }
             }
             // yq treats a null/number/boolean target as an empty container
@@ -37382,10 +37389,11 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         // #1755: to_owned_checked, not to_owned
                         // -- an undecodable picked value must
                         // raise, not silently become "".
-                        let owned = match to_owned_checked(&field.value) {
-                            Ok(v) => v,
-                            Err(e) => return QueryResult::Error(e),
-                        };
+                        // #2001: ...or_suppress -- a #1194 malformed-member
+                        // error nested inside the picked value must respect
+                        // `optional`, matching this function's own
+                        // `keys_owned` conversion above (#2010).
+                        let owned = to_owned_checked_or_suppress!(&field.value, optional);
                         result.insert(k.clone(), owned);
                     }
                     // If key not found, yq silently skips it
@@ -37415,10 +37423,8 @@ fn builtin_pick<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     // #1755: to_owned_checked, not to_owned -- an
                     // undecodable picked element must raise, not silently
                     // become "".
-                    let owned = match to_owned_checked(&arr[actual_idx as usize]) {
-                        Ok(v) => v,
-                        Err(e) => return QueryResult::Error(e),
-                    };
+                    // #2001: ...or_suppress -- see the Object arm above.
+                    let owned = to_owned_checked_or_suppress!(&arr[actual_idx as usize], optional);
                     result.push(owned);
                 }
                 // If index out of bounds, yq silently skips it
@@ -37447,19 +37453,16 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // must raise, not silently become "" (and then fail the "must be an
     // array" check with the wrong message, or worse, silently omit
     // nothing correctly-named).
+    // #2001: each `to_owned_checked` below now routes through
+    // `to_owned_checked_or_suppress` -- mirrors `pick`'s own identical fix
+    // (#2010) for this same match shape.
     let keys_owned = match eval_single::<W, S>(keys_expr, value.clone(), optional) {
-        QueryResult::One(v) => match to_owned_checked(&v) {
-            Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
-        },
+        QueryResult::One(v) => to_owned_checked_or_suppress!(&v, optional),
         // Defensive only: `eval_single` (unlike top-level `eval`'s own
         // `Expr::Identity` special case) never actually produces
         // `OneCursor`, so this arm is unreachable in practice today --
         // kept fallible anyway rather than assuming that stays true.
-        QueryResult::OneCursor(c) => match to_owned_checked(&c.value()) {
-            Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
-        },
+        QueryResult::OneCursor(c) => to_owned_checked_or_suppress!(&c.value(), optional),
         QueryResult::Owned(v) => v,
         QueryResult::ManyOwned(v) if !v.is_empty() => v.into_iter().next().unwrap(),
         QueryResult::ManyOwned(_) => {
@@ -37473,10 +37476,7 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             return QueryResult::Error(EvalError::new("omit: keys expression produced no output"))
         }
         QueryResult::Many(v) if !v.is_empty() => {
-            match to_owned_checked(&v.into_iter().next().unwrap()) {
-                Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
-            }
+            to_owned_checked_or_suppress!(&v.into_iter().next().unwrap(), optional)
         }
         QueryResult::Many(_) => {
             return QueryResult::Error(EvalError::new("omit: keys expression produced no output"))
@@ -37542,10 +37542,8 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     // #1755: to_owned_checked, not to_owned -- an
                     // undecodable kept value must raise, not
                     // silently become "".
-                    let owned = match to_owned_checked(&field.value) {
-                        Ok(v) => v,
-                        Err(e) => return QueryResult::Error(e),
-                    };
+                    // #2001: ...or_suppress -- see `pick`'s identical fix.
+                    let owned = to_owned_checked_or_suppress!(&field.value, optional);
                     result.insert(key.into_owned(), owned);
                 }
             }
@@ -37570,6 +37568,14 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             // #1755: to_owned_checked, not to_owned -- an undecodable kept
             // element must raise, not silently become "".
+            // #2001: routed through `suppress_or_raise` -- can't use the
+            // `to_owned_checked_or_suppress!` macro directly inside the
+            // `.map()` closure below, since its `return` would return from
+            // the closure (changing the collected type), not this
+            // function, so the same check is applied once here instead,
+            // after `collect()` surfaces the first error in iteration
+            // order -- equivalent to checking it at the point of failure,
+            // since either way only the first element error is ever seen.
             let result: Result<Vec<OwnedValue>, EvalError> = arr
                 .iter()
                 .enumerate()
@@ -37578,7 +37584,7 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 .collect();
             let result = match result {
                 Ok(result) => result,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
 
             QueryResult::Owned(OwnedValue::Array(result))
@@ -40510,6 +40516,33 @@ mod tests {
         }
     }
 
+    /// #2001: `eval_single`'s `Expr::Slice`/`Expr::SliceNumber` `Array` arm
+    /// (available in both jq and yq mode, unlike the `Object` arm above,
+    /// which is yq-only) has the identical gap the `Object` arm's own
+    /// #1953 fix already closed -- found by code review as a sibling site
+    /// missed at the time. `end: Some(1)` (rather than the `Object` arm
+    /// test's `None, None`) so the array fast-path (`start: None|Some(0)
+    /// && end: None` -- an identity slice, returned without ever calling
+    /// `to_owned_checked`) isn't taken.
+    #[test]
+    fn test_eval_single_array_slice_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let slice_expr = Expr::Slice {
+            start: None,
+            end: Some(1),
+        };
+        match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
     /// See `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
     /// doc comment above for the full rationale shared by all seven of
     /// these per-site tests. `eval_assign`'s `YqAssignNoopCheck::NotChecked`
@@ -40652,6 +40685,116 @@ mod tests {
             other => panic!("expected None, got {other:?}"),
         }
         match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001: `pick`/`omit` (yq-only) had the same gap as the seven sites
+    /// above, in the value/element conversion each performs once a
+    /// requested key/index actually matches -- PR #2010 migrated `pick`'s
+    /// own *keys-expression* conversion (the `keys_owned` match) to
+    /// `to_owned_checked_or_suppress!` but left its two per-match value
+    /// conversions (Object arm's `field.value`, Array arm's indexed
+    /// element) on the raw unconditional pattern, and didn't touch `omit`
+    /// at all -- `omit` mirrors `pick` exactly (same `keys_owned` match
+    /// shape, same per-kept-value conversion in both its Object and Array
+    /// arms) and needs the identical five-site fix.
+    ///
+    /// The malformed member must be nested inside the *picked*/*kept*
+    /// value, not the top-level document `pick`/`omit` themselves iterate
+    /// over -- that outer structure is already validated by
+    /// `effective_fields_checked` before either function reaches a single
+    /// field's own value.
+    #[test]
+    fn test_builtin_pick_object_value_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":{"x":1,"y"},"b":2}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("a".into()))));
+        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_builtin_pick_object_value_respects_optional_for_malformed_member_error_2001`'s
+    /// doc comment above -- `pick`'s Array arm sibling.
+    #[test]
+    fn test_builtin_pick_array_element_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::Int(0))));
+        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_builtin_pick_object_value_respects_optional_for_malformed_member_error_2001`'s
+    /// doc comment above -- `omit`'s own `keys_owned` conversion (its
+    /// `QueryResult::One` arm, reached here via `Expr::Identity` since the
+    /// keys expression and the value being omitted-from are the same input
+    /// under test).
+    #[test]
+    fn test_builtin_omit_keys_expr_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"x":1,"y"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Identity;
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_builtin_pick_object_value_respects_optional_for_malformed_member_error_2001`'s
+    /// doc comment above -- `omit`'s Object arm. Omits a non-matching key
+    /// (`"z"`) so `"a"`'s malformed value is *kept* (and so converted)
+    /// rather than skipped.
+    #[test]
+    fn test_builtin_omit_object_value_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"{"a":{"x":1,"y"},"b":2}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("z".into()))));
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// See `test_builtin_pick_object_value_respects_optional_for_malformed_member_error_2001`'s
+    /// doc comment above -- `omit`'s Array arm. Omits a non-matching index
+    /// (`5`) so the malformed element at index 0 is *kept*.
+    #[test]
+    fn test_builtin_omit_array_element_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::Int(5))));
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15936,10 +15936,14 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // own finding for `eval_single`'s array arm),
                             // so an undecodable string here used to
                             // silently become `""` instead of raising.
-                            QueryResult::One(v) => match to_owned_checked(&v) {
-                                Ok(v) => out.push(v),
-                                Err(e) => return QueryResult::Error(e),
-                            },
+                            // #2001 (code review): ...or_suppress -- this
+                            // is the computed-bounds sibling of
+                            // `eval_single`'s own literal-bounds `Expr::
+                            // Slice` array arm, which had the identical
+                            // unconditional-raise gap this same PR fixes.
+                            QueryResult::One(v) => {
+                                out.push(to_owned_checked_or_suppress!(&v, optional));
+                            }
                             QueryResult::Owned(v) => out.push(v),
                             QueryResult::None => {}
                             QueryResult::Error(e) => return QueryResult::Error(e),
@@ -37568,26 +37572,19 @@ fn builtin_omit<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             // #1755: to_owned_checked, not to_owned -- an undecodable kept
             // element must raise, not silently become "".
-            // #2001: routed through `suppress_or_raise` -- can't use the
-            // `to_owned_checked_or_suppress!` macro directly inside the
-            // `.map()` closure below, since its `return` would return from
-            // the closure (changing the collected type), not this
-            // function, so the same check is applied once here instead,
-            // after `collect()` surfaces the first error in iteration
-            // order -- equivalent to checking it at the point of failure,
-            // since either way only the first element error is ever seen.
-            let result: Result<Vec<OwnedValue>, EvalError> = arr
+            // #2001: routed through `suppress_or_raise` -- see
+            // `eval_single`'s own `Expr::Slice` array arm above for why
+            // the macro can't be used directly inside `.map()` here.
+            match arr
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !omit_indices.contains(i))
                 .map(|(_, v)| to_owned_checked(v))
-                .collect();
-            let result = match result {
-                Ok(result) => result,
-                Err(e) => return suppress_or_raise(e, optional),
-            };
-
-            QueryResult::Owned(OwnedValue::Array(result))
+                .collect::<Result<Vec<OwnedValue>, EvalError>>()
+            {
+                Ok(result) => QueryResult::Owned(OwnedValue::Array(result)),
+                Err(e) => suppress_or_raise(e, optional),
+            }
         }
         // #1755: a decode failure on the scalar itself must raise
         // unconditionally, checked ahead of `optional` -- see
@@ -40518,12 +40515,16 @@ mod tests {
 
     /// #2001: `eval_single`'s `Expr::Slice`/`Expr::SliceNumber` `Array` arm
     /// (available in both jq and yq mode, unlike the `Object` arm above,
-    /// which is yq-only) has the identical gap the `Object` arm's own
-    /// #1953 fix already closed -- found by code review as a sibling site
-    /// missed at the time. `end: Some(1)` (rather than the `Object` arm
-    /// test's `None, None`) so the array fast-path (`start: None|Some(0)
-    /// && end: None` -- an identity slice, returned without ever calling
-    /// `to_owned_checked`) isn't taken.
+    /// which is yq-only -- this arm has no `S::TAG` gate at all) has the
+    /// identical gap the `Object` arm's own #1953 fix already closed --
+    /// found by code review as a sibling site missed at the time. `end:
+    /// Some(1)` (rather than the `Object` arm test's `None, None`) so the
+    /// array fast-path (`start: None|Some(0) && end: None` -- an identity
+    /// slice, returned without ever calling `to_owned_checked`) isn't
+    /// taken. Checked under both semantics (code review, #2001): the arm's
+    /// own lack of an `S::TAG` gate means a future edit that *adds* one
+    /// could silently regress either mode while a single-mode test stayed
+    /// green.
     #[test]
     fn test_eval_single_array_slice_respects_optional_for_malformed_member_error_2001() {
         let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
@@ -40538,6 +40539,52 @@ mod tests {
             other => panic!("expected None, got {other:?}"),
         }
         match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2001 (code review): `eval_slice_expr`'s `Targets::Borrowed` arm
+    /// (the computed-bounds `.[$s:$e]` dispatch path -- the sibling of
+    /// `eval_single`'s literal-bounds `Expr::Slice` array arm above) had
+    /// the identical gap on the same fast-path-then-convert shape. `start:
+    /// Some(0), end: None` so the inner `eval_single` call takes the
+    /// fully-open-bound fast path (returning the target's original
+    /// borrowed value unconverted) and reaches this function's own
+    /// `to_owned_checked` call, not `eval_single`'s.
+    #[test]
+    fn test_eval_slice_expr_borrowed_respects_optional_for_malformed_member_error_2001() {
+        let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let target = Expr::Identity;
+        let start = Some(Box::new(Expr::Literal(Literal::Int(0))));
+        let end = None;
+        match eval_slice_expr::<Vec<u64>, JqSemantics>(&target, &start, &end, cursor.value(), true)
+        {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_slice_expr::<Vec<u64>, JqSemantics>(&target, &start, &end, cursor.value(), false)
+        {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+        match eval_slice_expr::<Vec<u64>, YqSemantics>(&target, &start, &end, cursor.value(), true)
+        {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_slice_expr::<Vec<u64>, YqSemantics>(&target, &start, &end, cursor.value(), false)
+        {
             QueryResult::Error(e) => assert!(!e.is_decode_failure()),
             other => panic!("expected Error, got {other:?}"),
         }
@@ -40690,16 +40737,28 @@ mod tests {
         }
     }
 
-    /// #2001: `pick`/`omit` (yq-only) had the same gap as the seven sites
-    /// above, in the value/element conversion each performs once a
-    /// requested key/index actually matches -- PR #2010 migrated `pick`'s
-    /// own *keys-expression* conversion (the `keys_owned` match) to
+    /// #2001: `pick`/`omit` had the same gap as the seven sites above, in
+    /// the value/element conversion each performs once a requested
+    /// key/index actually matches -- PR #2010 migrated `pick`'s own
+    /// *keys-expression* conversion (the `keys_owned` match) to
     /// `to_owned_checked_or_suppress!` but left its two per-match value
     /// conversions (Object arm's `field.value`, Array arm's indexed
     /// element) on the raw unconditional pattern, and didn't touch `omit`
     /// at all -- `omit` mirrors `pick` exactly (same `keys_owned` match
     /// shape, same per-kept-value conversion in both its Object and Array
     /// arms) and needs the identical five-site fix.
+    ///
+    /// Neither builtin is yq-only despite the doc comment on this function
+    /// previously claiming so (code review, #2001): both are reachable and
+    /// functional under `JqSemantics` too (real jq itself has no `pick`/
+    /// `omit`, but `succinctly jq` accepts both as its own extension --
+    /// live-verified: `succinctly jq 'pick([0])'`/`'omit([1])'` on
+    /// `[{"x":1,"y"},2,3]` both exit 5, matching the raise this whole gap
+    /// is about). Checked under both semantics below for that reason, not
+    /// just yq's -- unlike `eval_single`'s array-slice arm above, `?` *is*
+    /// reachable here through real CLI syntax (`pick([0])?` exits 0
+    /// live-verified), so a regression in either mode is not merely an
+    /// internal-consistency concern.
     ///
     /// The malformed member must be nested inside the *picked*/*kept*
     /// value, not the top-level document `pick`/`omit` themselves iterate
@@ -40712,13 +40771,23 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("a".into()))));
-        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            for (got, mode) in [
+                (
+                    builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional),
+                    "jq",
+                ),
+                (
+                    builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), optional),
+                    "yq",
+                ),
+            ] {
+                match got {
+                    QueryResult::None if optional => {}
+                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
+                }
+            }
         }
     }
 
@@ -40730,13 +40799,23 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::Int(0))));
-        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            for (got, mode) in [
+                (
+                    builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional),
+                    "jq",
+                ),
+                (
+                    builtin_pick::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), optional),
+                    "yq",
+                ),
+            ] {
+                match got {
+                    QueryResult::None if optional => {}
+                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
+                }
+            }
         }
     }
 
@@ -40751,13 +40830,23 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Identity;
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            for (got, mode) in [
+                (
+                    builtin_omit::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional),
+                    "jq",
+                ),
+                (
+                    builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), optional),
+                    "yq",
+                ),
+            ] {
+                match got {
+                    QueryResult::None if optional => {}
+                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
+                }
+            }
         }
     }
 
@@ -40771,13 +40860,23 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("z".into()))));
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            for (got, mode) in [
+                (
+                    builtin_omit::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional),
+                    "jq",
+                ),
+                (
+                    builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), optional),
+                    "yq",
+                ),
+            ] {
+                match got {
+                    QueryResult::None if optional => {}
+                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
+                }
+            }
         }
     }
 
@@ -40790,13 +40889,23 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Array(Box::new(Expr::Literal(Literal::Int(5))));
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            for (got, mode) in [
+                (
+                    builtin_omit::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional),
+                    "jq",
+                ),
+                (
+                    builtin_omit::<Vec<u64>, YqSemantics>(&keys_expr, cursor.value(), optional),
+                    "yq",
+                ),
+            ] {
+                match got {
+                    QueryResult::None if optional => {}
+                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
+                }
+            }
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7315,9 +7315,19 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     if let Some(elements) = target.as_array() {
         let items = elements.collect_values();
         let range = SliceBounds::from_literals(start, end).resolve(items.len());
-        return GenericResult::Owned(OwnedValue::Array(owned_or_err!(to_owned_all(
-            items[range].iter()
-        ))));
+        // #2001 (code review): a #1194 malformed-member error nested
+        // inside a sliced element respects `optional` here too -- this is
+        // the `eval_generic` twin of `eval.rs`'s own `eval_single`
+        // literal-bounds `Expr::Slice` array arm, which had the identical
+        // gap this same PR fixed (see that arm's own #2001 comment). Can't
+        // reuse `eval.rs`'s `suppress_or_raise`/`to_owned_checked_or_suppress!`
+        // directly: different result type (`GenericResult` vs
+        // `QueryResult`), so the equivalent check is inlined instead.
+        return match to_owned_all(items[range].iter()) {
+            Ok(v) => GenericResult::Owned(OwnedValue::Array(v)),
+            Err(e) if optional && !e.is_decode_failure() => GenericResult::None,
+            Err(e) => GenericResult::Error(e),
+        };
     }
     // yq's object AST-child-layout slicing rule (#1102) — mirrors
     // `eval.rs`'s cursor-backed `Expr::Slice` arm for the same target type;
@@ -7327,7 +7337,15 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
     // `IndexMap` `slice_object_as_yq_children` needs — same technique as
     // `eval.rs`'s own arm, for the same reason.
     if S::TAG == EvalTag::Yq && target.as_object().is_some() {
-        let OwnedValue::Object(map) = owned_or_err!(to_owned(&target)) else {
+        // #2001 (code review): same fix as the Array arm above -- a #1194
+        // malformed-member error nested inside the object respects
+        // `optional`.
+        let owned = match to_owned(&target) {
+            Ok(v) => v,
+            Err(e) if optional && !e.is_decode_failure() => return GenericResult::None,
+            Err(e) => return GenericResult::Error(e),
+        };
+        let OwnedValue::Object(map) = owned else {
             unreachable!("target.as_object() just confirmed this materializes to an Object")
         };
         return GenericResult::Owned(slice_object_as_yq_children(&map, start, end));


### PR DESCRIPTION
## Summary

Continues #2001's audit of `to_owned_checked` call sites that bypass `optional` for a #1194 malformed-member error, following the chain #1194→#1953→#1972→#1999→#2010. This batch fixes 8 sites across 3 functions, all directly precedented by an already-fixed sibling in the same function:

- `builtin_pick`'s Object/Array arms (per-key value conversion) — PR #2010 migrated `pick`'s own `keys_owned` conversion to `to_owned_checked_or_suppress` but left these two.
- `builtin_omit`, all 5 sites — mirrors `pick` exactly (same `keys_owned` match shape, same per-kept-value conversion in both its Object and Array arms) but got none of #2010's treatment.
- `eval_single`'s `Expr::Slice`/`SliceNumber` Array arm — sibling of the yq-only Object arm's own #1953 fix, missed at the time.

Each fix is verified via a direct unit test proving the bug is real (fails without the fix, passes with it), following the established #1953 pattern: `JsonIndex::build` on a deliberately malformed document, calling the builtin directly with `optional` true/false. None of these 8 sites are reachable with `optional=true` through any real `?`/`try` syntax today (matching every other site in this issue family, per its own documented rationale) — fixed anyway for internal consistency, the same reasoning the rest of this family already established.

The remaining ~49 `to_owned_checked` sites from #2001's own audit stay out of scope for this pass; the issue is left open for whoever picks up the next batch.

## Test plan

- [x] 6 new direct unit tests (covering 8 call sites), each confirmed to fail on pre-fix code and pass post-fix
- [x] `cargo test` (default features, 3109 lib tests + all doctests)
- [x] `cargo test --features cli` across all CLI-gated integration test binaries
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` (CI's simd-feature leg)
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --all -- --check`
- [x] Live-verified ordinary `pick`/`omit`/array-slice behavior is unaffected, against the pinned oracles

Continues #2001