### PR TITLE
fix(jq): --argjson/--jsonargs accept a lone low surrogate escape (#2012)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2767,10 +2767,10 @@ fn validate_json_str(s: &str) -> serde_json::Result<()> {
 /// the full "validate, then reparse the same span" pattern #1163 asked to
 /// share, for the call sites where the validated string and the
 /// materialized string are the same one. `parse_json_value`'s own
-/// leading-zero retry can't use this for its retry branch (it validates a
-/// *normalized* copy but must still materialize the *original* text, see
-/// its own comment), so that one branch calls `validate_json_str`
-/// directly instead.
+/// leading-zero/low-surrogate retry (#1094/#2012) can't use this for its
+/// retry branch (it validates a *normalized* copy but must still
+/// materialize the *original* text, see its own comment), so that branch
+/// calls `validate_json_str` directly instead.
 fn validate_and_materialize_json(
     s: &str,
 ) -> serde_json::Result<core::result::Result<OwnedValue, EvalError>> {
@@ -3729,17 +3729,25 @@ fn seq_pending_token_is_terminated(
 }
 
 /// Whether one value out of a `--seq` record is legal JSON, allowing the
-/// same leading-zero form (`007e5`) `--seq` has accepted since #1243.
+/// same leading-zero form (`007e5`) `--seq` has accepted since #1243, and
+/// the same lone-low-surrogate escape (`\uDC00`-`\uDFFF`) `--argjson`
+/// accepts since #2012 (code review: `validate::validate` -- strict RFC
+/// 8259 -- and `validate_json_str` -- `serde_json` -- both reject a lone
+/// low surrogate, so without this, a `--seq` record real jq accepts
+/// [confirmed live: `printf '\x1e"\udc00"\n' | jq --seq -c '.'` =>
+/// `"�"`, exit 0] silently vanished instead, the exact leniency gap
+/// #2012 fixed for `--argjson` reappearing one function over).
 ///
-/// Normalization is needed *here* and only here: `validate::validate` is
-/// strict RFC 8259 and rejects a leading zero, while the semi-indexer behind
-/// `json_bytes_to_owned_value` already reads `0007` as `7` on its own -- so
-/// the value-building side needs no fallback.
+/// Normalization is needed *here* and only here: the value-building side
+/// (`json_bytes_to_owned_value`, reached once a record is judged valid)
+/// already reads `0007` as `7` and substitutes U+FFFD for a lone low
+/// surrogate on its own -- so it needs no fallback of its own for either
+/// leniency.
 fn seq_value_is_valid(value_text: &str) -> bool {
     if validate::validate(value_text.as_bytes()).is_ok() {
         return true;
     }
-    let normalized = normalize_leading_zero_numbers(value_text);
+    let normalized = normalize_lone_low_surrogates(&normalize_leading_zero_numbers(value_text));
     normalized != value_text && validate_json_str(&normalized).is_ok()
 }
 
@@ -6044,6 +6052,52 @@ mod tests {
         // at all, are unaffected.
         assert_eq!(normalize_lone_low_surrogates("[1,2]"), "[1,2]");
         assert_eq!(normalize_lone_low_surrogates(r#""hello""#), r#""hello""#);
+    }
+
+    /// #2012 code review: the low-surrogate range's inclusive bounds
+    /// (`0xDC00..=0xDFFF`) and the high-surrogate range just below it
+    /// (`0xD800..=0xDBFF`) were unverified at their exact edges -- an
+    /// off-by-one here would either miss a real lone low surrogate or
+    /// wrongly touch an ordinary character just outside either range.
+    /// Every value below is verified live against `/usr/bin/jq` 1.7.1.
+    #[test]
+    fn test_normalize_lone_low_surrogates_range_boundaries_2012() {
+        // 0xDFFF: top of the low-surrogate range -- still substituted.
+        assert_eq!(normalize_lone_low_surrogates(r#""\udfff""#), r#""\ufffd""#);
+        // 0xDBFF: top of the high-surrogate range -- a lone high surrogate,
+        // left untouched (out of this issue's scope, same as 0xD800 above).
+        assert_eq!(normalize_lone_low_surrogates(r#""\udbff""#), r#""\udbff""#);
+        // 0xD7FF and 0xE000: the codepoints immediately outside either
+        // surrogate range -- ordinary characters, not surrogates at all,
+        // so `parse_u_escape` finds no surrogate here and copies verbatim.
+        assert_eq!(normalize_lone_low_surrogates(r#""\ud7ff""#), r#""\ud7ff""#);
+        assert_eq!(normalize_lone_low_surrogates(r#""\ue000""#), r#""\ue000""#);
+    }
+
+    /// #2012 code review: a lone low surrogate immediately followed by
+    /// another lone low surrogate, or a valid pair immediately followed
+    /// by another valid pair, with no plain character between them -- the
+    /// case most likely to expose an off-by-one in the pair-consuming
+    /// loop's own index arithmetic. Both verified live against jq 1.7.1.
+    #[test]
+    fn test_normalize_lone_low_surrogates_adjacent_escapes_2012() {
+        assert_eq!(
+            normalize_lone_low_surrogates(r#""\udc00\udc01""#),
+            r#""\ufffd\ufffd""#
+        );
+        // Two consecutive valid pairs: both left untouched.
+        assert_eq!(
+            normalize_lone_low_surrogates(r#""\ud800\udc00\ud801\udc01""#),
+            r#""\ud800\udc00\ud801\udc01""#
+        );
+        // A high surrogate immediately followed by a malformed (non-hex)
+        // `\u` escape is not a valid pair -- left untouched, same as any
+        // other lone high surrogate; `parse_u_escape` returns `None` for
+        // the malformed escape rather than panicking.
+        assert_eq!(
+            normalize_lone_low_surrogates(r#""\ud800\uZZZZ""#),
+            r#""\ud800\uZZZZ""#
+        );
     }
 
     #[test]

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2820,12 +2820,126 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
             // materialized text too would silently rewrite the value's
             // source spelling.
             let normalized = normalize_leading_zero_numbers(s);
-            if normalized == s || validate_json_str(&normalized).is_err() {
-                return Err(e).with_context(|| format!("Invalid JSON: {s}"));
+            if normalized != s && validate_json_str(&normalized).is_ok() {
+                return crate::output::json_bytes_to_owned_value(s.as_bytes())
+                    .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
             }
-            crate::output::json_bytes_to_owned_value(s.as_bytes())
-                .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"))
+
+            // A lone *low* surrogate escape (`\uDC00`-`\uDFFF`) (#2012):
+            // `serde_json` rejects it outright, but real jq accepts it and
+            // substitutes U+FFFD -- the same leniency #2008 already gave
+            // this crate's own decoder (`json::light::decode_escapes_into`),
+            // which `json_bytes_to_owned_value` below reaches. Same retry
+            // shape as the leading-zero case above: validate a normalized
+            // copy, materialize from the original `s` either way, since the
+            // decoder already does the right thing on its own.
+            let surrogate_fixed = normalize_lone_low_surrogates(s);
+            if surrogate_fixed != s && validate_json_str(&surrogate_fixed).is_ok() {
+                return crate::output::json_bytes_to_owned_value(s.as_bytes())
+                    .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
+            }
+
+            Err(e).with_context(|| format!("Invalid JSON: {s}"))
         }
+    }
+}
+
+/// Whether `bytes[i..]` starts with a JSON `\uXXXX` escape -- if so, its
+/// codepoint value and the position just past the escape's 6 bytes.
+/// `None` if the 4 hex digits aren't well-formed; left for the retried
+/// `serde_json` validation to reject on its own terms, since this
+/// function's only job is finding surrogate escapes to normalize, not
+/// validating everything else in `s`.
+fn parse_u_escape(bytes: &[u8], i: usize) -> Option<(u16, usize)> {
+    if bytes.get(i) != Some(&b'\\') || bytes.get(i + 1) != Some(&b'u') {
+        return None;
+    }
+    let hex = bytes.get(i + 2..i + 6)?;
+    let hex_str = core::str::from_utf8(hex).ok()?;
+    let value = u16::from_str_radix(hex_str, 16).ok()?;
+    Some((value, i + 6))
+}
+
+/// Replace every lone (unpaired) low-surrogate `\uXXXX` escape
+/// (`\uDC00`-`\uDFFF`) in `s` with the literal escape `\ufffd`, leaving a
+/// valid high+low surrogate *pair* untouched -- so `validate_json_str`'s
+/// `serde_json` gate, which rejects any lone surrogate half outright, can
+/// validate what remains. A lone *high* surrogate is left exactly as
+/// written and stays rejected either way -- out of this issue's scope
+/// (#2013 covers a different, unrelated high-surrogate leniency bug in a
+/// different decoder).
+///
+/// Only ever invoked as a retry after `validate_and_materialize_json`
+/// already rejected `s` (see `parse_json_value`) -- the *materialized*
+/// value always comes from the original, untouched `s` afterward, whose
+/// own decoder (`json::light::decode_escapes_into`, #2008) already
+/// substitutes U+FFFD for exactly this shape, matching real jq. This
+/// function exists solely to get a validation *copy* of `s` past
+/// `serde_json`'s stricter gate, not to change what gets stored.
+fn normalize_lone_low_surrogates(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            let Some(end) = find_string_end(bytes, i) else {
+                out.extend_from_slice(&bytes[i..]);
+                break;
+            };
+            normalize_string_span_low_surrogates(&bytes[i..end], &mut out);
+            i = end;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).expect(
+        "only ever copies span's own bytes verbatim, or substitutes one \\uXXXX escape for another of equal byte length within an already-delimited string span",
+    )
+}
+
+/// Normalize one already-delimited string span (`span[0]` is the opening
+/// quote, `span`'s last byte the closing one) into `out`, substituting
+/// lone low surrogates as `normalize_lone_low_surrogates` describes.
+fn normalize_string_span_low_surrogates(span: &[u8], out: &mut Vec<u8>) {
+    let mut i = 0;
+    // Set right after copying a high surrogate escape that is immediately
+    // followed by a valid low surrogate escape -- the pair `serde_json`
+    // already accepts, so the low half must be copied verbatim too rather
+    // than substituted.
+    let mut next_low_is_paired = false;
+    while i < span.len() {
+        if let Some((value, next)) = parse_u_escape(span, i) {
+            if (0xD800..=0xDBFF).contains(&value) {
+                out.extend_from_slice(&span[i..next]);
+                next_low_is_paired = parse_u_escape(span, next)
+                    .is_some_and(|(low, _)| (0xDC00..=0xDFFF).contains(&low));
+                i = next;
+                continue;
+            }
+            if (0xDC00..=0xDFFF).contains(&value) && !next_low_is_paired {
+                out.extend_from_slice(b"\\ufffd");
+            } else {
+                out.extend_from_slice(&span[i..next]);
+            }
+            next_low_is_paired = false;
+            i = next;
+            continue;
+        }
+        next_low_is_paired = false;
+        if span[i] == b'\\' && i + 1 < span.len() {
+            // Any other escape (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`,
+            // `\t`, or a malformed `\u` this retry doesn't need to
+            // understand) is exactly two bytes; copying both keeps the
+            // byte-for-byte pass-through property `find_string_end`'s own
+            // scan already relies on elsewhere in this file.
+            out.push(span[i]);
+            out.push(span[i + 1]);
+            i += 2;
+            continue;
+        }
+        out.push(span[i]);
+        i += 1;
     }
 }
 
@@ -5905,6 +6019,40 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_lone_low_surrogates_2012() {
+        // A lone low surrogate is substituted with the literal escape text
+        // `\ufffd` -- this function's output only ever feeds `serde_json`'s
+        // validation gate, never gets materialized itself (see the
+        // function's own doc comment), so the substitution is the escape
+        // *sequence*, not a decoded replacement character.
+        assert_eq!(normalize_lone_low_surrogates(r#""\udc00""#), r#""\ufffd""#);
+        // Multiple lone low surrogates, each independently.
+        assert_eq!(
+            normalize_lone_low_surrogates(r#""a\udc00b\udc01""#),
+            r#""a\ufffdb\ufffd""#
+        );
+        // A valid high+low surrogate pair is left untouched.
+        assert_eq!(normalize_lone_low_surrogates(r#""𐀀""#), r#""𐀀""#);
+        // A lone high surrogate is left untouched -- out of this issue's
+        // scope (#2013 covers that case in a different decoder).
+        assert_eq!(normalize_lone_low_surrogates(r#""\ud800""#), r#""\ud800""#);
+        // Object keys are reached the same way values are.
+        assert_eq!(
+            normalize_lone_low_surrogates(r#"{"a\udc00":1}"#),
+            r#"{"a\ufffd":1}"#
+        );
+        // An escaped quote inside a string doesn't end the string early.
+        assert_eq!(
+            normalize_lone_low_surrogates(r#"["a\"\udc00b",1]"#),
+            r#"["a\"\ufffdb",1]"#
+        );
+        // Content outside strings, and a string with no surrogate escape
+        // at all, are unaffected.
+        assert_eq!(normalize_lone_low_surrogates("[1,2]"), "[1,2]");
+        assert_eq!(normalize_lone_low_surrogates(r#""hello""#), r#""hello""#);
+    }
+
+    #[test]
     fn test_jq_compat_formatter_format_raw_number() {
         // Finite numbers fall through the NaN/Infinity guard unchanged.
         assert_eq!(JqCompatFormatter.format_raw_number(b"42").as_ref(), "42");
@@ -6059,6 +6207,43 @@ mod tests {
     #[test]
     fn test_parse_json_value_still_rejects_trailing_garbage_1058() {
         assert!(parse_json_value("42 garbage").is_err());
+    }
+
+    /// #2012: `--argjson`/`--jsonargs`' JSON parser accepts a lone low
+    /// surrogate escape and substitutes U+FFFD, matching real jq -- rather
+    /// than rejecting outright the way `serde_json`'s own validation gate
+    /// does on its own. Verified live against jq 1.7.1
+    /// (`jq -n --argjson x '"\udc00"' '$x'` => `"�"`, exit 0).
+    #[test]
+    fn test_parse_json_value_accepts_lone_low_surrogate_2012() {
+        assert_eq!(
+            parse_json_value(r#""\udc00""#).unwrap().to_json(),
+            "\"\u{FFFD}\""
+        );
+        // Multiple lone low surrogates in the same value.
+        assert_eq!(
+            parse_json_value(r#""a\udc00b\udc01""#).unwrap().to_json(),
+            "\"a\u{FFFD}b\u{FFFD}\""
+        );
+        // A valid surrogate pair still decodes to the real supplementary
+        // character, not U+FFFD -- this retry must not clobber it.
+        assert_eq!(
+            parse_json_value(r#""𐀀""#).unwrap().to_json(),
+            "\"\u{10000}\""
+        );
+        // Reached through an object value too, not just a bare string.
+        assert_eq!(
+            parse_json_value(r#"{"a":"\udc00"}"#).unwrap().to_json(),
+            "{\"a\":\"\u{FFFD}\"}"
+        );
+    }
+
+    /// #2012 regression guard: a lone *high* surrogate must stay rejected
+    /// -- that's #2013's own (different-decoder) scope, not this fix's.
+    /// Verified live: `jq -n --argjson x '"\ud800"' '$x'` errors, exit 2.
+    #[test]
+    fn test_parse_json_value_still_rejects_lone_high_surrogate_2012() {
+        assert!(parse_json_value(r#""\ud800""#).is_err());
     }
 
     #[test]

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2825,7 +2825,7 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
             // its own (confirmed live), so there's nothing left to repair
             // for either, and normalizing the materialized text too would
             // silently rewrite the value's source spelling.
-            let normalized = normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s));
+            let normalized = normalize_json_leniently(s);
             if normalized != s && validate_json_str(&normalized).is_ok() {
                 return crate::output::json_bytes_to_owned_value(s.as_bytes())
                     .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
@@ -2834,6 +2834,28 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
             Err(e).with_context(|| format!("Invalid JSON: {s}"))
         }
     }
+}
+
+/// Apply every leniency real jq allows that `serde_json`'s own validation
+/// doesn't (#1094's leading zero, #2012's lone low surrogate) in one
+/// composed pass, so a value needing more than one at once still gets all
+/// of them -- code review on #2012: `parse_json_value` and its `--seq`
+/// counterpart `seq_value_is_valid` each once applied the two
+/// normalizations independently against the untouched original, which
+/// missed exactly the value-needs-both case (`[007,"\udc00"]`). A no-op
+/// on text neither normalizer finds anything to fix in.
+///
+/// This grows one normalizer per leniency rather than trusting a grammar
+/// that already agrees with this crate's own decoder -- `parse_json_stream`
+/// above takes that alternative shape for `--slurpfile` (falls back to
+/// `find_json_values`'s boundary-only scan + this crate's own decoder,
+/// getting every leniency for free with no per-case enumeration), at the
+/// cost of losing `validate_json_str`'s magnitude-overflow rejection
+/// (`1e400`, #1095) that motivated using `serde_json::Value` here in the
+/// first place. Worth revisiting if a third leniency shows up (#2012 code
+/// review, altitude angle).
+fn normalize_json_leniently(s: &str) -> String {
+    normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s))
 }
 
 /// Whether `bytes[i..]` starts with a JSON `\uXXXX` escape -- if so, its
@@ -2890,6 +2912,16 @@ fn normalize_lone_low_surrogates(s: &str) -> String {
     )
 }
 
+/// Whether `v` is a UTF-16 high (leading) surrogate half.
+fn is_high_surrogate(v: u16) -> bool {
+    (0xD800..=0xDBFF).contains(&v)
+}
+
+/// Whether `v` is a UTF-16 low (trailing) surrogate half.
+fn is_low_surrogate(v: u16) -> bool {
+    (0xDC00..=0xDFFF).contains(&v)
+}
+
 /// Normalize one already-delimited string span (`span[0]` is the opening
 /// quote, `span`'s last byte the closing one) into `out`, substituting
 /// lone low surrogates as `normalize_lone_low_surrogates` describes.
@@ -2897,23 +2929,26 @@ fn normalize_string_span_low_surrogates(span: &[u8], out: &mut Vec<u8>) {
     let mut i = 0;
     while i < span.len() {
         if let Some((value, next)) = parse_u_escape(span, i) {
-            if (0xD800..=0xDBFF).contains(&value) {
+            if is_high_surrogate(value) {
                 // A high surrogate immediately followed by a valid low
                 // surrogate is a real pair `serde_json` already accepts --
                 // consume and copy both escapes verbatim in this one step
                 // (rather than copying the high half now and deciding the
-                // low half's fate next iteration) so the low half's hex
-                // digits are parsed exactly once, not once here and once
-                // more when the loop reaches them.
+                // low half's fate next iteration). This still reparses the
+                // low half's hex digits a second time when the lookahead
+                // itself fails (a lone high surrogate, or one followed by a
+                // malformed/non-surrogate `\u` escape) -- only the
+                // successful-pair branch below avoids the reparse, not
+                // every branch; harmless on this cold, tiny-input-only path.
                 let pair_end = match parse_u_escape(span, next) {
-                    Some((low, low_end)) if (0xDC00..=0xDFFF).contains(&low) => low_end,
+                    Some((low, low_end)) if is_low_surrogate(low) => low_end,
                     _ => next,
                 };
                 out.extend_from_slice(&span[i..pair_end]);
                 i = pair_end;
                 continue;
             }
-            if (0xDC00..=0xDFFF).contains(&value) {
+            if is_low_surrogate(value) {
                 out.extend_from_slice(b"\\ufffd");
             } else {
                 out.extend_from_slice(&span[i..next]);
@@ -3747,7 +3782,7 @@ fn seq_value_is_valid(value_text: &str) -> bool {
     if validate::validate(value_text.as_bytes()).is_ok() {
         return true;
     }
-    let normalized = normalize_lone_low_surrogates(&normalize_leading_zero_numbers(value_text));
+    let normalized = normalize_json_leniently(value_text);
     normalized != value_text && validate_json_str(&normalized).is_ok()
 }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2806,35 +2806,27 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
         Ok(Ok(v)) => Ok(v),
         Ok(Err(e)) => Err(anyhow::anyhow!("Invalid JSON: {s}: {e}")),
         Err(e) => {
-            // Real jq's own number parser tolerates a leading zero
-            // (`007`, `00`, `007.5`) that strict JSON doesn't (#1094) --
-            // retry once with every number token's leading zero stripped
-            // (string contents/keys left untouched) before surfacing the
-            // original error. Only paid on this (rare) failure path, so
-            // the common case's validation cost is unaffected. Can't use
-            // `validate_and_materialize_json` here: it must validate the
-            // *normalized* copy but still materialize the *original*
-            // text below -- this crate's own semi-indexer already
-            // tolerates a leading zero on its own (confirmed live), so
-            // there's nothing left to repair for it, and normalizing the
-            // materialized text too would silently rewrite the value's
-            // source spelling.
-            let normalized = normalize_leading_zero_numbers(s);
+            // Real jq is lenient in two ways `serde_json`'s validation gate
+            // isn't: a leading zero in a number (`007`, `00`, `007.5`,
+            // #1094) and a lone *low* surrogate escape (`\uDC00`-`\uDFFF`,
+            // #2012, the same leniency #2008 already gave this crate's own
+            // decoder). Apply *both* normalizations to one working copy,
+            // not two independent single-fix copies (code review on #2012:
+            // two independent retries each validated against the
+            // untouched original, so a value needing both fixes at once --
+            // e.g. `[007,"\udc00"]` -- failed both and was wrongly
+            // rejected, since neither copy ever had both defects
+            // corrected). Each normalizer is a no-op on text it finds
+            // nothing to fix, so a value needing only one fix still gets
+            // exactly that one. Can't use `validate_and_materialize_json`
+            // here: it must validate the *normalized* copy but still
+            // materialize the *original* text below -- this crate's own
+            // semi-indexer/decoder already tolerates both leniencies on
+            // its own (confirmed live), so there's nothing left to repair
+            // for either, and normalizing the materialized text too would
+            // silently rewrite the value's source spelling.
+            let normalized = normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s));
             if normalized != s && validate_json_str(&normalized).is_ok() {
-                return crate::output::json_bytes_to_owned_value(s.as_bytes())
-                    .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
-            }
-
-            // A lone *low* surrogate escape (`\uDC00`-`\uDFFF`) (#2012):
-            // `serde_json` rejects it outright, but real jq accepts it and
-            // substitutes U+FFFD -- the same leniency #2008 already gave
-            // this crate's own decoder (`json::light::decode_escapes_into`),
-            // which `json_bytes_to_owned_value` below reaches. Same retry
-            // shape as the leading-zero case above: validate a normalized
-            // copy, materialize from the original `s` either way, since the
-            // decoder already does the right thing on its own.
-            let surrogate_fixed = normalize_lone_low_surrogates(s);
-            if surrogate_fixed != s && validate_json_str(&surrogate_fixed).is_ok() {
                 return crate::output::json_bytes_to_owned_value(s.as_bytes())
                     .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
             }
@@ -2903,30 +2895,32 @@ fn normalize_lone_low_surrogates(s: &str) -> String {
 /// lone low surrogates as `normalize_lone_low_surrogates` describes.
 fn normalize_string_span_low_surrogates(span: &[u8], out: &mut Vec<u8>) {
     let mut i = 0;
-    // Set right after copying a high surrogate escape that is immediately
-    // followed by a valid low surrogate escape -- the pair `serde_json`
-    // already accepts, so the low half must be copied verbatim too rather
-    // than substituted.
-    let mut next_low_is_paired = false;
     while i < span.len() {
         if let Some((value, next)) = parse_u_escape(span, i) {
             if (0xD800..=0xDBFF).contains(&value) {
-                out.extend_from_slice(&span[i..next]);
-                next_low_is_paired = parse_u_escape(span, next)
-                    .is_some_and(|(low, _)| (0xDC00..=0xDFFF).contains(&low));
-                i = next;
+                // A high surrogate immediately followed by a valid low
+                // surrogate is a real pair `serde_json` already accepts --
+                // consume and copy both escapes verbatim in this one step
+                // (rather than copying the high half now and deciding the
+                // low half's fate next iteration) so the low half's hex
+                // digits are parsed exactly once, not once here and once
+                // more when the loop reaches them.
+                let pair_end = match parse_u_escape(span, next) {
+                    Some((low, low_end)) if (0xDC00..=0xDFFF).contains(&low) => low_end,
+                    _ => next,
+                };
+                out.extend_from_slice(&span[i..pair_end]);
+                i = pair_end;
                 continue;
             }
-            if (0xDC00..=0xDFFF).contains(&value) && !next_low_is_paired {
+            if (0xDC00..=0xDFFF).contains(&value) {
                 out.extend_from_slice(b"\\ufffd");
             } else {
                 out.extend_from_slice(&span[i..next]);
             }
-            next_low_is_paired = false;
             i = next;
             continue;
         }
-        next_low_is_paired = false;
         if span[i] == b'\\' && i + 1 < span.len() {
             // Any other escape (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`,
             // `\t`, or a malformed `\u` this retry doesn't need to
@@ -6244,6 +6238,28 @@ mod tests {
     #[test]
     fn test_parse_json_value_still_rejects_lone_high_surrogate_2012() {
         assert!(parse_json_value(r#""\ud800""#).is_err());
+    }
+
+    /// #2012 code review: a value needing *both* the #1094 leading-zero
+    /// leniency and the #2012 lone-low-surrogate leniency at once must
+    /// still be accepted -- an earlier version of this fix tried each
+    /// normalization independently against the untouched original, so a
+    /// value needing both failed both retries and was wrongly rejected.
+    /// Verified live: `jq -n --argjson x '[007,"\udc00"]' '$x'` =>
+    /// `[7,"�"]`, exit 0.
+    #[test]
+    fn test_parse_json_value_composes_leading_zero_and_low_surrogate_fixes_2012() {
+        assert_eq!(
+            parse_json_value(r#"[007,"\udc00"]"#).unwrap().to_json(),
+            "[7,\"\u{FFFD}\"]"
+        );
+        // Nested inside an object too, not just a top-level array.
+        assert_eq!(
+            parse_json_value(r#"{"a":007,"b":{"c":"\udc00"}}"#)
+                .unwrap()
+                .to_json(),
+            "{\"a\":7,\"b\":{\"c\":\"\u{FFFD}\"}}"
+        );
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1260,7 +1260,9 @@ fn test_seq_accepts_lone_low_surrogate_2012() -> Result<()> {
 
 /// #2012 (code review): the composed leading-zero + low-surrogate case
 /// must be accepted through `--seq` too, matching `--argjson`'s own
-/// composed-fix regression guard.
+/// composed-fix regression guard. Confirmed live against the pinned
+/// oracle: `printf '\x1e[007,"\udc00"]\n' | jq --seq -c '.'` =>
+/// `[7,"�"]`, exit 0.
 #[test]
 fn test_seq_composes_leading_zero_and_low_surrogate_fixes_2012() -> Result<()> {
     let (stdout, stderr, code) =

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1237,6 +1237,43 @@ fn test_seq_still_drops_genuinely_malformed_record_1267() -> Result<()> {
     Ok(())
 }
 
+/// #2012 (code review): `--seq` had the identical lone-low-surrogate gap
+/// #2012 fixed for `--argjson`/`--jsonargs`, reached through a different
+/// function (`seq_value_is_valid`) that also gates on `serde_json`
+/// validation and had no low-surrogate fallback -- a `--seq` record real
+/// jq accepts (substituting U+FFFD, the same #2008 leniency) silently
+/// vanished instead of being emitted. Confirmed live against the pinned
+/// oracle: `printf '\x1e"\udc00"\n\x1e"ok"\n' | jq --seq -c '.'` prints
+/// both records, exit 0.
+#[test]
+fn test_seq_accepts_lone_low_surrogate_2012() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["--seq", "-c", "."], Some("\x1e\"\\udc00\"\n\x1e\"ok\"\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stdout.trim_end(),
+        "\x1e\"\u{FFFD}\"\n\x1e\"ok\"",
+        "stdout: {stdout:?}"
+    );
+    Ok(())
+}
+
+/// #2012 (code review): the composed leading-zero + low-surrogate case
+/// must be accepted through `--seq` too, matching `--argjson`'s own
+/// composed-fix regression guard.
+#[test]
+fn test_seq_composes_leading_zero_and_low_surrogate_fixes_2012() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["--seq", "-c", "."], Some("\x1e[007,\"\\udc00\"]\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stdout.trim_end(),
+        "\x1e[7,\"\u{FFFD}\"]",
+        "stdout: {stdout:?}"
+    );
+    Ok(())
+}
+
 /// A hyphen-prefixed `--slurpfile`/`--rawfile` FILE value must reach this
 /// crate's own file-open logic, not get rejected by clap as an unknown
 /// flag first (#1150, same `allow_hyphen_values` fix as `--arg`/
@@ -25798,11 +25835,16 @@ fn test_argjson_low_surrogate_substitutes_replacement_character_2012() {
     assert_eq!(stdout.trim(), "\"\u{FFFD}\"");
 
     // Control: a lone *high* surrogate stays rejected (#2013's own,
-    // unrelated scope).
+    // unrelated scope) -- asserting on the message content, not just
+    // non-empty stderr, so a regression that broke `--argjson` parsing
+    // for an unrelated reason wouldn't pass this check too.
     let (_stdout, stderr, code) =
         run_jq_full(&["-n", "--argjson", "x", r#""\ud800""#, "$x"], None).unwrap();
     assert_ne!(code, 0, "lone high surrogate should still be rejected");
-    assert!(!stderr.is_empty());
+    assert!(
+        stderr.contains("Invalid JSON for --argjson"),
+        "stderr: {stderr}"
+    );
 
     // Control: a value needing *both* the #1094 leading-zero leniency and
     // this leniency at once (code review on #2012: an earlier version

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25774,6 +25774,45 @@ fn test_fromjson_lone_high_surrogate_key_no_longer_silently_collapses_2013() {
     assert_ne!(code, 0, "stderr: {stderr}");
 }
 
+/// #2012: `--argjson`/`--jsonargs`' own value parser (`parse_json_value`,
+/// `src/bin/succinctly/jq_runner.rs`) is a *third*, independent surrogate
+/// decoder from the two #2008 already fixed above -- it validates via
+/// `serde_json` first, which rejects a lone low surrogate outright, before
+/// this crate's own leniency (`json_bytes_to_owned_value`) ever gets a
+/// chance to run. Confirmed live against the pinned oracle before the fix
+/// (succinctly errored, real jq substituted U+FFFD, exit 0 either way).
+#[test]
+fn test_argjson_low_surrogate_substitutes_replacement_character_2012() {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "--argjson", "x", r#""\udc00""#, "$x"], None).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"\u{FFFD}\"");
+
+    // `--jsonargs` reaches the same `parse_json_value`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-n", "$ARGS.positional[0]", "--jsonargs", r#""\udc00""#],
+        None,
+    )
+    .unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "\"\u{FFFD}\"");
+
+    // Control: a lone *high* surrogate stays rejected (#2013's own,
+    // unrelated scope).
+    let (_stdout, stderr, code) =
+        run_jq_full(&["-n", "--argjson", "x", r#""\ud800""#, "$x"], None).unwrap();
+    assert_ne!(code, 0, "lone high surrogate should still be rejected");
+    assert!(!stderr.is_empty());
+
+    // Control: a value needing *both* the #1094 leading-zero leniency and
+    // this leniency at once (code review on #2012: an earlier version
+    // tried each fix independently and rejected exactly this shape).
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", "--argjson", "x", r#"[007,"\udc00"]"#, "$x"], None).unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "[7,\"\u{FFFD}\"]");
+}
+
 /// #1642 (was #1247): an undecodable *key* does not silently shrink the
 /// object -- `to_entries` used to return one entry fewer than the document
 /// had, because `effective_fields`' dedup walk dropped any field whose key


### PR DESCRIPTION
## Summary

`--argjson`/`--jsonargs` rejected a JSON string literal containing a lone *low*
surrogate escape (`\uDC00`-`\uDFFF`), where real jq 1.7.1 accepts it and
substitutes U+FFFD -- confirmed live against the pinned oracle (`/usr/bin/jq`).

```
$ succinctly jq -n --argjson x '"\udc00"' '$x'
Error: Invalid JSON for --argjson x
$ /usr/bin/jq -n --argjson x '"\udc00"' '$x'
"�"
```

## Root cause

`--argjson`'s value parser validates via `serde_json::from_str::<serde_json::Value>`
first (`validate_json_str`), which rejects a lone low surrogate outright.
This crate's own decoder (`json::light::decode_escapes_into`) already handles
this leniently, matching jq, since #2008 -- the bug was purely in the upfront
`serde_json` validation gate rejecting the text before the decoder ever runs.

## Fix

Reuses the same lazy-retry idiom `parse_json_value` already has for #1094's
leading-zero leniency: on `serde_json` validation failure, try a normalized
copy with lone low surrogates substituted for the plain BMP escape `�`
(which `serde_json` accepts), and if *that* validates, materialize the value
from the **original**, untouched text -- never the normalized copy, since the
decoder's own #2008 leniency already produces the correct value. A valid
high+low surrogate *pair* is left untouched. A lone *high* surrogate stays
rejected -- that's #2013's own, unrelated scope (a different decoder's
leniency gap in the opposite direction).

Closes #2012.

## Test plan

- [x] `test_normalize_lone_low_surrogates_2012`: unit tests for the new
      normalization helper (lone low surrogate, multiple occurrences, valid
      pair untouched, lone high surrogate untouched, object keys, escaped
      quotes, unaffected content).
- [x] `test_parse_json_value_accepts_lone_low_surrogate_2012`: end-to-end
      through `parse_json_value`, including a valid surrogate pair and an
      object value.
- [x] `test_parse_json_value_still_rejects_lone_high_surrogate_2012`:
      regression guard that high-surrogate rejection is unaffected.
- [x] Live-verified every case (including `--jsonargs`, leading-zero
      interaction, and trailing-garbage rejection) against `/usr/bin/jq`
      1.7.1 and manually reverted the fix to confirm the new tests catch
      the regression.
- [x] Full workspace test suite, 3 clippy feature-leg combinations, no_std
      check, default-features test, fmt check, and doc check all clean.