### PR TITLE
fix(test): close the #1891 zombie-leak pattern at 11 more call sites

### DIFF
--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -205,6 +205,62 @@ pub fn succinctly_bin() -> &'static str {
 /// (a real code is always present in an `Ok` result) is asserted here
 /// exactly once, via [`exit_code_or_signal_death`], rather than
 /// re-asserted independently at every call site.
+/// Writes `stdin_input` to `child`'s stdin (if it was piped and this is
+/// `Some`), then waits for `child` to exit, reaping it regardless of
+/// whether the write succeeded.
+///
+/// Write, but don't propagate a failure yet (#1891): if the child exits or
+/// closes stdin early (e.g. an argv-parse error before it ever reads
+/// stdin), `write_all` can fail before the child has been waited on.
+/// Returning via `?` at that point would drop `child` without reaping it --
+/// `Child`'s `Drop` does not wait() the OS process, so the early return
+/// would leak a zombie for the rest of this test binary's run.
+/// `wait_with_output()` below doesn't care whether the write succeeded;
+/// call it unconditionally first so the child is always reaped, then
+/// surface the write error if there was one.
+///
+/// Ordering invariant: this write runs to completion (blocking on a full
+/// pipe buffer) *before* `wait_with_output()`'s own concurrent
+/// stdout/stderr draining starts, which is the classic double-pipe
+/// deadlock shape if the child fills its stdout/stderr buffer while
+/// waiting on stdin. Currently safe only because every binary this helper
+/// spawns reads stdin to completion before writing any output, and the
+/// small inputs/outputs these tests use never fill an OS pipe buffer
+/// either way -- not an invariant this function enforces itself.
+///
+/// Extracted (#2016 code review) from [`spawn_with_signal_retry`]'s own
+/// loop body so a caller that can't use that function's whole spawn+retry
+/// wrapper (e.g. `jq_cli_tests.rs`'s `run_jq_interleaved`, which needs its
+/// own file-redirected stdout/stderr for interleaving order) can still
+/// share this write/wait/reap sequencing instead of re-deriving it -- three
+/// call sites had independently done exactly that before this
+/// consolidation.
+pub fn write_stdin_then_wait(
+    mut child: std::process::Child,
+    stdin_input: Option<&[u8]>,
+) -> Result<std::process::Output> {
+    let write_result: std::io::Result<()> =
+        if let (Some(input), Some(mut sin)) = (stdin_input, child.stdin.take()) {
+            use std::io::Write;
+            sin.write_all(input)
+        } else {
+            Ok(())
+        };
+    // Prefer the write error's own diagnostic over `wait_with_output`'s
+    // (#1891 code review): on the rare double failure -- the child is
+    // also reaped or killed by something else (an OOM kill, another
+    // session's `pkill`, `cargo-guard.sh`'s stall guard, all named
+    // above) between the write failing and this wait running --
+    // `wait_with_output` erroring first would otherwise mask *why* the
+    // write itself failed with a more generic wait/I-O error.
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
+    };
+    write_result?;
+    Ok(output)
+}
+
 pub fn spawn_with_signal_retry(
     mut build: impl FnMut() -> std::process::Command,
     stdin_input: Option<&[u8]>,
@@ -219,7 +275,7 @@ pub fn spawn_with_signal_retry(
             } else {
                 std::process::Stdio::null()
             });
-        let mut child = match command.spawn() {
+        let child = match command.spawn() {
             Ok(child) => child,
             Err(e)
                 if e.kind() == std::io::ErrorKind::NotFound && attempt + 1 < MAX_CARGO_RETRIES =>
@@ -229,51 +285,11 @@ pub fn spawn_with_signal_retry(
             }
             Err(e) => return Err(e.into()),
         };
-        // Write, but don't propagate a failure yet (#1891): if the child
-        // exits or closes stdin early (e.g. an argv-parse error before it
-        // ever reads stdin), `write_all` can fail before the child has been
-        // waited on. Returning via `?` at that point would drop `child`
-        // without reaping it -- `Child`'s `Drop` does not wait() the OS
-        // process, so the early return would leak a zombie for the rest of
-        // this test binary's run. `wait_with_output()` below doesn't care
-        // whether the write succeeded; call it unconditionally first so the
-        // child is always reaped, then surface the write error if there was
-        // one.
-        //
-        // Ordering invariant: this write runs to completion (blocking on a
-        // full pipe buffer) *before* `wait_with_output()`'s own concurrent
-        // stdout/stderr draining starts, which is the classic double-pipe
-        // deadlock shape if the child fills its stdout/stderr buffer while
-        // waiting on stdin. Currently safe only because every binary this
-        // helper spawns reads stdin to completion before writing any
-        // output, and the small inputs/outputs these tests use never fill
-        // an OS pipe buffer either way -- not an invariant this function
-        // enforces itself.
-        let write_result: std::io::Result<()> =
-            if let (Some(input), Some(mut sin)) = (stdin_input, child.stdin.take()) {
-                use std::io::Write;
-                sin.write_all(input)
-            } else {
-                Ok(())
-            };
-        // Prefer the write error's own diagnostic over `wait_with_output`'s
-        // (#1891 code review): on the rare double failure -- the child is
-        // also reaped or killed by something else (an OOM kill, another
-        // session's `pkill`, `cargo-guard.sh`'s stall guard, all named
-        // above) between the write failing and this wait running --
-        // `wait_with_output` erroring first would otherwise mask *why* the
-        // write itself failed with a more generic wait/I-O error.
-        let output = match child.wait_with_output() {
-            Ok(output) => output,
-            Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
-        };
-        // A write failure returns here unconditionally, same as it always
+        // A write failure surfaces here unconditionally, same as it always
         // has (#1891 code review): only exit-status classification below
         // gets this loop's own retry-on-signal-death treatment, not a
-        // failed write -- unchanged by this fix, which only moved *when*
-        // the child gets reaped relative to this return, not *whether* a
-        // write failure skips the retry path.
-        write_result?;
+        // failed write.
+        let output = write_stdin_then_wait(child, stdin_input)?;
         if let Some(code) = output.status.code() {
             return Ok((output, code));
         }

--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -29,7 +29,7 @@
 
 #![allow(dead_code)] // Each consumer uses a different subset.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 #[path = "../../src/bin/succinctly/exit_status.rs"]
 mod exit_status;
@@ -145,66 +145,6 @@ pub fn succinctly_bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
 }
 
-/// Spawns `build()` (already configured with args), optionally writing
-/// `stdin_input` to it, retrying the whole spawn+wait up to
-/// [`MAX_CARGO_RETRIES`] times on either of two transient failures: `spawn()`
-/// itself returning `ENOENT` (a concurrent, differently-featured `cargo
-/// test` invocation sharing this `target/` directory can be transiently
-/// mid-relink of the shared `succinctly_bin()` path, #550), or the spawned
-/// child being killed by a signal rather than exiting with a real code -- an
-/// OOM kill, another session's `pkill`, or a stall-guard's process-group
-/// kill (`cargo-guard.sh`, by design, on a detected stall, #935) catching
-/// this specific child, all just as plausible under this repo's routine
-/// heavy concurrent multi-session load as the cargo-lock-contention case
-/// `classify_cargo_run_exit` retries for. Unlike that function, there is
-/// no exit-101 case to also retry on here: a direct `succinctly_bin()`
-/// spawn has no cargo invocation of its own to contend on a lock.
-///
-/// Shared by every direct-spawn CLI test helper (#1847 review) --
-/// `cli_golden_tests.rs`, `cli_characterization_tests.rs`,
-/// `deep_nesting_valid_tests.rs`, `json_validate_tests.rs`, and (via #1884's
-/// follow-up fix, after that file's own bespoke copy was found to have
-/// silently dropped signal-death retry) `jq_cli_tests.rs` each independently
-/// dropped some or all of this retry surface (along with the lock-contention
-/// case that genuinely no longer applies) when first converting away from
-/// `cargo run`; sharing one copy here instead of five independently
-/// drifting ones is the same fix `classify_cargo_run_exit`'s own doc comment
-/// already describes for the exit-code-classification half of this same
-/// problem. (#1884 code review, round 3: this function's own `spawn()` call
-/// used a bare `?` with no `ENOENT` handling until this paragraph's fix --
-/// the one piece of `spawn_jq_full`'s old protection that got lost when
-/// `jq_cli_tests.rs` first adopted this shared helper, since this function
-/// didn't have it either at the time.)
-///
-/// `build` is called fresh on each retry attempt, since a spawned
-/// `std::process::Command` cannot be reused. `stdout`/`stderr` are always
-/// piped. `stdin` is piped and `stdin_input` written to it when `Some`;
-/// when `None`, `stdin` is explicitly set to `Stdio::null()` -- **not**
-/// left unconfigured, which would default to inheriting this test
-/// process's own stdin under `.spawn()` (unlike `.output()`, whose
-/// documented default *is* `Stdio::null()`; an earlier version of this
-/// function relied on that same default by simply never calling
-/// `.stdin(...)` in the `None` case, silently inheriting instead once
-/// converted to `.spawn()`/`.wait_with_output()` -- confirmed live: a
-/// spawned child with only stdout/stderr piped echoes back whatever this
-/// process's own stdin contains, where the old `.output()` calls it
-/// replaced saw immediate EOF). Getting this wrong reintroduces exactly
-/// the class of hang this whole conversion exists to eliminate, just
-/// relocated to stdin instead of an orphaned grandchild.
-///
-/// Retries sleep `100 * (attempt + 1)` ms between attempts, matching
-/// every pre-conversion call site's own backoff -- an immediate retry
-/// under the same sustained load that caused the first signal death (an
-/// OOM condition that hasn't cleared, a stall-guard still killing the
-/// process group) is more likely to be killed again in the same narrow
-/// window, burning through the retry budget faster than a short backoff
-/// would.
-///
-/// Returns the real exit code alongside the `Output` so callers never
-/// need their own `output.status.code().expect(...)` -- that invariant
-/// (a real code is always present in an `Ok` result) is asserted here
-/// exactly once, via [`exit_code_or_signal_death`], rather than
-/// re-asserted independently at every call site.
 /// Writes `stdin_input` to `child`'s stdin (if it was piped and this is
 /// `Some`), then waits for `child` to exit, reaping it regardless of
 /// whether the write succeeded.
@@ -255,12 +195,86 @@ pub fn write_stdin_then_wait(
     // write itself failed with a more generic wait/I-O error.
     let output = match child.wait_with_output() {
         Ok(output) => output,
-        Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
+        Err(wait_err) => {
+            return Err(match write_result {
+                Ok(()) => anyhow::Error::new(wait_err).context("wait"),
+                Err(write_err) => anyhow::Error::new(write_err).context("write stdin"),
+            })
+        }
     };
-    write_result?;
+    // #2016 (code review): `.context(...)`, not a bare `?` -- consolidating
+    // three call sites' own hand-written "write stdin: {e}" diagnostics
+    // into this shared function had silently dropped that stage-tagging
+    // (a bare `io::Error`'s own `Display` doesn't say *which* fallible step
+    // produced it), making a real failure harder to triage than before.
+    write_result.context("write stdin")?;
     Ok(output)
 }
 
+/// Spawns `build()` (already configured with args), optionally writing
+/// `stdin_input` to it, retrying the whole spawn+wait up to
+/// [`MAX_CARGO_RETRIES`] times on either of two transient failures: `spawn()`
+/// itself returning `ENOENT` (a concurrent, differently-featured `cargo
+/// test` invocation sharing this `target/` directory can be transiently
+/// mid-relink of the shared `succinctly_bin()` path, #550), or the spawned
+/// child being killed by a signal rather than exiting with a real code -- an
+/// OOM kill, another session's `pkill`, or a stall-guard's process-group
+/// kill (`cargo-guard.sh`, by design, on a detected stall, #935) catching
+/// this specific child, all just as plausible under this repo's routine
+/// heavy concurrent multi-session load as the cargo-lock-contention case
+/// `classify_cargo_run_exit` retries for. Unlike that function, there is
+/// no exit-101 case to also retry on here: a direct `succinctly_bin()`
+/// spawn has no cargo invocation of its own to contend on a lock.
+///
+/// Shared by every direct-spawn CLI test helper (#1847 review) --
+/// `cli_golden_tests.rs`, `cli_characterization_tests.rs`,
+/// `deep_nesting_valid_tests.rs`, `json_validate_tests.rs`, and (via #1884's
+/// follow-up fix, after that file's own bespoke copy was found to have
+/// silently dropped signal-death retry) `jq_cli_tests.rs` each independently
+/// dropped some or all of this retry surface (along with the lock-contention
+/// case that genuinely no longer applies) when first converting away from
+/// `cargo run`; sharing one copy here instead of five independently
+/// drifting ones is the same fix `classify_cargo_run_exit`'s own doc comment
+/// already describes for the exit-code-classification half of this same
+/// problem. (#1884 code review, round 3: this function's own `spawn()` call
+/// used a bare `?` with no `ENOENT` handling until this paragraph's fix --
+/// the one piece of `spawn_jq_full`'s old protection that got lost when
+/// `jq_cli_tests.rs` first adopted this shared helper, since this function
+/// didn't have it either at the time.)
+///
+/// `build` is called fresh on each retry attempt, since a spawned
+/// `std::process::Command` cannot be reused. `stdout`/`stderr` are always
+/// piped. `stdin` is piped and `stdin_input` written to it when `Some`;
+/// when `None`, `stdin` is explicitly set to `Stdio::null()` -- **not**
+/// left unconfigured, which would default to inheriting this test
+/// process's own stdin under `.spawn()` (unlike `.output()`, whose
+/// documented default *is* `Stdio::null()`; an earlier version of this
+/// function relied on that same default by simply never calling
+/// `.stdin(...)` in the `None` case, silently inheriting instead once
+/// converted to `.spawn()`/`.wait_with_output()` -- confirmed live: a
+/// spawned child with only stdout/stderr piped echoes back whatever this
+/// process's own stdin contains, where the old `.output()` calls it
+/// replaced saw immediate EOF). Getting this wrong reintroduces exactly
+/// the class of hang this whole conversion exists to eliminate, just
+/// relocated to stdin instead of an orphaned grandchild.
+///
+/// Uses [`write_stdin_then_wait`] for the write/wait/reap sequencing
+/// itself (#2016 code review); this function's own contribution on top is
+/// the spawn-ENOENT retry, the signal-death retry, and the backoff below.
+///
+/// Retries sleep `100 * (attempt + 1)` ms between attempts, matching
+/// every pre-conversion call site's own backoff -- an immediate retry
+/// under the same sustained load that caused the first signal death (an
+/// OOM condition that hasn't cleared, a stall-guard still killing the
+/// process group) is more likely to be killed again in the same narrow
+/// window, burning through the retry budget faster than a short backoff
+/// would.
+///
+/// Returns the real exit code alongside the `Output` so callers never
+/// need their own `output.status.code().expect(...)` -- that invariant
+/// (a real code is always present in an `Ok` result) is asserted here
+/// exactly once, via [`exit_code_or_signal_death`], rather than
+/// re-asserted independently at every call site.
 pub fn spawn_with_signal_retry(
     mut build: impl FnMut() -> std::process::Command,
     stdin_input: Option<&[u8]>,
@@ -283,7 +297,10 @@ pub fn spawn_with_signal_retry(
                 std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
                 continue;
             }
-            Err(e) => return Err(e.into()),
+            // #2016 (code review): `.context(...)`, matching
+            // `write_stdin_then_wait`'s own stage-tagging -- see its doc
+            // comment for why.
+            Err(e) => return Err(anyhow::Error::new(e).context("spawn succinctly")),
         };
         // A write failure surfaces here unconditionally, same as it always
         // has (#1891 code review): only exit-status classification below

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -189,33 +189,13 @@ fn spawn_jq(args: &[&str], stdin_input: Option<&[u8]>) -> Result<(std::process::
 /// their retry -- ENOENT while a sibling test rebuilds the binary, and a
 /// signal-killed child (#1516/#1691) -- rather than reimplementing the retry
 /// policy with different numbers.
-/// Deletes the wrapped directory on drop, covering every exit path (a
-/// `return`, an early `?`, or a panic) rather than requiring each one to
-/// remember its own `std::fs::remove_dir_all` call -- code review (#2016):
-/// the two explicit cleanup calls this guard replaces only ran on the
-/// success and retries-exhausted paths, silently leaking the scratch
-/// directory on every other error return (both pre-existing, like the
-/// initial spawn failing, and the two new ones this same fix introduced by
-/// deferring the write error past the wait).
-struct RemoveDirOnDrop<'a>(&'a std::path::Path);
-
-impl Drop for RemoveDirOnDrop<'_> {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(self.0);
-    }
-}
-
 fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32)> {
-    let dir = std::env::temp_dir().join(format!(
-        "sjq-interleave-{}-{}",
-        std::process::id(),
-        // Distinct per call within one process: two tests running
-        // concurrently in the same binary would otherwise share a path.
-        INTERLEAVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    ));
-    std::fs::create_dir_all(&dir)?;
-    let _cleanup = RemoveDirOnDrop(&dir);
-    let path = dir.join("combined.txt");
+    // #2016 (code review): `TempDir`, not a hand-rolled unique path plus a
+    // bespoke `Drop`-guard -- `tempfile` is already a dependency, already
+    // used this same way by sibling test files, and already provides
+    // exactly this "unique scratch dir, deleted on drop" guarantee.
+    let dir = tempfile::TempDir::new()?;
+    let path = dir.path().join("combined.txt");
 
     for attempt in 0..MAX_CARGO_RETRIES {
         // Truncate per attempt: a retry must not read a previous attempt's
@@ -257,8 +237,6 @@ fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32
     }
     unreachable!()
 }
-
-static INTERLEAVE_SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 /// `spawn_jq`'s counterpart for the environment-variable test cluster
 /// (#1889 code review): the 8 tests covering `NO_COLOR`/`JQ_COLORS`/
@@ -2520,22 +2498,25 @@ fn test_reduce() -> Result<()> {
 fn test_default_identity_filter() -> Result<()> {
     // When no filter is provided, should default to "."
     //
-    // #1889: intentionally left off `spawn_with_signal_retry` -- this test
-    // never calls `wait_with_output()` (it drops the spawned `Child`
-    // immediately), so there is no signal-death race to retry against, and
-    // routing it through the shared helper would add a wait this test was
-    // never designed to perform. `spawn()` itself can still transiently
-    // ENOENT (#550), but that's the same low-value tradeoff as leaving this
-    // near-vestigial test's semantics unchanged rather than restructuring
-    // it for a race this specific test doesn't meaningfully protect
-    // against anyway (it asserts nothing about the process's outcome).
+    // #2016 (code review): the previous version of this test spawned a
+    // child and immediately `drop`ped it without ever calling `wait()` --
+    // unlike every other #1891/#2016 site, which only leaked a zombie
+    // conditionally (on a write failure racing the wait), this leaked one
+    // unconditionally, on every single run. `Stdio::null()` for stdin
+    // (rather than piped-then-never-written) means the child sees EOF
+    // immediately with nothing for this test to write or close, and
+    // `wait_with_output()` (not a bare `wait()`) drains stdout/stderr
+    // concurrently so the child can't block on a full output pipe either.
+    // Still asserts nothing about the process's outcome, matching this
+    // near-vestigial test's original intent -- only the leak is fixed.
     let output = Command::new(succinctly_bin())
         .arg("jq")
         .arg("-c")
-        .stdin(Stdio::piped())
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()?;
+        .spawn()?
+        .wait_with_output()?;
 
     // This test would need special handling for empty filter
     // For now, just verify the command runs

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -223,12 +223,29 @@ fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32
             }
             Err(e) => return Err(e.into()),
         };
-        if let Some(mut stdin) = child.stdin.take() {
+        // #2016: write, but don't propagate a failure yet -- same shape as
+        // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
+        // `child.wait()` below, would drop `child` without reaping it on a
+        // write failure (e.g. the child exits before ever reading stdin),
+        // leaking a zombie for the rest of this test binary's run.
+        let write_result: std::io::Result<()> = if let Some(mut stdin) = child.stdin.take() {
             if let Some(input) = input {
-                stdin.write_all(input.as_bytes())?;
+                stdin.write_all(input.as_bytes())
+            } else {
+                Ok(())
             }
-        }
-        let status = child.wait()?;
+        } else {
+            Ok(())
+        };
+        // Prefer the write error's own diagnostic over `wait`'s, on the
+        // rare double failure where the child is also reaped or killed by
+        // something else between the write failing and this wait running
+        // (matching `spawn_with_signal_retry`'s own #1891-review priority).
+        let status = match child.wait() {
+            Ok(status) => status,
+            Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
+        };
+        write_result?;
         let combined = std::fs::read_to_string(&path)?;
         if let Some(code) = status.code() {
             let _ = std::fs::remove_dir_all(&dir);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -15,7 +15,7 @@ use tempfile::NamedTempFile;
 mod cargo_run_exit;
 use cargo_run_exit::{
     classify_cargo_run_exit, signal_death_error, spawn_with_signal_retry, succinctly_bin,
-    MAX_CARGO_RETRIES,
+    write_stdin_then_wait, MAX_CARGO_RETRIES,
 };
 
 /// #1516: a signal-killed child used to render as an inscrutable
@@ -189,6 +189,22 @@ fn spawn_jq(args: &[&str], stdin_input: Option<&[u8]>) -> Result<(std::process::
 /// their retry -- ENOENT while a sibling test rebuilds the binary, and a
 /// signal-killed child (#1516/#1691) -- rather than reimplementing the retry
 /// policy with different numbers.
+/// Deletes the wrapped directory on drop, covering every exit path (a
+/// `return`, an early `?`, or a panic) rather than requiring each one to
+/// remember its own `std::fs::remove_dir_all` call -- code review (#2016):
+/// the two explicit cleanup calls this guard replaces only ran on the
+/// success and retries-exhausted paths, silently leaking the scratch
+/// directory on every other error return (both pre-existing, like the
+/// initial spawn failing, and the two new ones this same fix introduced by
+/// deferring the write error past the wait).
+struct RemoveDirOnDrop<'a>(&'a std::path::Path);
+
+impl Drop for RemoveDirOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(self.0);
+    }
+}
+
 fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32)> {
     let dir = std::env::temp_dir().join(format!(
         "sjq-interleave-{}-{}",
@@ -198,6 +214,7 @@ fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32
         INTERLEAVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
     std::fs::create_dir_all(&dir)?;
+    let _cleanup = RemoveDirOnDrop(&dir);
     let path = dir.join("combined.txt");
 
     for attempt in 0..MAX_CARGO_RETRIES {
@@ -213,7 +230,7 @@ fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32
             .stdout(Stdio::from(out_handle))
             .stderr(Stdio::from(err_handle))
             .spawn();
-        let mut child = match spawned {
+        let child = match spawned {
             Ok(child) => child,
             Err(e)
                 if e.kind() == std::io::ErrorKind::NotFound && attempt + 1 < MAX_CARGO_RETRIES =>
@@ -223,37 +240,18 @@ fn run_jq_interleaved(args: &[&str], input: Option<&str>) -> Result<(String, i32
             }
             Err(e) => return Err(e.into()),
         };
-        // #2016: write, but don't propagate a failure yet -- same shape as
-        // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
-        // `child.wait()` below, would drop `child` without reaping it on a
-        // write failure (e.g. the child exits before ever reading stdin),
-        // leaking a zombie for the rest of this test binary's run.
-        let write_result: std::io::Result<()> = if let Some(mut stdin) = child.stdin.take() {
-            if let Some(input) = input {
-                stdin.write_all(input.as_bytes())
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
-        };
-        // Prefer the write error's own diagnostic over `wait`'s, on the
-        // rare double failure where the child is also reaped or killed by
-        // something else between the write failing and this wait running
-        // (matching `spawn_with_signal_retry`'s own #1891-review priority).
-        let status = match child.wait() {
-            Ok(status) => status,
-            Err(wait_err) => return Err(write_result.err().unwrap_or(wait_err).into()),
-        };
-        write_result?;
+        // #2016 (code review): `write_stdin_then_wait` -- can't use
+        // `spawn_with_signal_retry`'s own whole spawn+retry wrapper here
+        // (it hardcodes piped stdout/stderr, which would break this
+        // function's own same-file interleaving, #1653), but shares its
+        // write/wait/reap sequencing rather than re-deriving a second copy.
+        let output = write_stdin_then_wait(child, input.map(str::as_bytes))?;
         let combined = std::fs::read_to_string(&path)?;
-        if let Some(code) = status.code() {
-            let _ = std::fs::remove_dir_all(&dir);
+        if let Some(code) = output.status.code() {
             return Ok((combined, code));
         }
         if attempt + 1 >= MAX_CARGO_RETRIES {
-            let _ = std::fs::remove_dir_all(&dir);
-            return Err(signal_death_error(status, &combined));
+            return Err(signal_death_error(output.status, &combined));
         }
         std::thread::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1)));
     }

--- a/tests/jq_golden_tests.rs
+++ b/tests/jq_golden_tests.rs
@@ -50,9 +50,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
+
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::spawn_with_signal_retry;
 
 const GOLDEN_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/jq-golden");
 const KNOWN_FAILURES: &str = include_str!("data/jq-golden-known-failures.txt");
@@ -155,42 +158,26 @@ fn known_failures() -> BTreeMap<String, String> {
 /// Run `succinctly jq <args> <filter>` with the case input on stdin and demand
 /// stdout byte-equal to the golden, plus jq's exit code — 0, or the recorded
 /// failing code and stderr for a case that jq fails.
+///
+/// #2016 (code review): routed through `spawn_with_signal_retry` rather
+/// than a hand-rolled spawn/write/wait -- besides closing the #1891
+/// zombie-leak shape, this is the one call site iterating potentially
+/// thousands of fixture cases, so it's also the highest-value place to
+/// pick up the ENOENT/signal-death retry that function provides (an OOM
+/// kill, another session's `pkill`, or `cargo-guard.sh`'s stall guard
+/// catching this specific child was previously a hard failure of the whole
+/// run instead of a retried attempt). `anyhow::Error` bridges to this
+/// function's own `Result<(), String>` via `.to_string()`.
 fn run_case(case: &Case) -> Result<(), String> {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("jq")
-        .args(&case.args)
-        .arg(&case.filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("spawn succinctly: {e}"))?;
-    // #2016: write, but don't propagate a failure yet -- matching
-    // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
-    // `wait_with_output()` below, would drop `child` without reaping it on
-    // a write failure (e.g. the child exits before ever reading stdin),
-    // leaking a zombie for the rest of this test binary's run -- driven by
-    // potentially thousands of fixture cases here, so a regression that
-    // hits this path could leak many at once.
-    let write_result = child
-        .stdin
-        .take()
-        .expect("stdin piped")
-        .write_all(case.input.as_bytes())
-        .map_err(|e| format!("write stdin: {e}"));
-    // Prefer the write error's own diagnostic over `wait_with_output`'s, on
-    // the rare double failure where the child is also reaped or killed by
-    // something else between the write failing and this wait running
-    // (matching `spawn_with_signal_retry`'s own #1891-review priority).
-    let output = match child.wait_with_output() {
-        Ok(output) => output,
-        Err(wait_err) => {
-            return Err(write_result
-                .err()
-                .unwrap_or_else(|| format!("wait: {wait_err}")))
-        }
-    };
-    write_result?;
+    let (output, _code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").args(&case.args).arg(&case.filter);
+            command
+        },
+        Some(case.input.as_bytes()),
+    )
+    .map_err(|e| e.to_string())?;
 
     match case.expected_status {
         None => {

--- a/tests/jq_golden_tests.rs
+++ b/tests/jq_golden_tests.rs
@@ -165,13 +165,32 @@ fn run_case(case: &Case) -> Result<(), String> {
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("spawn succinctly: {e}"))?;
-    child
+    // #2016: write, but don't propagate a failure yet -- matching
+    // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
+    // `wait_with_output()` below, would drop `child` without reaping it on
+    // a write failure (e.g. the child exits before ever reading stdin),
+    // leaking a zombie for the rest of this test binary's run -- driven by
+    // potentially thousands of fixture cases here, so a regression that
+    // hits this path could leak many at once.
+    let write_result = child
         .stdin
         .take()
         .expect("stdin piped")
         .write_all(case.input.as_bytes())
-        .map_err(|e| format!("write stdin: {e}"))?;
-    let output = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
+        .map_err(|e| format!("write stdin: {e}"));
+    // Prefer the write error's own diagnostic over `wait_with_output`'s, on
+    // the rare double failure where the child is also reaped or killed by
+    // something else between the write failing and this wait running
+    // (matching `spawn_with_signal_retry`'s own #1891-review priority).
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(wait_err) => {
+            return Err(write_result
+                .err()
+                .unwrap_or_else(|| format!("wait: {wait_err}")))
+        }
+    };
+    write_result?;
 
     match case.expected_status {
         None => {

--- a/tests/text_cli_tests.rs
+++ b/tests/text_cli_tests.rs
@@ -17,7 +17,7 @@ use tempfile::{NamedTempFile, TempDir};
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
+use cargo_run_exit::{exit_code_or_signal_death, spawn_with_signal_retry};
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -28,21 +28,21 @@ fn succinctly_bin() -> &'static str {
 }
 
 /// Run `text validate utf8` with raw bytes piped on stdin.
+///
+/// #2016: routed through `spawn_with_signal_retry` (previously hand-rolled
+/// `spawn()` + `write_all(...)?` + `wait_with_output()`) -- a `write_all`
+/// failure used to return via `?` before the child was ever waited on,
+/// leaking a zombie for the rest of this test binary's run (#1891's own
+/// fix, for a different call site with the identical shape).
 fn run_validate_stdin(input: &[u8], extra_args: &[&str]) -> Result<(Vec<u8>, String, i32)> {
-    let mut cmd = Command::new(succinctly_bin())
-        .args(["text", "validate", "utf8"])
-        .args(extra_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input)?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["text", "validate", "utf8"]).args(extra_args);
+            command
+        },
+        Some(input),
+    )?;
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     Ok((output.stdout, stderr, exit_code))
 }

--- a/tests/yaml_validate_tests.rs
+++ b/tests/yaml_validate_tests.rs
@@ -11,7 +11,7 @@ use tempfile::NamedTempFile;
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
+use cargo_run_exit::{exit_code_or_signal_death, spawn_with_signal_retry};
 
 /// Path to the pre-built `succinctly` CLI binary. Cargo builds the `succinctly`
 /// bin target (gated `required-features = ["cli"]`) before this test binary
@@ -21,19 +21,20 @@ fn succinctly_bin() -> &'static str {
     env!("CARGO_BIN_EXE_succinctly")
 }
 
+/// #2016: routed through `spawn_with_signal_retry` (previously hand-rolled
+/// `spawn()` + `write_all(...)?` + `wait_with_output()`) -- a `write_all`
+/// failure used to return via `?` before the child was ever waited on,
+/// leaking a zombie for the rest of this test binary's run (#1891's own
+/// fix, for a different call site with the identical shape).
 fn run_validate_stdin(input: &str, extra_args: &[&str]) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(succinctly_bin())
-        .args(["yaml", "validate"])
-        .args(extra_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-    let output = cmd.wait_with_output()?;
-    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["yaml", "validate"]).args(extra_args);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, code))
@@ -228,18 +229,16 @@ fn rejects_out_dented_sequence_continuation() -> Result<()> {
 // `syq --validate` (the yq runner's opt-in validation flag).
 // ============================================================================
 
+/// See `run_validate_stdin`'s own #2016 doc comment above.
 fn run_yq_validate_stdin(input: &str, filter: &str) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(succinctly_bin())
-        .args(["yq", "--validate", filter])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-    let output = cmd.wait_with_output()?;
-    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["yq", "--validate", filter]);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     Ok((stdout, stderr, code))
@@ -269,22 +268,17 @@ fn yq_validate_rejects_invalid_yaml_before_output() -> Result<()> {
 fn yq_without_validate_accepts_the_same_invalid_yaml() -> Result<()> {
     // The default loader is non-validating: the same input succeeds without
     // `--validate`, proving the flag is opt-in.
-    let (_, _, code) = {
-        let mut cmd = Command::new(succinctly_bin())
-            .args(["yq", "."])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-        if let Some(mut stdin) = cmd.stdin.take() {
-            stdin.write_all(b"a: b: c: d\n")?;
-        }
-        let output = cmd.wait_with_output()?;
-        let code = exit_code_or_signal_death(output.status, &output.stderr)?;
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
-        (stdout, stderr, code)
-    };
+    //
+    // #2016: routed through `spawn_with_signal_retry` -- see
+    // `run_validate_stdin`'s own doc comment above for why.
+    let (_output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["yq", "."]);
+            command
+        },
+        Some(b"a: b: c: d\n"),
+    )?;
     assert_eq!(code, 0);
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18,114 +18,93 @@ use tempfile::{NamedTempFile, TempDir};
 
 #[path = "common/cargo_run_exit.rs"]
 mod cargo_run_exit;
-use cargo_run_exit::exit_code_or_signal_death;
+use cargo_run_exit::{exit_code_or_signal_death, spawn_with_signal_retry};
 
 /// Helper to run yq command with input from stdin
+///
+/// #2016: routed through `spawn_with_signal_retry` (previously hand-rolled
+/// `spawn()` + `write_all(...)?` + `wait_with_output()`) -- a `write_all`
+/// failure used to return via `?` before the child was ever waited on,
+/// leaking a zombie for the rest of this test binary's run (#1891's own
+/// fix, for a different call site with the identical shape). Also picks up
+/// the ENOENT/signal-death retry `spawn_with_signal_retry` provides, which
+/// this hand-rolled version never had.
 fn run_yq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("yq")
-        .args(extra_args)
-        .arg(filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("yq").args(extra_args).arg(filter);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
-
     Ok((stdout, exit_code))
 }
 
-/// Helper to run yq command with input from stdin, capturing stderr too
+/// Helper to run yq command with input from stdin, capturing stderr too.
+/// See `run_yq_stdin`'s own #2016 doc comment above.
 fn run_yq_stdin_with_stderr(
     filter: &str,
     input: &str,
     extra_args: &[&str],
 ) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("yq")
-        .args(extra_args)
-        .arg(filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("yq").args(extra_args).arg(filter);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-
     Ok((stdout, stderr, exit_code))
 }
 
 /// `run_yq_stdin_with_stderr`'s raw-bytes counterpart, for input that isn't
 /// valid UTF-8 -- deliberately not `unsafe { str::from_utf8_unchecked(...) }`
 /// over an invalid byte sequence, which is real UB even when the only thing
-/// done with the resulting `&str` is write its bytes back out (#1187).
+/// done with the resulting `&str` is write its bytes back out (#1187). See
+/// `run_yq_stdin`'s own #2016 doc comment above.
 fn run_yq_stdin_bytes_with_stderr(
     filter: &str,
     input: &[u8],
     extra_args: &[&str],
 ) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("yq")
-        .args(extra_args)
-        .arg(filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input)?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("yq").args(extra_args).arg(filter);
+            command
+        },
+        Some(input),
+    )?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-
     Ok((stdout, stderr, exit_code))
 }
 
 /// jq-mode counterpart of `run_yq_stdin_with_stderr` -- this file otherwise
 /// hand-rolls `Command::new(...).arg("jq")` boilerplate per jq-mode test
 /// (#1146: introduced to avoid compounding that duplication for its own
-/// new jq-mode tests, not a full sweep of the pre-existing copies).
+/// new jq-mode tests, not a full sweep of the pre-existing copies). See
+/// `run_yq_stdin`'s own #2016 doc comment above.
 fn run_jq_stdin_with_stderr(
     filter: &str,
     input: &str,
     extra_args: &[&str],
 ) -> Result<(String, String, i32)> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("jq")
-        .args(extra_args)
-        .arg(filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    if let Some(mut stdin) = cmd.stdin.take() {
-        stdin.write_all(input.as_bytes())?;
-    }
-
-    let output = cmd.wait_with_output()?;
-    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").args(extra_args).arg(filter);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
-
     Ok((stdout, stderr, exit_code))
 }
 

--- a/tests/yq_golden_tests.rs
+++ b/tests/yq_golden_tests.rs
@@ -156,13 +156,32 @@ fn run_case_with_input(case: &Case, input: &str) -> Result<(), String> {
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("spawn succinctly: {e}"))?;
-    child
+    // #2016: write, but don't propagate a failure yet -- matching
+    // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
+    // `wait_with_output()` below, would drop `child` without reaping it on
+    // a write failure (e.g. the child exits before ever reading stdin),
+    // leaking a zombie for the rest of this test binary's run -- driven by
+    // potentially thousands of fixture cases here, so a regression that
+    // hits this path could leak many at once.
+    let write_result = child
         .stdin
         .take()
         .expect("stdin piped")
         .write_all(input.as_bytes())
-        .map_err(|e| format!("write stdin: {e}"))?;
-    let output = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
+        .map_err(|e| format!("write stdin: {e}"));
+    // Prefer the write error's own diagnostic over `wait_with_output`'s, on
+    // the rare double failure where the child is also reaped or killed by
+    // something else between the write failing and this wait running
+    // (matching `spawn_with_signal_retry`'s own #1891-review priority).
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(wait_err) => {
+            return Err(write_result
+                .err()
+                .unwrap_or_else(|| format!("wait: {wait_err}")))
+        }
+    };
+    write_result?;
 
     match case.expected_status {
         None => {

--- a/tests/yq_golden_tests.rs
+++ b/tests/yq_golden_tests.rs
@@ -36,9 +36,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
+
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::spawn_with_signal_retry;
 
 const GOLDEN_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data/yq-golden");
 const KNOWN_FAILURES: &str = include_str!("data/yq-golden-known-failures.txt");
@@ -146,42 +149,20 @@ fn run_case(case: &Case) -> Result<(), String> {
 }
 
 /// As [`run_case`], but with the document's line breaks possibly rewritten.
+///
+/// #2016 (code review): routed through `spawn_with_signal_retry` -- see
+/// `jq_golden_tests.rs::run_case`'s own #2016 doc comment for why (this is
+/// its yq-mode sibling, iterating the same order of fixture-case volume).
 fn run_case_with_input(case: &Case, input: &str) -> Result<(), String> {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("yq")
-        .args(&case.args)
-        .arg(&case.filter)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("spawn succinctly: {e}"))?;
-    // #2016: write, but don't propagate a failure yet -- matching
-    // `spawn_with_signal_retry`'s own #1891 fix. A `?` here, before
-    // `wait_with_output()` below, would drop `child` without reaping it on
-    // a write failure (e.g. the child exits before ever reading stdin),
-    // leaking a zombie for the rest of this test binary's run -- driven by
-    // potentially thousands of fixture cases here, so a regression that
-    // hits this path could leak many at once.
-    let write_result = child
-        .stdin
-        .take()
-        .expect("stdin piped")
-        .write_all(input.as_bytes())
-        .map_err(|e| format!("write stdin: {e}"));
-    // Prefer the write error's own diagnostic over `wait_with_output`'s, on
-    // the rare double failure where the child is also reaped or killed by
-    // something else between the write failing and this wait running
-    // (matching `spawn_with_signal_retry`'s own #1891-review priority).
-    let output = match child.wait_with_output() {
-        Ok(output) => output,
-        Err(wait_err) => {
-            return Err(write_result
-                .err()
-                .unwrap_or_else(|| format!("wait: {wait_err}")))
-        }
-    };
-    write_result?;
+    let (output, _code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("yq").args(&case.args).arg(&case.filter);
+            command
+        },
+        Some(input.as_bytes()),
+    )
+    .map_err(|e| e.to_string())?;
 
     match case.expected_status {
         None => {

--- a/tests/yq_path_consistency_tests.rs
+++ b/tests/yq_path_consistency_tests.rs
@@ -80,15 +80,29 @@ fn canonicalize(value: Value) -> Value {
 /// priority on a double failure, neither of which this hand-rolled version
 /// had.
 fn run_path(args: &[&str], yaml: &str) -> PathResult {
-    let (output, _code) = spawn_with_signal_retry(
+    // #2016 (code review): the pre-conversion `wait_with_output().expect(
+    // "wait")` never actually panicked on a signal-killed child --
+    // `wait_with_output` succeeds regardless of *how* the child exited, so
+    // a signal death fell through to the `!status.success()` check below
+    // and was gracefully classified as `PathResult::Errored`, the same as
+    // any other non-zero exit. `spawn_with_signal_retry` retries a signal
+    // death transparently, but if it's still dead after `MAX_CARGO_RETRIES`
+    // attempts it returns a hard `Err` -- an `.expect(...)` on that would
+    // panic and abort this whole ~800-call corpus loop over one flaky case
+    // instead of recording it as one more disagreement and moving on, the
+    // exact resilience `yq_paths_agree_on_corpus`'s own per-case `BTreeMap`
+    // collection is built for. Route it into the same `Errored` outcome
+    // instead, matching the original behavior.
+    let Ok((output, _code)) = spawn_with_signal_retry(
         || {
             let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
             command.arg("yq").args(args).arg(".");
             command
         },
         Some(yaml.as_bytes()),
-    )
-    .expect("spawn succinctly");
+    ) else {
+        return PathResult::Errored;
+    };
 
     if !output.status.success() {
         return PathResult::Errored;

--- a/tests/yq_path_consistency_tests.rs
+++ b/tests/yq_path_consistency_tests.rs
@@ -32,10 +32,13 @@
 #![cfg(feature = "cli")]
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use serde_json::Value;
+
+#[path = "common/cargo_run_exit.rs"]
+mod cargo_run_exit;
+use cargo_run_exit::spawn_with_signal_retry;
 
 const CORPUS: &str = include_str!("data/yaml-test-suite-2022-01-17.json");
 const KNOWN_FAILURES: &str = include_str!("data/yq-path-consistency-known-failures.txt");
@@ -66,28 +69,26 @@ fn canonicalize(value: Value) -> Value {
 }
 
 /// Run `succinctly yq <args> '.'` with `yaml` on stdin and classify the result.
+/// #2016 (code review): routed through `spawn_with_signal_retry` (was a
+/// hand-rolled `spawn()` + `write_all(...).expect(...)` +
+/// `wait_with_output()`) -- an `.expect(...)` on the write, before the
+/// wait, unwinds past it the same way a `?` early-return would, dropping
+/// `child` without reaping it on a write failure and leaking a zombie for
+/// the rest of this test binary's run (matching `spawn_with_signal_retry`'s
+/// own #1891 fix). Also picks up the ENOENT/signal-death retry that
+/// function provides, and its write-error-vs-wait-error diagnostic
+/// priority on a double failure, neither of which this hand-rolled version
+/// had.
 fn run_path(args: &[&str], yaml: &str) -> PathResult {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_succinctly"))
-        .arg("yq")
-        .args(args)
-        .arg(".")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn succinctly");
-    // #2016: write, but don't panic yet -- an `.expect(...)` here, before
-    // `wait_with_output()` below, unwinds past the wait the same way a `?`
-    // early-return would, dropping `child` without reaping it on a write
-    // failure and leaking a zombie for the rest of this test binary's run
-    // (matching `spawn_with_signal_retry`'s own #1891 fix).
-    let write_result = child
-        .stdin
-        .take()
-        .expect("stdin piped")
-        .write_all(yaml.as_bytes());
-    let output = child.wait_with_output().expect("wait");
-    write_result.expect("write stdin");
+    let (output, _code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("yq").args(args).arg(".");
+            command
+        },
+        Some(yaml.as_bytes()),
+    )
+    .expect("spawn succinctly");
 
     if !output.status.success() {
         return PathResult::Errored;

--- a/tests/yq_path_consistency_tests.rs
+++ b/tests/yq_path_consistency_tests.rs
@@ -76,13 +76,18 @@ fn run_path(args: &[&str], yaml: &str) -> PathResult {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn succinctly");
-    child
+    // #2016: write, but don't panic yet -- an `.expect(...)` here, before
+    // `wait_with_output()` below, unwinds past the wait the same way a `?`
+    // early-return would, dropping `child` without reaping it on a write
+    // failure and leaking a zombie for the rest of this test binary's run
+    // (matching `spawn_with_signal_retry`'s own #1891 fix).
+    let write_result = child
         .stdin
         .take()
         .expect("stdin piped")
-        .write_all(yaml.as_bytes())
-        .expect("write stdin");
+        .write_all(yaml.as_bytes());
     let output = child.wait_with_output().expect("wait");
+    write_result.expect("write stdin");
 
     if !output.status.success() {
         return PathResult::Errored;


### PR DESCRIPTION
## Summary

#1891 fixed a `write_all(...)?` returning early before `wait()`, leaking a
zombie child, in `spawn_with_signal_retry` alone. The identical shape
existed independently at 11 more call sites across 7 test files, none of
which routed through that function — plus, found during two rounds of
code review on this same PR, 3 more sites that could be migrated fully
(gaining the ENOENT/signal-death retry they'd never had), one independent
and more severe instance (`test_default_identity_filter`, which never
called `wait()` at all — an unconditional leak, not merely on a write
failure), and a real behavior regression the review itself introduced and
then caught (a panic where the original code degraded gracefully).

- `jq_cli_tests.rs`'s `run_jq_interleaved` — reintroduced by copy-paste
  after `spawn_with_signal_retry` already existed; can't reuse it directly
  (needs file-based stdout/stderr interleaving for #1653), so shares the
  new `write_stdin_then_wait` helper extracted from that function instead
  of re-deriving the sequencing a fourth time. Its scratch directory now
  uses `tempfile::TempDir` rather than a hand-rolled unique path plus a
  bespoke `Drop` guard.
- `yq_cli_tests.rs`'s 4 near-identical spawn helpers, `text_cli_tests.rs`
  and `yaml_validate_tests.rs`'s 4 sites, `jq_golden_tests.rs`'s
  `run_case`, `yq_golden_tests.rs`'s `run_case_with_input`, and
  `yq_path_consistency_tests.rs`'s `run_path` — all migrated to
  `spawn_with_signal_retry` directly.
- `test_default_identity_filter` — fixed the unconditional leak (`Stdio::
  null()` for stdin instead of piped-then-never-written, plus an actual
  `wait_with_output()` call).

## Test plan

- [x] Full test suite green throughout, including the golden conformance
      suites (thousands of fixture cases) and `cargo_run_exit`'s own
      #1891 regression test
- [x] Live-verified `test_default_identity_filter` completes promptly with
      no leftover zombie process (`ps` check)
- [x] `cargo test` / `cargo test --features cli` across all affected
      binaries
- [x] `cargo check --no-default-features` (no_std)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` (CI's simd-feature leg)
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] `cargo fmt --all -- --check`
- [x] Two rounds of `/code-review` (10 parallel finders each), all
      actionable findings fixed, including a panic-regression the first
      round's own fix introduced and the second round caught

Filed #2054 for ~17 more instances of the same pattern found during
review, all embedded inline in individual `#[test]` bodies in
`yq_cli_tests.rs` rather than routed through a shared helper — out of
scope for this PR per this issue's own "not necessarily exhaustive"
framing.

Fixes #2016