### PR TITLE
fix(jq): alpha-rename callee binders that would capture a substituted arg

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26017,16 +26017,33 @@ fn fresh_var_name(name: &str) -> String {
 
 /// Whether `expr` contains a free-standing `$name` reference anywhere.
 ///
+/// Every `$name` referenced anywhere in `expr`.
+///
 /// #2077: used to decide whether substituting `arg` into a binder's scope
 /// would let that binder recapture one of `arg`'s own variable references.
 /// Deliberately not scope-aware over `expr` itself -- a `$name` that is
-/// actually bound *within* `expr` (not free) still trips this, which only
-/// costs an unnecessary rename. Renaming a binder that would not actually
-/// have captured anything is still alpha-equivalent, so over-approximating
-/// here is safe, unlike the rename itself (see [`capturing_pattern_renames`]),
-/// which must not touch a binder that isn't actually `name`.
-fn expr_mentions_var(expr: &Expr, name: &str) -> bool {
-    any_subexpr(expr, &mut |e| matches!(e, Expr::Var(n) if n == name))
+/// actually bound *within* `expr` (not free) still ends up in the set, which
+/// only costs an unnecessary rename. Renaming a binder that would not
+/// actually have captured anything is still alpha-equivalent, so
+/// over-approximating here is safe, unlike the rename itself (see
+/// [`capturing_pattern_renames`]), which must not touch a binder that isn't
+/// actually free in `arg`.
+///
+/// One walk regardless of how many names are later checked against it --
+/// [`capturing_pattern_renames`] used to call an `any_subexpr`-per-name
+/// membership test instead, which re-walked `arg` from scratch for every
+/// bound name (a wide `?//` alternation or a many-parameter nested `def`
+/// turned that into a multiplicative cost, and this runs fresh on every
+/// evaluation of a `def` node -- `expand_func_calls` is not cached).
+fn expr_free_vars(expr: &Expr) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    any_subexpr(expr, &mut |e| {
+        if let Expr::Var(n) = e {
+            names.insert(n.clone());
+        }
+        false
+    });
+    names
 }
 
 /// For every distinct name `patterns` binds that also appears as a free
@@ -26049,9 +26066,14 @@ fn capturing_pattern_renames(patterns: &[Pattern], arg: &Expr) -> Vec<(String, S
     }
     bound_names.sort();
     bound_names.dedup();
+    if bound_names.is_empty() {
+        return Vec::new();
+    }
+
+    let free_vars = expr_free_vars(arg);
     bound_names
         .into_iter()
-        .filter(|name| expr_mentions_var(arg, name))
+        .filter(|name| free_vars.contains(name.as_str()))
         .map(|name| {
             let fresh = fresh_var_name(&name);
             (name, fresh)
@@ -41213,19 +41235,16 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                 // `foreach` do.
                 let as_patterns: Vec<Pattern> = params.iter().cloned().map(Pattern::Var).collect();
                 let renames = capturing_pattern_renames(&as_patterns, arg);
-                let new_params = if renames.is_empty() {
-                    params.clone()
-                } else {
-                    params
-                        .iter()
-                        .map(|p| {
-                            renames
-                                .iter()
-                                .find(|(old_name, _)| old_name == p)
-                                .map_or_else(|| p.clone(), |(_, new_name)| new_name.clone())
-                        })
-                        .collect()
-                };
+                let new_params = apply_pattern_renames(&as_patterns, &renames)
+                    .into_iter()
+                    .map(|p| match p {
+                        Pattern::Var(name) => name,
+                        // `as_patterns` above is built entirely from
+                        // `Pattern::Var`, and `apply_pattern_renames` never
+                        // changes a pattern's shape, only its bound names.
+                        _ => unreachable!("FuncDef params are always wrapped as Pattern::Var"),
+                    })
+                    .collect();
                 let renamed_body = apply_scope_renames(body, &renames);
                 (
                     new_params,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -301,7 +301,7 @@ use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 
 use super::expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Literal, MergeFlags, NumberKey,
-    ObjectEntry, ObjectKey, Pattern, StringPart,
+    ObjectEntry, ObjectKey, Pattern, PatternEntry, StringPart,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -25970,6 +25970,131 @@ fn pattern_binds_var(pattern: &Pattern, var_name: &str) -> bool {
     }
 }
 
+/// Replace every binding occurrence of `old_name` in a pattern with
+/// `new_name`, leaving every other name untouched.
+///
+/// #2077: applies an alpha-rename decided by [`capturing_pattern_renames`]
+/// to the pattern itself, so the renamed binder and its own body stay in
+/// sync (`reduce`/`foreach`/`?//` alternatives, and `as`-patterns).
+fn rename_pattern_var(pattern: &Pattern, old_name: &str, new_name: &str) -> Pattern {
+    match pattern {
+        Pattern::Var(name) if name == old_name => Pattern::Var(new_name.to_string()),
+        Pattern::Var(name) => Pattern::Var(name.clone()),
+        Pattern::Object(entries) => Pattern::Object(
+            entries
+                .iter()
+                .map(|entry| PatternEntry {
+                    key: entry.key.clone(),
+                    pattern: rename_pattern_var(&entry.pattern, old_name, new_name),
+                })
+                .collect(),
+        ),
+        Pattern::Array(patterns) => Pattern::Array(
+            patterns
+                .iter()
+                .map(|p| rename_pattern_var(p, old_name, new_name))
+                .collect(),
+        ),
+    }
+}
+
+/// A synthetic replacement for `name` that no real jq/yq program can ever
+/// spell.
+///
+/// #2077: `#` cannot appear in a jq/yq identifier (`Parser::parse_ident`
+/// stops at the first non-alphanumeric, non-`_`, and -- in yq mode -- non-`-`
+/// character), so appending it always produces a name distinct from every
+/// binder the user actually wrote, however many times the source name has
+/// already been through this rename (nested captures just grow more `#`s).
+/// No counter is needed for global uniqueness: each rename only rewrites
+/// occurrences strictly within the one binder's own scope (via
+/// [`substitute_func_param`]'s existing shadow-aware recursion), so two
+/// unrelated renames of the same source name can never see each other's
+/// output.
+fn fresh_var_name(name: &str) -> String {
+    format!("{name}#")
+}
+
+/// Whether `expr` contains a free-standing `$name` reference anywhere.
+///
+/// #2077: used to decide whether substituting `arg` into a binder's scope
+/// would let that binder recapture one of `arg`'s own variable references.
+/// Deliberately not scope-aware over `expr` itself -- a `$name` that is
+/// actually bound *within* `expr` (not free) still trips this, which only
+/// costs an unnecessary rename. Renaming a binder that would not actually
+/// have captured anything is still alpha-equivalent, so over-approximating
+/// here is safe, unlike the rename itself (see [`capturing_pattern_renames`]),
+/// which must not touch a binder that isn't actually `name`.
+fn expr_mentions_var(expr: &Expr, name: &str) -> bool {
+    any_subexpr(expr, &mut |e| matches!(e, Expr::Var(n) if n == name))
+}
+
+/// For every distinct name `patterns` binds that also appears as a free
+/// `$name` reference in `arg`, pick a fresh replacement -- the alpha-renames
+/// [`substitute_func_param`]'s binder arms (`As`, `Reduce`, `Foreach`,
+/// `AsPattern`, and a nested `FuncDef`'s own parameters, the latter wrapped
+/// one `Pattern::Var` per parameter by its caller) must apply before
+/// substituting `param -> arg` into that binder's own scope.
+///
+/// #2077: without this, `def f(g): 5 as $x | g; 2 as $x | f($x)` silently
+/// returns `5` instead of `2` -- substituting `g -> $x` (the caller's `$x`)
+/// into `5 as $x | g` places a fresh `$x` reference *inside* the callee's
+/// own `$x` binding, which then captures it. Real jq binds a function
+/// argument as a closure over the caller's environment, so the callee's own
+/// `as $x` can never observe it.
+fn capturing_pattern_renames(patterns: &[Pattern], arg: &Expr) -> Vec<(String, String)> {
+    let mut bound_names = Vec::new();
+    for p in patterns {
+        collect_pattern_var_names(p, &mut bound_names);
+    }
+    bound_names.sort();
+    bound_names.dedup();
+    bound_names
+        .into_iter()
+        .filter(|name| expr_mentions_var(arg, name))
+        .map(|name| {
+            let fresh = fresh_var_name(&name);
+            (name, fresh)
+        })
+        .collect()
+}
+
+/// Apply every `(old, new)` rename from [`capturing_pattern_renames`] to a
+/// pattern list, in order.
+fn apply_pattern_renames(patterns: &[Pattern], renames: &[(String, String)]) -> Vec<Pattern> {
+    if renames.is_empty() {
+        return patterns.to_vec();
+    }
+    let mut result = patterns.to_vec();
+    for (old_name, new_name) in renames {
+        result = result
+            .iter()
+            .map(|p| rename_pattern_var(p, old_name, new_name))
+            .collect();
+    }
+    result
+}
+
+/// Apply every `(old, new)` rename from [`capturing_pattern_renames`] to an
+/// expression that lives in the renamed binder's scope (a `reduce`/`foreach`
+/// `update`/`extract`, an `as`/`as`-pattern `body`, or a nested `FuncDef`'s
+/// own `body`).
+///
+/// Reuses [`substitute_func_param`] itself as the rename primitive: replacing
+/// `old_name` with `Expr::Var(new_name)` is exactly a variable rename, and
+/// doing it this way gets the same shadow-aware recursion the real
+/// substitution needs for free -- a *further* nested binder that rebinds
+/// `old_name` again (e.g. `reduce .[] as $x ($init; reduce .[] as $x (...))`)
+/// correctly stops the rename at its own boundary, the same as it stops
+/// substitution.
+fn apply_scope_renames(scope: &Expr, renames: &[(String, String)]) -> Expr {
+    let mut result = scope.clone();
+    for (old_name, new_name) in renames {
+        result = substitute_func_param(&result, old_name, &Expr::Var(new_name.clone()));
+    }
+    result
+}
+
 /// Substitute variable in a builtin expression.
 fn substitute_var_in_builtin(
     builtin: &Builtin,
@@ -40929,10 +41054,22 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                     body: body.clone(),
                 }
             } else {
+                // #2077: `var` doesn't shadow `param`, but it can still
+                // *capture* `arg` if `arg` itself references a `$var` of the
+                // same name -- alpha-rename `var` within `body` first so the
+                // substituted-in reference stays free.
+                let renames = capturing_pattern_renames(
+                    core::slice::from_ref(&Pattern::Var(var.clone())),
+                    arg,
+                );
+                let new_var = renames
+                    .first()
+                    .map_or_else(|| var.clone(), |(_, new_name)| new_name.clone());
+                let renamed_body = apply_scope_renames(body, &renames);
                 Expr::As {
                     expr: Box::new(substitute_func_param(expr, param, arg)),
-                    var: var.clone(),
-                    body: Box::new(substitute_func_param(body, param, arg)),
+                    var: new_var,
+                    body: Box::new(substitute_func_param(&renamed_body, param, arg)),
                 }
             }
         }
@@ -40950,11 +41087,17 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                     update: update.clone(),
                 }
             } else {
+                // #2077: `patterns` doesn't shadow `param`, but its own
+                // bound names can still capture `arg`'s free variables (the
+                // last repro row in the issue: `reduce`'s pattern variable
+                // captures a substituted-in `$x` the same way `as` does).
+                let renames = capturing_pattern_renames(patterns, arg);
+                let renamed_update = apply_scope_renames(update, &renames);
                 Expr::Reduce {
                     input: Box::new(substitute_func_param(input, param, arg)),
-                    patterns: patterns.clone(),
+                    patterns: apply_pattern_renames(patterns, &renames),
                     init: Box::new(substitute_func_param(init, param, arg)),
-                    update: Box::new(substitute_func_param(update, param, arg)),
+                    update: Box::new(substitute_func_param(&renamed_update, param, arg)),
                 }
             }
         }
@@ -40974,14 +41117,20 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                     extract: extract.clone(),
                 }
             } else {
+                // #2077: same capture risk as `Reduce` above -- `update`
+                // *and* `extract` both see the pattern's bindings, so both
+                // need the same renames applied.
+                let renames = capturing_pattern_renames(patterns, arg);
+                let renamed_update = apply_scope_renames(update, &renames);
                 Expr::Foreach {
                     input: Box::new(substitute_func_param(input, param, arg)),
-                    patterns: patterns.clone(),
+                    patterns: apply_pattern_renames(patterns, &renames),
                     init: Box::new(substitute_func_param(init, param, arg)),
-                    update: Box::new(substitute_func_param(update, param, arg)),
-                    extract: extract
-                        .as_ref()
-                        .map(|e| Box::new(substitute_func_param(e, param, arg))),
+                    update: Box::new(substitute_func_param(&renamed_update, param, arg)),
+                    extract: extract.as_ref().map(|e| {
+                        let renamed_extract = apply_scope_renames(e, &renames);
+                        Box::new(substitute_func_param(&renamed_extract, param, arg))
+                    }),
                 }
             }
         }
@@ -41019,14 +41168,21 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
             body,
         } => {
             let shadowed = patterns.iter().any(|p| pattern_binds_var(p, param));
-            Expr::AsPattern {
-                expr: Box::new(substitute_func_param(expr, param, arg)),
-                patterns: patterns.clone(),
-                body: if shadowed {
-                    body.clone()
-                } else {
-                    Box::new(substitute_func_param(body, param, arg))
-                },
+            if shadowed {
+                Expr::AsPattern {
+                    expr: Box::new(substitute_func_param(expr, param, arg)),
+                    patterns: patterns.clone(),
+                    body: body.clone(),
+                }
+            } else {
+                // #2077: same capture risk as plain `As`/`Reduce` above.
+                let renames = capturing_pattern_renames(patterns, arg);
+                let renamed_body = apply_scope_renames(body, &renames);
+                Expr::AsPattern {
+                    expr: Box::new(substitute_func_param(expr, param, arg)),
+                    patterns: apply_pattern_renames(patterns, &renames),
+                    body: Box::new(substitute_func_param(&renamed_body, param, arg)),
+                }
             }
         }
         Expr::FuncDef {
@@ -41035,16 +41191,57 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
             body,
             then,
         } => {
-            let shadowed = params.contains(&param.to_string());
+            // #2077 defect B: a nested `def` of the same name *and arity*
+            // (zero, matching how a function parameter is referenced --
+            // see the `FuncCall` arm below) shadows `param` in `then` too,
+            // not just in `body` -- `def f(g): def g: 99; g; f(1)` must
+            // leave the `g` in `then` alone so the evaluator's own
+            // innermost-first def lookup resolves it to the nested `def g`,
+            // not to `param`'s substituted argument.
+            let then_shadowed = name == param && params.is_empty();
+            // A nested def's own parameter list shadows `param` within its
+            // own body the same way an outer `as $param` would.
+            let body_shadowed = params.contains(&param.to_string());
+
+            let (new_params, new_body) = if body_shadowed {
+                (params.clone(), body.clone())
+            } else {
+                // #2077 defect A: the nested def's own parameters are
+                // binders too (its `body` sees them the same way an
+                // `as`-bound scope sees its variable), so they can capture
+                // `arg`'s free variables exactly like `as`/`reduce`/
+                // `foreach` do.
+                let as_patterns: Vec<Pattern> = params.iter().cloned().map(Pattern::Var).collect();
+                let renames = capturing_pattern_renames(&as_patterns, arg);
+                let new_params = if renames.is_empty() {
+                    params.clone()
+                } else {
+                    params
+                        .iter()
+                        .map(|p| {
+                            renames
+                                .iter()
+                                .find(|(old_name, _)| old_name == p)
+                                .map_or_else(|| p.clone(), |(_, new_name)| new_name.clone())
+                        })
+                        .collect()
+                };
+                let renamed_body = apply_scope_renames(body, &renames);
+                (
+                    new_params,
+                    Box::new(substitute_func_param(&renamed_body, param, arg)),
+                )
+            };
+
             Expr::FuncDef {
                 name: name.clone(),
-                params: params.clone(),
-                body: if shadowed {
-                    body.clone()
+                params: new_params,
+                body: new_body,
+                then: if then_shadowed {
+                    then.clone()
                 } else {
-                    Box::new(substitute_func_param(body, param, arg))
+                    Box::new(substitute_func_param(then, param, arg))
                 },
-                then: Box::new(substitute_func_param(then, param, arg)),
             }
         }
         Expr::FuncCall { name, args } => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -55438,6 +55438,86 @@ mod tests {
     }
 
     #[test]
+    fn test_func_arg_as_binder_does_not_capture_caller_var_2077() {
+        // #2077 defect A: substituting `g -> $n` (the caller's own `$n`)
+        // into `add`'s body must not let `add`'s own `100 as $n | ...`
+        // recapture it -- confirmed against jq 1.7.1: `101`, not `200`.
+        assert_eq!(
+            outputs(b"null", "def add(g): 100 as $n | g + $n; 1 as $n | add($n)"),
+            ["101"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_reduce_pattern_does_not_capture_caller_var_2077() {
+        // #2077 defect A, `reduce`'s own pattern variable (not just `as`)
+        // -- confirmed against jq 1.7.1: `14`, not `1`.
+        assert_eq!(
+            outputs(
+                b"null",
+                "def f(g): reduce range(2) as $x (0; . + g); 7 as $x | f($x)"
+            ),
+            ["14"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_foreach_pattern_and_extract_do_not_capture_caller_var_2077() {
+        // #2077 defect A extended to `foreach`: both `update` and `extract`
+        // see the pattern's binding, so both must be renamed when the
+        // pattern's own name shadows a substituted-in caller variable.
+        assert_eq!(
+            outputs(
+                b"null",
+                "def f(g): [foreach (1,2) as $x (0; .; g)]; 5 as $x | f($x)"
+            ),
+            ["[5,5]"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_nested_def_dollar_param_does_not_capture_caller_var_2077() {
+        // #2077 defect A, "scope note": a nested `def`'s own `$`-parameter
+        // is a binder too, not just `as`/`reduce`/`foreach`/`?//` patterns.
+        assert_eq!(
+            outputs(
+                b"null",
+                "def f(g): def h($n): g + $n; h(100); 1 as $n | f($n)"
+            ),
+            ["101"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_nested_def_same_name_and_arity_shadows_param_2077() {
+        // #2077 defect B: a nested `def` of the same name *and* arity as
+        // the outer parameter must shadow it -- confirmed against jq
+        // 1.7.1: `99`, not `1`. `expand_func_calls` leaves the reference
+        // in `then` alone so the evaluator's own innermost-first def
+        // lookup resolves it to the nested `def g`.
+        assert_eq!(outputs(b"null", "def f(g): def g: 99; g; f(1)"), ["99"]);
+    }
+
+    #[test]
+    fn test_func_arg_nested_def_different_arity_does_not_shadow_param_2077() {
+        // #2077 defect B control: a nested def of a *different* arity
+        // must not shadow a bare (zero-arity) parameter reference --
+        // confirmed against jq 1.7.1: `1`.
+        assert_eq!(outputs(b"null", "def f(g): def g(x): x; g; f(1)"), ["1"]);
+    }
+
+    #[test]
+    fn test_func_arg_value_param_shadowed_by_later_as_is_not_renamed_2077() {
+        // #2077 control: ordinary lexical shadowing (a *later*, unrelated
+        // same-named binder in the body) is not capture and must not be
+        // alpha-renamed -- confirmed against jq 1.7.1: `9`.
+        assert_eq!(
+            outputs(b"null", "def f($v): 9 as $v | $v; 1 as $q | f($q)"),
+            ["9"]
+        );
+    }
+
+    #[test]
     fn test_until_budget_exceeded_errors() {
         // `cond` is always falsy, so `until_step`'s single-output fast path
         // never emits anything before the `WHILE_UNTIL_MAX_STEPS` cap trips.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -55537,6 +55537,58 @@ mod tests {
     }
 
     #[test]
+    fn test_func_arg_array_destructure_pattern_does_not_capture_caller_var_2077() {
+        // #2077 defect A, array-destructuring pattern: exercises
+        // `rename_pattern_var`'s `Array` arm, and its non-matching `Var`
+        // arm for `$b` (only `$a` collides with the substituted-in `$a`) --
+        // confirmed against jq 1.7.1: `5`, not `1`.
+        assert_eq!(
+            outputs(
+                b"null",
+                "def f(g): reduce ([1,2]) as [$a,$b] (0; . + g); 5 as $a | f($a)"
+            ),
+            ["5"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_object_destructure_pattern_does_not_capture_caller_var_2077() {
+        // #2077 defect A, object-destructuring pattern: exercises
+        // `rename_pattern_var`'s `Object` arm -- confirmed against jq
+        // 1.7.1: `5`, not the destructured `1`.
+        assert_eq!(
+            outputs(
+                b"null",
+                r#"def f(g): {"a":1,"b":2} as {a: $x, b: $y} | g; 5 as $x | f($x)"#
+            ),
+            ["5"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_as_pattern_shadowed_by_param_name_leaves_body_untouched_2077() {
+        // #2077 control: an `as`-pattern that binds a name identical to the
+        // outer parameter shadows it, so `body` must not be substituted at
+        // all (the pre-existing `pattern_binds_var` shadow check, now on
+        // the restructured `if`/`else` in the `AsPattern` arm) -- confirmed
+        // against jq 1.7.1: `3` (the pattern's own $g=1, $y=2 summed),
+        // regardless of what `f` was called with.
+        assert_eq!(
+            outputs(b"null", "def f(g): [1,2] as [$g, $y] | $g + $y; f(99)"),
+            ["3"]
+        );
+    }
+
+    #[test]
+    fn test_func_arg_nested_def_own_param_shadows_outer_param_in_body_2077() {
+        // #2077 control: a nested `def`'s own parameter of the same name
+        // as the outer parameter shadows it within the nested def's own
+        // `body` (the pre-existing `body_shadowed` check) -- confirmed
+        // against jq 1.7.1: `1` (h's own g=1), not `2` (f's outer g).
+        assert_eq!(outputs(b"null", "def f(g): def h(g): g; h(1); f(2)"), ["1"]);
+    }
+
+    #[test]
     fn test_until_budget_exceeded_errors() {
         // `cond` is always falsy, so `until_step`'s single-output fast path
         // never emits anything before the `WHILE_UNTIL_MAX_STEPS` cap trips.


### PR DESCRIPTION
## Summary

- `expand_func_calls` inlines a `def`'s body by statically substituting each call's argument expressions into it. That substitution was unhygienic: an argument referencing a caller variable was captured by a same-named binding inside the callee's own body (`as`, `reduce`, `foreach`, `?//` patterns, and a nested `def`'s own `$`-parameters), silently resolving to the callee's value instead of the caller's.
- `substitute_func_param`'s binder arms (`As`, `Reduce`, `Foreach`, `AsPattern`, nested `FuncDef` params) now alpha-rename any binder whose name collides with a free variable of the argument being substituted, before recursing into that binder's own scope. The rename reuses `substitute_func_param` itself as the primitive (replace the old name with a fresh `Var` reference), so it gets the same shadow-aware recursion the real substitution already needed. The fresh name always contains `#`, which no jq/yq identifier can spell, so it can never collide with anything the user actually wrote.
- Separately (defect B in the issue): a nested `def` of the same name *and* arity as the parameter (`def f(g): def g: 99; g; f(1)`) shadows the parameter within `then`, not just within its own `body` — the existing shadow check only gated `body`, so `then` was still substituted, ignoring the nested `def` entirely.

Both defects and the issue's own control cases are verified live against `/usr/bin/jq` 1.7.1.

Fixes #2077

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 3195+ tests, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Every repro row and control case from the issue diffed live against `/usr/bin/jq` 1.7.1 — all match
- [x] Additional capture scenarios not in the issue's table (foreach pattern+extract, as-pattern array destructure, `?//` alternatives, nested-def own `$`-param) diffed live against jq 1.7.1 — all match
- [x] 7 new regression tests added covering both defects and 2 controls
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only`