### PR TITLE
fix(jq): evaluate user-defined defs as runtime calls, not static substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Self-recursive and branching user-defined `def`s now evaluate** (#1371). `def
+  sum_to(n): if n == 0 then 0 else n + sum_to(n-1) end; sum_to(100)` returns `5050`, and
+  `sum_to(10000)` returns `50005000`, both matching jq 1.7.1; naive `fib` works where
+  every branching recursion previously failed at *any* depth, zero included.
+
+  `def` bodies were substituted into their call sites before evaluation began, which
+  cannot terminate for a self-recursive definition — expansion has no way to observe that
+  a runtime base case will be reached — and so was bounded by three guards that refused
+  ordinary recursive filters. Calls are now bound to their definition and substituted per
+  call, when evaluation reaches them, with arguments captured behind a shared node that
+  keeps the recursion linear rather than quadratic. See
+  [ADR-0020](docs/adrs/adr-0020.md).
+
+  A non-terminating `def` still fails, now as a catchable error rather than the abort real
+  jq produces for the same input. Deep recursion in a body that holds a lot of structure
+  live stops earlier than jq's heap-allocated VM stack does; both are recorded in
+  [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md).
+
 ### Added
 
 - **`reduce`/`foreach`'s own `as` clause accepts a full destructuring pattern**

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -46,6 +46,7 @@ by Michael Nygard.
 | [ADR-0017](adr-0017.md) | ✅ Accepted | 2026-08-11 | Presentation-Metadata Side-Trees over a Mutable YAML Document |
 | [ADR-0018](adr-0018.md) | ✅ Accepted | 2026-08-22 | Reference-Tool Fidelity, Decided by Mode Rather than Format   |
 | [ADR-0019](adr-0019.md) | ✅ Accepted | 2026-08-22 | Reject Regex-Engine Swap for jq's l/n Flag Gaps (#920, #922)  |
+| [ADR-0020](adr-0020.md) | ✅ Accepted | 2026-09-01 | Evaluate User-Defined `def`s as Runtime Calls (#1371)         |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0020.md
+++ b/docs/adrs/adr-0020.md
@@ -1,0 +1,126 @@
+# ADR-0020: Evaluate User-Defined `def`s as Runtime Calls, Not Static Substitution (#1371)
+
+## Status
+
+✅ Accepted
+
+## Context
+
+`succinctly jq` evaluated `def name(params): body; then` by **statically substituting**
+every call to `name` with `body`, with `params` replaced by the call's argument
+expressions, before any evaluation began (`expand_func_calls`, `src/jq/eval.rs`). For a
+self-recursive `def` the substituted body always contains another syntactic call to the
+same name, and expansion cannot observe that a runtime condition (`n == 0`) will
+eventually hold — only evaluation can. Left unguarded it unrolled until the native stack
+overflowed.
+
+Three guards were added over time to bound that non-termination, each closing a hole the
+last one left:
+
+| guard | bounded | added by |
+|---|---|---|
+| `MAX_FUNC_EXPANSION_DEPTH` (50) | self-reference hits per occurrence | #1016 |
+| `MAX_FUNC_EXPANSION_CHAIN_DEPTH` (300) | live native stack during expansion | #1016 review |
+| `MAX_FUNC_EXPANSION_WEIGHTED_COST` (250,000) | hits weighted by body size | #1381 |
+
+They worked — a runaway `def` failed cleanly instead of aborting — but they bounded
+*expansion*, and expansion is charged for work a real run never performs. Four
+consequences, all confirmed live against jq 1.7.1:
+
+- **Ordinary recursion depth was unreachable.** `def sum_to(n): if n == 0 then 0 else n +
+  sum_to(n-1) end; sum_to(100)` failed; jq returns `5050`, and handles `sum_to(10000)`.
+- **Branching recursion failed at every depth, zero included.** Naive `fib` exhausted the
+  budget for `fib(2)` exactly as for `fib(1000)`, because expansion unrolled the `else`
+  arm it could not know a given input would never take.
+- **Arguments were substituted textually**, so a recursive call inlined the caller's own
+  argument tree at every level: the tree being walked grew with depth, making work and
+  native stack `O(d²)`. Measured against a spike that made expansion lazy but left
+  argument substitution alone: ~40 usable levels for a one-parameter `def`, and 8x the
+  stack bought only ~3x the depth (#2080).
+- **The model produced silently wrong values**, not only errors: expansion ran before
+  variable substitution, so a callee binder captured a caller's argument (#2077, fixed
+  separately by alpha-renaming — which this change makes unnecessary for arguments).
+
+## Decision
+
+Bind a call to its definition when the enclosing `def` is evaluated; substitute the body
+**per call**, when evaluation reaches the call site. Two AST nodes carry it:
+
+- **`Expr::DefCall { def: Rc<FuncDefData>, args, frames }`** — a call resolved to its
+  definition but not yet substituted. `install_def_calls` replaces each matching
+  `Expr::FuncCall` in `then` with one of these; `bind_def_call` does the substitution
+  later, when the node is evaluated, and re-installs the definition over the result so
+  the *next* level's self-calls are bound in turn. Recursion therefore stops where jq
+  stops it — at the base case the program itself evaluates — and a branch never taken
+  costs nothing.
+- **`Expr::Shared(Rc<Expr>)`** — an argument captured at call time, opaque to every
+  substitution pass and transparent to evaluation. This is what keeps recursion linear:
+  each level adds `O(1)` nodes over a pointer to the level before instead of inlining the
+  previous argument tree. It also gives hygiene for free — a pass that stops at a `Shared`
+  cannot reach inside an argument, so a callee's `3 as $x` cannot capture a caller's `$x`.
+
+Arguments are bound at *evaluation*, not at install time, for a reason that is easy to get
+wrong: a call site can sit inside a binder that has not run yet, so an argument captured
+during the install walk would never see that binder's substitution.
+
+The three expansion guards are replaced by one evaluation guard, `MAX_EVAL_FRAMES`
+(40,000), which counts **live native frames rather than calls** — `install_def_calls`
+charges one unit per structural level it descends and each call carries its parent's total
+forward. A call count cannot work here: it is not how many calls are outstanding that
+exhausts the stack but how much structure each holds live across its own recursive call.
+Measured at 256 MB, a body whose call sits in a pipe survives ~57,500 levels; one wrapping
+the same call in 40 array constructors dies between 4,000 and 8,000. Both crash at
+170,000–260,000 frames by this charge — within a factor of 1.5, where the raw depths differ
+by 10x.
+
+Evaluation runs on a thread with an explicitly sized stack (`EVAL_STACK_SIZE`,
+`main.rs`), since one live level costs ~4.4 KB (#2080) and the platform default of 8 MB
+would cap recursion below 1,000. The stack is **larger in debug builds** (2 GB against
+256 MB): an unoptimized frame is ~9x an optimized one, so a single stack size would force
+one frame ceiling to be either unsafe for the binary `cargo test` runs or far too tight
+for the one that ships. Scaling the stack with the profile lets one ceiling be correct for
+both, which also means the tests exercise the limit the shipped binary enforces.
+
+## Consequences
+
+**What now works, matching jq 1.7.1 byte for byte:** `sum_to(100)` → `5050`,
+`sum_to(10000)` → `50005000`, `fib` over `range(12)`, `deep(60)`, and #1381's three
+chained recursive `def`s (which previously needed 4+ GB before its own guard was added).
+
+**A non-terminating `def` still errors, and that divergence is deliberate.** `def deep:
+[deep]; deep` and `def f: [f, f]; f` exceed `MAX_EVAL_FRAMES` and raise a catchable error.
+Real jq dies on both with `cannot allocate memory`, exit 134 (confirmed live). Erroring
+instead is a divergence in the only direction ADR-0018 permits — matching would take the
+process down — and it is the property #1016 exists to preserve.
+
+**Deep recursion in a heavy body errors earlier than jq.** jq evaluates on a heap-allocated
+VM stack, so its depth does not depend on how much structure a body holds live; this
+evaluator recurses natively, so it does. The 40-array-constructor shape above stops at
+~900 levels where jq reaches 12,000+. Recorded in
+[docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
+
+**Recursion is quadratic in time — as it is in jq.** Both evaluate a call-by-name parameter
+afresh at each use, so a chain of depth `d` costs `O(d)` to read and `O(d²)` overall.
+Measured interleaved on the same machine: `sum_to(8000)` takes 10.8 s here against jq's
+4.3 s, the same complexity within a ~2.5x constant. Memoizing a parameter would break
+call-by-name and is not attempted.
+
+**A `Shared` stays lazy only when it wraps an argument the user wrote.** Routing a
+recursion's own argument chain through the demand-driven evaluator cost ~70x the native
+stack of the plain path — `sum_to` fell from ~20,000 levels to ~300 — and bought nothing,
+since an arithmetic chain is single-valued. A chain link is exactly an argument that
+already contains a `Shared`; those take the eager path, which the sink protocol guarantees
+is a missed optimization rather than a behaviour change. The laziness that *is* observable
+is kept: `isempty(def f(g): g; f(1, ("B"|stderr)))` stays silent, as in jq.
+
+**Deep values can now be built, and the output path had to stop asserting.** With recursion
+working, an ordinary filter reaches values nested past `MAX_VALUE_TREE_DEPTH` (384), where
+`JqValue::from_owned` panics. The CLI now converts through `try_from_owned` and reports an
+error instead — a filter a user typed must not abort the process (#1098). The panicking
+constructor remains for library callers that own their input. The same ceiling is still
+reachable as a panic through routes that do not involve `def` at all (`reduce range(400) as
+$x ([]; [.])`), which predates this change and is filed separately.
+
+**`resolve.rs` is unaffected.** It runs on the parsed program before evaluation, so it never
+sees either new node; both are given real arms rather than folded into a leaf group so that
+a future evaluation-time caller gets a compile error instead of silence.

--- a/docs/adrs/adr-0020.md
+++ b/docs/adrs/adr-0020.md
@@ -99,6 +99,22 @@ evaluator recurses natively, so it does. The 40-array-constructor shape above st
 ~900 levels where jq reaches 12,000+. Recorded in
 [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
 
+**A self-recursive comma generator streams thousands of elements, not indefinitely.**
+Every element the demand-driven evaluator (`eval_each`) pulls from `def naturals: 0,
+(naturals|.+1);`-shaped recursion is a genuinely deeper native call under that evaluator's
+own ~70x-native-stack-per-level sink design (the same cost the `Shared` split above exists
+to avoid where it can) — so the guard is catching a real native-stack cost here, not an
+overcounted one. `[limit(100000; naturals)]` errors where jq streams without limit. A real
+fix needs a trampolined or otherwise bounded-stack `eval_each`, out of this ADR's scope;
+recorded in [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
+
+**`MAX_EVAL_FRAMES` is only a guarantee behind the CLI's own dedicated stack.** The ceiling
+is calibrated against `EVAL_STACK_SIZE`, the 256 MB (release) / 2 GB (debug) stack
+`src/bin/succinctly/main.rs` reserves for evaluation. A library caller invoking
+`succinctly::jq::eval` on a thread of ordinary size does not get that guarantee and can
+still abort the process with a native stack overflow well under the ceiling. Recorded in
+[docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
+
 **Recursion is quadratic in time — as it is in jq.** Both evaluate a call-by-name parameter
 afresh at each use, so a chain of depth `d` costs `O(d)` to read and `O(d²)` overall.
 Measured interleaved on the same machine: `sum_to(8000)` takes 10.8 s here against jq's
@@ -108,10 +124,35 @@ call-by-name and is not attempted.
 **A `Shared` stays lazy only when it wraps an argument the user wrote.** Routing a
 recursion's own argument chain through the demand-driven evaluator cost ~70x the native
 stack of the plain path — `sum_to` fell from ~20,000 levels to ~300 — and bought nothing,
-since an arithmetic chain is single-valued. A chain link is exactly an argument that
-already contains a `Shared`; those take the eager path, which the sink protocol guarantees
-is a missed optimization rather than a behaviour change. The laziness that *is* observable
-is kept: `isempty(def f(g): g; f(1, ("B"|stderr)))` stays silent, as in jq.
+since an arithmetic chain is single-valued. A genuine chain link is an *operator* applied
+around a `Shared` (`Shared(prev) - 1`); those take the eager path. A bare pass-through —
+`inner` is itself directly a `Shared`, an ordinary parameter threaded unchanged through
+another level of recursion rather than a computed link — is peeled one layer at a time
+through the same lazy path instead, since it can wrap arbitrary user code underneath
+(multi-valued, infinite, or side-effecting). An earlier version of this split treated any
+nested `Shared` as proof of a settled single value, which took the eager path for a
+threaded parameter too: `first(f(3; (1, (2|debug))))` printed `DEBUG:` before jq's answer,
+and a threaded `repeat(...)` argument re-ran up to 1,000x. The laziness that *is*
+observable is kept: `isempty(def f(g): g; f(1, ("B"|stderr)))` stays silent, as in jq.
+
+**A call embedded in an already-installed sibling call's arguments is now installed too.**
+`install_def_calls`'s `DefCall` arm used to treat `args` as fully opaque on the reasoning
+that they were "installed when the node was created" — true only with respect to the `def`
+that created it, not a different `def` whose own install pass walks over the same tree
+afterward. `def g(m): m + 1; def f(n): if n == 0 then 0 else g(f(n-1)) end; f(3)` left the
+nested `f(n-1)` a bare, uninstalled `FuncCall` forever, which `eval_func_call` rejected as
+undefined. Fixed by recursing into `args` there too, matching `substitute_func_param`'s and
+`substitute_var_impl`'s own `DefCall` arms, which already did.
+
+**`MAX_EVAL_FRAMES` now composes across independently-recursing `def`s.** A `DefCall`'s
+`frames` field used to be fixed once, at whatever (usually shallow) structural depth its
+owning `def` sat at when originally installed, and never updated afterward. A different,
+independently-recursive `def` whose own deep recursion embeds that call in its base case
+walked over the stale node without raising its charge — so each `def`'s own guard could
+pass individually while their real native stacks summed past what either alone was
+calibrated safe for. `frames` is now refreshed to the larger of its stale value and the
+ambient depth each subsequent install pass finds it at, so a composed call is charged for
+the real depth it will actually run at, not the depth it was first written at.
 
 **Deep values can now be built, and the output path had to stop asserting.** With recursion
 working, an ordinary filter reaches values nested past `MAX_VALUE_TREE_DEPTH` (384), where

--- a/docs/adrs/adr-0020.md
+++ b/docs/adrs/adr-0020.md
@@ -121,6 +121,21 @@ constructor remains for library callers that own their input. The same ceiling i
 reachable as a panic through routes that do not involve `def` at all (`reduce range(400) as
 $x ([]; [.])`), which predates this change and is filed separately.
 
+**Binding is memoized per call site, which is what keeps ordinary `def` usage from
+regressing.** Moving substitution from "once, before evaluation" to "at the call" charges
+it per call, and a `def` used inside `.[]` over 200,000 elements re-substituted its body
+200,000 times: measured interleaved against the pre-change binary, +7.8% for one call per
+element and +26.7% for three chained definitions. A bound body is a pure function of its
+node, so `BoundBody` computes it once and reuses it; the same measurement then reads
+0.996x and 0.978x, with byte-identical output. Recursion is unaffected — each level
+installs its own fresh nodes, so each level still binds once. The two substitution passes
+rebuild a call's arguments and therefore reset the cache; every other path carries
+arguments through unchanged and keeps it.
+
+The six queries the Perf Regression Guard tracks contain no `def` at all, so none of this
+is visible to it either way; the measurement above was run because the guard would not
+have caught it.
+
 **`resolve.rs` is unaffected.** It runs on the parsed program before evaluation, so it never
 sees either new node; both are given real arms rather than folded into a leaf group so that
 a future evaluation-time caller gets a compile error instead of silence.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1439,6 +1439,44 @@ yq has no `def` at all — its lexer rejects `def f: 42; f` outright — so succ
 support there is an extension (ADR-0018 rule 5) rather than a behaviour with a reference to
 match.
 
+## Recursive `def`s: what a native call stack costs that jq's own does not — #1371
+
+`succinctly jq` used to substitute a `def`'s body into each call site before evaluating
+anything, which cannot terminate for a self-recursive `def` (expansion has no way to see
+that `n == 0` will eventually hold) and so had to be bounded by three guards. The
+consequence was not a deep-recursion edge case: `sum_to(100)` was refused where jq returns
+`5050`, and a *branching* body — naive `fib` — failed at every depth including zero,
+because expansion unrolled the `else` arm it could not know a given input would never take.
+
+[#1371](https://github.com/rust-works/succinctly/issues/1371) replaced that with real
+runtime calls (ADR-0020): a call is bound to its definition when the `def` is evaluated and
+substituted when evaluation reaches it, with each argument captured behind a shared,
+substitution-opaque node. Recursion now stops at the base case the program itself
+evaluates. `sum_to(100)`, `sum_to(10000)`, `fib`, and #1381's chained-`def` repro all match
+jq 1.7.1 byte for byte.
+
+Three differences remain, all in the direction of erroring rather than aborting:
+
+- **A non-terminating `def` errors; jq dies.** `def deep: [deep]; deep` and `def f: [f, f];
+  f` exceed `MAX_EVAL_FRAMES` and raise a catchable error, exit 5. Real jq aborts on both
+  with `cannot allocate memory` and exit 134 (confirmed live). Divergence in the only
+  direction ADR-0018 permits: matching would take the process down.
+- **A heavy body runs out of depth sooner than jq's does.** jq evaluates on a
+  heap-allocated VM stack, so its recursion depth is unaffected by how much structure a
+  body holds live across its own recursive call; this evaluator recurses natively, so it is
+  not. A body wrapping its call in 40 array constructors stops at ~900 levels where jq
+  reaches 12,000+. The ceiling counts live frames rather than calls precisely because the
+  two differ by 10x across body shapes — see `MAX_EVAL_FRAMES` (`src/jq/eval.rs`).
+- **A recursively-built value can exceed `MAX_VALUE_TREE_DEPTH` (384) where jq has no such
+  limit.** `def deep(m): if m == 0 then . else [[…]]deep(m-1)[[…]] end; deep(60)` builds
+  1,200 levels; jq prints it, succinctly reports `nesting depth exceeds limit of 384` and
+  exits 5. Before #1371 this shape could not recurse far enough to reach the ceiling at
+  all.
+
+Recursion is quadratic in time in both tools — a call-by-name parameter is re-evaluated at
+each use, so reading one at depth `d` costs `O(d)`. Measured interleaved on one machine,
+`sum_to(8000)` is 10.8 s here against jq's 4.3 s: same complexity, ~2.5x constant.
+
 ## `input`/`inputs` residuals after #1309
 
 [#1309](https://github.com/rust-works/succinctly/issues/1309) closed four of the five gaps

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1472,10 +1472,29 @@ Three differences remain, all in the direction of erroring rather than aborting:
   1,200 levels; jq prints it, succinctly reports `nesting depth exceeds limit of 384` and
   exits 5. Before #1371 this shape could not recurse far enough to reach the ceiling at
   all.
+- **A self-recursive comma generator streams for thousands of elements, not
+  indefinitely.** `def naturals: 0, (naturals|.+1); [limit(100000; naturals)]` errors
+  (`naturals/0 exceeded maximum recursion depth`) somewhere between 10,000 and 20,000
+  pulled elements; jq streams it without limit. Every element the demand-driven evaluator
+  (`eval_each`) pulls from a self-recursive generator is a genuinely deeper native call —
+  that evaluator's own sink-based, non-tail-recursive design measures at ~70x the native
+  stack per level that the plain evaluator's does (see `Expr::Shared`'s doc comment,
+  `src/jq/eval.rs`) — so the guard is catching a real, not merely counted, native-stack
+  cost. Fixing this needs a trampolined or otherwise bounded-stack `eval_each`, not an
+  accounting change; tracked separately as a future architectural improvement, not part of
+  #1371's scope.
 
 Recursion is quadratic in time in both tools — a call-by-name parameter is re-evaluated at
 each use, so reading one at depth `d` costs `O(d)`. Measured interleaved on one machine,
 `sum_to(8000)` is 10.8 s here against jq's 4.3 s: same complexity, ~2.5x constant.
+
+`MAX_EVAL_FRAMES`'s ceiling is calibrated against the 256 MB (release) / 2 GB (debug)
+stack the CLI reserves for evaluation (`EVAL_STACK_SIZE`, `src/bin/succinctly/main.rs`).
+A library caller invoking `succinctly::jq::eval` directly, on a thread sized for anything
+smaller, does not get that guarantee — the same recursion that errors cleanly under the CLI
+can still abort the process with a native stack overflow on an ordinary (e.g. default 8 MB)
+thread. Callers embedding this crate and expecting to run recursive `def`s at any real depth
+should evaluate on a thread reserved at a comparable size.
 
 ## `input`/`inputs` residuals after #1309
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4260,6 +4260,30 @@ fn evaluate_bytes_lazy<'a>(
 ///
 /// This is similar to query_result_to_jq_values but works with the
 /// cursor-aware GenericResult type from eval_generic.
+/// Convert one materialized value for output, reporting an over-deep one as
+/// an ordinary error rather than letting it panic (#1371).
+///
+/// `JqValue::from_owned` asserts past `MAX_VALUE_TREE_DEPTH` (384), which is
+/// a reasonable contract for a library caller that owns its input and a very
+/// unreasonable one here: with `def` now recursing by evaluation rather than
+/// by pre-substituted body, an ordinary recursive filter can build a value
+/// deeper than that ceiling, and a filter a user typed must not be able to
+/// abort the process (#1098). Returns no values on failure, having reported
+/// the error, exactly as every other erroring arm around it does.
+fn to_jq_values<'a, W: Clone + AsRef<[u64]>>(
+    value: OwnedValue,
+    at: &InputLocation,
+    sink: &mut ErrorSink,
+) -> Vec<JqValue<'a, W>> {
+    match JqValue::try_from_owned(value) {
+        Ok(v) => vec![v],
+        Err(e) => {
+            sink.report(DiagStyle::Jq, &e, at);
+            Vec::new()
+        }
+    }
+}
+
 fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
     result: GenericResult<StandardJson<'a, W>>,
     cursor: JsonCursor<'a, W>,
@@ -4324,9 +4348,11 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         } => match effective_keys(&fields, collapse) {
             Ok(mut keys) => {
                 keys.sort();
-                vec![JqValue::from_owned(OwnedValue::Array(
-                    keys.into_iter().map(OwnedValue::String).collect(),
-                ))]
+                to_jq_values(
+                    OwnedValue::Array(keys.into_iter().map(OwnedValue::String).collect()),
+                    at,
+                    sink,
+                )
             }
             Err(e) => {
                 sink.report(DiagStyle::Jq, &e, at);
@@ -4343,7 +4369,7 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         // wrapping via `from_owned` reuses the existing `write_json` path
         // entirely.
         GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-            Ok(v) => vec![JqValue::from_owned(v)],
+            Ok(v) => to_jq_values(v, at, sink),
             Err(jq::Control::Error(e)) => {
                 sink.report(DiagStyle::Jq, &e, at);
                 vec![]
@@ -4362,8 +4388,11 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             sink.report(DiagStyle::Jq, &e, at);
             vec![]
         }
-        GenericResult::Owned(v) => vec![JqValue::from_owned(v)],
-        GenericResult::ManyOwned(vs) => vs.into_iter().map(JqValue::from_owned).collect(),
+        GenericResult::Owned(v) => to_jq_values(v, at, sink),
+        GenericResult::ManyOwned(vs) => vs
+            .into_iter()
+            .flat_map(|v| to_jq_values(v, at, sink))
+            .collect(),
         GenericResult::Break(label) => {
             sink.report_break(DiagStyle::Jq, &label, at);
             vec![]

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4405,18 +4405,28 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
             vec![]
         }
         // The outputs already produced no longer vanish behind the failure
-        // (#400, #494).
+        // (#400, #494). Each one still goes through the checked
+        // `to_jq_values`, not `JqValue::from_owned` directly -- these can be
+        // built by an ordinary recursive `def` now (#1371), so an
+        // over-deep one must report cleanly rather than panic, same as
+        // every other arm in this function (see `to_jq_values`'s own doc).
         GenericResult::Partial(vs, jq::Control::Error(e)) => {
             sink.report(DiagStyle::Jq, &e, at);
-            vs.into_iter().map(JqValue::from_owned).collect()
+            vs.into_iter()
+                .flat_map(|v| to_jq_values(v, at, sink))
+                .collect()
         }
         GenericResult::Partial(vs, jq::Control::Break(label)) => {
             sink.report_break(DiagStyle::Jq, &label, at);
-            vs.into_iter().map(JqValue::from_owned).collect()
+            vs.into_iter()
+                .flat_map(|v| to_jq_values(v, at, sink))
+                .collect()
         }
         GenericResult::Partial(vs, jq::Control::Halt(code)) => {
             sink.request_halt(code);
-            vs.into_iter().map(JqValue::from_owned).collect()
+            vs.into_iter()
+                .flat_map(|v| to_jq_values(v, at, sink))
+                .collect()
         }
     }
 }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -6062,6 +6062,33 @@ mod tests {
         assert!(!should_force_read_under_null_input(true, true, true, true));
     }
 
+    /// #1371: `rewrite_namespaced_calls` runs once, on the freshly parsed
+    /// program, strictly before evaluation ever builds an `Expr::Shared` or
+    /// `Expr::DefCall` -- so this pass can never actually receive one from
+    /// its real caller. Named rather than wildcarded (see the arm's own
+    /// comment), so exercised directly here: each node must come back
+    /// unchanged, not e.g. have its nested args silently dropped or
+    /// rewritten as if it were some other variant.
+    #[test]
+    fn test_rewrite_namespaced_calls_passes_through_shared_and_defcall_1371() {
+        use std::rc::Rc;
+
+        let shared = Expr::Shared(Rc::new(Expr::Identity));
+        assert_eq!(rewrite_namespaced_calls(shared.clone()), shared);
+
+        let def_call = Expr::DefCall {
+            def: Rc::new(jq::FuncDefData {
+                name: "f".to_string(),
+                params: Vec::new(),
+                body: Expr::Identity,
+            }),
+            args: vec![Expr::Literal(jq::Literal::Int(1))],
+            frames: 3,
+            bound: jq::BoundBody::default(),
+        };
+        assert_eq!(rewrite_namespaced_calls(def_call.clone()), def_call);
+    }
+
     /// #1154: direct unit coverage for the extracted token-boundary
     /// finder, independent of the CLI-level `--argjson` tests (which
     /// already cover `normalize_leading_zero_numbers`'s end-to-end

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -204,6 +204,11 @@ impl ModuleLoader {
 /// by transforming `namespace::func(args)` to `namespace::func(args)` as a regular call
 fn rewrite_namespaced_calls(expr: Expr) -> Expr {
     match expr {
+        // #1371: parse-time only, so neither can occur -- both are built by
+        // evaluation, which happens after this rewrite. Named rather than
+        // wildcarded so a future evaluation-time caller gets a compile error
+        // here instead of silently keeping a `NamespacedCall` inside one.
+        Expr::Shared(_) | Expr::DefCall { .. } => expr,
         Expr::NamespacedCall {
             namespace,
             name,

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1328,7 +1328,45 @@ fn try_multicall() -> Result<Option<i32>> {
     }
 }
 
+/// Native stack given to the thread every command actually runs on
+/// (#1371).
+///
+/// A user-defined `def` now recurses by real evaluation rather than by
+/// pre-substituting its own body, so recursion depth is bounded by native
+/// stack instead of by a substitution budget. One live call level costs
+/// ~4.4 KB, measured (#2080) by bisecting the deepest working recursion at
+/// two stack sizes an 8x multiple apart -- 4406 B/level at 8 MB and 4381
+/// B/level at 64 MB, agreeing to within 0.6%, so the cost is linear in depth
+/// and this size converts directly into a depth.
+///
+/// 256 MB carries `MAX_CALL_DEPTH`'s 10,000 levels (~44 MB for the shape
+/// measured) with room for bodies far heavier than that one, on a platform
+/// whose *default* main-thread stack is 8 MB and would cap the same
+/// recursion below 1,000. It is reserved address space, not committed
+/// memory: pages are faulted in only as the stack is actually used, so a
+/// filter that never recurses pays nothing for it.
+///
+/// Applied here, at the single point every subcommand passes through, rather
+/// than around `run_jq` alone -- `yq` shares the same evaluator, and the
+/// alternative is one wrapper per command that each has to remember.
+const EVAL_STACK_SIZE: usize = 256 * 1024 * 1024;
+
 fn main() -> Result<()> {
+    // Run everything on a thread with an explicitly sized stack, then
+    // propagate its result. A panic in the child is resumed here rather than
+    // swallowed, so panic behaviour (and the abort/backtrace a panic produces)
+    // is exactly what it was when this ran on the main thread.
+    let child = std::thread::Builder::new()
+        .stack_size(EVAL_STACK_SIZE)
+        .spawn(run_main)
+        .expect("failed to spawn the evaluation thread");
+    match child.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+fn run_main() -> Result<()> {
     // Multi-call binary: check if invoked via a known alias name (e.g., sjq, syq)
     if let Some(exit_code) = try_multicall()? {
         std::process::exit(exit_code);

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1339,8 +1339,9 @@ fn try_multicall() -> Result<Option<i32>> {
 /// B/level at 64 MB, agreeing to within 0.6%, so the cost is linear in depth
 /// and this size converts directly into a depth.
 ///
-/// 256 MB carries `MAX_CALL_DEPTH`'s 10,000 levels (~44 MB for the shape
-/// measured) with room for bodies far heavier than that one, on a platform
+/// 256 MB carries `MAX_EVAL_FRAMES`'s ~13,000 levels for a `sum_to`-shaped
+/// body (~57 MB at this per-level cost) with room for bodies far heavier
+/// than that one, on a platform
 /// whose *default* main-thread stack is 8 MB and would cap the same
 /// recursion below 1,000. It is reserved address space, not committed
 /// memory: pages are faulted in only as the stack is actually used, so a

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1349,7 +1349,22 @@ fn try_multicall() -> Result<Option<i32>> {
 /// Applied here, at the single point every subcommand passes through, rather
 /// than around `run_jq` alone -- `yq` shares the same evaluator, and the
 /// alternative is one wrapper per command that each has to remember.
-const EVAL_STACK_SIZE: usize = 256 * 1024 * 1024;
+///
+/// **Bigger in a debug build, deliberately.** An unoptimized frame for the
+/// same evaluator is ~9x the size of an optimized one -- measured at the same
+/// stack, a recursion that survives ~57,500 levels in release dies at ~6,250
+/// in debug. A single stack size would therefore mean `MAX_EVAL_FRAMES` had
+/// to be calibrated for debug and would then cap release far below what its
+/// stack could carry, or be calibrated for release and abort the debug
+/// binary -- which is what `cargo test` and CI actually run. Scaling the
+/// stack with the profile instead keeps *one* frame ceiling correct for both,
+/// so the tests exercise the same limit the shipped binary enforces. Reserved
+/// address space either way: pages are faulted in only as used.
+const EVAL_STACK_SIZE: usize = if cfg!(debug_assertions) {
+    2 * 1024 * 1024 * 1024
+} else {
+    256 * 1024 * 1024
+};
 
 fn main() -> Result<()> {
     // Run everything on a thread with an explicitly sized stack, then

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34,8 +34,6 @@ use alloc::rc::Rc;
 #[cfg(test)]
 use std::rc::Rc;
 
-use core::cell::Cell;
-
 use indexmap::IndexMap;
 
 use super::document::{
@@ -300,8 +298,8 @@ impl EvalSemantics for YqSemantics {
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 
 use super::expr::{
-    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Literal, MergeFlags, NumberKey,
-    ObjectEntry, ObjectKey, Pattern, PatternEntry, StringPart,
+    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefData, Literal, MergeFlags,
+    NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, StringPart,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -867,6 +865,20 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // as a known gap rather than paying for a full
         // `expand_func_calls` just to answer this routing question.
         Expr::FuncDef { body, then, .. } => needs_path_context(body) || needs_path_context(then),
+        // #1371: same reasoning as `FuncDef` above, one step further along.
+        // By the time a call has been bound, the definition is reachable from
+        // the node itself, so the "does `then` ever call `name`" guess that
+        // arm has to make is not needed here -- the body genuinely runs, and
+        // its arguments genuinely run in the caller's own position. This also
+        // closes that arm's documented gap for bound calls: a path-context
+        // builtin passed *as an argument* (`def f(x): x; .a | f(key)`) is
+        // visible here, because `args` are right there.
+        Expr::DefCall { def, args, .. } => {
+            needs_path_context(&def.body) || args.iter().any(needs_path_context)
+        }
+        // Transparent: a `Shared` is its inner expression as far as
+        // evaluation -- and therefore routing -- is concerned.
+        Expr::Shared(inner) => needs_path_context(inner),
         // `EXPR as $v | body` (#1663): neither `expr` nor `body` navigate
         // away from the caller's own position -- `eval_as` evaluates both
         // against the same `value` -- so a `key`/`parent`/`file_index`
@@ -1284,6 +1296,19 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             then,
         } => eval_func_def::<W, S>(name, params, body, then, value, optional),
         Expr::FuncCall { name, args } => eval_func_call::<W>(name, args, value, optional),
+
+        // #1371: a call already bound to its definition. Unlike `FuncCall`
+        // above (which only ever errors, since an unbound call is a compile
+        // error `resolve.rs` rejects earlier), this is where a user-defined
+        // function actually runs.
+        Expr::DefCall { def, args, frames } => {
+            eval_def_call::<W, S>(def, args, *frames, value, optional)
+        }
+
+        // #1371: an argument captured at call time. Transparent to
+        // evaluation -- it is the substitution passes, not this one, that
+        // must treat it as opaque.
+        Expr::Shared(inner) => eval_single::<W, S>(inner, value, optional),
         Expr::NamespacedCall {
             namespace,
             name,
@@ -3367,9 +3392,23 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             body,
             then,
         } => {
-            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
-            eval_each::<W, S>(&expanded_then, value, optional, sink)
+            let bound_then = bind_def(name, params, body, then);
+            eval_each::<W, S>(&bound_then, value, optional, sink)
         }
+
+        // #1371: a bound call needs its own arm here for the same reason the
+        // `FuncDef` arm above exists -- without one it falls to the generic
+        // `drain_result` fallback, which materializes the whole body before a
+        // wrapping consumer can say it has seen enough. That is observable,
+        // not just slower: `isempty(def f: (1, ("B"|stderr)); f)` printed `B`
+        // where jq prints nothing, because the second branch ran after the
+        // answer was already known.
+        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
+            Ok(bound) => eval_each::<W, S>(&bound, value, optional, sink),
+            Err(e) => Flow::Escaped(Control::Error(e)),
+        },
+        // Transparent, so the wrapped argument's own laziness survives.
+        Expr::Shared(inner) => eval_each::<W, S>(inner, value, optional, sink),
 
         // #1462 (Stage 5): demand-forwarding through a nested consumer.
         // `each_take_n` (Stage 2) already stops asking `expr` for more once
@@ -20471,6 +20510,26 @@ fn resolve_node<'a, S: EvalSemantics>(
         Expr::Pipe(exprs) => resolve_seq::<S>(exprs, value, trackable, snapshot),
         Expr::Paren(inner) => resolve_node::<S>(inner, value, trackable, snapshot),
 
+        // #1371: `path(f)` has to see *through* a call to whatever its body
+        // navigates, exactly as it did when the body was substituted in
+        // before evaluation began. Binding the call here and resolving the
+        // result keeps that: `def f: .[1.5:3.5]; path(f)` reports the slice,
+        // not "invalid path expression" for an opaque call node.
+        //
+        // The depth guard's error is surfaced as a path-resolution failure
+        // with no branches, the same shape every other erroring arm here
+        // uses -- a runaway recursion inside `path()` must not be able to
+        // exhaust the stack just because it is being resolved rather than
+        // evaluated.
+        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
+            Ok(bound) => resolve_node::<S>(&bound, value, trackable, snapshot),
+            Err(e) => Err((Vec::new(), e.into())),
+        },
+        // Transparent, like `Paren`: the wrapped argument is ordinary code
+        // whose own navigation is exactly as trackable here as it would be
+        // written out in place.
+        Expr::Shared(inner) => resolve_node::<S>(inner, value, trackable, snapshot),
+
         Expr::Comma(exprs) => {
             let mut out = Vec::new();
             for e in exprs {
@@ -25289,6 +25348,28 @@ fn substitute_var_impl(
     mark_trackable: bool,
 ) -> Expr {
     match expr {
+        // #1371: opaque, in both directions. A `Shared` holds an argument the
+        // caller had already fully substituted before the call ran, so there
+        // is nothing here to substitute -- and reaching inside it is exactly
+        // the capture #2077 fixed: a binder in the callee (`3 as $x`) must
+        // not rewrite a `$x` the *caller* wrote in an argument. Descending
+        // would also re-walk every argument from every level below on each
+        // binding, which is the O(depth^2) traversal this design removes.
+        Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
+        // A `DefCall`'s arguments are ordinary caller-scope code and must
+        // stay reachable: the call site can sit inside an `as` that has not
+        // been evaluated yet, so this is the pass that binds `$x` in
+        // `1 as $x | f($x)`. The definition itself is not descended into --
+        // it was captured with every variable in scope at its own definition
+        // site already substituted, and its body is a fresh scope per call.
+        Expr::DefCall { def, args, frames } => Expr::DefCall {
+            def: Rc::clone(def),
+            args: args
+                .iter()
+                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
+                .collect(),
+            frames: *frames,
+        },
         Expr::Var(name) if name == var_name => {
             if mark_trackable {
                 Expr::TrackedVar(Rc::new(replacement.clone()))
@@ -30613,6 +30694,43 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // result *is* this arm's result, with nothing wrapping it) -- it's
         // a simple delegation, the same shape as the `Paren` arm above,
         // which also threads `optional` straight through unchanged.
+        // #1371: a bound call, in the evaluator that keeps `key`/`parent`/
+        // `file_index` and `path()` working. The generic `_` fallback below
+        // would evaluate it correctly but *without* path context, so
+        // `path(f)` over a `def` whose body navigates would report the call
+        // as an untrackable leaf rather than seeing through to the
+        // navigation. Binding here and continuing in this same evaluator is
+        // what the `FuncDef` arm just below already does one step earlier.
+        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
+            Err(e) => QueryResult::Error(e),
+            Ok(bound) => {
+                let mut stages = vec![bound];
+                stages.extend(rest.iter().cloned());
+                eval_pipe_with_path_context_internal::<W, S>(
+                    &stages,
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                )
+            }
+        },
+        // Transparent, for the same reason it is transparent to evaluation:
+        // the argument this wraps is ordinary code, and it must keep the
+        // caller's own path context when it runs.
+        Expr::Shared(inner) => {
+            let mut stages = vec![(**inner).clone()];
+            stages.extend(rest.iter().cloned());
+            eval_pipe_with_path_context_internal::<W, S>(
+                &stages,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
         Expr::FuncDef {
             name,
             params,
@@ -30622,8 +30740,8 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
-            let mut then_stages = vec![expanded_then];
+            let bound_then = bind_def(name, params, body, then);
+            let mut then_stages = vec![bound_then];
             if paired {
                 then_stages.push(path_probe_stage());
             }
@@ -39801,10 +39919,22 @@ fn dedup_keep_last_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, 
         .collect()
 }
 
-/// Evaluate function definition: `def name(params): body; then`.
+/// Evaluate `def name(params): body; then` (#1371).
 ///
-/// In jq, function definitions are scoped - the function is available in `then`.
-/// We implement this by substituting function calls with the body (with args substituted).
+/// Binds every call to this definition inside `then` — replacing each
+/// `Expr::FuncCall` with an `Expr::DefCall` that carries the definition —
+/// and then evaluates `then`. It does **not** substitute the body anywhere;
+/// that happens per call, in [`eval_def_call`], when evaluation reaches the
+/// call site.
+///
+/// The previous model substituted here instead, before any evaluation, which
+/// could not terminate for a self-recursive `def`: the substituted body
+/// always contains another syntactic call to the same name, and expansion
+/// cannot observe that a runtime condition (`n == 0`) will eventually hold.
+/// Three guards (`MAX_FUNC_EXPANSION_DEPTH`, `..._CHAIN_DEPTH`,
+/// `..._WEIGHTED_COST`) existed only to bound that non-termination, and are
+/// gone: recursion now stops where jq stops it, at the base case the program
+/// itself evaluates.
 fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     name: &str,
     params: &[String],
@@ -39813,247 +39943,109 @@ fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Substitute all calls to this function in `then` with the body
-    let expanded_then = expand_func_calls(then, name, params, body, None, 0);
-    eval_single::<W, S>(&expanded_then, value, optional)
+    let bound_then = bind_def(name, params, body, then);
+    eval_single::<W, S>(&bound_then, value, optional)
 }
 
-/// Caps how many times [`expand_func_calls`] will re-enter its own
-/// `FuncCall` self-reference arm while inlining one `def` (#1016).
+/// Install `def name(params): body` over `then`, the shared first half of
+/// every `Expr::FuncDef` evaluation arm (#1371).
 ///
-/// `succinctly jq` evaluates `def name(params): body; then` by statically
-/// substituting each call to `name` with `body` (with `params` replaced by
-/// the call's arguments) -- entirely before any evaluation happens. For a
-/// self-recursive `def` (e.g. `def deep(n): if n == 0 then . else
-/// [deep(n-1)] end;`), the substituted `body` always contains another
-/// syntactic call to `name`, since expansion can't observe that a runtime
-/// condition like `n == 0` will eventually hold -- only real evaluation
-/// (which hasn't happened yet) could. Left unguarded, this unrolls forever
-/// and overflows the native stack; confirmed live (`def deep(n): if n == 0
-/// then . else [deep(n-1)] end; deep(1)` crashes with SIGABRT even at the
-/// shallowest possible depth, since expansion never terminates on its own).
-///
-/// **This does not, and cannot, match real jq's usable recursion depth.**
-/// jq evaluates function calls at runtime rather than expanding them
-/// statically, so a self-recursive `def` there costs one interpreter frame
-/// per call and works up to jq's own memory limits (confirmed live against
-/// jq 1.7.1: this issue's own `deep(n)` repro returns cleanly through at
-/// least `n = 10_000`). `expand_func_calls`'s substitution has a much
-/// steeper native-stack cost per level -- confirmed empirically (debug
-/// build, default thread stack, this crate's usual methodology for `MAX_*`
-/// ceilings) across several `def` shapes (1, 2, and 4 parameters; plain
-/// arithmetic and string/array/object bodies): even the *cheapest possible*
-/// case (a zero-argument `def deep: [deep]; deep`) crashes at only ~383
-/// levels, and every parameterized shape tested crashed between ~189 and
-/// ~192 -- each unrolling re-substitutes the *entire* argument expression
-/// from the level before into a fresh clone of `body`, so the tree being
-/// walked keeps growing with depth, unlike jq's own runtime call. Genuinely
-/// matching jq's depth needs a different evaluation strategy for self-
-/// recursive `def`s (real runtime calls, not static substitution) -- a
-/// real architectural change, filed separately as #1371, not this guard.
-///
-/// Picked with a wide safety margin below every crash observed above (the
-/// lowest was ~189) precisely because that margin has to absorb `def`
-/// bodies more expensive than anything tested here, not because legitimate
-/// use is expected to need this many levels. A `def` recursing deeper than
-/// this now gets a clean, catchable error -- worse than jq's own result
-/// (which would still succeed) but strictly better than a SIGABRT that
-/// takes the whole process down; see #1016 and #1371 for that gap.
-///
-/// **This counts total substitutions within one occurrence's own
-/// resolution, not nesting depth along one chain -- and not globally
-/// across the whole expansion either.** Two earlier versions of this guard
-/// each had a real bug code review caught:
-///
-/// - A plain per-call-chain `depth: usize`, incremented only along the
-///   single path from one self-call to the next, is defeated entirely by a
-///   `def` body with more than one syntactic self-call (e.g. `def f: [f,
-///   f]; f`, or an everyday naive `def fib(n): if n < 2 then n else
-///   fib(n-1) + fib(n-2) end;`): every structural arm visiting more than
-///   one child (`Comma`, arithmetic's `left`/`right`, an `if`'s
-///   `then`/`else`, etc.) passes the *same* depth to each child, so `k`
-///   self-calls per body level compound to `O(k^depth)` total
-///   substitutions even though no single chain exceeds the cap. Confirmed
-///   live: `def f: [f, f]; f` consumed tens of GB and never terminated.
-/// - Fixing that by sharing *one* counter across the *entire* expansion
-///   (one `Cell` per call to [`expand_func_calls`] from
-///   [`eval_func_def`]) stops the blowup above, but starves every later,
-///   syntactically-independent call to the same function once an earlier
-///   one has consumed the budget -- confirmed live, `[fact(3), fact(4),
-///   fact(5)]` failed even though each call alone succeeds trivially, and
-///   real jq returns `[6,24,120]`.
-///
-/// The counter this guard actually uses is scoped per *occurrence*: a
-/// `FuncCall` reached by ordinary structural descent through code that is
-/// *not* itself generated by resolving some earlier occurrence (an
-/// independent, originally-distinct call the user wrote) gets its own
-/// fresh counter (`budget: Option<&Cell<(usize, Option<usize>)>>` is `None` on the way in).
-/// A `FuncCall` found *while already resolving* an earlier occurrence's own
-/// substituted body or arguments -- a genuine self-reference within that
-/// resolution, e.g. the two `f`s inside `def f: [f, f]; f`'s own body --
-/// keeps sharing that occurrence's counter (`budget` is `Some(cell)`).
-/// This bounds total work for branching self-recursion (the first bug
-/// above) without cross-contaminating unrelated sibling calls (the second).
-///
-/// One consequence of counting total work instead of path depth: for a
-/// `def` whose body has more than one self-call, expansion exhausts the
-/// budget regardless of how shallow the real runtime recursion needed for
-/// a given input actually is -- `fib(0)` hits this ceiling exactly the same
-/// as `fib(1000)`, since expansion never evaluates `n < 2` and so can't
-/// stop unrolling the `else` branch just because a real run would take the
-/// `then` branch instead. Only a `def` with exactly one self-call per body
-/// (the shape #1016's own repro uses) gets the "shallow succeeds, only
-/// truly deep recursion errors" behavior the rest of this doc comment
-/// describes; a branching `def` always errors, at any depth. Making
-/// branching self-recursive `def`s work at all is exactly the runtime-call
-/// architecture #1371 tracks -- this guard's job is only to make the
-/// failure clean and bounded, for every shape, not to make any shape work.
-///
-/// **Also known to not close**: chaining several small recursive `def`s,
-/// each calling the previous one as its base case (e.g. `def r0(n): ...;
-/// def r1(n): if n==0 then r0(n) else [r1(n-1)] end; def r2(n): if n==0
-/// then r1(n) else [r2(n-1)] end; r2(45)`), still causes unbounded memory
-/// blowup (multiple GB, confirmed live) -- `r1`'s own expansion clones a
-/// `body` that already embeds `r0`'s full ~50-node expansion, so `r1`'s own
-/// budget-bounded substitutions multiply that size rather than bounding it,
-/// and each further chained `def` repeats the multiplication. Neither
-/// `budget` (bounds hit *count*) nor `chain_depth` (bounds live *stack*
-/// depth, which stays modest for this breadth-wise, not depth-wise, blowup)
-/// catches it. Pre-existing on `main` (crashes there too, via SIGABRT
-/// instead), not introduced by this guard; tracked separately as #1381.
-const MAX_FUNC_EXPANSION_DEPTH: usize = 50;
+/// Four evaluators have their own `FuncDef` arm — the plain one, the
+/// demand-driven `eval_each`, the path-context one, and `eval_generic`'s —
+/// and all four need exactly this before continuing into their own
+/// evaluation of `then`.
+pub(crate) fn bind_def(name: &str, params: &[String], body: &Expr, then: &Expr) -> Expr {
+    let def = Rc::new(FuncDefData {
+        name: name.to_string(),
+        params: params.to_vec(),
+        body: body.clone(),
+    });
+    install_def_calls(then, &def, 0)
+}
 
-/// Caps `chain_depth` in [`expand_func_calls`]/[`expand_func_calls_in_builtin`]
-/// -- a plain, per-call-chain `usize` incremented on *every* recursive call
-/// in either function, not just `FuncCall` self-reference hits, bounding
-/// native stack usage directly rather than counting substitutions.
+/// How deep a user-defined function may recurse before evaluation gives up
+/// (#1371).
 ///
-/// `MAX_FUNC_EXPANSION_DEPTH`'s `budget` bounds *how many self-references*
-/// one occurrence's resolution performs, which is the right guard against
-/// runaway *work* (memory, time) -- but it says nothing about how much
-/// *native stack* each one of those self-references costs to reach, which
-/// depends on how much structure (`if`/`else`, array/object literals,
-/// pipes) a `def` body wraps around its recursive call. Code review
-/// confirmed live: a `def` whose body wraps its self-call in only ~20
-/// levels of array nesting overflows the native stack (SIGABRT) well
-/// before `budget` is anywhere near exhausted -- the exact failure mode
-/// this PR exists to eliminate, surviving through a gap `budget` alone
-/// cannot close, since `budget` only increments at self-reference hits
-/// while the *structural* descent between one hit and the next (walking
-/// through that 20-level wrapper) is exactly what overflows the stack.
+/// This is a genuine recursion-depth limit — one unit per *live* call, the
+/// thing jq itself bounds only by memory — not the substitution budget it
+/// replaces. The distinction is the point of #1371: the old ceiling was
+/// charged during expansion, so it was consumed by branches a real run would
+/// never take (`fib(0)` failed exactly like `fib(1000)`, since expansion
+/// unrolled the `else` arm it could not know was dead), and a `def` with more
+/// than one self-call exhausted it at every depth including zero. Nothing is
+/// charged here until a call actually runs.
 ///
-/// `chain_depth` closes this by bounding the live call-stack depth at any
-/// moment, independent of how many self-references have fired. This
-/// required its own, separate calibration (debug build, default thread
-/// stack, temporarily raising both ceilings far past any real crash to let
-/// `chain_depth` run to actual failure): the *raw* recursion-depth crash
-/// floor turned out to be essentially shape-independent -- ~549 for the
-/// single-argument shape `MAX_FUNC_EXPANSION_DEPTH`'s own doc comment
-/// tested, ~682-704 for the same shape with its recursive call wrapped in
-/// 20 levels of array nesting, ~612-714 wrapped in 100 levels. That makes
-/// sense: `chain_depth` counts total live stack frames directly, and each
-/// frame here costs roughly the same regardless of which `Expr`/`Builtin`
-/// variant it's processing, so the crash floor in *this* metric doesn't
-/// move the way `MAX_FUNC_EXPANSION_DEPTH`'s self-reference-hit count does
-/// (that one crashed at wildly different hit counts across body shapes,
-/// exactly *because* raw frames-per-hit varies with how much structure
-/// separates one hit from the next -- see its own doc comment).
+/// **Calibrated against measured native stack use, not guessed** (#2080): one
+/// live call level costs ~4.4 KB of native stack, measured by bisecting the
+/// deepest working recursion at two stack sizes an 8x multiple apart (4406
+/// B/level at 8 MB, 4381 B/level at 64 MB — 0.6% apart, so consumption is
+/// linear in depth, not quadratic as it was while arguments were substituted
+/// textually). At that rate this ceiling needs ~44 MB of stack, which is why
+/// the CLI runs evaluation on a thread with an explicitly sized one
+/// (`jq_runner.rs`) rather than the default 8 MB main thread, and why
+/// exceeding it must stay a clean, catchable error: the alternative is the
+/// `SIGABRT` stack overflow #1016 exists to prevent.
 ///
-/// Picked with a wide margin below the lowest of those (~549) for the same
-/// reason `MAX_FUNC_EXPANSION_DEPTH` was: real `def` bodies will be more
-/// expensive per frame than anything tested here. Also picked comfortably
-/// above the ~150 frames a `MAX_FUNC_EXPANSION_DEPTH`-worth of self-
-/// reference hits costs for the *thin*-body shape (roughly 3 frames per
-/// hit there) -- low enough to catch a thick-bodied `def` before its stack
-/// overflows, high enough that it doesn't itself become the limiting
-/// factor for the thin-bodied shape `MAX_FUNC_EXPANSION_DEPTH` already
-/// covers.
-const MAX_FUNC_EXPANSION_CHAIN_DEPTH: usize = 300;
+/// Matches the depth jq itself was confirmed to handle for this issue's own
+/// repro (`sum_to(10000)`), rather than being set to whatever happened not to
+/// crash — a library embedder with a smaller stack is the case this does not
+/// cover, and is why the limit is a constant here rather than derived from
+/// whatever stack the caller happens to have.
+const MAX_EVAL_FRAMES: u32 = 100_000;
 
-/// Caps *total substitution cost, weighted by `body`'s own size* -- the
-/// narrower stopgap #1381 (see `MAX_FUNC_EXPANSION_DEPTH`'s own doc
-/// comment, "Also known to not close") describes for the gap neither
-/// `MAX_FUNC_EXPANSION_DEPTH` nor `MAX_FUNC_EXPANSION_CHAIN_DEPTH` closes:
-/// chaining several small recursive `def`s, each calling the previous as
-/// its base case.
+/// Evaluate one call to a user-defined function (#1371).
 ///
-/// `MAX_FUNC_EXPANSION_DEPTH` bounds *hit count* -- a flat "1 per
-/// self-reference" charge, regardless of how large `body` actually is at
-/// that hit. That's fine standing alone: for an ordinary, un-chained
-/// recursive `def`, `body` is a fixed, small size throughout its own
-/// resolution. But for `def r1(n): if n==0 then r0(n) else [r1(n-1)] end;`
-/// coming right after `def r0(n): ...;`, `r0`'s own occurrence *inside*
-/// `r1`'s body gets fully expanded (up to `MAX_FUNC_EXPANSION_DEPTH`
-/// clones of `r0`'s body) *before* `r1`'s own self-reference loop ever
-/// runs -- so by the time that loop starts, the `body` it clones on every
-/// one of its own (still flat-"1 per hit") 50 allowed hits is no longer
-/// `r1`'s small original body, but `r1`'s body *with `r0`'s entire
-/// expansion embedded in it*. Each further chained `def` repeats this,
-/// compounding roughly 50x per level -- confirmed live, 3 chained `def`s
-/// (`r0`..`r2`) hit 4+ GB peak RSS.
+/// Substitutes the arguments into a fresh copy of the body, re-installs the
+/// definition over that copy so its own self-calls become `DefCall`s one
+/// level deeper, and evaluates the result.
 ///
-/// This charges each hit `body`'s own `{:?}`-formatted length instead of a
-/// flat `1`, and caps the *cumulative* weighted total -- so a hit against
-/// an already-inflated `body` costs proportionally more, and naturally
-/// throttles down to far fewer than `MAX_FUNC_EXPANSION_DEPTH` hits once
-/// `body` has absorbed a prior chained `def`'s own expansion. A `Debug`-
-/// string length is a deliberately weak, approximate size proxy rather
-/// than an exact AST node count: `Expr`'s `Debug` impl is a plain
-/// `#[derive]`, which -- unlike a hand-matched node-counter needing an arm
-/// per one of `Expr`'s 55 variants -- cannot silently undercount when the
-/// AST gains a new variant, at the cost of being only roughly proportional
-/// to the tree's real memory footprint rather than exact. Computed once
-/// per occurrence and cached alongside `hits_so_far` in the same shared
-/// `Cell` (see the `FuncCall` arm below), not recomputed on every hit --
-/// an earlier version of this guard recomputed it every hit; code review
-/// measured a real ~30-40% slowdown on ordinary (non-recursive-triggering)
-/// `def` usage from that, since `body` never changes within one
-/// occurrence's own resolution.
+/// Each argument is wrapped in [`Expr::Shared`] rather than cloned in. Two
+/// things follow, and both are load-bearing:
 ///
-/// Calibrated so an ordinary, non-chained `def`'s `MAX_FUNC_EXPANSION_DEPTH`
-/// budget is unaffected -- **this needed two calibration passes.** The
-/// first (`50 * 600 = 30_000`) used only two thin, minimal example bodies
-/// (299-301 and 515 chars) and regressed real usage: code review measured
-/// live that a moderately-complex-but-entirely-ordinary single-argument
-/// recursive `def` (an `if`/`else` building a small object literal with a
-/// handful of fields, one nested array, one string) has a `Debug` length
-/// of 1372-1561 chars, well past that budget's real headroom -- `deep(20)`
-/// failed with "recursion depth exceeds limit of 50" where pre-#1381 `main`
-/// succeeded through `deep(45)`+. Recalibrated with a much wider margin:
-/// `50 * 5_000 = 250_000` gives every measured real body (up to 1561 chars)
-/// more than **8x** headroom above what `MAX_FUNC_EXPANSION_DEPTH`'s own
-/// 50-hit budget would need, so `hits_so_far * body_debug_len` cannot reach
-/// this cap before `hits_so_far` itself reaches `MAX_FUNC_EXPANSION_DEPTH`
-/// for any realistic single (non-chained) `def` body -- while still
-/// throttling a chained `def`'s inflated `body` (tens of thousands of
-/// chars after just one prior expansion already exceeds this cap outright)
-/// down to a small handful of further hits, keeping total blowup additive
-/// across a chain rather than multiplicative. Re-verified live after the
-/// recalibration: the moderately-complex body above now succeeds through
-/// its own natural depth (matching pre-#1381 `main`), and the original
-/// 3-chained-`def` repro (`r0`..`r2`, 4+ GB pre-fix) still fails cleanly
-/// and fast rather than exhausting memory.
-const MAX_FUNC_EXPANSION_WEIGHTED_COST: usize = 250_000;
+/// - **The recursion is linear, not quadratic.** Substituting the argument
+///   *expression* inlined the caller's own argument tree at every level, so
+///   the tree being walked grew with depth — `O(d^2)` work and native stack,
+///   measured at ~40 usable levels for a one-parameter `def`. A shared
+///   pointer adds `O(1)` per level over the level before.
+/// - **The callee cannot capture the caller's variables.** A substitution
+///   pass stops at a `Shared`, so a binder inside the body (`3 as $x`, a
+///   `reduce` pattern) cannot reach into an argument that mentions `$x`
+///   (#2077).
+pub(crate) fn bind_def_call(
+    def: &Rc<FuncDefData>,
+    args: &[Expr],
+    frames: u32,
+) -> Result<Expr, EvalError> {
+    if frames >= MAX_EVAL_FRAMES {
+        return Err(EvalError::new(format!(
+            "{}/{} exceeded maximum recursion depth",
+            def.name,
+            def.params.len()
+        )));
+    }
+    let mut bound = def.body.clone();
+    for (param, arg) in def.params.iter().zip(args.iter()) {
+        bound = substitute_func_param(&bound, param, &Expr::Shared(Rc::new(arg.clone())));
+    }
+    Ok(install_def_calls(&bound, def, frames + 1))
+}
 
-/// Builds an `Expr::Error` node carrying a plain string message, evaluated
-/// via [`eval_error`]'s `Expr::Error` arm the same way a real `error("...")`
-/// call would be -- the mechanism `expand_func_calls` uses to report a
-/// problem discovered during expansion (which happens before any real
-/// evaluation, so it has no `QueryResult`/`EvalError` to return directly)
-/// without panicking.
-fn expansion_error(msg: String) -> Expr {
-    Expr::Error(Some(Box::new(Expr::Literal(Literal::String(msg)))))
+/// Evaluate an `Expr::DefCall` in the plain evaluator (#1371).
+fn eval_def_call<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    def: &Rc<FuncDefData>,
+    args: &[Expr],
+    frames: u32,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    match bind_def_call(def, args, frames) {
+        Ok(bound) => eval_single::<W, S>(&bound, value, optional),
+        Err(e) => QueryResult::Error(e),
+    }
 }
 
 /// Expand function calls to a defined function by inlining the body.
-pub(crate) fn expand_func_calls(
-    expr: &Expr,
-    func_name: &str,
-    params: &[String],
-    body: &Expr,
-    budget: Option<&Cell<(usize, Option<usize>)>>,
-    chain_depth: usize,
-) -> Expr {
+pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32) -> Expr {
     match expr {
         // #1376: the arity check used to live *inside* this arm, matching
         // on name alone and erroring on any arity mismatch -- which broke
@@ -40088,108 +40080,33 @@ pub(crate) fn expand_func_calls(
         // -- so expansion is never handed one. Do not read the fallthrough
         // below as *permitting* a forward reference: it is unreachable for
         // one, and would still mis-resolve it if that pass were bypassed.
-        Expr::FuncCall { name, args } if name == func_name && args.len() == params.len() => {
-            // #1016: a self-recursive `def` (e.g. `def deep(n): if n == 0
-            // then . else [deep(n-1)] end;`) has no base case at expansion
-            // time -- expansion is static AST substitution, run before any
-            // evaluation, so it can never observe that a runtime condition
-            // like `n == 0` will eventually hold. Each hop back into this
-            // arm re-substitutes the body, which (for a genuinely recursive
-            // `def`) always contains another syntactic call to `func_name`,
-            // so this would otherwise unroll forever and overflow the
-            // native stack -- see `MAX_FUNC_EXPANSION_DEPTH`'s and
-            // `MAX_FUNC_EXPANSION_CHAIN_DEPTH`'s doc comments. Same
-            // non-panicking `Expr::Error` shape as the arity check above,
-            // not a panic (#1098 established that panicking here is
-            // live-reachable through ordinary CLI usage, not just a
-            // theoretical safety net).
+        Expr::FuncCall { name, args } if *name == def.name && args.len() == def.params.len() => {
+            // #1371: bind the call to its definition, but do **not**
+            // substitute yet. Substitution happens in `eval_def_call`, when
+            // evaluation actually reaches this node.
             //
-            // `chain_depth` bounds *native stack usage* directly: it
-            // increments on every recursive call in this function, not just
-            // self-reference hits, so it catches a def body that wraps its
-            // recursive call in substantial structure (nested arrays,
-            // objects, pipes) between one self-reference and the next --
-            // see that constant's own doc comment for why `budget` alone
-            // (below) cannot catch this. It is intentionally a single
-            // running total over the whole expression being expanded, not
-            // scoped to `func_name`'s own self-reference chain (code review
-            // asked about this): live stack depth at any moment includes
-            // *all* nesting the traversal is currently inside, including
-            // structure with nothing to do with this recursion, and that
-            // depth is real regardless of its source -- so the message
-            // below doesn't claim the nesting is `func_name`'s own doing.
-            if chain_depth >= MAX_FUNC_EXPANSION_CHAIN_DEPTH {
-                return expansion_error(format!(
-                    "expression nesting exceeds depth limit of {MAX_FUNC_EXPANSION_CHAIN_DEPTH} while expanding function {func_name}"
-                ));
-            }
-            // `budget` bounds *total substitution work*, shared by
-            // reference across every self-reference reached while
-            // resolving one originally-independent occurrence -- see
-            // `MAX_FUNC_EXPANSION_DEPTH`'s doc comment for why a per-chain
-            // value alone isn't enough (a def body with more than one
-            // self-call compounds exponentially otherwise).
+            // Doing it here instead -- which is what this function used to do
+            // -- cannot terminate for a self-recursive `def`: the substituted
+            // body contains another syntactic call to the same name, and
+            // static expansion can never observe that a runtime condition
+            // (`n == 0`) will eventually hold, so it unrolled until a guard
+            // stopped it. Every one of those guards (`MAX_FUNC_EXPANSION_*`)
+            // is gone with this arm; the depth ceiling is now a genuine
+            // recursion-depth limit checked per call, not a substitution
+            // budget that a branching body exhausts at depth zero.
             //
-            // `budget` is `None` when this occurrence was reached by
-            // ordinary structural descent through code that is *not*
-            // itself generated by resolving some earlier occurrence --
-            // e.g. two independent top-level calls the user wrote side by
-            // side (`[fact(3), fact(4)]`). Such an occurrence gets a fresh
-            // counter of its own here, rather than sharing one with
-            // unrelated sibling calls (code review found sharing one
-            // global counter for the whole `then` starves later,
-            // independent calls once an earlier one has consumed the
-            // budget -- confirmed live, `[fact(3), fact(4), fact(5)]`
-            // failed even though each call alone succeeds trivially).
-            // `budget` is `Some(cell)` when this occurrence was itself
-            // found *while* resolving an earlier occurrence's own
-            // substituted body/arguments (a genuine self-reference within
-            // that resolution, e.g. the two `f`s inside `def f: [f, f];
-            // f`'s own body) -- that case must keep sharing the same
-            // counter, or the branching-explosion bug above comes back.
-            let fresh_cell = Cell::new((0, None));
-            let cell = budget.unwrap_or(&fresh_cell);
-            let (hits_so_far, cached_body_debug_len) = cell.get();
-            if hits_so_far >= MAX_FUNC_EXPANSION_DEPTH {
-                return expansion_error(format!(
-                    "function {func_name} recursion depth exceeds limit of {MAX_FUNC_EXPANSION_DEPTH} while expanding"
-                ));
+            // `args` are installed but left otherwise untouched, so a call to
+            // this same definition *inside* an argument is bound too, while
+            // the argument itself stays ordinary caller-scope code that an
+            // enclosing, not-yet-evaluated `as` can still substitute into.
+            Expr::DefCall {
+                def: Rc::clone(def),
+                args: args
+                    .iter()
+                    .map(|a| install_def_calls(a, def, frames + 1))
+                    .collect(),
+                frames,
             }
-            // #1381: `hits_so_far` alone doesn't catch a chained `def`
-            // whose `body` has already absorbed a prior chained `def`'s
-            // own full expansion -- see `MAX_FUNC_EXPANSION_WEIGHTED_COST`'s
-            // own doc comment for the full mechanism and calibration.
-            // `body` never changes across every hit sharing this `cell`
-            // (it's the same parameter threaded through unchanged), so its
-            // `Debug` length is computed once per occurrence and cached
-            // here rather than reformatted on every hit.
-            let body_debug_len = cached_body_debug_len.unwrap_or_else(|| format!("{body:?}").len());
-            if hits_so_far.saturating_mul(body_debug_len) >= MAX_FUNC_EXPANSION_WEIGHTED_COST {
-                return expansion_error(format!(
-                    "function {func_name} substitution cost exceeds limit of {MAX_FUNC_EXPANSION_WEIGHTED_COST} while expanding"
-                ));
-            }
-            cell.set((hits_so_far + 1, Some(body_debug_len)));
-            // Substitute parameters with arguments in the body
-            let mut result = body.clone();
-            // First, expand any nested function calls in the arguments
-            let expanded_args: Vec<Expr> = args
-                .iter()
-                .map(|a| expand_func_calls(a, func_name, params, body, Some(cell), chain_depth + 1))
-                .collect();
-            // Then substitute each parameter
-            for (param, arg) in params.iter().zip(expanded_args.iter()) {
-                result = substitute_func_param(&result, param, arg);
-            }
-            // Also expand any recursive calls in the result
-            expand_func_calls(
-                &result,
-                func_name,
-                params,
-                body,
-                Some(cell),
-                chain_depth + 1,
-            )
         }
         // Recursively expand in all subexpressions
         Expr::Identity => Expr::Identity,
@@ -40216,293 +40133,103 @@ pub(crate) fn expand_func_calls(
         },
         Expr::Iterate => Expr::Iterate,
         Expr::IndexExpr { target, key } => Expr::IndexExpr {
-            target: Box::new(expand_func_calls(
-                target,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            key: Box::new(expand_func_calls(
-                key,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            target: Box::new(install_def_calls(target, def, frames + 1)),
+            key: Box::new(install_def_calls(key, def, frames + 1)),
         },
         Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
-            target: Box::new(expand_func_calls(
-                target,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            start: start.as_deref().map(|e| {
-                Box::new(expand_func_calls(
-                    e,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
-            end: end.as_deref().map(|e| {
-                Box::new(expand_func_calls(
-                    e,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
+            target: Box::new(install_def_calls(target, def, frames + 1)),
+            start: start
+                .as_deref()
+                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
+            end: end
+                .as_deref()
+                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
         },
         Expr::RecursiveDescent => Expr::RecursiveDescent,
-        Expr::Optional(e) => Expr::Optional(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::Optional(e) => Expr::Optional(Box::new(install_def_calls(e, def, frames + 1))),
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
-                .map(|e| expand_func_calls(e, func_name, params, body, budget, chain_depth + 1))
+                .map(|e| install_def_calls(e, def, frames + 1))
                 .collect(),
         ),
         Expr::Comma(exprs) => Expr::Comma(
             exprs
                 .iter()
-                .map(|e| expand_func_calls(e, func_name, params, body, budget, chain_depth + 1))
+                .map(|e| install_def_calls(e, def, frames + 1))
                 .collect(),
         ),
-        Expr::Array(e) => Expr::Array(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::Array(e) => Expr::Array(Box::new(install_def_calls(e, def, frames + 1))),
         Expr::Object(entries) => Expr::Object(
             entries
                 .iter()
                 .map(|entry| {
                     let new_key = match &entry.key {
                         ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                        ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(expand_func_calls(
-                            e,
-                            func_name,
-                            params,
-                            body,
-                            budget,
-                            chain_depth + 1,
-                        ))),
+                        ObjectKey::Expr(e) => {
+                            ObjectKey::Expr(Box::new(install_def_calls(e, def, frames + 1)))
+                        }
                     };
                     ObjectEntry {
                         key: new_key,
-                        value: expand_func_calls(
-                            &entry.value,
-                            func_name,
-                            params,
-                            body,
-                            budget,
-                            chain_depth + 1,
-                        ),
+                        value: install_def_calls(&entry.value, def, frames + 1),
                     }
                 })
                 .collect(),
         ),
         Expr::Literal(lit) => Expr::Literal(lit.clone()),
-        Expr::Paren(e) => Expr::Paren(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::Paren(e) => Expr::Paren(Box::new(install_def_calls(e, def, frames + 1))),
         Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
             op: *op,
-            left: Box::new(expand_func_calls(
-                left,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            right: Box::new(expand_func_calls(
-                right,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            left: Box::new(install_def_calls(left, def, frames + 1)),
+            right: Box::new(install_def_calls(right, def, frames + 1)),
         },
-        Expr::Negate(operand) => Expr::Negate(Box::new(expand_func_calls(
-            operand,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::Negate(operand) => {
+            Expr::Negate(Box::new(install_def_calls(operand, def, frames + 1)))
+        }
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
-            left: Box::new(expand_func_calls(
-                left,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            right: Box::new(expand_func_calls(
-                right,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            left: Box::new(install_def_calls(left, def, frames + 1)),
+            right: Box::new(install_def_calls(right, def, frames + 1)),
         },
         Expr::And(l, r) => Expr::And(
-            Box::new(expand_func_calls(
-                l,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            Box::new(expand_func_calls(
-                r,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            Box::new(install_def_calls(l, def, frames + 1)),
+            Box::new(install_def_calls(r, def, frames + 1)),
         ),
         Expr::Or(l, r) => Expr::Or(
-            Box::new(expand_func_calls(
-                l,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            Box::new(expand_func_calls(
-                r,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            Box::new(install_def_calls(l, def, frames + 1)),
+            Box::new(install_def_calls(r, def, frames + 1)),
         ),
         Expr::Not => Expr::Not,
         Expr::Alternative(l, r) => Expr::Alternative(
-            Box::new(expand_func_calls(
-                l,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            Box::new(expand_func_calls(
-                r,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            Box::new(install_def_calls(l, def, frames + 1)),
+            Box::new(install_def_calls(r, def, frames + 1)),
         ),
         Expr::If {
             cond,
             then_branch,
             else_branch,
         } => Expr::If {
-            cond: Box::new(expand_func_calls(
-                cond,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            then_branch: Box::new(expand_func_calls(
-                then_branch,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            else_branch: Box::new(expand_func_calls(
-                else_branch,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            cond: Box::new(install_def_calls(cond, def, frames + 1)),
+            then_branch: Box::new(install_def_calls(then_branch, def, frames + 1)),
+            else_branch: Box::new(install_def_calls(else_branch, def, frames + 1)),
         },
         Expr::Try { expr, catch } => Expr::Try {
-            expr: Box::new(expand_func_calls(
-                expr,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            catch: catch.as_ref().map(|c| {
-                Box::new(expand_func_calls(
-                    c,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
+            expr: Box::new(install_def_calls(expr, def, frames + 1)),
+            catch: catch
+                .as_ref()
+                .map(|c| Box::new(install_def_calls(c, def, frames + 1))),
         },
         Expr::Error(msg) => Expr::Error(msg.clone()),
-        Expr::Builtin(b) => Expr::Builtin(expand_func_calls_in_builtin(
-            b,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        )),
+        Expr::Builtin(b) => Expr::Builtin(install_def_calls_in_builtin(b, def, frames + 1)),
         Expr::StringInterpolation(parts) => Expr::StringInterpolation(
             parts
                 .iter()
                 .map(|p| match p {
                     StringPart::Literal(s) => StringPart::Literal(s.clone()),
-                    StringPart::Expr(e) => StringPart::Expr(Box::new(expand_func_calls(
-                        e,
-                        func_name,
-                        params,
-                        body,
-                        budget,
-                        chain_depth + 1,
-                    ))),
+                    StringPart::Expr(e) => {
+                        StringPart::Expr(Box::new(install_def_calls(e, def, frames + 1)))
+                    }
                 })
                 .collect(),
         ),
@@ -40525,23 +40252,9 @@ pub(crate) fn expand_func_calls(
             var,
             body: as_body,
         } => Expr::As {
-            expr: Box::new(expand_func_calls(
-                expr,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            expr: Box::new(install_def_calls(expr, def, frames + 1)),
             var: var.clone(),
-            body: Box::new(expand_func_calls(
-                as_body,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            body: Box::new(install_def_calls(as_body, def, frames + 1)),
         },
         Expr::Reduce {
             input,
@@ -40549,31 +40262,10 @@ pub(crate) fn expand_func_calls(
             init,
             update,
         } => Expr::Reduce {
-            input: Box::new(expand_func_calls(
-                input,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            input: Box::new(install_def_calls(input, def, frames + 1)),
             patterns: patterns.clone(),
-            init: Box::new(expand_func_calls(
-                init,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            update: Box::new(expand_func_calls(
-                update,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            init: Box::new(install_def_calls(init, def, frames + 1)),
+            update: Box::new(install_def_calls(update, def, frames + 1)),
         },
         Expr::Foreach {
             input,
@@ -40582,190 +40274,50 @@ pub(crate) fn expand_func_calls(
             update,
             extract,
         } => Expr::Foreach {
-            input: Box::new(expand_func_calls(
-                input,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            input: Box::new(install_def_calls(input, def, frames + 1)),
             patterns: patterns.clone(),
-            init: Box::new(expand_func_calls(
-                init,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            update: Box::new(expand_func_calls(
-                update,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            extract: extract.as_ref().map(|e| {
-                Box::new(expand_func_calls(
-                    e,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
+            init: Box::new(install_def_calls(init, def, frames + 1)),
+            update: Box::new(install_def_calls(update, def, frames + 1)),
+            extract: extract
+                .as_ref()
+                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
         },
         Expr::Limit { n, expr } => Expr::Limit {
-            n: Box::new(expand_func_calls(
-                n,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            expr: Box::new(expand_func_calls(
-                expr,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            n: Box::new(install_def_calls(n, def, frames + 1)),
+            expr: Box::new(install_def_calls(expr, def, frames + 1)),
         },
-        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
-        Expr::LastExpr(e) => Expr::LastExpr(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(install_def_calls(e, def, frames + 1))),
+        Expr::LastExpr(e) => Expr::LastExpr(Box::new(install_def_calls(e, def, frames + 1))),
         Expr::NthExpr { n, expr } => Expr::NthExpr {
-            n: Box::new(expand_func_calls(
-                n,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            expr: Box::new(expand_func_calls(
-                expr,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            n: Box::new(install_def_calls(n, def, frames + 1)),
+            expr: Box::new(install_def_calls(expr, def, frames + 1)),
         },
         Expr::Until { cond, update } => Expr::Until {
-            cond: Box::new(expand_func_calls(
-                cond,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            update: Box::new(expand_func_calls(
-                update,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            cond: Box::new(install_def_calls(cond, def, frames + 1)),
+            update: Box::new(install_def_calls(update, def, frames + 1)),
         },
         Expr::While { cond, update } => Expr::While {
-            cond: Box::new(expand_func_calls(
-                cond,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            update: Box::new(expand_func_calls(
-                update,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            cond: Box::new(install_def_calls(cond, def, frames + 1)),
+            update: Box::new(install_def_calls(update, def, frames + 1)),
         },
-        Expr::Repeat(e) => Expr::Repeat(Box::new(expand_func_calls(
-            e,
-            func_name,
-            params,
-            body,
-            budget,
-            chain_depth + 1,
-        ))),
+        Expr::Repeat(e) => Expr::Repeat(Box::new(install_def_calls(e, def, frames + 1))),
         Expr::Range { from, to, step } => Expr::Range {
-            from: Box::new(expand_func_calls(
-                from,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            to: to.as_ref().map(|e| {
-                Box::new(expand_func_calls(
-                    e,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
-            step: step.as_ref().map(|e| {
-                Box::new(expand_func_calls(
-                    e,
-                    func_name,
-                    params,
-                    body,
-                    budget,
-                    chain_depth + 1,
-                ))
-            }),
+            from: Box::new(install_def_calls(from, def, frames + 1)),
+            to: to
+                .as_ref()
+                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
+            step: step
+                .as_ref()
+                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
         },
         Expr::AsPattern {
             expr,
             patterns,
             body: pattern_body,
         } => Expr::AsPattern {
-            expr: Box::new(expand_func_calls(
-                expr,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            expr: Box::new(install_def_calls(expr, def, frames + 1)),
             patterns: patterns.clone(),
-            body: Box::new(expand_func_calls(
-                pattern_body,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            body: Box::new(install_def_calls(pattern_body, def, frames + 1)),
         },
         Expr::FuncDef {
             name: inner_name,
@@ -40787,29 +40339,15 @@ pub(crate) fn expand_func_calls(
             // case below already does -- only a genuine same-arity
             // redefinition (which really does make the earlier definition
             // permanently unreachable from this point on) stops expansion.
-            if inner_name == func_name && inner_params.len() == params.len() {
+            if *inner_name == def.name && inner_params.len() == def.params.len() {
                 // Don't expand in the body or then - this is a new definition
                 expr.clone()
             } else {
                 Expr::FuncDef {
                     name: inner_name.clone(),
                     params: inner_params.clone(),
-                    body: Box::new(expand_func_calls(
-                        inner_body,
-                        func_name,
-                        params,
-                        body,
-                        budget,
-                        chain_depth + 1,
-                    )),
-                    then: Box::new(expand_func_calls(
-                        then,
-                        func_name,
-                        params,
-                        body,
-                        budget,
-                        chain_depth + 1,
-                    )),
+                    body: Box::new(install_def_calls(inner_body, def, frames + 1)),
+                    then: Box::new(install_def_calls(then, def, frames + 1)),
                 }
             }
         }
@@ -40822,7 +40360,7 @@ pub(crate) fn expand_func_calls(
                 name: name.clone(),
                 args: args
                     .iter()
-                    .map(|a| expand_func_calls(a, func_name, params, body, budget, chain_depth + 1))
+                    .map(|a| install_def_calls(a, def, frames + 1))
                     .collect(),
             }
         }
@@ -40835,94 +40373,52 @@ pub(crate) fn expand_func_calls(
             name: name.clone(),
             args: args
                 .iter()
-                .map(|a| expand_func_calls(a, func_name, params, body, budget, chain_depth + 1))
+                .map(|a| install_def_calls(a, def, frames + 1))
                 .collect(),
         },
         Expr::Assign { path, value } => Expr::Assign {
-            path: Box::new(expand_func_calls(
-                path,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            value: Box::new(expand_func_calls(
-                value,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            path: Box::new(install_def_calls(path, def, frames + 1)),
+            value: Box::new(install_def_calls(value, def, frames + 1)),
         },
         Expr::Update { path, filter } => Expr::Update {
-            path: Box::new(expand_func_calls(
-                path,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            filter: Box::new(expand_func_calls(
-                filter,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            path: Box::new(install_def_calls(path, def, frames + 1)),
+            filter: Box::new(install_def_calls(filter, def, frames + 1)),
         },
         Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
             op: *op,
-            path: Box::new(expand_func_calls(
-                path,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            value: Box::new(expand_func_calls(
-                value,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            path: Box::new(install_def_calls(path, def, frames + 1)),
+            value: Box::new(install_def_calls(value, def, frames + 1)),
         },
         Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
-            path: Box::new(expand_func_calls(
-                path,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
-            value: Box::new(expand_func_calls(
-                value,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            path: Box::new(install_def_calls(path, def, frames + 1)),
+            value: Box::new(install_def_calls(value, def, frames + 1)),
         },
 
         // Label-break
         Expr::Label { name, body: lbody } => Expr::Label {
             name: name.clone(),
-            body: Box::new(expand_func_calls(
-                lbody,
-                func_name,
-                params,
-                body,
-                budget,
-                chain_depth + 1,
-            )),
+            body: Box::new(install_def_calls(lbody, def, frames + 1)),
+        },
+        // #1371: opaque. A `Shared` holds an argument that was captured at
+        // call time, after every enclosing substitution had run and after
+        // this same installer had already visited it -- so there is nothing
+        // left to install inside, and descending would re-walk the whole
+        // chain of arguments from every level below, restoring exactly the
+        // O(depth^2) traversal this design removes.
+        Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
+        // Likewise opaque: a `DefCall`'s own definition was captured with all
+        // outer definitions already installed in it, and its arguments were
+        // installed when it was created. Descending would also re-install
+        // *this* definition inside a call that is deliberately deferred,
+        // which is the unrolling this fix exists to stop.
+        Expr::DefCall {
+            def: d,
+            args,
+            frames: n,
+        } => Expr::DefCall {
+            def: Rc::clone(d),
+            args: args.clone(),
+            frames: *n,
         },
         Expr::Break(name) => Expr::Break(name.clone()),
     }
@@ -40931,6 +40427,26 @@ pub(crate) fn expand_func_calls(
 /// Substitute a function parameter with an argument expression.
 fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
     match expr {
+        // #1371: opaque, for the same reasons `substitute_var_impl` gives --
+        // and for one more that is specific to parameters. Binding a
+        // multi-parameter call substitutes each parameter in turn over the
+        // result of the last, so this arm is what stops the second parameter
+        // from being substituted *into the first argument*: arguments live in
+        // the caller's scope and cannot mention the callee's own parameters.
+        Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
+        // A nested call's arguments, by contrast, are code in *this* body's
+        // scope and can mention this parameter -- `def outer(n): inner(n);`
+        // binds `n` here, through the inner call. Reached whenever an outer
+        // definition was installed over a body before this one's parameters
+        // were bound, which is the ordinary case for two sibling `def`s.
+        Expr::DefCall { def, args, frames } => Expr::DefCall {
+            def: Rc::clone(def),
+            args: args
+                .iter()
+                .map(|a| substitute_func_param(a, param, arg))
+                .collect(),
+            frames: *frames,
+        },
         // A variable reference to the parameter becomes the argument expression
         Expr::Var(name) if name == param => arg.clone(),
         Expr::Var(_) => expr.clone(),
@@ -41318,17 +40834,8 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
 }
 
 /// Expand function calls in a builtin expression.
-fn expand_func_calls_in_builtin(
-    builtin: &Builtin,
-    func_name: &str,
-    params: &[String],
-    body: &Expr,
-    budget: Option<&Cell<(usize, Option<usize>)>>,
-    chain_depth: usize,
-) -> Builtin {
-    map_builtin_subexprs(builtin, &mut |e| {
-        expand_func_calls(e, func_name, params, body, budget, chain_depth + 1)
-    })
+fn install_def_calls_in_builtin(builtin: &Builtin, def: &Rc<FuncDefData>, depth: u32) -> Builtin {
+    map_builtin_subexprs(builtin, &mut |e| install_def_calls(e, def, depth))
 }
 
 /// Substitute function parameter in a builtin expression.
@@ -66015,7 +65522,15 @@ mod tests {
             slice_number
         );
         assert_eq!(
-            expand_func_calls(&slice_number, "f", &[], &Expr::Identity, None, 0),
+            install_def_calls(
+                &slice_number,
+                &Rc::new(FuncDefData {
+                    name: "f".into(),
+                    params: Vec::new(),
+                    body: Expr::Identity,
+                }),
+                0,
+            ),
             slice_number
         );
         assert_eq!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -298,8 +298,8 @@ impl EvalSemantics for YqSemantics {
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 
 use super::expr::{
-    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefData, Literal, MergeFlags,
-    NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, StringPart,
+    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefData, Literal,
+    MergeFlags, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, StringPart,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -1301,9 +1301,12 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // above (which only ever errors, since an unbound call is a compile
         // error `resolve.rs` rejects earlier), this is where a user-defined
         // function actually runs.
-        Expr::DefCall { def, args, frames } => {
-            eval_def_call::<W, S>(def, args, *frames, value, optional)
-        }
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } => eval_def_call::<W, S>(def, args, *frames, bound, value, optional),
 
         // #1371: an argument captured at call time. Transparent to
         // evaluation -- it is the substitution passes, not this one, that
@@ -3403,8 +3406,13 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // not just slower: `isempty(def f: (1, ("B"|stderr)); f)` printed `B`
         // where jq prints nothing, because the second branch ran after the
         // answer was already known.
-        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
-            Ok(bound) => eval_each::<W, S>(&bound, value, optional, sink),
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } => match bind_def_call(def, args, *frames, bound) {
+            Ok(bound) => eval_each::<W, S>(bound, value, optional, sink),
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Lazy only for an argument the *user* wrote, not for a link in a
@@ -20547,8 +20555,13 @@ fn resolve_node<'a, S: EvalSemantics>(
         // uses -- a runaway recursion inside `path()` must not be able to
         // exhaust the stack just because it is being resolved rather than
         // evaluated.
-        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
-            Ok(bound) => resolve_node::<S>(&bound, value, trackable, snapshot),
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } => match bind_def_call(def, args, *frames, bound) {
+            Ok(bound) => resolve_node::<S>(bound, value, trackable, snapshot),
             Err(e) => Err((Vec::new(), e.into())),
         },
         // Transparent, like `Paren`: the wrapped argument is ordinary code
@@ -25388,13 +25401,18 @@ fn substitute_var_impl(
         // `1 as $x | f($x)`. The definition itself is not descended into --
         // it was captured with every variable in scope at its own definition
         // site already substituted, and its body is a fresh scope per call.
-        Expr::DefCall { def, args, frames } => Expr::DefCall {
+        Expr::DefCall {
+            def, args, frames, ..
+        } => Expr::DefCall {
             def: Rc::clone(def),
             args: args
                 .iter()
                 .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
                 .collect(),
             frames: *frames,
+            // Fresh: `args` just changed, so anything cached against the old
+            // ones would be stale.
+            bound: BoundBody::default(),
         },
         Expr::Var(name) if name == var_name => {
             if mark_trackable {
@@ -30727,10 +30745,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // as an untrackable leaf rather than seeing through to the
         // navigation. Binding here and continuing in this same evaluator is
         // what the `FuncDef` arm just below already does one step earlier.
-        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } => match bind_def_call(def, args, *frames, bound) {
             Err(e) => QueryResult::Error(e),
             Ok(bound) => {
-                let mut stages = vec![bound];
+                let mut stages = vec![(**bound).clone()];
                 stages.extend(rest.iter().cloned());
                 eval_pipe_with_path_context_internal::<W, S>(
                     &stages,
@@ -40049,23 +40072,26 @@ const MAX_EVAL_FRAMES: u32 = 40_000;
 ///   pass stops at a `Shared`, so a binder inside the body (`3 as $x`, a
 ///   `reduce` pattern) cannot reach into an argument that mentions `$x`
 ///   (#2077).
-pub(crate) fn bind_def_call(
+pub(crate) fn bind_def_call<'e>(
     def: &Rc<FuncDefData>,
     args: &[Expr],
     frames: u32,
-) -> Result<Expr, EvalError> {
-    if frames >= MAX_EVAL_FRAMES {
-        return Err(EvalError::new(format!(
-            "{}/{} exceeded maximum recursion depth",
-            def.name,
-            def.params.len()
-        )));
-    }
-    let mut bound = def.body.clone();
-    for (param, arg) in def.params.iter().zip(args.iter()) {
-        bound = substitute_func_param(&bound, param, &Expr::Shared(Rc::new(arg.clone())));
-    }
-    Ok(install_def_calls(&bound, def, frames + 1))
+    bound: &'e BoundBody,
+) -> Result<&'e Rc<Expr>, EvalError> {
+    bound.get_or_try_init(|| {
+        if frames >= MAX_EVAL_FRAMES {
+            return Err(EvalError::new(format!(
+                "{}/{} exceeded maximum recursion depth",
+                def.name,
+                def.params.len()
+            )));
+        }
+        let mut body = def.body.clone();
+        for (param, arg) in def.params.iter().zip(args.iter()) {
+            body = substitute_func_param(&body, param, &Expr::Shared(Rc::new(arg.clone())));
+        }
+        Ok(Rc::new(install_def_calls(&body, def, frames + 1)))
+    })
 }
 
 /// Evaluate an `Expr::DefCall` in the plain evaluator (#1371).
@@ -40073,11 +40099,12 @@ fn eval_def_call<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     def: &Rc<FuncDefData>,
     args: &[Expr],
     frames: u32,
+    cache: &BoundBody,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    match bind_def_call(def, args, frames) {
-        Ok(bound) => eval_single::<W, S>(&bound, value, optional),
+    match bind_def_call(def, args, frames, cache) {
+        Ok(bound) => eval_single::<W, S>(bound, value, optional),
         Err(e) => QueryResult::Error(e),
     }
 }
@@ -40144,6 +40171,7 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                     .map(|a| install_def_calls(a, def, frames + 1))
                     .collect(),
                 frames,
+                bound: BoundBody::default(),
             }
         }
         // Recursively expand in all subexpressions
@@ -40453,10 +40481,14 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
             def: d,
             args,
             frames: n,
+            bound,
         } => Expr::DefCall {
             def: Rc::clone(d),
             args: args.clone(),
             frames: *n,
+            // `args` come through unchanged, so whatever this node has
+            // already bound is still exactly what it would bind again.
+            bound: bound.clone(),
         },
         Expr::Break(name) => Expr::Break(name.clone()),
     }
@@ -40477,13 +40509,17 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         // binds `n` here, through the inner call. Reached whenever an outer
         // definition was installed over a body before this one's parameters
         // were bound, which is the ordinary case for two sibling `def`s.
-        Expr::DefCall { def, args, frames } => Expr::DefCall {
+        Expr::DefCall {
+            def, args, frames, ..
+        } => Expr::DefCall {
             def: Rc::clone(def),
             args: args
                 .iter()
                 .map(|a| substitute_func_param(a, param, arg))
                 .collect(),
             frames: *frames,
+            // Fresh, for the reason `substitute_var_impl`'s own arm gives.
+            bound: BoundBody::default(),
         },
         // A variable reference to the parameter becomes the argument expression
         Expr::Var(name) if name == param => arg.clone(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3407,8 +3407,34 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(bound) => eval_each::<W, S>(&bound, value, optional, sink),
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
-        // Transparent, so the wrapped argument's own laziness survives.
-        Expr::Shared(inner) => eval_each::<W, S>(inner, value, optional, sink),
+        // Lazy only for an argument the *user* wrote, not for a link in a
+        // recursion's own argument chain (#1371).
+        //
+        // Laziness here is observable and has to be kept: `isempty(def f(g):
+        // g; f(1, ("B"|stderr)))` must not run the second branch after the
+        // answer is known, which the eager `drain_result` fallback would.
+        //
+        // But a recursive call's argument is `Shared(previous) - 1`, a chain
+        // one link deep per level, and walking it through this sink-based
+        // evaluator costs roughly 70x the native stack that `eval_single`'s
+        // own path does -- measured: `sum_to` reached ~20,000 levels before
+        // this arm existed and crashed at ~300 with it applied
+        // unconditionally. Nothing is gained there either: an arithmetic
+        // chain is single-valued, so there is no demand to forward.
+        //
+        // A link is exactly an argument that already contains a `Shared`,
+        // which `any_subexpr` reports without walking the chain (its
+        // predicate fires on the first one, at depth 1). An enclosing
+        // definition's parameter threaded into an inner call looks the same
+        // and is treated the same -- conservative, and still correct: an
+        // un-lazified arm is a missed optimization, never a behaviour change.
+        Expr::Shared(inner) => {
+            if any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
+                drain_result(eval_single::<W, S>(inner, value, optional), sink)
+            } else {
+                eval_each::<W, S>(inner, value, optional, sink)
+            }
+        }
 
         // #1462 (Stage 5): demand-forwarding through a nested consumer.
         // `each_take_n` (Stage 2) already stops asking `expr` for more once
@@ -39963,35 +39989,47 @@ pub(crate) fn bind_def(name: &str, params: &[String], body: &Expr, then: &Expr) 
     install_def_calls(then, &def, 0)
 }
 
-/// How deep a user-defined function may recurse before evaluation gives up
-/// (#1371).
+/// How much live native evaluation a user-defined function may accumulate
+/// before the call is refused (#1371).
 ///
-/// This is a genuine recursion-depth limit — one unit per *live* call, the
-/// thing jq itself bounds only by memory — not the substitution budget it
-/// replaces. The distinction is the point of #1371: the old ceiling was
-/// charged during expansion, so it was consumed by branches a real run would
-/// never take (`fib(0)` failed exactly like `fib(1000)`, since expansion
-/// unrolled the `else` arm it could not know was dead), and a `def` with more
-/// than one self-call exhausted it at every depth including zero. Nothing is
-/// charged here until a call actually runs.
+/// Counts **frames, not calls.** `install_def_calls` charges one unit per
+/// structural level it descends, and each call carries its parent's total
+/// forward, so a `DefCall`'s `frames` is the nesting the evaluator is
+/// actually holding live when it reaches that node. A plain call count would
+/// not do: it is not how many calls are outstanding that exhausts the stack
+/// but how much structure each one holds live across its own recursive call.
+/// Measured at 256 MB, release: a body whose call sits directly in a pipe
+/// survives ~57,500 levels, while one wrapping the same call in 40 array
+/// constructors dies between 4,000 and 8,000 -- a 10x spread that one count
+/// cannot straddle, and that this charge tracks (both crash at ~172,000-258,000
+/// frames by this measure, within a factor of 1.5 of each other).
 ///
-/// **Calibrated against measured native stack use, not guessed** (#2080): one
-/// live call level costs ~4.4 KB of native stack, measured by bisecting the
-/// deepest working recursion at two stack sizes an 8x multiple apart (4406
-/// B/level at 8 MB, 4381 B/level at 64 MB — 0.6% apart, so consumption is
-/// linear in depth, not quadratic as it was while arguments were substituted
-/// textually). At that rate this ceiling needs ~44 MB of stack, which is why
-/// the CLI runs evaluation on a thread with an explicitly sized one
-/// (`jq_runner.rs`) rather than the default 8 MB main thread, and why
-/// exceeding it must stay a clean, catchable error: the alternative is the
-/// `SIGABRT` stack overflow #1016 exists to prevent.
+/// This replaces three substitution budgets (`MAX_FUNC_EXPANSION_DEPTH`,
+/// `..._CHAIN_DEPTH`, `..._WEIGHTED_COST`) that bounded *expansion* work
+/// rather than evaluation. The difference is not just where the cost is
+/// charged: nothing is charged here until a call actually runs, so a branch a
+/// given input never takes costs nothing. That is what makes an ordinary
+/// branching `def` work at all -- `fib(0)` used to exhaust the old ceiling
+/// exactly like `fib(1000)`, because expansion unrolled the `else` arm it
+/// could not know was dead.
 ///
-/// Matches the depth jq itself was confirmed to handle for this issue's own
-/// repro (`sum_to(10000)`), rather than being set to whatever happened not to
-/// crash — a library embedder with a smaller stack is the case this does not
-/// cover, and is why the limit is a constant here rather than derived from
-/// whatever stack the caller happens to have.
-const MAX_EVAL_FRAMES: u32 = 100_000;
+/// **Calibrated in both profiles, against the tightest shape of each**
+/// (release at 256 MB, debug at 2 GB -- see `EVAL_STACK_SIZE` in
+/// `main.rs` for why the two stacks differ). Crash floors, bisected: thin
+/// body ~57,500 levels release / ~50,000 debug; 40-deep wrapping body
+/// 4,000-8,000 release / 4,000-6,000 debug. At 40,000 frames the guard fires
+/// first in every one of those, by 4x or better, while still clearing the
+/// depth this issue's own repro needs: `sum_to(10000)` returns 50005000,
+/// matching jq 1.7.1 (~3 frames per level for that body, so ~13,000 levels
+/// available).
+///
+/// Exceeding it must stay a *catchable error*, never a stack overflow: an
+/// abort is the failure mode #1016 exists to prevent, and #1098 established
+/// that a filter a user typed must not be able to take the process down.
+/// Real jq does not manage this on the same input -- `def deep: [deep]; deep`
+/// dies there with `cannot allocate memory`, exit 134 (confirmed live) -- so
+/// erroring instead is a divergence in the only direction ADR-0018 permits.
+const MAX_EVAL_FRAMES: u32 = 40_000;
 
 /// Evaluate one call to a user-defined function (#1371).
 ///

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3432,10 +3432,24 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         //
         // A link is exactly an argument that already contains a `Shared`,
         // which `any_subexpr` reports without walking the chain (its
-        // predicate fires on the first one, at depth 1). An enclosing
-        // definition's parameter threaded into an inner call looks the same
-        // and is treated the same -- conservative, and still correct: an
-        // un-lazified arm is a missed optimization, never a behaviour change.
+        // predicate fires on the first one, at depth 1). But that predicate
+        // cannot tell a computed chain link (`Shared(prev) - 1`: an operator
+        // applied *around* a `Shared`, always single-valued if `prev` is)
+        // from a bare pass-through (`inner` *is itself* a `Shared`: an
+        // ordinary parameter threaded unchanged into a nested call, one more
+        // wrapper deep than the level below). A pass-through can be anything
+        // the user wrote inside it -- multi-valued, infinite, side-effecting
+        // -- so treating it as a settled single value ran a branch first()/
+        // limit() would never have asked for, and re-ran it once per level
+        // the value was threaded through un-memoized.
+        //
+        // Peel a bare pass-through first, by re-entering this same arm on
+        // what it wraps -- `eval_each` dispatches straight back here for
+        // another `Shared`, or into whatever real expression or chain-link
+        // operator was underneath once the pass-through chain runs out.
+        Expr::Shared(inner) if matches!(&**inner, Expr::Shared(_)) => {
+            eval_each::<W, S>(inner, value, optional, sink)
+        }
         Expr::Shared(inner) => {
             if any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
                 drain_result(eval_single::<W, S>(inner, value, optional), sink)
@@ -40472,23 +40486,50 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // chain of arguments from every level below, restoring exactly the
         // O(depth^2) traversal this design removes.
         Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
-        // Likewise opaque: a `DefCall`'s own definition was captured with all
-        // outer definitions already installed in it, and its arguments were
-        // installed when it was created. Descending would also re-install
-        // *this* definition inside a call that is deliberately deferred,
-        // which is the unrolling this fix exists to stop.
+        // The definition itself is opaque for the same reason `Shared` is --
+        // it was captured with every outer definition already installed, and
+        // re-installing it here would re-walk work this same pass already
+        // did when the node was created. `args`, though, are not: they are
+        // ordinary caller-scope code, and "installed when it was created"
+        // only holds with respect to *that* creating pass's own `def` --
+        // a sibling `def` being installed afterward (e.g. this call sits
+        // nested inside an already-installed call's arguments, as in
+        // `g(f(n-1))` while installing `f`) has never had its own
+        // occurrences installed inside `args` at all. Not descending left
+        // such a nested self-call as a bare `FuncCall` forever, which
+        // `eval_func_call` then rejected as "undefined function" (#1371).
+        //
+        // `frames` is refreshed to the larger of its own stale count and the
+        // ambient depth this pass is walking at, for the same reason: `n`
+        // was fixed once, when this call's owning `def` was originally
+        // installed at whatever (usually shallow) structural depth it sat
+        // at textually. A different `def` whose own recursion embeds this
+        // call deeper on the *real* call stack -- e.g. this `DefCall` sits
+        // in the base case of an unrelated, independently-recursing `def`
+        // -- walks over it again here with a much larger ambient `frames`.
+        // Leaving `n` untouched would let this call's own guard fire based
+        // on a native depth that no longer describes where it actually
+        // runs, permitting its own budget to stack on top of the ambient
+        // one already spent and blow past the real native stack -- exactly
+        // the composed-recursion overflow `MAX_EVAL_FRAMES` exists to
+        // prevent, just spread across two different `def`s instead of one.
         Expr::DefCall {
             def: d,
             args,
             frames: n,
-            bound,
+            bound: _,
         } => Expr::DefCall {
             def: Rc::clone(d),
-            args: args.clone(),
-            frames: *n,
-            // `args` come through unchanged, so whatever this node has
-            // already bound is still exactly what it would bind again.
-            bound: bound.clone(),
+            args: args
+                .iter()
+                .map(|a| install_def_calls(a, def, frames + 1))
+                .collect(),
+            frames: frames.max(*n),
+            // `args` (and possibly `frames`) may have changed, so a stale
+            // cached binding cannot be reused (though in practice `bound`
+            // is always still empty here -- install only ever runs on a
+            // node before it has been evaluated).
+            bound: BoundBody::default(),
         },
         Expr::Break(name) => Expr::Break(name.clone()),
     }
@@ -40909,7 +40950,12 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
 
 /// Expand function calls in a builtin expression.
 fn install_def_calls_in_builtin(builtin: &Builtin, def: &Rc<FuncDefData>, depth: u32) -> Builtin {
-    map_builtin_subexprs(builtin, &mut |e| install_def_calls(e, def, depth))
+    // Every other structural arm in `install_def_calls` charges `frames + 1`
+    // at each descent step (once at the call site into this function, again
+    // here for the step into each subexpression) -- matching that keeps a
+    // `DefCall` reached through a builtin argument (`map(recurse_def)`,
+    // `select(...)`) charged the same as an equivalent plain-expression path.
+    map_builtin_subexprs(builtin, &mut |e| install_def_calls(e, def, depth + 1))
 }
 
 /// Substitute function parameter in a builtin expression.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3412,7 +3412,10 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             frames,
             bound,
         } => match bind_def_call(def, args, *frames, bound) {
-            Ok(bound) => eval_each::<W, S>(bound, value, optional, sink),
+            Ok(bound) => {
+                let _guard = enter_def_call_frame(*frames);
+                eval_each::<W, S>(bound, value, optional, sink)
+            }
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Lazy only for an argument the *user* wrote, not for a link in a
@@ -3430,18 +3433,39 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // unconditionally. Nothing is gained there either: an arithmetic
         // chain is single-valued, so there is no demand to forward.
         //
-        // A link is exactly an argument that already contains a `Shared`,
-        // which `any_subexpr` reports without walking the chain (its
-        // predicate fires on the first one, at depth 1). But that predicate
-        // cannot tell a computed chain link (`Shared(prev) - 1`: an operator
-        // applied *around* a `Shared`, always single-valued if `prev` is)
-        // from a bare pass-through (`inner` *is itself* a `Shared`: an
-        // ordinary parameter threaded unchanged into a nested call, one more
-        // wrapper deep than the level below). A pass-through can be anything
-        // the user wrote inside it -- multi-valued, infinite, side-effecting
-        // -- so treating it as a settled single value ran a branch first()/
-        // limit() would never have asked for, and re-ran it once per level
-        // the value was threaded through un-memoized.
+        // A link is a *pure, single-valued* combination of the previous
+        // level's `Shared` and literals -- `is_pure_chain_link` recognizes
+        // exactly that shape (see its own doc comment). This used to be
+        // `any_subexpr(inner, |e| matches!(e, Expr::Shared(_)))`: "does a
+        // `Shared` appear anywhere in this subtree" -- which fires on any
+        // node that merely *mentions* one, not just a computed chain link
+        // built around one. Two ways that misfired, both confirmed live:
+        //
+        // - A composed argument that mixes a genuine chain-link reference
+        //   with an unrelated side-effecting/multi-valued branch in the same
+        //   expression -- not a bare double-`Shared`, so the pass-through
+        //   peel below doesn't catch it either, but `any_subexpr` still
+        //   found the `Shared` and took the eager path anyway
+        //   (`def f(n; g): if n==0 then g else f(n-1; (g, "SIDE"|debug)) end;
+        //   isempty(f(1; 1))` ran the debug branch `isempty` never asked
+        //   for).
+        // - `any_subexpr`'s own `DefCall` arm walks into `def.body` too (so
+        //   it can answer "is X called anywhere", a question other callers
+        //   of `any_subexpr` legitimately need) -- so a *nested* `def` that
+        //   merely closes over an already-`Shared`-wrapped outer parameter
+        //   reports a "nested `Shared`" match via its own frozen body,
+        //   despite the call site itself carrying no argument at all
+        //   (`def outer(g): def inner: g; def id(x): x; first(id(inner));
+        //   outer((1, ("SIDE"|stderr)))` ran the stderr branch `first` never
+        //   asked for).
+        //
+        // `is_pure_chain_link` is a whitelist instead: it never recurses
+        // into what a `Shared` node wraps (any `Shared` is trivially "pure"
+        // here -- its own producer already went through this same
+        // classification), and it only recognizes `Shared`/literals combined
+        // by pure, single-valued operators. Anything else -- `Comma`,
+        // `Pipe`, a `FuncCall`/`DefCall`, a builtin -- is not in the
+        // whitelist and falls through to the always-correct lazy path below.
         //
         // Peel a bare pass-through first, by re-entering this same arm on
         // what it wraps -- `eval_each` dispatches straight back here for
@@ -3451,7 +3475,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             eval_each::<W, S>(inner, value, optional, sink)
         }
         Expr::Shared(inner) => {
-            if any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
+            if is_pure_chain_link(inner) {
                 drain_result(eval_single::<W, S>(inner, value, optional), sink)
             } else {
                 eval_each::<W, S>(inner, value, optional, sink)
@@ -30767,6 +30791,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         } => match bind_def_call(def, args, *frames, bound) {
             Err(e) => QueryResult::Error(e),
             Ok(bound) => {
+                let _guard = enter_def_call_frame(*frames);
                 let mut stages = vec![(**bound).clone()];
                 stages.extend(rest.iter().cloned());
                 eval_pipe_with_path_context_internal::<W, S>(
@@ -40010,6 +40035,77 @@ fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     eval_single::<W, S>(&bound_then, value, optional)
 }
 
+/// Ambient "how many frames deep is the recursion the caller is already
+/// inside" counter, consulted by [`bind_def`] in place of hardcoding `0`.
+///
+/// A `def` declared *inside* another `def`'s recursively-called body gets a
+/// brand new [`FuncDefData`] and a brand new `install_def_calls` pass every
+/// time `bind_def` runs for it — there is no pre-existing `DefCall` node to
+/// carry a `frames` count forward, because none of the inner def's own calls
+/// have been installed yet. Without this, that fresh install always started
+/// counting from `0`, so `MAX_EVAL_FRAMES` never saw how much native stack
+/// the *enclosing* recursion had already spent: a `def` nested inside a
+/// separately-recursing `def`, each individually well under the guard's
+/// ceiling, could still overflow the stack outright — a raw abort, exactly
+/// what #1098/#1016 exist to prevent (confirmed live: `def outer(n): if n ==
+/// 0 then 0 else (def inner(m): if m == 0 then 0 else inner(m-1) end;
+/// inner(2000)) + outer(n-1) end; outer(2000)` — 2,000 well under 40,000 on
+/// both axes individually — crashed with `fatal runtime error: stack
+/// overflow` before this existed).
+///
+/// Mirrors `remaining_inputs`' own "reach outside the pure per-document
+/// evaluation model via ambient state" shape (see its doc comment) rather
+/// than threading a depth parameter through every evaluator signature —
+/// consistent with this codebase having no environment parameter anywhere.
+/// `#[cfg(feature = "std")]` only, same rationale as `remaining_inputs`: a
+/// `no_std` embedding has no `thread_local!`. This leaves `no_std` exactly as
+/// exposed to the gap above as it already was, not more — the guard itself
+/// (`MAX_EVAL_FRAMES`, checked via the ordinary `frames` parameter) still
+/// applies unconditionally in both configurations.
+#[cfg(feature = "std")]
+mod ambient_frame_depth {
+    use std::cell::Cell;
+
+    thread_local! {
+        static CURRENT: Cell<u32> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn get() -> u32 {
+        CURRENT.with(Cell::get)
+    }
+
+    /// Raises the ambient depth to at least `frames` for the caller's scope,
+    /// restoring the previous value on drop — so a call that has returned
+    /// (or a sibling call not nested inside this one) never inherits it.
+    #[must_use]
+    pub(crate) struct Guard(u32);
+
+    pub(crate) fn enter(frames: u32) -> Guard {
+        let previous = get();
+        CURRENT.with(|c| c.set(previous.max(frames)));
+        Guard(previous)
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            CURRENT.with(|c| c.set(self.0));
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod ambient_frame_depth {
+    pub(crate) fn get() -> u32 {
+        0
+    }
+
+    pub(crate) struct Guard;
+
+    pub(crate) fn enter(_frames: u32) -> Guard {
+        Guard
+    }
+}
+
 /// Install `def name(params): body` over `then`, the shared first half of
 /// every `Expr::FuncDef` evaluation arm (#1371).
 ///
@@ -40023,7 +40119,50 @@ pub(crate) fn bind_def(name: &str, params: &[String], body: &Expr, then: &Expr) 
         params: params.to_vec(),
         body: body.clone(),
     });
-    install_def_calls(then, &def, 0)
+    install_def_calls(then, &def, ambient_frame_depth::get())
+}
+
+/// Widens the ambient frame-depth floor (see [`ambient_frame_depth`]) to
+/// `frames` for the duration of evaluating one `DefCall`'s bound body — every
+/// `Expr::DefCall` evaluation arm wraps its recursive call into the bound
+/// body with this, so a `def` reached while that body evaluates (via
+/// [`bind_def`]) inherits how deep this call already is instead of starting
+/// over at `0` (#1371 follow-up).
+pub(crate) fn enter_def_call_frame(frames: u32) -> ambient_frame_depth::Guard {
+    ambient_frame_depth::enter(frames)
+}
+
+/// Whether `expr` is a pure, single-valued combination of `Shared` nodes and
+/// literals -- safe for `eval_each`'s `Expr::Shared` arm to evaluate eagerly
+/// instead of preserving demand-driven laziness (#1371 follow-up).
+///
+/// A whitelist, not a blacklist, on purpose: this replaces `any_subexpr(expr,
+/// |e| matches!(e, Expr::Shared(_)))`, which asked "does a `Shared` appear
+/// *anywhere* in this subtree" -- true for a genuine chain link
+/// (`Shared(prev) - 1`), but also true for a `Comma`/`Pipe`/call that merely
+/// *contains* one alongside unrelated multi-valued or side-effecting code, or
+/// for a nested `def` whose own frozen body happens to close over an
+/// already-`Shared`-wrapped outer parameter. Both shapes leaked side effects
+/// past a demand-driven consumer (`first`/`isempty`/`limit`) that never asked
+/// for them -- see the call site's own doc comment for both confirmed
+/// repros.
+///
+/// Never recurses into what a `Shared` node wraps: that value's own producer
+/// already went through this same classification when *it* was evaluated, so
+/// treating any `Shared` as trivially pure here does not re-open the hole
+/// above. Everything not explicitly recognized -- `Comma`, `Pipe`, a
+/// `FuncCall`/`DefCall`, a builtin, `Index`/`Field` navigation -- is
+/// conservatively *not* a pure chain link, which only ever costs the slower,
+/// always-correct lazy path, never correctness.
+pub(crate) fn is_pure_chain_link(expr: &Expr) -> bool {
+    match expr {
+        Expr::Shared(_) | Expr::Literal(_) => true,
+        Expr::Paren(inner) | Expr::Negate(inner) => is_pure_chain_link(inner),
+        Expr::Arithmetic { left, right, .. } | Expr::Compare { left, right, .. } => {
+            is_pure_chain_link(left) && is_pure_chain_link(right)
+        }
+        _ => false,
+    }
 }
 
 /// How much live native evaluation a user-defined function may accumulate
@@ -40118,7 +40257,10 @@ fn eval_def_call<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     match bind_def_call(def, args, frames, cache) {
-        Ok(bound) => eval_single::<W, S>(bound, value, optional),
+        Ok(bound) => {
+            let _guard = enter_def_call_frame(frames);
+            eval_single::<W, S>(bound, value, optional)
+        }
         Err(e) => QueryResult::Error(e),
     }
 }
@@ -41047,6 +41189,103 @@ mod tests {
     /// gap in both at once. Every case names the exact
     /// `(shape, optional, atomic)` combination it covers; `type W = Vec<u64>`
     /// is an arbitrary concrete choice, the function is generic over it.
+    /// #1371 follow-up (code-review regression): `bind_def` used to
+    /// hardcode `install_def_calls`'s starting `frames` at `0`, so a `def`
+    /// reached while evaluation was already deep inside another `def`'s own
+    /// recursion started counting from scratch -- bypassing
+    /// `MAX_EVAL_FRAMES` entirely for the nested `def` and letting composed
+    /// recursion overflow the native stack outright (confirmed live: `def
+    /// outer(n): if n == 0 then 0 else (def inner(m): if m == 0 then 0 else
+    /// inner(m-1) end; inner(2000)) + outer(n-1) end; outer(2000)` --
+    /// `2000` well under `MAX_EVAL_FRAMES` on both axes individually --
+    /// crashed with `fatal runtime error: stack overflow, aborting` before
+    /// this fix; see `enter_def_call_frame`'s own doc comment).
+    ///
+    /// Exercised directly against `bind_def`/`ambient_frame_depth` here
+    /// rather than through a CLI-level deep recursion, which would need
+    /// many thousands of levels -- prohibitively slow in a debug build --
+    /// to actually reach `MAX_EVAL_FRAMES`; this white-box check reaches
+    /// the same boundary in one call.
+    #[test]
+    fn test_bind_def_seeds_defcall_frames_from_ambient_depth_1371() {
+        let Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } = parse("def f: f; f").unwrap()
+        else {
+            panic!("expected a top-level FuncDef");
+        };
+
+        // No ambient depth entered yet: a fresh top-level `def` still seeds
+        // from `0`, matching every evaluator's actual call site.
+        match bind_def(&name, &params, &body, &then) {
+            Expr::DefCall { frames, .. } => assert_eq!(frames, 0),
+            other => panic!("expected DefCall, got {other:?}"),
+        }
+
+        // Simulates evaluation already being `MAX_EVAL_FRAMES - 1` frames
+        // deep inside an *enclosing* `def`'s own recursion (what
+        // `enter_def_call_frame` wraps around every `Expr::DefCall`
+        // evaluation arm) when it reaches this nested `def name: ...`
+        // FuncDef node.
+        {
+            let _guard = enter_def_call_frame(MAX_EVAL_FRAMES - 1);
+            match bind_def(&name, &params, &body, &then) {
+                Expr::DefCall { frames, .. } => assert_eq!(frames, MAX_EVAL_FRAMES - 1),
+                other => panic!("expected DefCall, got {other:?}"),
+            }
+        }
+
+        // The guard's `Drop` must restore the previous ambient value, so a
+        // `def` reached *after* the nested call returns -- a sibling, not
+        // something nested inside it -- does not inherit a depth that no
+        // longer applies to it.
+        match bind_def(&name, &params, &body, &then) {
+            Expr::DefCall { frames, .. } => assert_eq!(frames, 0),
+            other => panic!("expected DefCall, got {other:?}"),
+        }
+    }
+
+    /// Companion to the test above: confirms the ambient floor it pins is
+    /// exactly what makes `MAX_EVAL_FRAMES` catch a nested `def` instead of
+    /// letting it run unguarded off the end of the native stack. A `def`
+    /// whose own recursion would need only one more frame to matter is
+    /// refused immediately once the ambient floor alone already meets the
+    /// ceiling -- this is the guard actually firing, not just the frame
+    /// count being recorded correctly (the test above).
+    #[test]
+    fn test_ambient_frame_depth_composes_with_defcall_guard_1371() {
+        let Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } = parse("def f: f; f").unwrap()
+        else {
+            panic!("expected a top-level FuncDef");
+        };
+
+        let _guard = enter_def_call_frame(MAX_EVAL_FRAMES);
+        let Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } = bind_def(&name, &params, &body, &then)
+        else {
+            panic!("expected DefCall");
+        };
+        let err = bind_def_call(&def, &args, frames, &bound)
+            .expect_err("ambient depth at the ceiling must refuse the call, not run it");
+        assert!(
+            err.message.contains("exceeded maximum recursion depth"),
+            "message: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn test_catch_error_under_optional_full_truth_table_1888() {
         type W = Vec<u64>;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40205,7 +40205,7 @@ pub(crate) fn is_pure_chain_link(expr: &Expr) -> bool {
 /// Real jq does not manage this on the same input -- `def deep: [deep]; deep`
 /// dies there with `cannot allocate memory`, exit 134 (confirmed live) -- so
 /// erroring instead is a divergence in the only direction ADR-0018 permits.
-const MAX_EVAL_FRAMES: u32 = 40_000;
+pub(crate) const MAX_EVAL_FRAMES: u32 = 40_000;
 
 /// Evaluate one call to a user-defined function (#1371).
 ///
@@ -65896,6 +65896,85 @@ mod tests {
             substitute_func_param(&slice_number, "x", &Expr::Identity),
             slice_number
         );
+    }
+
+    /// #1371: `Expr::NthExpr` is never constructed by the parser -- a CLI
+    /// `nth(n; expr)` always parses through `Builtin::NthStream` instead (see
+    /// `eval_nth_expr_n_argument_propagates_halt`'s doc comment) -- so
+    /// `install_def_calls`'s own rebuild arm for it can only be reached by a
+    /// direct call. Unlike `Expr::SliceNumber` above (a leaf `install_def_calls`
+    /// just clones), `NthExpr` carries two sub-expressions it must actually
+    /// recurse into: both `n` and `expr` need their own call to `f` rewritten
+    /// to a `DefCall`, not silently left as an unresolvable `FuncCall`.
+    #[test]
+    fn install_def_calls_descends_into_nth_expr_1371() {
+        let def = Rc::new(FuncDefData {
+            name: "f".into(),
+            params: Vec::new(),
+            body: Expr::Identity,
+        });
+        let call_f = || Expr::FuncCall {
+            name: "f".into(),
+            args: Vec::new(),
+        };
+        let nth = Expr::NthExpr {
+            n: Box::new(call_f()),
+            expr: Box::new(call_f()),
+        };
+
+        match install_def_calls(&nth, &def, 0) {
+            Expr::NthExpr { n, expr } => {
+                assert!(
+                    matches!(*n, Expr::DefCall { .. }),
+                    "n must be installed, got {n:?}"
+                );
+                assert!(
+                    matches!(*expr, Expr::DefCall { .. }),
+                    "expr must be installed, got {expr:?}"
+                );
+            }
+            other => panic!("expected NthExpr, got {other:?}"),
+        }
+    }
+
+    /// #1371: `Expr::NamespacedCall`'s own name is never this pass's call to
+    /// resolve -- `f` and `ns::f` are different names -- so only its `args`
+    /// can carry a call to `f`, checked the same way `Expr::FuncCall`'s own
+    /// arm checks its own `args`. Pinned directly for the same reason as
+    /// `install_def_calls_descends_into_nth_expr_1371` above: nothing in this
+    /// crate's own test suite otherwise builds a `def` in scope alongside a
+    /// namespaced call, so the CLI can't be relied on to reach this arm.
+    #[test]
+    fn install_def_calls_descends_into_namespaced_call_args_1371() {
+        let def = Rc::new(FuncDefData {
+            name: "f".into(),
+            params: Vec::new(),
+            body: Expr::Identity,
+        });
+        let ns_call = Expr::NamespacedCall {
+            namespace: "ns".into(),
+            name: "g".into(),
+            args: vec![Expr::FuncCall {
+                name: "f".into(),
+                args: Vec::new(),
+            }],
+        };
+
+        match install_def_calls(&ns_call, &def, 0) {
+            Expr::NamespacedCall {
+                namespace,
+                name,
+                args,
+            } => {
+                assert_eq!(namespace, "ns");
+                assert_eq!(name, "g");
+                assert!(
+                    matches!(args.as_slice(), [Expr::DefCall { .. }]),
+                    "arg must be installed, got {args:?}"
+                );
+            }
+            other => panic!("expected NamespacedCall, got {other:?}"),
+        }
     }
 
     /// Build a single-step [`DeleteTrie`] whose one edge is `component`.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5694,8 +5694,13 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         // #1371: mirrors `eval.rs`'s own `DefCall`/`Shared` pair -- see there
         // for why the generic fallback is not good enough (a consumer that
         // stops early must not have already run the rest of the body).
-        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
-            Ok(bound) => eval_each_generic::<S, V>(&bound, value, optional, cursor, sink),
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound,
+        } => match bind_def_call(def, args, *frames, bound) {
+            Ok(bound) => eval_each_generic::<S, V>(bound, value, optional, cursor, sink),
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Same split as `eval.rs`'s own `Shared` arm, for the same measured

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5707,7 +5707,14 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         // reason -- see there. A link in a recursion's own argument chain
         // takes the cheaper eager path (it is single-valued, so no demand is
         // lost); an argument the user wrote stays lazy, because *its*
-        // laziness is observable.
+        // laziness is observable. A bare pass-through (`inner` is itself a
+        // `Shared` -- a parameter threaded unchanged through another level,
+        // not a computed chain link) can be arbitrary user code underneath,
+        // so it is peeled by re-entering this same arm rather than taken as
+        // settled -- see `eval.rs`'s identical split for the full reasoning.
+        Expr::Shared(inner) if matches!(&**inner, Expr::Shared(_)) => {
+            eval_each_generic::<S, V>(inner, value, optional, cursor, sink)
+        }
         Expr::Shared(inner) => {
             if crate::jq::walk::any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
                 drain_result_generic(eval_single::<S, V>(inner, value, optional, cursor), sink)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5698,7 +5698,18 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             Ok(bound) => eval_each_generic::<S, V>(&bound, value, optional, cursor, sink),
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
-        Expr::Shared(inner) => eval_each_generic::<S, V>(inner, value, optional, cursor, sink),
+        // Same split as `eval.rs`'s own `Shared` arm, for the same measured
+        // reason -- see there. A link in a recursion's own argument chain
+        // takes the cheaper eager path (it is single-valued, so no demand is
+        // lost); an argument the user wrote stays lazy, because *its*
+        // laziness is observable.
+        Expr::Shared(inner) => {
+            if crate::jq::walk::any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
+                drain_result_generic(eval_single::<S, V>(inner, value, optional, cursor), sink)
+            } else {
+                eval_each_generic::<S, V>(inner, value, optional, cursor, sink)
+            }
+        }
 
         // See `each_limit_generic`'s own doc comment.
         Expr::Limit { n, expr } => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -17352,4 +17352,57 @@ mod tests {
         let result = eval_with_cursor(&expr, index.root(json));
         assert_eq!(result.into_owned().unwrap().unwrap(), OwnedValue::Int(3));
     }
+
+    /// #1371: `eval_each_generic`'s own `Expr::DefCall` arm (mirroring
+    /// `eval.rs`'s eager `eval_def_call`) has to turn a `bind_def_call`
+    /// failure into `Flow::Escaped(Control::Error(_))` rather than, say,
+    /// unwrapping or silently stopping -- a consumer stacked on top of the
+    /// generic/lazy sink (`limit`, `first`, `[...]`) must see the same
+    /// recursion-depth error the eager path raises, not a truncated or empty
+    /// result.
+    ///
+    /// Reaches `MAX_EVAL_FRAMES` via the ambient-depth guard directly, the
+    /// same white-box shortcut `eval.rs`'s own
+    /// `test_ambient_frame_depth_composes_with_defcall_guard_1371` uses,
+    /// rather than actually recursing 40,000 levels deep. `eval_each_generic`
+    /// is reached (rather than `eval_single`'s "fall back to the full
+    /// evaluator" wildcard arm) by driving the constructed `Expr::DefCall`
+    /// straight through [`eval_each_with_cursor_using`], which calls
+    /// `eval_each_generic` as its own entry point.
+    #[test]
+    fn eval_each_generic_reports_defcall_binding_failure_1371() {
+        let Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+        } = parse("def f: f; f").unwrap()
+        else {
+            panic!("expected a top-level FuncDef");
+        };
+
+        let _guard = enter_def_call_frame(crate::jq::eval::MAX_EVAL_FRAMES);
+        let defcall = bind_def(&name, &params, &body, &then);
+        assert!(
+            matches!(&defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
+            "expected bind_def to seed frames from the ambient depth"
+        );
+
+        let json = b"null";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+
+        let mut on_value = |_item: GenericResult<_>| true;
+        let control =
+            eval_each_with_cursor_using::<JqSemantics, _>(&defcall, cursor, &mut on_value);
+
+        match control {
+            Some(Control::Error(err)) => assert!(
+                err.message.contains("exceeded maximum recursion depth"),
+                "message: {}",
+                err.message
+            ),
+            other => panic!("expected Control::Error, got {other:?}"),
+        }
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -35,14 +35,15 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call, classify_limit_n,
-    classify_nth_n, collapse_vec, collect_pattern_var_names, compare_values, eval as full_eval,
-    eval_each_owned, eval_foreach_with_values, eval_reduce_with_values, extract_pattern_bindings,
-    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
-    index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
-    numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
-    slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var, substitute_vars,
-    suppresses, tonumber_from_str, try_reserve_product, vec_with_capacity, Control, Demand,
-    EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
+    classify_nth_n, collapse_vec, collect_pattern_var_names, compare_values, enter_def_call_frame,
+    eval as full_eval, eval_each_owned, eval_foreach_with_values, eval_reduce_with_values,
+    extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_component_value,
+    index_in_array_bounds, index_one_owned as index_owned_by_key, is_pure_chain_link,
+    literal_to_owned, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
+    owned_bound_to_i64, owned_to_string, slice_object_as_yq_children, slice_owned_value_read,
+    substitute_bound_var, substitute_vars, suppresses, tonumber_from_str, try_reserve_product,
+    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
@@ -5700,7 +5701,10 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             frames,
             bound,
         } => match bind_def_call(def, args, *frames, bound) {
-            Ok(bound) => eval_each_generic::<S, V>(bound, value, optional, cursor, sink),
+            Ok(bound) => {
+                let _guard = enter_def_call_frame(*frames);
+                eval_each_generic::<S, V>(bound, value, optional, cursor, sink)
+            }
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Same split as `eval.rs`'s own `Shared` arm, for the same measured
@@ -5716,7 +5720,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             eval_each_generic::<S, V>(inner, value, optional, cursor, sink)
         }
         Expr::Shared(inner) => {
-            if crate::jq::walk::any_subexpr(inner, &mut |e| matches!(e, Expr::Shared(_))) {
+            if is_pure_chain_link(inner) {
                 drain_result_generic(eval_single::<S, V>(inner, value, optional, cursor), sink)
             } else {
                 eval_each_generic::<S, V>(inner, value, optional, cursor, sink)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -34,9 +34,9 @@ use super::document::{
     DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, as_var_refs, classify_limit_n, classify_nth_n, collapse_vec,
-    collect_pattern_var_names, compare_values, eval as full_eval, eval_each_owned,
-    eval_foreach_with_values, eval_reduce_with_values, expand_func_calls, extract_pattern_bindings,
+    apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call, classify_limit_n,
+    classify_nth_n, collapse_vec, collect_pattern_var_names, compare_values, eval as full_eval,
+    eval_each_owned, eval_foreach_with_values, eval_reduce_with_values, extract_pattern_bindings,
     format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, literal_to_owned, needs_path_context,
     numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
@@ -5687,9 +5687,18 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             body,
             then,
         } => {
-            let expanded_then = expand_func_calls(then, name, params, body, None, 0);
-            eval_each_generic::<S, V>(&expanded_then, value, optional, cursor, sink)
+            let bound_then = bind_def(name, params, body, then);
+            eval_each_generic::<S, V>(&bound_then, value, optional, cursor, sink)
         }
+
+        // #1371: mirrors `eval.rs`'s own `DefCall`/`Shared` pair -- see there
+        // for why the generic fallback is not good enough (a consumer that
+        // stops early must not have already run the rest of the body).
+        Expr::DefCall { def, args, frames } => match bind_def_call(def, args, *frames) {
+            Ok(bound) => eval_each_generic::<S, V>(&bound, value, optional, cursor, sink),
+            Err(e) => Flow::Escaped(Control::Error(e)),
+        },
+        Expr::Shared(inner) => eval_each_generic::<S, V>(inner, value, optional, cursor, sink),
 
         // See `each_limit_generic`'s own doc comment.
         Expr::Limit { n, expr } => {

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -487,6 +487,9 @@ pub enum Expr {
         /// 4,000 and 8,000. Charging the structural nesting at each call site
         /// tracks that difference; a count cannot.
         frames: u32,
+        /// The substituted body, remembered after the first evaluation of
+        /// this node.
+        bound: BoundBody,
     },
 
     /// Namespaced function call: `module::func` or `module::func(args)`
@@ -537,6 +540,68 @@ pub enum Expr {
         /// Default value expression (right side)
         value: Box<Self>,
     },
+}
+
+/// A [`Expr::DefCall`]'s substituted body, computed on first evaluation and
+/// reused afterwards (#1371).
+///
+/// Binding a call is a pure function of the node — substitute its `args` into
+/// a copy of `def.body`, then install the definition over the result — so for
+/// a given node the answer never changes and can be computed once. Without
+/// this, moving substitution from "once, before evaluation" to "at the call"
+/// charges it *per call*: a `def` used inside `.[]` over 200,000 elements
+/// re-substituted its body 200,000 times, measured at +8% for one call per
+/// element and +27% for three chained ones. With it, a repeated call site
+/// pays once, and a recursion still substitutes per level because each level
+/// installs its own fresh nodes.
+///
+/// Cloned along with the node it belongs to, which is safe wherever `args`
+/// come along unchanged. **The two substitution passes rebuild `args` and so
+/// must reset this** — they construct a fresh `BoundBody` rather than
+/// carrying the old node's, since a cache keyed on arguments that just
+/// changed is exactly a stale one.
+#[derive(Clone, Default)]
+pub struct BoundBody(core::cell::OnceCell<Rc<Expr>>);
+
+impl BoundBody {
+    /// The bound body, computing it with `bind` on first call.
+    pub fn get_or_init(&self, bind: impl FnOnce() -> Rc<Expr>) -> &Rc<Expr> {
+        self.0.get_or_init(bind)
+    }
+
+    /// The bound body, computing it with a fallible `bind` on first call.
+    ///
+    /// A failure (the recursion-depth guard) is deliberately **not** cached:
+    /// it depends on nothing this node owns that could change, but leaving it
+    /// uncached keeps the cache holding only successful, reusable results and
+    /// costs nothing — a node that failed the guard is not evaluated again.
+    pub fn get_or_try_init<E>(
+        &self,
+        bind: impl FnOnce() -> Result<Rc<Expr>, E>,
+    ) -> Result<&Rc<Expr>, E> {
+        if let Some(cached) = self.0.get() {
+            return Ok(cached);
+        }
+        let bound = bind()?;
+        Ok(self.0.get_or_init(|| bound))
+    }
+}
+
+/// Two `DefCall`s are equal when their definition, arguments and frame count
+/// are — whether either has been evaluated yet is derived state, not identity.
+impl PartialEq for BoundBody {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+/// Deliberately opaque: printing the cached body would make a node's `Debug`
+/// output depend on whether it had been evaluated, which is the shape that
+/// made `assert_eq!` on `{:?}` unreliable for YAML's own cursor cache.
+impl core::fmt::Debug for BoundBody {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("BoundBody")
+    }
 }
 
 /// The three parts of a `def` that [`Expr::DefCall`] carries from the

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -539,13 +539,14 @@ pub enum Expr {
     },
 }
 
-/// The three parts of a `def` that [`Expr::PendingDef`] carries between
-/// recursion levels (#1371).
+/// The three parts of a `def` that [`Expr::DefCall`] carries from the
+/// definition to each of its call sites (#1371).
 ///
 /// Split out of [`Expr::FuncDef`]'s inline fields so one `Rc` can hold all
-/// three: re-declaring the definition around each newly substituted body is
-/// the innermost step of every recursive call, and cloning a `body` there
-/// would reintroduce the per-level copy this design exists to remove.
+/// three: re-installing the definition over each newly substituted body is
+/// the innermost step of every recursive call, and cloning the definition
+/// there -- rather than bumping one refcount -- would put a per-level copy
+/// back into the path this design exists to keep flat.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FuncDefData {
     /// Function name.

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -564,11 +564,6 @@ pub enum Expr {
 pub struct BoundBody(core::cell::OnceCell<Rc<Expr>>);
 
 impl BoundBody {
-    /// The bound body, computing it with `bind` on first call.
-    pub fn get_or_init(&self, bind: impl FnOnce() -> Rc<Expr>) -> &Rc<Expr> {
-        self.0.get_or_init(bind)
-    }
-
     /// The bound body, computing it with a fallible `bind` on first call.
     ///
     /// A failure (the recursion-depth guard) is deliberately **not** cached:
@@ -1999,5 +1994,52 @@ mod tests {
         assert!(prog.module.is_none());
         assert!(prog.imports.is_empty());
         assert!(prog.includes.is_empty());
+    }
+
+    /// #1371: `BoundBody` is derived state, so it must not participate in
+    /// either of the two things `Expr` derives around it.
+    ///
+    /// **Equality** — two calls with the same definition, arguments and frame
+    /// count are the same call, whether or not one of them has been evaluated
+    /// yet. If the cache took part, a node would stop comparing equal to
+    /// itself the moment it ran, which would silently change what every
+    /// `assert_eq!` over an `Expr` in this crate means.
+    ///
+    /// **`Debug`** — the rendering must not change once the body is cached
+    /// either. A cache that prints is the exact shape that made `assert_eq!`
+    /// on `{:?}` unreliable for YAML's own sequential-cursor cache, where a
+    /// shared index leaked its `Cell` into the formatted output.
+    #[test]
+    fn test_bound_body_is_invisible_to_eq_and_debug_1371() {
+        let call = || Expr::DefCall {
+            def: Rc::new(FuncDefData {
+                name: "f".into(),
+                params: alloc_vec(["n"]),
+                body: Expr::Identity,
+            }),
+            args: vec![Expr::Literal(Literal::Int(1))],
+            frames: 3,
+            bound: BoundBody::default(),
+        };
+        let cold = call();
+        let warm = call();
+        let Expr::DefCall { bound, .. } = &warm else {
+            unreachable!("just built a DefCall")
+        };
+        // Populate one side's cache; the two must stay indistinguishable.
+        let _ = bound.get_or_try_init(|| Ok::<_, ()>(Rc::new(Expr::Identity)));
+
+        assert_eq!(cold, warm, "the cache must not affect equality");
+        assert_eq!(
+            format!("{cold:?}"),
+            format!("{warm:?}"),
+            "the cache must not affect Debug output"
+        );
+    }
+
+    /// Helper: `Vec<String>` from string literals, without repeating the
+    /// `to_string` dance at each call site.
+    fn alloc_vec<const N: usize>(names: [&str; N]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
     }
 }

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -421,6 +421,74 @@ pub enum Expr {
         args: Vec<Self>,
     },
 
+    /// A sub-expression that has already had every enclosing substitution
+    /// applied to it, and must therefore be treated as **opaque** by every
+    /// later substitution pass (#1371).
+    ///
+    /// Created when a user-defined function call binds its arguments: the
+    /// argument expression is captured as-is, behind an [`Rc`], instead of
+    /// being cloned into the callee's body. Two properties follow, and both
+    /// are load-bearing:
+    ///
+    /// - **No growth with recursion depth.** `def sum_to(n): … sum_to(n-1) …`
+    ///   used to inline the caller's own argument tree at every level, so the
+    ///   argument at depth `d` had `O(d)` nodes and the tree being walked kept
+    ///   growing — `O(d²)` work and native stack. Sharing makes each level add
+    ///   `O(1)` nodes over a pointer to the level before, so the same
+    ///   recursion is linear.
+    /// - **Hygiene.** A substitution that skips this node cannot reach inside
+    ///   an argument, so a binder in the callee (`3 as $x`, a `reduce`
+    ///   pattern) can never capture a caller variable the argument mentions
+    ///   (#2077).
+    ///
+    /// The contents are always fully substituted at construction time: the
+    /// node is built while *evaluating* a call, and everything that could
+    /// substitute into it lexically encloses that call and has therefore
+    /// already run. Evaluation is transparent — a `Shared` evaluates exactly
+    /// as its inner expression does.
+    Shared(Rc<Self>),
+
+    /// A call to a user-defined function, bound to its definition but **not
+    /// yet substituted** (#1371).
+    ///
+    /// Installed in place of an [`Expr::FuncCall`] when the enclosing
+    /// [`Expr::FuncDef`] is evaluated; the substitution of `args` into
+    /// `def.body` happens later, when evaluation actually reaches this node.
+    /// That split is the whole fix:
+    ///
+    /// - **Recursion terminates on its own.** Static substitution cannot see
+    ///   that a runtime condition (`n == 0`) will eventually hold, so it
+    ///   unrolls a self-recursive body forever and has to be cut off by a
+    ///   guard. Substituting one level per evaluation instead lets the base
+    ///   case simply not be evaluated — which is also why a branching body
+    ///   (`fib`) works at all now, rather than exhausting a budget at every
+    ///   depth including zero.
+    /// - **`args` stay ordinary caller-scope code until the call runs.** They
+    ///   are still reachable by an enclosing `as`-substitution, which an
+    ///   argument captured at install time would not be — the call site can
+    ///   sit inside a binder that has not been evaluated yet.
+    DefCall {
+        /// The definition this call resolves to, shared so that binding one
+        /// more level of recursion costs a pointer clone, not a body clone.
+        def: Rc<FuncDefData>,
+        /// Argument expressions, in the caller's scope and unsubstituted.
+        args: Vec<Self>,
+        /// How many native evaluation frames are already live above this
+        /// node, accumulated as the installer walks: one per structural level
+        /// it descends, carried across each call so it sums over the whole
+        /// live recursion. Carried in the node so the guard needs no ambient
+        /// state and stays deterministic under `no_std`.
+        ///
+        /// A plain call *count* would not do. It is not the number of calls
+        /// that exhausts the native stack but the frames each one holds live:
+        /// measured at 256 MB, a body whose recursive call sits directly in a
+        /// pipe survives ~57,500 levels, while one that wraps the same call in
+        /// 40 array constructors — which stay live across it — dies between
+        /// 4,000 and 8,000. Charging the structural nesting at each call site
+        /// tracks that difference; a count cannot.
+        frames: u32,
+    },
+
     /// Namespaced function call: `module::func` or `module::func(args)`
     NamespacedCall {
         /// Module namespace
@@ -469,6 +537,23 @@ pub enum Expr {
         /// Default value expression (right side)
         value: Box<Self>,
     },
+}
+
+/// The three parts of a `def` that [`Expr::PendingDef`] carries between
+/// recursion levels (#1371).
+///
+/// Split out of [`Expr::FuncDef`]'s inline fields so one `Rc` can hold all
+/// three: re-declaring the definition around each newly substituted body is
+/// the innermost step of every recursive call, and cloning a `body` there
+/// would reintroduce the per-level copy this design exists to remove.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FuncDefData {
+    /// Function name.
+    pub name: String,
+    /// Parameter names (empty for a no-argument definition).
+    pub params: Vec<String>,
+    /// Function body.
+    pub body: Expr,
 }
 
 /// A complete jq program including module directives and the main expression.

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -2011,7 +2011,7 @@ mod tests {
     /// shared index leaked its `Cell` into the formatted output.
     #[test]
     fn test_bound_body_is_invisible_to_eq_and_debug_1371() {
-        let call = || Expr::DefCall {
+        let call = |bound| Expr::DefCall {
             def: Rc::new(FuncDefData {
                 name: "f".into(),
                 params: alloc_vec(["n"]),
@@ -2019,15 +2019,16 @@ mod tests {
             }),
             args: vec![Expr::Literal(Literal::Int(1))],
             frames: 3,
-            bound: BoundBody::default(),
+            bound,
         };
-        let cold = call();
-        let warm = call();
-        let Expr::DefCall { bound, .. } = &warm else {
-            unreachable!("just built a DefCall")
-        };
-        // Populate one side's cache; the two must stay indistinguishable.
-        let _ = bound.get_or_try_init(|| Ok::<_, ()>(Rc::new(Expr::Identity)));
+        let cold = call(BoundBody::default());
+
+        // Populate the warm side's cache before it's ever wrapped in an
+        // `Expr::DefCall`, so the two stay indistinguishable without needing
+        // to destructure `bound` back out of `warm` afterwards.
+        let warm_bound = BoundBody::default();
+        let _ = warm_bound.get_or_try_init(|| Ok::<_, ()>(Rc::new(Expr::Identity)));
+        let warm = call(warm_bound);
 
         assert_eq!(cold, warm, "the cache must not affect equality");
         assert_eq!(

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -239,6 +239,51 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
         }
     }
 
+    /// [`from_owned`](Self::from_owned)'s checked twin: reports a value
+    /// nested past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// as an ordinary [`EvalError`] instead of panicking (#1371).
+    ///
+    /// The panicking form stays for library callers that own their input and
+    /// treat over-deep nesting as a bug. The CLI is the opposite case: since
+    /// a `def` recurses by evaluation rather than by pre-substituted body
+    /// (#1371), an ordinary recursive filter can now build a value deeper
+    /// than the ceiling -- `def deep(n): if n == 0 then . else [[deep(n-1)]]
+    /// end;` at a few hundred levels -- and taking the whole process down
+    /// with a panic for a filter a user simply typed is the failure mode
+    /// #1098 established this codebase does not ship.
+    ///
+    /// Costs nothing extra: the depth is already being carried down the
+    /// conversion that has to happen anyway, so this is the same walk with
+    /// its assertion turned into a returned error.
+    pub fn try_from_owned(owned: OwnedValue) -> Result<Self, EvalError> {
+        Self::try_from_owned_at_depth(owned, 0)
+    }
+
+    fn try_from_owned_at_depth(owned: OwnedValue, depth: usize) -> Result<Self, EvalError> {
+        if depth >= super::value::MAX_VALUE_TREE_DEPTH {
+            return Err(EvalError::new(
+                super::value::nesting_depth_exceeded_message(super::value::MAX_VALUE_TREE_DEPTH),
+            ));
+        }
+        Ok(match owned {
+            OwnedValue::Array(arr) => JqValue::Array(
+                arr.into_iter()
+                    .map(|v| Self::try_from_owned_at_depth(v, depth + 1))
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            OwnedValue::Object(obj) => JqValue::Object(
+                obj.into_iter()
+                    .map(|(k, v)| Self::try_from_owned_at_depth(v, depth + 1).map(|v| (k, v)))
+                    .collect::<Result<IndexMap<_, _>, _>>()?,
+            ),
+            // Every scalar arm is exactly `from_owned_at_depth`'s, reached
+            // only after the depth check above; kept as one delegation
+            // rather than six duplicated arms so the two constructors cannot
+            // drift on how a scalar is represented.
+            scalar => Self::from_owned_at_depth(scalar, depth),
+        })
+    }
+
     // =========================================================================
     // Type checking
     // =========================================================================

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -102,8 +102,9 @@ pub use eval::{
 // `false` without `std`), so `eval_generic` can consult it unconditionally.
 pub use eval::input_queue_is_active;
 pub use expr::{
-    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MetaValue,
-    ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program, StringPart,
+    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefData, Import, Include, Literal,
+    MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program,
+    StringPart,
 };
 pub use lazy::JqValue;
 pub use parser::{

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -102,9 +102,9 @@ pub use eval::{
 // `false` without `std`), so `eval_generic` can consult it unconditionally.
 pub use eval::input_queue_is_active;
 pub use expr::{
-    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefData, Import, Include, Literal,
-    MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program,
-    StringPart,
+    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefData, Import,
+    Include, Literal, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
+    PatternEntry, Program, StringPart,
 };
 pub use lazy::JqValue;
 pub use parser::{

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -850,4 +850,61 @@ mod tests {
     fn a_later_same_arity_def_shadows_but_the_earlier_one_stays_resolvable() {
         assert_eq!(resolve("def f: 1; def g: f; def f: 2; g"), Ok(()));
     }
+
+    /// #1371: `Shared`/`DefCall` can never actually reach `check` -- this pass
+    /// runs once, on the freshly parsed program, strictly before evaluation
+    /// ever builds either variant. Named rather than folded into the leaf
+    /// group regardless (see the arm's own comment), so exercised directly
+    /// here via `check` itself rather than through `resolve_func_calls`'s
+    /// parser-only entry point: each arm must actually recurse into its
+    /// payload, not just be present and silently report "no unresolved
+    /// calls" the way the leaf arms correctly do for real leaves.
+    #[test]
+    fn check_recurses_through_shared_and_defcall() {
+        use alloc::rc::Rc;
+
+        let unresolved = || Expr::FuncCall {
+            name: "nosuchfn".into(),
+            args: Vec::new(),
+        };
+
+        let mut scope = Scope::new();
+        let mut errors = Vec::new();
+        check(
+            &Expr::Shared(Rc::new(unresolved())),
+            &mut scope,
+            &mut errors,
+        );
+        assert_eq!(
+            errors,
+            [UnresolvedCall {
+                name: "nosuchfn".into(),
+                arity: 0,
+            }]
+        );
+
+        let mut scope = Scope::new();
+        let mut errors = Vec::new();
+        check(
+            &Expr::DefCall {
+                def: Rc::new(crate::jq::FuncDefData {
+                    name: "f".into(),
+                    params: Vec::new(),
+                    body: Expr::Identity,
+                }),
+                args: alloc::vec![unresolved()],
+                frames: 0,
+                bound: crate::jq::BoundBody::default(),
+            },
+            &mut scope,
+            &mut errors,
+        );
+        assert_eq!(
+            errors,
+            [UnresolvedCall {
+                name: "nosuchfn".into(),
+                arity: 0,
+            }]
+        );
+    }
 }

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -390,6 +390,23 @@ fn in_scope(scope: &Scope, name: &str, arity: usize) -> bool {
 /// one pass (#2037).
 fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
     match expr {
+        // #1371: neither variant can occur here. This pass runs once, on the
+        // freshly parsed program, before evaluation begins; both are built
+        // *by* evaluation. They are still given real arms rather than being
+        // folded into a leaf group, so that if a future caller ever runs this
+        // check over an evaluation-time tree it reports honestly instead of
+        // silently treating a whole subtree as having no calls in it.
+        //
+        // A `DefCall` is by construction already resolved -- it holds the
+        // definition it resolved to -- so only its arguments can carry an
+        // unresolved call, and they are checked in the scope this node sits
+        // in. The definition's own body was checked at its `FuncDef`.
+        Expr::Shared(inner) => check(inner, scope, errors),
+        Expr::DefCall { args, .. } => {
+            for arg in args {
+                check(arg, scope, errors);
+            }
+        }
         // Leaves: nothing nested to descend into. Mirrors `walk::any_subexpr`'s
         // own grouping so the two stay comparable arm for arm.
         Expr::Identity

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -589,6 +589,18 @@ pub fn any_subexpr(expr: &Expr, pred: &mut dyn FnMut(&Expr) -> bool) -> bool {
     }
 
     match expr {
+        // #1371: both variants only ever exist mid-evaluation, never in a
+        // freshly parsed program -- but this function answers "does this tree
+        // mention X anywhere" for callers that do run against evaluation-time
+        // trees, so both descend. A `Shared` holds a real argument
+        // expression, and a `DefCall` holds both the definition it resolved
+        // to and that call's arguments; treating either as a leaf would
+        // reintroduce exactly the "silently reported no match" bug this
+        // module exists to prevent.
+        Expr::Shared(inner) => any_subexpr(inner, pred),
+        Expr::DefCall { def, args, .. } => {
+            any_subexpr(&def.body, pred) || args.iter().any(|a| any_subexpr(a, pred))
+        }
         // Leaves: nothing nested to descend into.
         Expr::Identity
         | Expr::Field(_)

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -992,6 +992,59 @@ mod tests {
         assert_eq!(seen, 2);
     }
 
+    /// #1371: unlike `resolve::check` (which runs once on the freshly parsed
+    /// program and so can never actually see an `Expr::DefCall`),
+    /// `any_subexpr` answers callers -- `streams_unbounded`, `has_navigation`
+    /// and others -- that run *during* evaluation, after `def` calls have
+    /// been installed. Both halves of the arm's `||` need their own case: a
+    /// predicate matching only inside the resolved definition's body, and one
+    /// matching only inside the call's own (unsubstituted) arguments, so a
+    /// regression that dropped either operand would still fail here even
+    /// though the other made the whole expression true.
+    #[test]
+    fn any_subexpr_descends_into_defcall_body_and_args() {
+        use alloc::rc::Rc;
+
+        let marker = || Expr::Var("marker".into());
+        let mut is_marker = |e: &Expr| matches!(e, Expr::Var(name) if name == "marker");
+
+        let in_body = Expr::DefCall {
+            def: Rc::new(crate::jq::FuncDefData {
+                name: "f".into(),
+                params: Vec::new(),
+                body: marker(),
+            }),
+            args: vec![Expr::Identity],
+            frames: 0,
+            bound: crate::jq::BoundBody::default(),
+        };
+        assert!(any_subexpr(&in_body, &mut is_marker));
+
+        let in_args = Expr::DefCall {
+            def: Rc::new(crate::jq::FuncDefData {
+                name: "f".into(),
+                params: Vec::new(),
+                body: Expr::Identity,
+            }),
+            args: vec![marker()],
+            frames: 0,
+            bound: crate::jq::BoundBody::default(),
+        };
+        assert!(any_subexpr(&in_args, &mut is_marker));
+
+        let neither = Expr::DefCall {
+            def: Rc::new(crate::jq::FuncDefData {
+                name: "f".into(),
+                params: Vec::new(),
+                body: Expr::Identity,
+            }),
+            args: vec![Expr::Identity],
+            frames: 0,
+            bound: crate::jq::BoundBody::default(),
+        };
+        assert!(!any_subexpr(&neither, &mut is_marker));
+    }
+
     fn find_builtin(filter: &str) -> Builtin {
         let expr = parse(filter).expect("filter should parse");
         let mut found = None;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17186,6 +17186,98 @@ fn test_chained_self_recursive_defs_now_match_jq_1371() -> Result<()> {
     Ok(())
 }
 
+/// #1371 code-review regression: a self-call to the `def` currently being
+/// installed can sit nested inside an *already-installed* sibling call's
+/// own arguments (`g(f(n-1))`, installing `f` while `g`'s own call is
+/// already a bound `DefCall`). `install_def_calls`'s `DefCall` arm used to
+/// treat `args` as fully opaque -- correct only with respect to the `def`
+/// that created the node, not one installed afterward -- so the nested
+/// `f(n-1)` was left a bare, never-installed `FuncCall` forever, and
+/// `eval_func_call` rejected it as undefined. Matches jq 1.7.1 live (`3`).
+#[test]
+fn test_self_call_nested_in_sibling_calls_args_is_installed_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "def g(m): m + 1; \
+             def f(n): if n == 0 then 0 else g(f(n-1)) end; \
+             f(3)",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "3");
+    Ok(())
+}
+
+/// #1371 code-review regression: composed recursion across two different
+/// `def`s must be charged for the real depth it runs at, not the shallow
+/// structural depth the call was first written at. A `DefCall`'s `frames`
+/// field used to be fixed once, when its owning `def` was installed, and
+/// never refreshed -- so an unrelated `def` embedding that call deep inside
+/// its own recursion (in its base case) could let both `def`s' guards pass
+/// individually while their real native stacks summed past what either
+/// alone was calibrated safe for. `frames` is now refreshed to the larger
+/// of its stale value and the ambient depth each later install pass finds
+/// it at. This pins the *safety* property, not a specific jq-matching
+/// output: composed enough recursion must still end in a catchable
+/// "exceeded maximum recursion depth" error (exit 5), never a native
+/// stack-overflow abort -- confirmed this exact shape aborts without the
+/// fix (`d1` and `d2` each individually complete at n=11000, only the
+/// composed call errors).
+#[test]
+fn test_composed_recursion_across_two_defs_errors_not_aborts_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "def d2(n): if n == 0 then 0 else 1 + d2(n-1) end; \
+             def d1(n): if n == 0 then d2(11000) else 1 + d1(n-1) end; \
+             d1(11000)",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(stdout.trim_end(), "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #1371 code-review regression: `generic_result_to_jq_values`'s three
+/// `GenericResult::Partial` arms (the already-produced outputs of a
+/// generator that later failed, #400/#494) used to convert via the
+/// panicking `JqValue::from_owned` instead of the checked `to_jq_values`
+/// every other arm in that function uses. A value built by an ordinary
+/// recursive `def` can now exceed `MAX_VALUE_TREE_DEPTH` (384, #1371's
+/// whole point), so an already-produced `Partial` output deeper than that
+/// used to panic the process instead of reporting a clean error -- exactly
+/// the class of bug #1098 closed everywhere else. `deep(500)` builds a
+/// value past the ceiling as the first, successful half of a comma whose
+/// second half then genuinely errors; both must surface as ordinary
+/// diagnostics, never a panic.
+#[test]
+fn test_partial_result_over_depth_value_reports_cleanly_not_panic_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "def deep(n): if n==0 then . else [deep(n-1)] end; \
+             (deep(500), error(\"boom\"))",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(stdout.trim_end(), "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 384"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1381 regression guard: the weighted-cost check must not fire before an
 /// *ordinary, non-chained* recursive `def` reaches its own
 /// `MAX_FUNC_EXPANSION_DEPTH` budget -- `deep(49)` (a thin single-argument
@@ -23851,6 +23943,24 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             &["-cn", r#"isempty(def f: (1,("B"|stderr)); f)"#],
             None,
             "false\n",
+            "",
+            0,
+        ),
+        // #1371 code-review: `Expr::Shared`'s eager/lazy split used to treat
+        // "the argument contains a nested `Shared`" as proof of a computed,
+        // single-valued chain link (safe to evaluate eagerly, e.g.
+        // `Shared(prev) - 1`) -- but a threaded parameter passed unchanged
+        // through another level of recursion is *also* a nested `Shared`
+        // (`inner` is itself directly a `Shared`, not a chain link at all),
+        // and can be arbitrary user code underneath. The eager fallback ran
+        // the side effect this demand-driven `first` never asked for.
+        (
+            &[
+                "-cn",
+                r#"first(def f(n; x): if n <= 0 then x else f(n-1; x) end; f(3; (1, ("B"|stderr))))"#,
+            ],
+            None,
+            "1\n",
             "",
             0,
         ),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17087,19 +17087,16 @@ fn nested_arrays(depth: usize) -> String {
     format!("{}1{}", "[".repeat(depth), "]".repeat(depth))
 }
 
-/// #1016: a self-recursive `def` has no base case at expansion time --
-/// `expand_func_calls` statically substitutes `deep`'s body in place of
-/// each call *before* any evaluation happens, so it can't observe that
-/// `n == 0` will eventually hold and unrolls unconditionally. Confirmed
-/// live before this fix: `deep(1)` crashed with SIGABRT (stack overflow)
-/// even at the shallowest possible depth, since expansion never terminates
-/// on its own regardless of `n`'s actual value.
+/// #1016/#1371: `deep(60)` used to be refused -- static expansion could not
+/// observe that `n == 0` would eventually hold, so it unrolled until
+/// `MAX_FUNC_EXPANSION_DEPTH` (50) stopped it and reported "recursion depth
+/// exceeds limit of 50" for a filter real jq evaluates without difficulty.
 ///
-/// `n = 60` safely exceeds `MAX_FUNC_EXPANSION_DEPTH` (50), so this must
-/// still fail -- but cleanly, as a catchable `EvalError`, not a SIGABRT
-/// that takes the whole process down.
+/// Now that a call is bound and substituted at evaluation time (#1371), the
+/// base case simply terminates the recursion, and the output is byte-for-byte
+/// jq 1.7.1's own (confirmed live).
 #[test]
-fn test_self_recursive_def_rejects_past_expansion_depth_1016() -> Result<()> {
+fn test_self_recursive_def_past_old_expansion_depth_now_matches_jq_1371() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -17107,10 +17104,10 @@ fn test_self_recursive_def_rejects_past_expansion_depth_1016() -> Result<()> {
         ],
         Some("null"),
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert!(
-        stderr.contains("recursion depth exceeds limit of 50"),
-        "stderr: {stderr:?}"
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        format!("{}null{}", "[".repeat(60), "]".repeat(60))
     );
     Ok(())
 }
@@ -17136,56 +17133,41 @@ fn test_self_recursive_def_accepts_depth_under_limit_1016() -> Result<()> {
     Ok(())
 }
 
-/// Pins the exact boundary rather than just "well under"/"well over": for
-/// this single-argument shape, `deep(49)` is the largest `n` that succeeds
-/// and `deep(50)` is the first that fails -- confirmed live. A future
-/// change to the budget check (e.g. `>` instead of `>=`, or a shifted
-/// increment) would silently move this boundary by one with nothing to
-/// catch it if only the "well within"/"well past" tests above existed.
+/// #1371: there is no longer a substitution boundary to pin. `deep(49)` and
+/// `deep(50)` used to be the last success and the first failure -- an
+/// artefact of `MAX_FUNC_EXPANSION_DEPTH` counting substitutions, not of
+/// anything jq does. Both now evaluate, and this pins that the old cliff is
+/// gone rather than merely moved: the two outputs differ only by one level of
+/// nesting, as they should.
 #[test]
-fn test_self_recursive_def_boundary_is_exactly_49_1016() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(
-        &[
-            "-c",
-            "def deep(n): if n == 0 then . else [deep(n-1)] end; deep(49)",
-        ],
-        Some("null"),
-    )?;
-    assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(
-        stdout.trim_end(),
-        format!("{}null{}", "[".repeat(49), "]".repeat(49))
-    );
-
-    let (stdout, stderr, code) = run_jq_full(
-        &[
-            "-c",
-            "def deep(n): if n == 0 then . else [deep(n-1)] end; deep(50)",
-        ],
-        Some("null"),
-    )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert!(
-        stderr.contains("recursion depth exceeds limit of 50"),
-        "stderr: {stderr:?}"
-    );
+fn test_old_expansion_depth_boundary_is_gone_1371() -> Result<()> {
+    for n in [49usize, 50] {
+        let (stdout, stderr, code) = run_jq_full(
+            &[
+                "-c",
+                &format!("def deep(n): if n == 0 then . else [deep(n-1)] end; deep({n})"),
+            ],
+            Some("null"),
+        )?;
+        assert_eq!(code, 0, "n={n} stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim_end(),
+            format!("{}null{}", "[".repeat(n), "]".repeat(n)),
+            "n={n}"
+        );
+    }
     Ok(())
 }
 
-/// #1381: chaining several small recursive `def`s, each calling the
-/// previous one as its base case, used to multiply size ~50x per chained
-/// level (`r0`'s occurrence inside `r1`'s own body gets fully expanded
-/// *before* `r1`'s own self-reference loop runs, so every one of `r1`'s
-/// own budget-bounded hits clones a `body` that already embeds `r0`'s
-/// entire expansion) -- confirmed live pre-fix at 4+ GB peak RSS for the
-/// 3-def repro below. The weighted-cost guard now throttles `r1`'s (and
-/// `r2`'s) own hit count down to a small handful once their `body` has
-/// absorbed a prior chained `def`'s expansion, so this now fails cleanly
-/// and fast instead of exhausting memory -- see
-/// `MAX_FUNC_EXPANSION_WEIGHTED_COST`'s own doc comment (`src/jq/eval.rs`)
-/// for the full mechanism.
+/// #1381/#1371: three chained recursive `def`s, each calling the previous one
+/// as its base case. Under static expansion this multiplied body size ~50x
+/// per chained level -- 4+ GB peak RSS before #1381 bounded it, and a clean
+/// "substitution cost exceeds limit of 250000" refusal after. The
+/// multiplication was inherent to expanding one `def`'s body *into* the next
+/// one's before either ran; binding calls at evaluation time removes it
+/// outright, and this now returns jq 1.7.1's own answer (confirmed live).
 #[test]
-fn test_chained_self_recursive_defs_bounded_by_weighted_cost_1381() -> Result<()> {
+fn test_chained_self_recursive_defs_now_match_jq_1371() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -17196,10 +17178,10 @@ fn test_chained_self_recursive_defs_bounded_by_weighted_cost_1381() -> Result<()
         ],
         Some("null"),
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert!(
-        stderr.contains("substitution cost exceeds limit of 250000"),
-        "stderr: {stderr:?}"
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        format!("{}null{}", "[".repeat(45), "]".repeat(45))
     );
     Ok(())
 }
@@ -17254,19 +17236,21 @@ fn test_weighted_cost_guard_does_not_regress_moderately_complex_body_1381() -> R
     Ok(())
 }
 
-/// A zero-argument self-recursive `def` (no growing argument expression to
-/// substitute) is the *cheapest possible* case for `expand_func_calls`'s own
-/// recursion, yet still crashed at only ~383 levels in a debug build before
-/// this fix (measured while calibrating `MAX_FUNC_EXPANSION_DEPTH`) -- it
-/// has no base case at all, so it must hit the depth guard on every build,
-/// not just adversarially deep ones. Confirms the guard covers this shape
-/// too, not just the parameterized one above.
+/// A `def` with no base case at all must still fail, and must fail *cleanly*
+/// -- the one thing #1016 established is non-negotiable, and the thing
+/// #1371's change could most easily have broken by trading a guard for
+/// unbounded native recursion.
+///
+/// Real jq does not survive this: `def deep: [deep]; deep` dies with
+/// `cannot allocate memory` and signal-level exit 134 (confirmed live against
+/// jq 1.7.1). Erroring instead of aborting is a deliberate divergence in the
+/// only direction ADR-0018 permits -- matching would take the process down.
 #[test]
 fn test_unconditional_self_recursive_def_rejects_cleanly_1016() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "def deep: [deep]; deep"], Some("null"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
-        stderr.contains("recursion depth exceeds limit of 50"),
+        stderr.contains("deep/0 exceeded maximum recursion depth"),
         "stderr: {stderr:?}"
     );
     Ok(())
@@ -17289,31 +17273,35 @@ fn test_non_self_recursive_constructs_unaffected_by_expansion_guard_1016() -> Re
     Ok(())
 }
 
-/// #1016 code review: a `def` body with *more than one* syntactic self-call
-/// (branching self-recursion, e.g. naive `fib`) defeats a plain per-chain
-/// depth counter -- every structural arm visiting multiple children (`+`'s
-/// two operands here) passes the same depth to each, so `k` self-calls per
-/// level compound to `O(k^depth)` total substitutions even though no single
-/// chain exceeds the cap. Confirmed live before this fix: `def f: [f, f];
-/// f` consumed tens of GB and never terminated. `MAX_FUNC_EXPANSION_DEPTH`
-/// must bound *total* expansion work (a shared budget, not a per-chain
-/// value) to stay safe for this shape too -- this must return quickly with
-/// a clean error, not hang or exhaust memory. Real jq resolves `fib(3)`
-/// instantly (`2`); this guard's shared-budget design means even this
-/// shallow, everyday case can't succeed under static expansion (see
-/// `MAX_FUNC_EXPANSION_DEPTH`'s doc comment) -- but it must fail cleanly.
+/// #1016/#1371: a `def` body with more than one syntactic self-call -- naive
+/// `fib`, the most ordinary recursive filter there is -- could not succeed at
+/// *any* depth under static expansion, `fib(0)` included, because expansion
+/// unrolled the `else` branch it could not know a given input would never
+/// take. `k` self-calls per level compounded as `O(k^depth)`, so a shared
+/// budget was the only thing keeping `def f: [f, f]; f` from consuming tens of
+/// GB.
+///
+/// Binding calls at evaluation time removes the branching problem with the
+/// depth problem: only the branch actually taken is ever substituted. Pinned
+/// against jq 1.7.1's own values (confirmed live).
 #[test]
-fn test_branching_self_recursive_def_bounded_not_exponential_1016() -> Result<()> {
+fn test_branching_self_recursive_def_now_matches_jq_1371() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
-            "def fib(n): if n < 2 then n else fib(n-1) + fib(n-2) end; fib(3)",
+            "def fib(n): if n < 2 then n else fib(n-1) + fib(n-2) end; [range(12)] | map(fib(.))",
         ],
         Some("null"),
     )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[0,1,1,2,3,5,8,13,21,34,55,89]");
+
+    // The unbounded branching shape must still fail cleanly, as above: real
+    // jq 1.7.1 aborts on it with `cannot allocate memory`, exit 134.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "def f: [f, f]; f"], Some("null"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
-        stderr.contains("recursion depth exceeds limit of 50"),
+        stderr.contains("f/0 exceeded maximum recursion depth"),
         "stderr: {stderr:?}"
     );
     Ok(())
@@ -17341,17 +17329,20 @@ fn test_independent_sibling_calls_do_not_share_budget_1016() -> Result<()> {
     Ok(())
 }
 
-/// #1016 code review: `MAX_FUNC_EXPANSION_DEPTH` only bounds how many
-/// times the `FuncCall` self-reference arm fires, not the native stack
-/// depth needed to walk from one self-reference to the next -- a `def`
-/// body that wraps its recursive call in substantial structure (here, 20
-/// levels of array nesting) overflows the native stack (SIGABRT) well
-/// before that budget is anywhere near exhausted, confirmed live before
-/// this fix. `MAX_FUNC_EXPANSION_CHAIN_DEPTH` bounds raw recursion depth
-/// directly and must catch this case too, cleanly, not just the thin-body
-/// shape the other tests in this group use.
+/// #1016/#1371: a body that wraps its recursive call in substantial structure
+/// (20 levels of array nesting here) is the shape that made a *call-count*
+/// ceiling unsafe -- it is not the number of calls that exhausts the native
+/// stack but the frames each one holds live, which is why the guard now
+/// accumulates structural nesting per call site (`MAX_EVAL_FRAMES`) instead
+/// of counting calls.
+///
+/// At 60 levels this builds a value 1,200 deep, past `MAX_VALUE_TREE_DEPTH`
+/// (384). Real jq prints it; succinctly refuses it -- but as a catchable
+/// error, which is the part this pins. Before the output path was routed
+/// through `JqValue::try_from_owned` (#1371) the same query took the process
+/// down with a panic, exit 101, which is precisely what #1098 forbids.
 #[test]
-fn test_thickly_wrapped_self_recursive_def_bounded_by_chain_depth_1016() -> Result<()> {
+fn test_thickly_wrapped_self_recursive_def_errors_without_aborting_1371() -> Result<()> {
     let wrap_open = "[".repeat(20);
     let wrap_close = "]".repeat(20);
     let query = format!(
@@ -17360,9 +17351,18 @@ fn test_thickly_wrapped_self_recursive_def_bounded_by_chain_depth_1016() -> Resu
     let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
-        stderr.contains("nesting exceeds depth limit of 300"),
+        stderr.contains("nesting depth exceeds limit of 384"),
         "stderr: {stderr:?}"
     );
+
+    // Shallow enough to stay inside the value-depth ceiling: the same shape
+    // evaluates, and matches jq 1.7.1 byte for byte (confirmed live).
+    let query = format!(
+        "def deep(m): if m == 0 then . else {wrap_open}deep(m-1){wrap_close} end; deep(3) | flatten | length"
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17245,6 +17245,36 @@ fn test_composed_recursion_across_two_defs_errors_not_aborts_1371() -> Result<()
     Ok(())
 }
 
+/// #1371 follow-up code-review: end-to-end companion to
+/// `jq::eval::tests::test_bind_def_seeds_defcall_frames_from_ambient_depth_1371`
+/// (a fast, white-box pin of the same mechanism -- see its own doc comment
+/// for why the guard-tripping boundary itself is tested there rather than
+/// through CLI-level deep recursion, which needs many thousands of levels
+/// to reach `MAX_EVAL_FRAMES` and is prohibitively slow in a debug build).
+/// This is the ordinary-usage half: a `def` declared *inside* another
+/// `def`'s recursively-called body, at depths too modest to approach any
+/// guard or native-stack boundary, must still just work and match jq --
+/// confirming the ambient-depth fix does not disturb everyday nested `def`
+/// usage while it was closing the crash this issue's other test pins.
+#[test]
+fn test_nested_def_inside_recursive_def_matches_jq_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "def outer(n): \
+               if n == 0 then 0 \
+               else (def inner(m): if m == 0 then 0 else inner(m-1) end; inner(5)) \
+                    + outer(n-1) \
+               end; \
+             outer(5)",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "0");
+    Ok(())
+}
+
 /// #1371 code-review regression: `generic_result_to_jq_values`'s three
 /// `GenericResult::Partial` arms (the already-produced outputs of a
 /// generator that later failed, #400/#494) used to convert via the
@@ -23958,6 +23988,53 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             &[
                 "-cn",
                 r#"first(def f(n; x): if n <= 0 then x else f(n-1; x) end; f(3; (1, ("B"|stderr))))"#,
+            ],
+            None,
+            "1\n",
+            "",
+            0,
+        ),
+        // #1371 follow-up code-review: the fix above (`Expr::Shared`'s
+        // eager/lazy split) only special-cased a *literal* double-`Shared`
+        // pass-through -- the underlying `any_subexpr(inner, |e| matches!(e,
+        // Expr::Shared(_)))` heuristic itself stayed coarse: "does a
+        // `Shared` appear *anywhere* in this subtree", true not just for a
+        // bare pass-through but for any subtree that merely *mentions* one
+        // alongside unrelated code. Here the recursive call's second
+        // argument composes the threaded parameter with an unrelated,
+        // side-effecting `Comma` branch (`g` is a `Shared`, but the argument
+        // as a whole is `(g, ("SIDE"|stderr))`, not a bare chain link) --
+        // `any_subexpr` still found the nested `Shared` and took the eager
+        // path, running `stderr` before `isempty`'s early exit ever asked
+        // for it. Replaced by `is_pure_chain_link`, a whitelist that only
+        // recognizes `Shared`/literals combined by pure single-valued
+        // operators, so anything built around a `Comma` stays lazy.
+        (
+            &[
+                "-cn",
+                r#"isempty(def f(n; g): if n == 0 then g else f(n - 1; (g, ("SIDE"|stderr))) end; f(1; 1))"#,
+            ],
+            None,
+            "false\n",
+            "",
+            0,
+        ),
+        // #1371 follow-up code-review: a second, distinct way the same
+        // coarse heuristic misfired -- `any_subexpr`'s own `DefCall` arm
+        // walks into `def.body` (needed so other callers of `any_subexpr`
+        // can answer "is X called anywhere"), so a *nested* `def` (`inner`)
+        // that merely closes over an already-`Shared`-wrapped outer
+        // parameter (`g`) reports a "nested `Shared`" match via its own
+        // frozen body -- even though the call site `inner` itself carries no
+        // argument at all. `first(id(inner))` never demands past its first
+        // value, but the eager path forced `inner`'s body (and the `stderr`
+        // buried in its closed-over `g`) to run anyway. `is_pure_chain_link`
+        // does not recognize `DefCall` at all, so this now stays lazy.
+        (
+            &[
+                "-n",
+                "def outer(g): def inner: g; def id(x): x; first(id(inner)); \
+                 outer((1, (\"SIDE\" | stderr)))",
             ],
             None,
             "1\n",

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17422,6 +17422,70 @@ fn test_bound_call_argument_stays_lazy_1371() -> Result<()> {
     Ok(())
 }
 
+/// #1371: the installer walks the whole expression tree to bind call sites, so
+/// a `def` body built out of unusual forms -- `?`, a computed object key,
+/// unary minus, comparison and boolean operators, string interpolation,
+/// `last`, an assignment's own path, `label`/`break`, an optional call -- must
+/// come through it unchanged.
+///
+/// Every arm is pure structural recursion, which is exactly the shape that
+/// looks obviously correct and stays untested until one arm forgets to
+/// recurse; a body that never reaches it would then silently keep an unbound
+/// `FuncCall`. Pinned end-to-end against jq 1.7.1's own output (confirmed
+/// live) rather than by calling the walker directly, so it fails if any arm
+/// drops a sub-expression *or* if evaluation of the rebuilt tree diverges.
+///
+/// Companion to `test_self_recursive_def_wrapping_varied_builtins_1016`, which
+/// covers the parallel `Builtin` walk.
+#[test]
+fn test_def_body_covering_varied_expression_forms_1371() -> Result<()> {
+    let filter = r#"def cover(x):
+  if x == 0 then []
+  else
+    label $done
+    | [
+        (.a.b? // 99),
+        ({("k" + (x | tostring)): (-x)} | keys[0]),
+        ((x > 0) and (x != 3)),
+        "n=\(x)",
+        ([1, 2, 3] | last),
+        ({} | .deep.path = x | .deep.path),
+        (if x == 1 then break $done else empty end),
+        cover(x - 1)
+      ]
+  end;
+cover(3) | flatten | length"#;
+    let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":{"b":7}}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "12");
+    Ok(())
+}
+
+/// #1371: the depth guard reached through `path()`'s own resolver and through
+/// the path-context pipeline, the two evaluators whose `DefCall` arms are
+/// separate from both the plain and the demand-driven one.
+///
+/// Real jq hangs indefinitely on all three (confirmed live, killed at
+/// timeout), so there is no oracle output to match here -- what is pinned is
+/// that the guard is reachable from these routes at all, rather than the
+/// recursion running until the native stack gives out.
+#[test]
+fn test_recursion_guard_reaches_path_routes_1371() -> Result<()> {
+    for filter in [
+        "def f: f; path(f)",
+        "def f: f; path(.a | f)",
+        "def f: f; .a | f | key",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":{"b":1}}"#))?;
+        assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("f/0 exceeded maximum recursion depth"),
+            "{filter}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #1371: recursion depth well past anything static expansion could reach,
 /// pinned against jq 1.7.1's own answer (confirmed live). The old ceiling was
 /// 49 for this exact shape.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17461,6 +17461,59 @@ cover(3) | flatten | length"#;
     Ok(())
 }
 
+/// #1371 (companion to the above): the rest of the installer's structural
+/// arms, reached through a `def` body that uses them -- `try`/`catch`, `or`,
+/// `first`/`last`/`nth`, `until`, `while`, `|=`, `+=`, `//=`, an `as`-binding
+/// and an optional (`?`) sub-expression, each wrapped around a recursive call
+/// so the walk has to descend through them to find it.
+///
+/// Byte-for-byte against jq 1.7.1 (confirmed live), including the two-output
+/// fan-out this body produces -- an arm that dropped a sub-expression would
+/// change the value, and one that dropped a *branch* would change the count.
+#[test]
+fn test_def_body_covering_control_and_assignment_forms_1371() -> Result<()> {
+    let filter = r#"def cover(x):
+  if x == 0 then {n: 0}
+  else
+    (cover(x - 1)) as $prev
+    | {n: ($prev.n + 1)}
+    | .try_arm = (try (x, error("no")) catch "caught")
+    | .or_arm = ((x > 5) or (x == 1))
+    | .first_arm = first(range(x))
+    | .last_arm = last(range(x + 1))
+    | .nth_arm = nth(0; range(x + 1))
+    | .until_arm = (0 | until(. >= x; . + 1))
+    | .while_arm = ([1 | while(. < x; . * 2)] | length)
+    | .n |= .
+    | .n += 0
+    | .alt //= "kept"
+    | .opt_call = ((cover(x - 1) | .n)?)
+  end;
+cover(3)
+| [.n, .try_arm, .or_arm, .first_arm, .last_arm, .nth_arm, .until_arm, .while_arm, .alt, .opt_call]"#;
+    let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    // 128 lines, two distinct: the `try (x, error) catch` arm forks each of
+    // the three levels, and `cover` is called twice per level. Asserted as
+    // count-plus-set rather than a 128-line blob -- an arm that dropped a
+    // sub-expression changes the values, one that dropped a branch changes
+    // the count, and both stay legible. Byte-identical to jq 1.7.1's own 128
+    // lines (confirmed live by direct diff).
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 128, "stdout: {stdout:?}");
+    let mut distinct: Vec<&str> = lines.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(
+        distinct,
+        vec![
+            r#"[3,"caught",false,0,3,0,3,2,"kept",2]"#,
+            r#"[3,3,false,0,3,0,3,2,"kept",2]"#,
+        ]
+    );
+    Ok(())
+}
+
 /// #1371: the depth guard reached through `path()`'s own resolver and through
 /// the path-context pipeline, the two evaluators whose `DefCall` arms are
 /// separate from both the plain and the demand-driven one.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17366,6 +17366,93 @@ fn test_thickly_wrapped_self_recursive_def_errors_without_aborting_1371() -> Res
     Ok(())
 }
 
+/// #1371: the depth guard has to be reachable from every evaluator, not just
+/// the plain one, and each reports it differently. A runaway recursion under a
+/// *truncating* consumer goes through `eval_each`'s own `DefCall` arm, and one
+/// inside `path()` through `resolve_node`'s -- neither of which the plain
+/// evaluator's arm covers.
+///
+/// Real jq survives none of these: `isempty`/`first` over `def f: [f]; f` die
+/// with `cannot allocate memory` (exit 134) and `path(def f: f; f)` never
+/// terminates at all (confirmed live, killed at timeout). Erroring is the
+/// deliberate divergence ADR-0018 permits; what this pins is that it stays an
+/// *error* on all three routes rather than an abort on any of them.
+#[test]
+fn test_recursion_guard_reaches_lazy_and_path_evaluators_1371() -> Result<()> {
+    for filter in [
+        "isempty(def f: [f]; f)",
+        "first(def f: [f]; f)",
+        "path(def f: f; f)",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("f/0 exceeded maximum recursion depth"),
+            "{filter}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1371: an argument the user wrote stays demand-driven through a bound call.
+/// `Expr::Shared` is opaque to substitution but must not be opaque to a
+/// consumer that stops early -- the eager fallback would run the second branch
+/// after `isempty` already knew its answer, which is observable through
+/// `stderr`. Pinned against jq 1.7.1, which prints nothing on stderr here.
+///
+/// The second case is the one that separates "lazy" from "lazy for the right
+/// node": a call whose argument is itself another bound call exercises
+/// `any_subexpr`'s own `DefCall` arm while deciding which path to take.
+#[test]
+fn test_bound_call_argument_stays_lazy_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", r#"def f(g): g; isempty(f(1, ("B"|stderr)))"#],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "false");
+    assert_eq!(stderr, "", "the second branch must not have run");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-cn", "[limit(1; def a(n): n; def b(g): g; b(a(1)))]"],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1]");
+    Ok(())
+}
+
+/// #1371: recursion depth well past anything static expansion could reach,
+/// pinned against jq 1.7.1's own answer (confirmed live). The old ceiling was
+/// 49 for this exact shape.
+///
+/// **2,000, not the 10,000 the issue was filed over**, purely for test
+/// runtime: a call-by-name parameter is re-read at every level in both tools,
+/// so the shape is quadratic in *both* (jq included -- measured, 4x the time
+/// per 2x the depth on each), and 10,000 takes ~79 s in an unoptimized build
+/// against ~2 s here. That depth was verified by hand and is recorded in
+/// `MAX_EVAL_FRAMES`'s own doc comment; what needs a standing test is that the
+/// ceiling is no longer anywhere near the substitution-era one, which 2,000
+/// pins 40x over.
+///
+/// Kept to a shape whose *value* stays shallow: a recursively built value is
+/// separately capped at `MAX_VALUE_TREE_DEPTH`, which
+/// `test_thickly_wrapped_self_recursive_def_errors_without_aborting_1371`
+/// covers.
+#[test]
+fn test_recursion_reaches_depth_far_past_expansion_era_1371() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-cn",
+            "def sum_to(n): if n == 0 then 0 else n + sum_to(n-1) end; sum_to(2000)",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2001000");
+    Ok(())
+}
+
 /// #1016 patch-coverage: `expand_func_calls_in_builtin`'s ~150-arm match
 /// forwards `budget`/`chain_depth` identically at every arm, verified
 /// mechanically correct by /code-review's exhaustive line-by-line trace of

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17425,8 +17425,8 @@ fn test_bound_call_argument_stays_lazy_1371() -> Result<()> {
 /// #1371: the installer walks the whole expression tree to bind call sites, so
 /// a `def` body built out of unusual forms -- `?`, a computed object key,
 /// unary minus, comparison and boolean operators, string interpolation,
-/// `last`, an assignment's own path, `label`/`break`, an optional call -- must
-/// come through it unchanged.
+/// `last`, `repeat`, an assignment's own path, `label`/`break`, an optional
+/// call -- must come through it unchanged.
 ///
 /// Every arm is pure structural recursion, which is exactly the shape that
 /// looks obviously correct and stays untested until one arm forgets to
@@ -17449,6 +17449,7 @@ fn test_def_body_covering_varied_expression_forms_1371() -> Result<()> {
         ((x > 0) and (x != 3)),
         "n=\(x)",
         ([1, 2, 3] | last),
+        ([limit(2; repeat(x))] | length),
         ({} | .deep.path = x | .deep.path),
         (if x == 1 then break $done else empty end),
         cover(x - 1)
@@ -17457,7 +17458,7 @@ fn test_def_body_covering_varied_expression_forms_1371() -> Result<()> {
 cover(3) | flatten | length"#;
     let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":{"b":7}}"#))?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout.trim_end(), "12");
+    assert_eq!(stdout.trim_end(), "14");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27491,3 +27491,78 @@ fn test_reduce_and_foreach_over_repeat_still_raise_1687() -> Result<()> {
     }
     Ok(())
 }
+
+/// #1371: `succinctly yq` shares the evaluator, so the runtime-call model has
+/// to reach `eval_generic`'s own arms too -- the cursor-based evaluator has a
+/// separate `DefCall`/`Shared` pair from `eval.rs`'s, and nothing in the jq
+/// suite exercises it.
+///
+/// `def` is a succinctly extension here (real yq's lexer rejects `def f: 42;
+/// f` outright, ADR-0018 rule 5), so these pin succinctly's own behaviour
+/// rather than a reference tool's. The values still match what `succinctly jq`
+/// returns for the same filters, which are in turn pinned against jq 1.7.1.
+#[test]
+fn test_recursive_def_evaluates_in_yq_mode_1371() -> Result<()> {
+    // Depth far past the 49 static expansion allowed.
+    let (stdout, code) = run_yq_stdin(
+        "def sum_to(n): if n == 0 then 0 else n + sum_to(n - 1) end; sum_to(100)",
+        "a: 1\n",
+        &[],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "5050");
+
+    // Branching recursion, which could not succeed at any depth before.
+    let (stdout, code) = run_yq_stdin(
+        "def fib(n): if n < 2 then n else fib(n - 1) + fib(n - 2) end; fib(12)",
+        "a: 1\n",
+        &[],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "144");
+    Ok(())
+}
+
+/// #1371: the generic evaluator's own demand-driven `DefCall`/`Shared` arms.
+/// A truncating consumer must not run the rest of a definition's body, nor the
+/// rest of an argument, after it already has its answer -- the same property
+/// `eval.rs`'s pair carries, reached through the cursor evaluator instead.
+///
+/// `isempty`/`first` are jq-only builtins that yq's own lexer rejects, hence
+/// `--jq-extensions` (#1512).
+#[test]
+fn test_bound_call_stays_lazy_in_yq_mode_1371() -> Result<()> {
+    for filter in ["isempty(def f: (1, 2); f)", "def f(g): g; isempty(f(1, 2))"] {
+        let (stdout, code) = run_yq_stdin(filter, "a: 1\n", &["--jq-extensions"])?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?}");
+        assert_eq!(stdout.trim_end(), "false", "{filter}");
+    }
+
+    let (stdout, code) = run_yq_stdin(
+        "def f(g): [first(g)]; f(1, 2)",
+        "a: 1\n",
+        &["--jq-extensions"],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "- 1");
+    Ok(())
+}
+
+/// #1371: a `def` that never reaches a base case must fail cleanly in yq mode
+/// too -- through the generic evaluator's eager arm and its demand-driven one
+/// alike, since a stack overflow is an abort whichever path reaches it.
+#[test]
+fn test_runaway_recursion_errors_cleanly_in_yq_mode_1371() -> Result<()> {
+    for (filter, args) in [
+        ("def f: [f]; f", &[][..]),
+        ("isempty(def f: [f]; f)", &["--jq-extensions"][..]),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", args)?;
+        assert_eq!(code, 1, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("f/0 exceeded maximum recursion depth"),
+            "{filter}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27556,6 +27556,10 @@ fn test_runaway_recursion_errors_cleanly_in_yq_mode_1371() -> Result<()> {
     for (filter, args) in [
         ("def f: [f]; f", &[][..]),
         ("isempty(def f: [f]; f)", &["--jq-extensions"][..]),
+        // `first` reaches the generic evaluator's *demand-driven* `DefCall`
+        // arm, a separate one from `isempty`'s route above.
+        ("first(def f: [f]; f)", &["--jq-extensions"][..]),
+        ("[limit(1; def f: [f]; f)]", &["--jq-extensions"][..]),
     ] {
         let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", args)?;
         assert_eq!(code, 1, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");


### PR DESCRIPTION
Closes #1371.

`succinctly jq` substituted a `def`'s body into each call site **before evaluating
anything**. That cannot terminate for a self-recursive `def` — expansion has no way to see
that a runtime condition (`n == 0`) will eventually hold — so three guards existed only to
bound the non-termination, and they bounded work a real run never performs.

This replaces expansion with real runtime calls. Design and the reasoning behind each
choice: [ADR-0020](docs/adrs/adr-0020.md).

## What changes for a user

| filter | before | after (= jq 1.7.1) |
|---|---|---|
| `def sum_to(n): …; sum_to(100)` | `recursion depth exceeds limit of 50` | `5050` |
| `def sum_to(n): …; sum_to(10000)` | same error | `50005000` |
| naive `fib(n)`, **any** `n ≥ 2` | same error | `0,1,1,2,3,5,…` |
| #1381's three chained recursive `def`s | `substitution cost exceeds limit` | the value |

Branching recursion is the one worth calling out: it could not succeed at *any* depth
before, `fib(0)` included, because expansion unrolled the `else` arm it could not know a
given input would never take.

## How

Two AST nodes, one guard.

- **`Expr::DefCall`** binds a call to its definition without substituting it. The
  substitution happens per call, when evaluation reaches the site, so recursion stops at
  the base case the program itself evaluates and a branch never taken costs nothing.
  Arguments stay ordinary caller-scope code until then — a call site can sit inside a
  binder that has not run yet.
- **`Expr::Shared`** captures each argument behind an `Rc` that every substitution pass
  treats as opaque. This is what keeps recursion linear: inlining the argument expression
  made the walked tree grow with depth (`O(d²)` work *and* stack, ~40 usable levels). It
  also gives hygiene for free — a pass that stops at a `Shared` cannot reach into an
  argument to capture a caller's `$x`.
- **`MAX_EVAL_FRAMES`** replaces the three expansion budgets, counting **live native
  frames rather than calls**. A count cannot work: measured at 256 MB, a body whose call
  sits in a pipe survives ~57,500 levels while one wrapping the same call in 40 array
  constructors dies between 4,000 and 8,000 — a 10x spread that lands within 1.5x of each
  other once charged as frames.

Evaluation runs on a thread with an explicitly sized stack (~4.4 KB per live level,
measured in #2080). It is **larger in debug builds** (2 GB against 256 MB) because an
unoptimized frame is ~9x an optimized one — otherwise one ceiling would have to be either
unsafe for the binary `cargo test` runs or far too tight for the one that ships.

## Deliberate divergences, all recorded

- **A non-terminating `def` errors where jq aborts.** `def deep: [deep]; deep` raises a
  catchable error, exit 5; jq 1.7.1 dies with `cannot allocate memory`, exit 134
  (confirmed live). ADR-0018 permits divergence exactly here — matching would take the
  process down, which is what #1016 exists to prevent.
- **A heavy body runs out of depth sooner than jq's heap-allocated VM stack does.**
- **A recursively built value can exceed `MAX_VALUE_TREE_DEPTH` (384)**, which jq has no
  equivalent of. Reported as an error, not the panic `JqValue::from_owned` would raise —
  CLI output now goes through a new checked `try_from_owned`, since a filter someone
  merely typed must not abort the process (#1098).

All three are in [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md).

## Performance

Moving substitution to call time charges it *per call*, which regressed ordinary `def` use
— measured interleaved against the pre-change binary over 200,000 elements, **+7.8%** for
one call per element and **+26.7%** for three chained definitions. A bound body is a pure
function of its node, so it is memoized; the same measurement then reads **0.996x** and
**0.978x** with byte-identical output. Recursion is unaffected, since each level installs
its own fresh nodes.

The Perf Regression Guard's six queries contain no `def`, so it would not have caught
this either way — hence the measurement. `size_of::<Expr>()` is unchanged at 96 bytes.

Recursion is quadratic in time in **both** tools (a call-by-name parameter is re-read at
every level): `sum_to(8000)` is 10.8 s here against jq's 4.3 s — same complexity, ~2.5x
constant.

## Verification

- 6,845 tests pass; patch coverage 94% (the remainder is arms that are unreachable by
  construction — `resolve.rs` runs before evaluation, `NamespacedCall` is rewritten at
  parse time, `Expr::NthExpr` is documented parser-unreachable).
- Every gate CI runs: both clippy legs, `cargo test` (default features and `--features
  cli`), `cargo check --no-default-features`, `cargo doc` with `-D warnings`, `cargo fmt
  --check`.
- The six tests that pinned the removed guards now pin what replaced them, against jq
  1.7.1 wherever jq survives the input at all.
- New coverage for each evaluator's own arm (plain, demand-driven, path-context,
  `path()`'s resolver, and `eval_generic`'s), for argument laziness, for the installer's
  structural arms, and for yq mode — where `def` is a succinctly extension, real yq's
  lexer rejecting it outright.
