### PR TITLE
test(jq): enumerate the #1653 M2 streaming parity gaps, close the terminal keys fault

### DIFF
--- a/scripts/jq-m2-streaming-sweep.sh
+++ b/scripts/jq-m2-streaming-sweep.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# Eager-vs-streaming parity sweep for the jq M2 lazy path (#1653).
+#
+# #1653 wants the M2 route -- a JSON document read from a file or stdin, the
+# CLI's default -- to write each output as the evaluator produces it, so
+# stdout and stderr interleave the way real jq's lazy generator does. PR
+# #1892 converted every other route; the M2 one still calls the *eager*
+# `eval_with_cursor`. Switching it to the demand-driven `eval_each_with_cursor`
+# is not just an ordering change: the eager evaluator's materializing arms
+# double as a validity gate, so arms that stream natively skip #1194/#1642
+# checks their eager twins performed as a side effect of building an
+# `OwnedValue`. An earlier attempt at the switch was reverted for exactly
+# that reason.
+#
+# This sweep separates the two variables. It runs each (document, filter)
+# case three ways -- the eager route, the streaming route, and the pinned jq
+# oracle -- and reports:
+#
+#   * PARITY divergences: eager vs streaming disagree on stdout/stderr/exit.
+#     **These are the gate.** Every one is a check the streaming route lost
+#     (or gained). Expected result: `0 unexpected`.
+#   * ORACLE rows: informational. Succinctly is a semi-index and detects a
+#     malformed document only opportunistically, where jq -- a full
+#     validating parser -- rejects every document below at parse time, exit
+#     5, whatever the filter. So most oracle columns read `jq=5 succ=0`
+#     already, on both routes, and closing those is not this issue's job.
+#     The rule that matters: **a cell must not move from 5 to 0.**
+#
+# Both routes are driven out of one binary via `SUCCINCTLY_JQ_M2_EVAL`, so a
+# single build measures both and the comparison cannot drift on a stale half.
+#
+# This is a verification tool, not a CI gate -- same standing as its sibling
+# scripts/jq-fanout-oracle-sweep.sh. The pinned rows in tests/jq_cli_tests.rs
+# are what CI enforces.
+#
+# Usage:
+#   cargo build --release --features cli
+#   ./scripts/jq-m2-streaming-sweep.sh [path-to-succinctly-binary]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIN="$(cat "$REPO_ROOT/tests/data/jq-golden/JQ_VERSION")"
+SUCC="${1:-$REPO_ROOT/target/release/succinctly}"
+
+if [[ ! -x "$SUCC" ]]; then
+  echo "error: succinctly binary not found at $SUCC — run: cargo build --release --features cli" >&2
+  exit 1
+fi
+
+# Prefer the pinned oracle binary directly (macOS ships jq-1.7.1 at
+# /usr/bin/jq; a PATH jq, e.g. Homebrew's, is often newer) — same reasoning
+# as tests/jq_cli_tests.rs's own pinned-oracle comments.
+if [[ -x /usr/bin/jq ]] && /usr/bin/jq --version | grep -q "^$PIN"; then
+  JQ=/usr/bin/jq
+elif command -v jq >/dev/null 2>&1 && jq --version | grep -q "^$PIN"; then
+  JQ="$(command -v jq)"
+else
+  echo "error: no jq matching pin $PIN found at /usr/bin/jq or on PATH" >&2
+  exit 1
+fi
+echo "oracle: $JQ ($("$JQ" --version)), succinctly: $SUCC" >&2
+
+WORK="$(mktemp -d -t jq-m2-sweep)"
+trap 'rm -rf "$WORK"' EXIT
+DOC_FILE="$WORK/doc.json"
+
+# Documents. The malformed ones are the three fault kinds the codebase keeps
+# deliberately distinct (src/jq/document.rs's normal / decode-failure /
+# structurally-malformed split, #1642), plus the delimiter fault #1677 added
+# and the duplicate-key case that is legitimately exit 0 in jq too.
+DOCS=(
+  '{"a":1,"b":2}'                      # well formed
+  '[1,2,3]'                            # well formed, array
+  '{"a":1,"a":2}'                      # duplicate key: jq collapses, exit 0
+  '{123:1,"b":2}'                      # #1194 structurally malformed key
+  '{"a":1,"b"}'                        # #1194 unpaired tail
+  '{"a":1, invalid}'                   # #1194 malformed tail member
+  '{"a" 1, "b":2}'                     # #1677 missing `:` delimiter
+  '[1,,3]'                             # #1597 malformed comma, mid-array
+  '{"\ud800":1,"\ud800":2}'            # #1642 colliding undecodable keys
+  '{"\ud800":1,"b":2}'                 # single undecodable key (preserved)
+  '{"a\q":1,"b":2}'                    # invalid escape in key
+)
+
+# Filters. Two groups, and the split is the point of the sweep.
+#
+#   * "transparent": shapes whose *eager* twin also forwards a cursor without
+#     materializing, so they answer identically on both routes today and must
+#     keep doing so — these are the hot default route and may not slow down.
+#   * "materializing": shapes whose eager twin falls to `eval_single`'s
+#     wildcard, which materializes the ambient value via `to_owned_with_cursor`
+#     and so validates the document as a side effect, while `eval_each_generic`
+#     has a native streaming arm that does not. This is where the lost checks
+#     live.
+FILTERS=(
+  # transparent
+  '.'
+  '.a'
+  '.b'
+  '.[]'
+  '.a, .b'
+  'keys_unsorted'
+  'keys_unsorted[]'
+  'keys'
+  'length'
+  'to_entries'
+  'first(keys_unsorted[])'
+  'limit(1; keys_unsorted[])'
+  'limit(2; keys_unsorted[])'
+  'first(.[])'
+  # materializing / native-streaming-arm shapes
+  '.,.'
+  'if . then . else . end'
+  'try .'
+  'try (1+1) catch "x"'
+  'try (1+1)'
+  '.?'
+  'label $x | .'
+  '. as $x | $x'
+  'def f: .; f'
+  'first(.)'
+  'limit(1;.)'
+  '[.]'
+  '{k: .}'
+  '. | .'
+  '1+1'
+  'keys_unsorted, length'
+  'debug'
+  '(., debug)'
+)
+
+# Attribute a parity divergence to an already-tracked, deliberately-accepted
+# gap, or return 1 for "this is new, look at it". Keep every entry tied to an
+# issue number.
+classify_parity() {
+  local doc="$1" filter="$2" eager_out="$3" stream_out="$4" eager_code="$5" stream_code="$6"
+
+  # #1770, generalised by #1653: the streaming route finds a document fault
+  # only when the walk reaches it, so outputs produced *before* the fault are
+  # already on stdout when it raises, where the eager route returned a single
+  # `Error` and printed nothing. The exit code still agrees. Real jq prints
+  # nothing either -- it rejects the document at parse time -- so this is a
+  # divergence from jq on stdout content, accepted for the same reason #1770
+  # accepted `limit(2; keys_unsorted[])` emitting `"a"` alongside exit 5.
+  if [[ "$eager_code" == "$stream_code" && -z "$eager_out" && -n "$stream_out" ]]; then
+    echo '#1770/#1653 (prefix produced before a lazily-detected document fault)'
+    return 0
+  fi
+
+  return 1
+}
+
+total=0
+parity_diverged=0
+parity_unexpected=0
+oracle_regressed=0
+parity_log=""
+oracle_log=""
+declare -a known_labels=()
+
+run_case() {
+  local doc="$1" filter="$2"
+  total=$((total + 1))
+  printf '%s' "$doc" > "$DOC_FILE"
+
+  local jq_out jq_code eager_out eager_err eager_code stream_out stream_err stream_code
+
+  jq_out="$("$JQ" -c "$filter" "$DOC_FILE" 2>/dev/null)" && jq_code=0 || jq_code=$?
+
+  eager_out="$(SUCCINCTLY_JQ_M2_EVAL=eager "$SUCC" jq -c "$filter" "$DOC_FILE" 2>"$WORK/e.err")" \
+    && eager_code=0 || eager_code=$?
+  eager_err="$(cat "$WORK/e.err")"
+
+  stream_out="$(SUCCINCTLY_JQ_M2_EVAL=stream "$SUCC" jq -c "$filter" "$DOC_FILE" 2>"$WORK/s.err")" \
+    && stream_code=0 || stream_code=$?
+  stream_err="$(cat "$WORK/s.err")"
+
+  # Paths appear in diagnostics; strip them so the two legs are comparable.
+  eager_err="${eager_err//$DOC_FILE/DOC}"
+  stream_err="${stream_err//$DOC_FILE/DOC}"
+
+  if [[ "$eager_out" != "$stream_out" || "$eager_err" != "$stream_err" || "$eager_code" != "$stream_code" ]]; then
+    parity_diverged=$((parity_diverged + 1))
+    local known
+    if known="$(classify_parity "$doc" "$filter" "$eager_out" "$stream_out" "$eager_code" "$stream_code")"; then
+      known_labels+=("$known")
+    else
+      parity_unexpected=$((parity_unexpected + 1))
+      parity_log+="[parity] doc=$doc filter=$filter
+  eager:   out=$(printf '%s' "$eager_out" | tr '\n' '|') err=$eager_err exit=$eager_code
+  stream:  out=$(printf '%s' "$stream_out" | tr '\n' '|') err=$stream_err exit=$stream_code
+"
+    fi
+  fi
+
+  # Directional oracle check: a cell may move toward jq, never away.
+  if [[ "$eager_code" == "$jq_code" && "$stream_code" != "$jq_code" ]]; then
+    oracle_regressed=$((oracle_regressed + 1))
+    oracle_log+="[oracle] doc=$doc filter=$filter — eager matched jq ($jq_code), streaming did not ($stream_code)
+"
+  fi
+}
+
+for doc in "${DOCS[@]}"; do
+  for filter in "${FILTERS[@]}"; do
+    run_case "$doc" "$filter"
+  done
+done
+
+printf '%s' "$parity_log"
+printf '%s' "$oracle_log"
+echo "== $total cases: $parity_unexpected unexpected parity divergence(s), $((parity_diverged - parity_unexpected)) known, $oracle_regressed oracle regression(s) =="
+if ((parity_diverged > parity_unexpected)); then
+  printf '%s\n' "${known_labels[@]}" | sort | uniq -c | sed 's/^/   known: /'
+fi
+if ((parity_unexpected > 0 || oracle_regressed > 0)); then
+  echo "FAIL: $parity_unexpected unexpected parity divergence(s), $oracle_regressed oracle regression(s) — see above" >&2
+  exit 1
+fi

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4239,6 +4239,13 @@ fn nesting_depth_panic_message(payload: &(dyn core::any::Any + Send)) -> Option<
         .then(|| text.to_string())
 }
 
+/// Read `SUCCINCTLY_JQ_M2_EVAL` (#1653). See its use in
+/// [`evaluate_bytes_lazy`]; `scripts/jq-m2-streaming-sweep.sh` is the only
+/// intended caller.
+fn m2_eval_override() -> Option<String> {
+    std::env::var("SUCCINCTLY_JQ_M2_EVAL").ok()
+}
+
 /// Evaluate expression against raw JSON bytes, returning lazy JqValues.
 ///
 /// This function preserves original number formatting by working directly
@@ -4251,6 +4258,25 @@ fn evaluate_bytes_lazy<'a>(
     sink: &mut ErrorSink,
 ) -> Vec<JqValue<'a, Vec<u64>>> {
     let cursor = index.root(json_bytes);
+    // #1653: the M2 route is mid-migration from the eager cursor evaluator to
+    // the demand-driven one. `SUCCINCTLY_JQ_M2_EVAL=eager|stream` selects a
+    // leg explicitly so `scripts/jq-m2-streaming-sweep.sh` can diff the two
+    // routes out of one binary; unset takes this build's own default. The
+    // variable exists for that sweep and is not a supported interface.
+    if m2_eval_override().as_deref() == Some("stream") {
+        let mut acc: Vec<JqValue<'a, Vec<u64>>> = Vec::new();
+        let control = jq::eval_generic::eval_each_with_cursor(expr, cursor, &mut |result| {
+            acc.extend(generic_result_to_jq_values(result, cursor, at, sink));
+            true
+        });
+        match control {
+            None => {}
+            Some(jq::Control::Error(e)) => sink.report(DiagStyle::Jq, &e, at),
+            Some(jq::Control::Break(label)) => sink.report_break(DiagStyle::Jq, &label, at),
+            Some(jq::Control::Halt(code)) => sink.request_halt(code),
+        }
+        return acc;
+    }
     // Use eval_with_cursor to preserve cursor context for position-based navigation
     let result = eval_with_cursor(expr, cursor);
     generic_result_to_jq_values(result, cursor, at, sink)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4338,21 +4338,28 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// a query that walks every key and matches none. Carrying the value
 /// through instead removes that redundancy without changing output.
 /// **Deliberate divergence, sibling of `each_lazy_seq_iterate_sink`'s own
-/// (#725/#1565): a malformed key past whatever the consumer actually pulls
-/// is never detected.** #1629 taught the non-demand-aware `keys_unsorted`
-/// arms (`fold_lazy_keys_stage`) to raise on a #1194 malformed member by
-/// walking the whole object -- correct there because those arms already pay
-/// for a full walk regardless. This function exists specifically so
-/// `first(keys_unsorted[])`/`limit(n; keys_unsorted[])` do NOT pay for a
-/// full walk, so an unconditional whole-object check would defeat the
-/// point. What it *can* do for free: `DistinctKeyCursors::next` already
-/// decodes every key it yields (to hash it), so a key the consumer actually
-/// pulls is checked below at no extra cost -- but a malformed key, or an
-/// unpaired tail, sitting *after* the last element the consumer pulled is
-/// never reached, the same way `each_lazy_seq_iterate_sink`'s doc comment
-/// above describes for a `map(f)` failure past what `first` needed. Pinned
-/// by the `..._1770` tests below; recorded in
-/// `docs/compliance/jq/limitations.md`.
+/// (#725/#1565): a malformed key past whatever the consumer pulls is never
+/// detected *when the consumer stops early*.** #1629 taught the
+/// non-demand-aware `keys_unsorted` arms (`fold_lazy_keys_stage`) to raise
+/// on a #1194 malformed member by walking the whole object -- correct there
+/// because those arms already pay for a full walk regardless. This function
+/// exists specifically so `first(keys_unsorted[])`/`limit(n;
+/// keys_unsorted[])` do NOT pay for a full walk, so an unconditional
+/// whole-object check would defeat the point.
+///
+/// Two halves, and only one of them is a gap. **Per key**, for free:
+/// `DistinctKeyCursors::next` already decodes every key it yields (to hash
+/// it), so a key the consumer actually pulls is checked below at no extra
+/// cost. **Terminally** -- `ended_unpaired`/`delimiter_fault`, which have no
+/// per-key signal at all -- the check runs when, and only when, the walk
+/// reached exhaustion (#1653): a consumer that ran to the end already paid
+/// for the whole walk, so asking costs it two bool reads, while a consumer
+/// that stopped early is never charged. What remains a gap is therefore
+/// exactly what #1770 scoped it to: a malformed key, or an unpaired tail,
+/// sitting *after* the last element a truncating consumer pulled -- the same
+/// way `each_lazy_seq_iterate_sink`'s doc comment above describes for a
+/// `map(f)` failure past what `first` needed. Pinned by the `..._1770`
+/// tests below; recorded in `docs/compliance/jq/limitations.md`.
 fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     fields: &V::Fields,
     sorted: bool,
@@ -4362,8 +4369,15 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     if !sorted {
-        return drive_pipe_elements_generic::<S, V>(
-            DistinctKeyCursors::new(fields, collapse).map(|(value, cursor)| {
+        // Held by `by_ref` rather than moved into the `map` closure so the
+        // *terminal* half of the #1194 check is still reachable once the
+        // walk ends: `ended_unpaired`/`delimiter_fault` have no per-key
+        // signal (`uncons_key` returns the same `None` either way), so only
+        // the walk that finished can tell them apart. `DistinctKeyCursors`
+        // owns clones of `fields`, so this borrow conflicts with nothing.
+        let mut cursors = DistinctKeyCursors::new(fields, collapse);
+        let flow = drive_pipe_elements_generic::<S, V>(
+            cursors.by_ref().map(|(value, cursor)| {
                 if key_is_malformed(&value) {
                     Err(Control::Error(fields.malformed_member_error()))
                 } else {
@@ -4374,6 +4388,18 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
             optional,
             sink,
         );
+        // Only on exhaustion. A consumer that stopped early (`first`,
+        // `limit`) returns `Flow::Stopped` without the walk ever reaching
+        // the tail, and charging it for one would restore exactly the whole-
+        // object probe such a consumer exists to avoid (#1514/#1599) --
+        // which is the divergence #1770 accepted, scoped to early exit.
+        if matches!(flow, Flow::Exhausted) && cursors.is_malformed() {
+            return drain_result_generic(
+                GenericResult::Error(cursors.malformed_member_error()),
+                sink,
+            );
+        }
+        return flow;
     }
 
     let mut keys = match effective_keys(fields, collapse) {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -17431,4 +17431,85 @@ mod tests {
             other => panic!("expected Control::Error, got {other:?}"),
         }
     }
+
+    /// Drive `expr` through [`eval_each_with_cursor_using`] against `json`,
+    /// returning how many outputs reached the sink and the terminating
+    /// control, if any. The demand-aware `keys_unsorted[]` arm
+    /// ([`each_lazy_keys_iterate_sink`]) is reachable only from this entry
+    /// point -- the CLI's default M2 route still uses the eager
+    /// `eval_with_cursor` (#1653) -- so these tests call it directly rather
+    /// than through a CLI round trip that would exercise the other evaluator.
+    fn drive_each(json: &[u8], expr: &str) -> (usize, Option<Control>) {
+        let expr = parse(expr).unwrap();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let mut count = 0usize;
+        let mut on_value = |_item: GenericResult<_>| {
+            count += 1;
+            true
+        };
+        let control = eval_each_with_cursor_using::<JqSemantics, _>(&expr, cursor, &mut on_value);
+        (count, control)
+    }
+
+    /// #1653: the terminal half of the #1194 check -- an unpaired tail or a
+    /// #1677 delimiter fault, neither of which has a per-key signal -- is
+    /// asked once the `keys_unsorted[]` walk reaches exhaustion, so a
+    /// consumer that walked the whole object gets the same verdict
+    /// `fold_lazy_keys_stage`'s eager arms already gave via
+    /// `walk_distinct_keys_checked`.
+    ///
+    /// The outputs produced *before* the fault are asserted too: the walk
+    /// finds it only on arrival, so the prefix has already reached the sink.
+    /// That is the same shape #1770 accepted for `limit(2;
+    /// keys_unsorted[])`, and it is what the eager route (which returns one
+    /// batched `Error` and emits nothing) does not do.
+    #[test]
+    fn each_lazy_keys_iterate_sink_raises_on_terminal_fault_at_exhaustion_1653() {
+        for json in [
+            &b"{\"a\":1,\"b\"}"[..],
+            &b"{\"a\":1,\"a\":2,\"b\"}"[..],
+            &b"{\"a\":1, invalid}"[..],
+        ] {
+            let (count, control) = drive_each(json, "keys_unsorted[]");
+            match control {
+                Some(Control::Error(err)) => assert!(
+                    err.message.contains("Invalid JSON text"),
+                    "json {json:?}: message: {}",
+                    err.message
+                ),
+                other => panic!("json {json:?}: expected Control::Error, got {other:?}"),
+            }
+            assert_eq!(count, 1, "json {json:?}: the prefix before the fault");
+        }
+    }
+
+    /// #1770's divergence, still scoped to early exit after #1653's terminal
+    /// check: a truncating consumer stops before the walk reaches the tail,
+    /// so it returns `Flow::Stopped` and is never charged for the
+    /// whole-object probe it exists to avoid. The same three documents that
+    /// raise for a bare `keys_unsorted[]` above answer at no error here.
+    #[test]
+    fn each_lazy_keys_iterate_sink_early_exit_still_skips_the_terminal_fault_1770() {
+        for json in [
+            &b"{\"a\":1,\"b\"}"[..],
+            &b"{\"a\":1,\"a\":2,\"b\"}"[..],
+            &b"{\"a\":1, invalid}"[..],
+        ] {
+            let (count, control) = drive_each(json, "first(keys_unsorted[])");
+            assert!(control.is_none(), "json {json:?}: control: {control:?}");
+            assert_eq!(count, 1, "json {json:?}");
+        }
+    }
+
+    /// The check costs a well-formed object nothing but a verdict: every key
+    /// still reaches the sink and no control is raised. Guards against the
+    /// `is_malformed()` call being asked before exhaustion, where
+    /// `ended_unpaired` is not yet meaningful.
+    #[test]
+    fn each_lazy_keys_iterate_sink_well_formed_object_is_unaffected_1653() {
+        let (count, control) = drive_each(b"{\"a\":1,\"b\":2,\"c\":3}", "keys_unsorted[]");
+        assert!(control.is_none(), "control: {control:?}");
+        assert_eq!(count, 3);
+    }
 }


### PR DESCRIPTION
Progresses #1653. **Deliberately not a `Fixes`** — this is the prerequisite half.

## Why this PR exists

#1653's remaining work is the M2 lazy path: a JSON document read from a file or stdin, the
CLI's default route, still collects an input's whole output before writing any of it. The
streaming machinery has been public since #1892 (`eval_each_with_cursor`); the blocker is
that flipping the route also swaps evaluators, and the eager evaluator's materializing arms
double as a validity gate. Natively-streaming arms skip #1194/#1642 checks their eager twins
performed as a side effect of building an `OwnedValue`. An earlier attempt was reverted for
exactly that reason — but the divergences were never enumerated, only counted ("six tests").

This PR enumerates them, and closes the first one. No default-route behaviour changes.

## 1. `scripts/jq-m2-streaming-sweep.sh`

Separates the two variables that the reverted attempt had entangled. Runs each
(document, filter) case three ways — eager route, streaming route, pinned jq 1.7.1 — and
gates on **eager-vs-streaming parity**, reporting the oracle column only directionally
(a cell may move toward jq, never away). Both routes come out of one binary via
`SUCCINCTLY_JQ_M2_EVAL`, so the comparison cannot drift on a stale half.

Standing matches its sibling `scripts/jq-fanout-oracle-sweep.sh`: a verification tool, not a
CI gate. 352 cases today (11 documents x 32 filters).

This is also what #1994 asks for.

### What it found

Running it against a scratch flip — evaluator swapped, output ordering held constant, so
every failure is necessarily a parity failure — gives exactly 7 failing tests in four
classes, not one:

| Class | What | Tests |
|---|---|---|
| **A** | terminal #1194 check missing in the streaming `keys_unsorted[]` arm | `..._1629`, `..._1770` |
| **B** | lost `ambiguous`/#1194 validity gate on arms whose eager twin materializes | `..._1642`, `..._1812` |
| **C** | undecodable-key spelling changes (raw echo vs re-escaped) | `..._1642` |
| **D** | a prefix reaches stdout before a lazily-detected document fault | `..._1597`, `..._1677` |

Class A is fixed below. B and C turn out to share one root cause and are filed separately.
Class D is inherent to streaming — jq emits no prefix, since it rejects the document at parse
time — but it is the same shape #1770 already accepted for `limit(2; keys_unsorted[])`
(exit 5 *with* stdout `"a"`), so the sweep classifies it as known rather than new.

Per-filter, 21 of 32 filters have zero divergence, including `.`, `.a`, `.[]`, `.a, .b`,
`keys`, `length`, `to_entries`, `first(...)` and `debug`. All 11 divergent filters forward or
discard the **root** cursor — note `.a, .b` is clean while `.,.` is not, so it is the root
cursor, not comma.

## 2. Class A — the terminal #1194 fault

`each_lazy_keys_iterate_sink`'s `keys_unsorted` arm moved its `DistinctKeyCursors` into the
`map` closure handed to `drive_pipe_elements_generic`, so nobody could ask the terminal half
of the #1194 check — `ended_unpaired`/`delimiter_fault` — once the walk finished. Those two
have no per-key signal at all (`uncons_key` returns the same `None` either way), so only the
walk that ended can tell a genuine end from an unpaired one. That is why the per-key
`key_is_malformed` half #1770 added could not cover them.

Hold the iterator `by_ref` and ask after the drive returns, **but only on `Flow::Exhausted`**.
A truncating consumer returns `Flow::Stopped` without the walk ever reaching the tail, so
`first`/`limit` are still never charged for the whole-object probe they exist to avoid
(#1514/#1599) — keeping #1770's accepted divergence scoped to exactly what it was scoped to.
A consumer that ran to the end already paid for the walk, so asking costs it two bool reads.

This is a 0 -> 5 move toward jq, which rejects all three documents.

## Verification

- `cargo fmt --all -- --check`, both clippy legs, `cargo test` — green.
- `cargo test --features cli` over `jq_cli_tests`, `jq_golden_tests`, `cli_golden_tests`,
  `cli_characterization_tests`, `deep_nesting_valid_tests`: **1,234 + 24 + 14 + 4 + 3 passed,
  0 failed**.
- New arm is unreachable from the CLI's default route until the flip, so it is pinned by
  three direct `eval_each_with_cursor_using` unit tests rather than a CLI round trip that
  would exercise the other evaluator. Non-vacuous: the same three documents were measured at
  exit 0 on the streaming route before the fix.

## Follow-ups

- Classes B and C, one root cause: `to_owned_with_cursor` on the ambient value was doing two
  jobs — validating the document, and producing the re-escaped spelling. Filed separately.
- The flip itself, gated on the cursor-transparent filter set the sweep identifies.
