### PR TITLE
fix(jq): make modulemeta arity 0, matching real jq's modulemeta/0

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2477,6 +2477,33 @@ narrower, lower-traffic case than the three arms fixed above, not attempted
 here). Full fan-out for it, if ever needed, remains out of scope per
 #1522's design doc.
 
+### `modulemeta` never errors, unlike real jq -- no carve-out; tracked in #2111
+
+Real jq's `modulemeta` is not a pure no-op: it reads `.` as a module name and always
+errors, since there is no module for it to actually find in ordinary use --
+non-string input gets a type error, any string gets "not found":
+
+```console
+$ echo 'null' | jq 'modulemeta'
+jq: error (at <stdin>:1): modulemeta input module name must be a string   # exit 5
+$ echo '"foo"' | jq 'modulemeta'
+jq: error (at <stdin>:1): module not found: foo                          # exit 5
+$ echo 'null' | succinctly jq 'modulemeta'
+null                                                                      # exit 0
+$ echo '"foo"' | succinctly jq 'modulemeta'
+null                                                                      # exit 0
+```
+
+`builtin_modulemeta` (`src/jq/eval.rs`) unconditionally returns `null` and ignores its
+input entirely -- a stub comment ("we don't support modules") that predates
+[#2035](https://github.com/rust-works/succinctly/issues/2035), which fixed only the
+builtin's *arity* (the parser previously demanded `modulemeta(name)`, inverted from
+jq's actual `modulemeta/0`) and did not touch this runtime behavior. None of ADR-0018's
+four permitted conditions cover it -- matching jq's error here would corrupt nothing,
+discard no write, and cannot crash the process -- so per rule 4 it is recorded here as a
+still-open gap rather than an accepted-forever divergence. Tracked in
+[#2111](https://github.com/rust-works/succinctly/issues/2111).
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -208,7 +208,7 @@ below and [ADR-0019](../adrs/adr-0019.md).
 - [x] `recurse` / `recurse(f)` / `recurse(f; cond)`
 - [x] `walk(f)`
 - [x] `isvalid(expr)`
-- [x] `modulemeta(name)` (stub)
+- [x] `modulemeta` (stub, arity 0 like real jq's — #2035)
 - [x] `tojsonstream` / `fromjsonstream`
 - [x] `tostream` / `fromstream(f)` / `truncate_stream(f)` — jq's standard streaming
   builtins (#396). Distinct from `tojsonstream`/`fromjsonstream` above, which predate

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37607,9 +37607,9 @@ fn builtin_builtins<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
         "trunc/0",
         // Type conversion (arity 0)
         "toboolean/0",
-        // Meta (arity 0-1)
+        // Meta (arity 0)
         "builtins/0",
-        "modulemeta/1",
+        "modulemeta/0",
         // Error handling (arity 0-1)
         "error/0",
         "error/1",
@@ -39190,8 +39190,11 @@ fn bsearch_one_target<W: Clone + AsRef<[u64]>>(
 
 // Object functions
 
-/// Builtin: modulemeta - get module metadata for the input module name
-/// (stub for compatibility). Arity 0, matching real jq (#2035).
+/// Builtin: modulemeta - get module metadata for the input module name.
+/// Arity 0, matching real jq (#2035) -- but the stub below always returns
+/// `null` rather than erroring the way real jq's `modulemeta` always does;
+/// that runtime-behavior gap is pre-existing, recorded in
+/// docs/compliance/jq/limitations.md, and tracked in #2111.
 fn builtin_modulemeta<W: Clone + AsRef<[u64]>>(
     _value: StandardJson<'_, W>,
     _optional: bool,
@@ -64234,6 +64237,20 @@ mod tests {
         query!(b"null", r#"builtins | map(select(startswith("now"))) | length"#,
             QueryResult::Owned(OwnedValue::Int(n)) => {
                 assert!(n >= 1, "should have now builtin");
+            }
+        );
+        // #2035: modulemeta is arity 0 (matching real jq's modulemeta/0),
+        // not the arity-1 entry this list carried before the parser fix --
+        // pinned here since builtin_builtins's hand-maintained list has no
+        // other guard tying it to the parser's actual accepted grammar.
+        query!(b"null", r#"builtins | any(. == "modulemeta/0")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(b, "builtins should list modulemeta/0");
+            }
+        );
+        query!(b"null", r#"builtins | any(. == "modulemeta/1")"#,
+            QueryResult::Owned(OwnedValue::Bool(b)) => {
+                assert!(!b, "builtins should not list modulemeta/1");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6576,7 +6576,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::BSearch(x) => builtin_bsearch::<W, S>(x, value, optional),
 
         // Phase 10: Object functions
-        Builtin::ModuleMeta(name) => builtin_modulemeta::<W>(name, value, optional),
+        Builtin::ModuleMeta => builtin_modulemeta::<W>(value, optional),
         Builtin::Pick(keys) => builtin_pick::<W, S>(keys, value, optional),
         Builtin::Omit(keys) => builtin_omit::<W, S>(keys, value, optional),
 
@@ -39190,12 +39190,12 @@ fn bsearch_one_target<W: Clone + AsRef<[u64]>>(
 
 // Object functions
 
-/// Builtin: modulemeta(name) - get module metadata (stub for compatibility)
-fn builtin_modulemeta<'a, W: Clone + AsRef<[u64]>>(
-    _name: &Expr,
-    _value: StandardJson<'a, W>,
+/// Builtin: modulemeta - get module metadata for the input module name
+/// (stub for compatibility). Arity 0, matching real jq (#2035).
+fn builtin_modulemeta<W: Clone + AsRef<[u64]>>(
+    _value: StandardJson<'_, W>,
     _optional: bool,
-) -> QueryResult<'a, W> {
+) -> QueryResult<'_, W> {
     // Return null as we don't support modules
     QueryResult::Owned(OwnedValue::Null)
 }
@@ -58125,8 +58125,8 @@ mod tests {
 
     #[test]
     fn test_modulemeta() {
-        // modulemeta returns null (stub)
-        query!(b"null", r#"modulemeta("test")"#, QueryResult::Owned(OwnedValue::Null) => {});
+        // modulemeta is arity 0 in real jq (#2035); returns null (stub).
+        query!(b"null", "modulemeta", QueryResult::Owned(OwnedValue::Null) => {});
     }
 
     #[test]

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1097,8 +1097,9 @@ pub enum Builtin {
     BSearch(Box<Expr>),
 
     // Phase 10: Object functions
-    /// `modulemeta(name)` - get module metadata (stub for compatibility)
-    ModuleMeta(Box<Expr>),
+    /// `modulemeta` - get module metadata for the input module name (stub
+    /// for compatibility). Real jq's builtin is arity 0, not arity 1 (#2035).
+    ModuleMeta,
     /// `pick(keys)` - select only specified keys from object/array (yq)
     Pick(Box<Expr>),
     /// `omit(keys)` - remove specified keys from object/indices from array (yq)

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3465,15 +3465,12 @@ impl<'a> Parser<'a> {
         }
 
         // Phase 10: Object functions
+        // modulemeta - real jq's builtin is arity 0 (takes the module name
+        // via `.`, not a paren'd argument); succinctly previously required
+        // `modulemeta(...)` here, inverted from jq's actual grammar (#2035).
         if self.matches_keyword("modulemeta") {
             self.consume_keyword("modulemeta");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let name = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::ModuleMeta(Box::new(name))));
+            return Ok(Some(Builtin::ModuleMeta));
         }
 
         // pick(keys) - yq: select only specified keys from object/array

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -57,7 +57,7 @@ pub enum BuiltinKids<'a> {
 /// is paid silently and repeatedly by everyone downstream.
 pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
     match builtin {
-        // --- No sub-expression (125) ---------------------------------------
+        // --- No sub-expression (126) ---------------------------------------
         Builtin::Type
         | Builtin::IsNull
         | Builtin::IsBoolean
@@ -149,6 +149,7 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
         | Builtin::Ltrim
         | Builtin::Rtrim
         | Builtin::Transpose
+        | Builtin::ModuleMeta
         | Builtin::Tag
         | Builtin::Anchor
         | Builtin::Style
@@ -184,7 +185,7 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
         | Builtin::FromUnix
         | Builtin::ToUnix => BuiltinKids::None,
 
-        // --- One sub-expression (60) ---------------------------------------
+        // --- One sub-expression (59) ---------------------------------------
         Builtin::Has(e)
         | Builtin::In(e)
         | Builtin::UpperIn(e)
@@ -228,7 +229,6 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
         | Builtin::HaltErrorCode(e)
         | Builtin::EnvVar(e)
         | Builtin::BSearch(e)
-        | Builtin::ModuleMeta(e)
         | Builtin::Pick(e)
         | Builtin::Omit(e)
         | Builtin::Del(e)
@@ -345,7 +345,7 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
 /// sub-expression-carrying arms at all.
 pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr) -> Builtin {
     match builtin {
-        // --- No sub-expression (125) ---------------------------------------
+        // --- No sub-expression (126) ---------------------------------------
         Builtin::Type
         | Builtin::IsNull
         | Builtin::IsBoolean
@@ -437,6 +437,7 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         | Builtin::Ltrim
         | Builtin::Rtrim
         | Builtin::Transpose
+        | Builtin::ModuleMeta
         | Builtin::Tag
         | Builtin::Anchor
         | Builtin::Style
@@ -472,7 +473,7 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         | Builtin::FromUnix
         | Builtin::ToUnix => builtin.clone(),
 
-        // --- One sub-expression (60) ---------------------------------------
+        // --- One sub-expression (59) ---------------------------------------
         Builtin::Has(e) => Builtin::Has(Box::new(f(e))),
         Builtin::In(e) => Builtin::In(Box::new(f(e))),
         Builtin::UpperIn(e) => Builtin::UpperIn(Box::new(f(e))),
@@ -516,7 +517,6 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         Builtin::HaltErrorCode(e) => Builtin::HaltErrorCode(Box::new(f(e))),
         Builtin::EnvVar(e) => Builtin::EnvVar(Box::new(f(e))),
         Builtin::BSearch(e) => Builtin::BSearch(Box::new(f(e))),
-        Builtin::ModuleMeta(e) => Builtin::ModuleMeta(Box::new(f(e))),
         Builtin::Pick(e) => Builtin::Pick(Box::new(f(e))),
         Builtin::Omit(e) => Builtin::Omit(Box::new(f(e))),
         Builtin::Del(e) => Builtin::Del(Box::new(f(e))),

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -26,12 +26,12 @@ use super::{Builtin, Expr, ObjectKey, StringPart};
 /// The sub-expressions a [`Builtin`] owns, in source order.
 ///
 /// Four shapes because that is all `Builtin` actually uses: of its 207
-/// variants, 125 carry no sub-expression, 60 carry one, 20 carry two and 2
+/// variants, 126 carry no sub-expression, 59 carry one, 20 carry two and 2
 /// carry three.
 #[derive(Debug, Clone, Copy)]
 pub enum BuiltinKids<'a> {
     /// A builtin with no sub-expression — `length`, `keys`, `inputs`, and the
-    /// 122 others, including the two that carry a non-expression payload
+    /// 123 others, including the two that carry a non-expression payload
     /// (`$ENV`-style `EnvObject(String)` and `StrEnv(String)`).
     None,
     /// One sub-expression — `map(f)`, `select(f)`, `first(f)`, …
@@ -326,7 +326,7 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
 /// guessing) to a tail call into the derived `<Builtin as Clone>::clone` --
 /// its own ~200-arm switch re-deciding the variant a second time -- rather
 /// than the old hand-written code's zero-cost direct materialization
-/// (`Builtin::Type => Builtin::Type`) for each of the 125 fieldless
+/// (`Builtin::Type => Builtin::Type`) for each of the 126 fieldless
 /// variants. Neither cost is new to this function; #1506 is what newly
 /// exposes both to genuinely hot per-element callers instead of only
 /// `rewrite_namespaced_calls`'s one-shot parse-time one. Measured

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28893,9 +28893,9 @@ fn test_seq_pending_literal_at_boundary_is_truncated_1928() -> Result<()> {
 /// checks the roster against `tests/data/jq-builtin-names.txt` entry by entry.
 /// This test covers the other half -- that the roster is actually consulted --
 /// on a representative sample rather than all 218 names: a whole-roster sweep
-/// through the CLI also exercises the *parser*, and `modulemeta` is a
-/// pre-existing parse divergence (succinctly's parser demands
-/// `modulemeta(...)` where jq's builtin is arity 0) unrelated to resolution.
+/// through the CLI also exercises the *parser*, which is a separate concern
+/// from resolution (`modulemeta` used to diverge there -- #2035 -- until its
+/// parser arity was fixed to match jq's actual `modulemeta/0`).
 #[test]
 fn test_unimplemented_jq_builtins_still_compile_when_unreached_1473() -> Result<()> {
     for call in [
@@ -28928,6 +28928,29 @@ fn test_unimplemented_jq_builtin_still_errors_when_reached_1473() -> Result<()> 
         stderr.contains("undefined function: cbrt/0"),
         "stderr: {stderr:?}"
     );
+    Ok(())
+}
+
+/// `modulemeta` is arity 0 in real jq (it reads the module name from `.`, not
+/// a paren'd argument) -- succinctly's parser previously demanded
+/// `modulemeta(...)`, inverted from jq's actual grammar. Confirmed against
+/// the pinned oracle (`/usr/bin/jq`, jq-1.7.1) (#2035).
+#[test]
+fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
+    // Bare `modulemeta`, no parens, must parse -- matching `if false then
+    // modulemeta else 1 end` => 1 in real jq (an unreached call still has to
+    // compile).
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", "if false then modulemeta else 1 end"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+
+    // Reached, bare `modulemeta` must not error (succinctly stubs module
+    // support out entirely rather than doing real module resolution).
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "modulemeta"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "null");
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28933,8 +28933,13 @@ fn test_unimplemented_jq_builtin_still_errors_when_reached_1473() -> Result<()> 
 
 /// `modulemeta` is arity 0 in real jq (it reads the module name from `.`, not
 /// a paren'd argument) -- succinctly's parser previously demanded
-/// `modulemeta(...)`, inverted from jq's actual grammar. Confirmed against
-/// the pinned oracle (`/usr/bin/jq`, jq-1.7.1) (#2035).
+/// `modulemeta(...)`, inverted from jq's actual grammar. The arity/parse
+/// dimension below is confirmed against the pinned oracle (`/usr/bin/jq`,
+/// jq-1.7.1) (#2035). The second assertion pins succinctly's current stub
+/// behavior (always `null`), not oracle-matched output -- real jq's
+/// `modulemeta` always errors instead (see
+/// docs/compliance/jq/limitations.md and #2111, which tracks closing that
+/// separate, pre-existing gap).
 #[test]
 fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
     // Bare `modulemeta`, no parens, must parse -- matching `if false then
@@ -28945,8 +28950,8 @@ fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "1");
 
-    // Reached, bare `modulemeta` must not error (succinctly stubs module
-    // support out entirely rather than doing real module resolution).
+    // Reached, bare `modulemeta` does not error -- succinctly's stub
+    // (#2111, not real jq's own behavior, which always errors).
     let (stdout, stderr, code) = run_jq_full(&["-nc", "modulemeta"], None)?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "null");


### PR DESCRIPTION
## Summary
- `modulemeta` is arity 0 in real jq (jq 1.7.1) — it reads the module name from `.`, not a paren'd argument. succinctly's parser required `modulemeta(...)`, the inverted grammar, so an unreached `if false then modulemeta else 1 end` failed to *compile* where real jq accepts it (exit 0, value `1`).
- Changed `Builtin::ModuleMeta(Box<Expr>)` to a zero-arity `Builtin::ModuleMeta` variant, updated the parser to consume the bare keyword (no `(...)`), and updated `walk.rs`'s two structural match blocks (moved from the "one sub-expression" arm to "no sub-expression", with count comments updated).
- `builtin_modulemeta`'s existing stub behavior (always returns `null`, since succinctly doesn't implement real module resolution) is unchanged — this issue is scoped to the parser-level arity divergence only, not module-resolution semantics.
- Confirmed against the pinned oracle (`/usr/bin/jq`, jq-1.7.1): `modulemeta(x)` is also rejected by real jq (`modulemeta/1 is not defined`, a compile error), and succinctly now also rejects it — with a parse error rather than jq's compile-error text, which matches the pre-existing behavior of every other 0-arity builtin in this codebase (e.g. `length(1)`, `not(1)` — confirmed live, not specific to this change). That broader arity-mismatch-error-text gap is out of scope here; filed as a separate follow-up.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite — 3224 lib tests + all integration suites, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against the pinned `/usr/bin/jq` (1.7.1) oracle directly
- [x] Added `test_modulemeta_is_arity_zero_2035` (CLI-level, covers both the unreached-compile case and the reached-bare case) and fixed the existing `jq::eval::tests::test_modulemeta` unit test, which used the old `modulemeta("test")` syntax
- [x] `cargo llvm-cov` patch coverage reviewed for the touched lines

Fixes #2035