### PR TITLE
test(jq): fix flaky broken-pipe race in test_713_jq_mode_unaffected

### DIFF
--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13822,39 +13822,18 @@ fn test_713_merge_flags_after_equals() -> Result<()> {
 /// must not regress just because yq mode gained it.
 #[test]
 fn test_713_jq_mode_unaffected() -> Result<()> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq")
-        .arg(".a * .b")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn()?;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
-    let output = child.wait_with_output()?;
-    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
-    assert_ne!(code, 0, "array * array must still error in jq mode");
-
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_succinctly"));
-    cmd.arg("jq")
-        .arg(".a *+ .b")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn()?;
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(br#"{"a":[1,2],"b":[3,4]}"#)?;
-    let output = child.wait_with_output()?;
-    let code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let (_stdout, stderr, code) =
+        run_jq_stdin_with_stderr(".a * .b", r#"{"a":[1,2],"b":[3,4]}"#, &[])?;
     assert_ne!(
         code, 0,
-        "flag suffixes must still be unrecognized in jq mode"
+        "array * array must still error in jq mode: {stderr}"
+    );
+
+    let (_stdout, stderr, code) =
+        run_jq_stdin_with_stderr(".a *+ .b", r#"{"a":[1,2],"b":[3,4]}"#, &[])?;
+    assert_ne!(
+        code, 0,
+        "flag suffixes must still be unrecognized in jq mode: {stderr}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- `test_713_jq_mode_unaffected` hand-rolled `spawn()` + `write_all(...)` + `wait_with_output()` for both of its sub-cases, which can race a fast jq-mode compile-error exit into a spurious `Error: Broken pipe (os error 32)` — observed on CI's advisory nightly-toolchain leg (#2098).
- This exact race was already fixed for every other jq-mode stdin test in the file via `run_jq_stdin_with_stderr`, which routes through `spawn_with_signal_retry` → `write_stdin_then_wait` (#1891/#2057) — the helper that swallows the benign `BrokenPipe` once the child has been reaped.
- Switches both sub-cases in `test_713_jq_mode_unaffected` to that existing helper instead of the raw spawn/write/wait sequence.

Closes #2098.

## Test plan
- [x] `cargo test --features cli --test yq_cli_tests test_713_jq_mode_unaffected` — passes
- [x] `cargo test --features cli --test yq_cli_tests` — full file passes (1354/1354)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean