### PR TITLE
fix(jq): thread path()'s register through resolve_seq (#1573)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -519,16 +519,34 @@ is the revert that established what the other one costs.
 
 1. **Variable-rooted navigation off a mismatched accumulator** —
    `path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))` on `{"a":{"b":1},"c":2}` is
-   `["a","b"]` ×2 in jq; succinctly refuses. Same root cause as the pre-existing, unrelated
-   `path(. as $x \| 5 \| $x.a)` on `{"a":1}` (jq `["a"]`, succinctly already refuses today) —
-   `resolve_node` conflates "current input" with a variable's own bound position outside any
-   fold too, so this isn't specific to #1440's own fix. `Expr::TrackedVar` witnesses only
-   `path=[]`, which is why `substitute_var_tracked` is gated on `is_identity_passthrough`:
-   a variable bound from a *navigated* position (`.a as $y`) carries no marker at all, so
-   `path(.a as $y \| reduce (1) as $i (.a; $y))` — jq `["a"]` — refuses too. Tracked as
-   [#1573](https://github.com/rust-works/succinctly/issues/1573), which proposes carrying the
-   binding's own path on the marker; goldens `fold_register_var_from_navigated_binding` and
-   `fold_register_snapshot_via_nested_init`.
+   `["a","b"]` ×2 in jq; succinctly refuses.
+
+   The *plain-pipe* half of this shape is closed.
+   [#1573](https://github.com/rust-works/succinctly/issues/1573) established that jq carries
+   a `(path, value_at_path)` **register** which only navigation advances — a literal never
+   moves it, so a `$var` frozen from where it still points steps back onto it — and
+   `resolve_seq` now threads that register (`PathBranch::register`,
+   `reestablishes_register`, `src/jq/eval.rs`). `path(. as $x \| 5 \| $x.a)` on `{"a":1}`,
+   which this list previously recorded as refusing, answers `["a"]` like jq.
+
+   What remains here is that [`FoldRegister`](../../../src/jq/eval.rs) does not seed *its*
+   register into the resolution of its own `UPDATE`/`EXTRACT`: the accumulator (`0`) is
+   resolved with tracking already off and no register to compare against, so `$x.a` cannot
+   re-establish the way it does in a plain pipe. Closing it means threading the register
+   into `resolve_node`/`resolve_leaf` as a parameter rather than carrying it on the branch,
+   which is a materially larger change across that function's ~20-call-site dispatch graph.
+
+   Separately, a variable bound from a *navigated* position (`.a as $y`) still carries no
+   marker at all, because `substitute_var_tracked` remains gated on
+   `is_identity_passthrough` — so `path(.a as $y \| reduce (1) as $i (.a; $y))`, jq `["a"]`,
+   refuses too. That gate **cannot simply be widened**: measured against jq 1.7.1, doing so
+   makes `path(.a as $y \| .c \| $y)` on `{"a":{"b":1},"c":{"b":1}}` answer `["c"]` where jq
+   refuses — reopening the accept-where-jq-refuses class #1466 closed, since
+   `register_identical`'s provenance bit records "never rebuilt", not "from *this*
+   position", and `OwnedValue` has no node identity. The marker needs a bind-time path
+   first; tracked as [#2042](https://github.com/rust-works/succinctly/issues/2042). Golden
+   `fold_register_var_from_navigated_binding`.
+
 2. **`?//`-alternatives folds aren't path-tracked at all** (refuse-only) —
    `path(. as $x \| reduce (1) as $y ?// $z (0; $x))` on `{"a":1}` is `[]` in jq; succinctly
    refuses. [#1365](https://github.com/rust-works/succinctly/issues/1365) (`?//`-alternatives

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -536,6 +536,31 @@ is the revert that established what the other one costs.
    into `resolve_node`/`resolve_leaf` as a parameter rather than carrying it on the branch,
    which is a materially larger change across that function's ~20-call-site dispatch graph.
 
+   The register is also carried **only across stages this resolver can prove did not move
+   it** (`cannot_move_register`, `src/jq/eval.rs`). jq's register advances on any `INDEX`
+   its own bytecode executes, which includes the ones hidden inside a jq-*defined* builtin
+   (`first` is `.[0]`, `add` is `reduce .[] as $x ...`) or a user function body — stages
+   that reach the resolver as one opaque computed value. Assuming those left the register
+   alone made `path(. as $x \| ([.a]\|first) \| $x)` answer `[]` where jq refuses, and
+   `=`/`|=`/`del()` then wrote through the fabricated path, so the allowlist is deliberately
+   narrow and everything outside it drops the register. Three shapes jq answers therefore
+   refuse here: a construction or interpolation that itself navigates
+   (`path(. as $x \| [.a] \| $x)`, `{k:.a}`, `"\(.a)"` — excluded because jq *also* raises
+   for a `.a` applied to a computed value, which this resolver never sees inside a
+   construction: `path(. as $x \| {k:.a} \| [.a] \| $x)` raises in jq on the second `.a`),
+   an `as` whose bind source navigates, and a `def` whose body is a constant
+   (`path(. as $x \| (def f: 5; f) \| $x)` — resolving a call to its body is not something a
+   syntactic predicate can do from a name). All three are refuse-only.
+
+   A fourth refusal is the `null`/`false` half of `register_identical` applied one stage
+   earlier than succinctly reaches: `path(.a \| null)` on `{"a":null}` and `path(.a \| false)`
+   on `{"a":false}` are `["a"]` in jq — the literal never moved the register, and a `null` is
+   `jv_identical` to a `null` whatever node it came from — while succinctly refuses, because
+   `reestablishes_register` only re-establishes a branch that is *already* untracked and a
+   stage sitting directly on a trackable one never gets there. Pre-existing (it predates the
+   register threading), refuse-only, and closing it is a widening that needs its own live
+   matrix.
+
    Separately, a variable bound from a *navigated* position (`.a as $y`) still carries no
    marker at all, because `substitute_var_tracked` remains gated on
    `is_identity_passthrough` — so `path(.a as $y \| reduce (1) as $i (.a; $y))`, jq `["a"]`,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -67656,7 +67656,10 @@ mod tests {
     /// and could only refuse.
     #[test]
     fn test_path_register_survives_intervening_literal_1573() {
-        assert_eq!(outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | $x)"), ["[]"]);
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | $x)"),
+            ["[]"]
+        );
     }
 
     /// The register is a *position*, not just a permission: navigation may

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20290,8 +20290,8 @@ impl<'a> PathBranch<'a> {
     fn with_register(mut self, register: Option<Cow<'a, OwnedValue>>) -> Self {
         debug_assert!(
             !(self.trackable && register.is_some()),
-            "a trackable branch's register is its own value; storing a second one \
-             would let `register_value` answer from a stale copy",
+            "a trackable branch's register is its own value at its own path; \
+             storing a second one would let a reader answer from a stale copy",
         );
         self.register = register;
         self
@@ -22034,41 +22034,6 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
     }
 }
 
-/// The register `path()`-tracking compares each `reduce`/`foreach` fold
-/// iteration's own navigation against — jq's `(path, value_at_path)` pair,
-/// derived empirically against jq 1.7.1 (#1440; no fold-specific machinery
-/// exists in real jq, since `reduce`/`foreach` are sugar over the same
-/// variable-binding primitive every other construct uses — confirmed by
-/// `substitute_var_impl`'s existing `Reduce`/`Foreach` arms, which already
-/// correctly thread an outer `Expr::TrackedVar` marker into UPDATE/EXTRACT;
-/// the only missing piece was `resolve_node` never walking into the
-/// construct at all).
-///
-/// **Fixed once per INIT fork ([`FoldRegister::enter`]) — never advances
-/// across source-element iterations of the same fold.** Confirmed live:
-/// `path(reduce (1,2) as $i (.a; .b))` on `{"a":{"b":{"b":9}}}` raises
-/// "near attempt to access element \"b\" of {\"b\":9}" on the *second*
-/// iteration — if the register had advanced to iteration 1's own result
-/// (path `["a","b"]`, value `{"b":9}`), iteration 2's `.b` would have
-/// navigated it successfully instead of raising. `foreach` has the
-/// identical reset between source elements (confirmed live the same way),
-/// even though *within* one source element it does chain UPDATE into
-/// EXTRACT (see [`FoldRegister::advance`]) — the register resets at every
-/// "re-entry" into UPDATE for a new element, but not at the direct,
-/// same-step continuation from UPDATE into EXTRACT.
-///
-/// `reduce`'s own *final* accumulator gets the identical reset treatment,
-/// even though it isn't itself a new UPDATE call: confirmed live,
-/// `path(reduce (1) as $i (.a; .b))` on `{"a":{"b":9}}` raises "Invalid
-/// path expression with result 9" — `.b`'s own navigation inside that one
-/// UPDATE call *was* genuinely trackable (path `["a","b"]`), but reduce's
-/// exit back into its own caller is itself another such boundary, so the
-/// emitted value is re-checked against the same fixed register one more
-/// time rather than keeping UPDATE's own transient path. `foreach`'s own
-/// per-element emission (UPDATE directly, or via EXTRACT) is *not* such a
-/// boundary — confirmed live, `path(foreach (1) as $i (.a; .b; .))` on
-/// `{"a":{"b":5},"c":5}` is `["a","b"]`, inheriting UPDATE's own
-/// trackable result through EXTRACT directly, no reset.
 /// jq's own `jv_identical(v, jq->value_at_path)`, modeled for a value type
 /// that has no pointer to compare — the single definition shared by every
 /// site that has to answer "is this branch still sitting *on* the path
@@ -22108,6 +22073,41 @@ fn register_identical(register: &OwnedValue, value: &OwnedValue, snapshot: bool)
     value == register && (snapshot || matches!(*value, OwnedValue::Null | OwnedValue::Bool(_)))
 }
 
+/// The register `path()`-tracking compares each `reduce`/`foreach` fold
+/// iteration's own navigation against — jq's `(path, value_at_path)` pair,
+/// derived empirically against jq 1.7.1 (#1440; no fold-specific machinery
+/// exists in real jq, since `reduce`/`foreach` are sugar over the same
+/// variable-binding primitive every other construct uses — confirmed by
+/// `substitute_var_impl`'s existing `Reduce`/`Foreach` arms, which already
+/// correctly thread an outer `Expr::TrackedVar` marker into UPDATE/EXTRACT;
+/// the only missing piece was `resolve_node` never walking into the
+/// construct at all).
+///
+/// **Fixed once per INIT fork ([`FoldRegister::enter`]) — never advances
+/// across source-element iterations of the same fold.** Confirmed live:
+/// `path(reduce (1,2) as $i (.a; .b))` on `{"a":{"b":{"b":9}}}` raises
+/// "near attempt to access element \"b\" of {\"b\":9}" on the *second*
+/// iteration — if the register had advanced to iteration 1's own result
+/// (path `["a","b"]`, value `{"b":9}`), iteration 2's `.b` would have
+/// navigated it successfully instead of raising. `foreach` has the
+/// identical reset between source elements (confirmed live the same way),
+/// even though *within* one source element it does chain UPDATE into
+/// EXTRACT (see [`FoldRegister::advance`]) — the register resets at every
+/// "re-entry" into UPDATE for a new element, but not at the direct,
+/// same-step continuation from UPDATE into EXTRACT.
+///
+/// `reduce`'s own *final* accumulator gets the identical reset treatment,
+/// even though it isn't itself a new UPDATE call: confirmed live,
+/// `path(reduce (1) as $i (.a; .b))` on `{"a":{"b":9}}` raises "Invalid
+/// path expression with result 9" — `.b`'s own navigation inside that one
+/// UPDATE call *was* genuinely trackable (path `["a","b"]`), but reduce's
+/// exit back into its own caller is itself another such boundary, so the
+/// emitted value is re-checked against the same fixed register one more
+/// time rather than keeping UPDATE's own transient path. `foreach`'s own
+/// per-element emission (UPDATE directly, or via EXTRACT) is *not* such a
+/// boundary — confirmed live, `path(foreach (1) as $i (.a; .b; .))` on
+/// `{"a":{"b":5},"c":5}` is `["a","b"]`, inheriting UPDATE's own
+/// trackable result through EXTRACT directly, no reset.
 struct FoldRegister {
     path: Rc<PathPrefix>,
     value: OwnedValue,
@@ -24110,8 +24110,8 @@ fn reestablishes_register(
 ///
 /// - The branch is trackable again (either it never stopped being, or
 ///   `reestablishes_register` just put it back): the register is the
-///   branch's own value at its own path, so nothing is stored — see
-///   [`PathBranch::register_value`].
+///   branch's own value at its own path, so nothing is stored — that is
+///   exactly what `trackable` means.
 /// - The step navigated: it moved the register onto what it reached, which
 ///   is exactly the trackable case above; if the branch is nonetheless
 ///   untracked here, the navigation was refused and no register survives.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24319,6 +24319,13 @@ fn reestablishes_register(
 ///   ambient value on the very transition that drops trackability, the only
 ///   place that value is still in hand — or, once already untracked, from
 ///   the branch's own carried copy.
+///
+/// That last arm clones the carried `Cow`, which is a deep copy when the
+/// register has been forced owned (`into_owned_value`, #668) and the stage
+/// fans out into several outputs. `Rc` would make the clone O(1) but would
+/// cost an allocation at *every* recording, including the overwhelmingly
+/// common case where the register is never consulted again; the borrow
+/// `resolve_leaf` records today costs nothing. Kept as `Cow` deliberately.
 fn carry_register<'a>(
     facts: StepRegisterFacts,
     reestablished: bool,
@@ -24480,9 +24487,6 @@ fn resolve_seq<'a, S: EvalSemantics>(
             value: current,
             trackable: branch_trackable,
             snapshot: branch_snapshot,
-            register: branch_register,
-        } in branches
-        {
             // The path register as it stands *entering* this stage (#1573).
             //
             // While `branch_trackable` holds, the register is `current`
@@ -24494,7 +24498,9 @@ fn resolve_seq<'a, S: EvalSemantics>(
             // by hand is the *already*-untracked case, where the register
             // is live somewhere behind us and no step below can see it any
             // more.
-            let carried_register = branch_register;
+            register: carried_register,
+        } in branches
+        {
             // #986: each branch carries its own trackability now, so this
             // passes *that* rather than the single outer parameter. It is
             // what makes `1 | .[K]` reach `resolve_index_expr` already

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21888,6 +21888,15 @@ fn resolve_leaf<'a, S: EvalSemantics>(
             // Only meaningful when the incoming position *was* the register
             // (`trackable`); otherwise the register is somewhere further
             // back and `resolve_seq` carries its own copy forward instead.
+            //
+            // This records where the register stood *entering* the stage,
+            // which is a fact about the incoming branch. Whether it
+            // survives *out* of the stage is a different question — reaching
+            // this arm means only that this resolver could not decompose
+            // the stage into path components, not that jq did not navigate
+            // inside it — and it is answered where the stage's own
+            // expression is in view, by `resolve_seq`'s
+            // `stage_preserves_register` ([`cannot_move_register`]).
             trackable.then(|| Cow::Borrowed(value)),
         )]),
         // No output prunes the branch — unless there never would have been
@@ -22034,6 +22043,159 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
     }
 }
 
+/// Whether evaluating `expr` as one pipe stage provably leaves jq's path
+/// register (`value_at_path`) exactly where it was (#1573).
+///
+/// An allowlist, and deliberately a *syntactic* one: the answer has to be
+/// "no" for every shape this resolver cannot see inside. jq's register
+/// moves on any `INDEX` its bytecode executes in the stage's own extent —
+/// not only on the navigation this resolver can decompose into path
+/// components. A user-defined function body, or a jq-*defined* builtin like
+/// `first`/`last`/`add`/`any` (each of which is `.[0]`/`.[-1]`/`reduce .[]
+/// ...` underneath), indexes from inside a stage that arrives at
+/// [`resolve_leaf`] as one opaque computed value, and jq's register moves
+/// with it:
+///
+/// ```text
+/// $ jq -c 'path(. as $x | ([.a]|first) | $x)'    # refuses: `first` is `.[0]`,
+///                                                # which moved the register onto
+///                                                # the constructed array's element
+/// $ jq -c 'path(. as $x | (def f: .a; f) | $x)'  # refuses: same, via the body
+/// $ jq -c 'path(. as $x | ([1]|first) | $x)'     # refuses with no navigation
+///                                                # anywhere in the stage's *text*
+/// ```
+///
+/// Recording the ambient value as the register for those stages made
+/// [`reestablishes_register`] answer a path jq refuses — and, through
+/// `=`/`|=`/`del()`, *write* a document jq leaves untouched, which is the
+/// accept-where-jq-refuses class #1466 closed. So only the forms below
+/// qualify, each confirmed live against jq 1.7.1 to leave the register in
+/// place; everything else is `false`, which can only ever cost a refusal.
+///
+/// `[...]`, `{...}` and string interpolation recurse into their contents
+/// even though jq wraps each of them in `SUBEXP_BEGIN`/`SUBEXP_END`, which
+/// does save and restore the register: the register is not the only thing
+/// at stake. jq *also* raises "Invalid path expression near attempt to
+/// access element" for a `.a` applied to a computed value anywhere inside
+/// `path()`, subexpression or not, and this resolver never sees the `.a`
+/// inside a construction at all — it evaluates the whole construction as
+/// one value. Letting the register through such a stage therefore lets a
+/// later `$var` re-establish on a pipeline jq had already refused:
+///
+/// ```text
+/// $ jq -c 'path(. as $x | {k:.a} | [.a] | $x)'   # refuses — the second
+///                                                # `.a` is applied to the
+///                                                # constructed {"k":null}
+/// ```
+///
+/// So a construction qualifies only when nothing inside it navigates,
+/// which costs the single-construction shapes jq does accept
+/// (`path(. as $x | [.a] | $x)` is `[]` in jq and refuses here) — a
+/// refusal, the safe direction. An `as` binding's *source* is
+/// subexp-restored the same way (`path(.a as $y | .b)` is `["b"]`) and is
+/// recursed into for the same reason. Every other composite recurses into
+/// all of its operands, which is stricter than jq needs for the ones it
+/// also subexp-wraps (an arithmetic operand, an `if` condition) — stricter
+/// is the safe direction, and a false `false` is invisible except as a
+/// refusal.
+///
+/// The builtin arm is an explicit list rather than a property of the
+/// [`Builtin`] enum, because the distinction it draws — C-implemented
+/// versus defined in jq's own `builtin.jq` — is not visible from this AST:
+/// `length` and `first` are one variant each here, and only one of them
+/// indexes. Add a variant only with an oracle row to go with it.
+///
+/// A `def` and a call are always `false`, even when the body is a constant
+/// — deciding otherwise would mean resolving the call to its body here, and
+/// a name is not a body. The whole cost of that is
+/// `path(. as $x | (def f: 5; f) | $x)`, which jq answers `[]` and this
+/// refuses: one more refusal on a shape nothing writes, versus a rule that
+/// has to be right about every `def` anyone does write.
+fn cannot_move_register(expr: &Expr) -> bool {
+    match expr {
+        // Nothing here reads the document's structure at all.
+        Expr::Identity
+        | Expr::Literal(_)
+        | Expr::Var(_)
+        | Expr::TrackedVar(_)
+        | Expr::Env
+        | Expr::Loc { .. }
+        | Expr::Not
+        | Expr::Format(_) => true,
+
+        // Subexp-restored, so the register survives — but only safe to
+        // carry when nothing inside navigates; see the doc comment.
+        Expr::Array(inner) => cannot_move_register(inner),
+        Expr::Object(entries) => entries.iter().all(|entry| {
+            cannot_move_register(&entry.value)
+                && match &entry.key {
+                    ObjectKey::Literal(_) => true,
+                    ObjectKey::Expr(key) => cannot_move_register(key),
+                }
+        }),
+        Expr::StringInterpolation(parts) => parts.iter().all(|part| match part {
+            StringPart::Literal(_) => true,
+            StringPart::Expr(inner) => cannot_move_register(inner),
+        }),
+
+        // Composites: safe exactly when every operand is.
+        Expr::Paren(inner) | Expr::Optional(inner) | Expr::Negate(inner) => {
+            cannot_move_register(inner)
+        }
+        Expr::Pipe(stages) | Expr::Comma(stages) => stages.iter().all(cannot_move_register),
+        Expr::Arithmetic { left, right, .. }
+        | Expr::Compare { left, right, .. }
+        | Expr::And(left, right)
+        | Expr::Or(left, right)
+        | Expr::Alternative(left, right) => {
+            cannot_move_register(left) && cannot_move_register(right)
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            cannot_move_register(cond)
+                && cannot_move_register(then_branch)
+                && cannot_move_register(else_branch)
+        }
+        Expr::Try { expr, catch } => {
+            cannot_move_register(expr)
+                && match catch {
+                    Some(handler) => cannot_move_register(handler),
+                    None => true,
+                }
+        }
+        Expr::As { expr, body, .. } => cannot_move_register(expr) && cannot_move_register(body),
+
+        // `error` raises; it navigates nothing. Its message expression is
+        // still evaluated, so that recurses. Needed by the escaping-prefix
+        // shape `($x, error("boom"))`, whose already-emitted `$x` jq keeps
+        // (and re-establishes) before raising.
+        Expr::Error(message) => match message {
+            Some(inner) => cannot_move_register(inner),
+            None => true,
+        },
+
+        Expr::Builtin(builtin) => matches!(
+            builtin,
+            Builtin::Type
+                | Builtin::Length
+                | Builtin::Utf8ByteLength
+                | Builtin::Keys
+                | Builtin::KeysUnsorted
+                | Builtin::ToString
+                | Builtin::ToNumber
+                | Builtin::ToJson
+        ),
+
+        // Everything else — navigation, `reduce`/`foreach`, `label`, a
+        // function definition or call, `..`, and every builtin not listed
+        // above — is assumed to have moved the register.
+        _ => false,
+    }
+}
+
 /// jq's own `jv_identical(v, jq->value_at_path)`, modeled for a value type
 /// that has no pointer to compare — the single definition shared by every
 /// site that has to answer "is this branch still sitting *on* the path
@@ -22049,9 +22211,18 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
 /// `{"a":1,"c":1}`). Only `null`/`true`/`false` fall to its `default: r = 1`
 /// arm, where having the same kind *is* being identical — for those, and
 /// only those, structural equality is exact rather than an approximation
-/// (confirmed live: `path(.a | null)` on `{"a":null}` and `path(.a | false)`
-/// on `{"a":false}` both answer `["a"]`, while `path(.a | false)` on
-/// `{"a":true}` raises).
+/// (confirmed live: `path(reduce (1) as $i (.a; null))` on `{"a":null}` and
+/// the same filter with `false` on `{"a":false}` both answer `["a"]`, while
+/// `false` against `{"a":true}` raises).
+///
+/// jq applies that same `null`/`bool` arm one step earlier than succinctly
+/// does: `path(.a | null)` on `{"a":null}` is `["a"]` in jq, because the
+/// literal never moved the register and `null` is identical to it — while
+/// succinctly refuses, since `reestablishes_register` only re-establishes a
+/// branch that is *already* untracked and a stage sitting directly on a
+/// trackable one never gets there. Refuse-only, pre-existing, and recorded
+/// in `docs/compliance/jq/limitations.md`; do not read the arm below as
+/// claiming that shape works.
 ///
 /// So a value is identical to the register when it equals it *and* is
 /// either
@@ -24056,6 +24227,24 @@ fn apply_static_tail<'a, S: EvalSemantics>(
     Ok(out)
 }
 
+/// The register-relevant facts about one resolved step (#1573), bundled so
+/// the two rules below cannot be handed different subsets of them — and
+/// because four independent `bool`s at a call site is exactly what clippy's
+/// `fn_params_excessive_bools` is for (same reasoning as `SliceEditFlags`).
+#[derive(Clone, Copy)]
+struct StepRegisterFacts {
+    /// Was the branch entering this stage still sitting on the register?
+    branch_trackable: bool,
+    /// Did this step contribute path components of its own?
+    navigated: bool,
+    /// Can the stage's *expression* be proven not to have moved jq's own
+    /// register ([`cannot_move_register`])? Per stage, not per branch.
+    stage_preserves_register: bool,
+    /// Is the step's output a frozen `as`-binding snapshot
+    /// ([`PathBranch::snapshot`])?
+    step_snapshot: bool,
+}
+
 /// Whether one pipe stage's output re-establishes the path register, and so
 /// is trackable again despite arriving on an already-untracked branch
 /// (#1573).
@@ -24077,7 +24266,8 @@ fn apply_static_tail<'a, S: EvalSemantics>(
 /// All four confirmed live against jq 1.7.1, along with the rest of the
 /// matrix on #1573.
 ///
-/// The four preconditions are each load-bearing:
+/// The five preconditions are each load-bearing (the first four ride
+/// [`StepRegisterFacts`]):
 ///
 /// - `!branch_trackable` — a trackable branch needs no re-establishing, and
 ///   its `Expr::TrackedVar` arm already certifies against the ambient value
@@ -24085,6 +24275,10 @@ fn apply_static_tail<'a, S: EvalSemantics>(
 /// - `!navigated` — the step contributed no path components. A step that
 ///   navigated reached a genuinely new position, and `trackable` already
 ///   answers for it; re-pointing it at `prefix` would report the wrong path.
+/// - `stage_preserves_register` — the step's *own expression* provably left
+///   jq's register where it was ([`cannot_move_register`]). "Contributed no
+///   path components" is this resolver's answer, not jq's: a stage it
+///   cannot decompose may still have indexed inside jq's own bytecode.
 /// - a live `register` — `None` means "not known here", the safe answer.
 /// - [`register_identical`] — the whole rule, shared with the fold register
 ///   so the two cannot drift.
@@ -24093,20 +24287,19 @@ fn apply_static_tail<'a, S: EvalSemantics>(
 /// costs an accepted path jq refuses — the dangerous direction, and why
 /// every clause above is a conjunct rather than a heuristic.
 fn reestablishes_register(
-    branch_trackable: bool,
-    navigated: bool,
+    facts: StepRegisterFacts,
     register: Option<&OwnedValue>,
     resulting: &OwnedValue,
-    step_snapshot: bool,
 ) -> bool {
-    !branch_trackable
-        && !navigated
-        && register.is_some_and(|reg| register_identical(reg, resulting, step_snapshot))
+    !facts.branch_trackable
+        && !facts.navigated
+        && facts.stage_preserves_register
+        && register.is_some_and(|reg| register_identical(reg, resulting, facts.step_snapshot))
 }
 
 /// The path register to hand to the next pipe stage (#1573).
 ///
-/// Three cases, in the order they are tested:
+/// Four cases, in the order they are tested:
 ///
 /// - The branch is trackable again (either it never stopped being, or
 ///   `reestablishes_register` just put it back): the register is the
@@ -24115,6 +24308,11 @@ fn reestablishes_register(
 /// - The step navigated: it moved the register onto what it reached, which
 ///   is exactly the trackable case above; if the branch is nonetheless
 ///   untracked here, the navigation was refused and no register survives.
+/// - The step is one this resolver cannot see inside
+///   (`!stage_preserves_register`): jq may well have indexed within it —
+///   `first`, `add`, and every user-defined function body do — so any
+///   register that was live entering the stage is now of unknown position
+///   and is dropped. Costs a refusal; keeping it fabricates a path.
 /// - Otherwise the step computed something without navigating, so whatever
 ///   register was live entering the stage is still live at the same path.
 ///   It comes either from the step itself — `resolve_leaf` records the
@@ -24122,15 +24320,14 @@ fn reestablishes_register(
 ///   place that value is still in hand — or, once already untracked, from
 ///   the branch's own carried copy.
 fn carry_register<'a>(
-    branch_trackable: bool,
-    navigated: bool,
+    facts: StepRegisterFacts,
     reestablished: bool,
     carried: &Option<Cow<'a, OwnedValue>>,
     step_register: Option<Cow<'a, OwnedValue>>,
 ) -> Option<Cow<'a, OwnedValue>> {
-    if reestablished || navigated {
+    if reestablished || facts.navigated || !facts.stage_preserves_register {
         None
-    } else if branch_trackable {
+    } else if facts.branch_trackable {
         step_register
     } else {
         carried.clone()
@@ -24264,6 +24461,15 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // | .foo)` on `{"a":[{"c":[{"foo":1}]}]}` raises `t2`, not `t1`.
     let mut deferred_escape: Option<EvalEscape> = None;
     for element in &flat[..=last_dynamic] {
+        // Whether this stage can carry a live path register across itself
+        // at all (#1573). `false` is the answer for every stage this
+        // resolver cannot see inside, because jq's register moves on any
+        // `INDEX` the stage executes — including the ones hidden in a
+        // jq-defined builtin (`first` is `.[0]`) or a user function body,
+        // which arrive here as one opaque computed value. See
+        // [`cannot_move_register`]: dropping the register merely costs a
+        // refusal, keeping a stale one fabricates a path.
+        let stage_preserves_register = cannot_move_register(element);
         let mut next = Vec::new();
         // Consumes `branches` (not `&branches`) so each `current` arrives by
         // value: only then can `resolve_against_cow` recover the branch's
@@ -24295,107 +24501,80 @@ fn resolve_seq<'a, S: EvalSemantics>(
             // knowing its target is untracked, which is how jq's "near
             // attempt to access element K of 1" wording gets produced
             // without any new context parameter (see #989).
+            // Where one step's output lands, for both the `Ok` fan-out and
+            // the partial prefix an escaping stage leaves behind. Written
+            // once rather than twice: the two arms differ only in which
+            // list they walk, and #1573's register re-establishment had
+            // already been fixed in the `Ok` arm alone once before the
+            // `Err` arm's identical omission was noticed.
+            let place_step = |step: PathBranch<'a>| -> PathBranch<'a> {
+                let PathBranch {
+                    path: components,
+                    value: resulting,
+                    trackable: step_trackable,
+                    snapshot: step_snapshot,
+                    register: step_register,
+                } = step;
+                let facts = StepRegisterFacts {
+                    branch_trackable,
+                    navigated: components.depth() > 0,
+                    stage_preserves_register,
+                    step_snapshot,
+                };
+                let reestablished =
+                    reestablishes_register(facts, carried_register.as_deref(), &resulting);
+                let path = if reestablished {
+                    Rc::clone(&prefix)
+                } else {
+                    PathPrefix::extend_many(&prefix, components.to_vec())
+                };
+                PathBranch {
+                    register: carry_register(
+                        facts,
+                        reestablished,
+                        &carried_register,
+                        step_register,
+                    ),
+                    path,
+                    value: resulting,
+                    // Untracked is absorbing: nothing downstream can
+                    // re-certify a value that was computed rather than
+                    // navigated to. Erring toward `false` is also the safe
+                    // direction — it can only turn a silent acceptance into
+                    // a loud error, never the reverse (#985's revert is what
+                    // the reverse looks like).
+                    //
+                    // #1573 adds the one exception jq itself has: untracked
+                    // is absorbing for *navigation*, but a `$var` whose
+                    // frozen value is still identical to the live register
+                    // is not navigation — jq's own `path_intact` compares
+                    // against `value_at_path`, which a literal never moved,
+                    // so the variable re-establishes the register's position
+                    // rather than reaching a new one. See
+                    // `reestablishes_register`.
+                    trackable: reestablished || (branch_trackable && step_trackable),
+                    // Unlike `trackable`, this comes from the *step* alone:
+                    // the value leaving this stage is the step's own output,
+                    // so `.a | $x` still hands back the frozen snapshot
+                    // whatever `.a` was, and `$x | .a` no longer is one
+                    // (#1466).
+                    //
+                    // A re-established branch is `trackable` again, and this
+                    // type's invariant is that `snapshot` implies
+                    // `!trackable`: a certified snapshot has resolved to a
+                    // real path and needs no second marker (#1573).
+                    snapshot: step_snapshot && !reestablished,
+                }
+            };
             match resolve_against_cow::<S>(element, current, branch_trackable, branch_snapshot) {
                 Ok(resolved) => {
-                    for PathBranch {
-                        path: components,
-                        value: resulting,
-                        trackable: step_trackable,
-                        snapshot: step_snapshot,
-                        register: step_register,
-                    } in resolved
-                    {
-                        let navigated = components.depth() > 0;
-                        let reestablished = reestablishes_register(
-                            branch_trackable,
-                            navigated,
-                            carried_register.as_deref(),
-                            &resulting,
-                            step_snapshot,
-                        );
-                        let path = if reestablished {
-                            Rc::clone(&prefix)
-                        } else {
-                            PathPrefix::extend_many(&prefix, components.to_vec())
-                        };
-                        next.push(PathBranch {
-                            register: carry_register(
-                                branch_trackable,
-                                navigated,
-                                reestablished,
-                                &carried_register,
-                                step_register,
-                            ),
-                            path,
-                            value: resulting,
-                            // Untracked is absorbing: nothing downstream can
-                            // re-certify a value that was computed rather
-                            // than navigated to. Erring toward `false` is
-                            // also the safe direction — it can only turn a
-                            // silent acceptance into a loud error, never the
-                            // reverse (#985's revert is what the reverse
-                            // looks like).
-                            //
-                            // #1573 adds the one exception jq itself has:
-                            // untracked is absorbing for *navigation*, but a
-                            // `$var` whose frozen value is still identical to
-                            // the live register is not navigation — jq's own
-                            // `path_intact` compares against `value_at_path`,
-                            // which a literal never moved, so the variable
-                            // re-establishes the register's position rather
-                            // than reaching a new one. See
-                            // `reestablishes_register`.
-                            trackable: reestablished || (branch_trackable && step_trackable),
-                            // Unlike `trackable`, this comes from the *step*
-                            // alone: the value leaving this stage is the
-                            // step's own output, so `.a | $x` still hands
-                            // back the frozen snapshot whatever `.a` was,
-                            // and `$x | .a` no longer is one (#1466).
-                            //
-                            // A re-established branch is `trackable` again,
-                            // and this type's invariant is that `snapshot`
-                            // implies `!trackable`: a certified snapshot has
-                            // resolved to a real path and needs no second
-                            // marker (#1573).
-                            snapshot: step_snapshot && !reestablished,
-                        });
+                    for step in resolved {
+                        next.push(place_step(step));
                     }
                 }
                 Err((partial, e)) => {
-                    for PathBranch {
-                        path: components,
-                        value: resulting,
-                        trackable: step_trackable,
-                        snapshot: step_snapshot,
-                        register: step_register,
-                    } in partial
-                    {
-                        let navigated = components.depth() > 0;
-                        let reestablished = reestablishes_register(
-                            branch_trackable,
-                            navigated,
-                            carried_register.as_deref(),
-                            &resulting,
-                            step_snapshot,
-                        );
-                        let path = if reestablished {
-                            Rc::clone(&prefix)
-                        } else {
-                            PathPrefix::extend_many(&prefix, components.to_vec())
-                        };
-                        next.push(PathBranch {
-                            register: carry_register(
-                                branch_trackable,
-                                navigated,
-                                reestablished,
-                                &carried_register,
-                                step_register,
-                            ),
-                            path,
-                            value: resulting,
-                            trackable: reestablished || (branch_trackable && step_trackable),
-                            snapshot: step_snapshot && !reestablished,
-                        });
+                    for step in partial {
+                        next.push(place_step(step));
                     }
                     // Keep whatever this branch produced before its escape,
                     // record the escape, and stop attempting any
@@ -67753,6 +67932,117 @@ mod tests {
                 assert_eq!(e.message, "boom");
             }
         );
+    }
+
+    /// The register must **not** survive a stage this resolver cannot see
+    /// inside. jq's `value_at_path` moves on any `INDEX` its bytecode
+    /// executes, and a jq-*defined* builtin (`first` is `.[0]`, `add` is
+    /// `reduce .[] as $x ...`) or a user function body indexes from inside
+    /// a stage that arrives here as one opaque computed value — so jq's
+    /// register has moved even though this resolver produced no path
+    /// component. All four refuse in jq 1.7.1; before
+    /// [`cannot_move_register`] gated the carry, all four answered `[]`.
+    ///
+    /// `([1]|first)` is the one that rules out any syntactic "does the
+    /// stage mention `.a`" shortcut: no navigation appears in its text at
+    /// all, and jq still refuses, because `first`'s own body is the `.[0]`
+    /// that moves the register.
+    #[test]
+    fn test_path_register_dropped_across_opaque_navigating_stage_1573() {
+        for filter in [
+            r"path(. as $x | (def f: .a; f) | $x)",
+            r"path(. as $x | ([.a]|first) | $x)",
+            r"path(. as $x | ([1]|first) | $x)",
+            r"path(. as $x | ([.a]|add) | $x)",
+            r"path(. as $x | ([.a]|first) | 5 | $x)",
+        ] {
+            query!(br#"{"a":{"b":1},"c":{"b":1}}"#, filter,
+                QueryResult::Error(e) => {
+                    assert!(e.is_invalid_path_expression(), "{filter}: {}", e.message);
+                }
+            );
+        }
+    }
+
+    /// The same gap seen from the side that does damage: a fabricated path
+    /// is not refuse-only once it reaches `=`/`|=`/`del()`, which then
+    /// *write* a document jq leaves untouched — the accept-where-jq-refuses
+    /// class #1466 closed. jq 1.7.1 raises (exit 5) for all three.
+    #[test]
+    fn test_write_through_opaque_navigating_stage_refuses_1573() {
+        for filter in [
+            r"(. as $x | ([.a]|first) | $x.c) = 9",
+            r"(. as $x | ([.a]|first) | $x.c) |= 42",
+            r"del(. as $x | (def f: .a; f) | 5 | $x.c)",
+        ] {
+            query!(br#"{"a":{"b":1},"c":{"b":1}}"#, filter,
+                QueryResult::Error(e) => {
+                    // Both spellings count: a write reaches its refusal
+                    // through `$x.c`'s own untracked navigation, which is
+                    // jq's "near attempt to access element" wording rather
+                    // than the bare "with result" one.
+                    assert!(
+                        e.is_invalid_path_expression() || e.is_untracked_navigation_error(),
+                        "{filter}: {}",
+                        e.message
+                    );
+                }
+            );
+        }
+    }
+
+    /// The boundary on the other side: a construction or interpolation that
+    /// navigates nothing keeps carrying the register, so these still
+    /// answer. Pins the allowlist's positive half — narrowing it further
+    /// has to break a test rather than quietly cost these.
+    #[test]
+    fn test_path_register_survives_navigation_free_stages_1573() {
+        for filter in [
+            r"path(. as $x | [1] | $x)",
+            "path(. as $x | { k: 1 } | $x)",
+            r#"path(. as $x | "s" | $x)"#,
+            r"path(. as $x | (1+2) | $x)",
+            r"path(. as $x | keys | $x)",
+            r"path(. as $x | type | $x)",
+            r"path(. as $x | tostring | $x)",
+            r"path(. as $x | @json | $x)",
+            r"path(. as $x | (if 1 then 5 else 6 end) | $x)",
+            r"path(. as $x | (try 5) | $x)",
+            r"path(. as $x | (5 // 6) | $x)",
+        ] {
+            assert_eq!(outputs(br#"{"a":{"b":1}}"#, filter), ["[]"], "{filter}");
+        }
+    }
+
+    /// What the conservative allowlist costs, pinned so a later widening is
+    /// deliberate. jq answers `[]` for every one of these; succinctly
+    /// refuses.
+    ///
+    /// A construction that *does* navigate (`[.a]`, `{k:.a}`, `"\(.a)"`)
+    /// is excluded because jq raises for a `.a` applied to a computed value
+    /// anywhere inside `path()` — subexpression or not — and this resolver
+    /// never sees that `.a`, evaluating the construction as one value
+    /// instead. `path(. as $x | {k:.a} | [.a] | $x)` is the shape that
+    /// proves it: jq raises on the *second* `.a`, applied to the
+    /// constructed `{"k":null}`, so carrying the register through the first
+    /// construction answered a pipeline jq had already refused. A `def` and
+    /// a call are excluded because resolving a call to its body is not
+    /// something this predicate can do from a name.
+    #[test]
+    fn test_navigating_construction_and_def_cost_a_refusal_1573() {
+        for filter in [
+            r"path(. as $x | [.a] | $x)",
+            "path(. as $x | { k: .a } | $x)",
+            r#"path(. as $x | ("\(.a)") | $x)"#,
+            r"path(. as $x | (.a as $q | 1) | $x)",
+            r"path(. as $x | (def f: 5; f) | $x)",
+        ] {
+            query!(br#"{"a":{"b":1}}"#, filter,
+                QueryResult::Error(e) => {
+                    assert!(e.is_invalid_path_expression(), "{filter}: {}", e.message);
+                }
+            );
+        }
     }
 
     /// A variable bound from a *navigated* position still has no marker at

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -67738,6 +67738,23 @@ mod tests {
         );
     }
 
+    /// The register also has to survive into an *escaping* stage's partial
+    /// prefix. `($x, error(...))` emits `$x` and then raises, and jq keeps
+    /// the already-produced output rather than un-emitting it — so the
+    /// re-establishment has to happen on the `Err` side of the fan-out
+    /// loop too, not only the `Ok` side.
+    ///
+    /// Confirmed live against jq 1.7.1: prints `[]`, then raises `boom`.
+    #[test]
+    fn test_path_register_reestablished_in_escaping_partial_prefix_1573() {
+        query!(br#"{"a":1}"#, r#"path(. as $x | 5 | ($x, error("boom")))"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), ["[]"]);
+                assert_eq!(e.message, "boom");
+            }
+        );
+    }
+
     /// A variable bound from a *navigated* position still has no marker at
     /// all (`substitute_bound_var`'s `is_identity_passthrough` gate), so it
     /// keeps refusing regardless of the register. This is the half of #1573

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20124,6 +20124,29 @@ struct PathBranch<'a> {
     /// `FoldRegister` could only compare values, which promoted every
     /// reconstruction that happened to land on the same value (#1466).
     snapshot: bool,
+    /// The value jq's own path *register* (`value_at_path`) holds, when it
+    /// is still live at `self.path` but this branch's `value` has moved off
+    /// it (#1573).
+    ///
+    /// `path()` in real jq carries a `(path, value_at_path)` register that
+    /// only *navigation* advances: a literal, an arithmetic result, an
+    /// arbitrary builtin call all leave it exactly where it was. That is
+    /// what makes `path(. as $x | 5 | $x)` answer `[]` — the `5` never
+    /// moved the register off the root, so `$x` (frozen from that same
+    /// root) is still `jv_identical` to it when `path()` checks its own
+    /// output. `trackable` alone cannot express that: it says "this
+    /// branch's value *is* the register", which the `5` genuinely
+    /// falsified. Keeping the register's value here is what lets a later
+    /// `Expr::TrackedVar` re-establish trackability against it, by exactly
+    /// the rule [`register_identical`] already applies inside a fold.
+    ///
+    /// `None` means "no live register known here", and is always the safe
+    /// answer — it can only cost a refusal, never invent a path. Only ever
+    /// set while `!trackable`: when `trackable` holds, the branch's own
+    /// value *is* the register at its own path, which is exactly what
+    /// `trackable` means, so there is nothing separate to store —
+    /// [`PathBranch::with_register`] asserts that.
+    register: Option<Cow<'a, OwnedValue>>,
 }
 
 impl<'a> PathBranch<'a> {
@@ -20150,6 +20173,10 @@ impl<'a> PathBranch<'a> {
             value,
             trackable,
             snapshot: false,
+            // A navigation step's own value is the register (or it is
+            // untracked with no register knowledge to pass on) — either
+            // way nothing extra to record here (#1573).
+            register: None,
         }
     }
 
@@ -20184,6 +20211,14 @@ impl<'a> PathBranch<'a> {
             value,
             trackable,
             snapshot: snapshot && !trackable,
+            // #1573: `passthrough` hands a value straight through without
+            // navigating, so a live register would survive it — but every
+            // one of its call sites sits *inside* a single resolve step,
+            // with no access to the register `resolve_seq` threads between
+            // steps. `resolve_seq`'s own loop re-attaches it around the
+            // call instead (see `carried_register` there), which keeps this
+            // constructor's contract to its callers unchanged.
+            register: None,
         }
     }
 
@@ -20198,6 +20233,7 @@ impl<'a> PathBranch<'a> {
             value,
             trackable: false,
             snapshot: false,
+            register: None,
         }
     }
 
@@ -20209,6 +20245,7 @@ impl<'a> PathBranch<'a> {
             value,
             trackable: false,
             snapshot: true,
+            register: None,
         }
     }
 
@@ -20242,6 +20279,24 @@ impl<'a> PathBranch<'a> {
         }
     }
 
+    /// Attach the live path register to a freshly-built branch (#1573).
+    ///
+    /// A builder rather than a parameter on `untracked`/`new`: exactly one
+    /// construction site has a register to record (`resolve_leaf`'s
+    /// computed-value leaf, the single point where a branch steps off the
+    /// register while the register's value is still in scope), and every
+    /// other site would have to pass `None`. `debug_assert`s the field's own
+    /// invariant instead of silently tolerating a caller that ignores it.
+    fn with_register(mut self, register: Option<Cow<'a, OwnedValue>>) -> Self {
+        debug_assert!(
+            !(self.trackable && register.is_some()),
+            "a trackable branch's register is its own value; storing a second one \
+             would let `register_value` answer from a stale copy",
+        );
+        self.register = register;
+        self
+    }
+
     /// Force this branch's value to `Cow::Owned`, so it can outlive whatever
     /// it was borrowing from — see `resolve_against_cow` (#668).
     fn into_owned_value(self) -> PathBranch<'static> {
@@ -20250,6 +20305,9 @@ impl<'a> PathBranch<'a> {
             value: Cow::Owned(self.value.into_owned()),
             trackable: self.trackable,
             snapshot: self.snapshot,
+            // Same reason as `value`: a borrowed register would cap this
+            // branch at the borrow it is escaping (#1573/#668).
+            register: self.register.map(|r| Cow::Owned(r.into_owned())),
         }
     }
 }
@@ -20542,6 +20600,7 @@ fn resolve_node<'a, S: EvalSemantics>(
                              value: v,
                              trackable,
                              snapshot,
+                             register,
                          }| {
                             let components = components.to_vec();
                             let inner_path = if components.len() == 1 {
@@ -20569,6 +20628,11 @@ fn resolve_node<'a, S: EvalSemantics>(
                                     inner_path,
                                 ))]),
                                 value: v,
+                                // Same reason as `trackable`/`snapshot`
+                                // above: `?` navigates nothing, so a live
+                                // path register survives it untouched
+                                // (#1573).
+                                register,
                                 trackable,
                                 snapshot,
                             }
@@ -21812,7 +21876,20 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         // output — whether a bare `Escaped` the sink never had a chance to
         // avoid, or `pending` on a `Stopped` from an eager fallback — is
         // dropped: real jq never reaches whatever would have caused it.
-        Some(v) => Ok(vec![PathBranch::untracked(Cow::Owned(v))]),
+        Some(v) => Ok(vec![PathBranch::untracked(Cow::Owned(v)).with_register(
+            // #1573: this is the exact moment a branch steps *off* the path
+            // register — the value was computed, not navigated to — and the
+            // only place the register's own value is still in hand. Real jq
+            // does not lose it here: `value_at_path` is untouched by a
+            // literal, so a later `$var` frozen from this same position is
+            // still `jv_identical` to it (`path(. as $x | 5 | $x)` is `[]`).
+            // Recording it lets `resolve_seq` re-establish that.
+            //
+            // Only meaningful when the incoming position *was* the register
+            // (`trackable`); otherwise the register is somewhere further
+            // back and `resolve_seq` carries its own copy forward instead.
+            trackable.then(|| Cow::Borrowed(value)),
+        )]),
         // No output prunes the branch — unless there never would have been
         // one because evaluating `expr` itself broke/errored (Halt excluded,
         // handled above) before producing anything. `Flow::Stopped` with no
@@ -21992,6 +22069,45 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
 /// boundary — confirmed live, `path(foreach (1) as $i (.a; .b; .))` on
 /// `{"a":{"b":5},"c":5}` is `["a","b"]`, inheriting UPDATE's own
 /// trackable result through EXTRACT directly, no reset.
+/// jq's own `jv_identical(v, jq->value_at_path)`, modeled for a value type
+/// that has no pointer to compare — the single definition shared by every
+/// site that has to answer "is this branch still sitting *on* the path
+/// register?" (#1466 for the fold register, #1573 for `resolve_seq`'s own
+/// pipe register).
+///
+/// `jv_identical` is **not** structural equality. It compares the two `jv`s'
+/// kind/offset/size and then, for the three heap kinds — string, array,
+/// object — their *pointers*; for a number it compares the raw
+/// representation, which a reconstruction never reproduces (confirmed live
+/// against jq 1.7.1: `path(reduce (1) as $i (.a; 1))` on `{"a":1}` raises,
+/// even though `1 == 1`, and so does `path(.a as $y | .c | $y)` on
+/// `{"a":1,"c":1}`). Only `null`/`true`/`false` fall to its `default: r = 1`
+/// arm, where having the same kind *is* being identical — for those, and
+/// only those, structural equality is exact rather than an approximation
+/// (confirmed live: `path(.a | null)` on `{"a":null}` and `path(.a | false)`
+/// on `{"a":false}` both answer `["a"]`, while `path(.a | false)` on
+/// `{"a":true}` raises).
+///
+/// So a value is identical to the register when it equals it *and* is
+/// either
+///
+/// - a frozen `as`-binding snapshot (`PathBranch::snapshot`) — a value jq is
+///   still holding by the very same pointer, never rebuilt — or
+/// - a `null`/`true`/`false`.
+///
+/// A *trackable* branch never needs this: it navigated to a real path, and
+/// its caller places it directly. Both callers keep their own separate
+/// `trackable` precondition (a dead register can never match anything)
+/// rather than folding it in here, so this stays a pure statement about the
+/// two values.
+///
+/// Kept as one function precisely because it is now consulted from two
+/// unrelated places: a second, hand-inlined copy of this rule would be free
+/// to drift from jq's without either copy's tests noticing.
+fn register_identical(register: &OwnedValue, value: &OwnedValue, snapshot: bool) -> bool {
+    value == register && (snapshot || matches!(*value, OwnedValue::Null | OwnedValue::Bool(_)))
+}
+
 struct FoldRegister {
     path: Rc<PathPrefix>,
     value: OwnedValue,
@@ -22092,37 +22208,24 @@ impl FoldRegister {
         }
     }
 
-    /// jq's own `jv_identical(v, jq->value_at_path)`, modeled for a value
-    /// type that has no pointer to compare (#1466).
+    /// Whether `branch` is still sitting on this register — jq's own
+    /// `jv_identical(v, jq->value_at_path)`, modeled for a value type that
+    /// has no pointer to compare (#1466).
     ///
-    /// `jv_identical` is **not** structural equality. It compares the two
-    /// `jv`s' kind/offset/size and then, for the three heap kinds — string,
-    /// array, object — their *pointers*; for a number it compares the raw
-    /// representation, which a reconstruction never reproduces (confirmed
-    /// live against jq 1.7.1: `path(reduce (1) as $i (.a; 1))` on `{"a":1}`
-    /// raises, even though `1 == 1`). Only `null`/`true`/`false` fall to its
-    /// `default: r = 1` arm, where having the same kind *is* being identical
-    /// — for those, and only those, structural equality is exact rather than
-    /// an approximation (confirmed live: the same filter with `null` on
-    /// `{"a":null}`, and with `false` on `{"a":false}`, both answer `["a"]`,
-    /// while `true` against `{"a":false}` raises).
+    /// The rule itself lives in [`register_identical`], which
+    /// `resolve_seq`'s own pipe register shares (#1573); this adds only the
+    /// `trackable` precondition, since a register that never resolved to a
+    /// real path cannot recognise anything. A *trackable* branch never
+    /// needs this either way: it navigated to a real path and `relocate`'s
+    /// first arm already places it.
     ///
-    /// So a branch is identical to this register when it is either
-    ///
-    /// - a [`PathBranch::snapshot`] — a frozen `. as $x` binding jq is still
-    ///   holding by the very same pointer — carrying this register's value, or
-    /// - a `null`/`true`/`false` equal to it.
-    ///
-    /// A *trackable* branch never needs this: it navigated to a real path and
-    /// `relocate`'s first arm already places it. Before #1466 this compared
-    /// values alone, which promoted any reconstruction that happened to land
-    /// on the register's value — so `path(reduce (1) as $i (.; {a:.a}))`
-    /// answered `[]` where jq raises, and `=`/`|=`/`del()` through it wrote
-    /// to a document jq leaves untouched.
+    /// Before #1466 this compared values alone, which promoted any
+    /// reconstruction that happened to land on the register's value — so
+    /// `path(reduce (1) as $i (.; {a:.a}))` answered `[]` where jq raises,
+    /// and `=`/`|=`/`del()` through it wrote to a document jq leaves
+    /// untouched.
     fn identical(&self, branch: &PathBranch<'_>) -> bool {
-        self.trackable
-            && *branch.value == self.value
-            && (branch.snapshot || matches!(*branch.value, OwnedValue::Null | OwnedValue::Bool(_)))
+        self.trackable && register_identical(&self.value, &branch.value, branch.snapshot)
     }
 
     fn relocate<'a>(&self, branches: Vec<PathBranch<'a>>) -> Vec<PathBranch<'a>> {
@@ -23015,6 +23118,11 @@ fn resolve_recurse<'a, S: EvalSemantics>(
             value: current,
             trackable: node_trackable,
             snapshot: node_snapshot,
+            // #1573: the recurse family walks *into* the document, so every
+            // node it visits is reached by navigation and carries no
+            // separate register of its own. `resolve_seq` re-attaches the
+            // pipe register around this whole call if one is live.
+            register: _,
         } = stack.pop().unwrap();
         // `current.clone()` is cheap (`Cow`, #668). `prefix` is a
         // `PathPrefix` (#701): `Rc::clone` is O(1), not the O(path length)
@@ -23022,6 +23130,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         outputs.push(PathBranch {
             path: Rc::clone(&prefix),
             value: current.clone(),
+            register: None,
             // Propagated rather than assumed `true`. The shared
             // recurse-family guard means only a trackable value can enter
             // this loop today, so this is `true` in practice — but carrying
@@ -23077,6 +23186,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
             value: child_value,
             trackable: child_trackable,
             snapshot: child_snapshot,
+            register: _,
         } in children
         {
             let path = PathPrefix::extend_many(&prefix, child_components.to_vec());
@@ -23098,6 +23208,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                         next.push(PathBranch {
                             path,
                             value: child_value,
+                            register: None,
                             trackable: node_trackable && child_trackable,
                             // `f`'s own mark, propagated (#1591). Unlike
                             // `trackable` this is not `&&`-ed with the
@@ -23134,6 +23245,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
                             next.push(PathBranch {
                                 path: Rc::clone(&path),
                                 value: child_value.clone(),
+                                register: None,
                                 trackable: node_trackable && child_trackable,
                                 // Same propagation as the `None` arm above
                                 // (#1591); `cond` gates whether the child is
@@ -23886,6 +23998,7 @@ fn apply_static_tail<'a, S: EvalSemantics>(
         value: current,
         trackable,
         snapshot,
+        register,
     } in branches
     {
         // A dynamic element as the pipe's last component (e.g. `.a[.k]`) is
@@ -23931,9 +24044,97 @@ fn apply_static_tail<'a, S: EvalSemantics>(
             // navigated *into* the value and so produced a different one,
             // which is no longer the snapshot (#1466).
             snapshot: snapshot && tail.is_empty(),
+            // The register survives for exactly the same reason, and fails
+            // to for a different one: an empty tail navigates nothing, so a
+            // register live at `prefix` is still live here; a non-empty one
+            // *did* navigate, which by definition moves the register onto
+            // what it reached — at which point `trackable` already carries
+            // it and this field is not consulted (#1573).
+            register: register.filter(|_| tail.is_empty()),
         });
     }
     Ok(out)
+}
+
+/// Whether one pipe stage's output re-establishes the path register, and so
+/// is trackable again despite arriving on an already-untracked branch
+/// (#1573).
+///
+/// Real `path()` carries a `(path, value_at_path)` register that only
+/// *navigation* advances; `jq_next`'s `INDEX` and `PATH_END` both check the
+/// current value against it with `jv_identical`. A literal in the middle of
+/// a pipe therefore doesn't end path tracking, it merely steps off the
+/// register — and a `$var` frozen from where the register still points
+/// steps straight back onto it:
+///
+/// ```text
+/// $ jq -c 'path(. as $x | 5 | $x)'         # []      register never left the root
+/// $ jq -c 'path(.a as $y | .a | 5 | $y)'   # ["a"]   register is still .a
+/// $ jq -c 'path(.a as $y | .c | $y)'       # refuses .c MOVED the register
+/// $ jq -c 'path(.a | 5)'                   # refuses 5 is not the register
+/// ```
+///
+/// All four confirmed live against jq 1.7.1, along with the rest of the
+/// matrix on #1573.
+///
+/// The four preconditions are each load-bearing:
+///
+/// - `!branch_trackable` — a trackable branch needs no re-establishing, and
+///   its `Expr::TrackedVar` arm already certifies against the ambient value
+///   directly (which *is* the register while trackable).
+/// - `!navigated` — the step contributed no path components. A step that
+///   navigated reached a genuinely new position, and `trackable` already
+///   answers for it; re-pointing it at `prefix` would report the wrong path.
+/// - a live `register` — `None` means "not known here", the safe answer.
+/// - [`register_identical`] — the whole rule, shared with the fold register
+///   so the two cannot drift.
+///
+/// This only ever turns a refusal into an answer, so getting it *wrong*
+/// costs an accepted path jq refuses — the dangerous direction, and why
+/// every clause above is a conjunct rather than a heuristic.
+fn reestablishes_register(
+    branch_trackable: bool,
+    navigated: bool,
+    register: Option<&OwnedValue>,
+    resulting: &OwnedValue,
+    step_snapshot: bool,
+) -> bool {
+    !branch_trackable
+        && !navigated
+        && register.is_some_and(|reg| register_identical(reg, resulting, step_snapshot))
+}
+
+/// The path register to hand to the next pipe stage (#1573).
+///
+/// Three cases, in the order they are tested:
+///
+/// - The branch is trackable again (either it never stopped being, or
+///   `reestablishes_register` just put it back): the register is the
+///   branch's own value at its own path, so nothing is stored — see
+///   [`PathBranch::register_value`].
+/// - The step navigated: it moved the register onto what it reached, which
+///   is exactly the trackable case above; if the branch is nonetheless
+///   untracked here, the navigation was refused and no register survives.
+/// - Otherwise the step computed something without navigating, so whatever
+///   register was live entering the stage is still live at the same path.
+///   It comes either from the step itself — `resolve_leaf` records the
+///   ambient value on the very transition that drops trackability, the only
+///   place that value is still in hand — or, once already untracked, from
+///   the branch's own carried copy.
+fn carry_register<'a>(
+    branch_trackable: bool,
+    navigated: bool,
+    reestablished: bool,
+    carried: &Option<Cow<'a, OwnedValue>>,
+    step_register: Option<Cow<'a, OwnedValue>>,
+) -> Option<Cow<'a, OwnedValue>> {
+    if reestablished || navigated {
+        None
+    } else if branch_trackable {
+        step_register
+    } else {
+        carried.clone()
+    }
 }
 
 /// Resolve a pipe of path nodes, threading the value left to right.
@@ -24073,8 +24274,21 @@ fn resolve_seq<'a, S: EvalSemantics>(
             value: current,
             trackable: branch_trackable,
             snapshot: branch_snapshot,
+            register: branch_register,
         } in branches
         {
+            // The path register as it stands *entering* this stage (#1573).
+            //
+            // While `branch_trackable` holds, the register is `current`
+            // itself — but `current` is about to be moved into
+            // `resolve_against_cow`, and the step is the one that knows
+            // whether it navigated off it, so that case is left to the step
+            // (`resolve_leaf` records `current` as the register on the very
+            // transition that drops trackability). What has to be carried
+            // by hand is the *already*-untracked case, where the register
+            // is live somewhere behind us and no step below can see it any
+            // more.
+            let carried_register = branch_register;
             // #986: each branch carries its own trackability now, so this
             // passes *that* rather than the single outer parameter. It is
             // what makes `1 | .[K]` reach `resolve_index_expr` already
@@ -24088,10 +24302,30 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         value: resulting,
                         trackable: step_trackable,
                         snapshot: step_snapshot,
+                        register: step_register,
                     } in resolved
                     {
-                        let path = PathPrefix::extend_many(&prefix, components.to_vec());
+                        let navigated = components.depth() > 0;
+                        let reestablished = reestablishes_register(
+                            branch_trackable,
+                            navigated,
+                            carried_register.as_deref(),
+                            &resulting,
+                            step_snapshot,
+                        );
+                        let path = if reestablished {
+                            Rc::clone(&prefix)
+                        } else {
+                            PathPrefix::extend_many(&prefix, components.to_vec())
+                        };
                         next.push(PathBranch {
+                            register: carry_register(
+                                branch_trackable,
+                                navigated,
+                                reestablished,
+                                &carried_register,
+                                step_register,
+                            ),
                             path,
                             value: resulting,
                             // Untracked is absorbing: nothing downstream can
@@ -24101,13 +24335,29 @@ fn resolve_seq<'a, S: EvalSemantics>(
                             // silent acceptance into a loud error, never the
                             // reverse (#985's revert is what the reverse
                             // looks like).
-                            trackable: branch_trackable && step_trackable,
+                            //
+                            // #1573 adds the one exception jq itself has:
+                            // untracked is absorbing for *navigation*, but a
+                            // `$var` whose frozen value is still identical to
+                            // the live register is not navigation — jq's own
+                            // `path_intact` compares against `value_at_path`,
+                            // which a literal never moved, so the variable
+                            // re-establishes the register's position rather
+                            // than reaching a new one. See
+                            // `reestablishes_register`.
+                            trackable: reestablished || (branch_trackable && step_trackable),
                             // Unlike `trackable`, this comes from the *step*
                             // alone: the value leaving this stage is the
                             // step's own output, so `.a | $x` still hands
                             // back the frozen snapshot whatever `.a` was,
                             // and `$x | .a` no longer is one (#1466).
-                            snapshot: step_snapshot,
+                            //
+                            // A re-established branch is `trackable` again,
+                            // and this type's invariant is that `snapshot`
+                            // implies `!trackable`: a certified snapshot has
+                            // resolved to a real path and needs no second
+                            // marker (#1573).
+                            snapshot: step_snapshot && !reestablished,
                         });
                     }
                 }
@@ -24117,14 +24367,34 @@ fn resolve_seq<'a, S: EvalSemantics>(
                         value: resulting,
                         trackable: step_trackable,
                         snapshot: step_snapshot,
+                        register: step_register,
                     } in partial
                     {
-                        let path = PathPrefix::extend_many(&prefix, components.to_vec());
+                        let navigated = components.depth() > 0;
+                        let reestablished = reestablishes_register(
+                            branch_trackable,
+                            navigated,
+                            carried_register.as_deref(),
+                            &resulting,
+                            step_snapshot,
+                        );
+                        let path = if reestablished {
+                            Rc::clone(&prefix)
+                        } else {
+                            PathPrefix::extend_many(&prefix, components.to_vec())
+                        };
                         next.push(PathBranch {
+                            register: carry_register(
+                                branch_trackable,
+                                navigated,
+                                reestablished,
+                                &carried_register,
+                                step_register,
+                            ),
                             path,
                             value: resulting,
-                            trackable: branch_trackable && step_trackable,
-                            snapshot: step_snapshot,
+                            trackable: reestablished || (branch_trackable && step_trackable),
+                            snapshot: step_snapshot && !reestablished,
                         });
                     }
                     // Keep whatever this branch produced before its escape,
@@ -67365,6 +67635,120 @@ mod tests {
         );
         assert_eq!(paths.len(), 300);
         assert!(paths.iter().all(|p| p == r#"["root_marker",0]"#));
+    }
+
+    // =========================================================================
+    // #1573: `path()` carries a *register* — `jq_state`'s own
+    // `(path, value_at_path)` — that only navigation advances. A literal in
+    // the middle of a pipe steps off it without ending path tracking, so a
+    // `$var` frozen from where the register still points steps back onto it.
+    // Every expectation below is confirmed live against jq 1.7.1.
+    // =========================================================================
+
+    /// The register survives a literal stage: `5` never moved
+    /// `value_at_path` off the root, so `$x` — frozen from that same root —
+    /// is still `jv_identical` to it when `path()` checks its own output.
+    ///
+    /// This shape has a `TrackedVar` marker already (`.` is an
+    /// identity passthrough, so #844's gate admits it); what it lacked was
+    /// anywhere for the register to *survive* the literal, so the marker
+    /// reached its use site with the ambient value `5` to compare against
+    /// and could only refuse.
+    #[test]
+    fn test_path_register_survives_intervening_literal_1573() {
+        assert_eq!(outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | $x)"), ["[]"]);
+    }
+
+    /// The register is a *position*, not just a permission: navigation may
+    /// continue off the re-established variable, and the emitted path is the
+    /// register's own, not the empty one the ambient literal would give.
+    #[test]
+    fn test_path_register_navigates_off_reestablished_var_1573() {
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | $x.a)"),
+            [r#"["a"]"#]
+        );
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | $x | .a)"),
+            [r#"["a"]"#]
+        );
+    }
+
+    /// Consecutive non-navigating stages each carry the register forward —
+    /// the second one is already untracked when it runs, so it cannot
+    /// re-derive the register from its own ambient input the way the first
+    /// one does, and has to inherit the branch's carried copy.
+    #[test]
+    fn test_path_register_survives_consecutive_literals_1573() {
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | 5 | 6 | $x)"),
+            ["[]"]
+        );
+    }
+
+    /// Not only literals: any stage that computes rather than navigates
+    /// leaves the register where it was. `length` and a `Comma` fan-out are
+    /// both confirmed live (`(1,2)` yields the path twice, once per branch,
+    /// exactly as jq does).
+    #[test]
+    fn test_path_register_survives_non_literal_computed_stages_1573() {
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | length | $x)"),
+            ["[]"]
+        );
+        assert_eq!(
+            outputs(br#"{"a":{"b":1}}"#, r"path(. as $x | (1,2) | $x)"),
+            ["[]", "[]"]
+        );
+    }
+
+    /// Negative control, and the reason `reestablishes_register` insists on
+    /// `!navigated`: a stage that *did* navigate moved the register onto
+    /// what it reached, so a variable frozen from the old position no longer
+    /// matches. jq raises here, and must keep raising — accepting would
+    /// report `[]` for a position the register has left.
+    #[test]
+    fn test_path_register_moves_on_navigation_1573() {
+        query!(br#"{"a":{"b":1}}"#, r"path(. as $x | .a | $x)",
+            QueryResult::Error(e) => {
+                assert!(e.is_invalid_path_expression());
+            }
+        );
+    }
+
+    /// Negative control for the value half of the comparison: a computed
+    /// value that is *not* the register stays untracked however
+    /// non-navigating its stage was. `path(.a | 5)` raises in jq for exactly
+    /// this reason — `5` is not what `value_at_path` points at — and the
+    /// register threading must not turn that into an answer.
+    #[test]
+    fn test_path_register_rejects_value_that_is_not_the_register_1573() {
+        query!(br#"{"a":{"b":1}}"#, r"path(.a | 5)",
+            QueryResult::Error(e) => {
+                assert!(e.is_invalid_path_expression());
+            }
+        );
+        query!(br#"{"a":{"b":1},"c":9}"#, r"path(. as $x | 5 | $x | .c | 5)",
+            QueryResult::Error(e) => {
+                assert!(e.is_invalid_path_expression());
+            }
+        );
+    }
+
+    /// A variable bound from a *navigated* position still has no marker at
+    /// all (`substitute_bound_var`'s `is_identity_passthrough` gate), so it
+    /// keeps refusing regardless of the register. This is the half of #1573
+    /// the register does not close, pinned here so widening the gate later
+    /// has to come back and update this test deliberately rather than
+    /// silently flipping it — see the issue for why the marker needs a
+    /// bind-time path before that widening is sound.
+    #[test]
+    fn test_path_navigated_binding_still_refused_pending_gate_1573() {
+        query!(br#"{"a":{"b":1}}"#, r"path(.a as $y | .a | $y)",
+            QueryResult::Error(e) => {
+                assert!(e.is_invalid_path_expression());
+            }
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Real `path()` carries a **register** — `jq_state`'s own `(path, value_at_path)` pair —
that only *navigation* advances. `jq_next`'s `INDEX` and `PATH_END` both compare the
current value against it with `jv_identical`; a literal, an arithmetic result, or an
arbitrary builtin call leave it exactly where it was. So a `$var` frozen from where the
register still points steps straight back onto it:

```console
$ echo '{"a":{"b":1}}' | jq -c 'path(. as $x | 5 | $x)'
[]
$ echo '{"a":{"b":1}}' | succinctly jq -c 'path(. as $x | 5 | $x)'   # before: refuses, exit 5
```

`resolve_node`'s `Expr::TrackedVar` arm compared its frozen snapshot against the
**ambient input**, which is the register only while `trackable` holds. The moment any
stage computed a value, the register was lost and every such shape refused.

`PathBranch` now carries the register's value across the stages that don't navigate.
`resolve_leaf`'s computed-value leaf records it at the one transition where it is still
in hand — the step *off* the register — and `resolve_seq` carries it forward while no
stage navigates, re-establishing trackability at the register's own path when a snapshot
matches it.

The "is this branch still on the register?" rule is `FoldRegister`'s existing modelled
`jv_identical`, extracted to `register_identical` so the fold register and the new pipe
register share **one** definition instead of drifting apart.

### Scope: this is the register half of #1573, not the gate half

The issue also asks for `.a as $y`-style *navigated* bindings to track. That needs
`substitute_bound_var`'s `is_identity_passthrough` gate widened, and I found that
widening it alone is **unsound** — it regresses into exactly the accept-where-jq-refuses
class #1466 closed:

```console
$ echo '{"a":{"b":1},"c":{"b":1}}' | jq -c 'path(.a as $y | .c | $y)'
jq: error ...                       # equal value, DIFFERENT node
                                    # with the gate widened, succinctly answered ["c"]
```

`register_identical` compares values plus a "never rebuilt" provenance bit; that
distinguishes a snapshot from a reconstruction, but not *which node* the snapshot came
from. `OwnedValue` has no identity, so the marker needs a **bind-time path** before the
gate can be widened — which is the issue's original `(path, value)` proposal, and which
the spike's later comments concluded was unnecessary. It is necessary; it just isn't the
acceptance *criterion*. Filed as a follow-up with the repro rather than shipped
half-verified. `test_path_navigated_binding_still_refused_pending_gate_1573` pins the
current refusal so that widening has to update it deliberately.

## Verification

Model derived and every expectation confirmed live against pinned **jq 1.7.1**
(`/usr/bin/jq`), including the probes that refute the two earlier hypotheses on the
issue: the `as`-binding source does *not* move the register
(`path(.a as $y | .b)` = `["b"]`), and an intervening literal does not disqualify a
variable while an intervening navigation does.

**Randomised differential fuzz vs jq 1.7.1** (`path`/`del`/`=`/`|=` wrappers over
generated bind/navigate/compute pipelines), classified by *direction*:

> **Superseded by the review follow-up at the bottom of this description.** This run's
> generator could not emit a stage that navigates *inside jq's own bytecode* (a `def`
> body, `first`, `add`), which is exactly where a fabrication was hiding; the identity-
> passthrough row's single REFUSE also undercounts. Re-run numbers are below.

| run | shapes | agree | FABRICATE (succ answers, jq refuses) | MISMATCH | REFUSE (safe) |
|---|---|---|---|---|---|
| all binding shapes | 2500 | 2423 | **0** | **0** | 77 |
| identity-passthrough bindings only | 2500 | 2499 | **0** | **0** | 1 |

Zero fabrications and zero mismatches — nothing became acceptable that jq refuses. All 77
REFUSEs in the first run are the navigated-binding gate above. The single REFUSE in the
second run is a **pre-existing, unrelated** divergence the fuzz surfaced
(`path(null | .a)` on `null` — a computed `null` that is `jv_identical` to a `null`
register keeps navigation alive in jq); confirmed present on a build without this change,
and filed separately.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` — 56 suites, all green
- [x] `cargo test --no-fail-fast` (default features, CI's own `Test` job)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --no-default-features` (`no_std`)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps`
- [x] 6 new regression tests, including three negative controls (a navigating stage moves
      the register; a computed value that isn't the register stays untracked; the
      navigated-binding gate still refuses)
- [x] Differential fuzz vs pinned jq 1.7.1, 5000 shapes total (table above)

Refs #1573

---

## Review follow-up: the register must not survive a stage jq itself navigates through

The first cut of this PR recorded the ambient value as the register for **every** stage
`resolve_leaf` could not decompose. That is not the same as "the stage did not navigate":
jq's `value_at_path` moves on any `INDEX` its bytecode executes, including the ones inside
a jq-*defined* builtin (`first` is `.[0]`, `add` is `reduce .[] as $x ...`) or a user
function body — stages that arrive here as one opaque computed value. A later `$var` then
re-established at a position jq had already left:

```console
$ echo '{"a":{"b":1},"c":{"b":1}}' | jq -c '(. as $x | ([.a]|first) | $x.c) = 9'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of [{"b":1}]
$ echo '{"a":{"b":1},"c":{"b":1}}' | succinctly jq -c '(. as $x | ([.a]|first) | $x.c) = 9'
{"a":{"b":1},"c":9}                     # before this fix — a write jq refuses, exit 0
```

Refuse-only it was not: `=`, `|=` and `del()` all wrote through the fabricated path, which
is the accept-where-jq-refuses class #1466 closed. `main` refuses all of these.

### What changed

- **`cannot_move_register(expr)`** — a syntactic allowlist of stage shapes proven (live,
  jq 1.7.1) to leave the register in place: literals, `$var`, `@fmt`, `$ENV`/`$__loc__`,
  arithmetic/comparison/boolean/alternative/`if`/`try`/`error` over safe operands, a
  construction or interpolation that navigates nothing, and eight C-implemented builtins
  (`length`, `type`, `keys`, `keys_unsorted`, `tostring`, `tonumber`, `tojson`,
  `utf8bytelength`). Everything else — `first`/`add`/`any`, any `def` or call, `reduce`,
  `label`, `..` — drops the register. Getting it wrong in this direction costs a refusal;
  the other direction fabricates.
- **`resolve_seq` consults it once per stage** (`stage_preserves_register`), gating both
  `reestablishes_register` and `carry_register`. A construction that itself navigates is
  excluded because jq *also* raises for a `.a` applied to a computed value —
  `path(. as $x | {k:.a} | [.a] | $x)` raises in jq on the second `.a`, which this resolver
  never sees inside a construction.
- **One placement rule** for the `Ok` fan-out and the escaping partial prefix, instead of
  the two copies that had already caused one omission in this PR's own history.
- `StepRegisterFacts` bundles the four per-step bools (same reasoning as `SliceEditFlags`).

### Cost, all refuse-only and pinned by tests

`path(. as $x | [.a] | $x)`, `{k:.a}`, `"\(.a)"`, `(.a as $q | 1)` and
`(def f: 5; f)` are `[]` in jq and now refuse here. Recorded in
`docs/compliance/jq/limitations.md` alongside a fourth, pre-existing one the review found:
`path(.a | null)` on `{"a":null}` is `["a"]` in jq (the `null`/`bool` arm of
`register_identical` applied one stage earlier than `reestablishes_register` reaches).
The `register_identical` doc comment previously cited that shape as if succinctly matched
it; corrected.

### Re-verified

Differential fuzz vs pinned jq 1.7.1 over `path`/`del`/`=`/`|=`/`getpath(path(...))`
wrappers, with the generator's computed-stage pool extended to include the opaque
navigating stages the original run could not emit (`def f: .a; f`, `[.a]|first`,
`[1]|first`, `[.a]|add`, `map(1)|first`, `[1,2]|sort|first`, `first(.a)`, `.. | 5`):

| run | shapes | agree | FABRICATE | MISMATCH | REFUSE (safe) |
|---|---|---|---|---|---|
| all binding shapes, 3 seeds | 3590 | 3298 | **0** | **0** | 292 |
| identity-passthrough only, 2 seeds | 2379 | 2322 | **0** | **0** | 56 |

The remaining REFUSEs are the #2042 gate gap, the allowlist costs above, and #2044.
One row in the identity-passthrough run classifies as a fabrication and is not one:
`del(. as $x | {} | ([1]|first) | empty|1)` never references `$x`, and the identical
variable-free `del({} | ([1]|first) | empty|1)` diverges the same way on `main` — it is
`empty`'s lazy pruning racing jq's eager path check (#986/#987 territory), unrelated to
the register.
