### PR TITLE
test: stop a child's unread stdin failing the test with Broken pipe

### DIFF
--- a/tests/common/cargo_run_exit.rs
+++ b/tests/common/cargo_run_exit.rs
@@ -29,7 +29,10 @@
 
 #![allow(dead_code)] // Each consumer uses a different subset.
 
-use anyhow::{Context, Result};
+// `anyhow::Context` is no longer imported: every remaining stage tag in
+// this file is `anyhow::Error::new(e).context(..)`, an inherent method, and
+// the last `Result::context` call site went with #2057's `BrokenPipe` arm.
+use anyhow::Result;
 
 #[path = "../../src/bin/succinctly/exit_status.rs"]
 mod exit_status;
@@ -157,7 +160,10 @@ pub fn succinctly_bin() -> &'static str {
 /// would leak a zombie for the rest of this test binary's run.
 /// `wait_with_output()` below doesn't care whether the write succeeded;
 /// call it unconditionally first so the child is always reaped, then
-/// surface the write error if there was one.
+/// surface the write error if there was one -- except a `BrokenPipe`,
+/// which that same early-exit case makes routine rather than exceptional
+/// and which carries no information once the child has been waited on
+/// (#2057; see the match at the end of the body).
 ///
 /// Ordering invariant: this write runs to completion (blocking on a full
 /// pipe buffer) *before* `wait_with_output()`'s own concurrent
@@ -207,7 +213,66 @@ pub fn write_stdin_then_wait(
     // into this shared function had silently dropped that stage-tagging
     // (a bare `io::Error`'s own `Display` doesn't say *which* fallible step
     // produced it), making a real failure harder to triage than before.
-    write_result.context("write stdin")?;
+    match write_result {
+        Ok(()) => {}
+        // A child that has already exited has closed the read end, so a
+        // write to it fails with `BrokenPipe` -- and note that this is
+        // independent of how much room the pipe buffer has. Buffer capacity
+        // only decides anything while a reader still holds the pipe open,
+        // so for an already-exited child the sole discriminator is "did the
+        // child exit before this write started".
+        //
+        // For every CLI test whose filter fails to *compile*, that is the
+        // normal ordering rather than a contention symptom: `succinctly jq`
+        // reports the error and exits 3 without ever reading stdin. All
+        // four recorded observations of #2057 are that shape
+        // (`test_unresolved_call_is_not_catchable_1473`,
+        // `test_forward_reference_across_names_is_a_compile_error_1473`,
+        // and `test_func_def_arity_overload_unmatched_arity_still_errors_1376`
+        // twice).
+        //
+        // The race is *biased*, not decided: with the few-byte payloads
+        // those tests use, a parent that reaches its write first succeeds
+        // outright, since the bytes simply sit in the buffer that the child
+        // then never reads. Anything delaying the parent between `spawn()`
+        // and its first write -- coverage instrumentation, scheduler
+        // pressure from concurrent spawns -- pushes the bias toward the
+        // child. Three of the four observations are on `Coverage` legs and
+        // one is on a plain `Test` leg, so instrumentation amplifies it but
+        // is not required. A bias sitting high enough explains consecutive
+        // re-runs both failing without the outcome being strictly
+        // determined, which is what was seen on #2071.
+        //
+        // Once this point is reached the failed write carries no
+        // information: `wait_with_output` above already succeeded, so the
+        // child's real exit status, stdout and stderr are in hand, and those
+        // are what every caller asserts on. Swallowing it is what lets a
+        // compile-error test assert its compile error rather than die with a
+        // stack trace naming whichever test happened to be running.
+        //
+        // Deliberately *not* routed through `spawn_with_signal_retry`'s
+        // retry instead: re-spawning re-observes the same compile error at
+        // the same bias, so a retry mostly converts a fast failure into a
+        // slow one. A child killed by a signal mid-write is still caught, by
+        // that function's own exit-status check.
+        //
+        // Deliberately *not* narrowed to a non-zero exit status either,
+        // though that would preserve one diagnostic worth naming: a child
+        // that genuinely consumes stdin, exits 0, and whose write failed
+        // partway for a real reason now surfaces as a downstream assertion
+        // on truncated output instead of "write stdin failed". Narrowing
+        // trades that back for a spurious failure whenever a child exits 0
+        // *without* reading its input -- `-n` with no `inputs`, say -- which
+        // is precisely the flake class this fix exists to remove, and it
+        // would reintroduce it in a form no test here currently covers. The
+        // broad swallow is the safer side of that trade for a harness whose
+        // job is to make real assertions legible; revisit if a truncated-
+        // write case ever actually bites.
+        //
+        // Every other write error still surfaces with its stage tag.
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(e) => return Err(anyhow::Error::new(e).context("write stdin")),
+    }
     Ok(output)
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28864,3 +28864,39 @@ fn test_sort_family_propagates_halt_like_jq_1687() -> Result<()> {
     assert_eq!(stderr, "10\n");
     Ok(())
 }
+
+/// #2057: a child that exits *without reading stdin* must not fail the test
+/// with `Broken pipe`.
+///
+/// Every filter here fails to compile, so `succinctly jq` reports the error
+/// and exits 3 having never touched stdin. Writing to that closed pipe is
+/// then the normal outcome, not a symptom of load -- which is why the four
+/// recorded #2057 failures were all compile-error tests, and why re-running
+/// the job did not clear them.
+///
+/// In CI the race is only *biased*, not decided: the few-byte payloads those
+/// tests use land in the pipe buffer and succeed whenever the parent reaches
+/// its write first. This test removes the bias instead of relying on it. The
+/// payload spans many `write` calls, so the child -- which exits in
+/// milliseconds -- is certain to have exited before the last of them,
+/// whichever side started first. That is the narrower case where payload
+/// size is the discriminator at all; for an already-exited child `BrokenPipe`
+/// does not depend on buffer capacity.
+///
+/// Without the `BrokenPipe` arm in `write_stdin_then_wait` this therefore
+/// fails every run rather than occasionally, which is what makes it a usable
+/// pin for a bug whose own signature in CI is intermittent.
+#[test]
+fn test_compile_error_with_unread_stdin_is_not_a_broken_pipe_2057() -> Result<()> {
+    let payload = "0\n".repeat(2 * 1024 * 1024);
+    for filter in ["nosuchfn", "def f(x): x; f(1;2)"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(&payload))?;
+        assert_eq!(code, 3, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout, "", "{filter}: a compile error produces no output");
+        assert!(
+            stderr.contains("is not defined"),
+            "{filter}: stderr {stderr:?}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #2057.

## What was happening

`write_stdin_then_wait` surfaced every stdin write error, including
`BrokenPipe`. A child that has already exited has closed the read end, so a
write to it fails with exactly that — **independent of how much room the pipe
buffer has**, since capacity only decides anything while a reader still holds
the pipe open. For an already-exited child the sole discriminator is whether it
exited before the write started.

The detail the issue's "under CI contention" framing understates: for every CLI
test whose filter fails to **compile**, that ordering is the norm rather than a
contention symptom. `succinctly jq` reports the compile error and exits 3
without touching stdin.

All five recorded observations are that shape, across three unrelated branches:

| branch | job | test |
|---|---|---|
| `main` | `Test (x86_64)` | `test_func_def_arity_overload_unmatched_arity_still_errors_1376` |
| `issue-1909-…` | `Coverage (ARM64)` | `test_func_def_arity_overload_unmatched_arity_still_errors_1376` |
| `issue-1409` | `Coverage (ARM64)` | `test_unresolved_call_is_not_catchable_1473` |
| `issue-1409` | `Coverage (ARM64)` | `test_forward_reference_across_names_is_a_compile_error_1473` |
| `issue-2061` | `Coverage (ARM64)` | `test_syntax_error_exits_with_the_compile_error_code_1473` |

## The race is biased, not decided

An earlier draft of this PR said the child wins "deterministically". That was
wrong, and the correction matters for anyone reasoning about this later. With
the few-byte payloads those tests use, a parent that reaches its write first
**succeeds outright** — the bytes sit in the buffer the child never reads.

Anything delaying the parent between `spawn()` and its first write pushes the
bias toward the child:

- **Coverage instrumentation.** Four of five observations are on `Coverage`
  legs, one on a plain `Test` leg — so it amplifies but is not required.
- **Scheduler pressure from concurrent spawns.** Directly evidenced by a natural
  experiment on #2075: two heads on one branch with *identical library code*,
  differing only by a test commit adding ~14 `run_jq_stdin` spawns. The earlier
  head is green on both `Coverage` legs; the later one fails this way, in a
  compile-error test that branch's own diff cannot reach.

A bias sitting high enough explains consecutive re-runs both failing without the
outcome being strictly determined — which is what #2071 saw.

## The fix

Once `wait_with_output()` has succeeded the failed write carries no information:
the child's real exit status, stdout and stderr are in hand, and those are what
every caller asserts on. `BrokenPipe` specifically is now swallowed there; every
other write error still surfaces with its stage tag.

**Not routed through the retry** instead: re-spawning re-observes the same
compile error at the same bias, so a retry mostly converts a fast failure into a
slow one. A signal-killed child is still caught by `spawn_with_signal_retry`'s
own exit-status check.

**Not narrowed to a non-zero exit status** either — and this is the one place a
reviewer might reasonably overrule me. Narrowing would preserve a diagnostic
worth naming: a child that genuinely consumes stdin, exits 0, and whose write
failed partway for a real reason now surfaces as a downstream assertion on
truncated output rather than a clear "write stdin failed". But it trades that
back for a spurious failure whenever a child exits 0 *without* reading its input
(`-n` with no `inputs`), which is the very flake class this removes. I checked
both current tests that write stdin to a `-n` child — one consumes it via
`inputs`, the other writes zero bytes — so the hazard is future rather than
present. The broad swallow is the safer side of that trade for a harness whose
job is making real assertions legible; happy to narrow it if you disagree.

## The regression test

`test_compile_error_with_unread_stdin_is_not_a_broken_pipe_2057` removes the bias
rather than relying on it: its payload spans many `write` calls, so the child —
which exits in milliseconds — is certain to have exited before the last of them,
whichever side started first. That is the narrower case where payload size is
the discriminator at all.

Verified in both directions. Arm removed:

```
test test_compile_error_with_unread_stdin_is_not_a_broken_pipe_2057 ... FAILED
Error: write stdin
    Broken pipe (os error 32)
```

Arm restored: passes.

## Blast radius

Test harness only — two call sites (`jq_cli_tests.rs`'s `spawn_jq` and
`cargo_run_exit.rs`'s `spawn_with_signal_retry`), no library or binary code.

`anyhow::Context` is no longer imported: the last `Result::context` call site in
the file went with this change, and every remaining stage tag is
`anyhow::Error::new(e).context(..)`, an inherent method. Caught by
`clippy -D warnings`, not by the test run.

## Verification

Full CLI test-target list from `ci.yml`; workspace suite under
`cli,simd,regex,serde`; both clippy legs with `-D warnings`;
`cargo check --no-default-features`; `cargo fmt --all --check`.

## Note

This blocks #2071 (#1409's fix), which cannot go green on `Coverage (ARM64)`
until it lands, and has now hit #2075 as well.
