### PR TITLE
fix(jq): path-context Expr::Optional gets the plain evaluator's bracket carve-out

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30137,6 +30137,56 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 )
             }
         }
+        // `.[EXPR]?`/`.[S:E]?`: the same carve-out `eval_single` and
+        // `eval_each` each already make for this shape (their matching arms
+        // carry the full jq-1.7.1 derivation), missing here until #1410.
+        // `?` on a bare bracket guards only the *final* index/slice step,
+        // never evaluation of the bracket's own key/bounds sub-expression --
+        // and `eval_index_expr`/`eval_slice_expr` already implement that
+        // split internally (they hardcode key/bounds evaluation to
+        // `optional: false` and let `optional` reach only `index_one` /
+        // the final resolved-bounds application). So forward `optional:
+        // true` straight in, exactly as the plain evaluator does, instead
+        // of falling through to the isolate-and-atomically-catch arms
+        // below, which treat the whole `IndexExpr`/`SliceExpr` subtree as
+        // one unit to catch and so swallow the key error too.
+        //
+        // This arm exists because a *sibling* elsewhere in the same
+        // expression (`key`, `parent`, `file_index`) can flip the whole
+        // filter into path-context evaluation, which is what made the
+        // divergence easy to miss: `.a | .[error("boom")]?` correctly
+        // raises, but `.a | (.[error("boom")]?, key)` silently exited 0.
+        // There is no jq oracle for it -- every `needs_path_context`
+        // trigger but `path` is a succinctly extension, and all five
+        // jq-expressible path-context shapes (`path(...)`, `|=`, `del(...)`,
+        // ...) already agreed with jq 1.7.1 -- so the plain evaluator's own
+        // behavior is the reference this restores consistency with.
+        //
+        // Deliberately not `eval_and_continue_with_context`, which the
+        // `_ =>` catch-all below uses for the identical no-`?` case: its
+        // `Error(_) if optional => None` safety net would re-swallow the
+        // very key/bounds error this arm exists to let escape. This is that
+        // helper minus that one net. `rest` still gets the *ambient*
+        // `optional`, never the forced `true` -- it must not inherit this
+        // bracket's suppression. An escaping `Break` likewise propagates
+        // rather than being caught, matching `eval_index_expr`'s own
+        // `QueryResult::Break(label) => return ...` and `eval_single`'s
+        // carve-out, which never wraps this shape in `eval_try`.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            match eval_owned_input::<W, S>(inner, value, true) {
+                QueryResult::None => QueryResult::None,
+                result => continue_rest_with_context::<W, S>(
+                    result,
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                ),
+            }
+        }
         // This node *is* the `?`. Isolates `inner` with `optional` forced to
         // `false` (the same technique the Array arm's #1302 fix uses, not
         // eval_try's ambient-forwarding -- a leaf mustn't self-swallow

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8366,6 +8366,121 @@ fn test_optional_wrapped_navigation_still_threads_path_into_rest_1335() -> Resul
     Ok(())
 }
 
+/// `?` on a bare bracket guards only the final index/slice step, never the
+/// bracket's own key/bounds sub-expression -- in path-context evaluation too
+/// (#1410).
+///
+/// The plain evaluator has carved this out since #693 (`eval_single`'s and
+/// `eval_each`'s `Expr::Optional(IndexExpr|SliceExpr)` arms). The
+/// path-context evaluator had no equivalent, so its isolate-and-atomically-
+/// catch `Expr::Optional` arm (#1335) treated the whole `IndexExpr`/
+/// `SliceExpr` subtree as one unit to catch and swallowed the key error too.
+///
+/// What makes this easy to miss is that nothing in the bracket triggers it:
+/// a *sibling* `key`/`parent`/`file_index` elsewhere in the same expression
+/// flips the whole filter into path-context mode. Hence every case below
+/// pairs the bracket with such a sibling, and pins the sibling-free spelling
+/// as the control it must now agree with.
+///
+/// No jq oracle exists for the repro itself -- every `needs_path_context`
+/// trigger but `path` is a succinctly extension, and real jq rejects `key/0`
+/// at compile time (exit 3). The jq-expressible path-context shapes are
+/// pinned separately below; all of them already agreed with jq 1.7.1 before
+/// this fix and must continue to.
+#[test]
+fn test_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
+    // The headline repro: the sibling `key` forces path context, and the
+    // key sub-expression's error must still escape.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a | (.[error("boom")]?, key)"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // `parent` forces path context the same way `key` does.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a | (.[error("boom")]?, parent)"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    // Both slice bounds, not just the start: `eval_slice_expr` evaluates
+    // `S` outer and `T` middle, each with its own hardcoded `optional:
+    // false`, so an error in either must escape.
+    for filter in [
+        r#".a | (.[error("boom"):1]?, key)"#,
+        r#".a | (.[0:error("boom")]?, key)"#,
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_eq!(code, 5, "{filter} -- stderr: {stderr}");
+        assert!(stderr.contains("boom"), "{filter} -- stderr: {stderr}");
+    }
+
+    // Controls that were already correct and must stay so: the same bracket
+    // with no path-context sibling (plain evaluator), and with the `?`
+    // removed (the path-context evaluator's own no-`?` route through the
+    // `_ =>` catch-all). The fix makes the repro above agree with these two.
+    for filter in [
+        r#".a | .[error("boom")]?"#,
+        r#".a | (.[error("boom")], key)"#,
+        r#".a | (.[error("boom")]?, 1)"#,
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_eq!(code, 5, "{filter} -- stderr: {stderr}");
+        assert!(stderr.contains("boom"), "{filter} -- stderr: {stderr}");
+    }
+
+    // The other half of the carve-out: `?` must *still* suppress the final
+    // index step itself. Forwarding `optional: true` into
+    // `eval_index_expr`/`eval_slice_expr` (rather than `false` plus an outer
+    // catch) is what keeps both halves true at once.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[null]?, key)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".[null]?"], Some("{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // A multi-output key generator still fans out normally -- the new arm
+    // must not collapse `QueryResult::ManyOwned` on its way through
+    // `continue_rest_with_context`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", r#".a | (.[("b","c")]?, key)"#],
+        Some(r#"{"a":{"b":1,"c":2}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1\n2\n\"a\"");
+
+    // `rest` gets the *ambient* `optional`, never the forced `true` this arm
+    // hands the bracket -- so a later stage's own error is not suppressed.
+    let (_stdout, stderr, code) = run_jq_full(
+        &["-c", r#".a | (.[null]?, key) | error("later")"#],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains("later"), "stderr: {stderr}");
+
+    // The jq-expressible path-context shapes: `path`, not a succinctly
+    // extension, is the one `needs_path_context` trigger with an oracle.
+    // All five agree with jq 1.7.1 (verified live) and must stay that way.
+    for (filter, input) in [
+        (r#"path(.a[error("boom")]?)"#, r#"{"a":{"b":1}}"#),
+        (r#"[path(.a[error("boom")]?, .b)]"#, r#"{"a":{"b":1}}"#),
+        (r#"path(.. | .[error("boom")]?)"#, r#"{"a":{"b":1}}"#),
+        (r#".a |= (.[error("boom")]?)"#, r#"{"a":{"b":1}}"#),
+        (r#"del(.a[error("boom")]?)"#, r#"{"a":{"b":1}}"#),
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "{filter} -- stderr: {stderr}");
+        assert!(stderr.contains("boom"), "{filter} -- stderr: {stderr}");
+    }
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1511,6 +1511,35 @@ fn test_yq_iterate_path_context_ambient_optional_keeps_prefix_1869() -> Result<(
     Ok(())
 }
 
+/// #1410's yq-mode twin. Like #1869's test just above, the fixed arm lives
+/// in `eval_pipe_with_path_context_internal` -- generic over `EvalSemantics`
+/// and shared verbatim by both modes -- and `eval_generic.rs` bridges the
+/// whole pipe there whenever `needs_path_context` fires, so yq reproduced
+/// the divergence identically. Before the fix this printed `"a"` and exited
+/// 0; the bracket's own key error must escape instead.
+#[test]
+fn test_yq_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
+        r#".a | (.[error("boom")]?, key)"#,
+        "a: 1\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_ne!(code, 0, "stdout: {stdout}, stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert_eq!(stdout, "");
+
+    // The final index step itself must still be suppressed by the `?`.
+    let (stdout, code) = run_yq_stdin(
+        ".a | (.[null]?, key)",
+        "a: 1\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    Ok(())
+}
+
 /// #1251: `.a` field access on `--input-format json` input with a
 /// duplicate key must resolve to the *last* value, matching real jq /
 /// RFC 8259 convention -- the JSON-side sibling of #174's YAML fix, and


### PR DESCRIPTION
## Description

`?` on a bare bracket (`.[EXPR]?`, `.[S:E]?`) guards only the **final** index/slice
step, never evaluation of the bracket's own key/bounds sub-expression. The plain
evaluator has carved this out since #693, in two places — `eval_single` and
`eval_each` — each forwarding `optional: true` straight into
`eval_index_expr`/`eval_slice_expr`, which hardcode key/bounds evaluation to
`optional: false` internally and let `optional` reach only `index_one` / the final
resolved-bounds application.

`eval_pipe_with_path_context_internal` had no equivalent. Its isolate-and-atomically-
catch `Expr::Optional` arm (#1335) treated the whole `IndexExpr`/`SliceExpr` subtree
as one unit to catch, and so swallowed the key error too:

```console
$ echo '{"a":1}' | succinctly jq -c '.a | .[error("boom")]?'
jq: error (at <stdin>:1): boom            # exit 5, correct

$ echo '{"a":1}' | succinctly jq -c '.a | (.[error("boom")]?, key)'
"a"                                       # exit 0, wrong
```

Nothing in the bracket triggers it — a *sibling* `key`/`parent`/`file_index`
elsewhere in the same expression flips the whole filter into path-context mode,
which is what made it easy to miss. Both slice bounds are affected too, and
`succinctly yq` reproduced it identically, since `eval_generic.rs` bridges the whole
pipe into this same function.

### There is no jq oracle for this

Every `needs_path_context` trigger but `path` is a succinctly extension, and real jq
rejects `key/0` at compile time (exit 3). All five jq-expressible path-context shapes
already agreed with jq 1.7.1 before this change and still do:

| filter (input `{"a":{"b":1}}`) | jq 1.7.1 | succinctly (before & after) |
|---|---|---|
| `path(.a[error("boom")]?)` | exit 5 | exit 5 |
| `[path(.a[error("boom")]?, .b)]` | exit 5 | exit 5 |
| `path(.. \| .[error("boom")]?)` | exit 5 | exit 5 |
| `.a \|= (.[error("boom")]?)` | exit 5 | exit 5 |
| `del(.a[error("boom")]?)` | exit 5 | exit 5 |

So this is succinctly's plain evaluator and its path-context evaluator disagreeing
with **each other**, and the plain evaluator's own behaviour is the reference this
restores consistency with. Per ADR-0018 that makes it a self-consistency fix, not a
compliance divergence.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #1410

Filed while working on it: **#2100** — path context is never threaded into a computed
bracket at all (`.a | .["" + "b"] | key` answers `"a"` instead of `"b"`; `.a | .[key]`
errors on a null key). #1410's own triage comment assumed that was a *prerequisite*
for this fix; it is not — it reproduces with no `?` anywhere, and this change neither
introduces nor worsens it. Closing it needs the path-context twin of
`eval_index_expr`/`eval_slice_expr` that the comment describes, which is genuinely
its own design pass.

Context on the scope: #1410's *other* half (the shared-helper consolidation, plus the
dormant `Builtin::Map` risk) was split to #1826, fixed in #1866, and closed;
`Expr::Iterate`'s same-class bug followed as #1869; the `catch_error_under_optional`
helper landed as #1888. Only this carve-out gap remained. **#1410's title is stale**
— it still describes #1826's scope.

## Changes Made

- `src/jq/eval.rs`: one guarded `Expr::Optional(inner) if matches!(**inner,
  Expr::IndexExpr { .. } | Expr::SliceExpr { .. })` arm inserted **before** both
  existing `Expr::Optional` arms in `eval_pipe_with_path_context_internal`.
- `tests/jq_cli_tests.rs`: `test_optional_index_key_error_escapes_path_context_1410`.
- `tests/yq_cli_tests.rs`: `test_yq_optional_index_key_error_escapes_path_context_1410`.

Three deliberate choices in the new arm, each load-bearing:

1. **`optional: true` into the inner eval, not `false` + an outer catch.** That is
   what suppresses exactly the final index step and nothing more.
2. **Not `eval_and_continue_with_context`** — the obvious reuse candidate, and what
   the `_ =>` catch-all already uses for the identical no-`?` case. Its
   `Error(_) if optional => QueryResult::None` net would re-swallow the very error
   this arm exists to let escape. The new arm is that helper minus that one net.
3. **Ambient `optional` (not the forced `true`) into `continue_rest_with_context`** —
   `rest` must not inherit the bracket's suppression.

An escaping `Break` from a key sub-expression now propagates rather than being caught,
matching `eval_index_expr`'s own `QueryResult::Break(label) => return ...` and
`eval_single`'s carve-out, which never wraps this shape in `eval_try`.

### Deliberately out of scope

The remaining mechanical dedup — the `Expr::Optional` arm's hand-rolled catch, the
`Expr::Array` arm's, and a fifth copy in `Expr::StringInterpolation` — is **not**
collapsed into `catch_error_under_optional`. #1888 examined exactly these and judged
them a genuinely different shape (the `Optional` arm catches `Break` unconditionally
and ungated by ambient `optional`; the helper does not).

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

Before → after, verified live against the release binary:

| input `{"a":1}` | before | after |
|---|---|---|
| `.a \| (.[error("boom")]?, key)` | exit 0, `"a"` | **exit 5** |
| `.a \| (.[error("boom")]?, parent)` | exit 0, `{"a":1}` | **exit 5** |
| `.a \| (.[error("boom"):1]?, key)` | exit 0, `"a"` | **exit 5** |
| `.a \| (.[0:error("boom")]?, key)` | exit 0, `"a"` | **exit 5** |
| `.a \| (.[null]?, key)` | exit 0, `"a"` | exit 0, `"a"` |
| `.a \| .[error("boom")]?` | exit 5 | exit 5 |
| `.a \| (.[error("boom")], key)` | exit 5 | exit 5 |

The `.[null]?` row is the other half of the carve-out: `?` must **still** suppress the
final index step. Forwarding `optional: true` (rather than `false` plus an outer catch)
is what keeps both halves true at once.

Explicitly re-run, as the tests pinning behaviour nearest the changed arm — all pass:
`test_optional_dispatch_catches_atomically_not_broadcast_1335`,
`test_optional_wrapped_navigation_still_threads_path_into_rest_1335`,
`test_map_path_context_builtin_optional_is_atomic_1826`,
`test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869`,
`test_array_wrapped_path_context_builtin_optional_is_atomic_1302`,
`test_optional_does_not_suppress_key_errors`, `test_optional_suppresses_cannot_index`,
`test_computed_index_target_error_after_pending_halt_still_streams_prefix`.

**Manual Testing:**
- [x] Tested on aarch64/ARM (Apple silicon, local)
- [ ] Tested on x86_64 (covered by the CI matrix)

### Test Commands

Full gate set, derived from `.github/workflows/ci.yml` and run after
`cargo clean -p succinctly` (an incremental cache has false-passed clippy and `no_std`
in this repo before) — all green:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings
cargo check --no-default-features                       # no_std
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo test --verbose --no-fail-fast                     # default features
cargo test --features cli --no-fail-fast \
  --test jq_cli_tests --test yq_cli_tests --test jq_golden_tests --test yq_golden_tests \
  --test yq_path_consistency_tests --test cli_golden_tests --test cli_characterization_tests \
  --test jq_computed_key_tests
```

2,710 tests in the CLI leg, including both `jq` and `yq` golden suites.

## Performance Impact

- [x] No performance impact

One extra `matches!` guard on an arm reached only when the AST node is literally
`Expr::Optional`, inside the path-context evaluator — which is itself only entered
when `needs_path_context` fires.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed (no user-facing behaviour to document —
      this restores the documented plain-evaluator semantics in a second evaluator)
- [x] My changes generate no new warnings

## Additional Notes

**Adjacent open issue #2073** proposes dropping `Expr::Optional`'s
`needs_path_context` guard in favour of `path_probe_stage` (#1409). It touches the
same arm but is orthogonal — it concerns `rest` inheriting suppression, not the
bracket's own key. Whichever lands second will need a textual rebase in this arm;
there is no logical conflict.

**Patch coverage: 100%** (11/11 new lines), measured locally with
`cargo llvm-cov --features cli,simd,regex,serde --workspace` + `omni-dev coverage diff`.
