### PR TITLE
fix(jq): reduce/foreach's step budget no longer caps ordinary folds at 10,000 elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is left unbudgeted, since it does no evaluator work of its own and
   charging it too would wrongly cap legitimate high-cardinality output.
 
+- **`reduce`/`foreach`'s step budget (#695, above) no longer refuses an
+  ordinary fold over more than 10,000 elements** (#2079): with exactly one
+  INIT fork and a single-output UPDATE — the overwhelmingly common shape —
+  the shared budget degenerated into a plain cap on input-element count
+  rather than the multiplicative INIT-fork × element × UPDATE/EXTRACT-width
+  fanout it was meant to bound, so `reduce .[] as $x (0; . + $x)` on a
+  50,000-element array refused with `reduce: maximum iterations exceeded`
+  where real jq returns `1249975000`. `foreach`'s three-argument form
+  (explicit EXTRACT) compounded this further, capping at *half* the
+  two-argument ceiling. Fixed by splitting `REDUCE_FOREACH_MAX_STEPS` from
+  `repeat`'s own, unrelated per-round width cap (previously the same
+  constant by coincidence — now `REPEAT_WIDTH_BUDGET`, still `10000`) and
+  raising `reduce`/`foreach`'s own budget 100x, to `1_000_000` — the genuine
+  fanout-explosion case #695 introduced this guard for still errors, just at
+  a much higher, no-longer-accidentally-reachable-by-ordinary-use ceiling.
+
 - **A decode failure (invalid UTF-8, or a structurally malformed value) now
   raises instead of silently materializing as `null`, `""`, or a dropped
   field**, on nearly every route that turns lazily-indexed JSON/YAML into an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,9 +103,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two-argument ceiling. Fixed by splitting `REDUCE_FOREACH_MAX_STEPS` from
   `repeat`'s own, unrelated per-round width cap (previously the same
   constant by coincidence — now `REPEAT_WIDTH_BUDGET`, still `10000`) and
-  raising `reduce`/`foreach`'s own budget 100x, to `1_000_000` — the genuine
-  fanout-explosion case #695 introduced this guard for still errors, just at
-  a much higher, no-longer-accidentally-reachable-by-ordinary-use ceiling.
+  raising `reduce`/`foreach`'s own budget 10x, to `100_000` (2x above this
+  issue's own 50,000-element repro) — the genuine fanout-explosion case
+  #695 introduced this guard for still errors, just at a higher,
+  no-longer-accidentally-reachable-by-ordinary-use ceiling. See
+  [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md)
+  for why the raise stops at 10x rather than further: it bounds round-trip
+  *count*, not per-round-trip *cost*, and a superlinear-cost UPDATE/EXTRACT
+  body still burns real CPU proportional to the ceiling before erroring
+  (measured, not just theoretical — surfaced a separate O(n²)
+  string-accumulation gap against real jq's own near-linear cost, filed
+  as #2086).
 
 - **A decode failure (invalid UTF-8, or a structurally malformed value) now
   raises instead of silently materializing as `null`, `""`, or a dropped

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2086,58 +2086,64 @@ same way.
 
 ### `reduce`/`foreach`'s own step budget (#695/#2079): bounds genuine fanout, not ordinary element count
 
-Both evaluators charge a shared `REDUCE_FOREACH_MAX_STEPS` step budget against
-`reduce`/`foreach` (once per UPDATE eval, and -- `foreach` only -- once more
-per EXTRACT eval), independently in value mode (`eval_reduce_with_values`/
-`eval_foreach_with_values`) and path mode (`resolve_reduce`/`resolve_foreach`).
-[#695](https://github.com/rust-works/succinctly/issues/695) introduced it as a
-resource-exhaustion guard against a genuinely unbounded product: `reduce
-(range(100000)) as $x ((range(100000)); .+$x)` forks INIT into 100,000
-independent runs, each walking a 100,000-element stream -- 1e10 round trips,
-with no cap at all before #695.
+`REDUCE_FOREACH_MAX_STEPS` (`src/jq/eval.rs`) is a shared step budget charged
+against `reduce`/`foreach` once per UPDATE eval, and -- `foreach` only --
+once more per EXTRACT eval, independently in value mode and path mode.
+[#695](https://github.com/rust-works/succinctly/issues/695) introduced it
+(originally `10000`) as a resource-exhaustion guard against a genuinely
+unbounded product: `reduce (range(100000)) as $x ((range(100000)); .+$x)`
+forks INIT into 100,000 independent runs, each walking a 100,000-element
+stream -- 1e10 round trips, with no cap at all before #695.
 
-The budget that shipped charged one unit per UPDATE/EXTRACT invocation
-regardless of *why* the invocation happened, which degenerates into a plain
-cap on the input-element count whenever there is exactly one INIT fork and a
-single-output UPDATE -- the overwhelmingly common shape for an ordinary
-`reduce`/`foreach`, and not the multiplicative fanout #695 was actually
-guarding against. At the original `10000`,
-[#2079](https://github.com/rust-works/succinctly/issues/2079) found this
-refusing everyday folds real jq performs without issue:
-
-```console
-$ succinctly jq -c 'reduce .[] as $x (0; . + $x)' <(python3 -c 'import json;print(json.dumps(list(range(50000))))')
-jq: error (at <stdin>:1): reduce: maximum iterations exceeded
-$ jq -c 'reduce .[] as $x (0; . + $x)' <(python3 -c 'import json;print(json.dumps(list(range(50000))))')
-1249975000
-```
-
-`foreach`'s three-argument form (explicit EXTRACT) compounded this: since
-EXTRACT charges the same shared budget a second time per element, its
-effective ceiling was *half* `REDUCE_FOREACH_MAX_STEPS` -- a filter's element
-limit silently depended on whether it passed two or three arguments to
-`foreach`.
+Charging one flat unit per invocation regardless of *why* it happened
+degenerates into a plain cap on input-element count for the overwhelmingly
+common single-INIT-fork, single-output shape -- not the multiplicative fanout
+#695 was actually guarding against, and not something real jq caps at all
+(it streams the fold, bounded only by memory).
+[#2079](https://github.com/rust-works/succinctly/issues/2079) found the
+original `10000` refusing everyday folds as a result (`reduce .[] as $x (0; .
++ $x)` on a 50,000-element array; `succinctly` refused, real jq answered
+`1249975000`), with `foreach`'s three-argument form (explicit EXTRACT)
+compounding it further -- EXTRACT's second charge per element halved its
+effective ceiling again, so a filter's element limit silently depended on
+whether it passed two or three arguments to `foreach`.
 
 **Fix**: split the previously-coincidental sharing between this budget and
 `repeat`'s own unrelated per-round width cap (`REPEAT_WIDTH_BUDGET`, previous
-section) into two independent constants, then raised
-`REDUCE_FOREACH_MAX_STEPS` 100x (`10000` to `1_000_000`) now that doing so no
-longer also loosens `repeat`'s guard. This is accepted under ADR-0018 rule 4c
-(preventing a resource-exhaustion vector, not matching real jq's own
-memory-only bound) rather than removing the cap outright: real jq streams the
-fold with no cap of its own, bounded only by memory, and a fully faithful fix
-would need to bound the true fanout *product* (INIT-fork count x element
-count x UPDATE/EXTRACT output width) rather than a flat total -- tracked as a
-possible follow-up, not attempted here given the risk of a bespoke
-product-precomputation formula silently drifting from the four call sites'
-(value/path mode x pattern-alternative-matrix) subtly different shapes. The
-raised flat ceiling keeps #695's original protection (a genuine fork x
-element explosion still aborts, just at a higher, no-longer-accidentally-
-reachable threshold) while giving ordinary single-fork usage generous
-headroom -- 20x above this issue's own 50,000-element repro, and comfortably
-past any array size a `succinctly jq`/`yq` invocation is likely to see in
-practice (the CLI's own inputs must fit in memory as a document to index in
-the first place).
+section — raising one to fix #2079 must not silently loosen the other), then
+raised `REDUCE_FOREACH_MAX_STEPS` 10x, `10000` to `100000` -- 2x above this
+issue's own 50,000-element repro. Accepted under ADR-0018 rule 4c (preventing
+a resource-exhaustion vector, not matching real jq's own memory-only bound)
+rather than removing the cap outright.
+
+**Why 10x and not more, and why a flat count rather than a true fanout-product
+bound**: raising the flat per-invocation count also raises the worst-case CPU
+burned *before* the cap fires, for any UPDATE/EXTRACT body whose own
+per-invocation cost is superlinear -- concretely, repeated string growth:
+`reduce range(N) as $x (""; . + "x")` measures O(N²) in succinctly (`""`
+concatenation reallocates the whole accumulator each step) --
+**not** a divergence to accept under this section, but a genuine succinctly
+performance gap against real jq, which answers the identical query in
+apparently-linear time (`jq -cn '[range(N)] | length'`-scale cost, confirmed
+live: N=50,000/100,000/1,000,000 measure 0.01s/0.02s/0.15s against jq 1.7.1,
+vs. succinctly's 1.9s/7.8s at just the first two of those); filed separately
+as [#2086](https://github.com/rust-works/succinctly/issues/2086) rather than
+chased down here. Until that closes, this budget's real-world worst case
+before erroring is whatever that gap's own scaling implies at
+`REDUCE_FOREACH_MAX_STEPS` iterations -- measured directly at `100000`
+(this budget's own value): ~7.8s. A precomputed fanout-product bound
+(INIT-fork count x element count, both known before either loop starts)
+would not avoid this either way -- for the single-INIT-fork case #2079
+reports, fork count is 1, so the product collapses to the element count and
+the effective ceiling is identical to the flat count's; a product bound only
+changes *when* multi-fork cases are rejected (upfront vs. after partial
+work), not the single-fork ceiling this issue is about. A materially better
+bound would need to weight each invocation by its own body's cost, not just
+count invocations -- out of scope here; `10000 -> 100000` was chosen as a
+value with real headroom over #2079's own repro while keeping the
+pathological-body worst case in the single-digit seconds (measured, not
+extrapolated) rather than the tens of minutes a further 10x would cost at
+the same pathological shape.
 
 ### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2012,7 +2012,7 @@ $ succinctly jq -cn '[limit(80000; repeat(1))] | length'
 Two narrower caps remain by necessity, both accepted under ADR-0018 rule 4c
 (preventing a hang, not matching one) rather than removed:
 
-- **A per-*round* width budget** (`REDUCE_FOREACH_MAX_STEPS = 10000`, reset
+- **A per-*round* width budget** (`REPEAT_WIDTH_BUDGET = 10000`, reset
   at the start of every round): bounds how many values a *single* round may
   fork into at once -- a memory-safety net for a wide `f` like `.[]`, since
   a round is materialized into a `Vec` before being handed to the sink. Real
@@ -2083,6 +2083,61 @@ alone -- left open rather than fixed here since #2014's own scope and
 verification are both about value mode; a follow-up applying the identical
 demand-driven treatment to `resolve_repeat_bounded` would close this the
 same way.
+
+### `reduce`/`foreach`'s own step budget (#695/#2079): bounds genuine fanout, not ordinary element count
+
+Both evaluators charge a shared `REDUCE_FOREACH_MAX_STEPS` step budget against
+`reduce`/`foreach` (once per UPDATE eval, and -- `foreach` only -- once more
+per EXTRACT eval), independently in value mode (`eval_reduce_with_values`/
+`eval_foreach_with_values`) and path mode (`resolve_reduce`/`resolve_foreach`).
+[#695](https://github.com/rust-works/succinctly/issues/695) introduced it as a
+resource-exhaustion guard against a genuinely unbounded product: `reduce
+(range(100000)) as $x ((range(100000)); .+$x)` forks INIT into 100,000
+independent runs, each walking a 100,000-element stream -- 1e10 round trips,
+with no cap at all before #695.
+
+The budget that shipped charged one unit per UPDATE/EXTRACT invocation
+regardless of *why* the invocation happened, which degenerates into a plain
+cap on the input-element count whenever there is exactly one INIT fork and a
+single-output UPDATE -- the overwhelmingly common shape for an ordinary
+`reduce`/`foreach`, and not the multiplicative fanout #695 was actually
+guarding against. At the original `10000`,
+[#2079](https://github.com/rust-works/succinctly/issues/2079) found this
+refusing everyday folds real jq performs without issue:
+
+```console
+$ succinctly jq -c 'reduce .[] as $x (0; . + $x)' <(python3 -c 'import json;print(json.dumps(list(range(50000))))')
+jq: error (at <stdin>:1): reduce: maximum iterations exceeded
+$ jq -c 'reduce .[] as $x (0; . + $x)' <(python3 -c 'import json;print(json.dumps(list(range(50000))))')
+1249975000
+```
+
+`foreach`'s three-argument form (explicit EXTRACT) compounded this: since
+EXTRACT charges the same shared budget a second time per element, its
+effective ceiling was *half* `REDUCE_FOREACH_MAX_STEPS` -- a filter's element
+limit silently depended on whether it passed two or three arguments to
+`foreach`.
+
+**Fix**: split the previously-coincidental sharing between this budget and
+`repeat`'s own unrelated per-round width cap (`REPEAT_WIDTH_BUDGET`, previous
+section) into two independent constants, then raised
+`REDUCE_FOREACH_MAX_STEPS` 100x (`10000` to `1_000_000`) now that doing so no
+longer also loosens `repeat`'s guard. This is accepted under ADR-0018 rule 4c
+(preventing a resource-exhaustion vector, not matching real jq's own
+memory-only bound) rather than removing the cap outright: real jq streams the
+fold with no cap of its own, bounded only by memory, and a fully faithful fix
+would need to bound the true fanout *product* (INIT-fork count x element
+count x UPDATE/EXTRACT output width) rather than a flat total -- tracked as a
+possible follow-up, not attempted here given the risk of a bespoke
+product-precomputation formula silently drifting from the four call sites'
+(value/path mode x pattern-alternative-matrix) subtly different shapes. The
+raised flat ceiling keeps #695's original protection (a genuine fork x
+element explosion still aborts, just at a higher, no-longer-accidentally-
+reachable threshold) while giving ordinary single-fork usage generous
+headroom -- 20x above this issue's own 50,000-element repro, and comfortably
+past any array size a `succinctly jq`/`yq` invocation is likely to see in
+practice (the CLI's own inputs must fit in memory as a document to index in
+the first place).
 
 ### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26094,40 +26094,27 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// today is coincidence, not a relationship a shared symbol should
 /// encode.
 ///
-/// #2079: originally `10000`, which degenerates into a plain cap on the
-/// *input-element count* whenever there is exactly one INIT fork and a
-/// single-output UPDATE/EXTRACT (the overwhelmingly common shape) — an
-/// ordinary `reduce .[] as $x (0; . + $x)` over an 11,000-element array
-/// refused with no jq equivalent (real jq streams the fold, bounded only
-/// by memory). #695's actual concern was the *product* of INIT-fork
-/// count, element count, and UPDATE/EXTRACT output width (its own
-/// motivating example was a 100,000-fork × 100,000-element reduce, 1e10
-/// round trips) — a genuinely unbounded multiplicative blow-up, not an
-/// ordinary linear walk. Raised by 100x so realistic single-fork/
-/// single-output usage (this issue's own repro tops out at 50,000
-/// elements) has generous headroom, while a genuine fanout explosion
-/// still aborts (after this many round trips, not all of them) rather
-/// than running unbounded — see
-/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md)
-/// for the accepted-divergence writeup. No longer shared with `repeat`
-/// (see [`REPEAT_WIDTH_BUDGET`]) — that coupling was coincidental, not a
-/// relationship that should force the two to move together, and `repeat`
-/// has its own dedicated test pinning its cap to stay at `10000`
-/// (`test_path_repeat_width_budget_matches_value_mode_1933`).
-pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 1_000_000;
+/// #2079: originally `10000`, which degenerated into a plain cap on
+/// *input-element count* for the overwhelmingly common single-INIT-fork,
+/// single-output shape, rather than the multiplicative fanout it was
+/// meant to bound. Raised 10x, and no longer shared with `repeat` (see
+/// [`REPEAT_WIDTH_BUDGET`] — that coupling was coincidental). This bounds
+/// round-trip *count*, not per-round-trip *cost*: a superlinear-cost
+/// UPDATE/EXTRACT body (e.g. repeated string/array growth) can still
+/// consume real CPU time before the cap is reached, same as it already
+/// could at the old, lower count. Full rationale, the chosen magnitude's
+/// tradeoffs, and why a true fanout-product bound wasn't implemented
+/// instead: [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md).
+pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 100_000;
 
 /// `repeat(f)`'s own step budget — bounds how many values a *single*
 /// round may fork into at once (`resolve_repeat_bounded`/`each_repeat`),
 /// and separately (`eval_repeat`) the total output size of the eager,
 /// non-demand-driven fallback path. Split from [`REDUCE_FOREACH_MAX_STEPS`]
-/// by #2079: the two were previously the same constant by coincidence
-/// (both `10000`), which meant raising `reduce`/`foreach`'s cap to fix
-/// its own bug would have silently also loosened `repeat`'s unrelated
-/// per-round width cap. Kept at the original `10000` — see each call
-/// site's own doc comment, and
-/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md),
-/// for why `repeat` needs a materialize-before-emit memory-safety net
-/// that `reduce`/`foreach` do not.
+/// by #2079 (previously the same constant by coincidence); kept at the
+/// original `10000` — see each call site's own doc comment for why
+/// `repeat` needs a materialize-before-emit memory-safety net that
+/// `reduce`/`foreach` do not.
 pub(crate) const REPEAT_WIDTH_BUDGET: usize = 10_000;
 
 /// Check-and-charge one unit against a shared step budget (#695), the
@@ -55189,21 +55176,19 @@ mod tests {
 
     #[test]
     fn test_reduce_budget_exceeded_errors() {
-        // #2079: genuine fanout -- 2 INIT forks, each walking an
-        // 1,099,989-element source stream (`range(11) | range(99999)`,
-        // nested to stay under `range`'s own unrelated `MAX_RANGE =
-        // 100000` per-call cap) -- is exactly the resource-exhaustion
-        // shape #695 introduced this budget to bound (its own motivating
-        // example was a 100,000-fork x 100,000-element reduce, 1e10 round
-        // trips). The raised REDUCE_FOREACH_MAX_STEPS still aborts it,
-        // just at a much higher, no-longer-accidentally-reachable-by-
-        // ordinary-use ceiling. A single fork's own element count already
-        // exceeds the whole budget, so the very first fork never
-        // completes -- `reduce` only pushes output once a fork's fold
-        // completes, so no output survives to make this a `Partial`
-        // regardless of the second fork never being reached.
-        query!(b"null", r"reduce (range(11) | range(99999)) as $x ((0,1); .+$x)",
-            QueryResult::Error(e) => {
+        // #2079: genuine fanout -- 2 INIT forks (`(0,1)`), each walking
+        // the same 50,001-element source stream, 100,002 UPDATE evals
+        // total -- is exactly the resource-exhaustion shape #695
+        // introduced this budget to bound (its own motivating example was
+        // a 100,000-fork x 100,000-element reduce, 1e10 round trips).
+        // Neither dimension alone exceeds the 100,000 budget (50,001 <
+        // 100,000), only their product does. The first fork completes
+        // (50,001 charges) and its result survives as the `Partial`
+        // prefix; the second fork burns the remaining 49,999 charges
+        // before erroring partway through, contributing nothing.
+        query!(b"null", r"reduce range(50001) as $x ((0,1); .+$x)",
+            QueryResult::Partial(prefix, Control::Error(e)) => {
+                assert_eq!(prefix, [OwnedValue::Int(1_250_025_000)]);
                 assert!(e.message.contains("reduce: maximum iterations exceeded"));
             }
         );
@@ -55211,11 +55196,13 @@ mod tests {
 
     #[test]
     fn test_foreach_budget_exceeded_errors() {
-        // #2079: same genuine-fanout shape as the `reduce` case above,
-        // via 1001 INIT forks over a 1001-element stream (no EXTRACT, so
-        // only the per-input-element UPDATE charge fires). Outputs
-        // already produced survive as the `Partial` prefix.
-        query!(b"null", r"foreach range(1001) as $x (range(1001); .+1)",
+        // #2079: same genuine-fanout shape as the `reduce` case above --
+        // 2 INIT forks over the same 50,001-element stream, no EXTRACT,
+        // so only the per-input-element UPDATE charge fires. `foreach`
+        // emits progressively rather than per-fork, so exactly `budget`
+        // outputs survive as the `Partial` prefix regardless of which
+        // fork was mid-flight when it ran out.
+        query!(b"null", r"foreach range(50001) as $x ((0,1); .+1)",
             QueryResult::Partial(prefix, Control::Error(e)) => {
                 assert_eq!(prefix.len(), REDUCE_FOREACH_MAX_STEPS);
                 assert!(e.message.contains("foreach: maximum iterations exceeded"));
@@ -55225,17 +55212,17 @@ mod tests {
 
     #[test]
     fn test_foreach_extract_fanout_charged_independently_of_input_length() {
-        // A single input element whose UPDATE fans out far past the
-        // budget (1,099,989 outputs, via `range(11) | range(99999)` --
-        // nested to stay under `range`'s own unrelated `MAX_RANGE =
-        // 100000` per-call cap); each output gets its own EXTRACT eval
-        // (#695). Pins that EXTRACT fanout is charged on its own — a
-        // design charging only once per input element would never trip
-        // here, since there is only one. Scaled to #2079's raised
-        // REDUCE_FOREACH_MAX_STEPS.
-        query!(b"null", r"foreach (1) as $x (0; range(11) | range(99999); .)",
+        // Two input elements (far fewer than the budget) whose UPDATE
+        // each fans out to 50,001 outputs; each output gets its own
+        // EXTRACT eval (#695). Pins that EXTRACT fanout is charged
+        // independently of input-element count -- a design charging only
+        // once per input element would never trip here, since there are
+        // only two. 2 UPDATE charges (one per element) precede the
+        // EXTRACT fan-out, so `REDUCE_FOREACH_MAX_STEPS - 2` outputs
+        // survive before the budget is exhausted mid-fanout.
+        query!(b"null", r"foreach (1,2) as $x (0; range(50001); .)",
             QueryResult::Partial(prefix, Control::Error(e)) => {
-                assert_eq!(prefix.len(), REDUCE_FOREACH_MAX_STEPS - 1);
+                assert_eq!(prefix.len(), REDUCE_FOREACH_MAX_STEPS - 2);
                 assert!(e.message.contains("foreach: maximum iterations exceeded"));
             }
         );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21541,9 +21541,9 @@ fn resolve_limit_one_n<'a, S: EvalSemantics>(
 /// value-only semantics (its doc comment: "evaluates `expr` with the
 /// original input each time").
 ///
-/// `MAX_ITERATIONS` (round count) and `budget` (total branch count, shared
-/// with `reduce`/`foreach` via [`REDUCE_FOREACH_MAX_STEPS`]) together
-/// mirror `eval_repeat`'s own identical two-tier backstop
+/// `MAX_ITERATIONS` (round count) and `budget` (total branch count, via
+/// [`REPEAT_WIDTH_BUDGET`]) together mirror `eval_repeat`'s own identical
+/// two-tier backstop
 /// (`src/jq/eval.rs`) -- documented as a deliberate divergence from real
 /// jq's own hang/unbounded-allocation in
 /// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md),
@@ -21573,7 +21573,7 @@ fn resolve_repeat_bounded<'a, S: EvalSemantics>(
     n: usize,
 ) -> PathResolveResult<'a> {
     const MAX_ITERATIONS: usize = 1000;
-    let mut budget = REDUCE_FOREACH_MAX_STEPS;
+    let mut budget = REPEAT_WIDTH_BUDGET;
     let mut branches: Vec<PathBranch<'a>> = Vec::new();
     for _ in 0..MAX_ITERATIONS {
         if branches.len() >= n {
@@ -26093,7 +26093,42 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// pair per recursion-tree node there), so the shared numeric value
 /// today is coincidence, not a relationship a shared symbol should
 /// encode.
-pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 10000;
+///
+/// #2079: originally `10000`, which degenerates into a plain cap on the
+/// *input-element count* whenever there is exactly one INIT fork and a
+/// single-output UPDATE/EXTRACT (the overwhelmingly common shape) — an
+/// ordinary `reduce .[] as $x (0; . + $x)` over an 11,000-element array
+/// refused with no jq equivalent (real jq streams the fold, bounded only
+/// by memory). #695's actual concern was the *product* of INIT-fork
+/// count, element count, and UPDATE/EXTRACT output width (its own
+/// motivating example was a 100,000-fork × 100,000-element reduce, 1e10
+/// round trips) — a genuinely unbounded multiplicative blow-up, not an
+/// ordinary linear walk. Raised by 100x so realistic single-fork/
+/// single-output usage (this issue's own repro tops out at 50,000
+/// elements) has generous headroom, while a genuine fanout explosion
+/// still aborts (after this many round trips, not all of them) rather
+/// than running unbounded — see
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md)
+/// for the accepted-divergence writeup. No longer shared with `repeat`
+/// (see [`REPEAT_WIDTH_BUDGET`]) — that coupling was coincidental, not a
+/// relationship that should force the two to move together, and `repeat`
+/// has its own dedicated test pinning its cap to stay at `10000`
+/// (`test_path_repeat_width_budget_matches_value_mode_1933`).
+pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 1_000_000;
+
+/// `repeat(f)`'s own step budget — bounds how many values a *single*
+/// round may fork into at once (`resolve_repeat_bounded`/`each_repeat`),
+/// and separately (`eval_repeat`) the total output size of the eager,
+/// non-demand-driven fallback path. Split from [`REDUCE_FOREACH_MAX_STEPS`]
+/// by #2079: the two were previously the same constant by coincidence
+/// (both `10000`), which meant raising `reduce`/`foreach`'s cap to fix
+/// its own bug would have silently also loosened `repeat`'s unrelated
+/// per-round width cap. Kept at the original `10000` — see each call
+/// site's own doc comment, and
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md),
+/// for why `repeat` needs a materialize-before-emit memory-safety net
+/// that `reduce`/`foreach` do not.
+pub(crate) const REPEAT_WIDTH_BUDGET: usize = 10_000;
 
 /// Check-and-charge one unit against a shared step budget (#695), the
 /// same check `until_step`/`while_step` each inline for their own cap.
@@ -27595,7 +27630,7 @@ fn while_step<S: EvalSemantics>(
 /// still needs two safety nets, neither of which may cap the *round count*
 /// itself or that guarantee breaks:
 ///
-/// - **Per-round `budget`** (`REDUCE_FOREACH_MAX_STEPS`, reset at the start
+/// - **Per-round `budget`** (`REPEAT_WIDTH_BUDGET`, reset at the start
 ///   of *every* round and charged one output at a time before a value
 ///   reaches `sink`): bounds how many values a single round may fork into
 ///   at once, independent of how many rounds run in total. Without it,
@@ -27663,7 +27698,7 @@ fn each_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             continue;
         }
         empty_rounds = 0;
-        let mut budget = REDUCE_FOREACH_MAX_STEPS;
+        let mut budget = REPEAT_WIDTH_BUDGET;
         for val in vals {
             if let Some(control) = charge_budget(&mut budget, "repeat") {
                 return Flow::Escaped(control);
@@ -27720,7 +27755,7 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // produces removes that implicit cap unless charged explicitly here,
     // the same "width needs its own accounting" reasoning `foreach`'s own
     // per-EXTRACT charge already documents.
-    let mut budget = REDUCE_FOREACH_MAX_STEPS;
+    let mut budget = REPEAT_WIDTH_BUDGET;
 
     for _ in 0..MAX_ITERATIONS {
         // Evaluate expr with the original input each time, extending
@@ -55109,11 +55144,65 @@ mod tests {
     }
 
     #[test]
+    fn test_2079_reduce_ordinary_linear_fold_over_10001_elements_succeeds() {
+        // #2079: a single INIT fork walking an 11,000+ element source
+        // stream is an ordinary linear fold, not the multiplicative
+        // fanout REDUCE_FOREACH_MAX_STEPS exists to bound — before the
+        // fix, this refused with "reduce: maximum iterations exceeded"
+        // where real jq (1.7.1) answers 50005000. Value confirmed live
+        // against the pinned oracle.
+        assert_eq!(
+            outputs(b"null", r"reduce range(10001) as $x (0; .+$x)"),
+            ["50005000"]
+        );
+    }
+
+    #[test]
+    fn test_2079_foreach_ordinary_linear_fold_over_10001_elements_succeeds() {
+        // #2079: `foreach`'s two-argument form (no EXTRACT) has the same
+        // single-fork linear shape as the `reduce` case above and must
+        // not be capped at REDUCE_FOREACH_MAX_STEPS's old 10000 either —
+        // real jq's own `[foreach range(10001) as $x (0; .+$x)] | length`
+        // is `10001`.
+        assert_eq!(
+            outputs(b"null", r"[foreach range(10001) as $x (0; .+$x)] | length"),
+            ["10001"]
+        );
+    }
+
+    #[test]
+    fn test_2079_foreach_with_extract_over_5001_elements_succeeds() {
+        // #2079: three-argument `foreach` (explicit EXTRACT) used to cap
+        // at *half* the two-argument ceiling, since EXTRACT charges the
+        // same shared budget a second time per element -- a filter's
+        // effective element limit should not depend on whether it passes
+        // two or three arguments. Real jq's
+        // `[foreach range(5001) as $x (0; .+$x; .)] | length` is `5001`.
+        assert_eq!(
+            outputs(
+                b"null",
+                r"[foreach range(5001) as $x (0; .+$x; .)] | length"
+            ),
+            ["5001"]
+        );
+    }
+
+    #[test]
     fn test_reduce_budget_exceeded_errors() {
-        // 10001 UPDATE evals against a single INIT fork exceeds
-        // REDUCE_FOREACH_MAX_STEPS; `reduce` only pushes output after its
-        // fold completes, so no output survives to make this a `Partial`.
-        query!(b"null", r"reduce range(10001) as $x (0; .+$x)",
+        // #2079: genuine fanout -- 2 INIT forks, each walking an
+        // 1,099,989-element source stream (`range(11) | range(99999)`,
+        // nested to stay under `range`'s own unrelated `MAX_RANGE =
+        // 100000` per-call cap) -- is exactly the resource-exhaustion
+        // shape #695 introduced this budget to bound (its own motivating
+        // example was a 100,000-fork x 100,000-element reduce, 1e10 round
+        // trips). The raised REDUCE_FOREACH_MAX_STEPS still aborts it,
+        // just at a much higher, no-longer-accidentally-reachable-by-
+        // ordinary-use ceiling. A single fork's own element count already
+        // exceeds the whole budget, so the very first fork never
+        // completes -- `reduce` only pushes output once a fork's fold
+        // completes, so no output survives to make this a `Partial`
+        // regardless of the second fork never being reached.
+        query!(b"null", r"reduce (range(11) | range(99999)) as $x ((0,1); .+$x)",
             QueryResult::Error(e) => {
                 assert!(e.message.contains("reduce: maximum iterations exceeded"));
             }
@@ -55122,9 +55211,11 @@ mod tests {
 
     #[test]
     fn test_foreach_budget_exceeded_errors() {
-        // No EXTRACT, so only the per-input-element UPDATE charge fires;
-        // outputs already produced survive as the `Partial` prefix.
-        query!(b"null", r"foreach range(20000) as $x (0; .+1)",
+        // #2079: same genuine-fanout shape as the `reduce` case above,
+        // via 1001 INIT forks over a 1001-element stream (no EXTRACT, so
+        // only the per-input-element UPDATE charge fires). Outputs
+        // already produced survive as the `Partial` prefix.
+        query!(b"null", r"foreach range(1001) as $x (range(1001); .+1)",
             QueryResult::Partial(prefix, Control::Error(e)) => {
                 assert_eq!(prefix.len(), REDUCE_FOREACH_MAX_STEPS);
                 assert!(e.message.contains("foreach: maximum iterations exceeded"));
@@ -55135,11 +55226,14 @@ mod tests {
     #[test]
     fn test_foreach_extract_fanout_charged_independently_of_input_length() {
         // A single input element whose UPDATE fans out far past the
-        // budget; each output gets its own EXTRACT eval (#695). Pins that
-        // EXTRACT fanout is charged on its own — a design charging only
-        // once per input element would never trip here, since there is
-        // only one.
-        query!(b"null", r"foreach (1) as $x (0; range(20000); .)",
+        // budget (1,099,989 outputs, via `range(11) | range(99999)` --
+        // nested to stay under `range`'s own unrelated `MAX_RANGE =
+        // 100000` per-call cap); each output gets its own EXTRACT eval
+        // (#695). Pins that EXTRACT fanout is charged on its own — a
+        // design charging only once per input element would never trip
+        // here, since there is only one. Scaled to #2079's raised
+        // REDUCE_FOREACH_MAX_STEPS.
+        query!(b"null", r"foreach (1) as $x (0; range(11) | range(99999); .)",
             QueryResult::Partial(prefix, Control::Error(e)) => {
                 assert_eq!(prefix.len(), REDUCE_FOREACH_MAX_STEPS - 1);
                 assert!(e.message.contains("foreach: maximum iterations exceeded"));
@@ -69259,6 +69353,31 @@ mod tests {
         assert_eq!(
             outputs(br#"{"a":1}"#, "path(foreach (1,2) as $i (.; empty))"),
             Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_2079_path_reduce_ordinary_linear_fold_over_10001_elements_succeeds() {
+        // #2079: `resolve_reduce` (path-mode) has its own separate
+        // budget-charging loop from `eval_reduce_with_values` (value
+        // mode), so the fix needs its own coverage here too. UPDATE is
+        // `.` (identity) so the accumulator stays trackable throughout —
+        // only the sheer element count is under test, previously capped
+        // at 10000 by the since-raised REDUCE_FOREACH_MAX_STEPS.
+        assert_eq!(
+            outputs(b"1", "path(reduce range(10001) as $x (.; .))"),
+            ["[]"]
+        );
+    }
+
+    #[test]
+    fn test_2079_path_foreach_ordinary_linear_fold_over_10001_elements_succeeds() {
+        // #2079: same fix, `resolve_foreach`'s own path-mode loop. Each
+        // step emits the (unchanged, trackable) root path, so a
+        // successful run over all 10001 elements produces 10001 `[]`s.
+        assert_eq!(
+            outputs(b"1", "[path(foreach range(10001) as $x (.; .))] | length"),
+            ["10001"]
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5739,7 +5739,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
 /// wrapping `sink` does.
 ///
 /// Two independent caps, mirroring `eval.rs`'s own `each_repeat` exactly:
-/// a per-*round* `REDUCE_FOREACH_MAX_STEPS` budget, reset at the start of
+/// a per-*round* `REPEAT_WIDTH_BUDGET` budget, reset at the start of
 /// every round and charged one output at a time via `charge_budget` --
 /// bounding how many values a single round may fork into at once (a
 /// succinctly-only memory-safety net for a wide `f` like `.[]`, not jq
@@ -5779,7 +5779,7 @@ fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
         let mut stopped = false;
         let mut produced_any = false;
         let mut budget_control = None;
-        let mut budget = super::eval::REDUCE_FOREACH_MAX_STEPS;
+        let mut budget = super::eval::REPEAT_WIDTH_BUDGET;
         let flow = eval_each_owned::<S>(f, &owned, optional, &mut |v| {
             produced_any = true;
             if let Some(control) = super::eval::charge_budget(&mut budget, "repeat") {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13244,9 +13244,12 @@ fn test_repeat_value_budget_bounds_total_output_independent_of_fan_out() -> Resu
     // wrongly called it a succinctly extension with no upstream builtin to
     // compare against), but this specific budget-exceeded contract at this
     // exact threshold is succinctly's own choice, not something to compare
-    // against jq for: the budget (`REDUCE_FOREACH_MAX_STEPS`, shared with
-    // `reduce`/`foreach`) cuts the stream at exactly 10000 values with a
-    // clear error, not an unbounded allocation.
+    // against jq for: the budget (`REPEAT_WIDTH_BUDGET`) cuts the stream
+    // at exactly 10000 values with a clear error, not an unbounded
+    // allocation. #2079 split this constant from `reduce`/`foreach`'s own
+    // `REDUCE_FOREACH_MAX_STEPS` (previously the same value by
+    // coincidence) so raising the latter's much-too-low cap didn't also
+    // loosen this one.
     let (stdout, stderr, code) = run_jq_full(&["-c", "repeat(range(20001))"], Some("null"))?;
     assert_eq!(code, 5, "stderr: {stderr:?}");
     assert_eq!(stdout.lines().count(), 10000, "stdout: {stdout:?}");
@@ -13336,7 +13339,7 @@ fn test_path_repeat_error_dropped_once_limit_satisfied_1933() -> Result<()> {
 
 /// Code review on PR #1933: an earlier version of `resolve_repeat_bounded`
 /// had no per-branch budget at all, unlike `eval_repeat`'s value-mode
-/// sibling (`REDUCE_FOREACH_MAX_STEPS`) -- letting a large `limit()`-
+/// sibling (`REPEAT_WIDTH_BUDGET`) -- letting a large `limit()`-
 /// supplied `n` combined with a wide-fanning-out body allocate far more
 /// than value-mode allows for the identical query shape. Both modes now
 /// cut at exactly 10000 branches with the same "repeat: maximum


### PR DESCRIPTION
## Summary

- `reduce`/`foreach`'s shared step budget (`REDUCE_FOREACH_MAX_STEPS`, #695) charged one unit per UPDATE/EXTRACT eval regardless of *why* the invocation happened. With a single INIT fork and a single-output UPDATE — the overwhelmingly common shape — this degenerated into a plain cap on input-element count rather than the multiplicative INIT-fork × element × UPDATE/EXTRACT-width fanout it was meant to bound. An ordinary `reduce .[] as $x (0; . + $x)` over an 11,000-element array refused with `reduce: maximum iterations exceeded`, where real jq streams the fold unbounded. `foreach`'s three-argument form (explicit EXTRACT) compounded this, capping at *half* the two-argument ceiling.
- Splits the previously-coincidental sharing between this budget and `repeat`'s own unrelated per-round width cap into two independent constants (`REDUCE_FOREACH_MAX_STEPS` for `reduce`/`foreach`, `REPEAT_WIDTH_BUDGET` for `repeat`, still `10000`), then raises `REDUCE_FOREACH_MAX_STEPS` 10x to `100_000` (2x above this issue's own 50,000-element repro) now that doing so no longer also loosens `repeat`'s guard.
- **Revised after code review**: the initial fix raised the budget 100x (to `1_000_000`). Review measured that raising a flat per-invocation count also raises worst-case CPU for any UPDATE/EXTRACT body with superlinear per-invocation cost — a string-accumulating fold (`reduce range(N) as $x (""; . + "x")`) takes ~7.8s at N=100,000 in succinctly, where real jq is apparently linear there (~0.02s), a genuine separate succinctly performance gap filed as #2086. Dialed back to a 10x raise, keeping that pathological-body worst case in single-digit seconds instead of tens of minutes.
- The genuine fanout-explosion case #695 introduced this guard for still errors, just at a higher, no-longer-accidentally-reachable-by-ordinary-use ceiling.
- Recorded as an accepted ADR-0018 rule 4(c) divergence in `docs/compliance/jq/limitations.md` (real jq has no cap at all here, bounded only by memory), including an honest accounting of why a flat count was kept rather than a true fanout-product bound (it wouldn't change the single-fork ceiling this issue is about) and why the raise stops at 10x.

Fixes #2079

Follow-ups filed during this PR's own review and investigation, all out of scope here:
- #2083 — `cargo test --no-default-features` fails to build on `main` (unrelated, pre-existing)
- #2086 — string-accumulating `reduce`/`foreach` is O(n²) in succinctly vs. real jq's ~linear (surfaced while choosing this PR's budget magnitude)
- #2087 — `until`/`while`'s own `WHILE_UNTIL_MAX_STEPS` has the identical flat-budget bug this PR fixes for `reduce`/`foreach` (found during this PR's review)

## Test plan

- [x] New unit tests pinning the fix: `reduce`/`foreach` (both value-mode and path-mode) over 10,001 elements, and 3-arg `foreach` over 5,001 elements, all matching live jq 1.7.1 output.
- [x] Existing fanout-protection tests (`test_reduce_budget_exceeded_errors`, `test_foreach_budget_exceeded_errors`, `test_foreach_extract_fanout_charged_independently_of_input_length`) rewritten to use simpler, self-explanatory constructions (2 INIT forks over a single `range(50001)` stream) and rescaled to the new ceiling — genuine multiplicative fanout still errors, confirmed with hand-derived and test-verified exact output counts.
- [x] All 18 `repeat`-related tests pass unchanged (`REPEAT_WIDTH_BUDGET` decoupling verified safe).
- [x] Full test suite: `cargo test --features cli,simd,regex,serde` — 0 failures across all 56 test binaries/doc-tests (re-verified after the post-review revision).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean (CI's second leg).
- [x] `cargo fmt --check` — clean.
- [x] `cargo doc --no-deps` with `RUSTDOCFLAGS="-D warnings"` — clean.
- [x] Manually verified against the pinned `/usr/bin/jq` 1.7.1 oracle (issue's own 50,000-element file-driven repro, and the 5,001-element EXTRACT repro) — both match exactly.
- [x] `cargo test --no-default-features` was also run; it fails on unmodified `main` too (two unrelated pre-existing `std`-gating gaps, confirmed unaffected by this change) — filed separately as #2083.
- [x] Independent multi-agent code review (10 finders across correctness, simplification, reuse, efficiency, Rust pitfalls, cross-file tracing, CLAUDE.md conventions, and altitude/design-fit angles) — all substantive findings addressed (magnitude, test clarity, CI cost, doc duplication, two sibling follow-ups filed); one finding (yq-mode documentation gap) investigated and found not applicable — real yq has no `reduce`/`foreach` at all, confirmed live against the pinned v4.53.3 binary and already documented in this repo's own existing tests, so this is a succinctly extension exempt from the divergence-recording rule.
