### PR TITLE
docs(jq): link #2044 from the null/bool register gap it already tracks

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -559,7 +559,8 @@ is the revert that established what the other one costs.
    `reestablishes_register` only re-establishes a branch that is *already* untracked and a
    stage sitting directly on a trackable one never gets there. Pre-existing (it predates the
    register threading), refuse-only, and closing it is a widening that needs its own live
-   matrix.
+   matrix; tracked as [#2044](https://github.com/rust-works/succinctly/issues/2044), which
+   carries the same root cause under its own repro (`path(null \| .a)` on `null`).
 
    Separately, a variable bound from a *navigated* position (`.a as $y`) still carries no
    marker at all, because `substitute_var_tracked` remains gated on


### PR DESCRIPTION
## Summary

#2041's limitations entry recorded that `path(.a | null)` on `{"a":null}` is `["a"]` in jq
while succinctly refuses, but named no tracker for it. **#2044 is that gap**, filed from the
other direction (`path(null | .a)` on `null`) with the same root cause:
`reestablishes_register`'s `!branch_trackable` conjunct excludes a computed `null`/`bool`
sitting on a still-trackable branch, so `register_identical`'s `default: r = 1` arm is never
consulted there.

One sentence added; the divergence description itself is unchanged.

## Test plan

- [x] Doc-only; no code touched
- [x] `docs/compliance/jq/limitations.md` renders (link target checked, no trailing
      whitespace, no over-long lines introduced)
- [x] CI's Check Links job covers the new URL

Refs #2044