### PR TITLE
perf(jq): resolve navigational path() from cursors instead of materializing the document

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19941,7 +19941,7 @@ fn numeric_slice_bound_key(v: &OwnedValue) -> Option<NumberKey> {
 /// `key` is [`Expr::index_number_key`]'s answer for the component being
 /// rendered: `None` is a plain [`Expr::Index`], whose own `idx` is the
 /// component.
-fn index_component_value(idx: i64, key: Option<&NumberKey>) -> OwnedValue {
+pub(crate) fn index_component_value(idx: i64, key: Option<&NumberKey>) -> OwnedValue {
     match key {
         None => OwnedValue::Int(idx),
         Some(NumberKey::Float(f)) => OwnedValue::Float(*f),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -36,7 +36,7 @@ use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
     collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned,
     eval_foreach_with_values, eval_reduce_with_values, expand_func_calls, extract_pattern_bindings,
-    format_owned, has_type_mismatch_is_permissive, index_in_array_bounds,
+    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
     slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var, substitute_vars,
@@ -8422,6 +8422,259 @@ fn sort_keyed_elements<V: DocumentValue>(keyed: &mut [(OwnedValue, V::Cursor)]) 
     keyed.sort_by(|(a, _), (b, _)| compare_values(a, b));
 }
 
+/// Whether `path(expr)` can be resolved by walking cursors instead of
+/// materializing the whole document (#2061).
+///
+/// Deliberately narrow: only the pure-navigation shapes, whose emitted paths
+/// depend on the document's *structure* along the path and never on a value
+/// it has to compute. Anything else -- a computed index (`.[$k]`), a slice, a
+/// builtin, `getpath`, `first`/`last`, a comparison -- defers to
+/// `builtin_path_on_owned` unchanged, so this adds a fast path rather than a
+/// second implementation of path resolution.
+///
+/// `Expr::Comma` is included: `path(.a, .b)` is just both walks, and the
+/// walk below already fans out for `Iterate`.
+fn path_expr_is_cursor_navigable(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identity | Expr::Iterate => true,
+        Expr::Field(_) => true,
+        // A negative index needs no array length: `path(.[-1])` is `[-1]`
+        // verbatim in both jq and succinctly today (verified live), so the
+        // sign costs nothing here.
+        Expr::Index(_) | Expr::IndexNumber { .. } => true,
+        Expr::Paren(inner) | Expr::Optional(inner) => path_expr_is_cursor_navigable(inner),
+        Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_expr_is_cursor_navigable),
+        _ => false,
+    }
+}
+
+/// One node reached during a [`path_walk_generic`] step.
+///
+/// `Absent` is not an error: jq yields a path for a component that does not
+/// exist (`{} | path(.a)` is `["a"]`) and keeps navigating as if the value
+/// were `null` (`{} | path(.a.b)` is `["a","b"]`), so the walk has to carry
+/// "no such node" as a first-class position rather than stopping.
+enum PathNode<V: DocumentValue> {
+    At(V::Cursor),
+    Absent,
+}
+
+impl<V: DocumentValue> Clone for PathNode<V> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::At(c) => Self::At(*c),
+            Self::Absent => Self::Absent,
+        }
+    }
+}
+
+/// The type name to report in an indexing error, for a node that may be
+/// absent. An absent node is `null`, which both jq and succinctly allow every
+/// navigation through.
+fn path_node_type_name<V: DocumentValue>(node: &PathNode<V>) -> &'static str {
+    match node {
+        PathNode::At(c) => {
+            let v = c.value();
+            tagged_type_name(&v, Some(*c))
+        }
+        PathNode::Absent => "null",
+    }
+}
+
+/// Walk `expr` from `node`, appending one `OwnedValue::Array` per emitted
+/// path to `out` (#2061).
+///
+/// The whole point is that no `OwnedValue` tree is ever built for the
+/// *document*: only the path components themselves are owned, and those are
+/// bounded by the query's own depth and fan-out rather than the input's size.
+///
+/// Error texts are taken from the same constructors the materializing path
+/// uses, so the two agree exactly -- verified live against every shape in
+/// `test_path_cursor_native_matches_the_materializing_path_2061`.
+fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    node: &PathNode<V>,
+    path: &mut Vec<OwnedValue>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), EvalError> {
+    match expr {
+        Expr::Identity => {
+            out.push(OwnedValue::Array(path.clone()));
+            Ok(())
+        }
+        Expr::Paren(inner) => path_walk_generic::<S, V>(inner, node, path, out),
+        Expr::Optional(inner) => {
+            // `?` discards this branch's outputs as well as its error,
+            // matching `path(.a?)` on an array emitting nothing at all
+            // rather than a partial prefix (verified live against jq 1.7.1).
+            let mut branch = Vec::new();
+            match path_walk_generic::<S, V>(inner, node, &mut path.clone(), &mut branch) {
+                Ok(()) => {
+                    out.append(&mut branch);
+                    Ok(())
+                }
+                Err(_) => Ok(()),
+            }
+        }
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                path_walk_generic::<S, V>(e, node, &mut path.clone(), out)?;
+            }
+            Ok(())
+        }
+        Expr::Pipe(exprs) => match exprs.split_first() {
+            None => {
+                out.push(OwnedValue::Array(path.clone()));
+                Ok(())
+            }
+            Some((first, [])) => path_walk_generic::<S, V>(first, node, path, out),
+            Some((first, rest)) => {
+                // Each output of `first` is a distinct position to continue
+                // the rest of the pipe from, so the step is re-walked rather
+                // than batched -- the same per-output shape `Expr::Iterate`
+                // needs below.
+                let mut heads = Vec::new();
+                path_step_generic::<S, V>(first, node, path, &mut heads)?;
+                let rest_expr = if rest.len() == 1 {
+                    rest[0].clone()
+                } else {
+                    Expr::Pipe(rest.to_vec())
+                };
+                for (mut next_path, next_node) in heads {
+                    path_walk_generic::<S, V>(&rest_expr, &next_node, &mut next_path, out)?;
+                }
+                Ok(())
+            }
+        },
+        // A terminal navigation step: take it, then emit each resulting path.
+        _ => {
+            let mut heads = Vec::new();
+            path_step_generic::<S, V>(expr, node, path, &mut heads)?;
+            for (p, _) in heads {
+                out.push(OwnedValue::Array(p));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// One navigation step: from `node` at `path`, produce every (path, node)
+/// position the step reaches.
+fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    node: &PathNode<V>,
+    path: &[OwnedValue],
+    out: &mut Vec<(Vec<OwnedValue>, PathNode<V>)>,
+) -> Result<(), EvalError> {
+    match expr {
+        Expr::Identity => {
+            out.push((path.to_vec(), node.clone()));
+            Ok(())
+        }
+        Expr::Paren(inner) => path_step_generic::<S, V>(inner, node, path, out),
+        Expr::Field(name) => {
+            let next = match node {
+                PathNode::Absent => PathNode::Absent,
+                PathNode::At(c) => {
+                    let v = c.value();
+                    if v.is_null() {
+                        PathNode::Absent
+                    } else if let Some(fields) = v.as_object() {
+                        match fields.find_cursor(name)? {
+                            Some(fc) => PathNode::At(fc),
+                            None => PathNode::Absent,
+                        }
+                    } else {
+                        return Err(EvalError::cannot_index_with_field(
+                            path_node_type_name::<V>(node),
+                            name,
+                        ));
+                    }
+                }
+            };
+            let mut p = path.to_vec();
+            p.push(OwnedValue::String(name.clone()));
+            out.push((p, next));
+            Ok(())
+        }
+        Expr::Index(_) | Expr::IndexNumber { .. } => {
+            // The component is reported with its own source spelling
+            // (`path(.[2.0])` is `[2.0]`, not `[2]` -- #1088), which only
+            // `IndexNumber` carries. `index_component_value` is `eval.rs`'s
+            // own renderer for exactly this, shared rather than re-derived.
+            let (idx, key) = match expr {
+                Expr::Index(i) => (*i, None),
+                Expr::IndexNumber { idx, key } => (*idx, Some(key)),
+                _ => unreachable!("guarded by the match arm above"),
+            };
+            let next = match node {
+                PathNode::Absent => PathNode::Absent,
+                PathNode::At(c) => {
+                    let v = c.value();
+                    if v.is_null() {
+                        PathNode::Absent
+                    } else if let Some(elements) = v.as_array() {
+                        usize::try_from(idx)
+                            .ok()
+                            .and_then(|i| elements.get_cursor(i))
+                            .map_or(PathNode::Absent, PathNode::At)
+                    } else {
+                        return Err(EvalError::cannot_index_with_type(
+                            path_node_type_name::<V>(node),
+                            "number",
+                        ));
+                    }
+                }
+            };
+            let mut p = path.to_vec();
+            p.push(index_component_value(idx, key));
+            out.push((p, next));
+            Ok(())
+        }
+        Expr::Iterate => match node {
+            // `null` and a missing node are not iterable, matching
+            // `path(.[])` on `null` raising rather than yielding nothing.
+            PathNode::Absent => Err(EvalError::cannot_iterate_with(
+                EvalTag::Jq,
+                &OwnedValue::Null,
+            )),
+            PathNode::At(c) => {
+                let v = c.value();
+                if let Some(fields) = v.as_object() {
+                    // `effective_fields_checked` with the mode's own
+                    // duplicate-key rule, plus `key_display_string` -- the
+                    // same two helpers `collect_paths_generic` uses, reused
+                    // rather than re-derived. Walking `all_fields()` instead
+                    // emitted `[["a"],["a"]]` for `[path(.[])]` on
+                    // `{"a":1,"a":2}`, where jq mode collapses to `[["a"]]`
+                    // (#1385); caught by the evaluator-parity suite.
+                    for field in effective_fields_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS)? {
+                        let Some(key) = key_display_string(&field.key) else {
+                            return Err(fields.malformed_member_error());
+                        };
+                        let mut p = path.to_vec();
+                        p.push(OwnedValue::String(key.into_owned()));
+                        out.push((p, PathNode::At(field.value_cursor)));
+                    }
+                    Ok(())
+                } else if let Some(elements) = v.as_array() {
+                    for (i, ec) in elements.collect_cursors().into_iter().enumerate() {
+                        let mut p = path.to_vec();
+                        p.push(OwnedValue::Int(i as i64));
+                        out.push((p, PathNode::At(ec)));
+                    }
+                    Ok(())
+                } else {
+                    Err(EvalError::cannot_iterate_with(EvalTag::Jq, &to_owned(&v)?))
+                }
+            }
+        },
+        // `path_expr_is_cursor_navigable` gates every caller, so nothing else
+        // can arrive here.
+        other => unreachable!("non-navigable path expression reached the cursor walk: {other:?}"),
+    }
+}
+
 fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
     value: V,
@@ -9240,6 +9493,48 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // verbatim otherwise. See `reindex_bridge_is_identity`, and the
         // `Expr::Pipe` arm above for why `optional` isn't threaded in.
         Builtin::Path(path_expr) => {
+            // #2061: `path(...)` output is small and bounded, but this arm
+            // materialized the whole document to produce it -- `path(.[0])`
+            // on a 20 MB array cost 0.78s and 519 MiB against `.[0]`'s 0.09s
+            // and 34 MiB, and `path(.)` cost 1003 MiB to answer `[]`.
+            //
+            // For a purely navigational path expression the answer depends
+            // on the document's *structure* along the path, never on a value
+            // that has to be computed, so it can be walked with cursors.
+            //
+            // The whole-document walk is not skipped, only the tree build:
+            // `to_owned_with_cursor` doubles as a validity gate (#1755/
+            // #1953), and dropping it would make `path(.d)` start accepting
+            // documents it rejects today. `push_generic_truthiness_cursor_error`
+            // is that same traversal and validation with the `OwnedValue`
+            // construction removed, so error behaviour is unchanged while the
+            // allocation is not paid.
+            if let Some(root) = cursor.filter(|_| path_expr_is_cursor_navigable(path_expr)) {
+                if let Some(control) = push_generic_truthiness_cursor_error(&root, 0) {
+                    return match control {
+                        Control::Error(e) => GenericResult::Error(e),
+                        Control::Break(label) => GenericResult::Break(label),
+                        Control::Halt(code) => GenericResult::Halt(code),
+                    };
+                }
+                let mut out = Vec::new();
+                return match path_walk_generic::<S, V>(
+                    path_expr,
+                    &PathNode::At(root),
+                    &mut Vec::new(),
+                    &mut out,
+                ) {
+                    Ok(()) => owned_vec_to_generic_result(out),
+                    // Whatever resolved before the failure still stands:
+                    // jq's generator never un-emits an output it already
+                    // produced, so `path(.a.b, .c.d)` on `{"a":{"b":1},"c":1}`
+                    // emits `["a","b"]` and *then* errors. Discarding the
+                    // prefix here is what `builtin_path_on_owned`'s own doc
+                    // comment warns against, and the evaluator-parity and
+                    // golden suites both caught it.
+                    Err(e) => partial_generic(out, Control::Error(e)),
+                };
+            }
             let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
             if reindex_bridge_is_identity(&owned) {
                 return query_result_to_generic::<V>(crate::jq::eval::builtin_path_on_owned::<

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -28,9 +28,10 @@ use indexmap::IndexMap;
 
 use super::document::{
     collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
-    effective_keys, effective_len_checked, key_delimiter_ok, key_display_string, key_is_malformed,
-    resolve_display_key, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor,
-    DocumentElements, DocumentFields, DocumentValue, IndentSpec,
+    effective_keys, effective_len_checked, key_delimiter_ok, key_display_string,
+    key_display_string_kind, key_is_malformed, resolve_display_key, value_delimiter_ok,
+    DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
@@ -2226,17 +2227,74 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
     assert_nesting_depth(depth);
     let value = c.value();
     if let Some(fields) = value.as_object() {
+        // The #1642 collision map is built lazily, only from the point an
+        // undecodable key actually appears (#2061).
+        //
+        // `DisplayKeyGuard::check` reports a collision only when
+        // `map.contains_key(key)` *and* a fallback key is involved -- either
+        // this one, or an earlier one it recorded. So until the first
+        // fallback key, `collides` is false for every key no matter what the
+        // map holds, and the only thing building it accomplishes is one
+        // `String` allocation per key. That was the entire cost of this
+        // walk: it is what made `path(.[0])` over a 1,000,000-object array
+        // take 577ms, against 50ms with the walk removed altogether.
+        //
+        // When a fallback key *does* appear at position `k`, the map has to
+        // hold keys `0..k` before that key can be checked against them -- a
+        // later fallback can collide with an earlier clean key -- so the
+        // prefix is re-walked then, and only then. That keeps the error
+        // *order* identical to the eager version (a value's error at an
+        // earlier field still wins over a collision at a later one), which
+        // a cheaper "check all keys afterwards" split would have changed.
+        // Same cheap-probe shape `collapsed_fields` uses (#1514).
         let mut map: IndexMap<String, ()> = IndexMap::new();
         let mut guard = DisplayKeyGuard::default();
+        let mut seen_fallback = false;
+        let mut index = 0usize;
         let mut f = fields;
         while let Some((field, rest)) = f.uncons() {
-            match resolve_display_key(&field.key, &map, &mut guard) {
-                Ok(Some(key)) => {
-                    map.insert(key, ());
+            if !seen_fallback {
+                match key_display_string_kind(&field.key) {
+                    None => return Some(Control::Error(f.malformed_member_error())),
+                    // Clean key, no fallback seen yet: no collision is
+                    // possible, so nothing is recorded and nothing allocated.
+                    Some((_, false)) => {}
+                    Some((_, true)) => {
+                        seen_fallback = true;
+                        // Re-walk this object's first `index` keys to seed
+                        // the map, then let the guarded path below handle
+                        // this key and every one after it.
+                        if let Some(prefix) = value.as_object() {
+                            let mut p = prefix;
+                            for _ in 0..index {
+                                let Some((earlier, rest)) = p.uncons() else {
+                                    break;
+                                };
+                                match resolve_display_key(&earlier.key, &map, &mut guard) {
+                                    Ok(Some(key)) => {
+                                        map.insert(key, ());
+                                    }
+                                    Ok(None) => {
+                                        return Some(Control::Error(p.malformed_member_error()))
+                                    }
+                                    Err(e) => return Some(Control::Error(e)),
+                                }
+                                p = rest;
+                            }
+                        }
+                    }
                 }
-                Ok(None) => return Some(Control::Error(f.malformed_member_error())),
-                Err(e) => return Some(Control::Error(e)),
             }
+            if seen_fallback {
+                match resolve_display_key(&field.key, &map, &mut guard) {
+                    Ok(Some(key)) => {
+                        map.insert(key, ());
+                    }
+                    Ok(None) => return Some(Control::Error(f.malformed_member_error())),
+                    Err(e) => return Some(Control::Error(e)),
+                }
+            }
+            index += 1;
             if let Some(control) =
                 push_generic_truthiness_cursor_error(&field.value_cursor, depth + 1)
             {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29138,62 +29138,75 @@ fn test_path_cursor_native_keeps_output_before_a_later_error_2061() -> Result<()
 }
 
 /// #2061: the validity walk's lazy #1642 collision map, whose fallback branch
-/// only runs once an undecodable key actually appears.
+/// only runs once an undecodable *key* actually appears.
 ///
-/// All three layouts matter and are checked separately, because the branch
+/// All four layouts matter and are checked separately, because the branch
 /// re-walks the object's *preceding* keys to seed the map: a fallback key
 /// first exercises the empty-prefix case, a fallback key after a clean one
-/// exercises the re-walk itself, and two fallback keys exercise the guard
-/// finding a genuine collision. Byte-identical to the eager map on all three,
-/// verified against `main` before this change landed.
+/// exercises the re-walk itself, two fallback keys exercise the map holding
+/// more than one, and a fallback key whose display form collides with a real
+/// key exercises the guard actually raising. Byte-identical to the eager map
+/// on all four, verified against `main`.
 ///
-/// Raw invalid UTF-8 rather than a `\uXXXX` escape: succinctly's semi-index
-/// accepts these bytes (real jq does too, substituting U+FFFD), where every
-/// bad-escape form is rejected at parse time and never reaches this walk.
+/// **The key must be undecodable, not merely lossy.** An earlier version of
+/// this test used raw invalid UTF-8 (`"\xff\xfe"`) and reached none of this:
+/// those bytes decode lossily, `string_decode_error()` answers `None`, and
+/// `key_display_string_kind` therefore reports them as ordinary keys, so the
+/// eager path never engages. Only the `\uXXXX` family produces a genuine
+/// decode failure. An undecodable *value* does not reach it either -- that is
+/// the walk's separate scalar arm. Confirmed by planting a probe in the
+/// branch and checking which documents actually execute it, rather than
+/// assuming from the test passing.
 #[test]
 fn test_path_validity_walk_lazy_collision_map_2061() -> Result<()> {
-    let replacement = "\u{fffd}\u{fffd}";
-
     // Fallback key first: the re-walk runs with an empty prefix.
-    let (out, code) = run_jq_binary_stdin("[path(.[])]", b"{\"\xff\xfe\": 1, \"a\": 2}", &["-c"])?;
+    let (stdout, code) = run_jq_stdin("[path(.[])]", r#"{"\ud800":1,"a":2}"#, &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(
-        String::from_utf8_lossy(&out).trim(),
-        format!("[[\"{replacement}\"],[\"a\"]]")
-    );
+    assert_eq!(stdout, "[[\"\\\\ud800\"],[\"a\"]]\n");
 
     // Fallback key after a clean one: the re-walk has a prefix to seed from.
-    let (out, code) = run_jq_binary_stdin(
-        "[path(.[])]",
-        b"{\"a\": 1, \"\xff\xfe\": 2, \"b\": 3}",
-        &["-c"],
-    )?;
+    let (stdout, code) = run_jq_stdin("[path(.[])]", r#"{"a":1,"\ud800":2}"#, &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(
-        String::from_utf8_lossy(&out).trim(),
-        format!("[[\"a\"],[\"{replacement}\"],[\"b\"]]")
-    );
+    assert_eq!(stdout, "[[\"a\"],[\"\\\\ud800\"]]\n");
 
-    // Two fallback keys whose display forms collide: `keys` collapses them,
-    // and the walk must not raise for an ordinary repeat.
-    let (out, code) = run_jq_binary_stdin(
-        "[path(.[])]",
-        b"{\"\xff\xfe\": 1, \"\xff\xfd\": 2}",
-        &["-c"],
-    )?;
+    // Two distinct fallback keys, and a clean key on either side of one.
+    let (stdout, code) = run_jq_stdin("[path(.[])]", r#"{"\ud800":1,"\ud801":2}"#, &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(
-        String::from_utf8_lossy(&out).trim(),
-        format!("[[\"{replacement}\"]]")
-    );
+    assert_eq!(stdout, "[[\"\\\\ud800\"],[\"\\\\ud801\"]]\n");
+
+    let (stdout, code) = run_jq_stdin("[path(.[])]", r#"{"a":1,"\ud800":2,"b":3}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\"],[\"\\\\ud800\"],[\"b\"]]\n");
 
     // A navigation that never visits the undecodable key still sees it,
-    // because the walk validates the whole document -- this is the behaviour
-    // #2061 deliberately preserved rather than trading away for speed.
-    let (out, code) = run_jq_binary_stdin("path(.a)", b"{\"\xff\xfe\": 1, \"a\": 2}", &["-c"])?;
+    // because the walk validates the whole document -- the behaviour #2061
+    // deliberately preserved rather than trading away for speed.
+    let (stdout, code) = run_jq_stdin("path(.a)", r#"{"\ud800":1,"a":2}"#, &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(String::from_utf8_lossy(&out).trim(), "[\"a\"]");
+    assert_eq!(stdout, "[\"a\"]\n");
 
+    Ok(())
+}
+
+/// #2061: the collision the lazy map's guard exists to catch still raises --
+/// an undecodable key whose display spelling collides with a real key of that
+/// same name, which a display-keyed map cannot hold both of (#1642).
+///
+/// Checked in all three positions relative to the clean key, since the lazy
+/// map only seeds itself from the prefix once a fallback key appears: getting
+/// the seeding wrong would turn one of these into a silent success.
+#[test]
+fn test_path_validity_walk_still_raises_on_a_colliding_key_2061() -> Result<()> {
+    for doc in [
+        r#"{"\\ud800":1,"\ud800":2}"#,
+        r#"{"\ud800":1,"\ud800":2}"#,
+        r#"{"a":1,"\ud800":2,"\ud800":3}"#,
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.a)", doc, &["-c"])?;
+        assert_eq!(code, 5, "{doc}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "", "{doc}");
+        assert!(stderr.contains("is ambiguous"), "{doc}: {stderr}");
+    }
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29038,3 +29038,179 @@ fn test_catch_handler_outputs_keep_ambient_path_1409() -> Result<()> {
 
     Ok(())
 }
+
+/// #2061: every arm of the cursor-native `path()` walk, exercised through the
+/// CLI so it reaches `eval_generic.rs`'s `Builtin::Path` rather than
+/// `eval.rs`'s library-only entry point.
+///
+/// Every expectation is jq 1.7.1's own output, re-verified live: this arm
+/// exists to be faster, not to behave differently, so parity is the whole
+/// specification.
+#[test]
+fn test_path_cursor_native_navigational_shapes_2061() -> Result<()> {
+    for (filter, input, want) in [
+        // Identity, field, nested field.
+        ("path(.)", "{\"a\":1}", "[]\n"),
+        ("path(.a)", "{\"a\":1}", "[\"a\"]\n"),
+        ("path(.a.b)", "{\"a\":{\"b\":1}}", "[\"a\",\"b\"]\n"),
+        // A path need not exist: jq yields it and keeps navigating through
+        // the absent node as if it were null.
+        ("path(.a)", "{}", "[\"a\"]\n"),
+        ("path(.a.b)", "{}", "[\"a\",\"b\"]\n"),
+        ("path(.a.b)", "null", "[\"a\",\"b\"]\n"),
+        // Index, including the float spelling (#1088) and a negative index,
+        // neither of which needs the array's length.
+        ("path(.[0])", "[7,8]", "[0]\n"),
+        ("path(.[0])", "[]", "[0]\n"),
+        ("path(.[2.0])", "[1,2,3]", "[2.0]\n"),
+        ("path(.[-1])", "[1,2,3]", "[-1]\n"),
+        // Iterate over both container kinds.
+        ("[path(.[])]", "{\"a\":1,\"b\":2}", "[[\"a\"],[\"b\"]]\n"),
+        ("[path(.[])]", "[7,8]", "[[0],[1]]\n"),
+        ("[path(.[])]", "{}", "[]\n"),
+        // Comma, pipe through a fan-out, and `?`.
+        ("[path(.a,.b)]", "{\"a\":1,\"b\":2}", "[[\"a\"],[\"b\"]]\n"),
+        (
+            "[path(.[]|.x)]",
+            "[{\"x\":1},{\"x\":2}]",
+            "[[0,\"x\"],[1,\"x\"]]\n",
+        ),
+        ("[path(.a?)]", "[1,2]", "[]\n"),
+        ("[path((.a)?)]", "[1,2]", "[]\n"),
+        // A non-navigable body still works -- it defers to the materializing
+        // resolver rather than being rejected.
+        ("[path(.[]|select(.>1))]", "[1,2,3]", "[[1],[2]]\n"),
+        ("path(.[\"a\"])", "{\"a\":1}", "[\"a\"]\n"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on `{input}`");
+        assert_eq!(stdout, want, "`{filter}` on `{input}`");
+    }
+    Ok(())
+}
+
+/// #2061: the error arms of the same walk. Each message is jq 1.7.1's own,
+/// and comes from the same `EvalError` constructor the materializing resolver
+/// uses, so the two cannot drift.
+#[test]
+fn test_path_cursor_native_type_errors_2061() -> Result<()> {
+    for (filter, input, want) in [
+        ("path(.a)", "[1,2]", "Cannot index array with string \"a\""),
+        ("path(.a)", "5", "Cannot index number with string \"a\""),
+        ("path(.a)", "\"s\"", "Cannot index string with string \"a\""),
+        ("path(.a)", "true", "Cannot index boolean with string \"a\""),
+        (
+            "path(.a.b)",
+            "{\"a\":1}",
+            "Cannot index number with string \"b\"",
+        ),
+        ("path(.[0])", "{}", "Cannot index object with number"),
+        ("path(.[0])", "5", "Cannot index number with number"),
+        ("path(.[])", "null", "Cannot iterate over null (null)"),
+        ("path(.[])", "5", "Cannot iterate over number (5)"),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, input, &["-c"])?;
+        assert_eq!(code, 5, "`{filter}` on `{input}`: stdout {stdout:?}");
+        assert!(
+            stderr.contains(want),
+            "`{filter}` on `{input}`: wanted {want:?}, got {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2061: a partial result produced before a later sibling errors must still
+/// be emitted -- jq's generator never un-emits an output it already produced.
+///
+/// Discarding it is the bug the evaluator-parity and golden suites caught in
+/// this change's first cut, so it is pinned directly rather than left to them.
+#[test]
+fn test_path_cursor_native_keeps_output_before_a_later_error_2061() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("path(.a.b, .c.d)", "{\"a\":{\"b\":1},\"c\":1}", &["-c"])?;
+    assert_eq!(code, 5, "stderr {stderr}");
+    assert_eq!(stdout, "[\"a\",\"b\"]\n");
+    assert!(
+        stderr.contains("Cannot index number with string \"d\""),
+        "{stderr}"
+    );
+    Ok(())
+}
+
+/// #2061: the validity walk's lazy #1642 collision map, whose fallback branch
+/// only runs once an undecodable key actually appears.
+///
+/// All three layouts matter and are checked separately, because the branch
+/// re-walks the object's *preceding* keys to seed the map: a fallback key
+/// first exercises the empty-prefix case, a fallback key after a clean one
+/// exercises the re-walk itself, and two fallback keys exercise the guard
+/// finding a genuine collision. Byte-identical to the eager map on all three,
+/// verified against `main` before this change landed.
+///
+/// Raw invalid UTF-8 rather than a `\uXXXX` escape: succinctly's semi-index
+/// accepts these bytes (real jq does too, substituting U+FFFD), where every
+/// bad-escape form is rejected at parse time and never reaches this walk.
+#[test]
+fn test_path_validity_walk_lazy_collision_map_2061() -> Result<()> {
+    let replacement = "\u{fffd}\u{fffd}";
+
+    // Fallback key first: the re-walk runs with an empty prefix.
+    let (out, code) = run_jq_binary_stdin("[path(.[])]", b"{\"\xff\xfe\": 1, \"a\": 2}", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&out).trim(),
+        format!("[[\"{replacement}\"],[\"a\"]]")
+    );
+
+    // Fallback key after a clean one: the re-walk has a prefix to seed from.
+    let (out, code) = run_jq_binary_stdin(
+        "[path(.[])]",
+        b"{\"a\": 1, \"\xff\xfe\": 2, \"b\": 3}",
+        &["-c"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&out).trim(),
+        format!("[[\"a\"],[\"{replacement}\"],[\"b\"]]")
+    );
+
+    // Two fallback keys whose display forms collide: `keys` collapses them,
+    // and the walk must not raise for an ordinary repeat.
+    let (out, code) = run_jq_binary_stdin(
+        "[path(.[])]",
+        b"{\"\xff\xfe\": 1, \"\xff\xfd\": 2}",
+        &["-c"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        String::from_utf8_lossy(&out).trim(),
+        format!("[[\"{replacement}\"]]")
+    );
+
+    // A navigation that never visits the undecodable key still sees it,
+    // because the walk validates the whole document -- this is the behaviour
+    // #2061 deliberately preserved rather than trading away for speed.
+    let (out, code) = run_jq_binary_stdin("path(.a)", b"{\"\xff\xfe\": 1, \"a\": 2}", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(String::from_utf8_lossy(&out).trim(), "[\"a\"]");
+
+    Ok(())
+}
+
+/// #2061: a `\uXXXX`-family decode failure anywhere in the document still
+/// makes `path()` raise, unchanged from before this change.
+///
+/// This is the validity gate the cursor walk deliberately keeps: dropping it
+/// would have made `path()` roughly 8x faster still, but #1755/#1953 chose to
+/// raise on undecodable content rather than silently substitute, and a
+/// performance change is not the place to reverse that.
+#[test]
+fn test_path_still_raises_on_an_undecodable_sibling_2061() -> Result<()> {
+    for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
+        let input = format!("{{\"a\":\"{bad}\",\"d\":5}}");
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.d)", &input, &["-c"])?;
+        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "", "{bad}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29227,3 +29227,62 @@ fn test_path_still_raises_on_an_undecodable_sibling_2061() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2061: the walk's remaining arms — navigating *through* an absent node, and
+/// the multi-stage pipe forms.
+///
+/// These are the shapes the first round of tests missed: `Iterate` and the
+/// index/field steps each have a distinct `PathNode::Absent` arm, reached only
+/// when an earlier component did not exist in the document, and a pipe of more
+/// than two stages takes a different branch from a two-stage one. Every row is
+/// jq 1.7.1's own output.
+#[test]
+fn test_path_cursor_native_absent_nodes_and_pipes_2061() -> Result<()> {
+    for (filter, input, want) in [
+        // Navigating on through an absent node: jq keeps yielding the path.
+        ("path(.a.b.c)", "{}", "[\"a\",\"b\",\"c\"]\n"),
+        ("path(.a[0])", "{}", "[\"a\",0]\n"),
+        // Identity and a parenthesised stage inside a pipe.
+        ("path(.|.a)", "{}", "[\"a\"]\n"),
+        ("path((.a)|.b)", "{}", "[\"a\",\"b\"]\n"),
+        // Three stages: the `rest.len() > 1` branch, distinct from two.
+        ("path(.a|.|.b)", "{}", "[\"a\",\"b\"]\n"),
+        (
+            "path(.a.b.c)",
+            "{\"a\":{\"b\":{\"c\":1}}}",
+            "[\"a\",\"b\",\"c\"]\n",
+        ),
+        // Iterate as a later pipe stage, over both container kinds.
+        ("path(.[]|.[])", "{\"a\":{\"b\":1}}", "[\"a\",\"b\"]\n"),
+        ("path(.[]|.[])", "{\"a\":[1,2]}", "[\"a\",0]\n[\"a\",1]\n"),
+        ("path(.a[])", "{\"a\":[1,2]}", "[\"a\",0]\n[\"a\",1]\n"),
+        ("path(.a[])", "{\"a\":{\"b\":1}}", "[\"a\",\"b\"]\n"),
+        // An empty container iterates to nothing rather than erroring.
+        ("[path(.[]|.[])]", "{}", "[]\n"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on `{input}`");
+        assert_eq!(stdout, want, "`{filter}` on `{input}`");
+    }
+
+    // Iterating an absent node raises, exactly as iterating an explicit null
+    // does -- the `PathNode::Absent` arm of the `Iterate` step.
+    for (filter, input) in [("path(.a[])", "{}"), ("path(.a|.[])", "{}")] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, input, &["-c"])?;
+        assert_eq!(code, 5, "`{filter}` on `{input}`: stdout {stdout:?}");
+        assert!(
+            stderr.contains("Cannot iterate over null"),
+            "`{filter}` on `{input}`: {stderr}"
+        );
+    }
+
+    // A type error reached *after* an absent step still names the right type.
+    let (_, stderr, code) = run_jq_stdin_streams("path(.a.b.c)", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 5);
+    assert!(
+        stderr.contains("Cannot index array with string \"b\""),
+        "{stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Refs #2061. Cuts `path(...)` from 772ms/519 MiB to 379ms/34 MiB on a 20 MB document.

## The problem

`path(...)` output is small and bounded, but `eval_generic.rs`'s `Builtin::Path`
arm materialized the whole document to produce it. Reproduced on `main` before
changing anything, on a 1,000,000-element array:

| query | time | peak RSS |
|---|---:|---:|
| `.[0]` (plain read) | 94 ms | 34 MiB |
| `path(.[0])` | 772 ms | 519 MiB |
| `path(.)` | 985 ms | **1003 MiB** |

`path(.)` outputs `[]`.

## Two commits

**1. Resolve navigational `path()` from cursors.** For a purely navigational
path expression — `Identity`, `Field`, `Index`, `Iterate`, `Optional`, `Paren`,
`Pipe`, `Comma` — the answer depends on the document's *structure* along the
path and never on a value that must be computed, so it can be walked with
cursors. Anything else (computed indices, slices, builtins, `first`/`last`)
defers to `builtin_path_on_owned` unchanged: this adds a fast path, not a second
path resolver.

**2. Build the #1642 collision map lazily.** That left the whole-document
validity walk as the entire remaining cost — attributed by building without it:
577ms of the 577ms. The walk allocated an `IndexMap<String, ()>` per object, one
`String` per key, purely to answer #1642's colliding-display-key question. But
`DisplayKeyGuard::check` reports a collision only when `map.contains_key(key)`
**and** a fallback key is involved, so until the first undecodable key the map's
answer is unconditionally "no collision". Skip it until one appears; when one
does, re-walk that object's preceding keys to seed the map first, since a later
fallback can collide with an earlier clean key.

## What is deliberately *not* changed

`to_owned_with_cursor` doubles as a validity gate (#1755/#1953), so the
whole-document walk is kept — only the tree build is dropped.
`push_generic_truthiness_cursor_error` is that same traversal and validation
with the `OwnedValue` construction removed.

I checked whether the gate could just be dropped, since it costs the bulk of
what remains. It cannot be justified on jq-parity grounds either way — its
entire domain is documents no jq version will process:

| document | jq 1.7.1 | jq 1.8.2 | gate |
|---|---|---|---|
| `"\ud800"`, `"\uZZZZ"`, `"\x"`, `"\u12"` | rejects | rejects | fires |
| raw invalid UTF-8, well-formed | answers | answers | silent, succinctly agrees |

But #1755/#1953 deliberately chose to *raise* on undecodable content rather than
silently substitute, precisely because jq would have refused the document. That
stance is the project's, so this change preserves it rather than quietly
reversing it inside a performance PR. (There is a real residual inconsistency —
`.d` answers `5` where `path(.d)` raises on the same document — but the
consistent fix is making `.d` stricter, not `path()` looser, and that is not
this PR's call to make.)

## Verification

- Full workspace suite green under CI's feature set: **6804 passed, 0 failed**.
  Plus `cargo fmt`, all three `ci.yml` clippy legs, and `cargo check
  --no-default-features` (7 warnings, identical to the merge base).
- **Semantics pinned against `main`, not just against jq**: every decode-failure
  escape shape (lone surrogate, bad hex, unknown escape, truncated) and every
  colliding-fallback layout (both keys fallback, fallback after a clean key,
  fallback before a clean key) produce byte-identical output and exit codes.
  The error *order* is preserved too, which is why commit 2 re-walks the prefix
  instead of validating keys in a cheaper second pass.
- A 156-combination differential of `path()` shapes against `main` and jq 1.7.1.

### Three bugs the existing suite caught in the first cut

All three came from re-deriving what the materializing path already had, and all
three are now fixed by calling the same helper it calls:

- `path(.[2.0])` reported `[2]` instead of `[2.0]` (#1088) — now shares
  `eval.rs`'s `index_component_value`.
- `[path(.[])]` on `{"a":1,"a":2}` emitted two paths where jq mode collapses to
  one (#1385) — now shares `collect_paths_generic`'s `effective_fields_checked`
  + `key_display_string`.
- A partial result before a sibling's error was discarded rather than emitted;
  jq never un-emits an output it already produced.

My own differential missed all three, because its inputs had no float indices
and no duplicate keys.

## Results

Interleaved A/B against `main`, 7 reps, median, byte-identical output (Apple
M-series, AC power). Both absolute times shown so the direction cannot be
misread:

| query | before | after | faster | peak RSS |
|---|---:|---:|---|---|
| `path(.)` | 985 ms | 394 ms | **2.5x** | 1003 → **34 MiB** |
| `path(.[0])` | 772 ms | 379 ms | **2.0x** | 519 → **34 MiB** |
| `path(.[999999].k)` | 761 ms | 383 ms | **2.0x** | 519 → **34 MiB** |
| `length`, `.[0]`, `[.[]\|select(.k==1)]` | — | — | unchanged | unchanged |

Non-path queries are untouched, as expected — they never enter the changed arm.
