### PR TITLE
ci: run cargo test, not just cargo check, on the no_std leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,9 +193,12 @@ jobs:
         if: needs.gate.outputs.code == 'true'
         run: cargo test --verbose --features simd,scalar-yaml
 
-      - name: Check no_std compatibility
+      # #2114: `cargo check` doesn't build test targets at all, so it never
+      # caught #2083 (a std-only symbol reachable from test code with no
+      # matching cfg gate) -- `cargo test` both builds and runs them.
+      - name: Check no_std compatibility (build + run tests)
         if: needs.gate.outputs.code == 'true'
-        run: cargo check --no-default-features
+        run: cargo test --no-default-features --verbose
 
   test-arm:
     name: Test (ARM64)
@@ -437,8 +440,11 @@ jobs:
       - name: Run tests (portable-popcount feature)
         run: cargo test --verbose --features portable-popcount
 
-      - name: Check no_std compatibility
-        run: cargo check --no-default-features
+      # #2114: `cargo check` doesn't build test targets at all, so it never
+      # caught #2083 (a std-only symbol reachable from test code with no
+      # matching cfg gate) -- `cargo test` both builds and runs them.
+      - name: Check no_std compatibility (build + run tests)
+        run: cargo test --no-default-features --verbose
 
   # Skipped on `merge_group` (#310): a 3-arch `cargo bench` fan-out is far too
   # slow to run per queue entry, and it gates nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,9 +440,7 @@ jobs:
       - name: Run tests (portable-popcount feature)
         run: cargo test --verbose --features portable-popcount
 
-      # #2114: `cargo check` doesn't build test targets at all, so it never
-      # caught #2083 (a std-only symbol reachable from test code with no
-      # matching cfg gate) -- `cargo test` both builds and runs them.
+      # Same no_std cargo-test rationale as test-x86 (#2114).
       - name: Check no_std compatibility (build + run tests)
         run: cargo test --no-default-features --verbose
 


### PR DESCRIPTION
## Summary
- Both "Check no_std compatibility" CI steps (`Test (x86_64)` and `Test (macOS ARM64)` jobs) ran `cargo check --no-default-features`, which doesn't build test targets at all — so this leg could never have caught #2083 (a `std`-only symbol reachable from test code with no matching `#[cfg]` gate). `main`'s no_std CI stayed green the entire time that bug was live.
- Switched both to `cargo test --no-default-features --verbose`, matching every other feature-combo step in these same jobs (`cargo test --verbose --features ...`) — catches both compile-time gaps (like #2083's original two) and runtime std-only assumptions (like the `now`/`env`/`ambient_frame_depth` test fixes #2083's PR #2113 also had to make, once the build gap was closed and those became visible).
- Renamed the step to "Check no_std compatibility (build + run tests)" to reflect what it now actually does.
- Confirmed via `actionlint` that the pre-existing shellcheck warning in this file (line 587/581) is unrelated and present on unmodified `main` too.

Fixes #2114

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML is valid
- [x] `actionlint .github/workflows/ci.yml` — no new findings (pre-existing shellcheck warning unrelated, confirmed present on `main` too)
- [x] `cargo test --no-default-features` (the exact command the new CI step now runs) — 3155 passed, 0 failed, locally, confirming it's green before landing a workflow change that every future PR depends on