### PR TITLE
fix(jq): stop yq del()'s multi-branch computed-key panic on a scalar root

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -935,6 +935,44 @@ what distinguishes its call shape from its three siblings') until the real rever
 abort-without-rollback algorithm is implemented, tracked as
 [#1865](https://github.com/rust-works/succinctly/issues/1865) rather than guessed at here.
 
+### `del()` with a field key against a scalar root: errors instead of no-op
+
+Deleting a field key from a scalar document raises `Cannot index <type> with string
+"<key>"` in succinctly yq; real yq (v4.53.3) silently no-ops instead, returning the
+input unchanged at exit 0. Confirmed live for a static key, a single-branch computed
+key, and (after [#2049](https://github.com/rust-works/succinctly/issues/2049)'s fix
+for a live `unreachable!()` on this same shape) a mixed field+index multi-branch
+computed key:
+
+```bash
+$ echo '2.5' | yq            'del(.k0)'            # 2.5, no-op
+$ echo '2.5' | succinctly yq 'del(.k0)'             # Error: Cannot index number with string "k0"
+
+$ echo '2.5' | yq            'del(.[("k0",0)])'     # 2.5, no-op
+$ echo '2.5' | succinctly yq 'del(.[("k0",0)])'     # Error: Cannot index number with number
+```
+
+A purely-field multi-branch computed key (`del(.[("k0","k1")])`) *does* already
+no-op correctly — #2049's fix landed there as a side effect of removing the panic,
+since that shape reaches `delete_trie_object`'s trie walker directly rather than
+`resolve_node`'s earlier, always-erroring field-indexable check. The static,
+single-branch-computed and mixed-key shapes above still go through that earlier
+check (or, for the mixed case, `delete_trie_array`'s own separate non-array gate)
+and still error.
+
+A `null` root against that same purely-field multi-branch key is a third,
+non-erroring divergence in the same family: real yq materializes an object shape
+(`{}`) rather than leaving it `null`.
+
+```bash
+$ echo 'null' | yq            'del(.[("k0","k1")])'   # {}, materializes an object
+$ echo 'null' | succinctly yq 'del(.[("k0","k1")])'   # null, unchanged
+```
+
+`delete_trie_object`'s pre-existing `Null` branch (untouched by #2049's fix) always
+returns the root unchanged. Tracked, along with the field-key-on-scalar-root shapes
+above, as [#2106](https://github.com/rust-works/succinctly/issues/2106).
+
 ### Comma-grouped scalar-target assignment no-op
 
 [#1233](https://github.com/rust-works/succinctly/issues/1233) taught `=`/`+=`/`-=`/`*=`/`//=`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33815,20 +33815,21 @@ fn delete_trie_object(
     // the same `Cannot index … with …` error itself — before the trie was
     // ever built.
     //
-    // **Not for all of them, though: this `unreachable!()` is live-reachable
-    // and aborts the process.** `[] | del(.[0], .[1:2].b?[2:3])` reaches it
-    // in jq mode (where jq 1.7.1 prints `[]`), and `2.5 | del(.[("k0","k1")])`
-    // reaches it in yq mode (where real yq prints `2.5`) -- both confirmed
-    // live, both identically reachable before #1690 through this function's
-    // predecessor, whose own comment made the same false claim. Tracked as
-    // [#2049](https://github.com/rust-works/succinctly/issues/2049) rather
-    // than fixed here: turning it into an `EvalError` (which is what the
-    // array arm below already does for its own equivalent gate, and what
-    // #1098 established as this crate's rule) is a behaviour change needing
-    // its own oracle capture of *which* error -- or, per both references
-    // above, of no error at all -- and #1690 is gated on changing nothing.
+    // Not for all of them, though: `[] | del(.[0], .[1:2].b?[2:3])` (jq
+    // mode -- the `?` on `.b?` suppresses resolve_node's field-indexable
+    // check for that branch) and `2.5 | del(.[("k0","k1")])` (yq mode -- a
+    // multi-branch computed key isn't validated by resolve_node the way a
+    // static or single-branch one is) both reach here with a non-object,
+    // non-null root and no prior validation. Both are confirmed live against
+    // the oracle -- jq 1.7.1 prints `[]`, real yq prints `2.5` -- so this is
+    // a no-op through the unvalidated root rather than the `unreachable!()`
+    // that used to sit here and abort the process on this exact input
+    // (#2049).
+    if !matches!(value, OwnedValue::Object(_)) {
+        return Ok(value);
+    }
     let OwnedValue::Object(entries) = &mut value else {
-        unreachable!("delete_trie_object reached a non-object, non-null root")
+        unreachable!("checked above")
     };
     for &slot in &node.field_groups {
         let (name, &child) = node

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33758,9 +33758,13 @@ fn delete_trie_apply(
     //
     // `value` can only be one concrete type at a time, so at most one of
     // these two actually mutates it; the other sees a container of the wrong
-    // shape and takes that branch's optional-vs-error path. Both maps can be
-    // non-empty only when `value` is `null`, which accepts a string key, a
-    // numeric key or `.[]` alike.
+    // shape and takes that branch's optional-vs-error path. Both maps being
+    // non-empty isn't limited to `value` being `null` (which accepts a
+    // string key, a numeric key or `.[]` alike): a mixed-kind multi-branch
+    // computed key that skips `resolve_node`'s validation (#2049) can
+    // populate both maps against a non-null scalar root too -- the fields
+    // arm no-ops through it (below), and the indices arm raises its own
+    // type-mismatch error.
     if !node.fields.is_empty() {
         value = delete_trie_object(value, trie, id)?;
     }
@@ -33825,11 +33829,8 @@ fn delete_trie_object(
     // a no-op through the unvalidated root rather than the `unreachable!()`
     // that used to sit here and abort the process on this exact input
     // (#2049).
-    if !matches!(value, OwnedValue::Object(_)) {
+    let Some(entries) = value.as_object_mut() else {
         return Ok(value);
-    }
-    let OwnedValue::Object(entries) = &mut value else {
-        unreachable!("checked above")
     };
     for &slot in &node.field_groups {
         let (name, &child) = node

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -2213,6 +2213,15 @@ fn test_del_filtered_recursive_descent_1690() {
 #[test]
 fn test_del_multi_branch_optional_field_step_over_array_root_2049() {
     check("[]", "del(.[0], .[1:2].b?[2:3])", Outcome::values(&["[]"]));
+    // Same shape, but with a non-empty array reaching the no-op arm --
+    // `.[9]` is out of range (a dead end, not an error) and `.[0:2].b?`
+    // still swallows its own type error, so the whole filter is still the
+    // identity, not just the empty-array degenerate case above.
+    check(
+        "[1,2,3]",
+        "del(.[9], .[0:2].b?[2:3])",
+        Outcome::values(&["[1,2,3]"]),
+    );
 }
 
 /// #1322: `delete_expr_array_paths`'s multi-path type-mismatch check used to

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -2204,6 +2204,17 @@ fn test_del_filtered_recursive_descent_1690() {
     );
 }
 
+/// #2049: an array root reaches `delete_trie_object`'s field-group arm
+/// unvalidated when the second comma branch's `?` (`.b?`) suppresses
+/// `resolve_node`'s usual field-indexable check. This used to hit a live
+/// `unreachable!()` and abort the process; real jq 1.7.1 treats it as a
+/// no-op (the array has no `.[0]` to delete, and `.b?` swallows the type
+/// error), so the whole filter is the identity here.
+#[test]
+fn test_del_multi_branch_optional_field_step_over_array_root_2049() {
+    check("[]", "del(.[0], .[1:2].b?[2:3])", Outcome::values(&["[]"]));
+}
+
 /// #1322: `delete_expr_array_paths`'s multi-path type-mismatch check used to
 /// be gated behind `paths.iter().all(|p| p[start].optional)`, but every
 /// sibling here reaching this function already had its own `Expr::Optional`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20138,6 +20138,35 @@ fn test_1690_yq_del_slice_rules_over_a_merged_match_set() -> Result<()> {
     Ok(())
 }
 
+/// #2049: a multi-branch computed key (`.[("k0","k1")]`) against a scalar
+/// root isn't validated by `resolve_node` the way a static or single-branch
+/// computed key is, so it used to reach `delete_trie_object`'s field-group
+/// arm with a non-object, non-null root and hit a live `unreachable!()` —
+/// aborting the process with exit 101 on ordinary CLI input. Real yq v4.53.3
+/// no-ops through every scalar kind here; verified live.
+#[test]
+fn test_1690_del_multi_branch_computed_key_over_scalar_root_2049() -> Result<()> {
+    for input in ["2.5", "0", r#""a""#, "true", "false"] {
+        let (out, code) = run_yq_stdin(r#"del(.[("k0","k1")])"#, input, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "scalar root {input}");
+        assert_eq!(out.trim(), input, "scalar root {input}");
+    }
+
+    // Mixed key kinds (string + number): the field-group half of the trie
+    // walk still no-ops per the fix above, but the numeric key also
+    // populates the trie's *index* group, which then reaches
+    // `delete_trie_array`'s own pre-existing, deliberate non-array gate —
+    // a different, out-of-scope-for-#2049 typed-error path (real yq no-ops
+    // here too, but matching that is a broader change than removing this
+    // issue's `unreachable!()`). The fix's actual contract for this shape is
+    // narrower: no longer a process abort, exit 101 -> a catchable error.
+    let (out, code) = run_yq_stdin(r#"del(.[("k0",0)])"#, "2.5", &["-o=json", "-I=0"])?;
+    assert_ne!(code, 101, "must not crash the process: {out}");
+    assert_eq!(code, 1, "expected a catchable error, got: {out}");
+
+    Ok(())
+}
+
 /// del()'s parent-key rule also applies when the resolved path fans out
 /// into more than one target (a top-level comma, or a computed key with
 /// multiple values) — the multi-path delete walk never sees the original


### PR DESCRIPTION
## Summary
- `delete_trie_object`'s non-object/non-null root gate was a live `unreachable!()`, reachable via two known routes that both skip `resolve_node`'s usual field-indexable validation: a multi-branch computed field key over a scalar root in **yq mode** (`2.5 | del(.[("k0","k1")])`), and an optional-suppressed field step over an array root in **jq mode** (`[] | del(.[0], .[1:2].b?[2:3])`). Both aborted the process with exit 101 on ordinary CLI input.
- Both cases are confirmed no-ops in the real oracle (jq 1.7.1 prints `[]`; real yq v4.53.3 prints the scalar unchanged), so the fix returns the root unchanged instead of panicking.
- Filed follow-up #2106 for a related, pre-existing (not introduced here) divergence: `del()` with a field key on a scalar root still *errors* rather than no-ops for the static/single-branch-computed/mixed-key shapes — that's a separate, broader behavioural question out of scope for this crash fix.

Fixes #2049

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression tests added and passing:
  - `tests/jq_computed_key_tests.rs::test_del_multi_branch_optional_field_step_over_array_root_2049` (jq mode, both full and generic evaluators)
  - `tests/yq_cli_tests.rs::test_1690_del_multi_branch_computed_key_over_scalar_root_2049` (yq mode, all scalar kinds + mixed key kind)
- [x] Verified pre-fix panic reproduces (via `git stash`) and post-fix output matches the live oracle (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4.53.3) for both repro cases
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` — touched lines exercised by new tests