### PR TITLE
fix(jq): a pruned ?-guarded comma sibling no longer errors on = / |=

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19623,13 +19623,13 @@ fn needs_path_prepass(expr: &Expr) -> bool {
 /// in the pipe, or -- unconditionally -- `resolve_recurse` resolving `f`):
 /// can its "nothing left needs resolving" fast path assume the remaining
 /// tail is single-valued? For `Iterate` the answer is no --
-/// `value_after_components` silently collapses any component producing != 1
-/// output to `Null`, which `resolve_recurse` treats as "no children" and
-/// prunes, silently dropping every result whenever a trailing
-/// `.foo[]`/`.foo[]?` reaches a 2+-element container (#682). Fanning it out
-/// through the same loop already used for a genuine computed key fixes that,
-/// without touching `resolve_dynamic_indexes`'s much more common
-/// no-computed-key fast path.
+/// [`value_after_components`] treats any component producing zero or more
+/// than one output as pruning the whole branch (`Ok(None)`, #2124), which
+/// `resolve_recurse` reads as "no children" and drops, silently discarding
+/// every result whenever a trailing `.foo[]`/`.foo[]?` reaches a 2+-element
+/// container (#682). Fanning it out through the same loop already used for
+/// a genuine computed key fixes that, without touching
+/// `resolve_dynamic_indexes`'s much more common no-computed-key fast path.
 ///
 /// No `Expr::Pipe` arm: this function's only caller (`resolve_seq`) always
 /// calls it on `flat`'s already-`push_path_components`-flattened elements,
@@ -24347,7 +24347,7 @@ fn resolve_slice_bound<S: EvalSemantics>(
 fn value_after_components<S: EvalSemantics>(
     components: &[Expr],
     value: &OwnedValue,
-) -> Result<OwnedValue, EvalEscape> {
+) -> Result<Option<OwnedValue>, EvalEscape> {
     let mut current = value.clone();
     for component in components {
         let mut values = eval_owned_multi::<S>(component, &current)?;
@@ -24367,10 +24367,27 @@ fn value_after_components<S: EvalSemantics>(
         );
         match values.len() {
             1 => current = values.pop().expect("len checked"),
-            _ => return Ok(OwnedValue::Null),
+            // Zero outputs here can only come from a `?`-suppressed step
+            // that failed to navigate (#2124): every component reaching
+            // this loop is a bare `Field`/`Index`/`Slice`-family step
+            // (`needs_fanout_pass` routes anything else, `Iterate`
+            // included, through the real fan-out loop instead), and a
+            // *present* container always yields exactly one output for
+            // one of those -- `null` for a missing key, never nothing.
+            // The whole tail is pruned once any step in it prunes --
+            // `resolve_node`'s own `Expr::Optional` arm already does
+            // exactly this when the `?` isn't buried inside this fast
+            // path's flattened tail; returning `None` here propagates the
+            // same verdict instead of fabricating a `null` result at a
+            // path the input doesn't actually have this shape at. Fixes
+            // `=`/`|=` raising where jq treats a `?`-guarded comma sibling
+            // with a failing navigation as a no-write once it has a
+            // surviving sibling (`path()`/`del()` were already correct
+            // here via other means -- #2049/#2108).
+            _ => return Ok(None),
         }
     }
-    Ok(current)
+    Ok(Some(current))
 }
 
 /// [`value_after_components`], except when `trackable` is false (#843): then
@@ -24396,7 +24413,7 @@ fn resolve_static_tail<'a, S: EvalSemantics>(
     components: &[Expr],
     value: &OwnedValue,
     trackable: bool,
-) -> Result<OwnedValue, (Vec<PathBranch<'a>>, EvalEscape)> {
+) -> Result<Option<OwnedValue>, (Vec<PathBranch<'a>>, EvalEscape)> {
     if !trackable {
         let error = match components.first().and_then(navigation_element) {
             Some(element) => EvalError::invalid_path_expression_near_access(&element, value),
@@ -24451,7 +24468,13 @@ fn apply_static_tail<'a, S: EvalSemantics>(
             current
         } else {
             match resolve_static_tail::<S>(tail, &current, trackable) {
-                Ok(end) => Cow::Owned(end),
+                Ok(Some(end)) => Cow::Owned(end),
+                // A `?`-suppressed step in `tail` prunes this branch
+                // entirely (#2124) — the same verdict a plain Comma sibling
+                // with no `?` failure at all would give by simply
+                // contributing zero branches, not one fabricated `null`
+                // branch at a path the value doesn't have this shape at.
+                Ok(None) => continue,
                 Err((_, e)) => return Err((out, e)),
             }
         };
@@ -24652,7 +24675,14 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // bespoke message for it — still a hard error either way, never the
     // silent wrong-success #843 is about.
     let Some(last_dynamic) = flat.iter().rposition(needs_fanout_pass) else {
-        let end = resolve_static_tail::<S>(&flat, value, trackable)?;
+        let end = match resolve_static_tail::<S>(&flat, value, trackable)? {
+            Some(end) => end,
+            // A `?`-suppressed step somewhere in this purely-static pipe
+            // prunes the whole branch (#2124) — zero output, not a
+            // fabricated `null` one; see `value_after_components`'s own
+            // doc comment for why zero can only mean that here.
+            None => return Ok(Vec::new()),
+        };
         // `resolve_static_tail` above already raised for an untracked
         // value, so this is `true` in practice — carried rather than
         // asserted so the two can't drift.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30185,3 +30185,78 @@ fn fold_source_trackable_branch_falls_back_to_two_pass_1872() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2124: a `?`-guarded comma branch that fails to navigate is pruned when
+/// it is the *only* branch, but `=`/`|=` used to keep it (and raise its
+/// navigation error) once it had a surviving sibling -- `path()`/`del()`
+/// were already correct for this shape via unrelated fixes (#2049/#2108),
+/// but `=`/`|=`'s own resolution path (`resolve_seq`'s no-computed-key fast
+/// path, `value_after_components`) shared none of that. Root cause: a
+/// component reaching that fast path is proven single-valued by
+/// construction, so the only way it produces zero outputs is a
+/// `?`-suppressed failure -- that used to fabricate a `null` result instead
+/// of pruning the whole branch. All rows verified against jq 1.7.1.
+#[test]
+fn test_optional_comma_sibling_prunes_for_assignment_2124() -> Result<()> {
+    for (filter, why) in [
+        ("(.b, .c.a?) = 9", "plain assignment"),
+        ("(.b, .c.a?) |= 9", "update assignment"),
+        ("(.c.a?, .b) = 9", "argument order must not matter"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"c":1}"#))?;
+        assert_eq!(code, 0, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "{\"c\":1,\"b\":9}\n", "{why}");
+    }
+    Ok(())
+}
+
+/// #2124 sibling: the same pruning fix across non-object scalar shapes for
+/// `.c`, confirming it isn't accidentally keyed to a specific value type.
+/// Verified live against jq 1.7.1.
+#[test]
+fn test_optional_comma_sibling_prune_holds_across_scalar_shapes_for_assignment_2124() -> Result<()>
+{
+    for doc in [r#"{"c":"s"}"#, r#"{"c":true}"#, r#"{"c":[]}"#] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", "(.b, .c.a?) = 9"], Some(doc))?;
+        assert_eq!(
+            code, 0,
+            "doc={doc} -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        let expected = format!("{}\n", doc.trim_end_matches('}').to_owned() + ",\"b\":9}");
+        assert_eq!(stdout, expected, "doc={doc}");
+    }
+    Ok(())
+}
+
+/// #2124's fix has two call sites, not one: `resolve_seq`'s fully-static
+/// fast path (every test above) and `apply_static_tail`'s per-branch tail
+/// application, reached only once a *real* dynamic/computed element
+/// precedes the `?`-guarded step in the same pipe. `.[(0,1)].a?` fans out
+/// over the computed index first (dynamic), then applies `.a? = 9` as each
+/// branch's own static tail -- branch `0` (a scalar) must prune without
+/// disturbing branch `1` (an object, which resolves and writes normally).
+/// Verified against jq 1.7.1: the whole filter is a no-op here because both
+/// branches' writes are themselves no-ops (branch 0 prunes, branch 1's `.a`
+/// already holds `9`).
+#[test]
+fn test_optional_tail_after_dynamic_fanout_prunes_only_its_own_branch_2124() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[(0,1)].a? = 9"], Some(r#"[1, {"a":9}]"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,{\"a\":9}]\n");
+    Ok(())
+}
+
+/// #2124 regression guard: `path()` and `del()` were already correct for
+/// this shape before this fix (via #2049/#2108, unrelated code paths) --
+/// this pins that the shared `resolve_seq` fix doesn't disturb them.
+#[test]
+fn test_optional_comma_sibling_prune_still_correct_for_path_and_del_2124() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[path(.b, .c.a?)]"], Some(r#"{"c":1}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[[\"b\"]]\n");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "del(.b, .c.a?)"], Some(r#"{"c":1}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"c\":1}\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

**Retargeted from #2049 to #2124** — #2049 closed while this PR was in
flight, via an independent, narrower fix (#2108) merged from a
differently-named branch claiming the same issue (a duplicate-claim
collision the atomic branch-name lock doesn't catch across different
branch names -- see the issue's own comment thread). #2108's fix covers
del()'s crash correctly, and path() was already correct via unrelated
code. This PR's actual remaining scope, tracked as #2124, is =/|=.

resolve_seq's no-computed-key fast path (value_after_components) coerced a
?-suppressed step's genuinely-empty output into OwnedValue::Null instead of
pruning the whole branch. Every component reaching that loop is proven
single-valued by construction (needs_fanout_pass), so zero outputs can only
mean a ?-suppressed navigation failure -- the fix propagates that as "prune
this branch" (Option<OwnedValue>) instead of fabricating a resolved =/|=
write at a path the document doesn't actually have that shape at.

Two call sites needed the fix: resolve_seq's fully-static fast path, and
apply_static_tail's per-branch tail application (reached once a real
dynamic/computed element precedes the ?-guarded step in the same pipe).

## Test plan

- [x] cargo build --features cli
- [x] cargo test --features cli,simd,regex,serde (full suite, 0 failures)
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo fmt --check
- [x] All repros verified against the pinned oracle (/usr/bin/jq 1.7.1):
      =/|= for the comma-sibling shape, argument-order independence, a
      scalar-shape sweep, the dynamic-fanout-then-static-tail variant, and a
      regression check that path()/del() stay correct
- [x] New regression tests in tests/jq_cli_tests.rs covering all of the
      above

Fixes #2124