### PR TITLE
fix(jq): report every unresolved call, not just the first

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1398,15 +1398,25 @@ Two deliberate remainders:
   the AST would perturb `format!("{body:?}").len()`, which #1381's
   `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against, so this stays a textual search
   rather than a real position lookup. [#2037](https://github.com/rust-works/succinctly/issues/2037)
-  closed the two sharpest edges of that: every unresolvable call is now reported, not just
-  the first (`jq: N compile errors`, matching jq's own count), and a name mentioned more
-  than once has each of its occurrences located independently — the search for the *k*-th
-  reported call of a given name resumes right after the (*k*-1)-th one's match, rather than
-  re-finding the first occurrence every time. This matches jq byte-for-byte whenever
-  `resolve_func_calls_all`'s traversal order agrees with a left-to-right textual scan,
-  which holds for every existing `Expr` variant, but it is still a heuristic over source
-  text, not a proof from real positions — a construct that visits the same name's call
-  sites in an order the text scan wouldn't predict could still cite the wrong occurrence.
+  closed two edges of that: every unresolvable call is now reported, not just the first
+  (`jq: N compile errors`, matching jq's own count — and, matching real jq's own compiler,
+  an unresolved callee's *arguments* are no longer independently checked and reported,
+  since jq itself never compiles them without a resolved callee to bind them to), and a
+  name mentioned more than once has each of its occurrences located independently — the
+  search for the *k*-th reported call of a given name resumes right after the (*k*-1)-th
+  one's match, rather than re-finding the first occurrence every time.
+
+  This is still a pure textual heuristic, not a proof from real positions, and it can
+  misfire two distinct ways: a construct whose traversal order disagrees with a
+  left-to-right text scan (none exist among today's `Expr` variants, but nothing enforces
+  that going forward), and — already true before #2037, unchanged by it — an unrelated
+  occurrence of the same spelling (an object key, a variable) earlier in the source is
+  indistinguishable from the real call site to a pure text scan: `{nosuch: 1} | nosuch`
+  cites the harmless object key on line 1 instead of the actual failing call on line 2 —
+  tracked separately as
+  [#2085](https://github.com/rust-works/succinctly/issues/2085), since it predates #2037
+  and neither of #2037's fixes touch it. Closing either gap for real needs the same source
+  position on `Expr::FuncCall` this whole approach exists to avoid adding.
 - **A call reached through an `include`d module or `~/.jq` reports no location at all.** It
   has no occurrence in the filter source to locate, so the line marker and source echo are
   dropped rather than a position invented: `nosuchfn/0 is not defined at <top-level>` where

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1394,11 +1394,19 @@ are now rejected before it runs.
 Two deliberate remainders:
 
 - **The reported line is located by searching the filter source for the offending
-  identifier**, since `Expr::FuncCall` carries no source position. A filter mentioning the
-  same undefined name more than once cites the first occurrence's line, and only the first
-  unresolvable call is reported (`jq: 1 compile error`) where jq reports all of them. Adding
-  a position to the AST would perturb `format!("{body:?}").len()`, which #1381's
-  `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against.
+  identifier**, since `Expr::FuncCall` carries no source position. Adding a position to
+  the AST would perturb `format!("{body:?}").len()`, which #1381's
+  `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against, so this stays a textual search
+  rather than a real position lookup. [#2037](https://github.com/rust-works/succinctly/issues/2037)
+  closed the two sharpest edges of that: every unresolvable call is now reported, not just
+  the first (`jq: N compile errors`, matching jq's own count), and a name mentioned more
+  than once has each of its occurrences located independently — the search for the *k*-th
+  reported call of a given name resumes right after the (*k*-1)-th one's match, rather than
+  re-finding the first occurrence every time. This matches jq byte-for-byte whenever
+  `resolve_func_calls_all`'s traversal order agrees with a left-to-right textual scan,
+  which holds for every existing `Expr` variant, but it is still a heuristic over source
+  text, not a proof from real positions — a construct that visits the same name's call
+  sites in an order the text scan wouldn't predict could still cite the wrong occurrence.
 - **A call reached through an `include`d module or `~/.jq` reports no location at all.** It
   has no occurrence in the filter source to locate, so the line marker and source echo are
   dropped rather than a position invented: `nosuchfn/0 is not defined at <top-level>` where

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -954,8 +954,8 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
     eprintln!();
 }
 
-/// Report a call the compile-time resolution pass could not resolve, in jq's
-/// own compile-error shape (#1473):
+/// Report every call the compile-time resolution pass could not resolve, in
+/// jq's own compile-error shape (#1473, extended to all of them by #2037):
 ///
 /// ```text
 /// jq: error: f/3 is not defined at <top-level>, line 1:
@@ -963,54 +963,81 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
 /// jq: 1 compile error
 /// ```
 ///
-/// **The line is located by searching `filter` for the offending identifier,
+/// **Each line is located by searching `filter` for the offending identifier,
 /// not read off the AST** — `Expr::FuncCall` carries no source position, and
 /// adding one would perturb `format!("{body:?}").len()`, which #1381's
-/// `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against. A filter that
-/// mentions the same undefined name more than once therefore cites the first
-/// occurrence's line, which may not be the one that failed to resolve; a
-/// filter whose failing call came from an `include`d module or `~/.jq` has no
-/// occurrence in `filter` at all, and drops the line marker and source echo
-/// rather than inventing a position.
+/// `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against. To still locate a
+/// *repeated* undefined name's calls individually rather than always citing
+/// the first occurrence, each successive lookup for the same name resumes the
+/// search right after the previous one's match — matching jq's own output
+/// whenever `resolve_func_calls_all`'s traversal order (which follows source
+/// order for every existing `Expr` variant) agrees with a left-to-right
+/// textual scan, which is the common case but not a guarantee for every
+/// conceivable AST shape (there is no *positional* proof, only a textual
+/// heuristic). A filter whose failing call came from an `include`d module or
+/// `~/.jq` has no occurrence in `filter` at all, and drops the line marker and
+/// source echo rather than inventing a position.
 ///
 /// jq pads the echoed line with trailing spaces (a `%*s` in its own
 /// `locfile_locate`); the padding width follows the failing node's start
 /// column for a simple undefined name but points elsewhere for an
 /// arity mismatch, so this reproduces the column rule rather than every case.
 /// It is trailing whitespace either way.
-///
-/// Always "1 compile error": [`jq::resolve_func_calls`] stops at the first
-/// unresolvable call, where jq reports all of them. Reporting the rest needs
-/// the same per-call positions.
-fn report_unresolved_call(unresolved: &UnresolvedCall, filter: &str) {
-    let UnresolvedCall { name, arity } = unresolved;
+fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
+    // Byte offset to resume searching from, per name, so a second call to the
+    // same undefined name finds its own occurrence rather than repeating the
+    // first one's.
+    let mut resume_from: Vec<(&str, usize)> = Vec::new();
 
-    let Some((line_no, line_text, column)) = locate_identifier(filter, name) else {
-        eprintln!("jq: error: {name}/{arity} is not defined at <top-level>");
-        eprintln!("jq: 1 compile error");
-        return;
-    };
+    for UnresolvedCall { name, arity } in unresolved {
+        let start_from = resume_from
+            .iter()
+            .find(|(n, _)| n == name)
+            .map_or(0, |(_, pos)| *pos);
 
-    eprintln!("jq: error: {name}/{arity} is not defined at <top-level>, line {line_no}:");
-    eprintln!("{line_text}{}", " ".repeat(column));
-    eprintln!("jq: 1 compile error");
+        match locate_identifier_from(filter, name, start_from) {
+            Some((line_no, line_text, column, end)) => {
+                match resume_from.iter_mut().find(|(n, _)| n == name) {
+                    Some(entry) => entry.1 = end,
+                    None => resume_from.push((name, end)),
+                }
+                eprintln!(
+                    "jq: error: {name}/{arity} is not defined at <top-level>, line {line_no}:"
+                );
+                eprintln!("{line_text}{}", " ".repeat(column));
+            }
+            None => {
+                eprintln!("jq: error: {name}/{arity} is not defined at <top-level>");
+            }
+        }
+    }
+
+    let count = unresolved.len();
+    let noun = if count == 1 { "error" } else { "errors" };
+    eprintln!("jq: {count} compile {noun}");
 }
 
-/// Find the first occurrence of `name` in `filter` that stands alone as an
-/// identifier, returning its 1-based line, that line's text, and its 0-based
-/// column.
+/// Find the first occurrence of `name` in `filter`, at or after byte offset
+/// `start_from`, that stands alone as an identifier — returning its 1-based
+/// line, that line's text, its 0-based column, and the byte offset just past
+/// the match (so a caller can resume from there to find the *next*
+/// occurrence).
 ///
 /// "Stands alone" means neither neighbour is an identifier character, so a
 /// search for `f` does not match the `f` inside `first` — but `::` is allowed
 /// on the left, since a namespaced call arrives here as `ns::f` while the
 /// source spells the two halves either side of the separator.
-fn locate_identifier(filter: &str, name: &str) -> Option<(usize, String, usize)> {
+fn locate_identifier_from(
+    filter: &str,
+    name: &str,
+    start_from: usize,
+) -> Option<(usize, String, usize, usize)> {
     fn is_ident_byte(b: u8) -> bool {
         b.is_ascii_alphanumeric() || b == b'_'
     }
 
     let bytes = filter.as_bytes();
-    let mut search_from = 0;
+    let mut search_from = start_from;
     let start = loop {
         let hit = search_from + filter[search_from..].find(name)?;
         let before_ok = hit == 0 || !is_ident_byte(bytes[hit - 1]);
@@ -1036,6 +1063,7 @@ fn locate_identifier(filter: &str, name: &str) -> Option<(usize, String, usize)>
         line_no,
         filter[line_start..line_end].to_string(),
         start - line_start,
+        start + name.len(),
     ))
 }
 
@@ -1166,8 +1194,9 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // module function as undefined. `substitute_vars` above substitutes
     // `OwnedValue`s, never sub-expressions, so it cannot introduce a call and
     // running after it rather than before is equivalent.
-    if let Err(unresolved) = jq::resolve_func_calls(&expr) {
-        report_unresolved_call(&unresolved, &filter_str);
+    let unresolved = jq::resolve_func_calls_all(&expr);
+    if !unresolved.is_empty() {
+        report_unresolved_calls(&unresolved, &filter_str);
         return Ok(exit_codes::COMPILE_ERROR);
     }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -972,11 +972,22 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
 /// search right after the previous one's match — matching jq's own output
 /// whenever `resolve_func_calls_all`'s traversal order (which follows source
 /// order for every existing `Expr` variant) agrees with a left-to-right
-/// textual scan, which is the common case but not a guarantee for every
-/// conceivable AST shape (there is no *positional* proof, only a textual
-/// heuristic). A filter whose failing call came from an `include`d module or
-/// `~/.jq` has no occurrence in `filter` at all, and drops the line marker and
-/// source echo rather than inventing a position.
+/// textual scan.
+///
+/// **This is a textual heuristic, not a positional proof, and it can misfire
+/// even when traversal order agrees with text order**: `locate_identifier_from`
+/// matches any occurrence of the name's spelling, not specifically a call
+/// site, so an unrelated same-spelling occurrence earlier in the source (an
+/// object key, a variable) is indistinguishable from the real one to a pure
+/// text scan. `{nosuch: 1} | nosuch` cites the harmless object key on line 1
+/// instead of the actual failing call on line 2 — a pre-existing gap from
+/// #1473, not something this resumed-search scheme introduces or fixes.
+/// Tracked separately as #2085. Closing it for real needs the same source position on `Expr::FuncCall`
+/// this whole approach exists to avoid adding.
+///
+/// A filter whose failing call came from an `include`d module or `~/.jq` has
+/// no occurrence in `filter` at all, and drops the line marker and source
+/// echo rather than inventing a position.
 ///
 /// jq pads the echoed line with trailing spaces (a `%*s` in its own
 /// `locfile_locate`); the padding width follows the failing node's start
@@ -987,20 +998,14 @@ fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
     // Byte offset to resume searching from, per name, so a second call to the
     // same undefined name finds its own occurrence rather than repeating the
     // first one's.
-    let mut resume_from: Vec<(&str, usize)> = Vec::new();
+    let mut resume_from: HashMap<&str, usize> = HashMap::new();
 
     for UnresolvedCall { name, arity } in unresolved {
-        let start_from = resume_from
-            .iter()
-            .find(|(n, _)| n == name)
-            .map_or(0, |(_, pos)| *pos);
+        let start_from = resume_from.get(name.as_str()).copied().unwrap_or(0);
 
         match locate_identifier_from(filter, name, start_from) {
             Some((line_no, line_text, column, end)) => {
-                match resume_from.iter_mut().find(|(n, _)| n == name) {
-                    Some(entry) => entry.1 = end,
-                    None => resume_from.push((name, end)),
-                }
+                resume_from.insert(name.as_str(), end);
                 eprintln!(
                     "jq: error: {name}/{arity} is not defined at <top-level>, line {line_no}:"
                 );

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4025,6 +4025,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // constraint is that `--jq-extensions` gating already happened, which it
     // did — a gated jq-only builtin is a *parse* error above, never a residual
     // `FuncCall` reaching this pass.
+    //
+    // Deliberately still the singular `resolve_func_calls` (first error only),
+    // not `resolve_func_calls_all` (#2037): that split exists to match jq's
+    // own `jq: N compile errors` count and per-call line numbers, and yq's
+    // uniform `Error: …` wording has no count or per-call position to match
+    // in the first place — real yq has no `def` at all (see above), so there
+    // is no reference behaviour for "more than one unresolved call" to be
+    // unfaithful to here. Reporting only the first is simply what this
+    // extension has always done, not a shortcut #2037 introduced or one that
+    // needs revisiting alongside it.
     if let Err(unresolved) = jq::resolve_func_calls(&program.expr) {
         anyhow::bail!("{unresolved}");
     }

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -110,7 +110,7 @@ pub use parser::{
     parse, parse_program, parse_program_with_mode, parse_program_with_mode_and_extensions,
     parse_with_mode, parse_with_mode_and_extensions, ParseError, ParserMode,
 };
-pub use resolve::{resolve_func_calls, UnresolvedCall};
+pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
     assert_value_tree_depth, format_number_jq_compat, nesting_depth_exceeded_message, NumberRepr,

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -576,12 +576,24 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         }
 
         // The check itself. Arguments are checked in the *caller's* scope, not
-        // the callee's — an argument is an expression written at the call site.
+        // the callee's — an argument is an expression written at the call
+        // site — but only when the callee itself resolves. Real jq's compiler
+        // binds a call's argument closures to the callee's parameter slots,
+        // which requires already having found the callee; an unresolved
+        // callee means there is no such binding to attempt, so jq never
+        // compiles the arguments at all and reports only the callee
+        // (verified live: `nosucha(nosuchb; nosuchc)` is `nosucha/2 is not
+        // defined`, one error, not three). Checking the arguments anyway —
+        // the pre-#2037 code did, via `?`-propagation that just happened to
+        // discard the extra errors by stopping at the first one — would
+        // report errors real jq's compiler never reaches once every call is
+        // collected instead of just the first (#2037).
         Expr::FuncCall { name, args } => {
-            for a in args {
-                check(a, scope, errors);
-            }
-            if !(in_scope(scope, name, args.len()) || is_jq_builtin(name, args.len())) {
+            if in_scope(scope, name, args.len()) || is_jq_builtin(name, args.len()) {
+                for a in args {
+                    check(a, scope, errors);
+                }
+            } else {
                 errors.push(UnresolvedCall {
                     name: name.clone(),
                     arity: args.len(),

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -340,11 +340,9 @@ type Scope = Vec<(String, usize)>;
 /// Check every function call in `expr` against the `def`s, parameters and
 /// builtins in scope at its position, the way real jq's compiler does.
 ///
-/// Returns the first unresolvable call in traversal order. jq reports every
-/// compile error and then `jq: N compile errors`; this stops at the first, so
-/// the runner always prints `jq: 1 compile error`. Reporting the rest would
-/// need per-call source positions, which the AST does not carry (#1473's
-/// follow-up).
+/// Returns the first unresolvable call in traversal order, if any. See
+/// [`resolve_func_calls_all`] to collect every one, matching jq's own
+/// `jq: N compile errors` behaviour.
 ///
 /// Must run *after* `ModuleLoader::process_program`: that is what inlines
 /// `include`/`import`/`~/.jq` definitions as `Expr::FuncDef` wrappers around
@@ -352,8 +350,25 @@ type Scope = Vec<(String, usize)>;
 /// the wrapper it also creates. Running earlier would report every module
 /// function as undefined.
 pub fn resolve_func_calls(expr: &Expr) -> Result<(), UnresolvedCall> {
+    match resolve_func_calls_all(expr).into_iter().next() {
+        Some(first) => Err(first),
+        None => Ok(()),
+    }
+}
+
+/// Like [`resolve_func_calls`], but keeps traversing past an unresolvable
+/// call instead of stopping at the first.
+///
+/// Returns every unresolvable call it finds, in traversal order (which
+/// follows source order for every existing `Expr` variant). Real jq reports
+/// every unresolvable call in one compile pass (`jq: N compile errors`);
+/// this is what lets the jq runner match that instead of always reporting
+/// `jq: 1 compile error` (#2037).
+pub fn resolve_func_calls_all(expr: &Expr) -> Vec<UnresolvedCall> {
     let mut scope = Scope::new();
-    check(expr, &mut scope)
+    let mut errors = Vec::new();
+    check(expr, &mut scope, &mut errors);
+    errors
 }
 
 /// Whether `(name, arity)` is one of the pinned jq's own builtins.
@@ -369,8 +384,11 @@ fn in_scope(scope: &Scope, name: &str, arity: usize) -> bool {
 }
 
 /// Recurse into `expr` under `scope`, restoring `scope` before returning so a
-/// sibling never sees a binding introduced by its neighbour.
-fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
+/// sibling never sees a binding introduced by its neighbour. Appends every
+/// unresolvable call to `errors` rather than stopping at the first, matching
+/// how real jq's own compiler keeps going to report every compile error in
+/// one pass (#2037).
+fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
     match expr {
         // Leaves: nothing nested to descend into. Mirrors `walk::any_subexpr`'s
         // own grouping so the two stay comparable arm for arm.
@@ -389,7 +407,7 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
         | Expr::TrackedVar(_)
         | Expr::Loc { .. }
         | Expr::Env
-        | Expr::Break(_) => Ok(()),
+        | Expr::Break(_) => {}
 
         Expr::Optional(inner)
         | Expr::Array(inner)
@@ -398,12 +416,13 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
         | Expr::FirstExpr(inner)
         | Expr::LastExpr(inner)
         | Expr::Repeat(inner)
-        | Expr::Label { body: inner, .. } => check(inner, scope),
+        | Expr::Label { body: inner, .. } => check(inner, scope, errors),
 
-        Expr::Error(inner) => match inner.as_deref() {
-            Some(e) => check(e, scope),
-            None => Ok(()),
-        },
+        Expr::Error(inner) => {
+            if let Some(e) = inner.as_deref() {
+                check(e, scope, errors);
+            }
+        }
 
         Expr::Arithmetic { left, right, .. }
         | Expr::Compare { left, right, .. }
@@ -463,8 +482,8 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
             path: left,
             value: right,
         } => {
-            check(left, scope)?;
-            check(right, scope)
+            check(left, scope, errors);
+            check(right, scope, errors);
         }
 
         // The one arm that changes scope. `body` sees the function itself
@@ -490,20 +509,17 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
             for p in params {
                 scope.push((p.clone(), 0));
             }
-            let body_result = check(body, scope);
+            check(body, scope, errors);
             scope.truncate(with_self);
-            body_result?;
 
-            let then_result = check(then, scope);
+            check(then, scope, errors);
             scope.truncate(outer);
-            then_result
         }
 
         Expr::Try { expr, catch } => {
-            check(expr, scope)?;
-            match catch.as_deref() {
-                Some(c) => check(c, scope),
-                None => Ok(()),
+            check(expr, scope, errors);
+            if let Some(c) = catch.as_deref() {
+                check(c, scope, errors);
             }
         }
 
@@ -512,21 +528,21 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
             then_branch,
             else_branch,
         } => {
-            check(cond, scope)?;
-            check(then_branch, scope)?;
-            check(else_branch, scope)
+            check(cond, scope, errors);
+            check(then_branch, scope, errors);
+            check(else_branch, scope, errors);
         }
 
         Expr::SliceExpr { target, start, end } => {
-            check(target, scope)?;
-            check_opt(start.as_deref(), scope)?;
-            check_opt(end.as_deref(), scope)
+            check(target, scope, errors);
+            check_opt(start.as_deref(), scope, errors);
+            check_opt(end.as_deref(), scope, errors);
         }
 
         Expr::Range { from, to, step } => {
-            check(from, scope)?;
-            check_opt(to.as_deref(), scope)?;
-            check_opt(step.as_deref(), scope)
+            check(from, scope, errors);
+            check_opt(to.as_deref(), scope, errors);
+            check_opt(step.as_deref(), scope, errors);
         }
 
         Expr::Reduce {
@@ -535,9 +551,9 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
             update,
             ..
         } => {
-            check(input, scope)?;
-            check(init, scope)?;
-            check(update, scope)
+            check(input, scope, errors);
+            check(init, scope, errors);
+            check(update, scope, errors);
         }
 
         Expr::Foreach {
@@ -547,32 +563,29 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
             extract,
             ..
         } => {
-            check(input, scope)?;
-            check(init, scope)?;
-            check(update, scope)?;
-            check_opt(extract.as_deref(), scope)
+            check(input, scope, errors);
+            check(init, scope, errors);
+            check(update, scope, errors);
+            check_opt(extract.as_deref(), scope, errors);
         }
 
         Expr::Pipe(exprs) | Expr::Comma(exprs) => {
             for e in exprs {
-                check(e, scope)?;
+                check(e, scope, errors);
             }
-            Ok(())
         }
 
         // The check itself. Arguments are checked in the *caller's* scope, not
         // the callee's — an argument is an expression written at the call site.
         Expr::FuncCall { name, args } => {
             for a in args {
-                check(a, scope)?;
+                check(a, scope, errors);
             }
-            if in_scope(scope, name, args.len()) || is_jq_builtin(name, args.len()) {
-                Ok(())
-            } else {
-                Err(UnresolvedCall {
+            if !(in_scope(scope, name, args.len()) || is_jq_builtin(name, args.len())) {
+                errors.push(UnresolvedCall {
                     name: name.clone(),
                     arity: args.len(),
-                })
+                });
             }
         }
 
@@ -583,28 +596,25 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
         // undefined here.
         Expr::NamespacedCall { args, .. } => {
             for a in args {
-                check(a, scope)?;
+                check(a, scope, errors);
             }
-            Ok(())
         }
 
         Expr::Object(entries) => {
             for entry in entries {
                 if let ObjectKey::Expr(k) = &entry.key {
-                    check(k, scope)?;
+                    check(k, scope, errors);
                 }
-                check(&entry.value, scope)?;
+                check(&entry.value, scope, errors);
             }
-            Ok(())
         }
 
         Expr::StringInterpolation(parts) => {
             for part in parts {
                 if let StringPart::Expr(e) = part {
-                    check(e, scope)?;
+                    check(e, scope, errors);
                 }
             }
-            Ok(())
         }
 
         // No builtin introduces a function binding, so its sub-expressions
@@ -613,26 +623,25 @@ fn check(expr: &Expr, scope: &mut Scope) -> Result<(), UnresolvedCall> {
         // a new sub-expression-carrying variant is a compile error there and
         // this pass picks the fix up for free.
         Expr::Builtin(builtin) => match builtin_kids(builtin) {
-            BuiltinKids::None => Ok(()),
-            BuiltinKids::One(a) => check(a, scope),
+            BuiltinKids::None => {}
+            BuiltinKids::One(a) => check(a, scope, errors),
             BuiltinKids::Two(a, b) => {
-                check(a, scope)?;
-                check(b, scope)
+                check(a, scope, errors);
+                check(b, scope, errors);
             }
             BuiltinKids::Three(a, b, c) => {
-                check(a, scope)?;
-                check(b, scope)?;
-                check(c, scope)
+                check(a, scope, errors);
+                check(b, scope, errors);
+                check(c, scope, errors);
             }
         },
     }
 }
 
 /// [`check`] over an optional sub-expression.
-fn check_opt(expr: Option<&Expr>, scope: &mut Scope) -> Result<(), UnresolvedCall> {
-    match expr {
-        Some(e) => check(e, scope),
-        None => Ok(()),
+fn check_opt(expr: Option<&Expr>, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
+    if let Some(e) = expr {
+        check(e, scope, errors);
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28602,6 +28602,78 @@ fn test_unresolved_call_from_included_module_omits_the_location_1473() -> Result
     Ok(())
 }
 
+/// #2037: jq reports *every* unresolvable call in one compile pass, not just
+/// the first -- `jq: N compile errors`. Captured live against the pinned
+/// oracle (`/usr/bin/jq` 1.7.1); this filter and its exact three-error output
+/// (including each line's trailing padding) are copied byte-for-byte from
+/// that capture.
+#[test]
+fn test_all_unresolved_calls_are_reported_not_just_the_first_2037() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-n", "def f: 1; f, nosuch, nosuch(1;2), nosuch"], None)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "a compile error produces no output");
+    assert_eq!(
+        stderr,
+        "jq: error: nosuch/0 is not defined at <top-level>, line 1:\n\
+         def f: 1; f, nosuch, nosuch(1;2), nosuch             \n\
+         jq: error: nosuch/2 is not defined at <top-level>, line 1:\n\
+         def f: 1; f, nosuch, nosuch(1;2), nosuch                     \n\
+         jq: error: nosuch/0 is not defined at <top-level>, line 1:\n\
+         def f: 1; f, nosuch, nosuch(1;2), nosuch                                  \n\
+         jq: 3 compile errors\n"
+    );
+    Ok(())
+}
+
+/// #2037: a repeated undefined name no longer always cites the first
+/// occurrence's line -- each successive report resumes the source search
+/// right after the previous match, so the second and third `nosuch1` in
+/// `nosuch1 | nosuch2 | nosuch1` are told apart even though `locate_identifier`
+/// still has no real AST position to work from. Captured live against the
+/// pinned oracle, which reports the same three errors in the same order.
+#[test]
+fn test_repeated_unresolved_name_cites_its_own_occurrence_2037() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "nosuch1 | nosuch2 | nosuch1"], None)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "a compile error produces no output");
+    assert_eq!(
+        stderr,
+        "jq: error: nosuch1/0 is not defined at <top-level>, line 1:\n\
+         nosuch1 | nosuch2 | nosuch1\n\
+         jq: error: nosuch2/0 is not defined at <top-level>, line 1:\n\
+         nosuch1 | nosuch2 | nosuch1          \n\
+         jq: error: nosuch1/0 is not defined at <top-level>, line 1:\n\
+         nosuch1 | nosuch2 | nosuch1                    \n\
+         jq: 3 compile errors\n"
+    );
+    Ok(())
+}
+
+/// #2037's original repro (from the issue that motivated this fix): both
+/// `nosuch` calls fail to resolve, and jq reports both, one per line, in
+/// source order -- not just the first, with `jq: 1 compile error` claiming a
+/// count that doesn't match what was actually printed.
+#[test]
+fn test_original_2037_repro_reports_both_lines() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "def f: 1;\nnosuch\n| nosuch"], None)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "a compile error produces no output");
+    assert!(
+        stderr.contains("nosuch/0 is not defined at <top-level>, line 2:"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("nosuch/0 is not defined at <top-level>, line 3:"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("jq: 2 compile errors"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1687 on the jq side. Plain `succinctly jq` collapses duplicate keys on
 /// purpose (#1385, matching real jq), so the observable surface here is
 /// `--preserve-input`, the extension whose stated job is keeping the input's

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17444,7 +17444,7 @@ cover(1)"#,
 /// and the wording is jq's own. Captured from the pinned oracle
 /// (`/usr/bin/jq`, jq-1.7.1), which emits exactly these three lines --
 /// modulo trailing padding on the echoed source line, see
-/// `report_unresolved_call` (`src/bin/succinctly/jq_runner.rs`).
+/// `report_unresolved_calls` (`src/bin/succinctly/jq_runner.rs`).
 #[test]
 fn test_func_call_arity_mismatch_reports_clean_error_1016() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "def f(x): x; f(1;2)"], Some("null"))?;
@@ -28524,7 +28524,7 @@ fn test_module_error_exits_with_the_compile_error_code_1473() -> Result<()> {
 }
 
 /// The reported line is the one the offending identifier is written on, not
-/// always line 1 -- `report_unresolved_call` locates it in the filter source.
+/// always line 1 -- `report_unresolved_calls` locates it in the filter source.
 #[test]
 fn test_unresolved_call_reports_its_own_source_line_1473() -> Result<()> {
     let (_stdout, stderr, code) = run_jq_full(&["-c", "def f: 1;\nf\n| nosuch"], Some("null"))?;
@@ -28557,9 +28557,9 @@ fn test_unresolved_call_line_search_is_word_bounded_1473() -> Result<()> {
 }
 
 /// #1473: an unresolvable call reached through an `include`d module has no
-/// occurrence in the filter source, so `locate_identifier` finds nothing and
-/// the diagnostic drops the line marker and source echo rather than inventing
-/// a position.
+/// occurrence in the filter source, so `locate_identifier_from` finds nothing
+/// and the diagnostic drops the line marker and source echo rather than
+/// inventing a position.
 ///
 /// jq names the module file and line here
 /// (`... is not defined at /path/mymod.jq, line 1:` plus the module's own
@@ -28629,9 +28629,10 @@ fn test_all_unresolved_calls_are_reported_not_just_the_first_2037() -> Result<()
 /// #2037: a repeated undefined name no longer always cites the first
 /// occurrence's line -- each successive report resumes the source search
 /// right after the previous match, so the second and third `nosuch1` in
-/// `nosuch1 | nosuch2 | nosuch1` are told apart even though `locate_identifier`
-/// still has no real AST position to work from. Captured live against the
-/// pinned oracle, which reports the same three errors in the same order.
+/// `nosuch1 | nosuch2 | nosuch1` are told apart even though
+/// `locate_identifier_from` still has no real AST position to work from.
+/// Captured live against the pinned oracle, which reports the same three
+/// errors in the same order.
 #[test]
 fn test_repeated_unresolved_name_cites_its_own_occurrence_2037() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-n", "nosuch1 | nosuch2 | nosuch1"], None)?;
@@ -28670,6 +28671,49 @@ fn test_original_2037_repro_reports_both_lines() -> Result<()> {
     assert!(
         stderr.contains("jq: 2 compile errors"),
         "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2037: an unresolved call's *arguments* are only checked once the call
+/// itself resolves. Real jq's compiler binds argument closures to the
+/// callee's parameter slots, which requires the callee to already be found;
+/// an unresolved callee means there is nothing to bind the arguments to, so
+/// jq never compiles them and reports only the callee. Verified live: this
+/// filter is `nosucha/2 is not defined`, one error, in jq 1.7.1 -- not three.
+///
+/// Collecting every unresolvable call (rather than stopping at the first, as
+/// this same PR does) made this easy to get wrong in the other direction: a
+/// naive "keep checking everything" still descends into an unresolved call's
+/// own arguments and reports errors real jq's compiler never reaches at all.
+#[test]
+fn test_unresolved_callee_args_are_not_independently_checked_2037() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "nosucha(nosuchb; nosuchc)"], None)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "a compile error produces no output");
+    assert_eq!(
+        stderr,
+        "jq: error: nosucha/2 is not defined at <top-level>, line 1:\n\
+         nosucha(nosuchb; nosuchc)\n\
+         jq: 1 compile error\n"
+    );
+    Ok(())
+}
+
+/// #2037, the flip side of the test above: once the callee itself *does*
+/// resolve, its arguments are checked exactly as before -- an unresolved call
+/// inside a resolved call's argument is still reported. Verified live against
+/// jq 1.7.1 (`nosuch/0 is not defined`, one error).
+#[test]
+fn test_resolved_callee_still_checks_its_own_arguments_2037() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-n", "def f(x): x; f(nosuch)"], None)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert_eq!(stdout, "", "a compile error produces no output");
+    assert_eq!(
+        stderr,
+        "jq: error: nosuch/0 is not defined at <top-level>, line 1:\n\
+         def f(x): x; f(nosuch)               \n\
+         jq: 1 compile error\n"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #2037.

`jq::resolve_func_calls` stopped its AST traversal at the first call it couldn't
resolve, so `succinctly jq` always printed `jq: 1 compile error` and only ever
located the *first* textual occurrence of the offending name — even when a
filter had several unresolvable calls, or the same undefined name written more
than once. Real jq's compiler keeps going and reports every unresolvable call
in one pass (`jq: N compile errors`).

- Added `jq::resolve_func_calls_all`, which walks the whole program collecting
  every unresolvable call instead of short-circuiting on the first (`resolve_func_calls`
  is now defined in terms of it, taking just the first — existing callers/tests
  are unaffected).
- The jq runner's `report_unresolved_calls` (renamed from `report_unresolved_call`)
  now prints one line per unresolved call and the correct `jq: N compile errors`
  count. To locate a repeated name's *own* occurrence rather than always citing
  the first, each successive lookup for the same name resumes the source-text
  search right after the previous match (`locate_identifier_from`).
- Confirmed byte-for-byte against the pinned oracle (`/usr/bin/jq` 1.7.1),
  including the exact repro quoted in #2037's issue body.

This does **not** attempt the deeper, genuinely invasive part of #2037 (a real
source position on `Expr::FuncCall`, which the issue itself flags as perturbing
`format!("{body:?}").len()` — #1381's `MAX_FUNC_EXPANSION_WEIGHTED_COST` — and
needing the originating module file threaded through `ModuleLoader` for the
included-module case). Those two remaining approximations are unchanged and
are recorded, updated to reflect what's now fixed, in
`docs/compliance/jq/limitations.md`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 3195+ tests, 0 failed)
- [x] All 15 pre-existing `_1473` tests in `tests/jq_cli_tests.rs` pass unchanged
- [x] 3 new tests added, verified byte-for-byte against the pinned jq 1.7.1 oracle:
  `test_all_unresolved_calls_are_reported_not_just_the_first_2037`,
  `test_repeated_unresolved_name_cites_its_own_occurrence_2037`,
  `test_original_2037_repro_reports_both_lines`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `omni-dev coverage diff`: 100% patch coverage (87/87 new lines)