### PR TITLE
test(jq): gate two std-only test sites so --no-default-features builds

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -59891,6 +59891,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_parse_simple_tz_offset_errors_gracefully_on_overflow_894() {
         // #894: `hours * 3600`/`minutes * 60`/the final sign multiply were
         // unchecked, panicking on a malformed/adversarial `TZ` env var

--- a/tests/jq_eval_using_input_queue_gate_test.rs
+++ b/tests/jq_eval_using_input_queue_gate_test.rs
@@ -11,6 +11,11 @@
 //! thread's life -- kept to its own test binary (this file compiles to a
 //! separate process) so it can't leak into any other test file's shared
 //! process or test-thread pool.
+//!
+//! `seed_remaining_inputs` itself is `#[cfg(feature = "std")]` (`src/jq/mod.rs`),
+//! so this whole file compiles to nothing under `--no-default-features` (#2083).
+
+#![cfg(feature = "std")]
 
 use succinctly::jq::eval_generic::eval_using;
 use succinctly::jq::{parse, seed_remaining_inputs, JqSemantics, OwnedValue};


### PR DESCRIPTION
## Summary
- `tests/jq_eval_using_input_queue_gate_test.rs` unconditionally imports `succinctly::jq::seed_remaining_inputs`, which `src/jq/mod.rs` only re-exports under `#[cfg(feature = "std")]` — added a matching `#![cfg(feature = "std")]` to the whole file (its only purpose is exercising that function).
- `test_parse_simple_tz_offset_errors_gracefully_on_overflow_894` (`src/jq/eval.rs`) calls `parse_simple_tz_offset`, itself `#[cfg(feature = "std")]`-gated (TZ env var parsing), from an ungated `#[cfg(test)] mod tests` block — added a matching `#[cfg(feature = "std")]` on the test.
- Neither gap is reachable through this project's own documented local-verification commands (`cargo test`, `cargo test --features cli`, `cargo test --features large-tests`), which never exercise `--no-default-features` — confirmed both reproduce identically on unmodified `main`.
- Filed follow-up #2119: fixing these two build-breaking gaps exposes 10 pre-existing test failures once `cargo test --no-default-features` can actually run to completion — all genuine `std`-only assumptions in tests exercising already-`#[cfg(not(feature = "std"))]`-gated fallback code (`now`, `env`/`$ENV`/`strenv`, `ambient_frame_depth`), not new bugs, and out of scope for this issue's own repro (`--no-run`).

Fixes #2083

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo test --no-default-features --no-run` now succeeds (was: 2 compile errors)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` — no regression