### PR TITLE
fix(jq): stream the M2 lazy path so --unbuffered interleaves in real time

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1928,7 +1928,7 @@ underlying exit-code divergence properly needs `get_inputs` to be able to raise 
 fatal `EvalError` from this specific condition rather than only ever warning or returning
 values — not attempted here.
 
-## Real-time stdout/stderr interleaving: every route but the M2 lazy path
+## Real-time stdout/stderr interleaving
 
 Real jq is a lazy generator, so a filter that both writes to stdout and triggers a stderr
 side effect (`debug`, `stderr`, `halt_error`) or raises mid-stream interleaves the two as it
@@ -1937,19 +1937,12 @@ it, so every stderr write had already happened by the time the first stdout writ
 which no amount of buffering could fix, `--unbuffered`'s per-write `flush()` included
 ([#1653](https://github.com/rust-works/succinctly/issues/1653)).
 
-Fixed for every route except the M2 lazy path below — `-n`, `--slurp`, `--input-dsv`, the
-`input`/`inputs` bridge, and any flag that forces materialization (`-S`, `-a`, `-R`,
-`--seq`, `--args`) — all of which now write each output as the evaluator produces it
-(`evaluate_input_streaming`,
+Every route now writes each output as the evaluator produces it. `-n`, `--slurp`,
+`--input-dsv`, the `input`/`inputs` bridge and the materializing flags (`-S`, `-a`, `-R`,
+`--seq`, `--args`) go through `evaluate_input_streaming`; the M2 lazy path — a document read
+from a file or stdin, the default — goes through `evaluate_bytes_streaming`, both in
 [src/bin/succinctly/jq_runner.rs](../../../src/bin/succinctly/jq_runner.rs), over
-`eval_each_with_cursor`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
-
-```
-$ jq            --unbuffered -cn '1, debug, 2'   2>&1     # 1 / ["DEBUG:",null] / null / 2
-$ succinctly jq --unbuffered -cn '1, debug, 2'   2>&1     # same
-```
-
-**Still batched: a document read from a file or stdin** — the M2 lazy path:
+`eval_each_with_cursor` in [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs).
 
 ```
 $ echo '[1,2]' | jq            --unbuffered -c '.[]|debug'   2>&1
@@ -1957,29 +1950,60 @@ $ echo '[1,2]' | jq            --unbuffered -c '.[]|debug'   2>&1
 1
 ["DEBUG:",2]
 2
-$ echo '[1,2]' | succinctly jq --unbuffered -c '.[]|debug'   2>&1
-["DEBUG:",1]
-["DEBUG:",2]
-1
-2
+$ echo '[1,2]' | succinctly jq --unbuffered -c '.[]|debug'   2>&1     # same
 ```
 
-Not an oversight, and not merely unfinished: streaming that path means routing the CLI's
-*default* route through the demand-driven evaluator, whose `each_lazy_keys_iterate_sink`
-deliberately skips the malformed-key check (#1194) that
-[#1629](https://github.com/rust-works/succinctly/issues/1629) added so that bare
-`keys_unsorted[]` *would* raise. [#1770](https://github.com/rust-works/succinctly/issues/1770)
-closed that gap as an accepted trade for early-exit consumers like `first(...)` — see
-"A truncating consumer of `keys_unsorted[]` skips a malformed member it never needed" above
-— on the reasoning that detecting it requires the full walk such a consumer exists to avoid.
-Making it the default route would silently generalise that trade to every query. Tried and
-reverted while fixing #1653: it regressed six tests across #1642/#1629/#1770's
-undecodable-key handling, including `.,.` on a document with colliding undecodable keys
-emitting them twice at exit 0 instead of raising.
+Two things about the M2 path are worth stating, because neither is obvious from the output
+above.
 
-`test_streamed_ordering_not_yet_reached_on_m2_path_1653`
-([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)) pins the current batched output, so
-this stops being silent the moment it changes.
+### The M2 path streams only a cursor-transparent filter
+
+`expr_is_cursor_transparent` (jq_runner.rs) gates it. A filter that can emit the **root**
+cursor unchanged through an arm whose eager twin would have materialized it — `.,.`,
+`(., debug)`, `label $x | .`, `def f: .; f`, `try (1+1)`, `1+1` — still batches, and so still
+shows #1653's original ordering.
+
+That is not a leftover: the eager evaluator's `to_owned_with_cursor` on the ambient value
+doubles as a validity gate (#1194's structural checks, #1642's colliding-display-key raise)
+and also decides an undecodable key's spelling, and `eval_each_generic`'s native arms (#1596)
+do neither. Streaming such a filter would drop those checks.
+[#2103](https://github.com/rust-works/succinctly/issues/2103) tracks separating the two jobs;
+until it lands, those shapes stay on the eager route.
+
+The gate reaches further than the root, though: past a first stage that *descends* (`.[]`,
+`.a`, `.[0]`) the ambient value is a proper descendant, so everything downstream streams —
+`.[] | (., stderr)`, `.[] | if … end`, `.users[] | .name` all interleave. The set is measured
+by `scripts/jq-m2-streaming-sweep.sh`, which diffs both routes against each other and against
+pinned jq 1.7.1, not derived from first principles.
+
+### A fault found by walking to it leaves the prefix on stdout
+
+succinctly is a semi-index and finds a malformed document only when the walk reaches the
+fault, so outputs produced before it are already written. Real jq emits nothing at all here,
+because its strict parser rejects the document before any filter runs:
+
+```
+$ printf '[1,,3]' | jq            --unbuffered -c '.[]'   2>&1
+jq: parse error: Expected value before ',' at line 1, column 4      # exit 5, no stdout
+$ printf '[1,,3]' | succinctly jq --unbuffered -c '.[]'   2>&1
+1                                                                   # exit 5, with the prefix
+jq: error (at <stdin>:0): Invalid JSON text: expected JSON value, found ','
+```
+
+(`--unbuffered` only so the merged order above is deterministic; the prefix is on stdout
+either way.)
+
+The exit code agrees; only the prefix differs. This is the same shape
+[#1770](https://github.com/rust-works/succinctly/issues/1770) already accepted for
+`limit(2; keys_unsorted[])`, which exits 5 with `"a"` already on stdout — see "A truncating
+consumer of `keys_unsorted[]` skips a malformed member it never needed" above. Suppressing it
+would mean validating the whole document up front, which is the cost semi-indexing exists to
+avoid.
+
+Pinned by `test_unbuffered_interleaves_stdout_and_stderr_1653`,
+`test_array_iterate_lazy_skips_later_malformed_comma_1597` and
+`test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`
+([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
 
 ## Deliberate divergences (ADR-0018 rule 4)
 

--- a/scripts/jq-m2-streaming-sweep.sh
+++ b/scripts/jq-m2-streaming-sweep.sh
@@ -14,8 +14,15 @@
 # that reason.
 #
 # This sweep separates the two variables. It runs each (document, filter)
-# case three ways -- the eager route, the streaming route, and the pinned jq
-# oracle -- and reports:
+# case three ways -- the eager route, the route the build actually ships, and
+# the pinned jq oracle -- and reports:
+#
+# By default the second leg is the **shipped** route, so `0 unexpected` means
+# "the `expr_is_cursor_transparent` gate admits nothing that changes an
+# answer". Pass `--forced-stream` to make it stream *every* filter regardless
+# of the gate: that is the diagnostic view, and what it reports is the set of
+# divergences the gate exists to avoid -- i.e. #2103's worklist. Shrinking
+# that set is what lets the gate widen.
 #
 #   * PARITY divergences: eager vs streaming disagree on stdout/stderr/exit.
 #     **These are the gate.** Every one is a check the streaming route lost
@@ -36,13 +43,24 @@
 #
 # Usage:
 #   cargo build --release --features cli
-#   ./scripts/jq-m2-streaming-sweep.sh [path-to-succinctly-binary]
+#   ./scripts/jq-m2-streaming-sweep.sh [--forced-stream] [path-to-succinctly-binary]
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIN="$(cat "$REPO_ROOT/tests/data/jq-golden/JQ_VERSION")"
-SUCC="${1:-$REPO_ROOT/target/release/succinctly}"
+
+# Empty = let the build's own gate decide (the shipped route); "stream" =
+# force every filter through the demand-driven evaluator.
+STREAM_LEG=""
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --forced-stream) STREAM_LEG=stream ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+SUCC="${ARGS[0]:-$REPO_ROOT/target/release/succinctly}"
 
 if [[ ! -x "$SUCC" ]]; then
   echo "error: succinctly binary not found at $SUCC — run: cargo build --release --features cli" >&2
@@ -60,7 +78,7 @@ else
   echo "error: no jq matching pin $PIN found at /usr/bin/jq or on PATH" >&2
   exit 1
 fi
-echo "oracle: $JQ ($("$JQ" --version)), succinctly: $SUCC" >&2
+echo "oracle: $JQ ($("$JQ" --version)), succinctly: $SUCC, second leg: ${STREAM_LEG:-shipped gate}" >&2
 
 WORK="$(mktemp -d -t jq-m2-sweep)"
 trap 'rm -rf "$WORK"' EXIT
@@ -129,6 +147,23 @@ FILTERS=(
   'keys_unsorted, length'
   'debug'
   '(., debug)'
+  # descended shapes: after a first stage that descends, the ambient value is
+  # a proper descendant, so a branch forwarding it is not forwarding the root.
+  # These decide how far past the root the streaming gate can safely reach.
+  '.[]|debug'
+  '.[] | (., debug)'
+  '.[] | .,.'
+  '.[] | if . then . else . end'
+  '.[] | try (1+1) catch "x"'
+  '.[] | 1+1'
+  '.[] | label $x | .'
+  '.[] | def f: .; f'
+  '.[] | . as $x | $x'
+  '.a | (., debug)'
+  '.a | if . then . else . end'
+  '.a | 1+1'
+  '.[] | select(. != null)'
+  '.[] | tostring'
 )
 
 # Attribute a parity divergence to an already-tracked, deliberately-accepted
@@ -173,7 +208,7 @@ run_case() {
     && eager_code=0 || eager_code=$?
   eager_err="$(cat "$WORK/e.err")"
 
-  stream_out="$(SUCCINCTLY_JQ_M2_EVAL=stream "$SUCC" jq -c "$filter" "$DOC_FILE" 2>"$WORK/s.err")" \
+  stream_out="$(SUCCINCTLY_JQ_M2_EVAL="$STREAM_LEG" "$SUCC" jq -c "$filter" "$DOC_FILE" 2>"$WORK/s.err")" \
     && stream_code=0 || stream_code=$?
   stream_err="$(cat "$WORK/s.err")"
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1400,6 +1400,20 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
 
         // Check if we can use the identity fast path (raw bytes output, no materialization)
         let use_identity_fast_path = expr.is_identity() && output_config.can_use_raw_identity();
+        // #1653: stream each output as the evaluator produces it, so a
+        // `debug`/`stderr` side effect interleaves with stdout the way real
+        // jq's lazy generator does. Gated on `expr_is_cursor_transparent`,
+        // whose doc comment explains what the demand-driven evaluator would
+        // otherwise change beyond ordering, and why the set is measured
+        // (`scripts/jq-m2-streaming-sweep.sh`) rather than reasoned out.
+        // `SUCCINCTLY_JQ_M2_EVAL` overrides the gate in either direction so
+        // that sweep can diff both routes out of one binary; it is a
+        // verification hook, not a supported interface.
+        let use_streaming = match m2_eval_override().as_deref() {
+            Some("stream") => true,
+            Some("eager") => false,
+            _ => expr_is_cursor_transparent(&expr),
+        };
 
         for (idx, raw) in raw_inputs.iter().enumerate() {
             let filename: Option<String> = files.get(idx).map(|p| p.to_string_lossy().to_string());
@@ -1477,10 +1491,76 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // reverted (#1021): only the two outermost call sites
                 // reachable from ordinary CLI usage are wrapped here, not
                 // the guard itself.
-                let results = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink)
-                })) {
-                    Ok(results) => results,
+                //
+                // The write now happens *inside* the guard, because a
+                // streaming filter panics from within the sink callback
+                // rather than before the caller's loop starts. That puts
+                // `out`, `sink`, `had_output` and `last_output` under
+                // `AssertUnwindSafe`, which is sound here for the same reason
+                // the single `sink` was already: `assert_nesting_depth`
+                // panics unconditionally *before* any `write_all`, so `out`'s
+                // writer is never mid-record when the stack unwinds, and the
+                // other three are plain data.
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut on_value =
+                        |sink: &mut ErrorSink, result: JqValue<'_, Vec<u64>>| -> Result<bool> {
+                            had_output = true;
+                            // For exit_status tracking, we need to check the last value
+                            if args.exit_status {
+                                // `-e` is the flag that forces materialization at
+                                // all, so it is where a decode failure first
+                                // becomes observable here (#1247). Report and skip
+                                // the value rather than letting an undecodable
+                                // string count as a truthiness answer; `sink`
+                                // drives the exit code.
+                                match result.materialize() {
+                                    Ok(owned) => last_output = Some(owned),
+                                    Err(e) => {
+                                        sink.report(DiagStyle::Jq, &e, &at);
+                                        return Ok(true);
+                                    }
+                                }
+                            }
+                            // A malformed document is a data error, not an I/O
+                            // one: it belongs in jq's diagnostic channel (exit 5)
+                            // rather than aborting the process through `anyhow`
+                            // (#1194). Stop emitting results for *this* document,
+                            // but fall through to the halt check below and carry
+                            // on with the rest of the stream (#355) -- real jq
+                            // stops at the first parse error instead, a
+                            // divergence recorded in
+                            // `docs/compliance/jq/limitations.md`.
+                            let stop = route_write_error(
+                                sink,
+                                &mut out,
+                                || at.clone(),
+                                |o| write_output_jq_value(o, &result, &output_config),
+                            )?;
+                            Ok(!stop)
+                        };
+                    if use_streaming {
+                        evaluate_bytes_streaming(
+                            json_bytes,
+                            &expr,
+                            &index,
+                            &at,
+                            &mut sink,
+                            &mut on_value,
+                        )
+                    } else {
+                        // Consume results to free memory after each value is written
+                        for result in evaluate_bytes_lazy(json_bytes, &expr, &index, &at, &mut sink)
+                        {
+                            if !on_value(&mut sink, result)? {
+                                break;
+                            }
+                            // result is dropped here, freeing its memory immediately
+                        }
+                        Ok(())
+                    }
+                }));
+                match outcome {
+                    Ok(written) => written?,
                     Err(payload) => {
                         // `&*payload`, not `&payload` -- `payload` is a
                         // `Box<dyn Any + Send>`, and a bare `&payload`
@@ -1514,52 +1594,14 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                         // skip straight past that check for this iteration
                         // (review: every other early-exit in this loop still
                         // reaches it on the same iteration; this one didn't).
-                        if let Some(code) = sink.halted() {
-                            out.flush()?;
-                            return Ok(code);
-                        }
-                        continue;
                     }
-                };
-
-                // Consume results to free memory after each value is written
-                for result in results {
-                    had_output = true;
-                    // For exit_status tracking, we need to check the last value
-                    if args.exit_status {
-                        // `-e` is the flag that forces materialization at
-                        // all, so it is where a decode failure first becomes
-                        // observable here (#1247). Report and skip the value
-                        // rather than letting an undecodable string count as
-                        // a truthiness answer; `sink` drives the exit code.
-                        match result.materialize() {
-                            Ok(owned) => last_output = Some(owned),
-                            Err(e) => {
-                                sink.report(DiagStyle::Jq, &e, &at);
-                                continue;
-                            }
-                        }
-                    }
-                    // A malformed document is a data error, not an I/O one: it
-                    // belongs in jq's diagnostic channel (exit 5) rather than
-                    // aborting the process through `anyhow` (#1194). Stop
-                    // emitting results for *this* document, but fall through
-                    // to the halt check below and carry on with the rest of
-                    // the stream (#355) -- real jq stops at the first parse
-                    // error instead, a divergence recorded in
-                    // `docs/compliance/jq/limitations.md`.
-                    if route_write_error(
-                        &mut sink,
-                        &mut out,
-                        || at.clone(),
-                        |o| write_output_jq_value(o, &result, &output_config),
-                    )? {
-                        break;
-                    }
-                    // result is dropped here, freeing its memory immediately
                 }
                 // halt/halt_error (#791) outranks everything else, including
-                // remaining values/files still to process.
+                // remaining values/files still to process. The panic arm above
+                // used to `continue` past this check and repeat it itself;
+                // with the write loop folded into the guard there is nothing
+                // left between the two, so the single check below now covers
+                // both paths.
                 if let Some(code) = sink.halted() {
                     out.flush()?;
                     return Ok(code);
@@ -4239,6 +4281,101 @@ fn nesting_depth_panic_message(payload: &(dyn core::any::Any + Send)) -> Option<
         .then(|| text.to_string())
 }
 
+/// Whether every value this filter can emit is either a *proper descendant*
+/// cursor or a freshly-built value -- never the ambient root cursor forwarded
+/// on, and never an object key pulled from a lazy keys walk.
+///
+/// This is the gate on #1653's M2 streaming flip. Routing a filter through
+/// the demand-driven evaluator is not only an ordering change: the eager
+/// `eval_single`'s wildcard materializes the ambient value via
+/// `to_owned_with_cursor`, and that call is doing two jobs beyond producing a
+/// value -- validating the document (#1194's structural checks, #1642's
+/// colliding-display-key raise) and choosing an undecodable key's spelling.
+/// `eval_each_generic`'s native arms (#1596) do neither, so a filter whose
+/// eager twin is that wildcard answers differently on the two routes. #2103
+/// tracks splitting those two jobs apart; until it lands, such a filter stays
+/// on the eager route and only the shapes below stream.
+///
+/// The set is derived from `scripts/jq-m2-streaming-sweep.sh`, not from
+/// first principles: every shape admitted here measures byte-identical on
+/// stdout, stderr and exit code across both routes, on all eleven of the
+/// sweep's documents. Note `.a, .b` is admitted while `.,.` is not -- the
+/// divergence tracks the *root* cursor, not the comma -- which is why
+/// `Expr::Comma` is admitted only when no branch can yield the root.
+///
+/// Conservative by construction: a shape left out merely keeps today's
+/// batching, so the cost of omission is a missed improvement, never a wrong
+/// answer. `keys`/`length`/`to_entries`/`first(...)` all measure clean and
+/// are still omitted, because admitting builtins wholesale would also admit
+/// `keys_unsorted[]`, which does not.
+fn expr_is_cursor_transparent(expr: &jq::Expr) -> bool {
+    // A pipe is free from its first *descending* stage onwards. Past `.[]` or
+    // `.a` the ambient value is a proper descendant, so a downstream branch
+    // forwarding it is not forwarding the root, and the divergence this gate
+    // exists for cannot arise. Measured, not assumed: every `.[] | ...` and
+    // `.a | ...` shape in the sweep -- including `(., debug)`, `if`, `try`,
+    // `label`, `def`, `1+1`, the very shapes that diverge at the root -- is
+    // byte-identical on both routes across all eleven documents.
+    if let jq::Expr::Pipe(stages) = expr {
+        if let Some(cut) = stages.iter().position(expr_descends) {
+            return stages[..cut].iter().all(expr_is_root_safe);
+        }
+    }
+    expr_is_root_safe(expr)
+}
+
+/// Whether this stage necessarily moves off the ambient value onto a child
+/// (or onto a freshly-built `null` for a missing field), so nothing after it
+/// can still be holding the root cursor.
+fn expr_descends(expr: &jq::Expr) -> bool {
+    match expr {
+        jq::Expr::Field(_)
+        | jq::Expr::Index(_)
+        | jq::Expr::IndexNumber { .. }
+        | jq::Expr::Iterate => true,
+        jq::Expr::Paren(inner) => expr_descends(inner),
+        _ => false,
+    }
+}
+
+/// The conservative set for a filter still operating on the root: every shape
+/// here emits either a descendant cursor or a freshly-built value, never the
+/// ambient root cursor forwarded on through an arm whose eager twin would
+/// have materialized it.
+fn expr_is_root_safe(expr: &jq::Expr) -> bool {
+    match expr {
+        jq::Expr::Identity
+        | jq::Expr::Field(_)
+        | jq::Expr::Index(_)
+        | jq::Expr::IndexNumber { .. }
+        | jq::Expr::Iterate => true,
+        // `debug` forwards its input untouched, so it is root-safe for the
+        // same reason `.` is -- and it is the builtin #1653's own repro
+        // (`.[] | debug`) is built from.
+        jq::Expr::Builtin(jq::Builtin::Debug) => true,
+        jq::Expr::Paren(inner) => expr_is_root_safe(inner),
+        jq::Expr::Pipe(stages) => stages.iter().all(expr_is_root_safe),
+        jq::Expr::Comma(branches) => branches
+            .iter()
+            .all(|b| !expr_can_yield_root(b) && expr_is_root_safe(b)),
+        _ => false,
+    }
+}
+
+/// Whether `expr` can emit the ambient value unchanged. Only used to keep a
+/// root-forwarding branch out of an otherwise-root-safe `Expr::Comma`:
+/// `.,.` and `(., debug)` are exactly the shapes whose eager twin
+/// materializes, and so exactly the ones that diverge.
+fn expr_can_yield_root(expr: &jq::Expr) -> bool {
+    match expr {
+        jq::Expr::Identity | jq::Expr::Builtin(jq::Builtin::Debug) => true,
+        jq::Expr::Paren(inner) => expr_can_yield_root(inner),
+        jq::Expr::Pipe(stages) => stages.iter().all(expr_can_yield_root),
+        jq::Expr::Comma(branches) => branches.iter().any(expr_can_yield_root),
+        _ => false,
+    }
+}
+
 /// Read `SUCCINCTLY_JQ_M2_EVAL` (#1653). See its use in
 /// [`evaluate_bytes_lazy`]; `scripts/jq-m2-streaming-sweep.sh` is the only
 /// intended caller.
@@ -4246,10 +4383,20 @@ fn m2_eval_override() -> Option<String> {
     std::env::var("SUCCINCTLY_JQ_M2_EVAL").ok()
 }
 
+/// One M2 output, handed to the caller's writer. Named so the `&mut dyn`
+/// spelling below stays inside clippy's `type_complexity` budget.
+type JqValueSink<'a, 'w> = dyn FnMut(&mut ErrorSink, JqValue<'a, Vec<u64>>) -> Result<bool> + 'w;
+
 /// Evaluate expression against raw JSON bytes, returning lazy JqValues.
 ///
 /// This function preserves original number formatting by working directly
 /// with the source bytes instead of parsing through serde_json.
+///
+/// The eager half of #1653's migration: it evaluates the whole filter before
+/// the caller writes any of it, so a `debug`/`stderr` side effect reaches
+/// stderr ahead of stdout output that was logically produced first. Reached
+/// only by filters [`expr_is_cursor_transparent`] rejects; everything else
+/// goes through [`evaluate_bytes_streaming`].
 fn evaluate_bytes_lazy<'a>(
     json_bytes: &'a [u8],
     expr: &jq::Expr,
@@ -4258,28 +4405,65 @@ fn evaluate_bytes_lazy<'a>(
     sink: &mut ErrorSink,
 ) -> Vec<JqValue<'a, Vec<u64>>> {
     let cursor = index.root(json_bytes);
-    // #1653: the M2 route is mid-migration from the eager cursor evaluator to
-    // the demand-driven one. `SUCCINCTLY_JQ_M2_EVAL=eager|stream` selects a
-    // leg explicitly so `scripts/jq-m2-streaming-sweep.sh` can diff the two
-    // routes out of one binary; unset takes this build's own default. The
-    // variable exists for that sweep and is not a supported interface.
-    if m2_eval_override().as_deref() == Some("stream") {
-        let mut acc: Vec<JqValue<'a, Vec<u64>>> = Vec::new();
-        let control = jq::eval_generic::eval_each_with_cursor(expr, cursor, &mut |result| {
-            acc.extend(generic_result_to_jq_values(result, cursor, at, sink));
-            true
-        });
-        match control {
-            None => {}
-            Some(jq::Control::Error(e)) => sink.report(DiagStyle::Jq, &e, at),
-            Some(jq::Control::Break(label)) => sink.report_break(DiagStyle::Jq, &label, at),
-            Some(jq::Control::Halt(code)) => sink.request_halt(code),
-        }
-        return acc;
-    }
     // Use eval_with_cursor to preserve cursor context for position-based navigation
     let result = eval_with_cursor(expr, cursor);
     generic_result_to_jq_values(result, cursor, at, sink)
+}
+
+/// Evaluate against raw JSON bytes, handing each output to `on_value` the
+/// moment the evaluator produces it (#1653).
+///
+/// The M2 counterpart of [`evaluate_input_streaming`], and deliberately not a
+/// call into it: that one takes an already-materialized `OwnedValue` and
+/// re-indexes `input.to_json()`, where this streams from the `JsonIndex` the
+/// caller already built and keeps the lazy [`write_output_jq_value`] writer,
+/// so a transparent filter still writes raw source spans rather than
+/// materializing every output.
+///
+/// `on_value` returns `false` to stop the generator. `sink` is passed *into*
+/// it rather than captured, so this function can keep its own `&mut` for the
+/// control arms below -- the same shape `evaluate_input_streaming` uses.
+fn evaluate_bytes_streaming<'a>(
+    json_bytes: &'a [u8],
+    expr: &jq::Expr,
+    index: &'a JsonIndex,
+    at: &InputLocation,
+    sink: &mut ErrorSink,
+    on_value: &mut JqValueSink<'a, '_>,
+) -> Result<()> {
+    let cursor = index.root(json_bytes);
+    let mut write_err: Option<anyhow::Error> = None;
+    let control = jq::eval_generic::eval_each_with_cursor(expr, cursor, &mut |result| {
+        // `generic_result_to_jq_values` reports a per-result failure to
+        // `sink` and yields nothing for it, the same "report and keep going"
+        // contract the batched loop relied on (#355).
+        for value in generic_result_to_jq_values(result, cursor, at, sink) {
+            match on_value(sink, value) {
+                Ok(true) => {}
+                Ok(false) => return false,
+                Err(e) => {
+                    write_err = Some(e);
+                    return false;
+                }
+            }
+        }
+        true
+    });
+    // Reported *before* any write error is surfaced, for the reason
+    // `evaluate_input_streaming` gives at its own copy of this match: the
+    // eager path reported the control during evaluation, always before the
+    // caller's write loop could fail, so returning `Err` first here would let
+    // an I/O failure swallow the evaluator's own diagnostic.
+    match control {
+        None => {}
+        Some(jq::Control::Error(e)) => sink.report(DiagStyle::Jq, &e, at),
+        Some(jq::Control::Break(label)) => sink.report_break(DiagStyle::Jq, &label, at),
+        Some(jq::Control::Halt(code)) => sink.request_halt(code),
+    }
+    if let Some(e) = write_err {
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// Convert GenericResult to JqValue, preserving lazy cursor references.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18137,11 +18137,24 @@ fn test_identity_query_rejects_exactly_384_boundary_1819() -> Result<()> {
 /// first pass. Confirmed live before this follow-up fix: `succinctly jq -e
 /// '.[0]'` on a 200,000-level-deep document raw-stack-overflowed (SIGABRT,
 /// exit 134) even with `print_json`'s guard already in place.
+///
+/// **Exit 5, not the 101 this pinned until #1653.** `-e`'s `materialize()`
+/// call used to sit in the CLI's per-result write loop, *outside* the
+/// `catch_unwind` that #1793 wraps evaluation in, so `lazy.rs`'s guard
+/// panicked all the way out of the process. Streaming the M2 path folds that
+/// write loop inside the guard, so the panic is now caught and reported
+/// through the same channel as every other #1793 nesting diagnostic.
+///
+/// That is the outcome #1793's own rationale argues for -- it exists to turn
+/// this ceiling "into an ordinary, recoverable diagnostic" rather than a
+/// hard, uncontrolled process exit -- and the guard is still doing its job:
+/// the depth limit is enforced, the message is unchanged, and the run still
+/// fails. Only the manner of failing moved, from abort to diagnostic.
 #[test]
 fn test_exit_status_query_rejects_adversarial_nesting_998() -> Result<()> {
     let input = nested_arrays(500);
     let (_stdout, stderr, code) = run_jq_full(&["-e", "-c", ".[0]"], Some(&input))?;
-    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert_eq!(code, 5, "stderr: {stderr:?}");
     assert!(
         stderr.contains("nesting depth exceeds limit of 256"),
         "stderr: {stderr:?}"
@@ -19961,9 +19974,13 @@ fn test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677() -> R
         );
     }
 
+    // `.[]` streams since #1653, so the element before the missing delimiter
+    // is written before the walk reaches it. The raise is unchanged; the
+    // prefix is. See `test_array_iterate_lazy_skips_later_malformed_comma_1597`
+    // for why that prefix is accepted rather than suppressed.
     let (out, stderr, code) = run_jq_full(&["-c", ".[]"], Some("[1 2, 3]"))?;
     assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
-    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert_eq!(out, "1\n", "unexpected output {out:?}");
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
     let (out, stderr, code) = run_jq_full(&["-c", "add"], Some("[1 2, 3]"))?;
@@ -24945,14 +24962,20 @@ fn test_array_iterate_lazy_skips_later_malformed_comma_1597() -> Result<()> {
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
 
     // Plain `.[]` (no truncation) still walks the whole array and always
-    // catches it, unaffected by this change -- and produces no output at
-    // all, not just a nonzero exit, since it never routes through the new
-    // lazy arm in the first place (`evaluate_bytes_lazy`'s bare `.[]` path
-    // calls `eval_single` directly). Asserting `stdout` too, not just
-    // `code`, so this stays a real regression guard if a future change
-    // ever does route a top-level bare `.[]` through `eval_each_generic`.
+    // catches it. #1653 routed a top-level bare `.[]` through
+    // `eval_each_generic` -- the very change this assertion was written to
+    // catch -- so the element before the malformed comma is now written
+    // before the walk reaches the fault, where the eager route returned a
+    // single batched `Error` and emitted nothing. The exit code is
+    // unchanged; only the prefix is new.
+    //
+    // Real jq emits nothing here, because its strict parser rejects the
+    // document before any filter runs. That divergence is inherent to
+    // finding a fault by walking to it, and is the same shape #1770 already
+    // accepted for `limit(2; keys_unsorted[])`, which exits 5 with `"a"`
+    // already on stdout. Recorded in `docs/compliance/jq/limitations.md`.
     let (stdout, stderr, code) = run_jq_full(&["-c", ".[]"], Some("[1,,3]"))?;
-    assert_eq!((stdout.as_str(), code), ("", 5), "stderr: {stderr:?}");
+    assert_eq!((stdout.as_str(), code), ("1\n", 5), "stderr: {stderr:?}");
 
     Ok(())
 }
@@ -28267,9 +28290,16 @@ fn test_field_index_iterate_delete_on_empty_update_filter_1916() -> Result<()> {
 /// (`run_jq_interleaved`) -- separately-captured pipes would pass even with
 /// the batching bug, since each stream's own contents were always correct.
 ///
-/// The `-n` and `--slurp` forms are the routes this fix streams; a document
-/// read on the M2 lazy path is deliberately not asserted here (see
-/// `test_streamed_ordering_not_yet_reached_on_m2_path_1653`).
+/// The `-n` and `--slurp` forms were the first routes to stream (PR #1892).
+/// The M2 rows -- a document read from stdin, the CLI's default -- were added
+/// once that route was gated on `expr_is_cursor_transparent` and streamed
+/// too: `.[]|debug` is the shape the issue was filed about, and the `stderr`,
+/// `error` and `halt_error` rows check that a side effect mid-generator lands
+/// between the outputs either side of it rather than ahead of all of them.
+///
+/// A filter the gate rejects still batches. That is not asserted here; it is
+/// recorded in `docs/compliance/jq/limitations.md` and tracked by #2103,
+/// which owns the evaluator divergence the gate exists to avoid.
 #[test]
 fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
     // (args, stdin, combined stdout+stderr, exit code) -- all four captured
@@ -28340,6 +28370,43 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
             "1\n[\"DEBUG:\",{}]\n{}\n2\n",
             0,
         ),
+        // The M2 lazy path: a document read from stdin. `.[]|debug` is
+        // #1653's own repro -- every one of these was captured from jq
+        // 1.7.1 byte for byte, same as the rows above.
+        (
+            vec!["--unbuffered", "-c", ".[]|debug"],
+            Some("[1,2]"),
+            "[\"DEBUG:\",1]\n1\n[\"DEBUG:\",2]\n2\n",
+            0,
+        ),
+        // `stderr` writes its input and passes it through, so each element
+        // appears twice, adjacent -- not all the stderr copies first.
+        (
+            vec!["--unbuffered", "-c", ".[] | (., stderr)"],
+            Some("[1,2]"),
+            "1\n11\n2\n22\n",
+            0,
+        ),
+        // An error mid-document: the element before it is already written.
+        (
+            vec![
+                "--unbuffered",
+                "-c",
+                ".[] | if .==2 then error(\"x\") else . end",
+            ],
+            Some("[1,2,3]"),
+            "1\njq: error (at <stdin>:0): x\n",
+            5,
+        ),
+        // `halt_error` stops the process, so only what preceded it survives
+        // -- the `1` on stdout, then its own `2` on stderr. Exit 5, jq's
+        // default for a bare `halt_error`, not the halted value.
+        (
+            vec!["--unbuffered", "-c", ".[] | (., (2|halt_error))"],
+            Some("[1,2]"),
+            "1\n2\n",
+            5,
+        ),
     ] {
         let (combined, code) = run_jq_interleaved(&args, input)?;
         assert_eq!(combined, expected, "args {args:?} input {input:?}");
@@ -28348,31 +28415,6 @@ fn test_unbuffered_interleaves_stdout_and_stderr_1653() -> Result<()> {
         // `error(...)`/`halt_error` rows.
         assert_eq!(code, expected_code, "exit code for {args:?}");
     }
-    Ok(())
-}
-
-/// #1653: the M2 lazy path (a document read from stdin/a file) still batches.
-///
-/// Pinned deliberately rather than left untested. Streaming it means routing
-/// the CLI's default path through the demand-driven evaluator, and
-/// `each_lazy_keys_iterate_sink` there skips the #1194 malformed-key check
-/// that #1629 added specifically so bare `keys_unsorted[]` *would* raise --
-/// a gap #1770 closed as an accepted trade for early-exit consumers like
-/// `first(...)`, not one that may be universalized to the default path.
-/// Routing M2 through it was tried and reverted: it regressed six tests
-/// across #1642/#1629/#1770's undecodable-key handling.
-///
-/// When that is resolved, this test should start failing -- at which point
-/// the expectation becomes jq's own
-/// `["DEBUG:",1]\n1\n["DEBUG:",2]\n2\n` and it moves into the test above.
-#[test]
-fn test_streamed_ordering_not_yet_reached_on_m2_path_1653() -> Result<()> {
-    let (combined, code) = run_jq_interleaved(&["--unbuffered", "-c", ".[]|debug"], Some("[1,2]"))?;
-    assert_eq!(code, 0);
-    assert_eq!(
-        combined, "[\"DEBUG:\",1]\n[\"DEBUG:\",2]\n1\n2\n",
-        "M2 path still batches; see this test's doc comment"
-    );
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1653.

Retargeted onto `main`, so this PR is self-contained: four commits, the first three of which
are also #2102 (the parity sweep and the terminal-keys fix). Review #2102 first if you want
those separated — it is the same three commits and is independently green; this PR subsumes it,
so whichever merges first, the other needs only a rebase.

| commit | what |
|---|---|
| `8c19d17d` | `scripts/jq-m2-streaming-sweep.sh` — the eager-vs-shipped-vs-oracle parity sweep |
| `306eb0e7` | Gap 1: the terminal #1194 check when a `keys_unsorted[]` walk reaches the end |
| `a1c11e75` | its three `eval_each_with_cursor_using` unit tests |
| `6e2e3352` | **the flip** — everything described below |

## What changes

The M2 lazy path — a JSON document read from a file or stdin, the CLI's default — was the one
route PR #1892 left batching. It now writes each output the moment the evaluator produces it:

```console
$ echo '[1,2]' | jq            --unbuffered -c '.[]|debug'  2>&1   # ["DEBUG:",1] 1 ["DEBUG:",2] 2
$ echo '[1,2]' | succinctly jq --unbuffered -c '.[]|debug'  2>&1   # same, byte for byte
```

`evaluate_bytes_streaming` replaces the collect-then-write loop, and the write moves **inside**
#1793's `catch_unwind`, because a streaming filter panics from within the sink callback rather
than before the loop starts. That widens `AssertUnwindSafe` to `out`/`sink`/`had_output`/
`last_output`, which is sound because `assert_nesting_depth` panics unconditionally *before*
any `write_all`, so the writer is never mid-record when the stack unwinds. The panic arm's
duplicated halt check goes away with it — nothing now sits between it and the shared one.

## Why it is gated

Routing a filter through the demand-driven evaluator is not only an ordering change. The eager
`eval_single`'s wildcard materializes the ambient value via `to_owned_with_cursor`, and that
call is doing two more jobs: validating the document (#1194's structural checks, #1642's
colliding-display-key raise) and choosing an undecodable key's spelling.
`eval_each_generic`'s native arms (#1596) do neither. This is what sank the earlier attempt.

`expr_is_cursor_transparent` admits only filters that cannot emit the **root** cursor through
such an arm. The gate reaches further than that sounds: past a first stage that *descends*
(`.[]`, `.a`, `.[0]`) the ambient value is a proper descendant, so everything downstream
streams too — `.[] | (., stderr)`, `.[] | if … end`, `.users[] | .name` all interleave. What
still batches is root-forwarding shapes: `.,.`, `(., debug)`, `label $x | .`, `def f: .; f`,
`1+1`. #2103 owns removing that restriction.

The set is **measured, not derived**. `scripts/jq-m2-streaming-sweep.sh` (added in #2102) over
506 cases:

| leg | unexpected parity divergences | oracle regressions | known |
|---|---|---|---|
| shipped gate | **0** | **0** | 12 |
| `--forced-stream` | 33 | 11 | 27 |

The second row is what the gate is protecting against, and is now #2103's worklist — shrinking
it is what lets the gate widen. The sweep's second leg defaults to the *shipped* route for
exactly this reason, so `0 unexpected` means "the gate admits nothing that changes an answer".

## Three pinned expectations move

Each is toward jq, or a stated consequence of streaming:

- **`test_streamed_ordering_not_yet_reached_on_m2_path_1653`** was a tripwire for this change
  and says so in its own doc comment. Deleted; its case moves into
  `test_unbuffered_interleaves_stdout_and_stderr_1653` along with three more M2 rows captured
  live from jq 1.7.1 — `stderr` per element, an error mid-document, and `halt_error`.
- **`_1597` / `_1677`**: a fault found by *walking to it* leaves the prefix on stdout, where
  jq's strict parser rejects the document before any filter runs and emits nothing. Exit codes
  are unchanged. This is the same shape #1770 already accepted for `limit(2; keys_unsorted[])`
  (exit 5 with `"a"` already written); suppressing it would mean validating every document up
  front, which is the cost semi-indexing exists to avoid.
- **`_998`**: `-e`'s `materialize()` is now inside the guard, so the nesting panic is caught
  and reported as exit 5 instead of aborting the process at 101 — the outcome #1793's own
  rationale argues for ("an ordinary, recoverable diagnostic" rather than a hard exit). The
  limit is still enforced and the message is unchanged; only the manner of failing moved.

`docs/compliance/jq/limitations.md`'s interleaving section is rewritten accordingly: the
"every route but the M2 lazy path" framing is gone, replaced by the gate and the prefix
divergence.

## Verification

- `cargo fmt --all -- --check`; all three clippy legs; `cargo check --no-default-features`;
  `cargo test`, `cargo test --features simd` — green.
- CI's full `--features cli` test list: **1,234 jq CLI + 1,358 yq CLI + all others, 0 failed.**
- Sweep: `0 unexpected, 0 oracle regressions` (table above).
- Oracle differential against `/usr/bin/jq` 1.7.1 for `.[]|debug`, `.[] | (., stderr)`,
  `.[] | if .==2 then error("x") else . end`, `.[] | (., (2|halt_error))` — all byte-identical
  including exit codes.

### Outstanding: the A/B timing run

**Not yet run.** The M2 route is the hot default path, so it needs one, and this machine is not
idle (a concurrent worktree is running tests at ~291% CPU) — timing it here would be noise.
Note `scripts/perf-guard.py` cannot see this change either way: its six queries are `.` (the
identity fast path, untouched) and bare `keys_unsorted` (a `LazyKeys` item with no
`Expr::Iterate` stage), so green there is not evidence.

The change is expected to be neutral-to-positive — it removes a per-document `Vec`
accumulation without changing the evaluator's work — but that is a prediction, not a
measurement. Baseline binary and a 2 MB three-shape corpus are prepared for
`scripts/ab-cli.py`; **please hold merge until that lands in a comment here.**

