### PR TITLE
docs(jq): confirm try_pattern_alternatives' bare to_owned is CLI-unreachable

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38031,6 +38031,29 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             ),
         );
 
+        // #2027: the `One`/`Many` arms' bare `to_owned` below looked like a
+        // live silent-corruption gap (the same #1746/#1755 shape fixed
+        // elsewhere in this file) but is confirmed CLI-unreachable, not
+        // merely untested. `eval_generic.rs`'s eager `eval_single` has no
+        // native `Expr::As`/`Expr::AsPattern` arm, so every real CLI
+        // as-binding query reaches this function only via that module's
+        // wildcard `_` bridge, which calls `to_owned_with_cursor` -- a
+        // genuinely fallible, `EvalError`-raising conversion, not this
+        // file's own infallible `to_owned` -- on the *whole* ambient value
+        // before `full_eval` ever hands control to `eval_as_pattern`. That
+        // upstream conversion recursively decodes every string reachable
+        // from the ambient value (everything `body` could possibly
+        // navigate to, since `body` runs against that same value), so any
+        // genuine decode failure anywhere in it already raised before this
+        // loop starts -- confirmed live via reachability probes: on a
+        // document with a decode-failure-inducing string, `eval_as_pattern`
+        // and this function are never entered at all (even when the bad
+        // field is completely untouched by the query), while an
+        // all-valid document reaches both. Direct internal calls (e.g. this
+        // file's own `query!`-based tests) bypass that bridge and so remain
+        // a real way to exercise this arm's behavior -- matching the
+        // #1953/#1972 lesson this file's own comments already name
+        // elsewhere.
         match eval_single::<W, S>(&substituted_body, value.clone(), optional).materialize_cursor() {
             QueryResult::One(v) => {
                 carried.push(to_owned(&v));


### PR DESCRIPTION
## Summary

#2027 flagged `try_pattern_alternatives`'s `One`/`Many` arms (bare
`to_owned`, not `to_owned_checked`) as a candidate live silent-corruption
bug in the #1746/#1755 shape, found during #1989's own classification
pass.

## Verification (per #2027's own "verify against real jq before
implementing" instruction, and this file's own #1953/#1972 lesson)

Confirmed **CLI-unreachable**, not merely untested, via direct
reachability probes (temporary `eprintln!` instrumentation, reverted
before this commit):

- `eval_generic.rs`'s eager `eval_single` has **no native
  `Expr::As`/`Expr::AsPattern` arm** — every real CLI as-binding/`?//`
  query reaches `eval.rs`'s `eval_as_pattern`/`try_pattern_alternatives`
  only via that module's wildcard `_` bridge.
- That bridge calls `to_owned_with_cursor` — a genuinely fallible,
  `EvalError`-raising conversion — on the **whole ambient value** before
  ever handing off to `full_eval`. Since `body` runs against that same
  ambient value, this upstream conversion has already decoded (or raised
  on) everything `body` could possibly navigate to.
- Live confirmation: on a document containing a decode-failure-inducing
  string **anywhere** (even in a field the query never references), the
  query raises before `eval_as_pattern`/`try_pattern_alternatives` are
  ever entered. On an all-valid document, both are reached (probe
  fires). Raw invalid UTF-8 bytes can't even be used to test this at all
  — the CLI's own front-door `utf8_lossy_document` already normalizes
  them before parsing; a structurally-malformed `\uXXXX` escape (which
  survives that front door) was needed to get a genuine decode failure
  into the pipeline at all.

## Change

Doc-comment only, at the two affected match arms — no behavior change.
Documents the finding so a future reader doesn't re-spend the same
investigation. Direct internal calls (this file's own `query!`-based
tests) still bypass the bridge and remain a valid way to exercise these
arms' behavior in isolation.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace` (55/55 binaries green)
- [x] `cargo test --verbose` (default features)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --check`

All checks run against a genuinely clean build (`cargo clean -p succinctly` before the verification pass).

Refs #2027.