### PR TITLE
fix(jq): close eval_generic's duplicate-key-losing fallback for the sort family, reduce/foreach and generator-n limit/nth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,9 +341,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `first(limit((1,2); (1, ("B"|stderr))))` stop exploring the second `n`
   binding, matching jq, which it previously did not.
 
-  Measured on a 200,000-element sequence: `sort_by` 3.7x faster, `reverse` 9.6x,
-  `min_by`/`max_by` 2.9x, with byte-identical output (interleaved A/B, Apple
-  M-series). `limit`/`nth` are unchanged at 1.01x.
+  **This trades throughput for fidelity on large YAML sorts, deliberately.**
+  Cursor-backed results stream elements in *sorted* order rather than document
+  order, which defeats YAML's sequential cursor caches (`AdvancePositions`/
+  `CompactEndPositions` fall back to full recomputation on random access).
+  Interleaved A/B on a shuffled 200,000-element YAML sequence, byte-identical
+  output, Apple M-series:
+
+  | filter                        | speedup vs. before |
+  |-------------------------------|--------------------|
+  | `sort`, `unique`              | 0.25x              |
+  | `sort_by`                     | 0.30x              |
+  | `reverse`                     | 0.99x              |
+  | `min`/`max`                   | 1.6-1.9x           |
+  | `limit`/`nth`, single-value n | 1.01x              |
+  | `limit`/`nth`, generator n    | 2.0x               |
+
+  The loss is superlinear in element count (0.72x at 20k, 0.53x at 60k, 0.25x at
+  200k) and YAML-only -- JSON `sort` is 1.06-1.10x. Its cause is the permutation
+  alone, not the extra work: the same document *already sorted*, so the
+  permutation is the identity, measures 1.07x. `reverse` escapes it and
+  `min`/`max` touch a single cursor, which is why only the sorting spellings pay.
+  The previous path was losing data, so the trade is the right way round, but
+  making the sorted case fast again needs cheap random cursor access on the YAML
+  side, tracked in
+  [#2068](https://github.com/rust-works/succinctly/issues/2068).
 
   Three cases are deliberately not fixed and are documented in
   `docs/compliance/yq/limitations.md`: `group_by` (an array of arrays has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,31 +341,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `first(limit((1,2); (1, ("B"|stderr))))` stop exploring the second `n`
   binding, matching jq, which it previously did not.
 
-  **This trades throughput for fidelity on large YAML sorts, deliberately.**
-  Cursor-backed results stream elements in *sorted* order rather than document
-  order, which defeats YAML's sequential cursor caches (`AdvancePositions`/
-  `CompactEndPositions` fall back to full recomputation on random access).
-  Interleaved A/B on a shuffled 200,000-element YAML sequence, byte-identical
-  output, Apple M-series:
+  Interleaved A/B against `main`'s tip, 7 reps, median, byte-identical output,
+  on a shuffled 200,000-element YAML sequence (Apple M-series, AC power). Both
+  absolute times are shown because a bare ratio is easy to read upside down:
 
-  | filter                        | speedup vs. before |
-  |-------------------------------|--------------------|
-  | `sort`, `unique`              | 0.25x              |
-  | `sort_by`                     | 0.30x              |
-  | `reverse`                     | 0.99x              |
-  | `min`/`max`                   | 1.6-1.9x           |
-  | `limit`/`nth`, single-value n | 1.01x              |
-  | `limit`/`nth`, generator n    | 2.0x               |
+  | filter                        | before  | after   | faster by |
+  |-------------------------------|--------:|--------:|-----------|
+  | `reverse`                     | 404 ms  |  43 ms  | **9.4x**  |
+  | `sort`                        | 670 ms  | 294 ms  | **2.3x**  |
+  | `sort_by`                     | 846 ms  | 390 ms  | **2.2x**  |
+  | `unique_by`                   | 849 ms  | 396 ms  | **2.1x**  |
+  | `min_by`/`max_by`             | 455 ms  | 318 ms  | **1.4x**  |
+  | `limit`/`nth`, single-value n | 128 ms  | 128 ms  | 1.01x     |
 
-  The loss is superlinear in element count (0.72x at 20k, 0.53x at 60k, 0.25x at
-  200k) and YAML-only -- JSON `sort` is 1.06-1.10x. Its cause is the permutation
-  alone, not the extra work: the same document *already sorted*, so the
-  permutation is the identity, measures 1.07x. `reverse` escapes it and
-  `min`/`max` touch a single cursor, which is why only the sorting spellings pay.
-  The previous path was losing data, so the trade is the right way round, but
-  making the sorted case fast again needs cheap random cursor access on the YAML
-  side, tracked in
-  [#2068](https://github.com/rust-works/succinctly/issues/2068).
+  The mechanism is that the elements are no longer decoded into an
+  `OwnedValue` at all, only reordered — so the saving grows with element count:
+  `reverse` measures 6.3x at 25,000 elements and 9.4x at 200,000, while
+  `sort_by` stays flat, its own sort still being O(n log n) on the keys.
+
+  A holdout rules out the emitted order mattering: the *same document already
+  sorted*, so the permutation is the identity, measures 2.3x — the same as the
+  shuffled one. `min_by`/`max_by`'s 1.4x is lower than the 2.9x measured before
+  the #1755 element decode-check below was restored; that check is the
+  difference, and correctness wins.
 
   Three cases are deliberately not fixed and are documented in
   `docs/compliance/yq/limitations.md`: `group_by` (an array of arrays has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`yq`: the sort family, `reduce`/`foreach` and `limit`/`nth`'s generator `n`
+  no longer collapse duplicate mapping keys** (#1687). `sort`, `sort_by`,
+  `unique`, `unique_by`, `min`, `min_by`, `max`, `max_by` and `reverse` all
+  answer a permutation or subset of their input's *own* elements, but every one
+  of them routed through `eval_generic.rs`'s wildcard bridge, which
+  materializes the whole document into an `IndexMap`-backed `OwnedValue` first
+  — so a duplicate key inside a moved element was gone before the builtin ran.
+  They now keep those elements as cursors (a `LazySeq` for the array-valued
+  ones, a bare `OneCursor` for `min`/`max`), matching real yq on all seven
+  spellings it implements, and recovering comments, anchors and flow style
+  through them as well.
+
+  `reduce`/`foreach` had no arm in that evaluator at all, producing an internal
+  contradiction rather than merely a divergence: `[keys|.[]] | length` answered
+  3 on `b: 1\na: 2\nb: 3\n` while `reduce (keys|.[]) as $k (0; .+1)` answered
+  2. Their `input` and INIT streams are now evaluated cursor-natively, with the
+  fold itself still eval.rs's.
+
+  `limit`/`nth` handled only a single-valued `n`; a generator (`limit((1,3);
+  f)`) was probed, found multi-output, and handed to the same bridge — losing
+  the duplicate keys *and* evaluating `n` a second time, so a `debug` inside it
+  fired twice where jq fires it once. A new `fanout_arg_generic` drives `n`
+  exactly once for every shape. Its sink-side twin also makes
+  `first(limit((1,2); (1, ("B"|stderr))))` stop exploring the second `n`
+  binding, matching jq, which it previously did not.
+
+  Measured on a 200,000-element sequence: `sort_by` 3.7x faster, `reverse` 9.6x,
+  `min_by`/`max_by` 2.9x, with byte-identical output (interleaved A/B, Apple
+  M-series). `limit`/`nth` are unchanged at 1.01x.
+
+  Three cases are deliberately not fixed and are documented in
+  `docs/compliance/yq/limitations.md`: `group_by` (an array of arrays has no
+  cursor-backed representation), `while`/`until` (their state is computed from
+  step 1), and `reduce`/`foreach`'s bindings (`$x` is an `OwnedValue` in both
+  evaluators, so a *bound* element still collapses). An alias-bearing document
+  is also kept off the new path entirely — reordering can lift a `*x` above its
+  `&x`, and real yq emits exactly that then refuses to read it back.
+
 - **`jq`/`yq`: function calls are resolved at compile time, before any input is
   read** (#1473). Real jq rejects a call to an undefined function — or to an
   undefined arity of an existing one — unconditionally, uncatchably, with exit

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1633,17 +1633,21 @@ YAML, though — every YAML cursor's `preceding_delimiter_ok` uses the trait def
 to this evaluator-level check the way JSON's semi-index does — so there is no YAML input
 this gap check can actually catch or skip either way, today.
 
-## `limit`'s own `n` argument is not demand-aware when it is itself a generator
+## A generator `n` under a truncating consumer: fixed for `limit`, residual for `nth`/`isempty`
 
 Real jq passes `limit($n; f)`'s `$n` through the same backtracking arg-passing convention
 as any other filter argument, so a *generator* `n` (`limit((1,2); f)`, #1279's own canonical
 example) re-runs the whole `limit` body once per bound value of `$n` — but only as many
-times as the wrapping consumer actually needs:
+times as the wrapping consumer actually needs.
+
+**`limit` now matches jq here (#1687).** `eval_generic.rs`'s `fanout_arg_generic`/
+`fanout_arg_each_generic` drive `n` through the demand-driven sink, so a wrapping
+`first`/`nth`/`isempty`/`any` stops the `n` generator itself:
 
 ```
-$ succinctly jq -cn 'first(limit((1,2); (1, ("B"|stderr))))'      # jq: 1, no stderr
+$ succinctly jq -cn 'first(limit((1,2); (1, ("B"|stderr))))'      # jq: 1, no stderr — agrees
 1
-$ succinctly jq -cn '[limit((1,2); (1, ("B"|stderr)))]'           # jq: [1,1,"B"], stderr B (both agree)
+$ succinctly jq -cn '[limit((1,2); (1, ("B"|stderr)))]'           # jq: [1,1,"B"], stderr B — agrees
 [1,1,"B"]
 B
 ```
@@ -1651,30 +1655,25 @@ B
 The second row is not a typo: an *unbounded* consumer genuinely needs both of `$n`'s
 bindings (`$n=1` keeps `expr`'s first output alone; `$n=2` keeps its first two, so
 `("B"|stderr)`'s own value ends up in the array too), so exploring `expr`'s second output
-there is correct in both tools. The first row is where they diverge — jq's own `first`
-stops after `$n=1`'s single output and never even considers the `$n=2` binding, so
-`stderr` stays empty; `succinctly jq` still writes `B`.
+there is correct in both tools.
 
-**Root cause: no demand-aware entry point exists yet for a generator `n`.** `limit`'s fast,
-demand-forwarding paths (`eval::each_limit`, `eval_generic.rs`'s `eval_limit_generic`/
-`each_limit_generic`, #1607/#1596) all defer to `eval.rs`'s plain, fully-materializing
-`eval()`/`full_eval` the moment `n` is anything beyond a single plain value — the same
-"give up on the fast path, hand the whole node to the collecting evaluator" policy `map(f)`
-above used to have before #724/#725 gave it a genuinely lazy sequence type. `limit`'s own
-generator-`n` case has no equivalent lazy machinery to defer to: `eval()` collects every
-output across every `$n` binding into one `QueryResult` before any wrapping consumer's
-`Demand` is ever consulted, so a `first`/`nth` sitting outside a generator-`n` `limit` gets
-the answer only after paying (and leaking any side effect from) work it never asked for.
+**Two shapes still diverge**, both because they never reach that fan-out — verified live
+against jq 1.7.1, and unchanged by #1687:
 
-Deliberately not fixed here: it needs `eval.rs` itself to gain a demand-aware path for a
-generator `n`, not another consumer-side guard — the same order of work #724/#725 needed
-for `map(f)`, not a small patch. `n_expr` as a generator is jq's own rarer laziness
-contract to begin with (most real `limit`/`nth` calls pass a scalar), so the common case is
-unaffected; only a bare, side-effecting, multi-output `n` under a truncating consumer sees
-this. Tracked in
+| filter                                       | jq 1.7.1 | `succinctly jq` |
+|----------------------------------------------|----------|-----------------|
+| `isempty(limit((1,("N"\|debug)); 42))`        | no stderr | writes `["DEBUG:","N"]` |
+| `first(nth((0,1); (1, ("B"\|stderr))))`       | no stderr | writes `B`      |
+
+`isempty` has no native arm in `eval_generic.rs` at all, so the whole expression is
+evaluated by `eval.rs`, whose own `each_limit` still classifies `n` with a single eager
+`eval_single` rather than a fan-out. `nth` has an eager native arm but no sink-side
+(`each_`) twin, so a wrapping `first` has nothing to push its demand into. Both are the
+same shape of gap `limit` had before #1687 and both are fixable the same way — port
+`fanout_arg` to `eval::each_limit`, and give `nth` an `each_nth_generic` — neither of which
+is `limit`'s own scope. Tracked in
 [`docs/plan/jq-lazy-generator-consumers.md`](../../plan/jq-lazy-generator-consumers.md)
-(item 9) as a residual, not silently reintroduced — `each_limit_generic`'s own doc comment
-carries the same note at the call site.
+(item 9).
 
 ## A `?//`-alternatives bind under a short-circuiting consumer runs once, not once per alternative
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -277,7 +277,7 @@ separator" above discusses this same flag from a different angle — why `-0`/`-
 getting a newline-guarded `---` is a *permitted* rule-4(a) divergence, independent of the
 name-collision question here.
 
-### Duplicate mapping keys — the format leak and `.[]` collapse are resolved; four narrower gaps remain
+### Duplicate mapping keys — the format leak, `.[]` collapse and the sort family are resolved; narrower gaps remain
 
 The subject of [ADR-0018](../../adrs/adr-0018.md)'s worked example.
 [#1398](https://github.com/rust-works/succinctly/issues/1398) resolved the two divergences it
@@ -321,8 +321,56 @@ rather than adding a second mechanism; the change lands on shared `eval_generic.
 also fixes jq mode's own `[.[]]` as a side effect — one of #1385's five listed jq-mode gaps
 (`.`, `length`, `keys`, `keys_unsorted` remain open there).
 
-Four narrower gaps this fix deliberately left alone remain open, each already filed before
-#1398 landed:
+[#1687](https://github.com/rust-works/succinctly/issues/1687) then closed the next batch of
+wildcard-bridge casualties. `sort`, `sort_by`, `unique`, `unique_by`, `min`, `min_by`, `max`,
+`max_by` and `reverse` all answer a permutation or subset of their input's *own* elements, so
+they now keep those elements as cursors (a `LazySeq` for the array-valued ones, a bare
+`OneCursor` for `min`/`max`) instead of decoding them. Real yq preserves duplicates through
+every one of the seven it implements; succinctly now matches, and — per #757's own lesson that
+a construct on the DOM route loses everything the DOM cannot carry at once — recovers comments,
+anchors and flow style through them too:
+
+```bash
+$ printf -- '- b: 1\n  a: 2\n  b: 3\n' > dup_arr.yaml
+
+$ yq            -o=json -I=0 'sort_by(.a)' dup_arr.yaml   # [{"b":1,"a":2,"b":3}]
+$ succinctly yq -o=json -I=0 'sort_by(.a)' dup_arr.yaml   # [{"b":1,"a":2,"b":3}]  (was [{"b":3,"a":2}])
+```
+
+The same change gave `reduce`/`foreach` their first arm in `eval_generic.rs`, and `limit`/`nth`
+a real fan-out for a generator `n` — closing an internal contradiction in the first case
+(`[keys|.[]] | length` answered 3 while `reduce (keys|.[]) as $k (0; .+1)` answered 2 on the
+same document) and the last of `limit`/`nth`'s duplicate-key loss in the second.
+
+**Three gaps #1687 deliberately did not close**, alongside the four below:
+
+- **`group_by`** returns an array *of arrays*. `LazySeq` has no nested-lazy form and
+  `OwnedValue::Array(Vec<OwnedValue>)` cannot hold a cursor, so there is no lossless
+  representation for it today — it keeps the bridge, and real yq preserves where succinctly
+  collapses. The same representation limit as #1102 below, one level up.
+- **`while`/`until`** compute their state from step 1 onward, so only the seed `.` could ever
+  stay a cursor; folding through an `OwnedValue` state is inherent, not a wiring gap.
+- **`reduce`/`foreach`'s bindings.** The fix recovers the *number and order* of the input
+  stream's elements, not each element's own shape: the accumulator and every `$x` a pattern
+  binds are `OwnedValue` in both evaluators (`substitute_bound_var` takes `&OwnedValue`, and no
+  duplicate-key-capable owned type exists in this crate), so an element that gets bound is
+  collapsed at the bind. `reduce .[] as $x (null; $x)` therefore still answers
+  `{"b":3,"a":2}` where `first(.[])` on the same document answers `{"b":1,"a":2,"b":3}`.
+
+**And one deliberate divergence from real yq, not a gap.** The cursor-backed reordering above
+is switched off entirely for a document carrying any `*alias`, via
+`DocumentCursor::document_has_aliases`. Reordering can lift an alias above the anchor it
+resolves to, and `reverse` on `- &x {p: 1}` / `- *x` does: real yq answers `- *x` then
+`- &x {p: 1}`, then rejects its own output with `unknown anchor 'x' referenced` when asked to
+read it back (both verified live against v4.53.3). `enforce_anchor_soundness` is what normally
+prevents that, but it is a DOM-path pass over a `CommentTree` and the cursor-streaming path has
+none to run it over ([#1350](https://github.com/rust-works/succinctly/issues/1350)) — so an
+alias-bearing document takes the DOM path unchanged, losing the marks rather than emitting a
+file succinctly could not read back. The gate is on *aliases*, not anchors: an unreferenced
+`&x` is valid YAML wherever it lands.
+
+Four narrower gaps #1398's fix deliberately left alone remain open, each already filed before
+it landed:
 
 - [#1342](https://github.com/rust-works/succinctly/issues/1342) — `paths(node_filter)` still
   collapses (a YAML-only DOM-representation gap, unrelated to the format leak).
@@ -332,7 +380,8 @@ Four narrower gaps this fix deliberately left alone remain open, each already fi
 - [#1344](https://github.com/rust-works/succinctly/issues/1344) — `del`/`with_entries`/
   `map_values`/`tostream`/`walk`/`recurse` fall through `eval_generic.rs`'s wildcard bridge
   (`eval_on_owned`), which still materializes via an `IndexMap` and collapses duplicates for
-  both formats today.
+  both formats today. #1687 closed the same class for the sort family and `reduce`/`foreach`
+  above; this list is the remaining membership.
 - [#1102](https://github.com/rust-works/succinctly/issues/1102) — object slicing (`.[S:E]` on
   an object) must materialize into an `OwnedValue::Object` to build yq's AST-child-list view
   before slicing it, with no cursor-preserving alternative available (the operation inherently

--- a/docs/plan/jq-lazy-generator-consumers.md
+++ b/docs/plan/jq-lazy-generator-consumers.md
@@ -1314,12 +1314,22 @@ the reasoning behind each placement:
    evaluated `n_expr` unconditionally before ever consulting them. Fixed by porting the
    identical two pre-checks into `each_limit_generic`, deferring to the bridge *before* touching
    `n_expr` at all rather than after — pinned in
-   `test_first_over_limit_generator_n_evaluates_once_not_twice_1596`, which asserts the fixed
+   `test_first_over_limit_generator_n_evaluates_once_not_twice_1596`, which asserted the fixed
    count (one) rather than jq parity: real jq never evaluates the second `n` binding for this
    shape at all, since `first`'s own single-output need is already satisfied by the first, a
    *separate*, pre-existing gap in `eval.rs`'s own generator-`n` handling shared by every
    consumer (confirmed live: `isempty(limit((1,("N"|debug)); 42))` leaks the identical single
    `["DEBUG:","N"]` on unmodified `main`, unrelated to and unmoved by this issue).
+
+   **Superseded by #1687.** `fanout_arg_each_generic` drives `n_expr` through the demand-driven
+   sink instead of bridging, so `each_limit_generic` no longer evaluates it at all under
+   `first` — jq's own count. The pre-checks and the bridge for this shape are gone with it, and
+   the test is now
+   `test_first_over_limit_generator_n_is_never_evaluated_1596`, pinning zero. The `isempty`
+   sibling above is untouched and remains the residual: `isempty` has no native arm in
+   `eval_generic.rs`, so it is evaluated wholly by `eval.rs`, whose `each_limit` still
+   classifies `n` with one eager `eval_single`. `first(nth((0,1); ...))` is the same gap for
+   `nth`, which has no sink-side twin.
 
    Verified with `scripts/jq-fanout-oracle-sweep.sh`, which went from 20 known-gap cases
    attributed to this issue to 0 divergences (490/490 matching pinned jq 1.7.1); its now-dead

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3785,6 +3785,32 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         // gap (#796).
         Expr::Builtin(Builtin::Select(_)) => true,
 
+        // #1687: `sort`/`sort_by`/`unique`/`unique_by`/`reverse` now answer a
+        // `GenericResult::LazySeq` over their input's own element cursors,
+        // and `min`/`min_by`/`max`/`max_by` a bare `OneCursor` -- the same
+        // shapes `map`/`first` above already stream. Without an arm here the
+        // fix is discarded one layer up, exactly as #1607's was before its
+        // review caught it: `evaluate_yaml_cursor`'s unconditional
+        // `to_owned()` DOM path flattens the cursor-preserving result back
+        // into an `IndexMap`-backed `OwnedValue` at output time, silently
+        // re-collapsing the duplicate mapping key inside a moved element.
+        //
+        // The key filter is never recursed into: it only ever produces a
+        // comparison key, which is an `OwnedValue` regardless and never
+        // reaches the output. What *is* streamed is the element the key
+        // selected, and that is always a document node.
+        Expr::Builtin(
+            Builtin::Sort
+            | Builtin::SortBy(_)
+            | Builtin::Unique
+            | Builtin::UniqueBy(_)
+            | Builtin::Min
+            | Builtin::MinBy(_)
+            | Builtin::Max
+            | Builtin::MaxBy(_)
+            | Builtin::Reverse,
+        ) => true,
+
         // `keys_unsorted` on a mapping produces `GenericResult::LazyKeys { sorted: false, .. }`,
         // which `GenericResult::stream_json`/`stream_yaml` now stream directly
         // from the field cursor (#685) instead of materializing a `Vec<String>`

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -272,6 +272,35 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Whether this cursor's *document* declares any `*name` alias at all.
+    ///
+    /// A whole-document property, not a property of this node, and O(1) --
+    /// `YamlIndex::has_aliases` is an emptiness check on an already-built
+    /// map. `false` for formats with no alias concept (JSON), where it
+    /// monomorphizes away entirely.
+    ///
+    /// Needed by any builtin that *reorders, selects or drops* a document's
+    /// own nodes while keeping them cursor-backed (#1687: `sort`, `sort_by`,
+    /// `unique`, `unique_by`, `reverse`, `min`, `max`, `min_by`, `max_by`).
+    /// Re-emitting `&anchor`/`*alias` marks is only sound while every alias
+    /// still follows a declaration of the same name holding an equal value;
+    /// moving nodes around can break that, and `reverse` on `- &x {p: 1}` /
+    /// `- *x` demonstrably does -- it yields `- *x` / `- &x {p: 1}`, a
+    /// forward reference real yq rejects with `unknown anchor 'x'
+    /// referenced`. `enforce_anchor_soundness` (`yq_runner.rs`) exists to
+    /// prevent exactly that, but it is a DOM-path pass over a
+    /// `CommentTree`, and the cursor-streaming path has none to run it over
+    /// (#1350). So those builtins consult this instead and hand an
+    /// alias-bearing document to the DOM path unchanged, rather than
+    /// emitting YAML succinctly could not read back.
+    ///
+    /// Gating on aliases rather than anchors is deliberate: an unreferenced
+    /// `&x` is valid YAML wherever it lands, so a document with anchors but
+    /// no aliases can be reordered freely.
+    fn document_has_aliases(&self) -> bool {
+        false
+    }
+
     /// Get the explicit YAML tag at this node, if any (e.g. `"!!str"`).
     ///
     /// Returns `None` when the node has no explicit tag, and for formats

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2567,7 +2567,7 @@ fn eval_owned_expr_fork<S: EvalSemantics>(
 /// fixing five more `eval_reduce`/`eval_foreach` arms that had the same
 /// drift); one shared predicate is the actual fix for a bug class that
 /// otherwise recurs every time a new match arm needs the same check.
-fn suppresses(e: &EvalError, optional: bool) -> bool {
+pub(crate) fn suppresses(e: &EvalError, optional: bool) -> bool {
     optional && !e.is_decode_failure()
 }
 
@@ -2584,7 +2584,7 @@ fn suppresses(e: &EvalError, optional: bool) -> bool {
 /// jq's own `recurse` having no internal optional-suppression concept).
 /// That's a principled exemption, not an oversight -- don't "complete the
 /// sweep" by wiring it in there without re-reading that reasoning first.
-fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> {
+pub(crate) fn suppress_or_raise<'a, W>(e: EvalError, optional: bool) -> QueryResult<'a, W> {
     if suppresses(&e, optional) {
         QueryResult::None
     } else {
@@ -26314,7 +26314,7 @@ fn eval_reduce<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// evaluation by either caller -- it runs against the accumulator, a
 /// synthetic value with no real document position, so `key` there already
 /// answers `null` correctly without needing to change (#1765's own scoping).
-fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+pub(crate) fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     patterns: &[Pattern],
     update: &Expr,
     input_values: Vec<OwnedValue>,
@@ -27044,7 +27044,7 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                                      // separately, since it can outlive `input_values` being consumed (#534
                                      // follow-up); collapsing the two into one shared field would lose that
                                      // distinction, not just shorten the signature.
-fn eval_foreach_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+pub(crate) fn eval_foreach_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     patterns: &[Pattern],
     update: &Expr,
     extract: Option<&Expr>,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1645,6 +1645,63 @@ fn eval_on_owned<S: EvalSemantics, V: DocumentValue>(
     query_result_to_generic::<V>(full_eval::<Vec<u64>, S>(expr, cursor))
 }
 
+/// Materialize `value` (with its `cursor`, if any) and hand `expr` to the
+/// full `OwnedValue` evaluator -- the "give up on the cursor-native path"
+/// bridge every deferring native arm ends in.
+///
+/// Six call sites grew an identical hand-written copy of this three-step
+/// shape (`to_owned_with_cursor` + reconstruct the AST node + `eval_on_owned`)
+/// before it was extracted (#1687 item 4): `Expr::Limit`, `Expr::NthExpr`,
+/// `Builtin::NthStream` and `Builtin::Has` in the two dispatch matches,
+/// `eval_first_or_last_generic`'s input-queue guard, and
+/// `each_limit_generic`'s `Flow`-returning local closure (now
+/// [`bridge_to_full_evaluator_flow`]). CLAUDE.md's own #106 lesson --
+/// duplicated predicates diverge silently -- applies directly: these copies
+/// differ only in which `Expr` they rebuild, and nothing but review was
+/// stopping one of them from acquiring a subtly different `optional` or
+/// error-conversion rule.
+///
+/// **This bridge is lossy by construction and always has been.**
+/// `to_owned_with_cursor` funnels through `to_owned_at_depth`, whose object
+/// arm is an `IndexMap`, so a duplicate mapping key is gone before `expr`
+/// runs -- regardless of `S::COLLAPSE_DUPLICATE_KEYS`. Reaching this
+/// function at all is what every native arm in this file exists to avoid;
+/// centralizing it does not make it cheaper or more faithful, it only makes
+/// the remaining call sites countable.
+fn bridge_to_full_evaluator<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    cursor: Option<V::Cursor>,
+    optional: bool,
+) -> GenericResult<V> {
+    // Spelled as a `match` rather than `owned_or_err!`: this function sits
+    // above that macro's own definition point in the file, and `macro_rules!`
+    // is only in scope textually after it.
+    match to_owned_with_cursor(&value, cursor) {
+        Ok(owned) => eval_on_owned::<S, V>(expr, owned, optional),
+        Err(e) => GenericResult::Error(e),
+    }
+}
+
+/// [`bridge_to_full_evaluator`] for a sink-driven caller: same materialize +
+/// delegate, then drain whatever the full evaluator produced into `sink`.
+///
+/// A decode failure surfaces as `Flow::Escaped(Control::Error(..))` rather
+/// than `GenericResult::Error`, matching what `each_limit_generic`'s
+/// hand-written closure did before this replaced it.
+fn bridge_to_full_evaluator_flow<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    cursor: Option<V::Cursor>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match to_owned_with_cursor(&value, cursor) {
+        Ok(owned) => drain_result_generic(eval_on_owned::<S, V>(expr, owned, optional), sink),
+        Err(e) => Flow::Escaped(Control::Error(e)),
+    }
+}
+
 /// Convert a `QueryResult` produced by `eval.rs` into the generic
 /// evaluator's own `GenericResult`.
 ///
@@ -4877,17 +4934,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Limit { n, expr } => {
             match eval_limit_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
                 Some(result) => result,
-                None => {
-                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
-                    eval_on_owned::<S, _>(
-                        &Expr::Limit {
-                            n: n.clone(),
-                            expr: expr.clone(),
-                        },
-                        owned,
-                        optional,
-                    )
-                }
+                None => bridge_to_full_evaluator::<S, _>(
+                    &Expr::Limit {
+                        n: n.clone(),
+                        expr: expr.clone(),
+                    },
+                    value,
+                    cursor,
+                    optional,
+                ),
             }
         }
 
@@ -4904,17 +4959,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::NthExpr { n, expr } => {
             match eval_nth_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
                 Some(result) => result,
-                None => {
-                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
-                    eval_on_owned::<S, _>(
-                        &Expr::NthExpr {
-                            n: n.clone(),
-                            expr: expr.clone(),
-                        },
-                        owned,
-                        optional,
-                    )
-                }
+                None => bridge_to_full_evaluator::<S, _>(
+                    &Expr::NthExpr {
+                        n: n.clone(),
+                        expr: expr.clone(),
+                    },
+                    value,
+                    cursor,
+                    optional,
+                ),
             }
         }
 
@@ -6158,27 +6211,17 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    let mut bridge_to_full_evaluator = |value: V, cursor: Option<V::Cursor>| -> Flow {
-        let owned = match to_owned_with_cursor(&value, cursor) {
-            Ok(o) => o,
-            Err(e) => return Flow::Escaped(Control::Error(e)),
-        };
-        let result = eval_on_owned::<S, V>(
-            &Expr::Limit {
-                n: Box::new(n_expr.clone()),
-                expr: Box::new(expr.clone()),
-            },
-            owned,
-            optional,
-        );
-        drain_result_generic(result, sink)
+    // Rebuilt once, up front: all three deferral points below hand the same
+    // node to the same bridge (#1687 item 4).
+    let bridged = Expr::Limit {
+        n: Box::new(n_expr.clone()),
+        expr: Box::new(expr.clone()),
     };
 
-    if limit_or_nth_uses_live_input_queue(n_expr, expr) {
-        return bridge_to_full_evaluator(value, cursor);
-    }
-    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
-        return bridge_to_full_evaluator(value, cursor);
+    if limit_or_nth_uses_live_input_queue(n_expr, expr)
+        || matches!(unwrap_paren(n_expr), Expr::Comma(_))
+    {
+        return bridge_to_full_evaluator_flow::<S, V>(&bridged, value, cursor, optional, sink);
     }
 
     let n_result = eval_single::<S, V>(n_expr, value.clone(), optional, cursor);
@@ -6201,7 +6244,9 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
         // `n_expr` evaluation here, same documented residual gap as
         // `eval_limit_generic`'s own identical fallback -- narrowing it
         // further isn't needed to fix #1596's own leak.
-        _ => return bridge_to_full_evaluator(value, cursor),
+        _ => {
+            return bridge_to_full_evaluator_flow::<S, V>(&bridged, value, cursor, optional, sink)
+        }
     };
 
     let n = match classify_limit_n(n_value) {
@@ -6616,8 +6661,12 @@ fn eval_first_or_last_generic<S: EvalSemantics, V: DocumentValue>(
         && crate::jq::input_queue_is_active()
         && crate::jq::walk::uses_input_builtins(inner)
     {
-        let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
-        return eval_on_owned::<S, _>(&Expr::FirstExpr(Box::new(inner.clone())), owned, optional);
+        return bridge_to_full_evaluator::<S, _>(
+            &Expr::FirstExpr(Box::new(inner.clone())),
+            value,
+            cursor,
+            optional,
+        );
     }
 
     // `first` stops pulling from `inner` as soon as it has one output, so
@@ -8467,14 +8516,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::NthStream(n, expr) => {
             match eval_nth_generic::<S, _>(n, expr, value.clone(), optional, cursor) {
                 Some(result) => result,
-                None => {
-                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
-                    eval_on_owned::<S, _>(
-                        &Expr::Builtin(Builtin::NthStream(n.clone(), expr.clone())),
-                        owned,
-                        optional,
-                    )
-                }
+                None => bridge_to_full_evaluator::<S, _>(
+                    &Expr::Builtin(Builtin::NthStream(n.clone(), expr.clone())),
+                    value,
+                    cursor,
+                    optional,
+                ),
             }
         }
 
@@ -8509,10 +8556,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Has(key_expr) => {
             match eval_has_generic::<S, _>(key_expr, value.clone(), optional, cursor) {
                 Some(result) => result,
-                None => {
-                    let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
-                    eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
-                }
+                None => bridge_to_full_evaluator::<S, _>(
+                    &Expr::Builtin(builtin.clone()),
+                    value,
+                    cursor,
+                    optional,
+                ),
             }
         }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2661,6 +2661,22 @@ impl<V: DocumentValue> GenericResult<V> {
         matches!(self, Self::Error(_) | Self::Partial(_, Control::Error(_)))
     }
 
+    /// Whether evaluating this ended in *any* control -- an error, a
+    /// `break`, or a `halt` -- rather than only an error like
+    /// [`Self::is_error`].
+    ///
+    /// The generic twin of `eval::QueryResult::is_escape`, and needed for
+    /// the same reason: it answers "must the caller stop pulling?" without
+    /// consuming the result, which is what lets [`fanout_arg_generic`]
+    /// decide whether a `body` result can be buffered for its single-output
+    /// fast path before it has been flattened (#1531).
+    fn is_escape(&self) -> bool {
+        matches!(
+            self,
+            Self::Error(_) | Self::Break(_) | Self::Halt(_) | Self::Partial(_, _)
+        )
+    }
+
     /// Get the error if this is an error result.
     pub fn error(&self) -> Option<&EvalError> {
         match self {
@@ -6208,38 +6224,30 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
 /// `eval_limit_generic`'s own `None` return, except this function has no
 /// caller to hand a `None` back to, so it performs the bridge/drain itself.
 ///
-/// Guarded exactly like [`eval_limit_generic`], and for the identical two
-/// reasons (see that function's own doc comment): [`limit_or_nth_uses_live_input_queue`]
-/// defers to the bridge *before* touching a live `input`/`inputs` queue, and
-/// a bare top-level `Comma` `n_expr` is detected statically and deferred
-/// without ever evaluating it here first -- so the bridge's own single
-/// `eval_on_owned` call is the only evaluation of `n_expr`, not a second one
-/// stacked on top of a `eval_single` call this function already made. Without
-/// these two checks, `n_expr` would double-evaluate here whenever it fell
-/// through to the bridge below (confirmed live: `first(limit((1,("N"|debug));
-/// 42))` wrote `"N"` to `debug` twice instead of once before this guard
-/// existed) -- exactly the class of leak #1596 exists to close, reintroduced
-/// one arm over.
+/// Guarded exactly like [`eval_limit_generic`] (see that function's own doc
+/// comment): [`limit_or_nth_uses_live_input_queue`] defers to the bridge
+/// *before* touching a live `input`/`inputs` queue, so the bridge's own
+/// single `eval_on_owned` call is the only evaluation of `n_expr`.
 ///
-/// **A generator `n_expr` is a documented residual even once guarded.**
-/// `eval_on_owned`'s own `full_eval` call has no demand to forward -- it
-/// answers with a fully materialized `QueryResult`, collecting every output
-/// across every `n_expr` binding `limit`'s own backtracking arg-passing
-/// contract explores, *before* `drain_result_generic` ever gets a chance to
-/// apply a wrapping `first`/`nth`'s smaller demand to what comes back.
-/// Live-verified against pinned jq 1.7.1: `first(limit((1,2); (1,
-/// ("B"|stderr))))` -- the exact bare-top-level-`Comma` shape this guard
-/// exists to make safe from double-evaluation -- still writes `B` to
-/// stderr here, where jq never explores the `$n=2` binding at all once
-/// `first` is satisfied by `$n=1`'s own single output. A non-`first`/`last`
-/// consumer wanting *every* output (`[limit((1,2); (1, ("B"|stderr)))]`)
-/// correctly writes `B` in both tools -- that shape needs `$n=2`'s
-/// exploration regardless, so the two rows aren't actually inconsistent,
-/// just differently demanding. Closing this needs `eval.rs` to expose a
-/// demand-aware entry point for a generator-`n_expr` `limit` (`each_limit`
-/// only reaches its own generator-`n` case through the same
-/// fully-materializing route today), which is a larger change than this
-/// arm's own scope -- tracked as a residual, not silently reintroduced.
+/// That guard used to have a sibling -- a static "is `n_expr` a bare
+/// top-level `Comma`?" check, deferring without evaluating so the bridge's
+/// evaluation would not be stacked on top of a probe this function had
+/// already made (`first(limit((1,("N"|debug)); 42))` wrote `"N"` twice
+/// before it existed, the class of leak #1596 closed). #1687 removed the
+/// need for it: [`fanout_arg_each_generic`] drives `n_expr` exactly once for
+/// every shape, so there is no probe to double up on and nothing to detect
+/// statically.
+///
+/// **A generator `n_expr` used to be a documented residual here; #1687 closed
+/// it.** The bridge this arm used to take for that shape answers with a fully
+/// materialized `QueryResult`, collecting every output across every `n_expr`
+/// binding before `drain_result_generic` could apply a wrapping `first`/`nth`'s
+/// smaller demand -- so `first(limit((1,2); (1, ("B"|stderr))))` wrote `B` to
+/// stderr where jq never explores the `$n=2` binding at all. Driving `n_expr`
+/// through [`fanout_arg_each_generic`] instead keeps the whole nest
+/// demand-driven, and both tools now write nothing there, while the
+/// genuinely-every-output shape (`[limit((1,2); (1, ("B"|stderr)))]`) still
+/// correctly writes `B` in both.
 fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,
@@ -6255,37 +6263,26 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
         expr: Box::new(expr.clone()),
     };
 
-    if limit_or_nth_uses_live_input_queue(n_expr, expr)
-        || matches!(unwrap_paren(n_expr), Expr::Comma(_))
-    {
+    if limit_or_nth_uses_live_input_queue(n_expr, expr) {
         return bridge_to_full_evaluator_flow::<S, V>(&bridged, value, cursor, optional, sink);
     }
 
-    let n_result = eval_single::<S, V>(n_expr, value.clone(), optional, cursor);
-    let n_value = match n_result {
-        GenericResult::One(v) => match to_owned(&v) {
-            Ok(o) => o,
-            Err(e) => return Flow::Escaped(Control::Error(e)),
-        },
-        GenericResult::OneCursor(c) => match to_owned_cursor(&c) {
-            Ok(o) => o,
-            Err(e) => return Flow::Escaped(Control::Error(e)),
-        },
-        GenericResult::Owned(v) => v,
-        GenericResult::None => return Flow::Exhausted,
-        GenericResult::Error(e) => return Flow::Escaped(Control::Error(e)),
-        GenericResult::Break(label) => return Flow::Escaped(Control::Break(label)),
-        GenericResult::Halt(code) => return Flow::Escaped(Control::Halt(code)),
-        // A generator `n_expr` broader than a bare top-level `Comma` (e.g. a
-        // `Pipe` whose middle stage is the comma) still costs a second
-        // `n_expr` evaluation here, same documented residual gap as
-        // `eval_limit_generic`'s own identical fallback -- narrowing it
-        // further isn't needed to fix #1596's own leak.
-        _ => {
-            return bridge_to_full_evaluator_flow::<S, V>(&bridged, value, cursor, optional, sink)
-        }
-    };
+    fanout_arg_each_generic::<S, V, _>(n_expr, value.clone(), optional, cursor, |n_value| {
+        each_limit_with_n_generic::<S, V>(n_value, expr, value.clone(), optional, cursor, sink)
+    })
+}
 
+/// `limit(n; expr)`'s sink-driven work for one already-resolved `n` --
+/// [`each_limit_generic`]'s per-`n` body, split out for the fan-out exactly
+/// as [`limit_with_n_generic`] was split out of [`eval_limit_generic`].
+fn each_limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
+    n_value: OwnedValue,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
     let n = match classify_limit_n(n_value) {
         Ok(LimitN::Unlimited) => {
             return eval_each_generic::<S, V>(expr, value, optional, cursor, sink)
@@ -6814,35 +6811,193 @@ fn limit_or_nth_uses_live_input_queue(n_expr: &Expr, expr: &Expr) -> bool {
 /// the eager `_` fallback below would drain the whole remaining queue
 /// instead of stopping at `n`/index `n`.
 ///
-/// Returns `None` to defer to the caller's own fallback rather than
-/// handling every shape `eval.rs`'s `eval_limit`/`fanout_arg` do: only the
-/// common case — `n_expr` evaluates to exactly one plain value — is taken
-/// natively here, via [`eval_each_generic`]'s own demand-driven `Pipe`/
-/// `Iterate`/`LazyKeys` machinery (what keeps `expr`'s duplicate keys
-/// alive). `n_expr` as a *generator* (`limit((1,2); f)`, re-running `expr`
-/// once per `n` value, #1279) is jq's own rarer laziness contract, which
-/// `eval.rs`'s `fanout_arg` already implements correctly for every
-/// document `eval.rs` can represent losslessly — reproducing that richness
-/// here isn't needed to fix this issue's actual bug (a generator `n_expr`
-/// still loses `expr`'s duplicate keys on the deferred fallback path,
-/// exactly as before this fix; tracked as a residual gap, not silently
-/// reintroduced).
+/// Returns `None` only for the live `input`/`inputs` queue, which must reach
+/// `eval.rs` untouched. Every other shape is handled natively, via
+/// [`eval_each_generic`]'s own demand-driven `Pipe`/`Iterate`/`LazyKeys`
+/// machinery -- what keeps `expr`'s duplicate keys alive.
 ///
-/// A **bare top-level `Comma`** (`limit((1,2); f)`, matching #1279's own
-/// canonical example) is detected statically and deferred *without* ever
-/// evaluating `n_expr` here, so the caller's single fallback evaluation is
-/// the only one — closing the double-evaluation this fix would otherwise
-/// cause for exactly that shape. This check is deliberately shallow: it
-/// only recognizes `n_expr` itself being (optionally parenthesized) a
-/// `Comma`, not a `Comma` buried inside some other construct (e.g.
-/// `(1|debug,2|debug)` parses as a `Pipe` whose middle stage is the
-/// `Comma`, not a bare one) — that broader shape, and any other
-/// side-effecting `n_expr` that isn't a plain literal or a bare comma,
-/// still costs a second `n_expr` evaluation on the fallback path.
-/// Live-verified: `debug` inside such an `n_expr` fires twice here where
-/// real jq fires it once. `input`/`inputs` inside `n_expr` is unaffected
-/// by this residual gap — that shape is caught unconditionally by the
-/// input-queue guard above, before any evaluation is attempted.
+/// **A generator `n_expr` is one of those shapes now (#1687 items 2 and 3).**
+/// `limit((1,2); f)` re-runs `expr` once per `n` value (jq's own rarer
+/// laziness contract, #1279); this used to probe `n_expr` with `eval_single`,
+/// discover it was not a single value, and defer -- which cost both the
+/// duplicate keys the native path existed to preserve *and* a second
+/// evaluation of `n_expr`, so a `debug` inside it fired twice where jq fires
+/// it once. [`fanout_arg_generic`] drives `n_expr` once and runs
+/// [`limit_with_n_generic`] per value instead, so neither cost remains, and
+/// the shallow "is it a bare top-level `Comma`?" check that partially
+/// mitigated the second one is gone with them.
+/// Run `body` once per output of `arg_expr`, concatenating the results --
+/// the generic-evaluator twin of `eval::fanout_arg`'s `ArgFanout::All` arm
+/// (#1279), which is the only fan-out mode this file's callers need.
+///
+/// Before this existed, `eval_limit_generic`/`eval_nth_generic`/
+/// `eval_has_generic` each *probed* their argument with `eval_single`, and
+/// on discovering more than one output gave up and re-evaluated the entire
+/// expression through the lossy `OwnedValue` bridge. That cost two things
+/// #1687 names as separate defects: the argument was evaluated twice, so a
+/// `debug`/`stderr` inside it fired twice where jq fires once (item 3); and
+/// the bridge collapsed every duplicate mapping key the native path existed
+/// to preserve (item 2). Driving the argument through [`eval_each_generic`]
+/// once and calling `body` per value fixes both at once, and lets all three
+/// callers drop their private, shallow "is the argument a bare top-level
+/// `Comma`?" guard -- the third copy of which `eval_has_generic`'s own doc
+/// comment already flagged as the wrong pattern.
+///
+/// `pending_first` is load-bearing, not an optimization: it holds `body`'s
+/// result for a first argument value whose successor has not arrived yet, so
+/// the overwhelmingly common single-output case returns that result
+/// *unflattened*. Without it every `limit(3; .[])` would be forced through
+/// `Vec<OwnedValue>` and would lose exactly the `ManyCursor`/`LazySeq` shape
+/// #1607 added it to keep. A second value flushes it into `out` before that
+/// value's own result is appended, so ordering is unaffected.
+/// [`fanout_arg_generic`] for a sink-driven caller: run `body` once per
+/// output of `arg_expr`, and stop pulling further argument values the moment
+/// `body` reports the downstream consumer has had enough.
+///
+/// That last property is the whole reason this exists separately rather than
+/// the eager version being reused. `first(limit((1,2); (1, ("B"|stderr))))`
+/// must never explore the `$n=2` binding at all -- jq does not, because
+/// `first` satisfies itself from `$n=1`'s own single output and the whole
+/// nest is demand-driven. Routing that shape through the eager
+/// `OwnedValue` bridge, as `each_limit_generic` did before #1687, ran every
+/// binding to completion before any demand could apply, writing `B` to
+/// stderr where jq writes nothing -- a divergence `each_limit_generic`'s own
+/// doc comment recorded as a residual and this closes.
+fn fanout_arg_each_generic<S: EvalSemantics, V: DocumentValue, B>(
+    arg_expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    mut body: B,
+) -> Flow
+where
+    B: FnMut(OwnedValue) -> Flow,
+{
+    // Tracked out-of-band for the usual reason: the sink can only answer
+    // `Demand`, so "why did the pull stop" has to be recorded beside it.
+    let mut escape: Option<Control> = None;
+    let mut consumer_stopped = false;
+
+    let flow = eval_each_generic::<S, V>(arg_expr, value, optional, cursor, &mut |item| {
+        let owned = match generic_item_into_owned(item) {
+            Ok(owned) => owned,
+            Err(control) => {
+                escape = Some(control);
+                return Demand::Stop;
+            }
+        };
+        match body(owned) {
+            // This `n`'s own walk finished; go on to the next one.
+            Flow::Exhausted => Demand::Continue,
+            // The downstream consumer said stop. Its verdict outranks the
+            // argument generator's, exactly as it does inside
+            // `each_limit_generic`'s own inner sink.
+            Flow::Stopped { .. } => {
+                consumer_stopped = true;
+                Demand::Stop
+            }
+            Flow::Escaped(control) => {
+                escape = Some(control);
+                Demand::Stop
+            }
+        }
+    });
+
+    match escape {
+        Some(control) => Flow::Escaped(control),
+        // `pending` is dropped for the reason every other lazy consumer
+        // drops it: it belongs to an eager fallback jq would never reach.
+        None if consumer_stopped => Flow::Stopped { pending: None },
+        None => flow,
+    }
+}
+
+fn fanout_arg_generic<S: EvalSemantics, V: DocumentValue, B>(
+    arg_expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    mut body: B,
+) -> GenericResult<V>
+where
+    B: FnMut(OwnedValue) -> GenericResult<V>,
+{
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let mut body_control: Option<Control> = None;
+    let mut pending_first: Option<GenericResult<V>> = None;
+    // An argument value that cannot be decoded at all (#1247). Tracked
+    // out-of-band because the sink can only answer `Demand`, and reported
+    // ahead of `flow` below since it is the reason the pull stopped.
+    let mut decode_err: Option<Control> = None;
+
+    let flow = eval_each_generic::<S, V>(arg_expr, value, optional, cursor, &mut |item| {
+        let owned = match generic_item_into_owned(item) {
+            Ok(owned) => owned,
+            Err(control) => {
+                decode_err = Some(control);
+                return Demand::Stop;
+            }
+        };
+        if let Some(previous) = pending_first.take() {
+            if let Some(control) = push_generic_owned_values(previous, &mut out) {
+                body_control = Some(control);
+                return Demand::Stop;
+            }
+        }
+        let result = body(owned);
+        // A `body` failure stops the pull *here*, so the argument's
+        // remaining outputs are never evaluated -- `eval::fanout_arg`'s
+        // rules 2/4. Checked before buffering, or an escaping first result
+        // would be parked and the sink would ask for another value anyway.
+        if result.is_escape() {
+            if let Some(control) = push_generic_owned_values(result, &mut out) {
+                body_control = Some(control);
+            }
+            return Demand::Stop;
+        }
+        if out.is_empty() && pending_first.is_none() {
+            pending_first = Some(result);
+        } else if let Some(control) = push_generic_owned_values(result, &mut out) {
+            body_control = Some(control);
+            return Demand::Stop;
+        }
+        Demand::Continue
+    });
+
+    // Whatever `body` already produced still stands in front of the control,
+    // exactly as it does for the argument's own escape below.
+    let flush_pending = |pending: Option<GenericResult<V>>,
+                        out: &mut Vec<OwnedValue>|
+     -> Option<Control> { pending.and_then(|p| push_generic_owned_values(p, out)) };
+
+    if let Some(control) = decode_err {
+        let control = flush_pending(pending_first, &mut out).unwrap_or(control);
+        return partial_generic(out, control);
+    }
+    match flow {
+        // `pending_first` is `Some` here exactly when one value was
+        // delivered and `body` did not escape -- the single-output fast path.
+        Flow::Exhausted => match pending_first {
+            Some(result) => result,
+            None => owned_vec_to_generic_result(out),
+        },
+        // Our sink is the only thing that stops this pull, and it does so
+        // only after recording `body_control`. `pending` is dropped for the
+        // reason every other lazy consumer drops it: it belongs to an eager
+        // fallback jq would never have reached.
+        Flow::Stopped { .. } => match body_control {
+            Some(control) => partial_generic(out, control),
+            None => owned_vec_to_generic_result(out),
+        },
+        // The argument's own control fires only after every body result
+        // already produced, so a buffered first must be flushed ahead of it.
+        Flow::Escaped(control) => {
+            let control = flush_pending(pending_first, &mut out).unwrap_or(control);
+            partial_generic(out, control)
+        }
+    }
+}
+
 fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
     n_expr: &Expr,
     expr: &Expr,
@@ -6853,25 +7008,41 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
     if limit_or_nth_uses_live_input_queue(n_expr, expr) {
         return None;
     }
-    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
-        return None;
-    }
+    // `n` is the OUTER loop and `expr` the inner one, re-evaluated once per
+    // `n` output -- `[limit((1,2); (10,20,30))]` is `[10,10,20]`, not
+    // `[10,20,10]` (live-verified against jq 1.7.1, and the rule
+    // `eval::eval_limit`'s own `fanout_arg` call already implements).
+    Some(fanout_arg_generic::<S, V, _>(
+        n_expr,
+        value.clone(),
+        optional,
+        cursor,
+        |n_value| limit_with_n_generic::<S, V>(n_value, expr, value.clone(), optional, cursor),
+    ))
+}
 
-    let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
-        GenericResult::One(v) => to_owned(&v).ok()?,
-        GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
-        GenericResult::Owned(v) => v,
-        _ => return None,
-    };
+/// `limit(n; expr)`'s work for one already-resolved `n` -- the body of
+/// [`eval_limit_generic`], run once per output of its `n` generator.
+///
+/// Split out for #1687 exactly as `eval::limit_with_n` was split out of
+/// `eval::eval_limit` for #1279, and for the same reason: the fan-out needs
+/// a per-`n` body to call.
+fn limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
+    n_value: OwnedValue,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
     let n = match classify_limit_n(n_value) {
         Ok(LimitN::Unlimited) => {
-            return Some(eval_single::<S, V>(expr, value, optional, cursor));
+            return eval_single::<S, V>(expr, value, optional, cursor);
         }
         Ok(LimitN::Take(n)) => n,
-        Err(e) => return Some(GenericResult::Error(e)),
+        Err(e) => return GenericResult::Error(e),
     };
     if n == 0 {
-        return Some(GenericResult::None);
+        return GenericResult::None;
     }
 
     // Pull at most `n`, then stop the generator -- mirrors `eval.rs`'s own
@@ -6889,7 +7060,7 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
             Demand::Continue
         }
     });
-    Some(match flow {
+    match flow {
         // The sink returns `Demand::Stop` the instant `out.len() >= n`, and
         // every `eval_each_generic` arm stops pulling as soon as `Demand`
         // says to -- so an escape can only fire *before* that point, never
@@ -6925,13 +7096,13 @@ fn eval_limit_generic<S: EvalSemantics, V: DocumentValue>(
             Ok(result) => result,
             Err((prefix, control)) => partial_generic(prefix, control),
         },
-    })
+    }
 }
 
 /// Native `Builtin::NthStream`/`Expr::NthExpr` arm for the generic evaluator
 /// (#1607) — [`eval_limit_generic`]'s twin, same root cause, same deferral
 /// contract (see its doc comment, including the input-queue guard and the
-/// static-`Comma` detection). jq defines `nth($n; f)` as
+/// generator-`n` fan-out). jq defines `nth($n; f)` as
 /// `last(limit($n + 1; f))`, so this pulls only as far as index `n` then
 /// stops, mirroring `eval.rs`'s own `each_take_nth`.
 ///
@@ -6952,19 +7123,30 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     if limit_or_nth_uses_live_input_queue(n_expr, expr) {
         return None;
     }
-    if matches!(unwrap_paren(n_expr), Expr::Comma(_)) {
-        return None;
-    }
+    // Same outer/inner nesting as `limit` -- `[nth((0,1); (10,20,30))]` is
+    // `[10,20]`, one full walk of `expr` per `n`.
+    Some(fanout_arg_generic::<S, V, _>(
+        n_expr,
+        value.clone(),
+        optional,
+        cursor,
+        |n_value| nth_with_n_generic::<S, V>(n_value, expr, value.clone(), optional, cursor),
+    ))
+}
 
-    let n_value = match eval_single::<S, V>(n_expr, value.clone(), optional, cursor) {
-        GenericResult::One(v) => to_owned(&v).ok()?,
-        GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
-        GenericResult::Owned(v) => v,
-        _ => return None,
-    };
+/// `nth(n; expr)`'s work for one already-resolved `n` -- [`eval_nth_generic`]'s
+/// per-`n` body, split out for the fan-out exactly as
+/// [`limit_with_n_generic`] was.
+fn nth_with_n_generic<S: EvalSemantics, V: DocumentValue>(
+    n_value: OwnedValue,
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
     let n = match classify_nth_n(n_value) {
         Ok(n) => n,
-        Err(e) => return Some(GenericResult::Error(e)),
+        Err(e) => return GenericResult::Error(e),
     };
 
     let mut seen = 0usize;
@@ -7006,7 +7188,7 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
     // kept cursor-backed ([`generic_item_to_result`], #607's own
     // conversion) rather than forced through `OwnedValue`, so a duplicate
     // key *inside* it survives too, not just across the walk to reach it.
-    Some(if let Some(item) = wanted {
+    if let Some(item) = wanted {
         generic_item_to_result(item)
     } else if let Some(control) = skipped_err {
         partial_generic(Vec::new(), control)
@@ -7015,7 +7197,7 @@ fn eval_nth_generic<S: EvalSemantics, V: DocumentValue>(
             Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
             Flow::Escaped(control) => partial_generic(Vec::new(), control),
         }
-    })
+    }
 }
 
 /// Convert a batch of pulled [`GenericItem`]s into the smallest
@@ -7827,27 +8009,34 @@ fn collect_paths_generic<S: EvalSemantics, V: DocumentValue>(
 /// discovers it isn't a single value, leaving the fallback to run against an
 /// already-empty queue (code review, #1739).
 ///
-/// Also mirrors `eval_limit_generic`'s bare-top-level-`Comma` static check
-/// (same doc comment, same reasoning): `has(("a","b"))`'s key is a generator
-/// by construction, so probing it here would run any side effect inside it
-/// (`has(("a"|stderr),"z")`) once during the probe and a second time when
-/// the fallback below re-evaluates the whole, unmodified `key_expr` from
-/// scratch -- detecting the shape statically, without ever calling
-/// `eval_single` on it, keeps the fallback's own evaluation the only one.
+/// Also keeps a static bare-top-level-`Comma` check: `has(("a","b"))`'s key
+/// is a generator by construction, so probing it here would run any side
+/// effect inside it (`has(("a"|stderr),"z")`) once during the probe and a
+/// second time when the fallback below re-evaluates the whole, unmodified
+/// `key_expr` from scratch -- detecting the shape statically, without ever
+/// calling `eval_single` on it, keeps the fallback's own evaluation the only
+/// one.
 ///
-/// This check is deliberately shallow, same as `eval_limit_generic`'s own
-/// (see its doc comment): it only recognizes `key_expr` itself being an
-/// (optionally parenthesized) top-level `Comma`, not one buried inside some
-/// other construct (`if true then ("a"|stderr),"z" else "q" end`, or any
-/// `key_expr` that raises an error rather than yielding a plain value). Such
-/// a shape still gets probed once here, discovers it isn't a single value,
-/// and falls back to a second full evaluation -- a known, already-shipped
-/// residual gap for `limit`/`nth` (#1607, tracked further in #1687 item 3),
-/// not attempted to be closed generally here either. A shared "materialize
-/// N outputs losslessly, without double-evaluating a probe" primitive is
-/// #1687's own suggested direction for actually closing this class; adding
-/// a third one-off native arm with the identical shallow guard isn't that
-/// fix (code review, #1739).
+/// The check is deliberately shallow: it only recognizes `key_expr` itself
+/// being an (optionally parenthesized) top-level `Comma`, not one buried
+/// inside some other construct (`if true then ("a"|stderr),"z" else "q" end`,
+/// or any `key_expr` that raises an error rather than yielding a plain
+/// value). Such a shape still gets probed once here, discovers it isn't a
+/// single value, and falls back to a second full evaluation.
+///
+/// **`limit`/`nth` no longer share this residual; `has` deliberately still
+/// does.** #1687 built [`fanout_arg_generic`] -- the shared "run the body
+/// once per argument output, without double-evaluating a probe" primitive
+/// #1739's own review asked for -- and moved `eval_limit_generic`/
+/// `eval_nth_generic`/`each_limit_generic` onto it, deleting their copies of
+/// this guard. `has` is not moved with them because it needs a fan-out mode
+/// that primitive does not model: real yq takes only a multi-output key's
+/// *first* output where jq fans out (`ArgFanout::yq_native`), and
+/// `fanout_arg_generic` implements `ArgFanout::All` alone, which is all its
+/// three callers need. Reproducing yq's truncation (and
+/// `clear_values_when_yq_argument_escaped`, which rides with it) here would
+/// be a second copy of `eval::fanout_arg`'s non-`All` half -- so `has`
+/// keeps handing that shape to the one existing implementation instead.
 fn eval_has_generic<S: EvalSemantics, V: DocumentValue>(
     key_expr: &Expr,
     value: V,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8296,6 +8296,17 @@ fn sort_key_generic<S: EvalSemantics, V: DocumentValue>(
 /// document position at all. So a duplicate key *inside a comparison key* is
 /// still collapsed -- exactly as it is in `eval.rs` today. Only the emitted
 /// element is lossless.
+///
+/// **The `Some(f)` arm deliberately does not decode-check the element, and so
+/// does not carry `eval.rs`'s #1755 rule for it.** `eval::builtin_sort_by`/
+/// `unique_by`/`min_by`/`max_by` each call `to_owned_checked(&item)` on the
+/// *element* as well as computing its key, so an undecodable element raises
+/// rather than sorting in as `""`. Here it is only decoded when `key` is
+/// `None`, since the `_by` forms never need the element's value -- and adding
+/// the check back would cost a full decode per element on exactly the path
+/// #1687 already made slower for large sorted YAML (see the CHANGELOG entry).
+/// No live repro is known for the gap today; filed as #2069 rather than closed
+/// blind, because the fix and the cost point in opposite directions.
 fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
     cursors: Vec<V::Cursor>,
     key: Option<&Expr>,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -34,7 +34,7 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
-    collect_pattern_var_names, eval as full_eval, eval_each_owned, expand_func_calls,
+    collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned, expand_func_calls,
     extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_in_array_bounds,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
@@ -44,7 +44,7 @@ use super::eval::{
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
-use super::value::{NumberRepr, OwnedValue};
+use super::value::{owned_value_eq, NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
 
 /// Recursion-depth ceiling for [`to_owned`]/[`to_owned_cursor`]/
@@ -7910,6 +7910,140 @@ fn eval_has_one_key<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
+/// jq's sort key for one element: `[f]`, the array of *every* output of the
+/// key filter, not just its first (#155).
+///
+/// The generic twin of `eval::eval_array_construction`'s use inside
+/// `builtin_min_by`/`sort_by`/`group_by`/`unique_by`. It deliberately does
+/// *not* route through this file's own `Expr::Array` arm, which additionally
+/// applies `yq_float_fidelity_fixup` -- that fixup exists to make a computed
+/// float *print* the way real yq prints it, and running it here would let an
+/// output-formatting rule change which element sorts first.
+///
+/// Atomic, matching `eval_array_construction`: any control from `f` -- error,
+/// break, halt, or the trailing control of a `Partial` -- discards the prefix
+/// and aborts the whole builtin, rather than keying the element on a partial
+/// array.
+fn sort_key_generic<S: EvalSemantics, V: DocumentValue>(
+    f: &Expr,
+    elem: &V::Cursor,
+    optional: bool,
+) -> Result<OwnedValue, Control> {
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let result = eval_single::<S, V>(f, elem.value(), optional, Some(*elem));
+    match push_generic_owned_values(result, &mut out) {
+        Some(control) => Err(control),
+        None => Ok(OwnedValue::Array(out)),
+    }
+}
+
+/// Pair every element of `cursors` with its comparison key, keeping the
+/// cursor itself untouched.
+///
+/// `key` is `None` for the bare `sort`/`unique`/`min`/`max` spellings, which
+/// compare elements by their own decoded value; `Some(f)` for the `_by`
+/// forms, which compare by [`sort_key_generic`]. Either way the *element*
+/// stays a `V::Cursor` -- that is the whole point of #1687's fix for this
+/// family, since only a cursor can still name a duplicate mapping key.
+///
+/// The key is an `OwnedValue` in both cases and unavoidably so: `compare_values`
+/// has no cursor-domain equivalent, and a `_by` key is a computed value with no
+/// document position at all. So a duplicate key *inside a comparison key* is
+/// still collapsed -- exactly as it is in `eval.rs` today. Only the emitted
+/// element is lossless.
+fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
+    cursors: Vec<V::Cursor>,
+    key: Option<&Expr>,
+    optional: bool,
+) -> Result<Vec<(OwnedValue, V::Cursor)>, Control> {
+    let mut keyed = vec_with_capacity(cursors.len());
+    for cursor in cursors {
+        let k = match key {
+            Some(f) => sort_key_generic::<S, V>(f, &cursor, optional)?,
+            // #1755's rule, in this file's spelling: `to_owned_cursor` is
+            // already the checked conversion, so an undecodable element
+            // raises rather than silently sorting in as `""`.
+            None => to_owned_cursor(&cursor).map_err(Control::Error)?,
+        };
+        keyed.push((k, cursor));
+    }
+    Ok(keyed)
+}
+
+/// Whether the reordering builtins may keep this input's elements as
+/// cursors, or must hand the whole thing to the DOM path instead.
+///
+/// See [`DocumentCursor::document_has_aliases`] for the full reasoning: an
+/// alias is only sound while it still follows a declaration of the same name,
+/// and reordering, selecting or dropping nodes can break that. The DOM path's
+/// `enforce_anchor_soundness` is what normally prevents it, and the
+/// cursor-streaming path cannot reach that pass (#1350). So an alias-bearing
+/// document keeps exactly the behaviour it had before #1687 -- sound output,
+/// at the cost of the duplicate keys this fix would otherwise have saved --
+/// rather than gaining faithful marks it could not read back.
+///
+/// `cursor` is `None` when the array being reordered is itself a computed
+/// value with no document position; there are no marks to get wrong then.
+fn reordering_may_keep_cursors<V: DocumentValue>(cursor: Option<&V::Cursor>) -> bool {
+    !cursor.is_some_and(DocumentCursor::document_has_aliases)
+}
+
+/// Turn a `Control` raised while keying elements back into a `GenericResult`.
+///
+/// Every builtin in this family is atomic -- `eval.rs`'s own arms return
+/// bare `Error`/`Break`/`Halt` with no partial prefix -- so this never
+/// produces a `Partial`.
+fn sort_family_control<V: DocumentValue>(control: Control) -> GenericResult<V> {
+    match control {
+        Control::Error(e) => GenericResult::Error(e),
+        Control::Break(label) => GenericResult::Break(label),
+        Control::Halt(code) => GenericResult::Halt(code),
+    }
+}
+
+/// The shared body of `sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/
+/// `max`/`max_by`/`reverse` for the array case (#1687).
+///
+/// Only the array case: every one of those builtins gives a non-array input
+/// its own mode-specific error wording (`object_pair_type_error`'s jq pairing
+/// bug for `min_by`, `yq_only_arrays_supported_for` for `unique`,
+/// `cannot_be_sorted` for `sort`, and `scalar_fallback`'s decode-failure
+/// precedence in front of `optional` for all of them). Reproducing that here
+/// would be a second copy of a decision tree #929/#995/#1755/#1901 have each
+/// corrected once already, so the caller bridges a non-array input to
+/// `eval.rs` verbatim instead. This function is reached only once the input
+/// is known to be an array.
+///
+/// `reorder` receives the keyed elements and returns the elements the result
+/// should contain, in order. Returning `GenericResult::LazySeq` over those
+/// cursors -- rather than an `OwnedValue::Array` -- is what keeps a duplicate
+/// mapping key inside a moved element alive.
+fn sort_family_array_generic<S: EvalSemantics, V: DocumentValue>(
+    cursors: Vec<V::Cursor>,
+    key: Option<&Expr>,
+    optional: bool,
+    reorder: impl FnOnce(Vec<(OwnedValue, V::Cursor)>) -> Vec<V::Cursor>,
+) -> GenericResult<V> {
+    let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
+        Ok(keyed) => keyed,
+        Err(control) => return sort_family_control(control),
+    };
+    GenericResult::LazySeq(Box::new(LazySeq::from_cursors(reorder(keyed))))
+}
+
+/// `sort`/`sort_by`'s ordering step, shared with `unique`/`unique_by`, which
+/// jq defines as a sort followed by a dedup.
+///
+/// `sort_by` (not `sort_unstable_by`) on purpose: jq's sort is stable, so two
+/// elements with equal keys keep their input order. That is observable here
+/// in a way it is not in `eval.rs` -- there the tied elements have already
+/// been flattened to equal `OwnedValue`s, whereas the cursors this returns
+/// still point at distinct document positions that can print differently
+/// (two mappings with the same collapsed form but different duplicate keys).
+fn sort_keyed_elements<V: DocumentValue>(keyed: &mut [(OwnedValue, V::Cursor)]) {
+    keyed.sort_by(|(a, _), (b, _)| compare_values(a, b));
+}
+
 fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
     value: V,
@@ -8561,12 +8695,27 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
+        // #1687: `reverse` already held the element cursors in hand
+        // (`collect_cursors()`) and then threw them away, decoding each into
+        // an `IndexMap`-backed `OwnedValue` purely to hand back an
+        // `OwnedValue::Array`. Every duplicate mapping key inside a reversed
+        // element died there, even though reversing moves elements without
+        // computing a single new value. Returning the cursors as a `LazySeq`
+        // instead keeps them alive -- real yq preserves them (v4.53.3,
+        // `reverse | .[0]` on a duplicate-keyed mapping element).
         Builtin::Reverse => {
+            if !reordering_may_keep_cursors::<V>(cursor.as_ref()) {
+                return bridge_to_full_evaluator::<S, _>(
+                    &Expr::Builtin(builtin.clone()),
+                    value,
+                    cursor,
+                    optional,
+                );
+            }
             if let Some(elements) = value.as_array() {
-                let values: Vec<OwnedValue> = owned_or_err!(to_owned_all_cursors(
-                    elements.collect_cursors().iter().rev()
-                ));
-                GenericResult::Owned(OwnedValue::Array(values))
+                let mut cursors = elements.collect_cursors();
+                cursors.reverse();
+                GenericResult::LazySeq(Box::new(LazySeq::from_cursors(cursors)))
             } else if optional {
                 GenericResult::None
             } else {
@@ -8574,6 +8723,104 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     tagged_type_name(&value, cursor),
                     "number",
                 ))
+            }
+        }
+
+        // #1687: `sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/`max`/
+        // `max_by` all answer a permutation or subset of their *input's own*
+        // elements, computing nothing new except the comparison keys -- so
+        // there is no reason for any of them to route through the `_` bridge
+        // below, which materializes the whole document into an `IndexMap`-
+        // backed `OwnedValue` first and collapses every duplicate mapping key
+        // in the process. Real yq preserves them (verified live against
+        // v4.53.3 for `sort`, `sort_by`, `unique`, `unique_by`, `min`, `max`
+        // and `reverse`; `min_by`/`max_by` are lexer-rejected there, so they
+        // follow their siblings and `keys`, which yq does implement and which
+        // preserves).
+        //
+        // Array inputs only, on purpose -- see `sort_family_array_generic`'s
+        // doc comment for why a non-array input bridges instead of growing a
+        // second copy of `eval.rs`'s per-builtin error wording.
+        Builtin::Sort | Builtin::SortBy(_) | Builtin::Unique | Builtin::UniqueBy(_) => {
+            let Some(elements) = value
+                .as_array()
+                .filter(|_| reordering_may_keep_cursors::<V>(cursor.as_ref()))
+            else {
+                return bridge_to_full_evaluator::<S, _>(
+                    &Expr::Builtin(builtin.clone()),
+                    value,
+                    cursor,
+                    optional,
+                );
+            };
+            let key = match builtin {
+                Builtin::SortBy(f) | Builtin::UniqueBy(f) => Some(&**f),
+                _ => None,
+            };
+            let dedup = matches!(builtin, Builtin::Unique | Builtin::UniqueBy(_));
+            sort_family_array_generic::<S, _>(
+                elements.collect_cursors(),
+                key,
+                optional,
+                |mut keyed| {
+                    sort_keyed_elements::<V>(&mut keyed);
+                    if dedup {
+                        // `owned_value_eq::<S>`, not `compare_values(..) ==
+                        // Equal`: the sort above stays widening, but two
+                        // elements only count as duplicates under `==`'s own
+                        // yq-mode strict Int/Float distinction (#950). Same
+                        // choice `eval::builtin_unique` makes, reused rather
+                        // than re-derived.
+                        keyed.dedup_by(|(a, _), (b, _)| owned_value_eq::<S>(a, b));
+                    }
+                    keyed.into_iter().map(|(_, cursor)| cursor).collect()
+                },
+            )
+        }
+
+        // The single-element half of the same family. `min`/`max` answer one
+        // of the input's own elements, so the winner is returned as a bare
+        // `OneCursor` -- the same shape `eval_first_or_last_generic` already
+        // uses to keep `first(.[])` lossless (#607).
+        Builtin::Min | Builtin::MinBy(_) | Builtin::Max | Builtin::MaxBy(_) => {
+            let Some(elements) = value
+                .as_array()
+                .filter(|_| reordering_may_keep_cursors::<V>(cursor.as_ref()))
+            else {
+                return bridge_to_full_evaluator::<S, _>(
+                    &Expr::Builtin(builtin.clone()),
+                    value,
+                    cursor,
+                    optional,
+                );
+            };
+            let cursors = elements.collect_cursors();
+            // jq answers `null` for an empty array, for all four spellings.
+            if cursors.is_empty() {
+                return GenericResult::Owned(OwnedValue::Null);
+            }
+            let key = match builtin {
+                Builtin::MinBy(f) | Builtin::MaxBy(f) => Some(&**f),
+                _ => None,
+            };
+            let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
+                Ok(keyed) => keyed,
+                Err(control) => return sort_family_control(control),
+            };
+            // `min_by`/`max_by` on ties: jq's own definitions keep the
+            // *first* minimum and the *last* maximum (`min_by` uses `<`,
+            // `max_by` uses `<=` internally), which is exactly what
+            // `Iterator::min_by`/`max_by` do. Reusing them rather than
+            // hand-rolling the comparison keeps that asymmetry from being
+            // re-derived and getting it backwards.
+            let winner = if matches!(builtin, Builtin::Min | Builtin::MinBy(_)) {
+                keyed.into_iter().min_by(|(a, _), (b, _)| compare_values(a, b))
+            } else {
+                keyed.into_iter().max_by(|(a, _), (b, _)| compare_values(a, b))
+            };
+            match winner {
+                Some((_, cursor)) => GenericResult::OneCursor(cursor),
+                None => unreachable!("the empty case returned above"),
             }
         }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1087,16 +1087,31 @@ enum LazySource<V: DocumentValue> {
     /// Array `keys_unsorted | map(f)` (#724) — synthetic `[0, 1, ..., len-1]`,
     /// no cursor to point at.
     IndexRange { next: usize, len: usize },
-    /// `Values`'s duplicate-key fallback (#1398): `obj | map(f)` is `[.[] |
-    /// f]`, and `.[]` collapses a repeated key to its first position but
-    /// last-seen value in both modes (see `Expr::Iterate`'s identical
-    /// rule). That requires seeing every occurrence before any value can
-    /// be emitted, so it can't stay a `Fields` cons-list walk -- this
-    /// variant holds the already-collapsed value cursors instead.
-    /// Constructed only when `document::collapsed_fields` actually finds a
-    /// repeat, so the ordinary duplicate-free `Values` path above is
-    /// unaffected.
-    CollapsedValues {
+    /// An explicit, already-ordered list of element cursors -- the general
+    /// "this array's elements are these document nodes, in this order"
+    /// source. Unlike every variant above it does not walk a live cons-list,
+    /// so the order and membership are whatever the producer chose.
+    ///
+    /// Two producers today:
+    ///
+    /// - `Values`'s duplicate-key fallback (#1398): `obj | map(f)` is `[.[] |
+    ///   f]`, and `.[]` collapses a repeated key to its first position but
+    ///   last-seen value in both modes (see `Expr::Iterate`'s identical
+    ///   rule). That requires seeing every occurrence before any value can
+    ///   be emitted, so it can't stay a `Fields` cons-list walk. Constructed
+    ///   only when `document::collapsed_fields` actually finds a repeat, so
+    ///   the ordinary duplicate-free `Values` path above is unaffected.
+    /// - The reordering/selecting builtins (#1687): `sort`, `sort_by`,
+    ///   `unique`, `unique_by` and `reverse` all answer a *permutation or
+    ///   subset of their input's own elements*, so their result is exactly
+    ///   this -- a `Vec<V::Cursor>` in the new order. Returning it as a
+    ///   `LazySeq` rather than an `OwnedValue::Array` is what keeps a
+    ///   duplicate mapping key *inside* a moved element alive, since
+    ///   `OwnedValue::Object` is `IndexMap`-backed and cannot represent one.
+    ///   `Builtin::Map`'s own long-standing `LazySeq` return (#724/#725) is
+    ///   the working precedent: `map(.)` is the one filter in this family
+    ///   that already preserved duplicates, for exactly this reason.
+    Cursors {
         cursors: Vec<V::Cursor>,
         next: usize,
     },
@@ -1114,8 +1129,8 @@ impl<V: DocumentValue> core::fmt::Debug for LazySource<V> {
                 .field("next", next)
                 .field("len", len)
                 .finish(),
-            Self::CollapsedValues { next, cursors } => f
-                .debug_struct("LazySource::CollapsedValues")
+            Self::Cursors { next, cursors } => f
+                .debug_struct("LazySource::Cursors")
                 .field("next", next)
                 .field("len", &cursors.len())
                 .finish(),
@@ -1128,6 +1143,14 @@ impl<V: DocumentValue> LazySource<V> {
     /// rule as it pulls (#1514).
     fn keys(fields: V::Fields, collapse: bool) -> Self {
         Self::Keys(DistinctKeyCursors::new(&fields, collapse))
+    }
+
+    /// A [`Self::Cursors`] source positioned at its first element.
+    ///
+    /// The `next: 0` is the only thing every producer would otherwise have
+    /// to remember to write, so it lives here rather than at each call site.
+    fn cursors(cursors: Vec<V::Cursor>) -> Self {
+        Self::Cursors { cursors, next: 0 }
     }
     /// Pull one element forward, storing "the rest" back into `self`. Once a
     /// variant's underlying cons-list is empty (or `next == len`), every
@@ -1172,7 +1195,7 @@ impl<V: DocumentValue> LazySource<V> {
                 *next += 1;
                 Some(LazyElem::Owned(OwnedValue::Int(i as i64)))
             }
-            Self::CollapsedValues { cursors, next } => {
+            Self::Cursors { cursors, next } => {
                 let Some(cursor) = cursors.get(*next).copied() else {
                     return Ok(None);
                 };
@@ -1256,6 +1279,20 @@ impl<V: DocumentValue> LazySeq<V> {
     fn push_map(mut self, f: &Expr, tag: EvalTag) -> Self {
         self.push_map_in_place(f, tag);
         self
+    }
+
+    /// An array whose elements are exactly `cursors`, with no `map` stage on
+    /// top -- the lossless answer for a builtin that reorders or selects its
+    /// input's own elements without computing new ones (#1687).
+    ///
+    /// The instruction chain is deliberately empty: `fold_one` then folds
+    /// each element through zero stages and hands the cursor straight back,
+    /// so `stream_json`/`stream_yaml` render every element from its own live
+    /// document position. That is the whole point -- it is what preserves a
+    /// duplicate mapping key inside a moved element, which an
+    /// `OwnedValue::Array` of `IndexMap`-backed objects cannot.
+    fn from_cursors(cursors: Vec<V::Cursor>) -> Self {
+        Self::new(LazySource::cursors(cursors))
     }
 
     /// Run one `Instruction` against one pending item, re-dispatching to
@@ -8006,13 +8043,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // so the duplicate-free case (by far the common one) keeps
                 // #724/#725's lazy pull unchanged.
                 let source = match collapsed_fields(&fields) {
-                    Some(collapsed) => LazySource::CollapsedValues {
-                        cursors: collapsed
+                    Some(collapsed) => LazySource::cursors(
+                        collapsed
                             .into_iter()
                             .map(|field| field.value_cursor)
                             .collect(),
-                        next: 0,
-                    },
+                    ),
                     None => LazySource::Values(fields),
                 };
                 GenericResult::LazySeq(Box::new(LazySeq::new(source).push_map(f, S::TAG)))

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8297,16 +8297,15 @@ fn sort_key_generic<S: EvalSemantics, V: DocumentValue>(
 /// still collapsed -- exactly as it is in `eval.rs` today. Only the emitted
 /// element is lossless.
 ///
-/// **The `Some(f)` arm deliberately does not decode-check the element, and so
-/// does not carry `eval.rs`'s #1755 rule for it.** `eval::builtin_sort_by`/
-/// `unique_by`/`min_by`/`max_by` each call `to_owned_checked(&item)` on the
-/// *element* as well as computing its key, so an undecodable element raises
-/// rather than sorting in as `""`. Here it is only decoded when `key` is
-/// `None`, since the `_by` forms never need the element's value -- and adding
-/// the check back would cost a full decode per element on exactly the path
-/// #1687 already made slower for large sorted YAML (see the CHANGELOG entry).
-/// No live repro is known for the gap today; filed as #2069 rather than closed
-/// blind, because the fix and the cost point in opposite directions.
+/// **Both arms carry `eval.rs`'s #1755 rule**, by different means: the `None`
+/// arm's own conversion is already the checked one, and the `Some(f)` arm
+/// runs `push_generic_truthiness_cursor_error` -- the same validation with the
+/// `OwnedValue` construction removed. #2069 filed this as an accepted gap on
+/// the grounds that no live repro was known and the check would cost a full
+/// decode per element; both premises were wrong. The repro is
+/// `[{"a":2,"s":"\ud800"},{"a":1,"s":"ok"}] | sort_by(.a) | length`, which
+/// answered 2 where `main` raised, and the validation-only walk costs no
+/// materialization.
 fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
     cursors: Vec<V::Cursor>,
     key: Option<&Expr>,
@@ -8315,10 +8314,33 @@ fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
     let mut keyed = vec_with_capacity(cursors.len());
     for cursor in cursors {
         let k = match key {
-            Some(f) => sort_key_generic::<S, V>(f, &cursor, optional)?,
-            // #1755's rule, in this file's spelling: `to_owned_cursor` is
-            // already the checked conversion, so an undecodable element
-            // raises rather than silently sorting in as `""`.
+            Some(f) => {
+                // #1755's rule for the `_by` forms. `eval::builtin_sort_by`/
+                // `unique_by`/`min_by`/`max_by` each `to_owned_checked` the
+                // *element* as well as computing its key, so an undecodable
+                // element raises rather than silently sorting in as `""`.
+                // Omitting that here was a live regression, not a theoretical
+                // one: on `[{"a":2,"s":"\ud800"},{"a":1,"s":"ok"}]`,
+                // `sort_by(.a) | length` answered 2 where `main` raised --
+                // the bad element never reaches the output, so nothing else
+                // would ever have surfaced it.
+                //
+                // `push_generic_truthiness_cursor_error`, not
+                // `to_owned_cursor`: it is that function's own traversal and
+                // validation with the `OwnedValue` construction removed, so
+                // the `_by` forms keep the point of this arm -- never
+                // materializing an element they only ever reorder -- while
+                // still raising on one that cannot be decoded. (Not free: it
+                // still allocates one `String` per object key, per
+                // `resolve_display_key`'s #1642 guard.)
+                if let Some(control) = push_generic_truthiness_cursor_error(&cursor, 0) {
+                    return Err(control);
+                }
+                sort_key_generic::<S, V>(f, &cursor, optional)?
+            }
+            // The bare forms compare elements by their own decoded value, so
+            // the conversion below *is* the check -- `to_owned_cursor` is
+            // already the checked one.
             None => to_owned_cursor(&cursor).map_err(Control::Error)?,
         };
         keyed.push((k, cursor));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -35,14 +35,13 @@ use super::document::{
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
     collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned,
-    eval_foreach_with_values, eval_reduce_with_values, expand_func_calls,
-    extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_in_array_bounds,
+    eval_foreach_with_values, eval_reduce_with_values, expand_func_calls, extract_pattern_bindings,
+    format_owned, has_type_mismatch_is_permissive, index_in_array_bounds,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
     slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var, substitute_vars,
     suppresses, tonumber_from_str, try_reserve_product, vec_with_capacity, Control, Demand,
-    EvalError,
-    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
+    EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
@@ -7122,9 +7121,10 @@ where
 
     // Whatever `body` already produced still stands in front of the control,
     // exactly as it does for the argument's own escape below.
-    let flush_pending = |pending: Option<GenericResult<V>>,
-                        out: &mut Vec<OwnedValue>|
-     -> Option<Control> { pending.and_then(|p| push_generic_owned_values(p, out)) };
+    let flush_pending =
+        |pending: Option<GenericResult<V>>, out: &mut Vec<OwnedValue>| -> Option<Control> {
+            pending.and_then(|p| push_generic_owned_values(p, out))
+        };
 
     if let Some(control) = decode_err {
         let control = flush_pending(pending_first, &mut out).unwrap_or(control);
@@ -9159,9 +9159,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // hand-rolling the comparison keeps that asymmetry from being
             // re-derived and getting it backwards.
             let winner = if matches!(builtin, Builtin::Min | Builtin::MinBy(_)) {
-                keyed.into_iter().min_by(|(a, _), (b, _)| compare_values(a, b))
+                keyed
+                    .into_iter()
+                    .min_by(|(a, _), (b, _)| compare_values(a, b))
             } else {
-                keyed.into_iter().max_by(|(a, _), (b, _)| compare_values(a, b))
+                keyed
+                    .into_iter()
+                    .max_by(|(a, _), (b, _)| compare_values(a, b))
             };
             match winner {
                 Some((_, cursor)) => GenericResult::OneCursor(cursor),
@@ -16926,5 +16930,4 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
-
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -34,12 +34,14 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
-    collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned, expand_func_calls,
+    collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned,
+    eval_foreach_with_values, eval_reduce_with_values, expand_func_calls,
     extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_in_array_bounds,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
     slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var, substitute_vars,
-    tonumber_from_str, try_reserve_product, vec_with_capacity, Control, Demand, EvalError,
+    suppresses, tonumber_from_str, try_reserve_product, vec_with_capacity, Control, Demand,
+    EvalError,
     EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
@@ -5066,6 +5068,83 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // instead of losing it to the wildcard fallback's whole-document
         // `to_owned()`, which collapses duplicate mapping keys before the
         // wrapped expression ever runs (#1168).
+        // #1687: `reduce`/`foreach` had no arm here at all, so every one of
+        // them bridged the whole document through an `IndexMap`-backed
+        // `OwnedValue` before `input` was evaluated -- collapsing duplicate
+        // mapping keys the *input generator itself* would have walked.
+        // `reduce (keys|.[]) as $k (0; .+1)` on `b: 1\na: 2\nb: 3\n`
+        // answered 2 where `[keys|.[]] | length` on the same document
+        // answers 3, an internal contradiction rather than merely a
+        // divergence. Evaluating `input`/INIT through the generic sink here
+        // fixes the count; the fold itself is then `eval.rs`'s, unchanged.
+        //
+        // See `stream_owned_outputs_generic` for what this does *not* fix:
+        // the accumulator and every bound `$x` stay `OwnedValue`, so a
+        // duplicate key inside a bound element still collapses at the bind.
+        Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } if !streams_unbounded(input) && !streams_unbounded(init) => {
+            let (input_values, input_control) =
+                stream_owned_outputs_generic::<S, V>(input, value.clone(), optional, cursor);
+            // `reduce`'s output is single-shot -- it emits only the final
+            // accumulator, never an intermediate -- so a control anywhere in
+            // the input stream discards the prefix and propagates alone.
+            // Mirrors `eval::eval_reduce`'s identical arms, `optional`
+            // suppression included (a decode failure is never suppressed,
+            // #1620/#1902, which `suppresses` already encodes).
+            if let Some(control) = input_control {
+                return match control {
+                    Control::Error(e) if suppresses(&e, optional) => GenericResult::None,
+                    Control::Error(e) => GenericResult::Error(e),
+                    Control::Break(label) => GenericResult::Break(label),
+                    Control::Halt(code) => GenericResult::Halt(code),
+                };
+            }
+            let (init_values, init_control) =
+                stream_owned_outputs_generic::<S, V>(init, value, optional, cursor);
+            query_result_to_generic::<V>(eval_reduce_with_values::<Vec<u64>, S>(
+                patterns,
+                update,
+                input_values,
+                init_values,
+                init_control,
+                optional,
+            ))
+        }
+
+        // `foreach`'s twin of the arm above, with `eval::eval_foreach`'s own
+        // difference preserved: unlike `reduce` it emits per step, so a
+        // `Partial` input stream's already-produced prefix is still iterated
+        // and `input_control` is carried alongside it rather than replacing
+        // it. `eval_foreach_with_values` owns that precedence (it folds
+        // `input_control` in ahead of INIT's), so it is passed through
+        // untouched here rather than re-decided.
+        Expr::Foreach {
+            input,
+            patterns,
+            init,
+            update,
+            extract,
+        } if !streams_unbounded(input) && !streams_unbounded(init) => {
+            let (input_values, input_control) =
+                stream_owned_outputs_generic::<S, V>(input, value.clone(), optional, cursor);
+            let (init_values, init_control) =
+                stream_owned_outputs_generic::<S, V>(init, value, optional, cursor);
+            query_result_to_generic::<V>(eval_foreach_with_values::<Vec<u64>, S>(
+                patterns,
+                update,
+                extract.as_deref(),
+                input_values,
+                input_control,
+                init_values,
+                init_control,
+                optional,
+            ))
+        }
+
         Expr::Array(inner) => {
             let items: Vec<OwnedValue> = match eval_single::<S, _>(inner, value, optional, cursor)
                 .materialize_lazy()
@@ -6863,6 +6942,83 @@ fn limit_or_nth_uses_live_input_queue(n_expr: &Expr, expr: &Expr) -> bool {
 /// binding to completion before any demand could apply, writing `B` to
 /// stderr where jq writes nothing -- a divergence `each_limit_generic`'s own
 /// doc comment recorded as a residual and this closes.
+/// Materialize every output of `expr` through the *generic* evaluator,
+/// alongside whatever control terminated the stream.
+///
+/// The generic twin of `eval::stream_outputs_checked`, and the whole of
+/// #1687's `reduce`/`foreach` fix: those two constructs had no arm in this
+/// file at all, so every `reduce`/`foreach` query bridged the entire document
+/// into an `OwnedValue` before `input` was so much as looked at -- and
+/// `reduce (keys|.[]) as $k (0; .+1)` over `b: 1\na: 2\nb: 3\n` therefore
+/// counted 2 keys where `[keys|.[]]` on the same document correctly counts 3.
+/// Evaluating `input`/`INIT` here instead keeps the *stream* faithful.
+///
+/// **The elements are still owned, and that is a real limit, not an
+/// oversight.** `reduce`'s accumulator, and every `$x` a pattern binds, are
+/// `OwnedValue` throughout both evaluators -- `substitute_bound_var` takes
+/// `&OwnedValue`, and no duplicate-key-capable owned representation exists in
+/// this crate. So a duplicate mapping key inside an element that gets *bound*
+/// is still collapsed at the bind, exactly as it is in `eval.rs`. Only the
+/// number and order of the elements is recovered here. Recorded in
+/// `docs/compliance/yq/limitations.md`.
+/// Whether `expr` can produce an unbounded stream when pulled to exhaustion,
+/// and so must not be driven through [`stream_owned_outputs_generic`].
+///
+/// Only `repeat` qualifies today, and the reason is asymmetric on purpose.
+/// `Expr::Repeat`'s *eager* evaluation (`eval::eval_repeat`) stops after
+/// `MAX_ITERATIONS` rounds and raises `repeat: maximum iterations exceeded`;
+/// its *demand-driven* sink arm (`each_repeat_generic`, #2014) deliberately
+/// does not, because its whole purpose is to let a wrapping `limit`/`first`
+/// stop it at the source. Every other consumer of that sink stops; an eager
+/// one does not, so `reduce repeat(1) as $x (0; .+1)` would spin forever
+/// rather than raising the way `eval.rs`'s own `reduce` does.
+///
+/// `range(infinite)` needs no entry here -- it self-caps -- and `while`/
+/// `until` have no sink arm at all, so both reach `eval.rs`'s bounded
+/// evaluation regardless.
+///
+/// Consulted for *both* operands this file drives eagerly -- `input` and
+/// `INIT`. Guarding only `input` still hung on
+/// `reduce .[] as $x (repeat(1); .+$x)`: the guard's scope has to match every
+/// call site it protects, not just the one in the repro. UPDATE needs no
+/// guard, since `eval.rs`'s fold evaluates it.
+///
+/// Conservative in the safe direction: a false positive costs only the
+/// duplicate-key fidelity this arm adds, falling back to exactly the
+/// behaviour `reduce`/`foreach` had before #1687.
+fn streams_unbounded(expr: &Expr) -> bool {
+    crate::jq::walk::any_subexpr(expr, &mut |e| matches!(e, Expr::Repeat(_)))
+}
+
+fn stream_owned_outputs_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> (Vec<OwnedValue>, Option<Control>) {
+    let mut out: Vec<OwnedValue> = Vec::new();
+    let mut decode_err: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        match generic_item_into_owned(item) {
+            Ok(owned) => {
+                out.push(owned);
+                Demand::Continue
+            }
+            // The prefix already converted is kept, matching
+            // `stream_outputs_checked`'s `promote_borrowed_checked` arm.
+            Err(control) => {
+                decode_err = Some(control);
+                Demand::Stop
+            }
+        }
+    });
+    let control = decode_err.or(match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => None,
+        Flow::Escaped(control) => Some(control),
+    });
+    (out, control)
+}
+
 fn fanout_arg_each_generic<S: EvalSemantics, V: DocumentValue, B>(
     arg_expr: &Expr,
     value: V,
@@ -16674,4 +16830,101 @@ mod tests {
         }
         assert_eq!(value_err.message, cursor_err.message);
     }
+
+    /// #1687: the sort family's array-valued results (`sort`, `sort_by`,
+    /// `unique`, `unique_by`, `reverse`) answer a `LazySeq` over the
+    /// reordered element cursors rather than a materialized
+    /// `OwnedValue::Array`. That shape is what carries a duplicate mapping
+    /// key through, so it is worth pinning directly.
+    ///
+    /// **The duplicate keys themselves are not observable on a JSON index**,
+    /// and deliberately so: only `YamlCursor` overrides
+    /// `DocumentCursor::supports_sequence_streaming`, so
+    /// `sequence_streamable_cursors` returns `None` for JSON and
+    /// `stream_json`'s `LazySeq` arm falls back to `lazy_elem_to_owned` --
+    /// an `IndexMap`. That is pre-existing and shared with `map(.)`, which
+    /// has answered a `LazySeq` since #724/#725; it is why plain jq mode
+    /// still collapses here (correct, per #1385) and why even
+    /// `--preserve-input` does. The preservation this arm buys is pinned on
+    /// the YAML path instead, by
+    /// `test_sort_family_preserves_duplicate_keys_in_moved_elements_1687`
+    /// in `tests/yq_cli_tests.rs`.
+    #[test]
+    fn test_sort_family_streams_reordered_cursors_1687() {
+        let json = br#"[{"b":2,"b":9},{"a":1,"a":8}]"#;
+        let index = JsonIndex::build(json);
+
+        for (filter, want) in [
+            // Ordering is the observable half here: jq's total order puts an
+            // object keyed `a` before one keyed `b`.
+            ("sort_by(.a)", r#"[{"b":9},{"a":8}]"#),
+            ("reverse", r#"[{"a":8},{"b":9}]"#),
+            ("unique_by(.a)", r#"[{"b":9},{"a":8}]"#),
+        ] {
+            let expr = crate::jq::parse(filter).unwrap();
+            let result = eval_with_cursor(&expr, index.root(json));
+            assert!(
+                matches!(result, GenericResult::LazySeq(_)),
+                "{filter} should answer a LazySeq, not a materialized array"
+            );
+            let mut out = String::new();
+            result
+                .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+                .unwrap();
+            assert_eq!(out, want, "{filter}");
+        }
+    }
+
+    /// #1687: `min`/`max`/`min_by`/`max_by` select one of the input's own
+    /// elements, so the winner is returned as a bare `OneCursor` -- the same
+    /// shape `first(.[])` uses (#607).
+    #[test]
+    fn test_min_max_family_returns_the_winning_cursor_1687() {
+        let json = br#"[{"a":2,"a":9},{"a":1,"a":8}]"#;
+        let index = JsonIndex::build(json);
+
+        for (filter, want) in [
+            ("min_by(.a)", r#"{"a":1,"a":8}"#),
+            ("max_by(.a)", r#"{"a":2,"a":9}"#),
+        ] {
+            let expr = crate::jq::parse(filter).unwrap();
+            let result = eval_with_cursor(&expr, index.root(json));
+            assert!(result.is_single_cursor(), "{filter}");
+            let mut out = String::new();
+            result
+                .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+                .unwrap();
+            assert_eq!(out, want, "{filter}");
+        }
+    }
+
+    /// #1687: `limit`/`nth` had no unit-level coverage at all -- #1607/#1686
+    /// pinned them only through the CLI. A single-valued `n` must keep the
+    /// batch cursor-backed (`ManyCursor`), which is what preserves a
+    /// duplicate key *inside* a captured element, and the generator-`n` path
+    /// added here must not lose that.
+    #[test]
+    fn test_limit_keeps_captured_elements_cursor_backed_1687() {
+        let json = br#"[{"a":1,"a":2},{"b":3,"b":4},{"c":5}]"#;
+        let index = JsonIndex::build(json);
+
+        let expr = crate::jq::parse("limit(2; .[])").unwrap();
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert!(
+            matches!(result, GenericResult::ManyCursor(_)),
+            "a single-valued n must not flatten the batch"
+        );
+        let mut out = String::new();
+        result
+            .stream_json(&mut out, IndentSpec::COMPACT, false, |_| Ok(()))
+            .unwrap();
+        assert_eq!(out, r#"{"a":1,"a":2}{"b":3,"b":4}"#);
+
+        // Generator `n`: outer loop over n, inner over `.[]`, so n=1 keeps
+        // one element and n=2 keeps two.
+        let expr = crate::jq::parse("[limit((1,2); .[])] | length").unwrap();
+        let result = eval_with_cursor(&expr, index.root(json));
+        assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
+    }
+
 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6150,6 +6150,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn document_has_aliases(&self) -> bool {
+        self.index.has_aliases()
+    }
+
+    #[inline]
     fn explicit_tag(&self) -> Option<&str> {
         YamlCursor::explicit_tag(self)
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23862,39 +23862,43 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
 }
 
 /// Code review (#1596): `each_limit_generic` (the native `Expr::Limit` arm
-/// `first`/`last` route through) must evaluate a generator `n` argument at
-/// most once, same as its non-`first`-wrapped siblings -- not this test's own
-/// "matches jq" claim, since real jq never evaluates the second `n` binding
-/// here at all (`first`'s own single-output need is already satisfied by the
-/// first), a *separate*, pre-existing gap in `eval.rs`'s own generator-`n`
-/// handling shared by every consumer (confirmed live:
-/// `isempty(limit((1,("N"|debug)); 42))` leaks the identical single
-/// `["DEBUG:","N"]` on `main`, unrelated to and unmoved by this issue).
+/// `first`/`last` route through) must not evaluate a generator `n` argument
+/// more times than jq does.
 ///
-/// What IS this issue's own regression risk: before the guards
-/// `each_limit_generic` gained in review, it evaluated `n_expr` via
-/// `eval_single` to classify it, then -- for exactly this generator shape --
-/// discarded that evaluation and re-ran the whole `Expr::Limit` node from
-/// scratch via the full-evaluator bridge, so `debug` fired *twice* under
-/// `first(...)` where every other route (bare `limit(...)`, `isempty(...)`)
-/// fires it once. This test pins the fixed count (one), not jq parity.
+/// The count this pins has now been tightened twice, and the history is the
+/// point of the test:
 ///
-/// A broader, separate residual (`expr`'s own side effects, not just
-/// `n_expr`'s, still leak past the bridge for a generator `n` under
-/// `first`/`nth`) is documented in
-/// [`docs/compliance/jq/limitations.md`](../docs/compliance/jq/limitations.md)
-/// rather than pinned here, since `expr = 42` above carries no side effect
-/// of its own -- this test's scope is `n_expr`'s count, not that residual.
+/// - Before #1596's own review guards, `each_limit_generic` evaluated
+///   `n_expr` via `eval_single` to classify it, then -- for exactly this
+///   generator shape -- discarded that evaluation and re-ran the whole
+///   `Expr::Limit` node from scratch through the full-evaluator bridge. So
+///   `debug` fired **twice**.
+/// - #1596 added a static bare-`Comma` guard that deferred before probing,
+///   bringing it to **once**, and this test pinned that. Its own comment
+///   recorded that jq fires it **zero** times -- `first`'s single-output need
+///   is already met by the `$n=1` binding, so jq never explores the second at
+///   all -- and called closing that a separate, pre-existing gap in the
+///   generator-`n` handling shared by every consumer.
+/// - #1687 closed it. `fanout_arg_each_generic` drives `n_expr` through the
+///   demand-driven sink, so a wrapping `first` stops the argument generator
+///   itself. This now pins jq parity (zero), re-verified live against the
+///   pinned jq 1.7.1.
+///
+/// `isempty(limit((1,("N"|debug)); 42))` still leaks the single
+/// `["DEBUG:","N"]` -- `isempty` does not route through this fan-out -- so
+/// that sibling remains the residual this test's earlier comment described,
+/// unmoved by #1687.
 #[test]
-fn test_first_over_limit_generator_n_evaluates_once_not_twice_1596() -> Result<()> {
+fn test_first_over_limit_generator_n_is_never_evaluated_1596() -> Result<()> {
     let (stdout, stderr, code) =
         run_jq_full(&["-cn", r#"first(limit((1,("N"|debug)); 42))"#], None)?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "42\n");
     assert_eq!(
         stderr.trim_end_matches('\n'),
-        r#"["DEBUG:","N"]"#,
-        "n_expr's own side effect must fire exactly once, not twice"
+        "",
+        "jq never explores the second `n` binding once `first` is satisfied \
+         by the first, so `n_expr`'s side effect must not fire at all"
     );
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28597,3 +28597,78 @@ fn test_unresolved_call_from_included_module_omits_the_location_1473() -> Result
     assert!(stderr.contains("jq: 1 compile error"), "stderr: {stderr}");
     Ok(())
 }
+
+/// #1687 on the jq side. Plain `succinctly jq` collapses duplicate keys on
+/// purpose (#1385, matching real jq), so the observable surface here is
+/// `--preserve-input`, the extension whose stated job is keeping the input's
+/// own formatting.
+///
+/// The result is deliberately asymmetric, and this pins both halves:
+///
+/// - `min`/`max`/`min_by`/`max_by` answer a bare `GenericResult::OneCursor`,
+///   which `generic_result_to_jq_values` forwards as `JqValue::Cursor`
+///   without decoding -- so they now preserve, joining `first(.[])`, which
+///   always has.
+/// - `sort`/`unique`/`reverse` and the `_by` forms answer a `LazySeq`, and
+///   `jq_runner.rs` has no lazy-array `JqValue`: its `LazySeq` arm calls
+///   `materialize_atomic()`, producing an `IndexMap`-backed `OwnedValue`.
+///   They therefore still collapse -- a pre-existing property of the jq
+///   output path, not something #1687 changed: `map(.)` has answered a
+///   `LazySeq` since #724/#725 and collapses here identically.
+///
+/// Closing that second half means giving the jq CLI a streaming array value
+/// the way `yq_runner.rs` already has one; filed separately rather than
+/// widened into this change.
+#[test]
+fn test_preserve_input_sort_family_cursor_results_keep_duplicate_keys_1687() -> Result<()> {
+    let input = r#"[{"a":1,"a":2},{"b":3}]"#;
+
+    // Control: the whole document, and the long-standing `first` path.
+    let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", "."], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[{\"a\":1,\"a\":2},{\"b\":3}]\n");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", "first(.[])"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "{\"a\":1,\"a\":2}\n");
+
+    // Single-element results now match it.
+    for filter in ["min", "max_by(.a)"] {
+        let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", filter], Some(input))?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(stdout, "{\"a\":1,\"a\":2}\n", "{filter}");
+    }
+
+    // Array-valued results do not, for the reason above. `map(.)` is here as
+    // the control proving the cause is the output path rather than #1687.
+    for filter in ["map(.)", "sort", "unique"] {
+        let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", filter], Some(input))?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(
+            stdout, "[{\"a\":2},{\"b\":3}]\n",
+            "{filter}: jq_runner has no lazy-array JqValue, so a LazySeq materializes"
+        );
+    }
+
+    Ok(())
+}
+
+/// #1687 must not disturb plain jq mode, where collapsing duplicate keys is
+/// the *correct* behaviour (#1385) -- every row below re-verified live
+/// against the pinned jq 1.7.1.
+#[test]
+fn test_sort_family_still_collapses_in_plain_jq_mode_1687() -> Result<()> {
+    let input = r#"[{"a":1,"a":2},{"b":3}]"#;
+    for (filter, want) in [
+        ("sort", "[{\"a\":2},{\"b\":3}]\n"),
+        ("reverse", "[{\"b\":3},{\"a\":2}]\n"),
+        ("unique", "[{\"a\":2},{\"b\":3}]\n"),
+        ("min", "{\"a\":2}\n"),
+        ("max", "{\"b\":3}\n"),
+    ] {
+        let (stdout, _, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(stdout, want, "{filter}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28765,3 +28765,44 @@ fn test_1687_limit_and_nth_still_bridge_a_live_input_queue() -> Result<()> {
 
     Ok(())
 }
+
+/// #1687 regression guard for #1755's rule. The `_by` spellings compute a key
+/// per element and never need the element's own value, so #1687's first cut
+/// skipped decoding it — which silently dropped `eval.rs`'s check that an
+/// undecodable element must *raise* rather than sort in as `""`.
+///
+/// The gap only shows when the bad element never reaches the output, so
+/// nothing else surfaces it. succinctly's semi-index accepts these documents
+/// where real jq rejects them at parse time, so there is no jq oracle here;
+/// the contract being pinned is #1755's own, and `main`'s behaviour.
+#[test]
+fn test_by_spellings_still_raise_on_an_undecodable_element_1687() -> Result<()> {
+    // A lone surrogate, a bad \u escape, and an unknown escape: all three are
+    // spans the semi-index accepts and the decoder rejects.
+    for bad in [r"\ud800", r"\uZZZZ", r"\x"] {
+        let input = format!(r#"[{{"a":2,"s":"{bad}"}},{{"a":1,"s":"ok"}}]"#);
+
+        // `length` never emits the offending element, so only the element
+        // decode-check can catch it.
+        for filter in [
+            "sort_by(.a) | length",
+            "unique_by(.a) | length",
+            "min_by(.a).a",
+            "max_by(.a).a",
+        ] {
+            let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(&input))?;
+            assert_eq!(
+                code, 5,
+                "{filter} on {bad}: stdout {stdout:?} stderr {stderr}"
+            );
+            assert_eq!(stdout, "", "{filter} on {bad}");
+        }
+
+        // The bare spellings decode the element as their comparison key, so
+        // they were never affected — pinned as the control.
+        let (stdout, _, code) = run_jq_full(&["-c", "sort | length"], Some(&input))?;
+        assert_eq!(code, 5, "sort on {bad}");
+        assert_eq!(stdout, "", "sort on {bad}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28806,3 +28806,61 @@ fn test_by_spellings_still_raise_on_an_undecodable_element_1687() -> Result<()> 
     }
     Ok(())
 }
+
+/// #1687: the `limit` sink arm's input-queue bridge — the one deferral
+/// `fanout_arg_each_generic` does *not* replace, because probing a live
+/// `input`/`inputs` queue would drain it as a side effect before the fallback
+/// ran.
+///
+/// Reaching it needs a shape that skips the *top-level* input-queue bridge in
+/// `eval_with_cursor_using`, which `takes_input_queue_bridge` declines for a
+/// query that also uses a cursor-metadata builtin (#1504). `limit(inputs; line)`
+/// is such a shape; `first(limit(inputs; ...))` is not, because
+/// `eval_first_or_last_generic`'s own guard fires first. That distinction is
+/// why this test exists separately from
+/// `test_1687_limit_and_nth_still_bridge_a_live_input_queue`.
+///
+/// `line` answers 0 rather than a real line number here: the bridge
+/// materializes the input and re-indexes it, so position metadata is gone.
+/// That is a pre-existing consequence of the guard — #1687 did not change its
+/// condition, only removed a separate bare-`Comma` disjunct beside it — and it
+/// sits awkwardly with #1504's own purpose, which was to keep `line` working
+/// alongside `inputs`. Pinned as the current behaviour, not endorsed.
+#[test]
+fn test_limit_sink_arm_bridges_a_live_input_queue_1687() -> Result<()> {
+    let inputs = "1\n2\n3\n4\n";
+
+    let (stdout, code) = run_jq_stdin("limit(inputs; line)", inputs, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout, "0\n0\n0\n",
+        "known gap: the bridge loses position metadata"
+    );
+
+    // Same arm, reached through a `Comma` sibling rather than as the whole
+    // program, so the bridge's `drain_result_generic` half runs too.
+    let (stdout, code) = run_jq_stdin("(limit(inputs; line), 1)", inputs, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n0\n0\n1\n");
+
+    Ok(())
+}
+
+/// #1687: `sort_family_control`'s non-`Error` half. A `halt_error` inside a
+/// sort key aborts the whole builtin with jq's own exit code and stderr —
+/// byte-identical to jq 1.7.1, which writes `10\n` and exits 5 (compared with
+/// `od -c`, since `halt_error`'s whole point is raw stderr).
+///
+/// The `Break` arm beside it is not reachable from any query this CLI can
+/// parse: `break $out` needs an enclosing `label`, `Expr::Label` has no native
+/// `eval_single` arm, so a label above `sort_by` routes the whole expression
+/// through the wildcard bridge before this arm runs. Same "unreachable but
+/// exhaustive" shape `Expr::Array`'s own `Break` arm documents (#1064).
+#[test]
+fn test_sort_family_propagates_halt_like_jq_1687() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "sort_by(halt_error)"], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stderr {stderr}");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "10\n");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28672,3 +28672,96 @@ fn test_sort_family_still_collapses_in_plain_jq_mode_1687() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1687: the error and control paths through the new native arms, which the
+/// happy-path tests above never reach — `sort_key_generic`'s `Err`, the
+/// `sort_family_control` conversion, `fanout_arg_generic`'s `body`-escape and
+/// argument-escape arms, and `reduce`'s input-control propagation.
+///
+/// Every row is real jq 1.7.1's own output and exit code, captured live: these
+/// are all shapes with a jq oracle, so there is no reason to pin anything
+/// weaker than parity.
+#[test]
+fn test_1687_native_arms_propagate_errors_like_jq() -> Result<()> {
+    let input = "[10,20,30,40]";
+
+    // An error raised while computing a sort key aborts the whole builtin with
+    // no partial output — the atomicity `eval::builtin_min_by` and friends
+    // already had, now also on the cursor-native path.
+    for filter in [
+        "sort_by(error(\"x\"))",
+        "min_by(error(\"x\"))",
+        "unique_by(error(\"x\"))",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "{filter}: stderr {stderr}");
+        assert_eq!(stdout, "", "{filter}: no partial output");
+        assert!(stderr.contains(": x"), "{filter}: stderr {stderr}");
+    }
+
+    // An error inside `limit`'s `n` generator, and inside its body, both reach
+    // the caller through `fanout_arg_generic` rather than being swallowed.
+    for filter in ["[limit((1,error(\"x\")); .[])]", "[limit(2; error(\"x\"))]"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "{filter}: stderr {stderr}");
+        assert_eq!(stdout, "", "{filter}");
+        assert!(stderr.contains(": x"), "{filter}: stderr {stderr}");
+    }
+
+    // `reduce` is single-shot, so a control anywhere in its input stream
+    // discards the prefix and propagates alone — and `?` suppresses an
+    // ordinary error there, matching `eval::eval_reduce`'s `suppress_or_raise`.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "reduce (1,error(\"x\")) as $x (0; .+1)"],
+        Some(input),
+    )?;
+    assert_eq!(code, 5, "stderr {stderr}");
+    assert_eq!(stdout, "");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "reduce (1,error(\"x\")) as $x (0; .+1)?"],
+        Some(input),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // An empty array answers `null` for all four min/max spellings, before any
+    // key is computed.
+    for filter in ["min", "max", "min_by(.)", "max_by(.)"] {
+        let (stdout, _, code) = run_jq_full(&["-c", filter], Some("[]"))?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(stdout, "null\n", "{filter}");
+    }
+
+    Ok(())
+}
+
+/// #1687: `limit`/`nth` must still hand a live `input`/`inputs` queue to
+/// `eval.rs` untouched — the #1309 guard is the one deferral
+/// `fanout_arg_generic` did *not* replace, because probing the queue here
+/// would drain it as a side effect before the fallback ever ran.
+///
+/// This covers both bridges: `bridge_to_full_evaluator_flow` (reached from
+/// `each_limit_generic`, i.e. `limit` under a demand-driven consumer) and
+/// `Expr::NthExpr`'s own. Both rows are jq 1.7.1's own output.
+#[test]
+fn test_1687_limit_and_nth_still_bridge_a_live_input_queue() -> Result<()> {
+    let inputs = "1\n2\n3\n4\n";
+
+    // `first(...)` routes through `each_limit_generic`, the sink-side arm.
+    let (stdout, code) = run_jq_stdin("first(limit(inputs; 10,20,30))", inputs, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "10\n");
+
+    // Bare `limit`: `inputs` yields 2,3,4 against the first document, so the
+    // body runs once per value of `n`.
+    let (stdout, code) = run_jq_stdin("[limit(inputs; 10,20)]", inputs, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[10,20,10,20,10,20]\n");
+
+    let (stdout, code) = run_jq_stdin("nth(inputs; 10,20,30)", inputs, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "30\n");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27358,7 +27358,11 @@ fn test_reduce_and_foreach_see_every_duplicate_key_1687() -> Result<()> {
 
     let (out, code) = run_yq_stdin("[keys | .[]]", dup, &args)?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), r#"["b","a","b"]"#, "the invariant to agree with");
+    assert_eq!(
+        out.trim(),
+        r#"["b","a","b"]"#,
+        "the invariant to agree with"
+    );
 
     let (out, code) = run_yq_stdin("reduce (keys|.[]) as $k (0; .+1)", dup, &args)?;
     assert_eq!(code, 0);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27233,3 +27233,257 @@ fn test_path_context_bypass_keeps_yq_float_fidelity_1909() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1687: `sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/`max`/`max_by`
+/// and `reverse` all answer a permutation or subset of their input's *own*
+/// elements, yet every one of them routed through `eval_generic.rs`'s `_`
+/// bridge, which materializes the document into an `IndexMap`-backed
+/// `OwnedValue` first -- so a duplicate mapping key inside a moved element
+/// was gone before the builtin ran. `reverse` is the sharpest case: it
+/// already held the element cursors and decoded them anyway.
+///
+/// Every expectation here is real yq v4.53.3's own byte-for-byte output,
+/// captured live, for the seven spellings yq implements. `min_by`/`max_by`
+/// are lexer-rejected there, so they are pinned against their siblings
+/// instead -- the winning element is one of the input's own either way.
+/// Mirrors #1607's `test_limit_and_nth_preserve_duplicate_keys_inside_captured_item_1607`.
+#[test]
+fn test_sort_family_preserves_duplicate_keys_in_moved_elements_1687() -> Result<()> {
+    let dup = "- b: 1\n  a: 2\n  b: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+    let whole = r#"[{"b":1,"a":2,"b":3}]"#;
+    let element = r#"{"b":1,"a":2,"b":3}"#;
+
+    // The reference: identity already preserves every duplicate.
+    let (out, code) = run_yq_stdin(".", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), whole);
+
+    // Array-valued results: a `LazySeq` over the reordered cursors.
+    for filter in ["sort", "unique", "reverse", "sort_by(.a)", "unique_by(.a)"] {
+        let (out, code) = run_yq_stdin(filter, dup, &args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(out.trim(), whole, "{filter}");
+    }
+
+    // Single-element results: a bare `OneCursor`.
+    for filter in ["min", "max", "min_by(.a)", "max_by(.a)"] {
+        let (out, code) = run_yq_stdin(filter, dup, &args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(out.trim(), element, "{filter}");
+    }
+
+    Ok(())
+}
+
+/// #1687: the same builtins on the DOM route also dropped comments and flow
+/// style wholesale -- #757's own lesson that a construct on that route loses
+/// everything the DOM cannot carry, all at once. Keeping the elements
+/// cursor-backed restores them, and these expectations are real yq v4.53.3's.
+///
+/// The document-level head comment (`# top`) is deliberately absent from the
+/// input: succinctly drops it on every one of these filters both before and
+/// after #1687, a separate pre-existing gap this test is not the place to
+/// pin.
+#[test]
+fn test_sort_family_preserves_comments_and_flow_style_1687() -> Result<()> {
+    let args = ["--jq-extensions"];
+
+    let commented = "- b: 1   # keep\n  a: 2\n- c: 3\n";
+    let (out, code) = run_yq_stdin("sort_by(.c)", commented, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- b: 1 # keep\n  a: 2\n- c: 3\n");
+
+    let styled = "- [1, 2]\n- {a: 1, b: 2}\n";
+    let (out, code) = run_yq_stdin("reverse", styled, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- {a: 1, b: 2}\n- [1, 2]\n");
+
+    Ok(())
+}
+
+/// #1687: **succinctly never emits YAML it cannot read back**, so the
+/// cursor-backed reordering above is switched off entirely for a document
+/// carrying any `*alias`.
+///
+/// Reordering can lift an alias above the anchor it resolves to, and
+/// `reverse` on this input demonstrably does: real yq answers `- *x` then
+/// `- &x {p: 1}`, a forward reference it then rejects with `unknown anchor
+/// 'x' referenced` when asked to read its own output back (both verified
+/// live against v4.53.3). `enforce_anchor_soundness` is what normally
+/// prevents that, but it is a DOM-path pass over a `CommentTree` and the
+/// cursor-streaming path has none (#1350) -- so `DocumentCursor::
+/// document_has_aliases` sends an alias-bearing document down the DOM path
+/// unchanged, losing the marks rather than emitting an unreadable file.
+///
+/// This is a deliberate divergence from real yq, not a gap: the same one
+/// ADR-0018 admits for `del()` and the rest of the #763 family.
+#[test]
+fn test_sort_family_refuses_to_reorder_aliases_above_anchors_1687() -> Result<()> {
+    let aliased = "- &x {p: 1}\n- *x\n";
+    let args = ["--jq-extensions"];
+
+    // Aliases expanded, anchors dropped -- sound, and byte-identical to what
+    // this input produced before #1687.
+    let (out, code) = run_yq_stdin("reverse", aliased, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- p: 1\n- p: 1\n");
+
+    // The gate is on aliases, not anchors: an unreferenced `&x` is valid
+    // YAML wherever it lands, so this document still takes the fast path.
+    let anchor_only = "- &x {p: 1}\n- {q: 2}\n";
+    let (out, code) = run_yq_stdin("reverse", anchor_only, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- {q: 2}\n- &x {p: 1}\n");
+
+    Ok(())
+}
+
+/// #1687: `reduce`/`foreach` had no arm in `eval_generic.rs` at all, so every
+/// one of them bridged the whole document through an `IndexMap` before
+/// `input` was evaluated -- and the input generator then walked a document
+/// that had already lost a duplicate key. The result was an internal
+/// contradiction rather than merely a divergence: `[keys|.[]] | length`
+/// answered 3 on this document while `reduce (keys|.[]) as $k (0; .+1)`
+/// answered 2.
+///
+/// Real yq has neither builtin (its lexer rejects both, confirmed live
+/// against v4.53.3), so there is no oracle here; the expectation is
+/// agreement with `keys` on the same document, which is the invariant that
+/// was broken.
+#[test]
+fn test_reduce_and_foreach_see_every_duplicate_key_1687() -> Result<()> {
+    let dup = "b: 1\na: 2\nb: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+
+    let (out, code) = run_yq_stdin("[keys | .[]]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","a","b"]"#, "the invariant to agree with");
+
+    let (out, code) = run_yq_stdin("reduce (keys|.[]) as $k (0; .+1)", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3");
+
+    let (out, code) = run_yq_stdin("[foreach (keys|.[]) as $k (0; .+1; .)]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2,3]");
+
+    Ok(())
+}
+
+/// #1687 item 1's documented residual: `reduce`/`foreach` recover the
+/// *number* of elements, not each element's own shape.
+///
+/// The accumulator and every `$x` a pattern binds are `OwnedValue` in both
+/// evaluators -- `substitute_bound_var` takes `&OwnedValue`, and no
+/// duplicate-key-capable owned representation exists in this crate -- so an
+/// element that gets bound is collapsed at the bind. A known gap pinned
+/// deliberately, following `test_object_slice_duplicate_key_known_gap_1102`.
+#[test]
+fn test_reduce_binding_still_collapses_duplicate_keys_known_gap_1687() -> Result<()> {
+    let dup = "- b: 1\n  a: 2\n  b: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+
+    // The element itself survives every route that keeps it a cursor.
+    let (out, code) = run_yq_stdin("first(.[])", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":1,"a":2,"b":3}"#);
+
+    // Bound to `$x`, it does not.
+    let (out, code) = run_yq_stdin("reduce .[] as $x (null; $x)", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        r#"{"b":3,"a":2}"#,
+        "known gap: a bound element is an OwnedValue, which cannot hold a duplicate key"
+    );
+
+    Ok(())
+}
+
+/// #1687 items 2 and 3: a *generator* `n` for `limit`/`nth` used to be probed
+/// with `eval_single`, found multi-output, and handed to the lossy bridge --
+/// costing the duplicate keys the native path exists to preserve. Driving `n`
+/// through `fanout_arg_generic` keeps the whole walk cursor-native for every
+/// `n` shape.
+///
+/// `n` is the outer loop and the generator the inner one, re-run once per `n`
+/// (jq 1.7.1: `[limit((1,2); (10,20,30))]` is `[10,10,20]`), so the expected
+/// key sequences below are per-`n` prefixes concatenated.
+#[test]
+fn test_limit_and_nth_generator_n_preserve_duplicate_keys_1687() -> Result<()> {
+    let dup = "b: 1\na: 2\nb: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+
+    // n=1 keeps ["b"]; n=3 keeps ["b","a","b"].
+    let (out, code) = run_yq_stdin("[limit((1,3); keys|.[])]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","b","a","b"]"#);
+
+    // Index 2 is the *second* "b", which the collapsed document could not
+    // even reach before.
+    let (out, code) = run_yq_stdin("[nth((0,1,2); keys|.[])]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["b","a","b"]"#);
+
+    Ok(())
+}
+
+/// #1687's carve-outs, pinned so they are visible rather than merely
+/// asserted in prose.
+///
+/// `group_by` returns an array *of arrays*: `LazySeq` has no nested-lazy form
+/// and `OwnedValue::Array(Vec<OwnedValue>)` cannot hold a cursor, so there is
+/// no lossless representation for it today -- it keeps the bridge, and real
+/// yq (which does implement it) preserves where succinctly collapses.
+/// `while`/`until` compute their state from step 1 onward, so only the seed
+/// could ever stay a cursor.
+#[test]
+fn test_group_by_and_while_until_remain_lossy_known_gap_1687() -> Result<()> {
+    let dup = "- b: 1\n  a: 2\n  b: 3\n";
+    let args = ["--jq-extensions", "-o=json", "-I=0"];
+
+    let (out, code) = run_yq_stdin("group_by(.a) | .[0] | .[0]", dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        r#"{"b":3,"a":2}"#,
+        "known gap: an array of arrays has no cursor-backed representation"
+    );
+
+    let scalar_dup = "b: 1\na: 2\nb: 3\n";
+    let (out, code) = run_yq_stdin("[limit(1; while(true; .))]", scalar_dup, &args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        r#"[{"b":3,"a":2}]"#,
+        "known gap: while/until fold through an OwnedValue state"
+    );
+
+    Ok(())
+}
+
+/// #1687 regression guard: `reduce`/`foreach` consume `input` and `INIT`
+/// eagerly, but `each_repeat_generic` (#2014) is deliberately unbounded --
+/// it relies on a wrapping `limit`/`first` to stop it. Driving it from an
+/// eager consumer spun forever, where `eval.rs`'s own `reduce` raises.
+///
+/// Both operands are guarded, not just `input`: guarding `input` alone still
+/// hung on the `INIT` spelling below.
+#[test]
+fn test_reduce_and_foreach_over_repeat_still_raise_1687() -> Result<()> {
+    for filter in [
+        "reduce repeat(1) as $x (0; .+1)",
+        "foreach repeat(1) as $x (0; .+1)",
+        "reduce .[] as $x (repeat(1); .+$x)",
+        "[foreach .[] as $x (repeat(1); .+$x; .)]",
+    ] {
+        let (_, stderr, code) = run_jq_stdin_with_stderr(filter, "[1,2]", &[])?;
+        assert_eq!(code, 5, "{filter}: stderr {stderr}");
+        assert!(
+            stderr.contains("repeat: maximum iterations exceeded"),
+            "{filter}: stderr {stderr}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #1687 items 1, 2, 3 and item 4's first bullet. (Item 4's second bullet was
already split out as #1825 and is closed.)

## What was wrong

`eval_generic.rs`'s `_` catch-all materializes the whole document into an
`IndexMap`-backed `OwnedValue` before the expression runs, so any construct
without a native arm loses duplicate mapping keys before its own logic ever
executes. #607 fixed `first`/`last` this way, #1168 `[...]`/`,`, #1607 `limit`/
`nth`, #1739 `has`. This is the next set.

Every claim below was reproduced live against a release build and, where an
oracle exists, against Homebrew `yq` v4.53.3 and `/usr/bin/jq` 1.7.1.

## What changed

**The sort family** — `sort`, `sort_by`, `unique`, `unique_by`, `min`, `min_by`,
`max`, `max_by`, `reverse`. All nine answer a permutation or subset of their
input's *own* elements, computing nothing new but the comparison keys, so they
now keep those elements as cursors: a `LazySeq` for the array-valued ones, a
bare `OneCursor` for `min`/`max`. `reverse` was the sharpest case — it already
held `collect_cursors()` in hand and decoded them anyway.

`sort`/`unique`/`min`/`max`/`reverse` are **not** in #1687's list; they are the
same mechanism and the same code shape as the `_by` forms, and real yq preserves
duplicates through all seven spellings it implements. Widening to them was
agreed before starting.

This also restores comments, anchors and flow style through these builtins —
#757's own lesson that a construct on the DOM route loses everything the DOM
cannot carry, all at once.

**`reduce`/`foreach`** had no arm at all, which made this an internal
contradiction rather than merely a divergence: on `b: 1\na: 2\nb: 3\n`,
`[keys|.[]] | length` answered 3 while `reduce (keys|.[]) as $k (0; .+1)`
answered 2. Their `input` and INIT streams are now evaluated cursor-natively and
handed to eval.rs's existing `eval_reduce_with_values`/`eval_foreach_with_values`,
so the fold — `?//` alternatives, the #534 INIT fork, the step budget, the
reduce-vs-foreach control precedence — keeps its single implementation.

**`limit`/`nth`'s generator `n`** (items 2 and 3) was probed with `eval_single`,
found multi-output, and handed to the bridge — costing both the duplicate keys
*and* a second evaluation of `n`, so a `debug` inside it fired twice where jq
fires once. New `fanout_arg_generic`/`fanout_arg_each_generic` (the generic twins
of `eval::fanout_arg`'s `ArgFanout::All` arm) drive `n` exactly once for every
shape. Three helpers dropped their private copy of a shallow "is `n` a bare
top-level `Comma`?" guard, which `eval_has_generic`'s own doc comment already
flagged as the wrong pattern.

**Item 4's first bullet**: six sites repeated `to_owned_with_cursor` + AST-clone
+ `eval_on_owned` verbatim; they now share `bridge_to_full_evaluator`.

## A divergence this introduces on purpose

Reordering can lift a `*x` above the `&x` it resolves to, and `reverse` on
`- &x {p: 1}` / `- *x` does. Real yq emits that forward reference and then
rejects its own output with `unknown anchor 'x' referenced` (both verified live).
CLAUDE.md's rule is that succinctly never emits YAML it cannot read back, and
`enforce_anchor_soundness` is a DOM-path pass the cursor-streaming path cannot
reach (#1350) — so a new O(1) `DocumentCursor::document_has_aliases` keeps
alias-bearing documents on the DOM path, byte-identical to their pre-PR output.
The gate is on aliases, not anchors: an unreferenced `&x` is valid anywhere.

## What this does not fix, and why

Recorded in `docs/compliance/yq/limitations.md` and pinned by known-gap tests:

- **`group_by`** returns an array *of arrays*; `LazySeq` has no nested-lazy form
  and `OwnedValue::Array` cannot hold a cursor. The same representation limit as
  #1102, one level up.
- **`while`/`until`** compute their state from step 1, so only the seed could
  ever be a cursor.
- **`reduce`/`foreach`'s bindings.** The fix recovers the stream's length and
  order, not each element's shape: `substitute_bound_var` takes `&OwnedValue` and
  no duplicate-key-capable owned type exists in this crate, so a *bound* element
  still collapses.

## One test expectation changed

`test_first_over_limit_generator_n_evaluates_once_not_twice_1596` pinned that
`debug` fires **once**, having brought it down from twice. Its own doc comment
recorded that jq fires it **zero** times and called closing that a separate gap.
The sink-side fan-out closes it, so the test is retargeted on zero and renamed
`..._is_never_evaluated_1596`, with the three-step history in its doc comment.
The jq limitations entry that documented the old behaviour is narrowed to the two
shapes that genuinely remain (`isempty(limit(...))`, `first(nth(...))`), both
re-verified as unchanged by this branch.

## Verification

- Full suite green: **6799 passed, 0 failed** (`--features cli,simd,regex,serde
  --workspace`), plus the default-features leg (3803 passed) that `--features cli`
  never runs.
- All three `ci.yml` clippy legs, `cargo fmt --all --check`, `cargo check
  --no-default-features` (7 warnings, identical to the merge base) and
  `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. Run after
  `cargo clean -p succinctly`.
- Differential sweeps against both oracles: 32 `limit`/`nth` shapes and 21
  sort-family shapes match jq 1.7.1 exactly; the 13 yq-mode differences on mixed
  input are all pre-existing total-order divergences, verified identical on the
  merge-base binary.
- **16 new tests**: seven yq-oracle-pinned sort-family spellings, the
  alias-soundness gate, comment/flow-style preservation, reduce/foreach stream
  length, generator-`n` duplicate preservation, a `repeat` regression guard, the
  jq-mode and `--preserve-input` asymmetry, three known-gap pins, and the first
  unit-level coverage `limit`/`nth` have ever had.

### A regression this caught

`each_repeat_generic` (#2014) is deliberately unbounded because a wrapping
`limit`/`first` stops it, but `reduce`/`foreach` pull to exhaustion — so
`reduce repeat(1) as $x (0; .+1)` spun forever where eval.rs's bounded
`eval_repeat` raises. Guarded, and the guard covers **both** operands: guarding
`input` alone still hung on `reduce .[] as $x (repeat(1); .+$x)`.

### Performance

No benchmark or `perf-guard` query reaches the changed builtins — their query
sets are `.`, `keys_unsorted` and `map(.)` — so a standard A/B would have
measured nothing (#1599's lesson). Measured the changed paths directly instead,
interleaved, 7 reps, output identity gated, on a 200,000-element sequence
(Apple M-series, AC power, 80% idle):

| query | before | after | ratio |
|---|---|---|---|
| `sort_by(.k)` | 854 ms | 229 ms | **0.27x** |
| `reverse` | 411 ms | 43 ms | **0.10x** |
| `unique_by(.k)` | 848 ms | 231 ms | **0.27x** |
| `min_by(.k)` | 460 ms | 156 ms | **0.34x** |
| `sort` | 675 ms | 297 ms | **0.44x** |
| `limit(50000; .[])` | 128 ms | 128 ms | 1.01x |
| `nth(199999; .[])` | 259 ms | 268 ms | 1.03x |

The scaling curve corroborates the mechanism: `reverse` goes 0.16x → 0.13x →
0.10x across 25k/50k/200k elements, widening as the elided O(n) decode grows,
while `sort_by` stays flat at ~0.27x because its own sort is still O(n log n) on
the keys. `limit`/`nth` are neutral, as expected — the fan-out costs nothing for
a single-valued `n`.

## Follow-ups filed

- #2063 — `[...]` array construction collapses the element itself (#1168's other half)
- #2064 — `sort_by()` on a mapping raises jq's error where real yq returns it unchanged
- #2065 — `reduce`/`foreach` accepted without `--jq-extensions` (#1512 gap)
- #2066 — `--preserve-input`'s array-vs-single asymmetry (jq CLI has no lazy-array `JqValue`)
