### PR TITLE
fix(jq): fromjson raises on a lone high surrogate instead of substituting

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1316,12 +1316,15 @@ That gate is deliberately narrow -- it does not make yq-mode `fromjson` match re
 actual model, which rejects the entire surrogate-pairing mechanism, not just the lone-low
 case. A **valid** surrogate pair still silently decodes successfully in yq mode today
 (`succinctly yq -n '"\"\\ud83d\\ude00\"" | fromjson'` → the emoji, real yq → a parse
-error), and a lone **high** surrogate is wrongly *accepted* (substitutes U+FFFD) in both
-jq and yq mode alike -- a separate, pre-existing bug unrelated to #2008's own scope, filed
-as [#2013](https://github.com/rust-works/succinctly/issues/2013) (also documents a real
-data-loss case: two `fromjson`-parsed object keys differing only by an unpaired high
-surrogate silently collapse, last-value-wins). Fully aligning yq-mode `fromjson` with real
-yq's stricter, non-pairing model is filed separately as
+error). A lone **high** surrogate was also wrongly *accepted* (substituted U+FFFD) in both
+jq and yq mode alike -- a separate, pre-existing bug unrelated to #2008's own scope
+(also caused real data loss: two `fromjson`-parsed object keys differing only by an
+unpaired high surrogate silently collapsed, last-value-wins) -- fixed in both modes by
+[#2013](https://github.com/rust-works/succinctly/issues/2013): `parse_json_string_value`'s
+high-surrogate arm now raises unconditionally (no mode gate needed there, since both real
+jq and real yq reject it -- unlike the lone-low case above, where the two oracles
+disagree). Fully aligning yq-mode `fromjson` with real yq's stricter, non-pairing model
+(the still-open valid-pair gap) is filed separately as
 [#2018](https://github.com/rust-works/succinctly/issues/2018), since it needs its own
 yq-mode branch checked ahead of all of jq's pairing logic, not an arm-by-arm patch.
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -11517,14 +11517,23 @@ fn parse_json_string_value(
                                     }
                                     *pos += 5; // Move past the low surrogate (will be incremented again below)
                                 } else {
-                                    // Lone high surrogate - use replacement character
-                                    result.push('\u{FFFD}');
-                                    *pos -= 1; // Back up so we don't skip the next escape
+                                    // #2013: a lone high surrogate (this
+                                    // \u wasn't followed by a valid low
+                                    // surrogate) is an error, matching real
+                                    // jq (confirmed live) and this crate's
+                                    // own primary document decoder
+                                    // (`json::light::decode_escapes`'s
+                                    // sibling high-surrogate arm). No
+                                    // yq-mode split needed: real yq also
+                                    // rejects every surrogate escape
+                                    // unconditionally (#2018).
+                                    return Err("invalid unicode codepoint".to_string());
                                 }
                             } else {
-                                // Lone high surrogate
-                                result.push('\u{FFFD}');
-                                *pos -= 1;
+                                // #2013: lone high surrogate, not followed
+                                // by any `\u` escape at all -- same fix as
+                                // above.
+                                return Err("invalid unicode codepoint".to_string());
                             }
                         } else if (0xDC00..=0xDFFF).contains(&codepoint) {
                             // #2008: a lone low surrogate isn't a valid Rust

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25734,6 +25734,46 @@ fn test_fromjson_low_surrogate_substitutes_replacement_character_2008() {
     assert_eq!(stdout.trim(), "😀");
 }
 
+/// #2013: the opposite-direction bug from #2008/the test above -- a lone
+/// *high* surrogate (`\uD800`-`\uDBFF`) in `fromjson`'s own decoder wrongly
+/// substituted U+FFFD instead of raising, where real jq 1.7.1 rejects it
+/// (confirmed live). Covers every shape the issue's own investigation
+/// found: end-of-string, followed by a non-`\u` escape, followed by a
+/// `\u` escape that isn't a valid low surrogate, and two consecutive
+/// unpaired high surrogates -- each previously took a different silent
+/// path to the same wrong "succeeds with U+FFFD" outcome.
+#[test]
+fn test_fromjson_lone_high_surrogate_raises_2013() {
+    for filter in [
+        r#""\"\\ud800\"" | fromjson"#,
+        r#""\"\\ud800\\n\"" | fromjson"#,
+        r#""\"\\ud800\\u0041\"" | fromjson"#,
+        r#""\"\\ud800\\ud800\"" | fromjson"#,
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-n", "-r", filter], None).unwrap();
+        assert_ne!(code, 0, "filter={filter:?} should raise, stderr: {stderr}");
+    }
+}
+
+/// #2013: object keys go through the same decoder, so two `fromjson`-parsed
+/// keys differing only by an unpaired high surrogate used to silently
+/// collapse (last value wins) instead of the whole document raising --
+/// real data loss, not just a leniency mismatch. Confirmed live: real jq
+/// rejects the document outright.
+#[test]
+fn test_fromjson_lone_high_surrogate_key_no_longer_silently_collapses_2013() {
+    let (_stdout, stderr, code) = run_jq_full(
+        &[
+            "-n",
+            "-c",
+            r#""{\"a\\ud800\":1,\"a\\ud800\":2}" | fromjson"#,
+        ],
+        None,
+    )
+    .unwrap();
+    assert_ne!(code, 0, "stderr: {stderr}");
+}
+
 /// #1642 (was #1247): an undecodable *key* does not silently shrink the
 /// object -- `to_entries` used to return one entry fewer than the document
 /// had, because `effective_fields`' dedup walk dropped any field whose key

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27025,6 +27025,20 @@ fn test_yq_fromjson_low_surrogate_still_rejected_2008() -> Result<()> {
     Ok(())
 }
 
+/// #2013 (code review): the lone-*high*-surrogate fix in
+/// `parse_json_string_value` has no `yq_mode` gate at all (unlike the
+/// lone-low case above, real jq and real yq *agree* here -- both reject
+/// it), so it applies to both modes at once. Pins that yq mode picked up
+/// the fix too, not just jq mode's own
+/// `test_fromjson_lone_high_surrogate_raises_2013`.
+#[test]
+fn test_yq_fromjson_lone_high_surrogate_raises_2013() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(r#""\"x\\ud800y\"" | fromjson"#, "", &["-n"])?;
+    assert_ne!(code, 0, "stderr: {stderr}");
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // #1473: compile-time function resolution in yq mode.
 //


### PR DESCRIPTION
## Summary

`parse_json_string_value` (`fromjson`/`tonumber`'s own hand-rolled JSON
string decoder) substituted U+FFFD for a lone high surrogate escape
(`\uD800`-`\uDBFF`), where real jq 1.7.1 raises a parse error — confirmed
live against the pinned oracle. This is the opposite direction from #2008
(too lenient, not too strict) and predates that PR: the arm already did
this before #2008 touched the file, which only added the matching
low-surrogate arm real jq *does* want lenient.

```
$ succinctly jq -n -r '"\"\\ud800\"" | fromjson'   # before this fix
�
$ /usr/bin/jq -n -r '"\"\\ud800\"" | fromjson'
jq: error (...): Invalid \uXXXX\uXXXX surrogate pair escape ...
```

No yq-mode split needed (unlike #2008's own low-surrogate fix): real yq's
`fromjson` also rejects every surrogate escape unconditionally (#2018), so
both modes want the same outcome here.

Covers all four shapes found during investigation: end-of-string, followed
by a non-`\u` escape, followed by a `\u` escape that isn't a valid low
surrogate, and two consecutive unpaired high surrogates — plus the real
data-loss case: two object keys differing only by an unpaired high
surrogate used to silently collapse via last-value-wins instead of the
whole document raising.

Also fixes a code-review finding: `docs/compliance/yq/limitations.md`
still described this as an open bug, and no yq-mode test locked in the fix
despite it applying unconditionally to both modes.

## Test plan

- [x] New unit/CLI tests, each confirmed against the live oracle for every
      shape the issue's investigation found (jq mode + yq mode)
- [x] `cargo test` (default features)
- [x] `cargo test --features cli` across all CLI-gated integration test
      binaries
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` (CI's simd-feature leg)
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --all -- --check`
- [x] One round of `/code-review`, both findings fixed

Fixes #2013