### PR TITLE
test(jq): fix cargo test --no-default-features build+run gaps (#2083)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41458,7 +41458,12 @@ mod tests {
     /// many thousands of levels -- prohibitively slow in a debug build --
     /// to actually reach `MAX_EVAL_FRAMES`; this white-box check reaches
     /// the same boundary in one call.
+    ///
+    /// `#[cfg(feature = "std")]`: `ambient_frame_depth` itself is a no-op
+    /// under `no_std` (see its own module doc comment) -- there is no
+    /// no_std variant of this mechanism to test.
     #[test]
+    #[cfg(feature = "std")]
     fn test_bind_def_seeds_defcall_frames_from_ambient_depth_1371() {
         let Expr::FuncDef {
             name,
@@ -41507,7 +41512,11 @@ mod tests {
     /// refused immediately once the ambient floor alone already meets the
     /// ceiling -- this is the guard actually firing, not just the frame
     /// count being recorded correctly (the test above).
+    ///
+    /// `#[cfg(feature = "std")]`: same reason as the test above -- the
+    /// ambient-depth mechanism this exercises doesn't exist under `no_std`.
     #[test]
+    #[cfg(feature = "std")]
     fn test_ambient_frame_depth_composes_with_defcall_guard_1371() {
         let Expr::FuncDef {
             name,
@@ -58044,11 +58053,15 @@ mod tests {
 
     #[test]
     fn test_dollar_env_field_access() {
-        // $ENV.VAR should return the environment variable value
+        // $ENV.VAR should return the environment variable value (std), or
+        // null in no_std context ($ENV is an empty object there, same as
+        // test_dollar_env's own std/no_std split).
+        #[cfg(feature = "std")]
         query!(b"null", "$ENV.PATH", QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", "$ENV.PATH", QueryResult::Owned(OwnedValue::Null) => {});
     }
 
     #[test]
@@ -58067,47 +58080,64 @@ mod tests {
     #[test]
     fn test_dollar_env_bracket_access() {
         // $ENV["PATH"] should also work
+        #[cfg(feature = "std")]
         query!(b"null", r#"$ENV["PATH"]"#, QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", r#"$ENV["PATH"]"#, QueryResult::Owned(OwnedValue::Null) => {});
     }
 
     #[test]
     fn test_env_var() {
-        // env(VAR) returns the environment variable value
-        // This test uses PATH which should always exist
+        // env(VAR) returns the environment variable value (std), or an
+        // EvalError in no_std context (no env vars are ever provided
+        // there). This test uses PATH which should always exist under std.
+        #[cfg(feature = "std")]
         query!(b"null", "env(PATH)", QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
+        });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", "env(PATH)", QueryResult::Error(e) => {
+            assert!(e.message.contains("no_std"), "expected no_std env error, got: {}", e.message);
         });
     }
 
     #[test]
     fn test_strenv() {
         // strenv(VAR) returns the environment variable value as string
+        // (std), or an EvalError in no_std context.
+        #[cfg(feature = "std")]
         query!(b"null", "strenv(PATH)", QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
+        });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", "strenv(PATH)", QueryResult::Error(e) => {
+            assert!(e.message.contains("no_std"), "expected no_std env error, got: {}", e.message);
         });
     }
 
     #[test]
     fn test_env_field_access() {
-        // env.VAR should return the environment variable value (like $ENV.VAR)
+        // env.VAR should return the environment variable value (like
+        // $ENV.VAR), or null in no_std context.
+        #[cfg(feature = "std")]
         query!(b"null", "env.PATH", QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", "env.PATH", QueryResult::Owned(OwnedValue::Null) => {});
     }
 
     #[test]
     fn test_env_bracket_access() {
         // env["PATH"] should also work (like $ENV["PATH"])
+        #[cfg(feature = "std")]
         query!(b"null", r#"env["PATH"]"#, QueryResult::Owned(OwnedValue::String(s)) => {
-            #[cfg(feature = "std")]
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
+        #[cfg(not(feature = "std"))]
+        query!(b"null", r#"env["PATH"]"#, QueryResult::Owned(OwnedValue::Null) => {});
     }
 
     #[test]
@@ -59969,6 +59999,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_parse_simple_tz_offset_errors_gracefully_on_overflow_894() {
         // #894: `hours * 3600`/`minutes * 60`/the final sign multiply were
         // unchecked, panicking on a malformed/adversarial `TZ` env var
@@ -64196,13 +64227,21 @@ mod tests {
 
     #[test]
     fn test_now() {
-        // now returns current Unix timestamp as a float
+        // now returns current Unix timestamp as a float (std), or a fixed
+        // 0.0 fallback in no_std context (builtin_now has no clock there).
+        #[cfg(feature = "std")]
         query!(b"null", "now",
             QueryResult::Owned(OwnedValue::Float(n)) => {
                 // Should be a reasonable Unix timestamp (after year 2020)
                 assert!(n > 1577836800.0, "timestamp should be after 2020");
                 // Should be before year 2100
                 assert!(n < 4102444800.0, "timestamp should be before 2100");
+            }
+        );
+        #[cfg(not(feature = "std"))]
+        query!(b"null", "now",
+            QueryResult::Owned(OwnedValue::Float(n)) => {
+                assert_eq!(n, 0.0, "now should fall back to 0.0 in no_std context");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41547,6 +41547,37 @@ mod tests {
         );
     }
 
+    /// `bind_def_call`'s own `frames >= MAX_EVAL_FRAMES` guard (the check
+    /// the two tests above exercise *composed with* `ambient_frame_depth`)
+    /// is itself unconditional, feature-independent code -- calling it
+    /// directly with a hand-built `frames` value, bypassing `bind_def`/
+    /// `ambient_frame_depth` entirely, reaches it under `no_std` too. Added
+    /// alongside #2083's `no_std` test-gating fixes: without this, no test
+    /// anywhere exercises this guard under `--no-default-features` (the
+    /// two tests above are `std`-only, and the CLI-level recursion tests in
+    /// `tests/jq_cli_tests.rs`/`tests/yq_cli_tests.rs` require the `cli`
+    /// feature, which pulls in `std`) -- a future regression in the guard
+    /// itself would go undetected in a no_std build.
+    #[test]
+    fn test_bind_def_call_guard_fires_without_ambient_depth_2083() {
+        let def = Rc::new(FuncDefData {
+            name: "f".to_string(),
+            params: vec![],
+            body: Expr::FuncCall {
+                name: "f".to_string(),
+                args: vec![],
+            },
+        });
+        let bound = BoundBody::default();
+        let err = bind_def_call(&def, &[], MAX_EVAL_FRAMES, &bound)
+            .expect_err("frames at the ceiling must refuse the call, not run it");
+        assert!(
+            err.message.contains("exceeded maximum recursion depth"),
+            "message: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn test_catch_error_under_optional_full_truth_table_1888() {
         type W = Vec<u64>;
@@ -58051,17 +58082,35 @@ mod tests {
         });
     }
 
+    /// Shared no_std assertion for the four `$ENV`/`env` field/bracket
+    /// accessors below: each falls back to `Null` under `no_std` (`$ENV`/
+    /// `env` are an empty object there, same as `test_dollar_env`'s own
+    /// std/no_std split).
+    #[cfg(not(feature = "std"))]
+    fn assert_env_field_access_null_in_no_std(expr: &str) {
+        query!(b"null", expr, QueryResult::Owned(OwnedValue::Null) => {});
+    }
+
+    /// Shared no_std assertion for `env(VAR)`/`strenv(VAR)` below: both
+    /// raise an `EvalError` mentioning `"no_std"` (no env vars are ever
+    /// provided there).
+    #[cfg(not(feature = "std"))]
+    fn assert_env_call_errors_in_no_std(expr: &str) {
+        query!(b"null", expr, QueryResult::Error(e) => {
+            assert!(e.message.contains("no_std"), "expected no_std env error, got: {}", e.message);
+        });
+    }
+
     #[test]
     fn test_dollar_env_field_access() {
         // $ENV.VAR should return the environment variable value (std), or
-        // null in no_std context ($ENV is an empty object there, same as
-        // test_dollar_env's own std/no_std split).
+        // null in no_std context.
         #[cfg(feature = "std")]
         query!(b"null", "$ENV.PATH", QueryResult::Owned(OwnedValue::String(s)) => {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", "$ENV.PATH", QueryResult::Owned(OwnedValue::Null) => {});
+        assert_env_field_access_null_in_no_std("$ENV.PATH");
     }
 
     #[test]
@@ -58085,22 +58134,20 @@ mod tests {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", r#"$ENV["PATH"]"#, QueryResult::Owned(OwnedValue::Null) => {});
+        assert_env_field_access_null_in_no_std(r#"$ENV["PATH"]"#);
     }
 
     #[test]
     fn test_env_var() {
         // env(VAR) returns the environment variable value (std), or an
-        // EvalError in no_std context (no env vars are ever provided
-        // there). This test uses PATH which should always exist under std.
+        // EvalError in no_std context. This test uses PATH which should
+        // always exist under std.
         #[cfg(feature = "std")]
         query!(b"null", "env(PATH)", QueryResult::Owned(OwnedValue::String(s)) => {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", "env(PATH)", QueryResult::Error(e) => {
-            assert!(e.message.contains("no_std"), "expected no_std env error, got: {}", e.message);
-        });
+        assert_env_call_errors_in_no_std("env(PATH)");
     }
 
     #[test]
@@ -58112,9 +58159,7 @@ mod tests {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", "strenv(PATH)", QueryResult::Error(e) => {
-            assert!(e.message.contains("no_std"), "expected no_std env error, got: {}", e.message);
-        });
+        assert_env_call_errors_in_no_std("strenv(PATH)");
     }
 
     #[test]
@@ -58126,7 +58171,7 @@ mod tests {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", "env.PATH", QueryResult::Owned(OwnedValue::Null) => {});
+        assert_env_field_access_null_in_no_std("env.PATH");
     }
 
     #[test]
@@ -58137,7 +58182,7 @@ mod tests {
             assert!(!s.is_empty(), "PATH should be non-empty");
         });
         #[cfg(not(feature = "std"))]
-        query!(b"null", r#"env["PATH"]"#, QueryResult::Owned(OwnedValue::Null) => {});
+        assert_env_field_access_null_in_no_std(r#"env["PATH"]"#);
     }
 
     #[test]
@@ -59998,6 +60043,9 @@ mod tests {
             QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(s, "167 23 24 24 2024 24"));
     }
 
+    // `#[cfg(feature = "std")]`: `parse_simple_tz_offset` itself is
+    // `std`-only (it exists solely to parse `std::env::var("TZ")`), so
+    // this test cannot compile under `no_std` at all.
     #[test]
     #[cfg(feature = "std")]
     fn test_parse_simple_tz_offset_errors_gracefully_on_overflow_894() {
@@ -64228,19 +64276,19 @@ mod tests {
     #[test]
     fn test_now() {
         // now returns current Unix timestamp as a float (std), or a fixed
-        // 0.0 fallback in no_std context (builtin_now has no clock there).
-        #[cfg(feature = "std")]
+        // 0.0 fallback in no_std context (builtin_now has no clock there) --
+        // same variant either way, so one query! call covers both, same as
+        // test_env/test_dollar_env above.
         query!(b"null", "now",
             QueryResult::Owned(OwnedValue::Float(n)) => {
-                // Should be a reasonable Unix timestamp (after year 2020)
-                assert!(n > 1577836800.0, "timestamp should be after 2020");
-                // Should be before year 2100
-                assert!(n < 4102444800.0, "timestamp should be before 2100");
-            }
-        );
-        #[cfg(not(feature = "std"))]
-        query!(b"null", "now",
-            QueryResult::Owned(OwnedValue::Float(n)) => {
+                #[cfg(feature = "std")]
+                {
+                    // Should be a reasonable Unix timestamp (after year 2020)
+                    assert!(n > 1577836800.0, "timestamp should be after 2020");
+                    // Should be before year 2100
+                    assert!(n < 4102444800.0, "timestamp should be before 2100");
+                }
+                #[cfg(not(feature = "std"))]
                 assert_eq!(n, 0.0, "now should fall back to 0.0 in no_std context");
             }
         );

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -17395,7 +17395,13 @@ mod tests {
     /// evaluator" wildcard arm) by driving the constructed `Expr::DefCall`
     /// straight through [`eval_each_with_cursor_using`], which calls
     /// `eval_each_generic` as its own entry point.
+    ///
+    /// `#[cfg(feature = "std")]`: reaches `MAX_EVAL_FRAMES` via the
+    /// ambient-depth guard (`eval.rs`'s `ambient_frame_depth` module),
+    /// which is a no-op under `no_std` by design -- there is no no_std
+    /// variant of this mechanism to test.
     #[test]
+    #[cfg(feature = "std")]
     fn eval_each_generic_reports_defcall_binding_failure_1371() {
         let Expr::FuncDef {
             name,

--- a/tests/jq_eval_using_input_queue_gate_test.rs
+++ b/tests/jq_eval_using_input_queue_gate_test.rs
@@ -12,6 +12,8 @@
 //! separate process) so it can't leak into any other test file's shared
 //! process or test-thread pool.
 
+#![cfg(feature = "std")]
+
 use succinctly::jq::eval_generic::eval_using;
 use succinctly::jq::{parse, seed_remaining_inputs, JqSemantics, OwnedValue};
 use succinctly::json::JsonIndex;

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -785,20 +785,19 @@ fn test_config_file_pattern() {
 #[test]
 fn test_now_returns_timestamp() {
     // now returns the current Unix timestamp as a float (std), or a fixed
-    // 0.0 fallback in no_std context (builtin_now has no clock there).
-    #[cfg(feature = "std")]
+    // 0.0 fallback in no_std context (builtin_now has no clock there) --
+    // same variant either way, so one query! call covers both.
     query!(b"null", "now",
         QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
-            // Verify it's a reasonable timestamp (after 2024-01-01 and not too far in the future)
-            let jan_2024 = 1704067200.0; // 2024-01-01 00:00:00 UTC
-            let jan_2100 = 4102444800.0; // 2100-01-01 00:00:00 UTC
-            assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
-            assert!(ts < jan_2100, "timestamp {ts} should be before 2100-01-01");
-        }
-    );
-    #[cfg(not(feature = "std"))]
-    query!(b"null", "now",
-        QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
+            #[cfg(feature = "std")]
+            {
+                // Verify it's a reasonable timestamp (after 2024-01-01 and not too far in the future)
+                let jan_2024 = 1704067200.0; // 2024-01-01 00:00:00 UTC
+                let jan_2100 = 4102444800.0; // 2100-01-01 00:00:00 UTC
+                assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
+                assert!(ts < jan_2100, "timestamp {ts} should be before 2100-01-01");
+            }
+            #[cfg(not(feature = "std"))]
             assert_eq!(ts, 0.0, "now should fall back to 0.0 in no_std context");
         }
     );
@@ -806,17 +805,16 @@ fn test_now_returns_timestamp() {
 
 #[test]
 fn test_now_ignores_input() {
-    // now ignores its input
-    #[cfg(feature = "std")]
+    // now ignores its input; no_std fallback is the same fixed 0.0 as
+    // test_now_returns_timestamp above.
     query!(br#"{"foo": "bar"}"#, "now",
         QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
-            let jan_2024 = 1704067200.0;
-            assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
-        }
-    );
-    #[cfg(not(feature = "std"))]
-    query!(br#"{"foo": "bar"}"#, "now",
-        QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
+            #[cfg(feature = "std")]
+            {
+                let jan_2024 = 1704067200.0;
+                assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
+            }
+            #[cfg(not(feature = "std"))]
             assert_eq!(ts, 0.0, "now should fall back to 0.0 in no_std context");
         }
     );

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -784,7 +784,9 @@ fn test_config_file_pattern() {
 
 #[test]
 fn test_now_returns_timestamp() {
-    // now returns the current Unix timestamp as a float
+    // now returns the current Unix timestamp as a float (std), or a fixed
+    // 0.0 fallback in no_std context (builtin_now has no clock there).
+    #[cfg(feature = "std")]
     query!(b"null", "now",
         QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
             // Verify it's a reasonable timestamp (after 2024-01-01 and not too far in the future)
@@ -794,15 +796,28 @@ fn test_now_returns_timestamp() {
             assert!(ts < jan_2100, "timestamp {ts} should be before 2100-01-01");
         }
     );
+    #[cfg(not(feature = "std"))]
+    query!(b"null", "now",
+        QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
+            assert_eq!(ts, 0.0, "now should fall back to 0.0 in no_std context");
+        }
+    );
 }
 
 #[test]
 fn test_now_ignores_input() {
     // now ignores its input
+    #[cfg(feature = "std")]
     query!(br#"{"foo": "bar"}"#, "now",
         QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
             let jan_2024 = 1704067200.0;
             assert!(ts > jan_2024, "timestamp {ts} should be after 2024-01-01");
+        }
+    );
+    #[cfg(not(feature = "std"))]
+    query!(br#"{"foo": "bar"}"#, "now",
+        QueryResult::Owned(succinctly::jq::OwnedValue::Float(ts)) => {
+            assert_eq!(ts, 0.0, "now should fall back to 0.0 in no_std context");
         }
     );
 }


### PR DESCRIPTION
## Summary
- `tests/jq_eval_using_input_queue_gate_test.rs` unconditionally imported `succinctly::jq::seed_remaining_inputs`, which is `#[cfg(feature = "std")]`-only in `src/jq/mod.rs` — gated the whole test file behind `#![cfg(feature = "std")]`.
- `src/jq/eval.rs`'s `test_parse_simple_tz_offset_errors_gracefully_on_overflow_894` called the `std`-only `parse_simple_tz_offset` with no matching gate — added `#[cfg(feature = "std")]`.
- Once those two build-blocking gaps were fixed, the full `--no-default-features` suite still failed at *runtime* on the same underlying shape: several `env`/`$ENV`/`now` tests assumed std-only results (a real value) unconditionally, when the no_std fallback intentionally returns `Null`/an `EvalError`/`0.0`. Split each into an `std` arm (existing assertion) and a `not(std)` arm (asserts the documented no_std fallback).
- Two more tests (`eval.rs`'s `test_bind_def_seeds_defcall_frames_from_ambient_depth_1371`/`test_ambient_frame_depth_composes_with_defcall_guard_1371`, and `eval_generic.rs`'s `eval_each_generic_reports_defcall_binding_failure_1371`) exercise the `ambient_frame_depth` mechanism, which is a documented no-op under `no_std` — gated all three behind `#[cfg(feature = "std")]` since there's no no_std variant of that mechanism to test.

Fixes #2083.

## Test plan
- [x] `cargo test --no-default-features --no-run` builds clean (previously failed with 2 unrelated compile errors)
- [x] `cargo test --no-default-features` passes fully (previously also failed at runtime on 10 more tests once compilation succeeded)
- [x] `cargo test --features cli,simd,regex,serde` passes fully (56/56 test groups ok)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` clean
- [x] Test-only change; no new production code paths, so no coverage gap introduced