### PR TITLE
docs(jq): point #1409's three deferred follow-ups at their tracking issues

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -809,6 +809,13 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
+        // No `Expr::FirstExpr`/`Expr::LastExpr` arm, and no matching arm in
+        // `eval_pipe_with_path_context_internal` either, so `first(key)` and
+        // `last(key)` silently answer `null` where the sibling
+        // `limit(1; key)` answers correctly (#2074). Both halves are needed
+        // to close it -- the same pairing `Label` (#715) and `FuncDef`
+        // (#1306) each required -- so it is tracked rather than half-fixed
+        // here.
         Expr::Comma(exprs) => exprs.iter().any(needs_path_context),
         // `[key]`/`[parent]`/`[file_index]` (#1302): an array literal is
         // still just "collect this inner expression's outputs", the same
@@ -29835,7 +29842,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // (#1409), which would work here too -- but adopting it for
         // `Optional` also stops `rest` inheriting this arm's suppression,
         // an evaluator-wide model change #1826/#1869 both build on, so it
-        // is deliberately left for its own change. This arm
+        // is deliberately left for its own change -- #2073, which also
+        // records what that suppression currently costs: `.a | (.[])? |
+        // (key, error("boom"))` swallows an error real jq raises. This arm
         // must not regress the path threading meanwhile, so it only takes
         // the fast, isolated path when `rest` doesn't consult path context
         // in the first place, and otherwise falls back to evaluating

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28939,7 +28939,10 @@ fn test_isolated_subexpr_threads_per_output_path_1409() -> Result<()> {
         // `As` reaches its own path-context arm only when `expr` or `body`
         // needs path context on its own; `select(key >= 0)` is what routes
         // this shape there. The bare `. as $x | .[]` form is a separate,
-        // still-open routing gap, not this fix's subject.
+        // still-open routing gap (#2072): widening the guard to consult
+        // `rest` reaches it, but regresses `.x as $v | $v | file_index`,
+        // because `substitute_bound_var` re-materialises the bound value as
+        // a literal and erases the node identity real yq keeps.
         ".a | (. as $x | (.[] | select(key >= 0))) | key",
         ".a | (. as [$x] | (.[] | select(key >= 0))) | key",
     ] {


### PR DESCRIPTION
Comments only; no behaviour change.

The #1409 fix (#2071) left three gaps open on purpose. Each has a comment
saying what was deferred, but none named where it is tracked — a reader hitting
one had no route to the analysis short of digging through the PR. This adds the
issue numbers and, where it is short enough to be worth inlining, the reason.

| location | now names | added context |
|---|---|---|
| `Expr::Optional`'s arm, `eval.rs` | #2073 | what the suppression currently costs: `.a \| (.[])? \| (key, error("boom"))` swallows an error real jq raises |
| `needs_path_context`, `eval.rs` | #2074 | had **no** note at all; records why `first(key)` is `null` where `limit(1; key)` is correct, and that closing it needs a matching arm in `eval_pipe_with_path_context_internal` too — the pairing `Label` (#715) and `FuncDef` (#1306) each required |
| the `As` case in `test_isolated_subexpr_threads_per_output_path_1409` | #2072 | why widening the guard is not the fix: `substitute_bound_var` re-materialises the bound value as a literal, erasing the node identity real yq keeps |

The `needs_path_context` one is the most useful of the three: that function is
where someone would look to find out why a path-context builtin isn't resolving,
and the missing `FirstExpr`/`LastExpr` arms were invisible there.

Verified: workspace suite under `cli,simd,regex,serde`, `clippy --all-targets
--all-features -D warnings`, `cargo fmt --all --check`, `cargo doc` with
`RUSTDOCFLAGS=-D warnings`, `cargo check --no-default-features`.
