### PR TITLE
docs: verify jq's heap-allocated VM stack claim against pinned 1.7.1 source (#2097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A non-terminating `def` still fails, now as a catchable error rather than the abort real
   jq produces for the same input. Deep recursion in a body that holds a lot of structure
-  live stops earlier than jq's heap-allocated VM stack does; both are recorded in
+  live stops earlier than jq's heap-allocated VM stack does (confirmed against jq 1.7.1's
+  source, not just its behavior — see ADR-0020); both are recorded in
   [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md).
 
 ### Added

--- a/docs/adrs/adr-0020.md
+++ b/docs/adrs/adr-0020.md
@@ -94,9 +94,13 @@ instead is a divergence in the only direction ADR-0018 permits — matching woul
 process down — and it is the property #1016 exists to preserve.
 
 **Deep recursion in a heavy body errors earlier than jq.** jq evaluates on a heap-allocated
-VM stack, so its depth does not depend on how much structure a body holds live; this
-evaluator recurses natively, so it does. The 40-array-constructor shape above stops at
-~900 levels where jq reaches 12,000+. Recorded in
+VM stack (confirmed against jq 1.7.1's source, not just its observable behavior:
+`exec_stack.h`'s `struct stack` grows via `realloc` through `jv_mem_realloc`, and
+`execute.c`'s `CALL_JQ` opcode pushes a frame onto it and continues the same
+bytecode-dispatch loop rather than recursing through a C function call), so its depth does
+not depend on how much structure a body holds live; this evaluator recurses natively, so
+it does. The 40-array-constructor shape above stops at ~900 levels where jq reaches
+12,000+. Recorded in
 [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
 
 **A self-recursive comma generator streams thousands of elements, not indefinitely.**

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1507,11 +1507,15 @@ Three differences remain, all in the direction of erroring rather than aborting:
   with `cannot allocate memory` and exit 134 (confirmed live). Divergence in the only
   direction ADR-0018 permits: matching would take the process down.
 - **A heavy body runs out of depth sooner than jq's does.** jq evaluates on a
-  heap-allocated VM stack, so its recursion depth is unaffected by how much structure a
-  body holds live across its own recursive call; this evaluator recurses natively, so it is
-  not. A body wrapping its call in 40 array constructors stops at ~900 levels where jq
-  reaches 12,000+. The ceiling counts live frames rather than calls precisely because the
-  two differ by 10x across body shapes — see `MAX_EVAL_FRAMES` (`src/jq/eval.rs`).
+  heap-allocated VM stack (confirmed against jq 1.7.1's source: `exec_stack.h`'s
+  `struct stack` grows via `realloc` through `jv_mem_realloc`, and `execute.c`'s
+  `CALL_JQ` opcode pushes a frame onto it and continues the same bytecode-dispatch loop
+  rather than recursing through a C function call), so its recursion depth is unaffected
+  by how much structure a body holds live across its own recursive call; this evaluator
+  recurses natively, so it is not. A body wrapping its call in 40 array constructors stops
+  at ~900 levels where jq reaches 12,000+. The ceiling counts live frames rather than
+  calls precisely because the two differ by 10x across body shapes — see
+  `MAX_EVAL_FRAMES` (`src/jq/eval.rs`).
 - **A recursively-built value can exceed `MAX_VALUE_TREE_DEPTH` (384) where jq has no such
   limit.** `def deep(m): if m == 0 then . else [[…]]deep(m-1)[[…]] end; deep(60)` builds
   1,200 levels; jq prints it, succinctly reports `nesting depth exceeds limit of 384` and


### PR DESCRIPTION
## Summary

Every neighboring divergence claim in ADR-0020's "Consequences" section and `docs/compliance/jq/limitations.md`'s corresponding entries is tagged "confirmed live" — except the claim that "jq evaluates on a heap-allocated VM stack, so its depth does not depend on how much structure a body holds live". That's an assertion about jq's C implementation, not something confirmable by running the CLI and reading output.

Verified directly against jq 1.7.1's own source (cloned at the pinned tag):
- `src/exec_stack.h`'s `struct stack` is grown via `stack_reallocate` → `jv_mem_realloc`, which is a thin wrapper around plain `realloc` (`src/jv_alloc.c`) — a real heap allocation, not the native C call stack.
- `src/execute.c`'s `CALL_JQ` opcode handler pushes a new frame onto that heap-backed stack via `frame_push`, then simply continues the same bytecode-dispatch `while` loop (`pc = new_frame->bc->code; break;`) — it does **not** recurse through a C function call. jq's own C call stack therefore never grows with jq-level recursion depth at all.

This confirms the claim is true, so I cited the verification the same way neighboring claims cite live CLI confirmation, in all three locations the issue named: `docs/adrs/adr-0020.md`, `docs/compliance/jq/limitations.md`, `CHANGELOG.md`.

Fixes #2097.

## Test plan
- [x] Docs-only change — no code paths touched
- [x] Verified against jq 1.7.1 source directly (not from memory, per CLAUDE.md's own rule)
- [x] `cargo build --features cli` still succeeds (no code changed)