### PR TITLE
fix(jq): make repeat(f) demand-driven so limit/first stop it at the source

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1935,7 +1935,7 @@ precedent for a gap that doesn't fit the letter of rule 4 but is kept rather
 than silently left unrecorded. See
 [#1561](https://github.com/rust-works/succinctly/issues/1561).
 
-### `repeat(f)` silently caps at 1000 rounds, in both value and path mode
+### `repeat(f)` under `limit`/`first` (value mode): fixed (#2014); the eager fallback and path mode still cap, in two different ways
 
 `repeat(f)` (`def repeat(f): f, repeat(f);`) has no base case at all: an `f`
 that never errors and never produces a value on some round recurses forever.
@@ -1947,38 +1947,100 @@ $ timeout 3 jq -cn 'limit(3; repeat(empty))'; echo "exit: $?"
 exit: 124                                 # real jq hangs -- 124 is `timeout`'s own code
 ```
 
-`eval_repeat` (value mode, `src/jq/eval.rs`) already backstops this with a
-`MAX_ITERATIONS = 1000` round cap, so `limit(3; repeat(empty))` returns no
-output and exits 0 in succinctly instead of hanging the process --
-unquestionably permitted under ADR-0018 rule 4c (matching a reference's hang
-is not something this project attempts). [#1906](https://github.com/rust-works/succinctly/issues/1906)
-added the identical cap to `resolve_repeat_bounded` (path mode, the
-`path(repeat(f))`/`path(limit(n; repeat(f)))` route) for the same reason and
-to keep the two modes consistent with each other.
-
-The cap has a real side effect neither call site's own doc comment
-mentioned before now: it also silently truncates a *legitimate*, `n` greater
-than 1000 request, with no error and no warning, where jq itself handles a
-large `n` trivially:
+Before [#2014](https://github.com/rust-works/succinctly/issues/2014), value
+mode's `eval_repeat` ran `repeat`'s body *eagerly*, capped at a flat
+`MAX_ITERATIONS = 1000` rounds regardless of a wrapping `limit`/`first`'s own
+requested count, and silently returned whatever it had accumulated once that
+cap was hit -- so `limit(1500; repeat(1))` returned only 1000 values, exit 0,
+no error, where real jq returns all 1500. #2014 gave `eval_each`'s lazy
+dispatch (in both evaluators -- see the module-level note on the two
+evaluators elsewhere in this repo) a native `Expr::Repeat` arm
+(`each_repeat`/`each_repeat_generic`) that pulls one round at a time and
+stops exactly when the wrapping consumer's own `Demand::Stop` does, so a
+`limit`/`first`-bounded `repeat` is now uncapped in round count and matches
+jq exactly, confirmed at every scale the original issue's own table named:
 
 ```console
-$ jq -cn '[limit(1500; repeat(1))] | length'
-1500
 $ succinctly jq -cn '[limit(1500; repeat(1))] | length'
+1500
+$ succinctly jq -cn '[limit(80000; repeat(1))] | length'
+80000
+```
+
+Two narrower caps remain by necessity, both accepted under ADR-0018 rule 4c
+(preventing a hang, not matching one) rather than removed:
+
+- **A per-*round* width budget** (`REDUCE_FOREACH_MAX_STEPS = 10000`, reset
+  at the start of every round): bounds how many values a *single* round may
+  fork into at once -- a memory-safety net for a wide `f` like `.[]`, since
+  a round is materialized into a `Vec` before being handed to the sink. Real
+  jq has no such cap (`limit(50000; repeat(.[]))` over a 20001-element array
+  succeeds with all 50000 in jq 1.7.1); succinctly raises
+  `"repeat: maximum iterations exceeded"` once a single round's own output
+  passes 10000. This is scoped to one round, not the whole stream, so it
+  does not reintroduce the round-count cap #2014 removed -- a `repeat`
+  producing a handful of values per round runs indefinitely regardless of
+  total round count.
+- **A round-*emptiness* cap** (`MAX_EMPTY_REPEAT_ROUNDS = 1000` *consecutive*
+  empty rounds, reset by any productive round): `repeat`'s `expr` reruns
+  every round, so a round producing zero outputs will, if `expr` is pure
+  over the repeated value, produce zero outputs forever -- no wrapping
+  `Demand::Stop` can ever fire to stop it, since `sink` is never called on
+  an empty round. Exhausting this silently ends the stream (matching
+  `repeat(empty)`'s hang-instead-of-diverging precedent above) rather than
+  raising. **This cap is inherently approximate for an *impure* `f`** (one
+  that reads `input`/`inputs`, so a later round can differ even though the
+  repeated value itself does not): a body that happens to need 1000 or more
+  consecutive empty rounds before its first real output is silently cut
+  short with no error, exactly like the width budget above but with no
+  diagnostic at all. Any finite bound has this same edge at whatever number
+  it picks -- raising the constant only moves the cliff, per this section's
+  own prior finding about the old round-count cap -- so it is recorded here
+  as an accepted, structural limitation rather than something a bigger
+  number would fix.
+
+The **eager fallback** -- `repeat(f)` reached through any consumer that
+doesn't dispatch through `eval_each`'s lazy path (bare `[repeat(f)]`,
+`reduce repeat(f) as $x (...)`, `foreach repeat(f) as $x (...)`,
+`last(repeat(f))`) -- still runs `eval_repeat`'s original eager, capped loop,
+since none of those consumers can express a demand to stop early. #2014 also
+changed *its* cap-exhaustion behavior, from the same silent truncation
+described above to raising `"repeat: maximum iterations exceeded"`:
+
+```console
+$ succinctly jq -cn '[repeat(1)] | length'
+jq: error (at <unknown>): repeat: maximum iterations exceeded
+$ succinctly jq -cn 'last(repeat(1))'
+jq: error (at <unknown>): repeat: maximum iterations exceeded
+```
+
+Real jq hangs on all four of these shapes instead (there is no wrapping
+consumer to stop it early, and no #2014 fix changes that). Raising is a
+*third* outcome -- neither the old silent truncation nor jq's hang -- chosen
+deliberately: ADR-0018 rule 4c permits not matching a hang, and a loud,
+immediate error is strictly preferable to either alternative for these four
+shapes, which have no legitimate large-`n` use case in the first place
+(nothing here can ever stop the eager loop early, unlike the `limit`/`first`
+case above).
+
+**Path mode is unchanged and still has the original bug.**
+[#2014](https://github.com/rust-works/succinctly/issues/2014) only touched
+value mode's two evaluators; `resolve_repeat_bounded` (path mode, the
+`path(repeat(f))`/`path(limit(n; repeat(f)))` route added by
+[#1906](https://github.com/rust-works/succinctly/issues/1906)) still runs
+its own flat `MAX_ITERATIONS = 1000` round cap regardless of the wrapping
+consumer's requested count, and still silently truncates on exhaustion:
+
+```console
+$ succinctly jq -cn 'path(limit(1500; repeat(.))) | length' # counts output lines
 1000
 ```
 
-This half of the behavior doesn't fit any of ADR-0018's four conditions on
-its own (the output is readable, nothing is corrupted, and unlike the
-`repeat(empty)` case this input does not threaten to hang the process) --
-but it is the unavoidable other side of the same guard that rule 4c does
-cover, not a second, separable design choice: a per-round cap cannot
-distinguish "this round produced nothing because `f` is degenerate" from
-"this round produced nothing yet because we haven't gotten to round 1001",
-so raising the cap only moves where a sufficiently large `n` starts silently
-truncating rather than removing the tradeoff. Recorded here rather than left
-implicit in a doc comment that named only the case it was actually written
-to prevent.
+This is the same bug value mode had before #2014, now isolated to path mode
+alone -- left open rather than fixed here since #2014's own scope and
+verification are both about value mode; a follow-up applying the identical
+demand-driven treatment to `resolve_repeat_bounded` would close this the
+same way.
 
 ### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3382,6 +3382,20 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             each_range::<W, S>(from, to.as_deref(), step.as_deref(), value, optional, sink)
         }
 
+        // #2014: `repeat(f)` is infinite by design and meant to be bounded
+        // by a wrapping `limit`/`first` -- but the `_` fallback below
+        // evaluates it *eagerly* first (via `eval_single` -> `eval_repeat`),
+        // whose own `MAX_ITERATIONS` round cap exists only as a hang
+        // backstop for when nothing demand-drives it. Reached through
+        // `limit`, that cap silently truncated `limit(80000; repeat(f))` to
+        // 1000 values before this wrapping `limit` ever got a chance to
+        // stop the source itself. `each_repeat` below pulls one round at a
+        // time and stops as soon as `sink` does, so a wrapping `limit`
+        // reaches its own requested count with no artificial ceiling,
+        // matching jq exactly; a `repeat(f)` with no such wrapper is just
+        // as genuinely unbounded here as it is in real jq.
+        Expr::Repeat(expr) => each_repeat::<W, S>(expr, value, optional, sink),
+
         _ => drain_result(eval_single::<W, S>(expr, value, optional), sink),
     }
 }
@@ -25554,12 +25568,12 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// pair per recursion-tree node there), so the shared numeric value
 /// today is coincidence, not a relationship a shared symbol should
 /// encode.
-const REDUCE_FOREACH_MAX_STEPS: usize = 10000;
+pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 10000;
 
 /// Check-and-charge one unit against a shared step budget (#695), the
 /// same check `until_step`/`while_step` each inline for their own cap.
 /// `what` names the construct in the resulting error message.
-fn charge_budget(budget: &mut usize, what: &str) -> Option<Control> {
+pub(crate) fn charge_budget(budget: &mut usize, what: &str) -> Option<Control> {
     if *budget == 0 {
         return Some(Control::Error(EvalError::new(format!(
             "{what}: maximum iterations exceeded"
@@ -27043,6 +27057,92 @@ fn while_step<S: EvalSemantics>(
     }
 }
 
+/// Demand-driven twin of [`eval_repeat`] (#2014): pulls one round of
+/// `expr`'s outputs at a time via [`eval_owned_expr_fork`] (matching
+/// `eval_repeat`'s own per-round semantics exactly, including its
+/// multi-output-per-round forking -- see that function's doc comment for
+/// the live-verified `[limit(6; repeat((.+1, .+100)))]` example) and stops
+/// pulling further rounds as soon as `sink` does. A wrapping `limit`/
+/// `first` (routed here through [`eval_each`]'s own dispatch) supplies its
+/// own stop via `Demand::Stop` once satisfied, so `limit(80000; repeat(1))`
+/// genuinely runs all 80000 rounds, matching jq (confirmed live against jq
+/// 1.7.1, as does the equally narrow `limit(80000; repeat(.))`) -- but this
+/// still needs two safety nets, neither of which may cap the *round count*
+/// itself or that guarantee breaks:
+///
+/// - **Per-round `budget`** (`REDUCE_FOREACH_MAX_STEPS`, reset at the start
+///   of *every* round and charged one output at a time before a value
+///   reaches `sink`): bounds how many values a single round may fork into
+///   at once, independent of how many rounds run in total. Without it,
+///   `limit(50000; repeat(.[]))` over a 20001-element array would happily
+///   produce far more than the 10000 values value-mode and path-mode are
+///   supposed to agree on capping at
+///   (`test_path_repeat_width_budget_matches_value_mode_1933`) -- a
+///   demand-driven `Demand::Stop` from `limit` only ever fires *after*
+///   `sink` sees a value, so it cannot bound a single wide round on its own.
+///   This is a succinctly-only memory-safety net, not jq fidelity: real jq
+///   has no such cap either (confirmed live: `limit(50000; repeat(.[]))` on
+///   the same 20001-element array succeeds with all 50000 in jq 1.7.1) --
+///   `eval_owned_expr_fork` materializes a whole round into a `Vec` at once,
+///   so an unbounded single round could blow up memory on a wide-enough
+///   `expr`. **Charging cumulatively across rounds instead of resetting per
+///   round was tried and is wrong**: it silently reintroduces the exact
+///   `limit(80000; repeat(1))`-style truncation #2014 exists to fix, just
+///   as an error instead of a silent short-count -- caught by live-testing
+///   the `[limit(80000; repeat(1))]`/`repeat(.)` cases specifically, which
+///   no pinned test in this file happens to cover.
+/// - **Round-emptiness cap** (`MAX_EMPTY_REPEAT_ROUNDS`): `repeat`'s `expr`
+///   reruns against the *same* unchanging input every round (that is
+///   `repeat`'s whole definition), so a round producing zero outputs will
+///   produce zero outputs forever -- `sink` never receives anything to
+///   signal `Demand::Stop` from, no matter how small a wrapping `limit`'s
+///   own `n` is, so the per-round budget above (never charged, since
+///   nothing is ever pushed) cannot bound it either. Unlike the per-round
+///   budget, exhausting this one does not raise: it silently ends the
+///   stream (`Flow::Exhausted`), matching
+///   `test_repeat_empty_expr_yields_nothing_instead_of_looping_forever_on_nulls`'s
+///   own pinned, deliberately-jq-oracle-free convention for this shape
+///   (real jq has no answer to compare against -- a bare `repeat(empty)`
+///   spins forever there too).
+pub(crate) const MAX_EMPTY_REPEAT_ROUNDS: usize = 1000;
+
+fn each_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    value: StandardJson<'a, W>,
+    optional: bool,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let owned = match to_owned_checked(&value) {
+        Ok(v) => v,
+        Err(e) if suppresses(&e, optional) => return Flow::Exhausted,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
+    let mut empty_rounds = 0usize;
+    loop {
+        let (vals, control) = eval_owned_expr_fork::<S>(expr, &owned, optional);
+        if vals.is_empty() && control.is_none() {
+            empty_rounds += 1;
+            if empty_rounds >= MAX_EMPTY_REPEAT_ROUNDS {
+                return Flow::Exhausted;
+            }
+            continue;
+        }
+        empty_rounds = 0;
+        let mut budget = REDUCE_FOREACH_MAX_STEPS;
+        for val in vals {
+            if let Some(control) = charge_budget(&mut budget, "repeat") {
+                return Flow::Escaped(control);
+            }
+            if sink(Item::Owned(val)) == Demand::Stop {
+                return Flow::Stopped { pending: None };
+            }
+        }
+        if let Some(control) = control {
+            return Flow::Escaped(control);
+        }
+    }
+}
+
 /// Evaluate `repeat(expr)` - repeatedly evaluate expr with the original input.
 /// In jq, `repeat(expr)` evaluates `expr` with the original input each time,
 /// producing an infinite stream of outputs. This is different from feeding
@@ -27065,6 +27165,18 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // reach: an `expr` that produces zero outputs every round (e.g.
     // `repeat(empty)`) never charges `budget` below, so it would loop
     // forever without this backstop.
+    //
+    // #2014: this loop is only reached when `repeat` sits *outside* any
+    // demand-driven consumer (`eval_each`'s own `Expr::Repeat` arm,
+    // `each_repeat`, handles `limit`/`first`/etc. -- see that function's
+    // own doc comment). A bare `repeat(f)` with no such wrapper is exactly
+    // as unbounded in real jq as it is here (it hangs forever there too),
+    // so this cap existing at all is this eager fallback's own necessary
+    // concession, not a divergence to remove -- but exhausting it used to
+    // fall through to `owned_vec_to_result(outputs)` silently, returning a
+    // truncated-but-successful result with no signal. Now raises the same
+    // way the per-value `budget` two lines below already does, matching
+    // `resolve_repeat_bounded`'s identical guard.
     const MAX_ITERATIONS: usize = 1000;
     // Bounds total output size independent of `expr`'s own fan-out (#855
     // follow-up): the per-round loop below used to push at most one
@@ -27104,7 +27216,8 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    owned_vec_to_result(outputs)
+    let control = Control::Error(EvalError::new("repeat: maximum iterations exceeded"));
+    finish_fork(outputs, Some(control), optional)
 }
 
 /// A numeric argument to `range()`: kept as `i64` when exact so all-integer

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27104,6 +27104,16 @@ fn while_step<S: EvalSemantics>(
 ///   own pinned, deliberately-jq-oracle-free convention for this shape
 ///   (real jq has no answer to compare against -- a bare `repeat(empty)`
 ///   spins forever there too).
+///
+///   **Inherently approximate for an *impure* `expr`** (one reading
+///   `input`/`inputs`, so a later round can genuinely differ even though
+///   the repeated value itself never changes): a body needing 1000+
+///   consecutive empty rounds before its first real output is silently cut
+///   off here with no diagnostic, diverging from jq's own (correct, if
+///   unbounded) answer. Any finite bound has this same edge at whatever
+///   number it picks -- documented as an accepted, structural limitation in
+///   `docs/compliance/jq/limitations.md` rather than something a larger
+///   constant would actually fix.
 pub(crate) const MAX_EMPTY_REPEAT_ROUNDS: usize = 1000;
 
 fn each_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5348,7 +5348,110 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             None => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
         },
 
+        // #2014: `repeat(f)` has no native arm in this evaluator at all --
+        // the `_` fallback below evaluates it *eagerly*, which bridges all
+        // the way to `eval.rs`'s own `eval_repeat`, whose `MAX_ITERATIONS`
+        // round cap exists only as a hang backstop for when nothing
+        // demand-drives it (see that function's own doc comment). Reached
+        // through this fallback, `limit`/`first`/etc. above already stopped
+        // pulling by the time they'd see any of it -- `eval_repeat` ran to
+        // its own 1000-round cap (now raising, not silently truncating)
+        // before this arm's own caller ever got a chance to ask for fewer.
+        // Fixing this needs a *native* arm here, mirroring `eval.rs`'s own
+        // `each_repeat` fix for the identical bug on that evaluator's side
+        // (`Expr::Repeat`'s own arm in `eval_each`) -- one bridging to the
+        // owned-domain `eval_each_owned` per round rather than reproducing
+        // the whole pull loop against `V: DocumentValue` directly.
+        Expr::Repeat(f) => each_repeat_generic::<S, V>(f, value, optional, cursor, sink),
+
         _ => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
+    }
+}
+
+/// Demand-driven `Expr::Repeat` arm for the generic evaluator (#2014) --
+/// the generic-evaluator twin of `eval.rs`'s own `each_repeat`. Decodes
+/// `value` once (checked, matching `eval.rs`'s `eval_repeat`'s identical
+/// up-front decode), then pulls one round of `f`'s outputs at a time via
+/// the already-lazy `eval_each_owned` (the owned-domain twin of `eval_each`
+/// this file already imports for exactly this "loop back into eval.rs's
+/// lazy machinery on an owned snapshot" shape), stopping as soon as the
+/// wrapping `sink` does.
+///
+/// Two independent caps, mirroring `eval.rs`'s own `each_repeat` exactly:
+/// a per-*round* `REDUCE_FOREACH_MAX_STEPS` budget, reset at the start of
+/// every round and charged one output at a time via `charge_budget` --
+/// bounding how many values a single round may fork into at once (a
+/// succinctly-only memory-safety net for a wide `f` like `.[]`, not jq
+/// fidelity -- see `eval.rs`'s `each_repeat` doc comment for the live
+/// oracle checks: real jq has no such cap, and charging this cumulatively
+/// across rounds instead of resetting per round was tried and silently
+/// reintroduces the exact `limit(80000; repeat(1))`-style truncation #2014
+/// exists to fix). This *raises* on exhaustion, matching
+/// `resolve_repeat_bounded`'s path-context sibling so `path(repeat(f))`
+/// and `repeat(f)` agree on the same wide-round wall at the same count
+/// (`test_path_repeat_width_budget_matches_value_mode_1933`). A separate
+/// per-round-count `MAX_EMPTY_REPEAT_ROUNDS` cap counts consecutive rounds
+/// that produce nothing at all (reset by any productive round), which
+/// *silently* returns `Flow::Exhausted` instead -- `repeat`'s `f` reruns
+/// against the same unchanging input every round, so once a round produces
+/// nothing it never will, and no wrapping consumer's `Demand::Stop` can
+/// ever fire to save it (`sink` is never called on a zero-output round).
+/// Raising there instead would contradict
+/// `test_repeat_empty_expr_yields_nothing_instead_of_looping_forever_on_nulls`'s
+/// own pinned convention: a bare `repeat(empty)` has no jq oracle answer
+/// (it hangs forever there too), so succinctly silently yields nothing
+/// rather than erroring.
+fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
+    f: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let owned = match to_owned_with_cursor(&value, cursor) {
+        Ok(v) => v,
+        Err(e) if optional && !e.is_decode_failure() => return Flow::Exhausted,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
+    let mut empty_rounds = 0usize;
+    loop {
+        let mut stopped = false;
+        let mut produced_any = false;
+        let mut budget_control = None;
+        let mut budget = super::eval::REDUCE_FOREACH_MAX_STEPS;
+        let flow = eval_each_owned::<S>(f, &owned, optional, &mut |v| {
+            produced_any = true;
+            if let Some(control) = super::eval::charge_budget(&mut budget, "repeat") {
+                budget_control = Some(control);
+                stopped = true;
+                return Demand::Stop;
+            }
+            match sink(GenericItem::Owned(v)) {
+                Demand::Continue => Demand::Continue,
+                Demand::Stop => {
+                    stopped = true;
+                    Demand::Stop
+                }
+            }
+        });
+        if let Some(control) = budget_control {
+            return Flow::Escaped(control);
+        }
+        if stopped {
+            return Flow::Stopped { pending: None };
+        }
+        if !produced_any && matches!(flow, Flow::Exhausted) {
+            empty_rounds += 1;
+            if empty_rounds >= super::eval::MAX_EMPTY_REPEAT_ROUNDS {
+                return Flow::Exhausted;
+            }
+            continue;
+        }
+        empty_rounds = 0;
+        match flow {
+            Flow::Exhausted => continue,
+            other => return other,
+        }
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13326,6 +13326,52 @@ fn test_path_repeat_width_budget_matches_value_mode_1933() -> Result<()> {
     Ok(())
 }
 
+/// #2014: `limit(n; repeat(f))` used to cap at a flat 1000 rounds
+/// regardless of `n`, silently truncating any larger request -- verified
+/// against jq 1.7.1 at the issue's own scaling table (n=1500, well past the
+/// old cap, with a narrow one-value-per-round `f` so the unrelated
+/// per-round *width* budget in `test_path_repeat_width_budget_matches_value_mode_1933`
+/// above never triggers). `each_repeat`'s per-round `Demand::Stop` handoff
+/// to the wrapping `limit` should let this run 1500 full rounds with no
+/// error.
+#[test]
+fn test_repeat_limit_n_above_1000_no_longer_truncates_2014() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[limit(1500; repeat(1))] | length"], Some("null"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "1500\n");
+    Ok(())
+}
+
+/// #2014: the *eager* fallback -- `repeat(f)` reached through a consumer
+/// that never dispatches through `eval_each`'s lazy path (array
+/// construction, `reduce`, `foreach`, `last`) -- has no `Demand::Stop` to
+/// bound it, so it still runs `eval_repeat`'s original capped loop. #2014
+/// changed only how that cap fails on exhaustion: silent truncation to a
+/// short, successful result became a hard error, matching
+/// `resolve_repeat_bounded`'s (path-mode) existing convention instead of
+/// returning wrong-but-plausible output with no diagnostic. Real jq hangs
+/// on all of these instead (no oracle answer to compare against, same as
+/// `repeat(empty)` above) -- see limitations.md's own writeup of this
+/// three-way split (fixed / eager-fallback-raises / path-mode-still-caps).
+#[test]
+fn test_repeat_eager_fallback_raises_instead_of_silently_truncating_2014() -> Result<()> {
+    for query in [
+        "[repeat(1)] | length",
+        "reduce repeat(1) as $x (0; .+1)",
+        "foreach repeat(1) as $x (0; .+1)",
+        "last(repeat(1))",
+    ] {
+        let (_, stderr, code) = run_jq_full(&["-c", query], Some("null"))?;
+        assert_eq!(code, 5, "query {query:?}, stderr: {stderr}");
+        assert!(
+            stderr.contains("repeat: maximum iterations exceeded"),
+            "query {query:?}, stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
 /// #1935: `first(f)` needs the same `resolve_node_bounded` dispatch #1906/
 /// #1850 gave `limit` -- `first(f)` is exactly `limit(1; f)` for
 /// path-tracking purposes, but was routing through the generic


### PR DESCRIPTION
Fixes #2014

## Summary

`eval_repeat` bounded its round loop at a hardcoded 1000 iterations and, when
exhausted, silently returned the short list it had accumulated so far —
`limit(5000; repeat(1))` gave 1000 values, exit 0, nothing on stderr, instead
of jq's 5000.

This adds a native `Expr::Repeat` arm to **both** evaluators' lazy `eval_each`
dispatch — `eval.rs` and its generic-evaluator twin `eval_generic.rs`. This
codebase has two separate jq evaluators, and a fix landing in only one is
silently unreachable from the CLI; I confirmed via tracing that the generic
evaluator (`eval_generic.rs`) is what the real CLI dispatch actually reaches.

Each new arm pulls one round of `f`'s outputs at a time and stops as soon as
the wrapping `limit`/`first` does (via `Demand::Stop`), so
`limit(80000; repeat(1))` now runs all 80000 rounds, matching jq, instead of
hitting an artificial ceiling.

## Two safety nets, both required

Removing either of these was caught by verification (including a real ~2hr
CPU-spinning regression from an earlier attempt with no round-emptiness cap):

- **Per-round budget** (`REDUCE_FOREACH_MAX_STEPS`, reset every round): caps
  how many values a *single round* may fork into at once — a succinctly-only
  memory-safety net for a wide `f` like `.[]`, not jq fidelity (real jq has no
  such cap; confirmed live that `limit(50000; repeat(.[]))` over a
  20001-element array succeeds with all 50000 in jq 1.7.1). This must reset
  **per round** rather than accumulate across rounds — charging cumulatively
  was tried first and silently reintroduced the exact many-narrow-rounds
  truncation this issue is about, just as an error instead of a short count.
- **Round-emptiness cap** (`MAX_EMPTY_REPEAT_ROUNDS`): silently ends the
  stream after 1000 consecutive zero-output rounds, since `repeat`'s `f`
  reruns against the same unchanging input every round — a round producing
  nothing will produce nothing forever, and no wrapping consumer's
  `Demand::Stop` can ever fire to stop it (`sink` is never called on a
  zero-output round).

## Verification

- Issue's own scaling table against pinned jq 1.7.1: n=5/1000/10000/80000 now
  match exactly (previously flat-lined at 1000 for n≥1000).
- Wide-vs-narrow-round distinction: `limit(50000; repeat(.[]))` over a
  20001-element array still caps at exactly 10000 (matching
  `test_path_repeat_width_budget_matches_value_mode_1933`'s path/value
  parity), while `limit(80000; repeat(1))`/`repeat(.)` now succeed fully.
- `break`-to-label, error-with-partial-prefix, `first(repeat(f))`, and bare
  `repeat(empty)` (hang backstop) all re-verified against jq.
- Full local suite green: `cargo test` (default, `simd`, `portable-popcount`),
  `cargo check --no-default-features`, both `clippy --all-targets` feature
  legs, `cargo fmt --check`, `cargo doc --all-features` with
  `RUSTDOCFLAGS=-D warnings`, and the full `cli,simd,regex,serde` workspace
  suite (7000+ tests, including both pinned repeat tests).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --workspace` — all green
- [x] `cargo test` (default features)
- [x] `cargo test --features simd`
- [x] `cargo test --features portable-popcount`
- [x] `cargo check --no-default-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`)
- [x] Manual scaling table + edge cases verified live against jq 1.7.1