### PR TITLE
refactor(jq): converge set_path onto a peel-and-recurse walker (#1429)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -412,7 +412,9 @@ whatever container the path names. Four non-slice rows used to sit above these �
 on `null`, `.a.b = 1` on `{}`, `.[5] = 9` and `.[5] |= 9` on `[1,2]`, all reported as
 `Cannot index …`/`index N out of bounds (length M)` where jq builds or pads the container —
 closed together by [#486](https://github.com/rust-works/succinctly/issues/486)
-(`set_path`/`get_path_mut`/`update_path` now vivify `null` and pad past the array end, the
+(`set_path`/`update_path`, and `=`'s own chain walker — then `get_path_mut`, now
+`set_path_steps` since [#1429](https://github.com/rust-works/succinctly/issues/1429) —
+now vivify `null` and pad past the array end, the
 way `set_value_at_path` already did for `setpath()`) and
 [#498](https://github.com/rust-works/succinctly/issues/498) (the write-time negative-index
 bounds check now survives `?`, since padding is what makes the positive case succeed rather
@@ -485,7 +487,8 @@ the mechanism.
 `setpath` is the same operation without the syntax, and after #359 it does follow jq —
 `[1,2] | setpath([5]; 9)` is `[1,2,null,null,null,9]`, and `null | setpath(["a"]; 1)` is
 `{"a":1}`. The two used to disagree with each other in-tree; [#486](https://github.com/rust-works/succinctly/issues/486)
-closed that by teaching `set_path`/`get_path_mut`/`update_path` to vivify the way
+closed that by teaching `set_path`/`update_path` and `=`'s chain walker (then
+`get_path_mut`, now `set_path_steps`) to vivify the way
 `set_value_at_path` already did, so `=`/`|=`/the compound operators/`//=` now agree with
 `setpath` on every one of the four shapes removed from the table earlier in this section.
 `delete_at_path` deliberately keeps its own,

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -966,7 +966,9 @@ fix relies on).
 
 [#1232](https://github.com/rust-works/succinctly/issues/1232) widened #1181's scalar-target
 no-op to a scalar hit *before* the last path component (`.a.b = 99` on a scalar `.a`
-no-ops), but only for the *static*-path walkers (`get_path_mut`/`set_path`/`update_path`).
+no-ops), but only for the *static*-path walkers (`set_path`/`update_path` — at the time
+`=`'s own share of that lived in `get_path_mut`, folded into `set_path_steps` by
+[#1429](https://github.com/rust-works/succinctly/issues/1429)).
 A path that needs the full `resolve_dynamic_indexes` pre-pass — a computed key, or a
 `Comma`-grouped LHS — resolves each component through a plain read evaluator with no yq
 scalar-noop awareness at all, so the boundary this section's *previous* entry describes
@@ -994,7 +996,10 @@ silently, even though the write itself — `.[$k] = 99` — already correctly no
 under plain `=` (`.a[].b = 99`) always errored "invalid path component" — in both jq and yq
 mode, and predating #1232 entirely (`|=`/`+=`/`-=`/`*=`/`del()` were unaffected, their own
 recursive-descent walkers already supported fan-out). #1298 added `split_at_iterate`/
-`set_path_through_iterate` so `=` fans out per element like every other operator, and gave
+`set_path_through_iterate` so `=` fans out per element like every other operator (both since
+folded into `set_path_steps`' own mid-chain `Iterate` arm by
+[#1429](https://github.com/rust-works/succinctly/issues/1429), which replaced the whole
+pre-scan with one peel-and-recurse walk — same behaviour, verified byte-identical), and gave
 `navigate_read_only`'s prefix walk (`yq_assign_is_total_noop`'s own eager-RHS-discard
 pre-check, #1232's `PrefixNavOutcome`) an `Expr::Iterate` arm too — but only for the
 narrowest case, `.a` itself being a genuine scalar (`.a[].b = error("boom")` on `a: 5` now
@@ -1005,7 +1010,8 @@ RHS-discard rule for a mid-chain `Iterate` is broader than #1298's own narrowest
 container whose own elements *all* individually no-op also discards the RHS, and so does an
 empty container (vacuously). New `assign_path_all_noop` recurses into
 `.iter().all(...)`/`.values().all(...)` at such an `Iterate` instead of unconditionally
-deferring, a read-only dry run of `set_path_through_iterate`'s own per-element recursion:
+deferring, a read-only dry run of the `=` walker's own per-element recursion (then
+`set_path_through_iterate`, now `set_path_steps`' `Iterate` arm):
 
 ```bash
 $ printf 'a: [1, 2]\n' | yq            -o=json '.a[].b = error("boom")'   # {"a":[1,2]}, no-op

--- a/scripts/jq-assign-path-oracle-sweep.sh
+++ b/scripts/jq-assign-path-oracle-sweep.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# Oracle sweep for the assignment/delete *path walkers* (`set_path`,
+# `update_path`, `delete_at_path` in src/jq/eval.rs).
+#
+# Cross-products documents x path shapes x write operators x mode (jq/yq),
+# recording stdout/stderr/exit for the built succinctly binary alongside the
+# pinned oracle (jq 1.7.1, yq v4.53.3) for the identical case. Written for
+# #1429 (converging `set_path`'s flatten-then-split pre-scan onto a
+# peel-and-recurse walker), which is a pure restructuring: the primary gate
+# is not "matches the oracle" but "the *succinctly* columns are byte-identical
+# before and after", with the oracle columns present so a divergence can be
+# classified as pre-existing rather than re-triaged by hand.
+#
+# Two uses:
+#
+#   # A/B a restructuring (the primary gate):
+#   ./scripts/jq-assign-path-oracle-sweep.sh .ai/scratch/succinctly-pre > before.tsv
+#   ./scripts/jq-assign-path-oracle-sweep.sh target/release/succinctly > after.tsv
+#   diff before.tsv after.tsv && echo "byte-identical"
+#
+#   # Triage succinctly-vs-oracle divergence in one recording:
+#   ./scripts/jq-assign-path-oracle-sweep.sh --summary target/release/succinctly
+#
+# The record is a stable, sorted-by-construction TSV so `diff` is meaningful:
+#   mode <TAB> op <TAB> path <TAB> doc <TAB> succ_exit <TAB> succ_out <TAB> succ_err
+#        <TAB> oracle_exit <TAB> oracle_out <TAB> oracle_err
+# Newlines inside a field are escaped to \n so one case is always one line.
+#
+# `--no-oracle` skips the oracle columns (roughly halves the runtime) for a
+# fast A/B when divergence triage is not needed. The oracle columns are
+# identical between two recordings anyway, so a diff is unaffected either way
+# — but only recordings made with the *same* flag are comparable.
+#
+# Usage:
+#   cargo build --release --features cli,simd,regex,serde
+#   ./scripts/jq-assign-path-oracle-sweep.sh [--summary] [--no-oracle] [binary]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIN="$(cat "$REPO_ROOT/tests/data/jq-golden/JQ_VERSION")"
+
+SUMMARY=0
+USE_ORACLE=1
+SUCC=""
+for arg in "$@"; do
+  case "$arg" in
+    --summary) SUMMARY=1 ;;
+    --no-oracle) USE_ORACLE=0 ;;
+    *) SUCC="$arg" ;;
+  esac
+done
+SUCC="${SUCC:-$REPO_ROOT/target/release/succinctly}"
+
+if [[ ! -x "$SUCC" ]]; then
+  echo "error: succinctly binary not found at $SUCC — run: cargo build --release --features cli,simd,regex,serde" >&2
+  exit 1
+fi
+
+# Prefer the pinned oracle binary directly (macOS ships jq-1.7.1 at
+# /usr/bin/jq; a PATH jq, e.g. Homebrew's, is often newer) — same reasoning as
+# scripts/jq-fanout-oracle-sweep.sh and tests/jq_cli_tests.rs's own comments.
+# For yq the pin is the opposite way round: Homebrew's *is* the pin.
+JQ=""
+YQ=""
+if ((USE_ORACLE)); then
+  if [[ -x /usr/bin/jq ]] && /usr/bin/jq --version | grep -q "^$PIN"; then
+    JQ=/usr/bin/jq
+  elif command -v jq >/dev/null 2>&1 && jq --version | grep -q "^$PIN"; then
+    JQ="$(command -v jq)"
+  else
+    echo "error: no jq matching pin $PIN found at /usr/bin/jq or on PATH" >&2
+    exit 1
+  fi
+  if command -v yq >/dev/null 2>&1 && yq --version | grep -q 'v4\.'; then
+    YQ="$(command -v yq)"
+  else
+    echo "error: no yq v4 found on PATH" >&2
+    exit 1
+  fi
+  echo "oracles: $JQ ($("$JQ" --version)), $YQ ($("$YQ" --version 2>&1 | tail -1))" >&2
+fi
+echo "succinctly: $SUCC" >&2
+
+# --- matrix -----------------------------------------------------------------
+
+# Documents. JSON throughout: every one of these is also valid YAML flow, so
+# the same string feeds both modes without a second corpus to keep in sync.
+DOCS=(
+  'null'
+  '5'
+  '"str"'
+  'true'
+  '{}'
+  '[]'
+  '{"a":1}'
+  '{"a":null}'
+  '{"a":"notobj"}'
+  '{"a":{"c":5}}'
+  '{"a":{"b":[1,2,3]}}'
+  '{"a":[1,2,3,4]}'
+  '{"a":[{"b":1},{"b":2}]}'
+  '[1,2,3]'
+  '[[1,2],[3,4]]'
+  '{"items":[{"env":[{"v":1}]},{"env":[{"v":2}]}]}'
+)
+
+# Path shapes. Grouped by what they exercise; the groups overlap on purpose —
+# an `Iterate` before a `Slice` and a `Slice` before an `Iterate` are the two
+# halves of the ordering invariant #1429 is about, and both have to be here.
+PATHS=(
+  # plain field/index chains, with `?` at each position
+  '.a' '.a.b' '.a.b.c' '.a?' '.a?.b' '.a?.b.c' '.a.b?' '.a.b?.c' '.a.b.c?'
+  '.[0]' '.[-1]' '.[5]' '.[-9]' '.a[0]' '.a[-1]' '.a[5]' '.a[-9]' '.a[0].b'
+  # terminal and mid-chain iterate
+  '.[]' '.[]?' '.a[]' '.a[]?' '.a[].b' '.a[]?.b' '.a[].b?' '.a[][0]' '.[][]'
+  '.a[][]' '.a[].b[]' '.items[].env[]' '.items[].env[].v' '.items[]?.env[]?.v'
+  # terminal and mid-chain slice
+  '.[0:1]' '.[0:2]' '.a[0:2]' '.a[0:2]?' '.a[0:2].b' '.a[0:2].b?' '.a[0:2][0]'
+  '.a[0:1][0:2]' '.a[0:1][0:2]?' '.a[0:1]?[0]' '.[0:1][]'
+  # the ordering invariant: slice-before-iterate vs iterate-before-slice
+  '.a[0:2][]' '.a[0:2][]?' '.a[][0:2]' '.a[]?[0:2]' '.a[0:1][]?.b' '.a[][0:1][]'
+  # nested Paren/Pipe groups (the double-flatten case), incl. group-scoped `?`
+  '(.a|.c)' '(.a|.c)[0]' '(.a|.c).d' '(.a|.c)?' '((.a|.c)? | .y)'
+  '(.a[])[0]' '(.a[0:1])[0]' '(.a[0:1]?)[0]' '((.a[0:1])? | .[0])'
+  '(.a|.b|.c)' '(.a|.b)[0:1]' '((.a|.b)? | .[])'
+  # missing-parent / stranded-autovivify shapes (#1428)
+  '.a[0:1][]?' '.a[0:1].c[]?' '.a[0:1][0]?.c[]?' '.a?.b[].c' '.a.b[0:1][]?'
+)
+
+# Write operators. `__P__` is the path. `|=`/`+=`/`del` route through
+# `update_path`/`delete_at_path`, which #1429 does not restructure — they are
+# controls: a diff in those columns means collateral damage.
+OPS=(
+  '__P__ = 9'
+  '__P__ = [9]'
+  '__P__ = null'
+  '__P__ = {"z":1}'
+  '__P__ |= 9'
+  '__P__ |= empty'
+  '__P__ += 1'
+  'del(__P__)'
+)
+
+# --- runner -----------------------------------------------------------------
+
+# Normalises the document's temp-file path out of captured stderr: jq and yq
+# both name the input file in their error messages, and a per-run `mktemp`
+# name would otherwise make every error row differ between two recordings —
+# which is precisely what this record exists to compare.
+esc() {
+  printf '%s' "$1" \
+    | tr '\t' ' ' \
+    | sed "s|$DOC_FILE|DOC|g" \
+    | awk 'BEGIN{ORS=""} NR>1{print "\\n"} {print}'
+}
+
+DOC_FILE="$(mktemp -t assign-sweep-doc)"
+S_ERR="$(mktemp -t assign-sweep-serr)"
+O_ERR="$(mktemp -t assign-sweep-oerr)"
+trap 'rm -f "$DOC_FILE" "$S_ERR" "$O_ERR"' EXIT
+
+total=0
+diverged=0
+declare -a div_keys=()
+
+run_case() {
+  local mode="$1" op="$2" path="$3" doc="$4" filter="$5"
+  total=$((total + 1))
+  printf '%s' "$doc" > "$DOC_FILE"
+
+  local s_out s_code o_out o_code s_err o_err
+  if [[ "$mode" == jq ]]; then
+    s_out="$("$SUCC" jq -c "$filter" "$DOC_FILE" 2>"$S_ERR")" && s_code=0 || s_code=$?
+  else
+    s_out="$("$SUCC" yq -o=json -I=0 "$filter" "$DOC_FILE" 2>"$S_ERR")" && s_code=0 || s_code=$?
+  fi
+  s_err="$(cat "$S_ERR")"
+
+  o_out=""; o_err=""; o_code="-"
+  if ((USE_ORACLE)); then
+    if [[ "$mode" == jq ]]; then
+      o_out="$("$JQ" -c "$filter" "$DOC_FILE" 2>"$O_ERR")" && o_code=0 || o_code=$?
+    else
+      o_out="$("$YQ" -o=json -I=0 "$filter" "$DOC_FILE" 2>"$O_ERR")" && o_code=0 || o_code=$?
+    fi
+    o_err="$(cat "$O_ERR")"
+    if [[ "$s_out" != "$o_out" || "$s_code" != "$o_code" ]]; then
+      diverged=$((diverged + 1))
+      div_keys+=("$mode/$op")
+    fi
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$mode" "$op" "$path" "$(esc "$doc")" \
+    "$s_code" "$(esc "$s_out")" "$(esc "$s_err")" \
+    "$o_code" "$(esc "$o_out")" "$(esc "$o_err")"
+}
+
+for mode in jq yq; do
+  for op in "${OPS[@]}"; do
+    for path in "${PATHS[@]}"; do
+      filter="${op//__P__/$path}"
+      for doc in "${DOCS[@]}"; do
+        run_case "$mode" "$op" "$path" "$doc" "$filter"
+      done
+    done
+  done
+done
+
+# --- generated paths --------------------------------------------------------
+#
+# The curated matrix above only ever covers shapes its author already thought
+# of, which is exactly how a restructuring slips through a hand-picked oracle
+# check. These compose atoms mechanically instead, over a fixed seed so two
+# recordings are comparable and a failure is reproducible. A generated filter
+# that does not parse is still a useful A/B row — both recordings capture the
+# same parse error, and a *change* in it is the signal.
+#
+# Deterministic LCG rather than `$RANDOM`/`awk srand()`: those vary by shell
+# and libc, which would make `before.tsv` and `after.tsv` incomparable across
+# a machine or shell change.
+GEN_SEED=20260101
+_rand_state=$GEN_SEED
+next_rand() {
+  _rand_state=$(( (_rand_state * 1103515245 + 12345) % 2147483648 ))
+  echo $(( (_rand_state / 65536) % $1 ))
+}
+
+GEN_ATOMS=('.a' '.b' '.[0]' '.[-1]' '.[]' '.[0:2]' '.[1:]')
+GEN_DOCS=(
+  'null' '{"a":1}' '{"a":[1,2,3]}' '{"a":[{"b":1},{"b":2}]}' '[1,2,3]' '5'
+)
+GEN_OPS=('__P__ = 9' '__P__ |= 9' 'del(__P__)')
+GEN_PATHS=()
+while ((${#GEN_PATHS[@]} < 100)); do
+  depth=$(( $(next_rand 3) + 2 ))
+  parts=()
+  for ((k = 0; k < depth; k++)); do
+    atom="${GEN_ATOMS[$(next_rand ${#GEN_ATOMS[@]})]}"
+    # ~1 in 3 components carries its own `?`.
+    (( $(next_rand 3) == 0 )) && atom="${atom}?"
+    parts+=("$atom")
+  done
+  # ~1 in 3 paths puts its first two components in a parenthesised
+  # pipe group (`(.a|.b)[0]`), the nested-group shape that used to cost
+  # two full flatten passes before finding nothing.
+  if (( $(next_rand 3) == 0 )); then
+    path="(${parts[0]}|${parts[1]})"
+    for ((k = 2; k < depth; k++)); do path+="${parts[k]}"; done
+  else
+    path=""
+    for part in "${parts[@]}"; do path+="$part"; done
+  fi
+  GEN_PATHS+=("$path")
+done
+
+for mode in jq yq; do
+  for op in "${GEN_OPS[@]}"; do
+    for path in "${GEN_PATHS[@]}"; do
+      filter="${op//__P__/$path}"
+      for doc in "${GEN_DOCS[@]}"; do
+        run_case "$mode" "gen:$op" "$path" "$doc" "$filter"
+      done
+    done
+  done
+done
+
+if ((SUMMARY)); then
+  {
+    echo "== $total cases, $diverged succinctly-vs-oracle divergences =="
+    if ((diverged > 0)); then
+      printf '%s\n' "${div_keys[@]}" | sort | uniq -c | sort -rn | sed 's/^/   /'
+    fi
+  } >&2
+else
+  echo "== $total cases recorded ($diverged vs-oracle divergences) ==" >&2
+fi

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17898,6 +17898,39 @@ fn reaches_iterate(expr: &Expr) -> bool {
     }
 }
 
+/// Apply `edit` to every element of an array / every value of an object, or
+/// return `None` when `root` is neither (#1429).
+///
+/// The one definition behind the `.[]` fan-out the write walkers all need.
+/// There were four hand-maintained copies of this loop pair before: `=`'s
+/// terminal and mid-chain arms, and `|=`'s. Nothing made them agree, and
+/// they had already drifted once -- `update_path`'s mid-chain arm was
+/// missing #1181's `null`-to-`[]` autovivify that its own terminal twin
+/// had, closed separately as #1919.
+///
+/// Deliberately does *not* fold in the surrounding decisions each caller
+/// makes on either side of the loop -- the yq-only autovivify before it, and
+/// the `optional`/scalar-no-op/`cannot_iterate_with` disposition after it --
+/// which is why `None` is returned rather than an error: those differ per
+/// caller (operator-gated in one, `S::TAG`-gated in another) and folding
+/// them in would replace four visible copies with one hidden set of flags.
+///
+/// `update_path`'s *terminal* `Expr::Iterate` arm is the one fan-out left
+/// out. Its jq-mode #1916 branch rebuilds the container to drop the slots an
+/// empty update filter left behind, rather than mutating each in place, so
+/// it has to split on `Array`/`Object` before it splits on mode -- there is
+/// no in-place loop there to share.
+fn for_each_container_slot<E>(
+    root: &mut OwnedValue,
+    mut edit: impl FnMut(&mut OwnedValue) -> Result<(), E>,
+) -> Option<Result<(), E>> {
+    match root {
+        OwnedValue::Array(arr) => Some(arr.iter_mut().try_for_each(&mut edit)),
+        OwnedValue::Object(map) => Some(map.values_mut().try_for_each(&mut edit)),
+        _ => None,
+    }
+}
+
 /// Set a value at a path in an owned value.
 fn set_path<S: EvalSemantics>(
     root: &mut OwnedValue,
@@ -18012,21 +18045,14 @@ fn set_path<S: EvalSemantics>(
             if scalar_noop {
                 autovivify_array(root);
             }
-            match root {
-                OwnedValue::Array(arr) => {
-                    for elem in arr.iter_mut() {
-                        *elem = new_value.clone();
-                    }
-                    Ok(())
-                }
-                OwnedValue::Object(map) => {
-                    for (_, elem) in map.iter_mut() {
-                        *elem = new_value.clone();
-                    }
-                    Ok(())
-                }
-                _ if scalar_noop && is_yq_field_index_noop_scalar(root) => Ok(()),
-                _ => Err(EvalError::cannot_iterate_with(S::TAG, root)),
+            let fanned = for_each_container_slot(root, |slot| {
+                *slot = new_value.clone();
+                Ok(())
+            });
+            match fanned {
+                Some(result) => result,
+                None if scalar_noop && is_yq_field_index_noop_scalar(root) => Ok(()),
+                None => Err(EvalError::cannot_iterate_with(S::TAG, root)),
             }
         }
         // `.[a:b] = v` splices `v`'s elements over the range, so `v` has to be
@@ -18279,33 +18305,13 @@ fn set_path_steps<S: EvalSemantics>(
             if scalar_noop {
                 autovivify_array(root);
             }
-            match root {
-                OwnedValue::Array(arr) => {
-                    for elem in arr.iter_mut() {
-                        set_path_steps::<S>(
-                            elem,
-                            rest,
-                            new_value.clone(),
-                            scalar_noop,
-                            container_noop,
-                        )?;
-                    }
-                    Ok(())
-                }
-                OwnedValue::Object(map) => {
-                    for (_, elem) in map.iter_mut() {
-                        set_path_steps::<S>(
-                            elem,
-                            rest,
-                            new_value.clone(),
-                            scalar_noop,
-                            container_noop,
-                        )?;
-                    }
-                    Ok(())
-                }
-                _ if optional || noop_here => Ok(()),
-                _ => Err(EvalError::cannot_iterate_with(S::TAG, root)),
+            let fanned = for_each_container_slot(root, |slot| {
+                set_path_steps::<S>(slot, rest, new_value.clone(), scalar_noop, container_noop)
+            });
+            match fanned {
+                Some(result) => result,
+                None if optional || noop_here => Ok(()),
+                None => Err(EvalError::cannot_iterate_with(S::TAG, root)),
             }
         }
         // The chain continues *inside* the slice, so the rest of the walk
@@ -19225,33 +19231,19 @@ fn update_path<S: EvalSemantics>(
                         if S::TAG == EvalTag::Yq {
                             autovivify_array(root);
                         }
-                        match root {
-                            OwnedValue::Array(arr) => {
-                                for elem in arr.iter_mut() {
-                                    update_path::<S>(
-                                        elem,
-                                        &rest,
-                                        filter_expr,
-                                        optional,
-                                        scalar_noop,
-                                    )?;
-                                }
-                                Ok(true)
-                            }
-                            OwnedValue::Object(map) => {
-                                for value in map.values_mut() {
-                                    update_path::<S>(
-                                        value,
-                                        &rest,
-                                        filter_expr,
-                                        optional,
-                                        scalar_noop,
-                                    )?;
-                                }
-                                Ok(true)
-                            }
-                            _ if here || noop_scalar => Ok(false),
-                            _ => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
+                        // `Ok(true)` however many slots were actually
+                        // touched, including none -- see the `Field` arm's
+                        // "neither clause subsumes the other" note above for
+                        // why the stranded check needs `reaches_iterate`
+                        // rather than this answer.
+                        let fanned = for_each_container_slot(root, |slot| {
+                            update_path::<S>(slot, &rest, filter_expr, optional, scalar_noop)
+                                .map(|_| ())
+                        });
+                        match fanned {
+                            Some(result) => result.map(|()| true),
+                            None if here || noop_scalar => Ok(false),
+                            None => Err(EvalError::cannot_iterate_with(S::TAG, root).into()),
                         }
                     }
                     // `resolve_node`'s `?` arm emits `Optional(Pipe([…]))`
@@ -60888,6 +60880,131 @@ mod tests {
                 "((.a.b[0:1])? | .[0]) = 9",
                 Ok(r#"{"a":{"b":[9,2,3]}}"#),
             ),
+        ]);
+    }
+
+    /// #1429: whichever multi-slot construct comes *first* claims the walk.
+    ///
+    /// Before `set_path_steps`, this was an invariant maintained by hand:
+    /// `split_at_iterate` bailed whenever a `Slice` appeared earlier in the
+    /// chain, so that `split_at_slice` -- called *after* it -- got first
+    /// crack, while `split_at_slice` carried no reciprocal bail of its own.
+    /// Correctness therefore rested on the call-site ordering plus a doc
+    /// comment; nothing failed if either drifted. Peeling one component at a
+    /// time makes it structural instead: the first construct in the chain is
+    /// simply the first arm the walk reaches. Both orderings pinned here, and
+    /// both confirmed against real jq 1.7.1.
+    #[test]
+    fn test_assign_leftmost_multi_slot_construct_claims_the_walk_1429() {
+        assert_outcomes(&[
+            // Slice first: the iterate runs *inside* each sliced element.
+            (
+                br#"{"a":[[1,2],[3,4],[5,6]]}"#,
+                ".a[0:2][] = 9",
+                Ok(r#"{"a":[9,9,[5,6]]}"#),
+            ),
+            // Iterate first: the slice runs independently inside each
+            // fanned-out element. Same two constructs, opposite order,
+            // genuinely different answer -- which is why the ordering had to
+            // be right rather than merely consistent.
+            (
+                br#"{"a":[[1,2,3],[4,5,6]]}"#,
+                ".a[][0:2] = [9]",
+                Ok(r#"{"a":[[9,3],[9,6]]}"#),
+            ),
+            // Three constructs deep, alternating, so no two-way precedence
+            // rule could cover it.
+            (
+                br#"{"a":[[[1,2],[3,4]],[[5,6],[7,8]]]}"#,
+                ".a[][0:1][] = 9",
+                Ok(r#"{"a":[[9,[3,4]],[9,[7,8]]]}"#),
+            ),
+        ]);
+    }
+
+    /// #1429: a nested `Paren`/`Pipe` group with neither an iterate nor a
+    /// slice in it is walked once, not scanned twice.
+    ///
+    /// Behaviourally this is #1287's case and is pinned above; what this adds
+    /// is the shape that used to pay *both* `split_at_iterate`'s and
+    /// `split_at_slice`'s full allocate-and-clone flatten before either
+    /// concluded it had nothing to do. A regression here would most likely
+    /// show as a wrong answer rather than a slow one, since re-introducing a
+    /// pre-scan is what would make the group opaque again.
+    #[test]
+    fn test_assign_through_nested_group_without_iterate_or_slice_1429() {
+        assert_outcomes(&[
+            (
+                br#"{"a":{"c":[1,2,3]}}"#,
+                "(.a|.c)[0] = 9",
+                Ok(r#"{"a":{"c":[9,2,3]}}"#),
+            ),
+            (
+                br#"{"a":{"c":{}}}"#,
+                "(.a|.c).d = 9",
+                Ok(r#"{"a":{"c":{"d":9}}}"#),
+            ),
+            // A group nested inside another group -- the shape that
+            // reaches `push_path_components`' own recursion, not just its
+            // top-level splice. Parenthesised as a whole: a bare
+            // `(.a|.b)|(.c) = 9` binds as a *pipe* of two expressions
+            // (`|` is lower-precedence than `=`) and is `{"c":9}` in jq,
+            // not a path at all.
+            (
+                br#"{"a":{"b":{"c":1}}}"#,
+                "((.a|.b)|.c) = 9",
+                Ok(r#"{"a":{"b":{"c":9}}}"#),
+            ),
+        ]);
+    }
+
+    /// #1429: `=` walks a long chain by recursion now, where it used to loop
+    /// inside `get_path_mut`.
+    ///
+    /// `|=` and `del()` have always recursed per component, so this is not a
+    /// new class of depth limit -- but it is new for `=`, and a chain long
+    /// enough to matter has to actually be exercised rather than assumed.
+    ///
+    /// The depths are measured, not guessed. In a *debug* build (larger
+    /// frames, 2 MiB test-thread stack) `set_path_steps` clears 256
+    /// components comfortably while `update_path` -- unchanged by #1429 --
+    /// already aborts with `fatal runtime error: stack overflow` somewhere
+    /// between 128 and 192, so pinning the two at a shared depth would
+    /// mean pinning `=` at `|=`'s pre-existing ceiling. They are pinned
+    /// separately instead: 256 for the walker this issue rewrote, 128 for
+    /// the `|=` twin, which is where they can still be compared directly.
+    ///
+    /// The release CLI is bounded well before any of this: `=`, `|=` and
+    /// `del()` were each run at 256 / 1,000 / 5,000 / 20,000 / 50,000 and
+    /// 200,000 components against the binaries either side of #1429, and
+    /// every one of the thirty-six results is identical -- a clean
+    /// `nesting depth exceeds limit of 384` error (the pre-existing
+    /// *value*-nesting guard, which the rebuilt document trips long before
+    /// the walk itself runs out of stack), never a crash.
+    #[test]
+    fn test_assign_deep_chain_recurses_without_blowing_the_stack_1429() {
+        fn chain(depth: usize) -> (String, String) {
+            let path: String = (0..depth).map(|i| format!(".k{i}")).collect();
+            let mut expected = String::from("9");
+            for i in (0..depth).rev() {
+                expected = format!("{{\"k{i}\":{expected}}}");
+            }
+            (path, expected)
+        }
+
+        let (path, expected) = chain(256);
+        let set = format!("{path} = 9");
+        assert_outcomes(&[(b"null", set.as_str(), Ok(expected.as_str()))]);
+
+        // Shallower, so `|=`'s own deeper recursion still fits: the point
+        // here is that both operators build the identical document, not how
+        // far each can go.
+        let (path, expected) = chain(128);
+        let set = format!("{path} = 9");
+        let update = format!("{path} |= 9");
+        assert_outcomes(&[
+            (b"null", set.as_str(), Ok(expected.as_str())),
+            (b"null", update.as_str(), Ok(expected.as_str())),
         ]);
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16299,7 +16299,8 @@ impl PathAssignOutcome {
 /// only answers the per-path question.
 ///
 /// `path` is flattened via [`push_path_components`] first -- the same
-/// flattener `split_at_slice` already uses internally -- rather than
+/// flattener `set_path`'s own walk already uses (via
+/// [`flatten_path_components`]) -- rather than
 /// matched directly (bare component vs. `Expr::Pipe`), so a nested
 /// `Pipe`/`Paren`/`Optional` anywhere in the chain (`(.a|.b)[0] = v`,
 /// structurally the same target as `.a.b[0] = v`) is seen through
@@ -16309,8 +16310,9 @@ impl PathAssignOutcome {
 /// the prefix walk, silently disagreeing with itself on two spellings of
 /// the identical target (`.a.b[0] = error(...)` correctly no-op'd while
 /// `(.a|.b)[0] = error(...)` didn't) -- the exact "mirroring a precedent
-/// without its fix" pattern `get_path_mut`'s own #1287/#1294 nested-`Pipe`
-/// splice already had to solve once for the write side. `?` anywhere in
+/// without its fix" pattern #1287/#1294's own nested-`Pipe` splice already
+/// had to solve once for the write side (then inside `get_path_mut`'s walk,
+/// now done once up front by the same flattener named above -- #1429). `?` anywhere in
 /// the chain (whole-path, terminal, or a middle component) is transparent
 /// through the same flattening + [`unwrap_path_component`] the checks
 /// below use -- `?` introduces no evaluation of its own to worry about
@@ -16398,11 +16400,11 @@ fn yq_assign_classify(path: &Expr, root: &OwnedValue) -> PathAssignOutcome {
 /// `Array`/`Object` elements whenever a mid-chain `Expr::Iterate` fans into
 /// a real container, instead of `navigate_read_only`'s own unconditional
 /// `Absent` for that case (#1432) -- a read-only, non-mutating dry run of
-/// `set_path_through_iterate`'s own per-element recursion, restricted to
+/// [`set_path_steps`]'s own per-element `Iterate` recursion, restricted to
 /// the `Field`/`Index`/`IndexNumber`/`Iterate` step vocabulary that's all
 /// `yq_assign_classify`'s own slice/terminal-shape gates ever let through.
 /// `TotalNoop` whenever a fanned-into container is empty --
-/// `set_path_through_iterate` itself does nothing when there are no
+/// [`set_path_steps`]'s own `Iterate` arm does nothing when there are no
 /// elements to iterate -- and `RhsUnusedButChanges` (not `TotalNoop`)
 /// whenever a mid-chain `Iterate` reaches `Null`: real yq's `.a[].b = v` on
 /// `a: null` autovivifies `null` to `[]` as part of the write itself
@@ -16507,7 +16509,7 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
 /// `.all()`-based walks' own short-circuit), and otherwise aggregates
 /// `TotalNoop`/`RhsUnusedButChanges` across all of them -- `TotalNoop` only
 /// if every element was (vacuously true for zero elements, matching
-/// `set_path_through_iterate`'s own no-op-on-empty behavior), the wider
+/// [`set_path_steps`]'s own `Iterate` arm doing nothing when empty), the wider
 /// `RhsUnusedButChanges` as soon as even one element autovivified.
 fn classify_yq_assign_fanout<'a>(
     elements: impl Iterator<Item = &'a OwnedValue>,
@@ -16772,7 +16774,7 @@ fn yq_del_slice_outcome(
 
 /// Read-only navigation used by [`yq_del_slice_outcome`]'s prefix peek: does
 /// every step of `steps` resolve, through `root`, to an existing value?
-/// Unlike `get_path_mut`, never autovivifies (a peek must not create
+/// Unlike [`set_path_steps`], never autovivifies (a peek must not create
 /// structure the caller's own real walker would otherwise leave untouched).
 ///
 /// Used to return a three-way `Resolved`/`HitScalar`/`Absent` outcome
@@ -16790,7 +16792,7 @@ fn yq_del_slice_outcome(
 /// (#1863).
 ///
 /// A second, hand-synchronized walker rather than a shared traversal
-/// `get_path_mut` itself could call — code review flagged this against the
+/// [`set_path_steps`] itself could call — code review flagged this against the
 /// same "duplicated predicates diverge silently" lesson `is_owned_container`
 /// was factored out to avoid (#106). Kept separate anyway: the two have
 /// different write permissions (this one is read-only by design, the other
@@ -17896,38 +17898,6 @@ fn reaches_iterate(expr: &Expr) -> bool {
     }
 }
 
-/// #1428: does reaching `tail` from a *freshly created* parent actually write
-/// anything?
-///
-/// Walking to a write target autovivifies every missing step on the way, but
-/// some tails then write nothing at all -- an `Iterate` over the `Null` that
-/// autovivification just produced has no elements to assign to. jq treats path
-/// collection as read-only until a write is confirmed, so it leaves the
-/// document alone; succinctly used to leave the fabricated chain behind
-/// (`null | .a[]? = 9` gave `{"a":null}` instead of `null`).
-///
-/// Running the real tail against a detached `Null` answers the question
-/// without touching the document, and without a second copy of the walking
-/// rules that could drift from the one that does the writing:
-///
-/// * it raises -> the error propagates and the document stays pristine
-///   (matching jq, which emits no document for `null | .a[] = 9` either);
-/// * it leaves the probe `Null` -> nothing would be written, so the caller
-///   must not create anything;
-/// * it leaves a value behind -> something genuinely wants that parent. yq's
-///   own `null`-to-`[]` autovivify (#1181: `null | .a[] = 99` is `{"a": []}`
-///   in real yq) lands here, so the caller goes on to build the chain.
-///
-/// Only called when the parent is known to be missing, so the common case
-/// pays nothing.
-fn tail_writes_from_fresh_parent(
-    run: impl FnOnce(&mut OwnedValue) -> Result<(), EvalError>,
-) -> Result<bool, EvalError> {
-    let mut probe = OwnedValue::Null;
-    run(&mut probe)?;
-    Ok(!matches!(probe, OwnedValue::Null))
-}
-
 /// Set a value at a path in an owned value.
 fn set_path<S: EvalSemantics>(
     root: &mut OwnedValue,
@@ -17970,194 +17940,42 @@ fn set_path<S: EvalSemantics>(
             }
         }
         Expr::Pipe(exprs) if !exprs.is_empty() => {
-            // For chained paths like .a.b.c, navigate to parent and set at last element
-            if exprs.len() == 1 {
-                set_path::<S>(root, &exprs[0], new_value, scalar_noop, container_noop)
-            } else if let Some(split) = split_at_iterate(exprs) {
-                // #1428: walking to `split.before` autovivifies every missing
-                // step along the way, but an `Iterate` over the `Null` that
-                // creates yields *no* elements, so the tail writes nothing and
-                // the fabricated chain is stranded -- `null | .a[]? = 9` gave
-                // `{"a":null}` where jq leaves `null` untouched. jq treats path
-                // collection as read-only until a write is confirmed.
-                //
-                // Ask first whether `before` already resolves. If it does, no
-                // creation can happen and this is the pre-existing path,
-                // unchanged. If it does not, run the *same* tail against a
-                // detached `Null` to learn what reaching it would actually do,
-                // without touching `root`:
-                //
-                // * it raises (`.a[] = 9`, no `?`) -> propagate, `root` still
-                //   pristine, matching jq, which also emits no document;
-                // * it writes nothing -> return without creating anything;
-                // * it leaves a value behind -> yq's own `null`-to-`[]`
-                //   autovivify (#1181, `null | .a[] = 99` is `{"a": []}` in
-                //   real yq) genuinely wants the chain, so fall through and
-                //   build it for real.
-                //
-                // Probing costs one extra walk only when `before` is missing,
-                // and `new_value` is an already-computed value, so evaluating
-                // the tail twice cannot double any side effect.
-                let mut would_create = false;
-                if get_path_mut(root, &split.before, scalar_noop, false, &mut would_create)?
-                    .is_none()
-                    // Only when the parent is genuinely *missing*. A `None`
-                    // because an earlier component was `?`-suppressed
-                    // (`5 | .a?.b[].c = 9`) means the write is already
-                    // cancelled, and probing the tail from a `Null` would
-                    // manufacture a "Cannot iterate over null" that jq never
-                    // raises -- the creating walk below returns `Ok(())` for
-                    // that case on its own, exactly as it did before #1428.
-                    && would_create
-                    && !tail_writes_from_fresh_parent(|probe| {
-                        set_path_through_iterate::<S>(
-                            probe,
-                            split.optional,
-                            &split.tail,
-                            new_value.clone(),
-                            scalar_noop,
-                            container_noop,
-                        )
-                    })?
-                {
-                    return Ok(());
-                }
-                match get_path_mut(root, &split.before, scalar_noop, true, &mut false)? {
-                    None => Ok(()),
-                    Some(target) => set_path_through_iterate::<S>(
-                        target,
-                        split.optional,
-                        &split.tail,
-                        new_value,
-                        scalar_noop,
-                        container_noop,
-                    ),
-                }
-            } else if let Some(split) = split_at_slice(exprs) {
-                // #1428, the slice twin of the `split_at_iterate` guard above.
-                // A slice write on a missing parent usually *does* write
-                // (`null | .a[0:1] = [9]` is `{"a":[9]}`), which is why this
-                // arm was originally left alone -- but a slice can also be a
-                // read-through step whose own tail declines to write
-                // (`null | .a[0:1][]? = 9`), and then the `.a` built to reach
-                // it is stranded exactly as before.
-                //
-                // No `reaches_iterate` test is needed here: `through_slice`'s
-                // `Null` arm returns `Ok` with the probe still `Null` only
-                // when nothing was written at all, and a terminal slice
-                // assignment of `null` raises rather than landing there. So
-                // "the probe is still `Null`" is an exact reading on this
-                // path.
-                //
-                // jq mode only (`container_noop` is `S::TAG == EvalTag::Yq`
-                // at every call site, the same reading `through_slice`'s own
-                // `Null` arm relies on). Real yq keeps the chain here even
-                // though its container no-op discards the write itself:
-                // `null | .a[0:1] = 9` is `a: null` in yq v4.53.3, so the
-                // probe -- which sees only that nothing was written -- would
-                // wrongly skip creating `.a`.
-                let mut would_create = false;
-                if !container_noop
-                    && get_path_mut(root, &split.before, scalar_noop, false, &mut would_create)?
-                        .is_none()
-                    && would_create
-                    && !tail_writes_from_fresh_parent(|probe| {
-                        through_slice(
-                            probe,
-                            split.start,
-                            split.end,
-                            SliceEditFlags {
-                                optional: split.optional,
-                                scalar_noop,
-                                container_noop,
-                                terminal_write: matches!(split.tail, Expr::Identity),
-                            },
-                            // `set_path` (`=`) has no `|= empty` concept --
-                            // its RHS is always a real, already-materialized
-                            // value (#1877/#1894, see `always_wrote`).
-                            |sub| {
-                                always_wrote(set_path::<S>(
-                                    sub,
-                                    &split.tail,
-                                    new_value.clone(),
-                                    scalar_noop,
-                                    container_noop,
-                                ))
-                            },
-                        )
-                        .map(|_| ())
-                    })?
-                {
-                    return Ok(());
-                }
-                match get_path_mut(root, &split.before, scalar_noop, true, &mut false)? {
-                    None => Ok(()),
-                    Some(parent) => through_slice(
-                        parent,
-                        split.start,
-                        split.end,
-                        SliceEditFlags {
-                            optional: split.optional,
-                            scalar_noop,
-                            container_noop,
-                            // `split_at_slice` gives an `Identity` tail
-                            // when the slice is genuinely the *last* path
-                            // component (`.a[0:1] = v`, nothing after
-                            // it) — that's a terminal write in disguise,
-                            // not a mid-chain read-through, however this
-                            // arm reached it (#1321).
-                            terminal_write: matches!(split.tail, Expr::Identity),
-                        },
-                        // See the probe closure above for why this always
-                        // reports `true`.
-                        |sub| {
-                            always_wrote(set_path::<S>(
-                                sub,
-                                &split.tail,
-                                new_value,
-                                scalar_noop,
-                                container_noop,
-                            ))
-                        },
-                    )
-                    .map(|_| ()),
-                }
+            // #1429: one flat, peel-one-component-and-recurse walk, the shape
+            // `update_path` and `delete_at_path` already use -- not a
+            // pre-scan for special constructs ahead of a separate
+            // one-mutable-slot navigation pass. `get_path_mut` could only
+            // ever hand back a single slot, so every construct naming *many*
+            // slots (`.[]`, `[a:b]`) needed its own flatten-then-scan-then-
+            // bail helper bolted in front of it (`split_at_iterate`,
+            // `split_at_slice`), and "the leftmost such construct wins" was
+            // an invariant maintained by call-site ordering plus reciprocal
+            // bail checks between those helpers rather than by the code's
+            // shape. Walking one component at a time makes leftmost-wins
+            // structural: whichever construct comes first is simply the
+            // first arm [`set_path_steps`] reaches.
+            //
+            // Flattened at most once, here, rather than once per helper and
+            // again at every recursion level: `.items[].containers[].env[] =
+            // v` used to re-flatten an already-flat tail on each fan-out
+            // step, and `(.a|.c)[0] = 9` -- a nested group with neither an
+            // iterate nor a slice in it -- used to pay *both* helpers' full
+            // flatten before either concluded it had nothing to do.
+            if exprs.iter().all(is_atomic_path_component) {
+                // The overwhelmingly common shape (`.a.b.c[0] = 9`) is
+                // already flat, so walk it borrowed. Strictly fewer
+                // allocations than before, not merely parity:
+                // `get_path_mut` used to clone the component list
+                // (`path_parts.to_vec()`) plus a parallel `vec![false; len]`
+                // for this same case.
+                set_path_steps::<S>(root, exprs, new_value, scalar_noop, container_noop)
             } else {
-                // Navigate to parent
-                let parent_path = &exprs[..exprs.len() - 1];
-                let last_path = &exprs[exprs.len() - 1];
-
-                // #1428, same guard as the `split_at_iterate` arm above --
-                // needed separately because a *terminal* `Iterate`
-                // (`.a[]? = 9`) is explicitly not `split_at_iterate`'s case
-                // and lands here instead. A terminal `Field`/`Index` probe
-                // writes into the detached `Null` and so falls straight
-                // through, leaving `null | .a = 9` and friends untouched.
-                let mut would_create = false;
-                if reaches_iterate(last_path)
-                    && get_path_mut(root, parent_path, scalar_noop, false, &mut would_create)?
-                        .is_none()
-                    // See the `split_at_iterate` arm above.
-                    && would_create
-                    && !tail_writes_from_fresh_parent(|probe| {
-                        set_path::<S>(
-                            probe,
-                            last_path,
-                            new_value.clone(),
-                            scalar_noop,
-                            container_noop,
-                        )
-                    })?
-                {
-                    return Ok(());
-                }
-
-                match get_path_mut(root, parent_path, scalar_noop, true, &mut false)? {
-                    None => Ok(()),
-                    Some(parent) => {
-                        set_path::<S>(parent, last_path, new_value, scalar_noop, container_noop)
-                    }
-                }
+                set_path_steps::<S>(
+                    root,
+                    &flatten_path_components(exprs),
+                    new_value,
+                    scalar_noop,
+                    container_noop,
+                )
             }
         }
         Expr::Optional(inner) => {
@@ -18245,6 +18063,289 @@ fn set_path<S: EvalSemantics>(
         _ => Err(EvalError::new(
             "cannot use expression as assignment target".to_string(),
         )),
+    }
+}
+
+/// Is this path component already atomic — something [`set_path_steps`] can
+/// match directly, with no flattening needed?
+///
+/// [`unwrap_path_component`] is what the walker itself uses to look through
+/// `Optional`/`Paren` wrappers, so those are transparent here too: only a
+/// `Pipe` (or a `Pipe` hiding inside one of those wrappers), an `Identity`
+/// that has to be dropped, or an unresolved computed component makes a list
+/// non-atomic and sends it through [`flatten_path_components`] first.
+fn is_atomic_path_component(expr: &Expr) -> bool {
+    matches!(
+        unwrap_path_component(expr).0,
+        Expr::Field(_)
+            | Expr::Index(_)
+            | Expr::IndexNumber { .. }
+            | Expr::Iterate
+            | Expr::Slice { .. }
+            | Expr::SliceNumber { .. }
+    )
+}
+
+/// Walk a *flat* list of atomic path components, peeling one per call, and
+/// write `new_value` at the end (#1429).
+///
+/// The single walker behind `=`'s chained-path handling, replacing the
+/// `split_at_iterate`/`split_at_slice`/`get_path_mut` trio. `steps` is flat
+/// by construction — either already atomic (see [`is_atomic_path_component`])
+/// or run through [`flatten_path_components`] by the caller — so there is no
+/// `Pipe` arm here and no per-level re-flatten: `#1287`/`#1294`'s nested-pipe
+/// splicing and per-group `?` scoping are done once by
+/// [`push_path_components`], which recursively flattens an `Optional`'s own
+/// contents and re-wraps each resulting component individually (#1311),
+/// exactly as [`splice_optional_group`] does for `update_path`.
+///
+/// Mirrors `update_path`'s `Expr::Pipe` arm arm-for-arm, including its
+/// undo-after-write treatment of #1428's stranded autovivification: walking
+/// toward a write target creates every missing step on the way, but a tail
+/// that turns out to write nothing (an `Iterate` over the `Null` that
+/// autovivification just produced has no elements) must leave the document
+/// alone. `set_path` used to answer that by *probing* a detached `Null`
+/// before committing, because `get_path_mut`'s loop could not be walked back
+/// up; here the frame that created the slot is still live when the recursion
+/// returns, so it simply undoes it. An error on the way out needs no undo:
+/// `fork_rhs_over_paths` discards the whole partially-written document for
+/// that RHS output, so a half-built chain is never observable.
+fn set_path_steps<S: EvalSemantics>(
+    root: &mut OwnedValue,
+    steps: &[Expr],
+    new_value: OwnedValue,
+    scalar_noop: bool,
+    container_noop: bool,
+) -> Result<(), EvalError> {
+    let (first, rest) = match steps {
+        // Everything was `Identity` (`(. | .) = 9`), so this *is* the write.
+        [] => {
+            *root = new_value;
+            return Ok(());
+        }
+        [last] => {
+            // A `?`-marked *terminal slice* reached through a chain
+            // (`.a[0:1]? = 9`) is the one component that must not go through
+            // `set_path`'s `Expr::Optional` catch-and-swallow arm: the split
+            // this replaced threaded the `?` into `through_slice`'s own
+            // bounds gate instead (#1303), which suppresses an out-of-range
+            // slice while still leaving `slice_assign_non_array`/
+            // `cannot_update_string_slices` to raise. Catch-and-swallow
+            // would abandon the whole write instead. Every other terminal
+            // component -- including a `?`-marked `Field`/`Index`/`Iterate`,
+            // which the split-based walker also routed through
+            // catch-and-swallow -- delegates unchanged.
+            let (component, optional) = unwrap_path_component(last);
+            if let Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } = component {
+                return through_slice(
+                    root,
+                    *start,
+                    *end,
+                    SliceEditFlags {
+                        optional,
+                        scalar_noop,
+                        container_noop,
+                        // The slice genuinely is the last path component, so
+                        // this call's own `edit` is the write (#1321).
+                        terminal_write: true,
+                    },
+                    // Always `true` -- `=`'s RHS is an already-materialized
+                    // value, it has no `|= empty` concept (#1877/#1894).
+                    |sub| {
+                        *sub = new_value;
+                        Ok(true)
+                    },
+                )
+                .map(|_| ());
+            }
+            return set_path::<S>(root, last, new_value, scalar_noop, container_noop);
+        }
+        [first, rest @ ..] => (first, rest),
+    };
+
+    let (component, optional) = unwrap_path_component(first);
+    // #1232, as `get_path_mut` computed it: a scalar hit *before* the last
+    // path component (`.a.b = 99` on a scalar root) no-ops in yq mode rather
+    // than erroring. Computed once per frame rather than at each arm's own
+    // `else if`: `autovivify_object`/`autovivify_array` only ever convert
+    // `Null` into a container, and `is_yq_field_index_noop_scalar` already
+    // excludes `Null`, so the answer is identical before or after they run.
+    let noop_here = scalar_noop && is_yq_field_index_noop_scalar(root);
+    // #1428's undo, jq mode only -- the same gate `update_path` calls
+    // `undo_stranded`. Real yq *wants* the chain a suppressed write leaves
+    // behind (`null | .a[] = 99` is `{"a": []}` there, #1181), and the probe
+    // this replaced was already inert in yq mode for exactly that reason:
+    // yq's own `null`-to-`[]` autovivify made every probe come back
+    // non-`Null`, so it always fell through and built the chain.
+    let undo_stranded = S::TAG != EvalTag::Yq;
+    // Only an `Iterate` can decline to write over the `Null` this frame just
+    // created, so only when one is somewhere in `rest` does "the slot is
+    // still `Null`" mean "nothing was written" -- for every other component
+    // a write whose value happens to be `null` is indistinguishable from no
+    // write at all by looking at the slot (`null | (.a|.) = null` must keep
+    // `{"a": null}`). Checked across the whole remaining chain, not just its
+    // head: a frame two levels above the iterate still has to undo its own
+    // slot, and the inner frame restores *its* parent to `Null` on the way
+    // out, so the outer frame's reading is accurate again by the time it
+    // looks.
+    let rest_reaches_iterate = rest.iter().any(reaches_iterate);
+
+    match component {
+        // `push_path_components` drops these, but the borrowed fast path
+        // does not run it -- an `Identity` is simply nothing to navigate.
+        Expr::Identity => set_path_steps::<S>(root, rest, new_value, scalar_noop, container_noop),
+        Expr::Field(name) => {
+            let root_was_null = matches!(root, OwnedValue::Null);
+            autovivify_object(root);
+            if let OwnedValue::Object(map) = root {
+                let created = !map.contains_key(name);
+                let (result, stranded) = {
+                    let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
+                    let result =
+                        set_path_steps::<S>(current, rest, new_value, scalar_noop, container_noop);
+                    let stranded = created
+                        && undo_stranded
+                        && rest_reaches_iterate
+                        && result.is_ok()
+                        && matches!(*current, OwnedValue::Null);
+                    (result, stranded)
+                };
+                if stranded {
+                    map.shift_remove(name);
+                    if root_was_null && map.is_empty() {
+                        *root = OwnedValue::Null;
+                    }
+                }
+                result
+            } else if optional || noop_here {
+                Ok(())
+            } else {
+                Err(EvalError::cannot_index_with_field(
+                    owned_type_name(root),
+                    name,
+                ))
+            }
+        }
+        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+            let root_was_null = matches!(root, OwnedValue::Null);
+            autovivify_array(root);
+            if let OwnedValue::Array(arr) = root {
+                let original_len = arr.len();
+                let (result, stranded) = {
+                    // A still-negative index after counting back from the
+                    // end is jq's write-time bounds check, which `?` never
+                    // covers -- so `write_index`'s error propagates here
+                    // rather than being folded into the `optional` branch
+                    // below, exactly as `get_path_mut` had it.
+                    let current = write_index(arr, *idx)?;
+                    let result =
+                        set_path_steps::<S>(current, rest, new_value, scalar_noop, container_noop);
+                    let stranded = undo_stranded
+                        && rest_reaches_iterate
+                        && result.is_ok()
+                        && matches!(*current, OwnedValue::Null);
+                    (result, stranded)
+                };
+                // `write_index` pads with `Null`s to reach a positive
+                // out-of-range index, so the undo restores the original
+                // length rather than removing a single slot -- and does
+                // nothing at all when the slot already existed.
+                if stranded && arr.len() > original_len {
+                    arr.truncate(original_len);
+                    if root_was_null && arr.is_empty() {
+                        *root = OwnedValue::Null;
+                    }
+                }
+                result
+            } else if optional || noop_here {
+                Ok(())
+            } else {
+                Err(EvalError::cannot_index_with_type(
+                    owned_type_name(root),
+                    "number",
+                ))
+            }
+        }
+        Expr::Iterate => {
+            // `.[]` names every element/value, not one slot, so the write
+            // fans out and each element re-applies the whole remaining chain
+            // independently (#1298). Deliberately the same rules as
+            // `set_path`'s own terminal `Expr::Iterate` arm -- a mid-chain
+            // `.[]` is not semantically different from a terminal one, just
+            // followed by more path -- including #1181's yq-only
+            // `null`-to-`[]` autovivify, which unlike `Field`/`Index`'s
+            // unconditional autovivify is gated on `scalar_noop` rather than
+            // run up front.
+            if scalar_noop {
+                autovivify_array(root);
+            }
+            match root {
+                OwnedValue::Array(arr) => {
+                    for elem in arr.iter_mut() {
+                        set_path_steps::<S>(
+                            elem,
+                            rest,
+                            new_value.clone(),
+                            scalar_noop,
+                            container_noop,
+                        )?;
+                    }
+                    Ok(())
+                }
+                OwnedValue::Object(map) => {
+                    for (_, elem) in map.iter_mut() {
+                        set_path_steps::<S>(
+                            elem,
+                            rest,
+                            new_value.clone(),
+                            scalar_noop,
+                            container_noop,
+                        )?;
+                    }
+                    Ok(())
+                }
+                _ if optional || noop_here => Ok(()),
+                _ => Err(EvalError::cannot_iterate_with(S::TAG, root)),
+            }
+        }
+        // The chain continues *inside* the slice, so the rest of the walk
+        // runs against the extracted sub-array and is spliced back.
+        // `terminal_write` is always `false` here: `steps` is flat and this
+        // is not its last element, so there is real path left after the
+        // slice for `edit` to navigate (#1321).
+        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => through_slice(
+            root,
+            *start,
+            *end,
+            SliceEditFlags {
+                optional,
+                scalar_noop,
+                container_noop,
+                terminal_write: false,
+            },
+            // See the terminal-slice call above for why this is always `true`.
+            |sub| {
+                always_wrote(set_path_steps::<S>(
+                    sub,
+                    rest,
+                    new_value,
+                    scalar_noop,
+                    container_noop,
+                ))
+            },
+        )
+        .map(|_| ()),
+        // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
+        // into a static component before this runs. Explicit rather than left
+        // to the catch-all so a missed install point fails loudly here instead
+        // of being reported as a user error.
+        Expr::IndexExpr { .. } => Err(EvalError::new(
+            "internal error: unresolved computed index in path component",
+        )),
+        Expr::SliceExpr { .. } => Err(EvalError::new(
+            "internal error: unresolved computed slice in path component",
+        )),
+        _ => Err(EvalError::new("invalid path component")),
     }
 }
 
@@ -18643,412 +18744,21 @@ fn through_slice<E: From<EvalError>>(
     }
 }
 
-/// Where a chained path crosses a slice, as [`split_at_slice`] found it.
-struct SliceSplit {
-    /// The components to navigate before reaching the slice.
-    before: Vec<Expr>,
-    start: Option<i64>,
-    end: Option<i64>,
-    /// Whether the slice itself carried a `?` (`.a[0:1]?[0] = 9`) — threaded
-    /// into `through_slice`'s own `optional` parameter so a genuinely
-    /// non-sliceable target there is suppressed the same way a bare
-    /// `.a[0:1]? = 9` already is (#1303). Write-time application errors
-    /// (`slice_assign_non_array`/`cannot_update_string_slices`) are
-    /// unaffected either way — `through_slice` never gates those on
-    /// `optional` at all, matching real jq never suppressing them via an
-    /// inline `?`.
-    optional: bool,
-    /// Everything left to apply *inside* the slice, as one expression.
-    tail: Expr,
-}
-
-/// Flatten `exprs` via [`push_path_components`] — shared by [`split_at_slice`]
-/// and [`split_at_iterate`], which both need the identical flatten before
-/// their own scan (the first for the first `Slice`, the second for the
-/// first non-terminal `Iterate`).
+/// Flatten `exprs` into a list of atomic path components via
+/// [`push_path_components`] — nested `Pipe`/`Paren` groups spliced in place,
+/// `Identity` dropped, and an `Optional` group's own contents re-wrapped
+/// component by component (#1311) so a `?` on a whole group stays scoped to
+/// that group.
+///
+/// Run at most once per assignment, by `set_path`'s `Expr::Pipe` arm, and
+/// only when the components are not already atomic — [`set_path_steps`]
+/// then walks the result without ever flattening again (#1429).
 fn flatten_path_components(exprs: &[Expr]) -> Vec<Expr> {
     let mut flat = vec_with_capacity(exprs.len());
     for e in exprs {
         push_path_components(&mut flat, e);
     }
     flat
-}
-
-/// Split a chained path at its first slice, if it has one.
-///
-/// A slice names a *range*, not a slot, so `get_path_mut` cannot navigate
-/// through one — `.a[1:2][0] = 9` would fail on the middle component — and the
-/// walker has to hand off to [`through_slice`] there instead.
-///
-/// Flattens via [`flatten_path_components`] before scanning, so a slice
-/// nested inside a parenthesized sub-path that is itself only one of several
-/// top-level components — `(.a[0:1])[0] = 9`, where `(.a[0:1])` arrives as a
-/// single `Expr::Pipe([Field("a"), Slice{..}])` slot — is still found (#1292).
-/// A single-element Pipe never reaches here: `set_path`'s own `Paren`/`Pipe`
-/// arms already unwrap that case before calling this function, so the slice
-/// would already be at the top level of a *fresh* call. This function only
-/// has to handle a compound sub-path sitting *alongside* other components.
-///
-/// Each flattened element is matched via [`unwrap_path_component`] (not a
-/// bare `matches!`), so a `?`-marked slice — `.a[0:1]?[0] = 9`, or
-/// `(.a[0:1]?)[0] = 9` once `push_path_components` has flattened the
-/// enclosing parens away — is still found (#1303).
-///
-/// Also reaches through a `Pipe`/`Paren` nested *inside* an `Optional`
-/// wrapper — e.g. a `?` on a whole multi-component group ahead of a further
-/// step, `((.a[0:1])? | .[0]) = 9` — since `push_path_components` (#1311)
-/// recursively flattens an `Expr::Optional`'s own contents and re-wraps each
-/// resulting component individually, rather than leaving the wrapper
-/// opaque. Unlike the glued-postfix form (`(.a|.c)?[0] = 9`, confirmed a jq
-/// parse error), the `|`-separated spelling above genuinely parses in both
-/// real jq and here (`path((.a[0:1])? | .[0])` resolves fine), and now
-/// resolves through `=` too, matching jq.
-fn split_at_slice(exprs: &[Expr]) -> Option<SliceSplit> {
-    // Cheap common-case guard: the overwhelming majority of assignment
-    // targets (`.a.b.c[2] = 9`) contain neither a slice nor a nested
-    // `Pipe`/`Paren`/`Optional` component that could hide one, so skip the
-    // allocate-and-clone flatten below entirely when nothing here could
-    // possibly need it. Exactly equivalent to running the flatten and
-    // finding nothing: `push_path_components` only ever transforms a
-    // `Pipe`/`Paren` element, and the scan below only ever looks *through*
-    // `Optional`/`Paren` wrappers via `unwrap_path_component` — so a
-    // top-level element whose own unwrapped core is none of `Slice`/`Pipe`
-    // reaches the flattened list (and this scan) completely unchanged.
-    if exprs.iter().all(|e| {
-        let component = unwrap_path_component(e).0;
-        !component.is_slice() && !matches!(component, Expr::Pipe(_))
-    }) {
-        return None;
-    }
-    let mut flat = flatten_path_components(exprs);
-    let at = flat
-        .iter()
-        .position(|e| unwrap_path_component(e).0.is_slice())?;
-    let (optional, start, end) = match unwrap_path_component(&flat[at]) {
-        (Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. }, optional) => {
-            (optional, *start, *end)
-        }
-        _ => unreachable!("position matched a Slice"),
-    };
-    let rest = flat.split_off(at + 1);
-    flat.truncate(at);
-    Some(SliceSplit {
-        before: flat,
-        start,
-        end,
-        optional,
-        // An empty tail means the slice itself is the target, which `Identity`
-        // against the extracted sub-array says exactly.
-        tail: if rest.is_empty() {
-            Expr::Identity
-        } else {
-            Expr::Pipe(rest)
-        },
-    })
-}
-
-/// Where a chained path crosses a *non-terminal* `Iterate` (`.[]`), as
-/// [`split_at_iterate`] found it.
-struct IterateSplit {
-    /// The components to navigate before reaching the `Iterate`.
-    before: Vec<Expr>,
-    /// Whether the `Iterate` itself carried a `?` (`.a[]?[0] = 9`).
-    optional: bool,
-    /// Everything left to apply to *each* fanned-out element, as one
-    /// expression.
-    tail: Expr,
-}
-
-/// Split a chained path at its first *non-terminal* `Iterate`, if it has
-/// one.
-///
-/// `.[]` names every element/value in a container, not one slot, so
-/// `get_path_mut` cannot navigate through it the way it does a `Field`/
-/// `Index` — `.a[][0] = 9` has to fan out and apply `[0] = 9` independently
-/// to each of `.a`'s own elements, not find one shared parent slot to hand
-/// back (#1298). A *terminal* `Iterate` (`.a[] = 9`, nothing left after it)
-/// needs none of this: it already reaches `set_path`'s own top-level
-/// `Iterate` arm correctly via the ordinary `parent_path`/`last_path`
-/// split, so this function deliberately returns `None` for that shape —
-/// `at == flat.len() - 1` below is exactly that check.
-///
-/// Checked *before* [`split_at_slice`] in `set_path`'s `Pipe` arm: an
-/// `Iterate` fans out into independent per-element writes, each of which
-/// then re-resolves whatever slice/index/field remains in its own
-/// recursive `set_path` call — including a slice that comes *after* the
-/// `Iterate` in the chain (`.a[][0:2] = v`). A slice that comes *before*
-/// the `Iterate` is the opposite ordering, and is deliberately left to
-/// `split_at_slice` instead: this function bails (`None`) whenever a slice
-/// exists earlier in the flattened chain than the `Iterate` it would
-/// otherwise split on, so `split_at_slice` runs first, hands the residual
-/// `Iterate` to `through_slice`'s own closure as part of its `tail`, and
-/// this function gets a fresh, slice-free look at it on the next
-/// recursive `set_path` call. Without that check, this function's own
-/// `before` could itself contain the earlier slice — a component
-/// `get_path_mut` (which this function's caller navigates `before` with)
-/// cannot walk through any more than it can walk through an `Iterate`.
-///
-/// Flattens via [`flatten_path_components`] first, same as `split_at_slice`,
-/// so a `.[]` nested inside a parenthesized sub-path (`(.a[])[0] = 9`) is
-/// still found.
-fn split_at_iterate(exprs: &[Expr]) -> Option<IterateSplit> {
-    // Cheap common-case guard, mirroring `split_at_slice`'s own: skip the
-    // flatten entirely when nothing here could possibly hide an `Iterate`.
-    if exprs.iter().all(|e| {
-        let component = unwrap_path_component(e).0;
-        !matches!(component, Expr::Iterate | Expr::Pipe(_))
-    }) {
-        return None;
-    }
-    let mut flat = flatten_path_components(exprs);
-    let at = flat
-        .iter()
-        .position(|e| matches!(unwrap_path_component(e).0, Expr::Iterate))?;
-    if at == flat.len() - 1 {
-        // Terminal position -- not this function's case.
-        return None;
-    }
-    if flat[..at]
-        .iter()
-        .any(|e| unwrap_path_component(e).0.is_slice())
-    {
-        // An earlier slice takes precedence -- see the doc comment above.
-        return None;
-    }
-    let (_, optional) = unwrap_path_component(&flat[at]);
-    let rest = flat.split_off(at + 1);
-    flat.truncate(at);
-    // `rest` can never be empty here: the terminal-position check above
-    // already excluded `at == flat.len() - 1`, so there is always at least
-    // one component left after the `Iterate` -- self-checking rather than
-    // relying on a reader trusting this comment, since `SliceSplit`'s own
-    // `tail` (two structs above) visibly branches on an empty `rest`
-    // instead and it would be an easy, silently-wrong "fix" to copy that
-    // branch here by analogy.
-    debug_assert!(!rest.is_empty());
-    Some(IterateSplit {
-        before: flat,
-        optional,
-        tail: Expr::Pipe(rest),
-    })
-}
-
-/// Fan a `=` write out over every element/value of `target` — the
-/// non-terminal `Iterate` case [`split_at_iterate`] found (#1298).
-/// `get_path_mut` can only ever return one mutable slot, so a mid-chain
-/// `.[]` can't reuse its loop the way `Field`/`Index` do; each element
-/// instead gets its own independent recursive `set_path` call against
-/// `split.tail`. Mirrors `set_path`'s own top-level `Expr::Iterate` arm
-/// (the terminal-position case, #1181) for the yq-only null-to-`[]`
-/// autovivify and the scalar-target no-op — deliberately the same rules, a
-/// mid-chain `.[]` isn't semantically different from a terminal one, just
-/// followed by more path.
-fn set_path_through_iterate<S: EvalSemantics>(
-    target: &mut OwnedValue,
-    optional: bool,
-    tail: &Expr,
-    new_value: OwnedValue,
-    scalar_noop: bool,
-    container_noop: bool,
-) -> Result<(), EvalError> {
-    if scalar_noop {
-        autovivify_array(target);
-    }
-    match target {
-        OwnedValue::Array(arr) => {
-            for elem in arr.iter_mut() {
-                set_path::<S>(elem, tail, new_value.clone(), scalar_noop, container_noop)?;
-            }
-            Ok(())
-        }
-        OwnedValue::Object(map) => {
-            for (_, elem) in map.iter_mut() {
-                set_path::<S>(elem, tail, new_value.clone(), scalar_noop, container_noop)?;
-            }
-            Ok(())
-        }
-        _ if optional || (scalar_noop && is_yq_field_index_noop_scalar(target)) => Ok(()),
-        _ => Err(EvalError::cannot_iterate_with(S::TAG, target)),
-    }
-}
-
-/// Get a mutable reference to the parent named by `path_parts`, or `None` if
-/// a component along the way could not be walked and was itself marked
-/// optional (`?`).
-///
-/// Autovivification means a *wrong-type* mismatch — the only failure this can
-/// still raise — can only be reached through data the document already held:
-/// `Null` always vivifies into whatever the next step needs, so nothing this
-/// function creates can itself go on to fail. That is what makes per-step `?`
-/// safe to honour here without any risk of leaving a half-built container
-/// behind.
-///
-/// Each component's own `?` is scoped to that component only, mirroring
-/// `update_path`'s `Pipe`-chain arm: `{"a":5} | .a?.b.c = 1` still raises on
-/// `.c` (unprotected) even though `.a?` (protected, but never triggered here
-/// since `.a` reads fine) precedes it. This used to drop the bit entirely —
-/// "every path reaching a walker has already been resolved" is only true of
-/// the *computed-key* pre-pass (`resolve_dynamic_indexes`/`resolve_node`); a
-/// plain static chain like `.a?.b = 1` never goes through it at all
-/// (`needs_path_prepass` says no), so `get_path_mut` was the last word on
-/// whether `?` applied and was ignoring it: `"str" | .a?.b = 1` raised
-/// `Cannot index string with string "a"` instead of leaving `"str"`
-/// untouched, matching jq.
-fn get_path_mut<'a>(
-    root: &'a mut OwnedValue,
-    path_parts: &[Expr],
-    scalar_noop: bool,
-    create: bool,
-    would_create: &mut bool,
-) -> Result<Option<&'a mut OwnedValue>, EvalError> {
-    let mut current = root;
-    // A working copy, not a plain slice iteration: `resolve_node`'s `?` arm
-    // can emit `Optional(Pipe([…]))` when a branch resolves to more than one
-    // component, and a parenthesized static chain with no computed key at
-    // all (`(.a|.c)[0] = 9`) hands this walker an un-flattened `Pipe`
-    // directly, since `needs_path_prepass` never routes it through a
-    // flattening pass first. Splicing the nested `Pipe`'s components in
-    // place and reprocessing from the same position, rather than recursing,
-    // keeps this function's loop-based shape.
-    let mut parts = path_parts.to_vec();
-    // Parallel to `parts`: whether that slot's own failure should be
-    // suppressed because it came from splicing an `Optional(Pipe(inner))`
-    // group. `(.a|.c)?` is `try (.a|.c)` — real jq catches a failure from
-    // *either* `.a` or `.c`, confirmed live (`{"a":"notobj"} |
-    // ((.a|.c)? | .y) = 9` no-ops), but NOT from a pipe stage after the
-    // closing paren (confirmed live too: `{"a":{"c":5}} | ((.a|.c)? | .y) =
-    // 9` still raises `Cannot index number with string "y"` — `.y` is
-    // outside the `try`'s scope). A single carried-forward `optional` flag,
-    // the way `update_path`'s own `Expr::Pipe(inner)` arm handles this
-    // (line ~12045), does not draw that boundary: live-verified that arm's
-    // `|=` equivalent incorrectly no-ops the second case instead of
-    // erroring, over-suppressing everything after the group. Marking only
-    // the spliced-in slots keeps the suppression scoped to the group that
-    // was actually wrapped in `?`, leaving whatever follows unaffected.
-    let mut inherited_optional = vec![false; parts.len()];
-    let mut i = 0;
-
-    while i < parts.len() {
-        let (part, own_optional) = unwrap_path_component(&parts[i]);
-        let optional = own_optional || inherited_optional[i];
-
-        if let Expr::Pipe(inner) = part {
-            let inner = inner.clone();
-            let len = inner.len();
-            parts.splice(i..=i, inner);
-            inherited_optional.splice(i..=i, vec![optional; len]);
-            continue;
-        }
-
-        // #1232: same terminal-position no-op #1181 gave `set_path`'s own
-        // `Field`/`Index` arms, applied here so a scalar hit *before* the
-        // last path component (`.a.b = 99` on a scalar root) no-ops instead
-        // of erroring while still navigating toward the parent. Computed
-        // once per iteration rather than at each arm's own `else if`
-        // (previously duplicated across both): `autovivify_object`/
-        // `autovivify_array` below only ever convert `Null` into a
-        // container, and `is_yq_field_index_noop_scalar` already excludes
-        // `Null`, so the answer is identical whether checked before or
-        // after autovivification runs.
-        let noop_here = scalar_noop && is_yq_field_index_noop_scalar(current);
-
-        current = match part {
-            Expr::Identity => current,
-            Expr::Field(name) => {
-                if create {
-                    autovivify_object(current);
-                } else if matches!(current, OwnedValue::Null) {
-                    // #1428 probe mode: a `Null` here is exactly what the
-                    // creating walk would autovivify, so report "absent".
-                    *would_create = true;
-                    return Ok(None);
-                }
-                if let OwnedValue::Object(map) = current {
-                    if create {
-                        map.entry(name.clone()).or_insert(OwnedValue::Null)
-                    } else {
-                        // Probe mode: a missing key is likewise something the
-                        // creating walk would add.
-                        match map.get_mut(name) {
-                            Some(existing) => existing,
-                            None => {
-                                *would_create = true;
-                                return Ok(None);
-                            }
-                        }
-                    }
-                } else if optional || noop_here {
-                    return Ok(None);
-                } else {
-                    // Probe mode falls through to the *same* error the
-                    // creating walk raises. Reporting "absent" here instead
-                    // would let the caller skip a genuine type error --
-                    // `[] | .a[]? = 9` must still raise `Cannot index array
-                    // with string "a"`, because the `?` is on the iterate,
-                    // not on the field.
-                    return Err(EvalError::cannot_index_with_field(
-                        owned_type_name(current),
-                        name,
-                    ));
-                }
-            }
-            Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-                if create {
-                    autovivify_array(current);
-                } else if matches!(current, OwnedValue::Null) {
-                    // Probe mode, as in the `Field` arm above.
-                    *would_create = true;
-                    return Ok(None);
-                }
-                if let OwnedValue::Array(arr) = current {
-                    if !create {
-                        // Probe mode. `resolve_setpath_index` is shared with
-                        // `write_index`, so the index arithmetic (negative
-                        // indices in particular) cannot drift between the
-                        // probing and the creating walk; an index past the end
-                        // is what `write_index` would pad to, i.e. absent.
-                        let actual = resolve_setpath_index(&OwnedValue::Int(*idx), arr.len())?;
-                        match arr.get_mut(actual) {
-                            Some(existing) => existing,
-                            None => {
-                                *would_create = true;
-                                return Ok(None);
-                            }
-                        }
-                    } else {
-                        // A still-negative index is the write-time bounds check,
-                        // not a walking failure, so `?` never covers it here
-                        // either — same reasoning as `set_path`'s `Expr::Optional`
-                        // arm, just with nothing to catch: `write_index` never
-                        // returns that error for a component this function can
-                        // itself elect to suppress.
-                        write_index(arr, *idx)?
-                    }
-                } else if optional || noop_here {
-                    return Ok(None);
-                } else {
-                    return Err(EvalError::cannot_index_with_type(
-                        owned_type_name(current),
-                        "number",
-                    ));
-                }
-            }
-            Expr::IndexExpr { .. } => {
-                return Err(EvalError::new(
-                    "internal error: unresolved computed index in path component",
-                ))
-            }
-            Expr::SliceExpr { .. } => {
-                return Err(EvalError::new(
-                    "internal error: unresolved computed slice in path component",
-                ))
-            }
-            _ => return Err(EvalError::new("invalid path component")),
-        };
-        i += 1;
-    }
-
-    Ok(Some(current))
 }
 
 /// Update a value at a path by applying a filter.
@@ -19375,17 +19085,17 @@ fn update_path<S: EvalSemantics>(
 
                 match first {
                     Expr::Field(name) => {
-                        // #1428: mirror of the guard in `set_path`'s own
-                        // chain arms, in the shape this recursive walker
-                        // allows. `set_path` probes a detached `Null` up
-                        // front because its parent chain is built inside
+                        // #1428: the same guard `set_path_steps` applies on
+                        // the `=` side, and now the same shape too. `set_path`
+                        // used to *probe* a detached `Null` up front instead,
+                        // because its parent chain was built inside
                         // `get_path_mut`'s loop, which cannot be walked back
-                        // up; here the frame that creates the slot is still
-                        // live when the recursion returns, so it can simply
-                        // undo it. Probing would be wrong on this side
-                        // anyway: `filter_expr` is a *filter*, and running it
-                        // once to decide and again for real would double any
-                        // side effect it has.
+                        // up; #1429 replaced that loop with a peel-and-recurse
+                        // walker, so both sides now simply undo the slot from
+                        // the frame that created it. Probing would be wrong on
+                        // this side anyway: `filter_expr` is a *filter*, and
+                        // running it once to decide and again for real would
+                        // double any side effect it has.
                         //
                         // A mid-chain slot left `Null` by the recursion was
                         // never written: every component that can follow one
@@ -19651,7 +19361,7 @@ fn owned_type_name(value: &OwnedValue) -> &'static str {
 // Computed keys in path expressions (#360)
 // =============================================================================
 //
-// `set_path`, `get_path_mut`, `update_path`, `delete_at_path` and `walk_path`
+// `set_path`, `set_path_steps`, `update_path`, `delete_at_path` and `walk_path`
 // all understand only *static* path components: `Identity`, `Field`, `Index`,
 // `Iterate`, `Slice`. Rather than teach every walker about computed keys, the
 // key is resolved to the concrete component it denotes *before* they run, so
@@ -19667,7 +19377,7 @@ fn owned_type_name(value: &OwnedValue) -> &'static str {
 /// has to run to turn it into concrete `Field`/`Index`/`Slice` components?
 ///
 /// Written as an exclusion rather than a whitelist on purpose (#483): the
-/// single-path walkers (`walk_path`, `get_path_mut`, `set_path`,
+/// single-path walkers (`walk_path`, `set_path`, `set_path_steps`,
 /// `update_path`, `delete_at_path`) only understand `Identity`/`Field`/
 /// `Index`/`Slice`/`Iterate`, nested arbitrarily under `Pipe`/`Paren`/
 /// `Optional` — so *everything else* needs `resolve_node` first, whether
@@ -19749,10 +19459,10 @@ fn needs_fanout_pass(expr: &Expr) -> bool {
 /// Append `expr` to a path component list, splicing nested pipes and dropping
 /// `Identity`.
 ///
-/// `get_path_mut` matches a `&[Expr]` element-wise against
-/// `Identity | Field | Index` and rejects anything else as "invalid path
-/// component", so a nested `Pipe` emitted by the pre-pass would break
-/// assignment with a message that reads like user error.
+/// [`set_path_steps`] matches a `&[Expr]` element-wise against
+/// `Identity | Field | Index | Iterate | Slice` and rejects anything else as
+/// "invalid path component", so a nested `Pipe` emitted by the pre-pass
+/// would break assignment with a message that reads like user error.
 fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
     match expr {
         Expr::Identity => {}
@@ -19767,11 +19477,12 @@ fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
         // that `?` -- the same reasoning `splice_optional_group` already
         // applies for `update_path`/`delete_at_path` (#1294) -- rather
         // than being pushed as one opaque `Optional(Pipe(...))` element.
-        // Without this, neither `split_at_slice`'s slice scan (which
-        // unwraps `Optional`/`Paren` but not into a `Pipe` inside them)
-        // nor `get_path_mut`'s own per-step `Identity | Field | Index`
-        // match can see through it, and the whole thing falls to
-        // "invalid path component" (#1311).
+        // Without this, `set_path_steps`' own per-step match (which
+        // unwraps `Optional`/`Paren` via `unwrap_path_component`, but not
+        // into a `Pipe` inside them) cannot see through it, and the whole
+        // thing falls to "invalid path component" (#1311). Before #1429 the
+        // same blindness was shared by `split_at_slice`'s own slice scan
+        // and `get_path_mut`'s per-step `Identity | Field | Index` match.
         Expr::Optional(inner) => {
             let mut group = Vec::new();
             push_path_components(&mut group, inner);
@@ -20879,7 +20590,7 @@ fn resolve_node<'a, S: EvalSemantics>(
         // than routing `.[]?` through `resolve_recurse` is both simpler and
         // what keeps the components bare: resolving under a `?` wraps each
         // one in `Expr::Optional`, which the walkers that *write*
-        // (`get_path_mut`, `update_path`, `delete_at_path`) then have to
+        // (`set_path_steps`, `update_path`, `delete_at_path`) then have to
         // unwrap. They do, but there is no reason to make them.
         //
         // Reached only when `trackable` — the guard arm above already
@@ -25065,9 +24776,17 @@ fn resolve_del_path_branches<'a, S: EvalSemantics>(
 /// later step's failure outranks an earlier deferred one" ordering. The
 /// write-side callers cannot, on four counts measured against jq 1.7.1:
 ///
-/// - `get_path_mut`/`update_path` reject two adjacent `Iterate` components
-///   as an invalid path component, so `(.[("a","b")][][]) = 9` — which jq
-///   applies happily — would stop working entirely.
+/// - ~~Adjacent `Iterate` components are rejected as an invalid path
+///   component.~~ No longer true, and re-checked live while #1429 was
+///   restructuring `=`'s walker: `(.[("a","b")][][]) = 9` matches jq 1.7.1
+///   exactly, as does the plain `.a[][] = 9`/`.a[][] |= 9` pair. `.[]` has
+///   had a real mid-chain fan-out arm on the `=` side since #1298 and on
+///   the `|=` side for longer; the `get_path_mut` loop this count was
+///   written against never saw an `Iterate` after #1298 and is gone
+///   entirely since #1429. Kept, struck through, rather than deleted: the
+///   three counts below are what still carry the decision, and silently
+///   dropping a retired one would leave a reader wondering whether it was
+///   ever weighed.
 /// - The spliced-back components never pass through `assemble()`'s
 ///   `strip_resolved_optional`, so a deferred `.foo[]?` would carry its `?`
 ///   into `set_path`, which then suppresses a *write*-time failure jq raises
@@ -49771,7 +49490,7 @@ mod tests {
     }
 
     /// #1494: `builtin_any`/`builtin_all`/`builtin_flatten`/`builtin_from_entries`
-    /// (plus `set_path`/`set_path_through_iterate`, exercised separately by
+    /// (plus `set_path`/`set_path_steps`, exercised separately by
     /// `test_set_path_cannot_iterate_uses_the_real_mode_tag_1494`) used the
     /// jq-pinned `EvalError::cannot_iterate` shim unconditionally, so a
     /// yq-mode error message always carried jq's own value-preview
@@ -61174,9 +60893,11 @@ mod tests {
 
     #[test]
     fn test_yq_assign_through_parenthesized_pipe_target_noops_on_non_container_1287() {
-        // `get_path_mut`'s `Expr::Pipe` splice is shared by both evaluators
-        // -- before it, yq mode hit the exact same "invalid path component"
-        // internal error jq mode did, in place of the no-op real yq gives
+        // The nested-`Expr::Pipe` flattening is shared by both evaluators
+        // (`get_path_mut`'s in-walk splice when #1287 landed, the up-front
+        // `flatten_path_components` since #1429) -- before it, yq mode hit
+        // the exact same "invalid path component" internal error jq mode
+        // did, in place of the no-op real yq gives
         // for writing through a scalar (`scalar_noop`/`container_noop`,
         // #1101/#1142). Live-verified against real yq v4.53.3: all three
         // shapes leave the document unchanged, exit 0.
@@ -61207,11 +60928,12 @@ mod tests {
             (b"{}", ".a.b += 1", Ok(r#"{"a":{"b":1}}"#)),
             (b"{}", ".a.b //= 9", Ok(r#"{"a":{"b":9}}"#)),
             (b"[1,2]", ".[5] |= 9", Ok("[1,2,null,null,null,9]")),
-            // `|=`/`+=`/etc. walk a path recursively rather than looping like
-            // `get_path_mut` does for plain `=`, so a mid-path (not the last
-            // segment) `Index` step is a separate call site with its own
-            // autovivify_array + write_index calls — exercised only by an
-            // Index step that still has more path left after it.
+            // `|=`/`+=`/etc. have their own mid-chain `Index` arm, distinct
+            // from the terminal one, with its own autovivify_array +
+            // write_index calls — exercised only by an `Index` step that
+            // still has more path left after it. (`=` has the same split
+            // since #1429 gave it a peel-and-recurse walker of its own; it
+            // used to reach the same slot through `get_path_mut`'s loop.)
             (b"{}", ".a[0].b |= 9", Ok(r#"{"a":[{"b":9}]}"#)),
             (b"[{},{}]", ".[0].x += 1", Ok(r#"[{"x":1},{}]"#)),
         ]);
@@ -61682,7 +61404,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_path_and_get_path_mut_autovivify_null_directly() {
+    fn test_set_path_and_set_path_steps_autovivify_null_directly() {
         // Direct-function coverage for the three walkers `autovivify_object`/
         // `autovivify_array`/`write_index` touch (#486), bypassing the parser.
         let mut root = OwnedValue::Null;
@@ -61718,29 +61440,35 @@ mod tests {
             ])
         );
 
-        // `get_path_mut` vivifies each intermediate as it walks a multi-part
-        // parent path, not just the first step.
+        // `set_path_steps` vivifies each intermediate as it walks a
+        // multi-part chain, not just the first step (#1429: this used to be
+        // `get_path_mut`'s job, and its own direct-call coverage).
         let mut root = OwnedValue::Object(IndexMap::new());
-        let slot = get_path_mut(
+        set_path_steps::<JqSemantics>(
             &mut root,
-            &[Expr::Field("a".to_string()), Expr::Field("b".to_string())],
+            &[
+                Expr::Field("a".to_string()),
+                Expr::Field("b".to_string()),
+                Expr::Field("c".to_string()),
+            ],
+            OwnedValue::Int(7),
             false,
-            true,
-            &mut false,
+            false,
         )
-        .unwrap()
         .unwrap();
-        assert_eq!(*slot, OwnedValue::Null);
         assert_eq!(
             root,
             OwnedValue::Object(IndexMap::from([(
                 "a".to_string(),
-                OwnedValue::Object(IndexMap::from([("b".to_string(), OwnedValue::Null)])),
+                OwnedValue::Object(IndexMap::from([(
+                    "b".to_string(),
+                    OwnedValue::Object(IndexMap::from([("c".to_string(), OwnedValue::Int(7))])),
+                )])),
             )]))
         );
     }
 
-    /// #1494: `set_path`/`set_path_through_iterate` threaded `S:
+    /// #1494: `set_path`/`set_path_steps` threaded `S:
     /// EvalSemantics` through to `cannot_iterate_with(S::TAG, ...)`,
     /// matching the other four call sites this issue covers.
     ///
@@ -61771,28 +61499,21 @@ mod tests {
                 .unwrap_err();
         assert_eq!(err.message, "Cannot iterate over number (3)");
 
+        // The mid-chain fan-out arm, which #1429 folded out of
+        // `set_path_through_iterate` and into `set_path_steps` -- reached
+        // with a real tail after the `.[]` so it is the mid-chain arm and
+        // not the terminal one above that raises.
+        let steps = [Expr::Iterate, Expr::Field("b".to_string())];
         let mut target = OwnedValue::Float(3.0);
-        let err = set_path_through_iterate::<YqSemantics>(
-            &mut target,
-            false,
-            &Expr::Identity,
-            OwnedValue::Int(9),
-            false,
-            false,
-        )
-        .unwrap_err();
+        let err =
+            set_path_steps::<YqSemantics>(&mut target, &steps, OwnedValue::Int(9), false, false)
+                .unwrap_err();
         assert_eq!(err.message, "Cannot iterate over number (3.0)");
 
         let mut target = OwnedValue::Float(3.0);
-        let err = set_path_through_iterate::<JqSemantics>(
-            &mut target,
-            false,
-            &Expr::Identity,
-            OwnedValue::Int(9),
-            false,
-            false,
-        )
-        .unwrap_err();
+        let err =
+            set_path_steps::<JqSemantics>(&mut target, &steps, OwnedValue::Int(9), false, false)
+                .unwrap_err();
         assert_eq!(err.message, "Cannot iterate over number (3)");
     }
 
@@ -62216,9 +61937,11 @@ mod tests {
         );
         // The slice itself as the terminal write target (nothing after
         // it) must still refuse, whether reached bare-root or through a
-        // preceding field -- this is `split_at_slice`'s `Identity`-tail
-        // case, which looks structurally identical to the mid-chain case
-        // above but must NOT get the same treatment (code review, #1321:
+        // preceding field -- this is the terminal-slice case (#1429's
+        // `set_path_steps` reaches it as a one-element `steps`; before that
+        // it was `split_at_slice`'s `Identity` tail), which looks
+        // structurally identical to the mid-chain case above but must NOT
+        // get the same treatment (code review, #1321:
         // an earlier version of this fix mis-classified it and silently
         // no-op'd `.a[0:1] = v` instead of erroring).
         query!(br#"{"a":"hello"}"#, r#".a[0:1] = ["x"]"#,
@@ -65638,10 +65361,21 @@ mod tests {
         }
 
         #[test]
-        fn test_get_path_mut_refuses_an_unresolved_key() {
+        fn test_set_path_steps_refuses_an_unresolved_key() {
+            // Two components, not one: a single-component list is the
+            // terminal case `set_path_steps` delegates straight to
+            // `set_path`, which has its own (differently-worded) guard
+            // above. The mid-chain arm tested here is the one that used to
+            // live in `get_path_mut` (#1429).
             let mut root = OwnedValue::Null;
-            let err =
-                get_path_mut(&mut root, &[unresolved()], false, true, &mut false).unwrap_err();
+            let err = set_path_steps::<JqSemantics>(
+                &mut root,
+                &[unresolved(), Expr::Field("a".to_string())],
+                OwnedValue::Int(1),
+                false,
+                false,
+            )
+            .unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in path component"
@@ -65737,10 +65471,21 @@ mod tests {
         }
 
         #[test]
-        fn test_get_path_mut_refuses_an_unresolved_slice() {
+        fn test_set_path_steps_refuses_an_unresolved_slice() {
+            // Two components, not one: a single-component list is the
+            // terminal case `set_path_steps` delegates straight to
+            // `set_path`, which has its own (differently-worded) guard
+            // above. The mid-chain arm tested here is the one that used to
+            // live in `get_path_mut` (#1429).
             let mut root = OwnedValue::Null;
-            let err =
-                get_path_mut(&mut root, &[unresolved()], false, true, &mut false).unwrap_err();
+            let err = set_path_steps::<JqSemantics>(
+                &mut root,
+                &[unresolved(), Expr::Field("a".to_string())],
+                OwnedValue::Int(1),
+                false,
+                false,
+            )
+            .unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in path component"

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18097,13 +18097,20 @@ fn set_path<S: EvalSemantics>(
 ///
 /// [`unwrap_path_component`] is what the walker itself uses to look through
 /// `Optional`/`Paren` wrappers, so those are transparent here too: only a
-/// `Pipe` (or a `Pipe` hiding inside one of those wrappers), an `Identity`
-/// that has to be dropped, or an unresolved computed component makes a list
-/// non-atomic and sends it through [`flatten_path_components`] first.
+/// `Pipe` (or a `Pipe` hiding inside one of those wrappers) or an unresolved
+/// computed component makes a list non-atomic and sends it through
+/// [`flatten_path_components`] first.
+///
+/// `Identity` counts as atomic even though the flattener would drop it
+/// (`push_path_components`): the walker has a one-line arm for it, and
+/// treating it as non-atomic would send an otherwise-flat `.a | . | .b`
+/// through a full allocate-and-clone flatten purely to delete a step that
+/// costs nothing to skip.
 fn is_atomic_path_component(expr: &Expr) -> bool {
     matches!(
         unwrap_path_component(expr).0,
-        Expr::Field(_)
+        Expr::Identity
+            | Expr::Field(_)
             | Expr::Index(_)
             | Expr::IndexNumber { .. }
             | Expr::Iterate
@@ -18144,7 +18151,13 @@ fn set_path_steps<S: EvalSemantics>(
     container_noop: bool,
 ) -> Result<(), EvalError> {
     let (first, rest) = match steps {
-        // Everything was `Identity` (`(. | .) = 9`), so this *is* the write.
+        // Nothing left to navigate, so this *is* the write. Reached when a
+        // group that needed flattening turns out to hold only `Identity`
+        // steps, which `push_path_components` drops -- `((.|.)) = 9`, whose
+        // outer `Paren(Pipe(..))` is what forces the flatten in the first
+        // place. A bare `(.|.) = 9` never gets here: every component is
+        // already atomic, so it stays on the borrowed path and the trailing
+        // `Identity` is the terminal component.
         [] => {
             *root = new_value;
             return Ok(());
@@ -18217,8 +18230,10 @@ fn set_path_steps<S: EvalSemantics>(
     let rest_reaches_iterate = rest.iter().any(reaches_iterate);
 
     match component {
-        // `push_path_components` drops these, but the borrowed fast path
-        // does not run it -- an `Identity` is simply nothing to navigate.
+        // Only ever reached on the borrowed fast path: `.a | . | .b = 9` keeps
+        // its `Identity` because `is_atomic_path_component` accepts one, where
+        // `flatten_path_components` would have dropped it. Nothing to
+        // navigate either way.
         Expr::Identity => set_path_steps::<S>(root, rest, new_value, scalar_noop, container_noop),
         Expr::Field(name) => {
             let root_was_null = matches!(root, OwnedValue::Null);
@@ -60958,6 +60973,39 @@ mod tests {
         ]);
     }
 
+    /// #1429: an `Identity` inside a chain is a step to skip, not a shape to
+    /// flatten around.
+    ///
+    /// `is_atomic_path_component` accepts `Identity` so `.a | . | .b` stays on
+    /// the borrowed fast path, which makes `set_path_steps`' own `Identity`
+    /// arm the thing that skips it; the flattener would have dropped it
+    /// instead, at the cost of an allocate-and-clone pass. The two spellings
+    /// therefore take genuinely different routes and are pinned together.
+    /// All four confirmed against real jq 1.7.1.
+    #[test]
+    fn test_assign_identity_steps_inside_a_chain_1429() {
+        assert_outcomes(&[
+            // Borrowed path, `Identity` skipped mid-chain.
+            (
+                br#"{"a":{"b":1}}"#,
+                "(.a | . | .b) = 9",
+                Ok(r#"{"a":{"b":9}}"#),
+            ),
+            (
+                br#"{"a":{"b":1}}"#,
+                "(. | .a.b) = 9",
+                Ok(r#"{"a":{"b":9}}"#),
+            ),
+            // Borrowed path, `Identity` as the *terminal* component: the
+            // whole document is the write target.
+            (br#"{"a":{"b":1}}"#, "(.|.) = 9", Ok("9")),
+            // Forced through the flattener by the outer `Paren(Pipe(..))`,
+            // which drops every `Identity` and leaves an empty step list --
+            // the one route to `set_path_steps`' `[]` arm.
+            (br#"{"a":{"b":1}}"#, "((.|.)) = 9", Ok("9")),
+        ]);
+    }
+
     /// #1429: `=` walks a long chain by recursion now, where it used to loop
     /// inside `get_path_mut`.
     ///
@@ -65475,6 +65523,30 @@ mod tests {
                 err.message,
                 "internal error: unresolved computed index in assignment path"
             );
+        }
+
+        /// The mid-chain catch-all itself, reached with a component that is
+        /// neither a known path step nor an unresolved computed one.
+        ///
+        /// Unreachable through the public API for the same reason the two
+        /// guards below are -- `needs_path_prepass` routes everything but
+        /// `Identity`/`Field`/`Index`/`Slice`/`Iterate` (and the
+        /// `Pipe`/`Paren`/`Optional` wrappers) through `resolve_node` first --
+        /// and pinned here for the same reason: the wording is the signal that
+        /// a new path context was wired up without that pre-pass, so it has to
+        /// stay the wording a reader will actually recognise (#1429).
+        #[test]
+        fn test_set_path_steps_refuses_an_unwalkable_component() {
+            let mut root = OwnedValue::Null;
+            let err = set_path_steps::<JqSemantics>(
+                &mut root,
+                &[Expr::Var("k".to_string()), Expr::Field("a".to_string())],
+                OwnedValue::Int(1),
+                false,
+                false,
+            )
+            .unwrap_err();
+            assert_eq!(err.message, "invalid path component");
         }
 
         #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18151,13 +18151,17 @@ fn set_path_steps<S: EvalSemantics>(
     container_noop: bool,
 ) -> Result<(), EvalError> {
     let (first, rest) = match steps {
-        // Nothing left to navigate, so this *is* the write. Reached when a
-        // group that needed flattening turns out to hold only `Identity`
-        // steps, which `push_path_components` drops -- `((.|.)) = 9`, whose
-        // outer `Paren(Pipe(..))` is what forces the flatten in the first
-        // place. A bare `(.|.) = 9` never gets here: every component is
-        // already atomic, so it stays on the borrowed path and the trailing
-        // `Identity` is the terminal component.
+        // Nothing left to navigate, so this *is* the write. Reached only via
+        // the flattener, when every step it produces is an `Identity` it then
+        // drops -- which needs a nested group sitting *alongside* another
+        // component, `((.|.) | .) = 9` or `(.|(.|.)) = 9`, since that is what
+        // makes the list non-atomic in the first place. Neither `((.|.)) = 9`
+        // nor `(.|.) = 9` gets here: `set_path`'s own `Paren` arm unwraps the
+        // outer parens, leaving a list that is already atomic (`Identity`
+        // counts, see `is_atomic_path_component`), so both stay on the
+        // borrowed path with the trailing `Identity` as the terminal
+        // component. Confirmed by instrumenting this arm and running all
+        // four spellings.
         [] => {
             *root = new_value;
             return Ok(());
@@ -60999,10 +61003,15 @@ mod tests {
             // Borrowed path, `Identity` as the *terminal* component: the
             // whole document is the write target.
             (br#"{"a":{"b":1}}"#, "(.|.) = 9", Ok("9")),
-            // Forced through the flattener by the outer `Paren(Pipe(..))`,
-            // which drops every `Identity` and leaves an empty step list --
-            // the one route to `set_path_steps`' `[]` arm.
+            // Still the borrowed path: `set_path`'s `Paren` arm unwraps the
+            // outer parens before the list is ever classified.
             (br#"{"a":{"b":1}}"#, "((.|.)) = 9", Ok("9")),
+            // A nested group *alongside* another component is what makes the
+            // list non-atomic, so these two go through the flattener -- which
+            // drops every `Identity` and leaves an empty step list, the one
+            // route to `set_path_steps`' `[]` arm.
+            (br#"{"a":{"b":1}}"#, "((.|.) | .) = 9", Ok("9")),
+            (br#"{"a":{"b":1}}"#, "(.|(.|.)) = 9", Ok("9")),
         ]);
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18000,14 +18000,24 @@ fn set_path<S: EvalSemantics>(
                 // `get_path_mut` used to clone the component list
                 // (`path_parts.to_vec()`) plus a parallel `vec![false; len]`
                 // for this same case.
-                set_path_steps::<S>(root, exprs, new_value, scalar_noop, container_noop)
-            } else {
                 set_path_steps::<S>(
                     root,
-                    &flatten_path_components(exprs),
+                    exprs,
                     new_value,
                     scalar_noop,
                     container_noop,
+                    iterate_suffix_len(exprs),
+                )
+            } else {
+                let flat = flatten_path_components(exprs);
+                let iterate_suffix = iterate_suffix_len(&flat);
+                set_path_steps::<S>(
+                    root,
+                    &flat,
+                    new_value,
+                    scalar_noop,
+                    container_noop,
+                    iterate_suffix,
                 )
             }
         }
@@ -18119,6 +18129,72 @@ fn is_atomic_path_component(expr: &Expr) -> bool {
     )
 }
 
+/// #1428's stranded-write test, shared by `=`'s and `|=`'s chain walkers.
+///
+/// Walking toward a write target creates every missing step on the way. A
+/// tail that then turns out to write nothing -- an `Iterate` over the `Null`
+/// autovivification just produced has no elements -- must leave the document
+/// alone, so the frame that created the slot undoes it on the way out. The
+/// four call sites (two walkers x `Field`/`Index`) differ only in the
+/// container mechanics that follow: `map.shift_remove` against
+/// `arr.truncate`. The *decision* is one rule and lives here.
+///
+/// Factored out on review of #1429, for the reason that PR's own
+/// `for_each_container_slot` gives: the rule has already been amended more
+/// than once, four hand-maintained copies have no compiler-enforced link,
+/// and this file has watched that exact shape drift before.
+///
+/// `created` is whether this frame is responsible for the slot at all -- `=`'s
+/// `Index` arm and `|=`'s pass `true` and gate on the array having actually
+/// grown instead, since `write_index` pads rather than inserting one slot.
+/// `nothing_written` is the caller's own evidence that the tail declined to
+/// write: an `Iterate` still ahead in the chain, or (`|=` only, #1877/#1894)
+/// an update filter that produced no output at all. Neither subsumes the
+/// other -- the `Iterate` arms report `Ok(true)` for a container however many
+/// elements they touch, including none.
+///
+/// `still_null` is read last on purpose: a write whose value happens to be
+/// `null` is indistinguishable from no write at all by looking at the slot,
+/// which is why `nothing_written` has to be established independently
+/// (`null | (.a|.) = null` must keep `{"a": null}`).
+fn slot_was_stranded<T, E>(
+    created: bool,
+    undo_enabled: bool,
+    nothing_written: bool,
+    result: &Result<T, E>,
+    current: &OwnedValue,
+) -> bool {
+    created
+        && undo_enabled
+        && nothing_written
+        && result.is_ok()
+        && matches!(current, OwnedValue::Null)
+}
+
+/// Length of the shortest suffix of `steps` that still contains an `Iterate`,
+/// or `usize::MAX` when there is none.
+///
+/// [`set_path_steps`]'s stranded-write undo needs to know, at each frame,
+/// whether an `Iterate` remains anywhere in the chain ahead of it. Asking
+/// `rest.iter().any(reaches_iterate)` per frame is the obvious spelling and
+/// is quadratic: `rest` shrinks by one per frame and the scan never
+/// short-circuits when there is no `Iterate` to find, so a flat `.k0.k1…kN =
+/// 9` pays `N(N-1)/2` comparisons. Measured before this was hoisted: 0.15 s
+/// at N=16,000, 0.58 s at 32,000, 2.40 s at 64,000 -- a clean 4x per
+/// doubling, against a flat 0.02 s for the pre-#1429 walker, which asked the
+/// equivalent question once.
+///
+/// Because every recursive call receives a *suffix* of the same list, one
+/// number computed up front answers all of them: `rest` contains an
+/// `Iterate` exactly when `rest.len() >= iterate_suffix`. O(N) once, O(1)
+/// per frame.
+fn iterate_suffix_len(steps: &[Expr]) -> usize {
+    steps
+        .iter()
+        .rposition(reaches_iterate)
+        .map_or(usize::MAX, |at| steps.len() - at)
+}
+
 /// Walk a *flat* list of atomic path components, peeling one per call, and
 /// write `new_value` at the end (#1429).
 ///
@@ -18149,61 +18225,131 @@ fn set_path_steps<S: EvalSemantics>(
     new_value: OwnedValue,
     scalar_noop: bool,
     container_noop: bool,
+    iterate_suffix: usize,
 ) -> Result<(), EvalError> {
-    let (first, rest) = match steps {
-        // Nothing left to navigate, so this *is* the write. Reached only via
-        // the flattener, when every step it produces is an `Identity` it then
-        // drops -- which needs a nested group sitting *alongside* another
-        // component, `((.|.) | .) = 9` or `(.|(.|.)) = 9`, since that is what
-        // makes the list non-atomic in the first place. Neither `((.|.)) = 9`
-        // nor `(.|.) = 9` gets here: `set_path`'s own `Paren` arm unwraps the
-        // outer parens, leaving a list that is already atomic (`Identity`
-        // counts, see `is_atomic_path_component`), so both stay on the
-        // borrowed path with the trailing `Identity` as the terminal
-        // component. Confirmed by instrumenting this arm and running all
-        // four spellings.
-        [] => {
-            *root = new_value;
-            return Ok(());
-        }
-        [last] => {
-            // A `?`-marked *terminal slice* reached through a chain
-            // (`.a[0:1]? = 9`) is the one component that must not go through
-            // `set_path`'s `Expr::Optional` catch-and-swallow arm: the split
-            // this replaced threaded the `?` into `through_slice`'s own
-            // bounds gate instead (#1303), which suppresses an out-of-range
-            // slice while still leaving `slice_assign_non_array`/
-            // `cannot_update_string_slices` to raise. Catch-and-swallow
-            // would abandon the whole write instead. Every other terminal
-            // component -- including a `?`-marked `Field`/`Index`/`Iterate`,
-            // which the split-based walker also routed through
-            // catch-and-swallow -- delegates unchanged.
-            let (component, optional) = unwrap_path_component(last);
-            if let Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } = component {
-                return through_slice(
-                    root,
-                    *start,
-                    *end,
-                    SliceEditFlags {
-                        optional,
-                        scalar_noop,
-                        container_noop,
-                        // The slice genuinely is the last path component, so
-                        // this call's own `edit` is the write (#1321).
-                        terminal_write: true,
-                    },
-                    // Always `true` -- `=`'s RHS is an already-materialized
-                    // value, it has no `|= empty` concept (#1877/#1894).
-                    |sub| {
-                        *sub = new_value;
-                        Ok(true)
-                    },
-                )
-                .map(|_| ());
+    // A frame exists here for exactly one reason: so that the slot it created
+    // is still reachable when the recursion returns and may have to be undone
+    // (#1428). A step whose remaining chain holds no `Iterate` can never
+    // strand -- `rest_reaches_iterate` below is the whole undo condition --
+    // so that frame has nothing to come back to, and consuming the step in
+    // place is not an optimization of the recursion but the absence of a
+    // reason for it.
+    //
+    // Load-bearing, not a nicety. `=` navigated its prefix in
+    // `get_path_mut`'s loop before #1429; recursing unconditionally instead
+    // made a long flat chain abort on a blown stack in *release* where it had
+    // returned a clean `nesting depth exceeds limit of 384` -- measured at
+    // 500,000 components, SIGABRT against the pre-#1429 binary's exit 5.
+    // Bounding the frame count by the number of steps that can actually
+    // strand restores that, and leaves the recursion for the shapes that
+    // genuinely need it.
+    let mut root = root;
+    let mut steps = steps;
+    let (first, rest) = loop {
+        let (first, rest) = match steps {
+            // Nothing left to navigate, so this *is* the write. Reached only via
+            // the flattener, when every step it produces is an `Identity` it then
+            // drops -- which needs a nested group sitting *alongside* another
+            // component, `((.|.) | .) = 9` or `(.|(.|.)) = 9`, since that is what
+            // makes the list non-atomic in the first place. Neither `((.|.)) = 9`
+            // nor `(.|.) = 9` gets here: `set_path`'s own `Paren` arm unwraps the
+            // outer parens, leaving a list that is already atomic (`Identity`
+            // counts, see `is_atomic_path_component`), so both stay on the
+            // borrowed path with the trailing `Identity` as the terminal
+            // component. Confirmed by instrumenting this arm and running all
+            // four spellings.
+            [] => {
+                *root = new_value;
+                return Ok(());
             }
-            return set_path::<S>(root, last, new_value, scalar_noop, container_noop);
+            [last] => {
+                // A `?`-marked *terminal slice* reached through a chain
+                // (`.a[0:1]? = 9`) is the one component that must not go through
+                // `set_path`'s `Expr::Optional` catch-and-swallow arm: the split
+                // this replaced threaded the `?` into `through_slice`'s own
+                // bounds gate instead (#1303), which suppresses an out-of-range
+                // slice while still leaving `slice_assign_non_array`/
+                // `cannot_update_string_slices` to raise. Catch-and-swallow
+                // would abandon the whole write instead. Every other terminal
+                // component -- including a `?`-marked `Field`/`Index`/`Iterate`,
+                // which the split-based walker also routed through
+                // catch-and-swallow -- delegates unchanged.
+                let (component, optional) = unwrap_path_component(last);
+                if let Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } = component
+                {
+                    return through_slice(
+                        root,
+                        *start,
+                        *end,
+                        SliceEditFlags {
+                            optional,
+                            scalar_noop,
+                            container_noop,
+                            // The slice genuinely is the last path component, so
+                            // this call's own `edit` is the write (#1321).
+                            terminal_write: true,
+                        },
+                        // Always `true` -- `=`'s RHS is an already-materialized
+                        // value, it has no `|= empty` concept (#1877/#1894).
+                        |sub| {
+                            *sub = new_value;
+                            Ok(true)
+                        },
+                    )
+                    .map(|_| ());
+                }
+                return set_path::<S>(root, last, new_value, scalar_noop, container_noop);
+            }
+            [first, rest @ ..] => (first, rest),
+        };
+
+        // Same reading as below, hoisted so the in-place arms can use it: an
+        // `Iterate` still ahead means this step's slot may have to be undone,
+        // which needs the frame.
+        if rest.len() >= iterate_suffix {
+            break (first, rest);
         }
-        [first, rest @ ..] => (first, rest),
+        let (component, optional) = unwrap_path_component(first);
+        let noop_here = scalar_noop && is_yq_field_index_noop_scalar(root);
+        root = match component {
+            Expr::Identity => root,
+            Expr::Field(name) => {
+                autovivify_object(root);
+                if let OwnedValue::Object(map) = root {
+                    map.entry(name.clone()).or_insert(OwnedValue::Null)
+                } else if optional || noop_here {
+                    return Ok(());
+                } else {
+                    return Err(EvalError::cannot_index_with_field(
+                        owned_type_name(root),
+                        name,
+                    ));
+                }
+            }
+            Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+                autovivify_array(root);
+                if let OwnedValue::Array(arr) = root {
+                    // A still-negative index after counting back from the end
+                    // is jq's write-time bounds check, which `?` never covers
+                    // -- so this propagates rather than folding into the
+                    // `optional` branch, exactly as `get_path_mut` had it.
+                    write_index(arr, *idx)?
+                } else if optional || noop_here {
+                    return Ok(());
+                } else {
+                    return Err(EvalError::cannot_index_with_type(
+                        owned_type_name(root),
+                        "number",
+                    ));
+                }
+            }
+            // A `Slice` hands its tail to `through_slice`'s closure and the
+            // guard arms report their own errors; neither is a plain step to
+            // walk past. (`Iterate` cannot reach here at all -- one still
+            // ahead is what the `break` above tests for.)
+            _ => break (first, rest),
+        };
+        steps = rest;
     };
 
     let (component, optional) = unwrap_path_component(first);
@@ -18231,14 +18377,25 @@ fn set_path_steps<S: EvalSemantics>(
     // slot, and the inner frame restores *its* parent to `Null` on the way
     // out, so the outer frame's reading is accurate again by the time it
     // looks.
-    let rest_reaches_iterate = rest.iter().any(reaches_iterate);
+    // O(1) against [`iterate_suffix_len`], computed once for the whole walk:
+    // every recursive call gets a suffix of the same list, so "an `Iterate`
+    // remains in `rest`" is just a length comparison. Scanning `rest` here
+    // instead is quadratic over a long chain -- see that function.
+    let rest_reaches_iterate = rest.len() >= iterate_suffix;
 
     match component {
         // Only ever reached on the borrowed fast path: `.a | . | .b = 9` keeps
         // its `Identity` because `is_atomic_path_component` accepts one, where
         // `flatten_path_components` would have dropped it. Nothing to
         // navigate either way.
-        Expr::Identity => set_path_steps::<S>(root, rest, new_value, scalar_noop, container_noop),
+        Expr::Identity => set_path_steps::<S>(
+            root,
+            rest,
+            new_value,
+            scalar_noop,
+            container_noop,
+            iterate_suffix,
+        ),
         Expr::Field(name) => {
             let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_object(root);
@@ -18246,13 +18403,21 @@ fn set_path_steps<S: EvalSemantics>(
                 let created = !map.contains_key(name);
                 let (result, stranded) = {
                     let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                    let result =
-                        set_path_steps::<S>(current, rest, new_value, scalar_noop, container_noop);
-                    let stranded = created
-                        && undo_stranded
-                        && rest_reaches_iterate
-                        && result.is_ok()
-                        && matches!(*current, OwnedValue::Null);
+                    let result = set_path_steps::<S>(
+                        current,
+                        rest,
+                        new_value,
+                        scalar_noop,
+                        container_noop,
+                        iterate_suffix,
+                    );
+                    let stranded = slot_was_stranded(
+                        created,
+                        undo_stranded,
+                        rest_reaches_iterate,
+                        &result,
+                        current,
+                    );
                     (result, stranded)
                 };
                 if stranded {
@@ -18283,12 +18448,21 @@ fn set_path_steps<S: EvalSemantics>(
                     // rather than being folded into the `optional` branch
                     // below, exactly as `get_path_mut` had it.
                     let current = write_index(arr, *idx)?;
-                    let result =
-                        set_path_steps::<S>(current, rest, new_value, scalar_noop, container_noop);
-                    let stranded = undo_stranded
-                        && rest_reaches_iterate
-                        && result.is_ok()
-                        && matches!(*current, OwnedValue::Null);
+                    let result = set_path_steps::<S>(
+                        current,
+                        rest,
+                        new_value,
+                        scalar_noop,
+                        container_noop,
+                        iterate_suffix,
+                    );
+                    let stranded = slot_was_stranded(
+                        true,
+                        undo_stranded,
+                        rest_reaches_iterate,
+                        &result,
+                        current,
+                    );
                     (result, stranded)
                 };
                 // `write_index` pads with `Null`s to reach a positive
@@ -18325,7 +18499,14 @@ fn set_path_steps<S: EvalSemantics>(
                 autovivify_array(root);
             }
             let fanned = for_each_container_slot(root, |slot| {
-                set_path_steps::<S>(slot, rest, new_value.clone(), scalar_noop, container_noop)
+                set_path_steps::<S>(
+                    slot,
+                    rest,
+                    new_value.clone(),
+                    scalar_noop,
+                    container_noop,
+                    iterate_suffix,
+                )
             });
             match fanned {
                 Some(result) => result,
@@ -18356,6 +18537,7 @@ fn set_path_steps<S: EvalSemantics>(
                     new_value,
                     scalar_noop,
                     container_noop,
+                    iterate_suffix,
                 ))
             },
         )
@@ -19167,11 +19349,13 @@ fn update_path<S: EvalSemantics>(
                                 // registers as `Ok(false)`, and
                                 // `reaches_iterate` stays the only signal
                                 // that catches it.
-                                let stranded = created
-                                    && undo_stranded
-                                    && (reaches_iterate(&rest) || matches!(result, Ok(false)))
-                                    && result.is_ok()
-                                    && matches!(*current, OwnedValue::Null);
+                                let stranded = slot_was_stranded(
+                                    created,
+                                    undo_stranded,
+                                    reaches_iterate(&rest) || matches!(result, Ok(false)),
+                                    &result,
+                                    current,
+                                );
                                 (result, stranded)
                             };
                             if stranded {
@@ -19218,10 +19402,13 @@ fn update_path<S: EvalSemantics>(
                                 );
                                 // See the `Field` arm above, including the
                                 // `Ok(false)` OR-clause (#1877/#1894).
-                                let stranded = undo_stranded
-                                    && (reaches_iterate(&rest) || matches!(result, Ok(false)))
-                                    && result.is_ok()
-                                    && matches!(*current, OwnedValue::Null);
+                                let stranded = slot_was_stranded(
+                                    true,
+                                    undo_stranded,
+                                    reaches_iterate(&rest) || matches!(result, Ok(false)),
+                                    &result,
+                                    current,
+                                );
                                 (result, stranded)
                             };
                             if stranded && arr.len() > original_len {
@@ -61015,31 +61202,68 @@ mod tests {
         ]);
     }
 
-    /// #1429: `=` walks a long chain by recursion now, where it used to loop
-    /// inside `get_path_mut`.
+    /// #1429: [`iterate_suffix_len`]'s O(1) answer agrees with the O(N) scan
+    /// it replaced.
     ///
-    /// `|=` and `del()` have always recursed per component, so this is not a
-    /// new class of depth limit -- but it is new for `=`, and a chain long
-    /// enough to matter has to actually be exercised rather than assumed.
-    ///
-    /// The depths are measured, not guessed. In a *debug* build (larger
-    /// frames, 2 MiB test-thread stack) `set_path_steps` clears 256
-    /// components comfortably while `update_path` -- unchanged by #1429 --
-    /// already aborts with `fatal runtime error: stack overflow` somewhere
-    /// between 128 and 192, so pinning the two at a shared depth would
-    /// mean pinning `=` at `|=`'s pre-existing ceiling. They are pinned
-    /// separately instead: 256 for the walker this issue rewrote, 128 for
-    /// the `|=` twin, which is where they can still be compared directly.
-    ///
-    /// The release CLI is bounded well before any of this: `=`, `|=` and
-    /// `del()` were each run at 256 / 1,000 / 5,000 / 20,000 / 50,000 and
-    /// 200,000 components against the binaries either side of #1429, and
-    /// every one of the thirty-six results is identical -- a clean
-    /// `nesting depth exceeds limit of 384` error (the pre-existing
-    /// *value*-nesting guard, which the rebuilt document trips long before
-    /// the walk itself runs out of stack), never a crash.
+    /// This is the whole mechanism behind the stranded-write undo now, so it
+    /// is pinned against the definition it has to match --
+    /// `rest.iter().any(reaches_iterate)` -- rather than against hand-written
+    /// expectations, over every suffix of a chain that mixes both kinds of
+    /// component and both `Iterate` spellings.
     #[test]
-    fn test_assign_deep_chain_recurses_without_blowing_the_stack_1429() {
+    fn test_iterate_suffix_len_matches_a_direct_scan_1429() {
+        let steps = [
+            Expr::Field("a".to_string()),
+            Expr::Iterate,
+            Expr::Index(0),
+            Expr::Optional(Box::new(Expr::Iterate)),
+            Expr::Field("b".to_string()),
+            Expr::Slice {
+                start: None,
+                end: None,
+            },
+        ];
+        let suffix = iterate_suffix_len(&steps);
+        for cut in 0..=steps.len() {
+            let rest = &steps[cut..];
+            assert_eq!(
+                rest.len() >= suffix,
+                rest.iter().any(reaches_iterate),
+                "disagreement on suffix starting at {cut}"
+            );
+        }
+
+        // No `Iterate` anywhere: every suffix must answer `false`, which is
+        // what `usize::MAX` buys -- a sentinel no `rest.len()` can reach.
+        let none = [
+            Expr::Field("a".to_string()),
+            Expr::Index(0),
+            Expr::Field("b".to_string()),
+        ];
+        assert_eq!(iterate_suffix_len(&none), usize::MAX);
+        for cut in 0..=none.len() {
+            assert!(none[cut..].len() < iterate_suffix_len(&none));
+        }
+    }
+
+    /// #1429: a long chain writes the same document under `=` as under `|=`.
+    ///
+    /// `=` briefly recursed per path component during this refactor, which
+    /// review caught as a release-build stack-overflow regression; it now
+    /// consumes any step that cannot strand without leaving a frame, so its
+    /// stack use is bounded by the stranding-capable steps rather than by
+    /// path length. The end-to-end proof of that is
+    /// `test_deep_flat_assign_chain_exits_cleanly_not_stack_overflow_1429`
+    /// in tests/jq_cli_tests.rs, at 200,000 components.
+    ///
+    /// What is left here is the agreement check, and the depths are still
+    /// measured rather than guessed: `|=` -- untouched by #1429, and
+    /// recursive per component -- already aborts in a *debug* build (larger
+    /// frames, 2 MiB test-thread stack) somewhere between 128 and 192, so the
+    /// two operators are pinned at 256 and 128 rather than at a shared depth
+    /// that would silently be `|=`'s pre-existing ceiling.
+    #[test]
+    fn test_assign_deep_chain_agrees_with_the_update_walker_1429() {
         fn chain(depth: usize) -> (String, String) {
             let path: String = (0..depth).map(|i| format!(".k{i}")).collect();
             let mut expected = String::from("9");
@@ -61618,16 +61842,18 @@ mod tests {
         // multi-part chain, not just the first step (#1429: this used to be
         // `get_path_mut`'s job, and its own direct-call coverage).
         let mut root = OwnedValue::Object(IndexMap::new());
+        let steps = [
+            Expr::Field("a".to_string()),
+            Expr::Field("b".to_string()),
+            Expr::Field("c".to_string()),
+        ];
         set_path_steps::<JqSemantics>(
             &mut root,
-            &[
-                Expr::Field("a".to_string()),
-                Expr::Field("b".to_string()),
-                Expr::Field("c".to_string()),
-            ],
+            &steps,
             OwnedValue::Int(7),
             false,
             false,
+            iterate_suffix_len(&steps),
         )
         .unwrap();
         assert_eq!(
@@ -61679,15 +61905,27 @@ mod tests {
         // not the terminal one above that raises.
         let steps = [Expr::Iterate, Expr::Field("b".to_string())];
         let mut target = OwnedValue::Float(3.0);
-        let err =
-            set_path_steps::<YqSemantics>(&mut target, &steps, OwnedValue::Int(9), false, false)
-                .unwrap_err();
+        let err = set_path_steps::<YqSemantics>(
+            &mut target,
+            &steps,
+            OwnedValue::Int(9),
+            false,
+            false,
+            iterate_suffix_len(&steps),
+        )
+        .unwrap_err();
         assert_eq!(err.message, "Cannot iterate over number (3.0)");
 
         let mut target = OwnedValue::Float(3.0);
-        let err =
-            set_path_steps::<JqSemantics>(&mut target, &steps, OwnedValue::Int(9), false, false)
-                .unwrap_err();
+        let err = set_path_steps::<JqSemantics>(
+            &mut target,
+            &steps,
+            OwnedValue::Int(9),
+            false,
+            false,
+            iterate_suffix_len(&steps),
+        )
+        .unwrap_err();
         assert_eq!(err.message, "Cannot iterate over number (3)");
     }
 
@@ -65553,6 +65791,7 @@ mod tests {
                 OwnedValue::Int(1),
                 false,
                 false,
+                iterate_suffix_len(&[Expr::Var("k".to_string()), Expr::Field("a".to_string())]),
             )
             .unwrap_err();
             assert_eq!(err.message, "invalid path component");
@@ -65572,6 +65811,7 @@ mod tests {
                 OwnedValue::Int(1),
                 false,
                 false,
+                iterate_suffix_len(&[unresolved(), Expr::Field("a".to_string())]),
             )
             .unwrap_err();
             assert_eq!(
@@ -65682,6 +65922,7 @@ mod tests {
                 OwnedValue::Int(1),
                 false,
                 false,
+                iterate_suffix_len(&[unresolved(), Expr::Field("a".to_string())]),
             )
             .unwrap_err();
             assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20192,6 +20192,60 @@ fn test_jq_string_repetition_accepts_float_count_1230() -> Result<()> {
 /// ARG_MAX in CI ("Argument list too long", os error 7) well before the
 /// query is ever parsed, which is an unrelated process-spawn limit, not
 /// this fix's own behavior.
+/// A very long flat `=` chain exits cleanly rather than crashing, and does so
+/// in linear time -- the two regressions #1429's review caught in the
+/// `set_path_steps` refactor, both measured against the pre-#1429 binary.
+///
+/// `=` used to navigate its prefix in `get_path_mut`'s loop. Peeling one
+/// component per *recursive call* instead put one stack frame on every path
+/// component, and at 500,000 components a release build aborted (SIGABRT)
+/// where it had returned this same clean error (exit 5). The walker now
+/// consumes any step that provably cannot strand -- no `Iterate` left ahead
+/// of it, so there is no slot to undo on the way out -- without leaving a
+/// frame behind, which bounds the frame count by the stranding-capable steps
+/// rather than by path length.
+///
+/// The same shape also caught an O(N^2): the stranded-write test used to
+/// rescan the remaining chain at every frame, costing 0.15 s / 0.58 s /
+/// 2.40 s at N = 16,000 / 32,000 / 64,000 against a flat 0.02 s for the old
+/// walker. `iterate_suffix_len` now answers it in O(1). This test does not
+/// assert a wall-clock bound -- that would be flaky -- but a return of the
+/// quadratic makes it take minutes instead of well under a second, which is
+/// hard to miss; `iterate_suffix_len`'s own unit tests pin the mechanism.
+///
+/// Passed via `-f`, not argv: 200,000 components is a ~2 MB filter, well past
+/// `ARG_MAX` on Linux CI even though macOS would take it.
+#[test]
+fn test_deep_flat_assign_chain_exits_cleanly_not_stack_overflow_1429() -> Result<()> {
+    let n = 200_000;
+    let path: String = (0..n).map(|i| format!(".k{i}")).collect();
+
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, "{path} = 9")?;
+    let filter_path = filter_file.path().to_owned();
+
+    let mut input_file = NamedTempFile::new()?;
+    writeln!(input_file, "null")?;
+    let input_path = input_file.path().to_owned();
+
+    let (out, err, code) = run_jq_full(
+        &[
+            "-f",
+            filter_path.to_str().expect("temp path is utf-8"),
+            input_path.to_str().expect("temp path is utf-8"),
+        ],
+        None,
+    )?;
+    // A refusal, not a crash: the pre-existing value-nesting guard, which the
+    // rebuilt 200,000-deep document trips once the walk itself has completed.
+    assert_ne!(code, 0, "out={out:?} err={err:?}");
+    assert!(
+        err.contains("nesting depth exceeds limit"),
+        "expected the clean depth refusal, got err={err:?} code={code}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_as_pattern_deep_nesting_exits_cleanly_not_stack_overflow_1240() -> Result<()> {
     let n = 300;


### PR DESCRIPTION
Closes #1429.

## The problem

`set_path` (`=`'s walker) navigated a chained path by *pre-scanning* it for constructs that name more than one slot, then handing a prefix to `get_path_mut` — a loop that could only ever return a **single** mutable slot. Each such construct therefore needed its own flatten-then-scan-then-bail helper bolted in front of that loop: `split_at_slice`, then `split_at_iterate` (#1298).

#1429 (Low severity, design/maintainability, filed from #1298's own code review — no correctness bug) records four costs:

1. Two structurally near-identical split functions.
2. An **unenforced ordering invariant**. `split_at_iterate` bailed whenever a `Slice` appeared earlier in the chain so `split_at_slice` — called *after* it — got first crack; `split_at_slice` carried no reciprocal bail. "Leftmost construct wins" rested entirely on call-site ordering plus a doc comment, and an Nth construct would have turned it into a hand-maintained O(N²) precedence graph.
3. Duplicated "walk every array element / every object value" loops for `Expr::Iterate`.
4. A **double flatten** on any path with a nested `Paren`/`Pipe` but no iterate and no slice (`(.a|.c)[0] = 9` — both guards flattened in full before either concluded it had nothing to do), plus a re-flatten of an already-flat tail at every fan-out level of a chained mid-chain iterate (`.items[].containers[].env[] = v`).

## The change

`set_path`'s `Expr::Pipe` arm becomes a dispatcher into **`set_path_steps`**: flatten once, then peel one atomic component per call and recurse on the rest — the shape `update_path` and `delete_at_path` already use. Leftmost-wins becomes *structural*: whichever construct comes first is simply the first arm the walk reaches.

Deleted: `split_at_slice`, `split_at_iterate`, `SliceSplit`, `IterateSplit`, `set_path_through_iterate`, `get_path_mut`, `tail_writes_from_fresh_parent`.

All four costs go with them. The common flat path (`.a.b.c[0] = 9`) is now walked **borrowed** — strictly fewer allocations than before, since `get_path_mut` used to clone the component list plus a parallel `vec![false; len]` for that same case.

`for_each_container_slot` replaces three of the four duplicated `.[]` fan-out loop pairs. The fourth — `update_path`'s *terminal* `Expr::Iterate` arm — is deliberately left out and says why at the helper: its jq-mode #1916 branch rebuilds the container rather than mutating in place, so it splits on `Array`/`Object` before it splits on mode and has no in-place loop to share.

**#1428's stranded-autovivify guard changes mechanism, not behaviour.** It probed a detached `Null` before committing only because `get_path_mut`'s loop could not be walked back up. The frame that creates a slot is now still live when the recursion returns, so it undoes it directly, exactly as `update_path` does. Errors need no undo: `fork_rhs_over_paths` discards the whole partially-written document for that RHS output.

## Verification

**Primary gate — byte-identical output.** New `scripts/jq-assign-path-oracle-sweep.sh` records stdout/stderr/exit for every case against both succinctly and the pinned oracles, as a stable TSV two builds can be `diff`ed on. **20,496 cases** — 2 modes × 8 write operators × 60 curated path shapes × 16 documents, plus 3,600 deterministically generated paths — **byte-identical between the pre-#1429 binary and this branch**, re-run after every commit here.

The curated shapes cover exactly what the deleted helpers encoded: `?` at every position, `Paren`/`Pipe` groups including group-scoped `?`, iterate and slice at leading/mid/terminal position, **both orderings** (slice-before-iterate *and* iterate-before-slice), chained iterates, negative and out-of-range indices, missing parents (#1428), and scalar/container targets (#1181/#1232/#1101/#1142). The generated section composes atoms mechanically over a fixed seed, because a hand-picked matrix only covers shapes its author already thought of.

jq mode matches pinned jq 1.7.1 on every one of those cases. The 2,189 yq-mode divergences against pinned yq v4.53.3 are pre-existing and unchanged in count and content (e.g. real yq reads `.[0]` on an object as the string key `"0"`).

Also green: full suite (6,865 tests), all three CI clippy legs, `fmt`, `no_std`, rustdoc with `-D warnings`. **Patch coverage 100%** (310/310).

## Performance

Interleaved A/B per `docs/guides/benchmarking.md`, idle M4 Pro, `ab-cli.py`, 9 reps, output-identity gated, control run first (−0.4% median, −1.2%..+0.9% band). A 200k-document corpus so the *walk* rather than the parse dominates:

| workload | min Δ | median Δ |
|---|---:|---:|
| `(.a\|.b).c = 9` — the double-flatten case | **−8.0%** | **−9.1%** |
| `.a.b.c.d.e.f.g.h = 9` — long flat chain | −1.6% | −1.5% |
| `.a.b.c = 9` — short flat chain | −0.1% | −0.8% |
| `.a.b.c \|= 9` — untouched walker (control) | −0.3% | +0.2% |
| `del(.a.b.c)` — untouched walker (control) | +0.6% | +0.4% |

The −8%/−9% row reproduced across two runs. On a parse-dominated macro workload (1 MB / 4 MB k8s-shaped JSON) every row sits inside the control band except `.items[].containers[].env[].v = 9` at −1.6% min / −3.1% median — the chained mid-chain iterate that used to re-flatten its tail per level.

**x86 not measured**: the 7950X box needed a Tailscale re-auth this session could not perform. The change is allocation and branch structure rather than anything memory-bandwidth-bound, so it is not the class of result that usually fails to port — but it is unmeasured, and stated rather than implied.

## Three things reviewers should know

1. **The issue's scope note was wrong about `get_path_mut`.** It said `get_path_mut` was "also called from `yq_del_slice_outcome`'s sibling logic"; that is `navigate_read_only`, a separate read-only walker. `get_path_mut` had exactly one caller and could be deleted outright, so `del()` is untouched.

2. **A pre-existing depth asymmetry, surfaced by the deep-chain test.** In a *debug* build `set_path_steps` clears 256 path components while `update_path` — untouched here — already aborts with a stack overflow between 128 and 192, so the two are pinned at 256 and 128 rather than at a shared depth. The release CLI is bounded long before either: `=`, `\|=` and `del()` were run at 256 / 1,000 / 5,000 / 20,000 / 50,000 and 200,000 components against the binaries either side of this change, and all 36 results are identical — a clean `nesting depth exceeds limit of 384` from the pre-existing *value*-nesting guard, never a crash.

3. **`Expr::Identity` is now atomic, and that fixed a real mistake.** The first draft's `Identity` arm claimed to serve the borrowed fast path but `is_atomic_path_component` rejected `Identity`, so any chain containing one was flattened — which drops it — and the arm was dead. Accepting `Identity` makes `.a | . | .b = 9` stay on the borrowed path. The `[]` arm's own comment was likewise wrong about which spelling reaches it; the arm was instrumented and the answer is a nested group sitting *alongside* another component (`((.|.) | .) = 9`), not `((.|.)) = 9`, whose outer parens `set_path`'s `Paren` arm unwraps first. Both near-miss spellings are pinned alongside so the distinction stays visible.

No entry added to either `limitations.md` — there is no behaviour change. The existing prose there that named the deleted functions has been updated to keep the historical account while pointing at `set_path_steps`.
