### PR TITLE
fix(ci): refresh the x86_64 perf-guard baseline (ordinary drift, not #2012)

### DIFF
--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -8,11 +8,11 @@
     "wide_keys_unsorted": 289871551
   },
   "x86_64": {
-    "arrays_identity": 1506416474,
-    "users_identity": 375956384,
-    "users_keys_unsorted": 67388453,
-    "users_yq_keys_unsorted": 82548670,
-    "wide_identity": 742550939,
-    "wide_keys_unsorted": 351802447
+    "arrays_identity": 1602058719,
+    "users_identity": 397455066,
+    "users_keys_unsorted": 69246555,
+    "users_yq_keys_unsorted": 82479427,
+    "wide_identity": 775571299,
+    "wide_keys_unsorted": 373599725
   }
 }


### PR DESCRIPTION
## Summary

- `Perf Regression Guard (x86_64)` and `(ARM64-Linux)` have been failing on `main`'s own push-event commits (#2059) — `tests/data/perf-guard-baseline.json` had drifted 644 commits stale from when it was last updated.
- #2059's own suggested-fix-direction hypothesized attributing the drift to #2012's `--argjson`/`--jsonargs` work (~346 lines in `jq_runner.rs`), since the drift is uniform across every jq query and absent from the one yq query. **That hypothesis is disproven**: `cc6dcb9f6` — the commit immediately *before* #2012 started — already fails the same guard against the same checked-in baseline (confirmed live via `gh api .../check-runs`, not just trusting the issue's transcription). #2012 cannot be the cause of a failure that predates it.
- Given the guard's own module doc comment already documents this exact failure mode as expected ("at this project's merge cadence, `Ir` drifts 1-3% across every query within days from ordinary accumulated changes alone... baseline source commit vs. `main` 3 days/147 commits later"), and 644 commits at that rate would predict roughly 4-13% drift — comfortably bracketing the measured +2.8% to +6.3% — this reads as ordinary cumulative drift across many small changes, not a single-commit regression worth bisecting. A 644-commit `git bisect` chasing a single culprit that likely doesn't exist wasn't attempted.
- Measured live on `terminus` (pinned x86_64 box, Ryzen 9 7950X) via `valgrind --tool=cachegrind`, deterministic instruction counts (not wall-clock, so no A/B-interleaving discipline needed for this specific tool — see `scripts/perf-guard.py`'s own doc comment). Re-ran `--update-baseline`, confirmed 0.0% drift against the new numbers immediately after.
- **ARM64-Linux is intentionally left unfixed here.** `valgrind`/cachegrind has no Apple Silicon support (confirmed in `ci.yml`'s own comment), so my local ARM box (macOS) can't measure it, `nodes.yaml` has no Linux/ARM64 entry, and starting the EC2 Graviton node is a cost-incurring action reserved for explicit user request per this session's benchmark-machine policy — not something to trigger unilaterally. Filed as #2116 with the exact remaining command to run once ARM64 Linux + valgrind access is available.
- Also filed #2117: a structural fix (mirroring #1582's PR-relative `--baseline-binary` comparison onto `push` events too) that would prevent this exact staleness class from reaccumulating — out of scope for this data-only refresh.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (data-only change; confirmed no Rust code references this file — `scripts/perf-guard.py` is its only consumer)
- [x] Live-verified `cc6dcb9f6` (pre-#2012) already fails the guard, disproving the #2012 hypothesis
- [x] `python3 scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --check` on `terminus`: measured current drift (+2.8% to +6.3%, 2 failures) before this change
- [x] `python3 scripts/perf-guard.py --binary target/release/succinctly --arch x86_64 --update-baseline` then re-ran `--check`: confirmed 0.0% drift on every query after
- [x] `git diff` limited to the `x86_64` object only — `ARM64-Linux` untouched

Refs #2059 (this PR fixes the x86_64 half; ARM64-Linux tracked separately in #2116)