### PR TITLE
fix(jq): yq del() no-ops a field/index key on a scalar root

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32985,6 +32985,7 @@ fn delete_paths_sorted(
     mut value: OwnedValue,
     paths: &[&[OwnedValue]],
     start: usize,
+    yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     debug_assert!(
         paths.iter().all(|p| p.len() > start),
@@ -33005,11 +33006,11 @@ fn delete_paths_sorted(
         if paths[i].len() == start + 1 {
             del_keys.push(key);
         } else {
-            value = delete_paths_under(value, key, &paths[i..j], start + 1)?;
+            value = delete_paths_under(value, key, &paths[i..j], start + 1, yq_mode)?;
         }
         i = j;
     }
-    delete_keys(value, &del_keys)
+    delete_keys(value, &del_keys, yq_mode)
 }
 
 /// Recurse into the child of `value` under `key`. A key that names nothing is
@@ -33019,6 +33020,7 @@ fn delete_paths_under(
     key: &OwnedValue,
     paths: &[&[OwnedValue]],
     start: usize,
+    yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     match value {
         OwnedValue::Object(mut entries) => match key {
@@ -33028,7 +33030,7 @@ fn delete_paths_under(
                     // jq leaves an existing key where it was, and `IndexMap`
                     // would move it to the end after a `shift_remove`.
                     let old = core::mem::replace(slot, OwnedValue::Null);
-                    *slot = delete_paths_sorted(old, paths, start)?;
+                    *slot = delete_paths_sorted(old, paths, start, yq_mode)?;
                 }
                 Ok(OwnedValue::Object(entries))
             }
@@ -33044,7 +33046,8 @@ fn delete_paths_under(
             OwnedValue::Object(desc) => {
                 let range = SliceBounds::from_descriptor(desc)?.resolve(arr.len());
                 let sub = OwnedValue::Array(arr[range.clone()].to_vec());
-                let OwnedValue::Array(items) = delete_paths_sorted(sub, paths, start)? else {
+                let OwnedValue::Array(items) = delete_paths_sorted(sub, paths, start, yq_mode)?
+                else {
                     unreachable!("deleting from an array yields an array")
                 };
                 arr.splice(range, items);
@@ -33053,7 +33056,7 @@ fn delete_paths_under(
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
                 if let Some(index) = resolve_read_index(key, arr.len()) {
                     let old = core::mem::replace(&mut arr[index], OwnedValue::Null);
-                    arr[index] = delete_paths_sorted(old, paths, start)?;
+                    arr[index] = delete_paths_sorted(old, paths, start, yq_mode)?;
                 }
                 Ok(OwnedValue::Array(arr))
             }
@@ -33064,6 +33067,14 @@ fn delete_paths_under(
         // jq reads the child with `jv_get`: a `null` is skipped, and any other
         // scalar is `Cannot index <type> with <key>`.
         OwnedValue::Null => Ok(OwnedValue::Null),
+        // #2106 (delpaths half): real yq no-ops a delpaths() path component
+        // against a genuine scalar root, the same way `del()` does -- an
+        // array root still errors below, matching `is_yq_field_index_noop_scalar`'s
+        // established scalar-vs-array distinction (delpaths_one's own
+        // upfront validation already rejects any non-string/int component in
+        // yq mode, so `key` here is never a slice descriptor when
+        // `yq_mode` is true).
+        other if yq_mode && is_yq_field_index_noop_scalar(&other) => Ok(other),
         other => Err(EvalError::cannot_index(other.type_name(), key)),
     }
 }
@@ -33072,7 +33083,11 @@ fn delete_paths_under(
 /// pass. Keys naming nothing are ignored, and every array index resolves
 /// against the length the array had on entry, so one deletion cannot shift the
 /// array under its siblings.
-fn delete_keys(value: OwnedValue, keys: &[&OwnedValue]) -> Result<OwnedValue, EvalError> {
+fn delete_keys(
+    value: OwnedValue,
+    keys: &[&OwnedValue],
+    yq_mode: bool,
+) -> Result<OwnedValue, EvalError> {
     if keys.is_empty() {
         return Ok(value);
     }
@@ -33148,6 +33163,14 @@ fn delete_keys(value: OwnedValue, keys: &[&OwnedValue]) -> Result<OwnedValue, Ev
         // `null` has no fields to begin with, so deleting one is a no-op —
         // jq agrees. Every other scalar is `Cannot delete fields from <type>`.
         OwnedValue::Null => Ok(OwnedValue::Null),
+        // #2106 (delpaths half): real yq no-ops a delpaths() terminal
+        // deletion against a genuine scalar root too (reached for a
+        // single-component path, e.g. `2.5 | delpaths([["k0"]])`), the same
+        // `is_yq_field_index_noop_scalar` rule as `delete_paths_under`'s own
+        // mid-chain catch-all above -- an array root still errors below (it
+        // has its own dedicated `OwnedValue::Array` arm, never reaching
+        // here).
+        other if yq_mode && is_yq_field_index_noop_scalar(&other) => Ok(other),
         other => Err(EvalError::cannot_delete_fields_from(other.type_name())),
     }
 }
@@ -33811,7 +33834,7 @@ fn delete_trie_object(
         .collect();
     if !doomed.is_empty() {
         let key_refs: Vec<&OwnedValue> = doomed.iter().collect();
-        value = delete_keys(value, &key_refs)?;
+        value = delete_keys(value, &key_refs, yq_mode)?;
     }
 
     Ok(value)
@@ -33874,8 +33897,17 @@ fn delete_trie_array(
         // with number`), so this is gated to yq mode only, unlike
         // `delete_trie_object`'s sibling no-op above (which real jq's own
         // earlier `resolve_node` validation already keeps this function
-        // from ever seeing in a way that would need to differ).
-        if yq_mode && is_yq_field_index_noop_scalar(&value) {
+        // from ever seeing in a way that would need to differ). Scoped to
+        // `ArrayStep::Index` specifically, not `Slice` -- succinctly's
+        // parser currently rejects mixing a slice with any other step
+        // inside one computed multi-branch group, so a `Slice` step can
+        // never actually reach here today, but real yq's own behaviour for
+        // that (unreachable) shape is a hard arity error even against a
+        // scalar root ("expected to find 1 number, got 2 instead",
+        // confirmed live), not a no-op -- narrowing here keeps that
+        // correct if the parser gap ever closes, rather than silently
+        // no-oping a case real yq still rejects.
+        if yq_mode && matches!(step, ArrayStep::Index(_)) && is_yq_field_index_noop_scalar(&value) {
             return Ok(value);
         }
         return Err(match step {
@@ -33944,7 +33976,7 @@ fn delete_trie_array(
         .collect();
     if !doomed.is_empty() {
         let key_refs: Vec<&OwnedValue> = doomed.iter().collect();
-        value = delete_keys(value, &key_refs)?;
+        value = delete_keys(value, &key_refs, yq_mode)?;
     }
 
     Ok(value)
@@ -38034,7 +38066,8 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let result = match paths.first() {
         None => to_owned_checked(value),
         Some([]) => Ok(OwnedValue::Null),
-        Some(_) => to_owned_checked(value).and_then(|v| delete_paths_sorted(v, &paths, 0)),
+        Some(_) => to_owned_checked(value)
+            .and_then(|v| delete_paths_sorted(v, &paths, 0, S::TAG == EvalTag::Yq)),
     };
     match result {
         Ok(v) => QueryResult::Owned(v),
@@ -66651,6 +66684,30 @@ mod tests {
         let err = delete_trie_array(OwnedValue::Bool(true), &trie, DELETE_TRIE_ROOT, false)
             .expect_err("not an array");
         assert_eq!(err.message, "Cannot index boolean with object");
+    }
+
+    /// #2106: `delete_trie_array`'s new yq-mode scalar no-op is gated on the
+    /// failing step being `ArrayStep::Index`, not just on `value`'s own
+    /// shape -- called directly (bypassing the parser, which currently
+    /// rejects mixing a `Slice` step with any other step inside one
+    /// computed multi-branch group, so this exact input has no live CLI
+    /// repro today) to pin that a `Slice` step still errors under
+    /// `yq_mode: true` rather than silently no-oping a shape real yq itself
+    /// treats as a hard arity error, not a no-op.
+    #[test]
+    fn test_delete_trie_array_yq_mode_noop_scoped_to_index_step_2106() {
+        let index_trie = one_step_trie(Expr::Index(0));
+        let value = delete_trie_array(OwnedValue::Int(5), &index_trie, DELETE_TRIE_ROOT, true)
+            .expect("index step scalar no-op in yq mode");
+        assert_eq!(value, OwnedValue::Int(5));
+
+        let slice_trie = one_step_trie(Expr::Slice {
+            start: Some(1),
+            end: Some(3),
+        });
+        let err = delete_trie_array(OwnedValue::Int(5), &slice_trie, DELETE_TRIE_ROOT, true)
+            .expect_err("slice step must still error even in yq mode");
+        assert_eq!(err.message, "Cannot index number with object");
     }
 
     // #694: `collect_owned()`/`eval_owned_multi` silently dropped a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33691,6 +33691,7 @@ fn delete_trie_apply(
     mut value: OwnedValue,
     trie: &DeleteTrie,
     id: u32,
+    yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     let node = trie.node(id);
     // The pre-#1690 `delete_expr_paths_at`'s `paths.is_empty()` guard. Only the root can
@@ -33711,12 +33712,13 @@ fn delete_trie_apply(
     // computed key that skips `resolve_node`'s validation (#2049) can
     // populate both maps against a non-null scalar root too -- the fields
     // arm no-ops through it (below), and the indices arm raises its own
-    // type-mismatch error.
+    // type-mismatch error (a genuine yq-mode gap for a scalar root, #2106 --
+    // `yq_mode` threaded through both trie walks for exactly that arm).
     if !node.fields.is_empty() {
-        value = delete_trie_object(value, trie, id)?;
+        value = delete_trie_object(value, trie, id, yq_mode)?;
     }
     if !node.indices.is_empty() {
-        value = delete_trie_array(value, trie, id)?;
+        value = delete_trie_array(value, trie, id, yq_mode)?;
     }
     Ok(value)
 }
@@ -33731,7 +33733,12 @@ fn delete_trie_apply(
 /// `DeleteStep` shape that is not `null`-tolerant (the way `.[]` is not,
 /// #527) would otherwise silently skip validation here instead of raising.
 fn delete_trie_through_absent(trie: &DeleteTrie, id: u32) -> Result<(), EvalError> {
-    let deleted = delete_trie_apply(OwnedValue::Null, trie, id)?;
+    // `yq_mode` doesn't matter here: the value is always a synthetic `Null`,
+    // and this function's own doc comment already establishes every arm it
+    // can reach is `null`-tolerant regardless of mode -- `false` never
+    // reaches `delete_trie_array`'s new yq-mode gate (#2106), which only
+    // fires for a genuine scalar, never `Null`.
+    let deleted = delete_trie_apply(OwnedValue::Null, trie, id, false)?;
     debug_assert!(
         matches!(deleted, OwnedValue::Null),
         "deleting through a synthetic null produced a value to write back"
@@ -33744,6 +33751,7 @@ fn delete_trie_object(
     mut value: OwnedValue,
     trie: &DeleteTrie,
     id: u32,
+    yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     let node = trie.node(id);
     // `null` tolerates any field key unconditionally — `null | del(.a)` is
@@ -33787,7 +33795,7 @@ fn delete_trie_object(
         match entries.get_mut(name.as_str()) {
             Some(target) => {
                 let old = core::mem::replace(target, OwnedValue::Null);
-                *target = delete_trie_apply(old, trie, child)?;
+                *target = delete_trie_apply(old, trie, child, yq_mode)?;
             }
             // A field the object doesn't have is a dead end, not an error
             // (#527) — and the tail decides whether it stays one.
@@ -33814,6 +33822,7 @@ fn delete_trie_array(
     mut value: OwnedValue,
     trie: &DeleteTrie,
     id: u32,
+    yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     let node = trie.node(id);
     // Same per-step `null` exemption as `delete_trie_object` — applies to a
@@ -33857,6 +33866,18 @@ fn delete_trie_array(
             .indices
             .get_index(0)
             .expect("caller checked indices is non-empty");
+        // #2106: real yq no-ops an index key against a genuine scalar root
+        // (`2.5 | del(.[(0,1)])` stays `2.5`), matching the same
+        // `is_yq_field_index_noop_scalar` rule `delete_at_path`'s `Index`
+        // arm already applies for a non-comma path -- confirmed live that
+        // real jq still errors on this exact input (`Cannot index number
+        // with number`), so this is gated to yq mode only, unlike
+        // `delete_trie_object`'s sibling no-op above (which real jq's own
+        // earlier `resolve_node` validation already keeps this function
+        // from ever seeing in a way that would need to differ).
+        if yq_mode && is_yq_field_index_noop_scalar(&value) {
+            return Ok(value);
+        }
         return Err(match step {
             ArrayStep::Slice(..) if matches!(value, OwnedValue::String(_)) => {
                 EvalError::cannot_delete_fields_from("string")
@@ -33882,7 +33903,7 @@ fn delete_trie_array(
                         Some(actual) => {
                             let target = &mut arr[actual];
                             let old = core::mem::replace(target, OwnedValue::Null);
-                            *target = delete_trie_apply(old, trie, child)?;
+                            *target = delete_trie_apply(old, trie, child, yq_mode)?;
                         }
                         // An out-of-range index names nothing to delete
                         // through, so `delpaths` silently skips the step
@@ -33897,7 +33918,8 @@ fn delete_trie_array(
                 ArrayStep::Slice(s, e) => {
                     let range = SliceBounds::from_literals(*s, *e).resolve(arr.len());
                     let sub = OwnedValue::Array(arr[range.clone()].to_vec());
-                    let OwnedValue::Array(items) = delete_trie_apply(sub, trie, child)? else {
+                    let OwnedValue::Array(items) = delete_trie_apply(sub, trie, child, yq_mode)?
+                    else {
                         unreachable!("deleting from an array yields an array")
                     };
                     arr.splice(range, items);
@@ -34144,7 +34166,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Releases the borrow the branches hold on `result`, so the apply
         // walk below can take it by value.
         drop(resolved);
-        return match delete_trie_apply(result, &trie, DELETE_TRIE_ROOT) {
+        return match delete_trie_apply(result, &trie, DELETE_TRIE_ROOT, S::TAG == EvalTag::Yq) {
             Ok(result) => QueryResult::Owned(result),
             Err(_) if optional => QueryResult::None,
             Err(e) => e.into(),
@@ -34284,6 +34306,11 @@ fn delete_at_path(
             // `null` (#476).
             OwnedValue::Null => Ok(()),
             _ if optional => Ok(()),
+            // #2106: real yq no-ops a field key against a genuine scalar
+            // root (`2.5 | del(.k0)` stays `2.5`) — an array root still
+            // errors (`is_yq_field_index_noop_scalar` excludes it),
+            // matching real yq's own `cannot index array with 'k0'`.
+            _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
             _ => Err(EvalError::cannot_index_with_field(
                 owned_type_name(root),
                 name,
@@ -34302,6 +34329,9 @@ fn delete_at_path(
             // no-op — `null | del(.[0])` is `null` (#476).
             OwnedValue::Null => Ok(()),
             _ if optional => Ok(()),
+            // #2106: same scalar no-op as the `Field` arm above, for an
+            // index key (`2.5 | del(.[0])` stays `2.5` in real yq).
+            _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
             _ => Err(EvalError::cannot_index_with_type(
                 owned_type_name(root),
                 "number",
@@ -34388,6 +34418,13 @@ fn delete_at_path(
                         // (#527).
                         OwnedValue::Null => delete_at_path_through_absent(&rest, optional, yq_mode),
                         _ if here => Ok(()),
+                        // #2106: a mid-chain field step into a genuine
+                        // scalar no-ops the whole remaining chain in yq
+                        // mode (`2.5 | del(.[("k0","k1")].b)` stays `2.5`)
+                        // — there is nothing left to navigate into, so
+                        // `rest` is moot, same as the terminal `Field` arm
+                        // above.
+                        _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
                         _ => Err(EvalError::cannot_index_with_field(
                             owned_type_name(root),
                             name,
@@ -34415,6 +34452,9 @@ fn delete_at_path(
                         // `null | del(.[0][])` still raises (#527).
                         OwnedValue::Null => delete_at_path_through_absent(&rest, optional, yq_mode),
                         _ if here => Ok(()),
+                        // #2106: same mid-chain scalar no-op as `Field`
+                        // above, for an index step.
+                        _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
                         _ => Err(EvalError::cannot_index_with_type(
                             owned_type_name(root),
                             "number",
@@ -66577,7 +66617,7 @@ mod tests {
             idx: 2,
             key: NumberKey::Literal(2.0, "2.0".into()),
         });
-        let err = delete_trie_array(OwnedValue::Int(5), &trie, DELETE_TRIE_ROOT)
+        let err = delete_trie_array(OwnedValue::Int(5), &trie, DELETE_TRIE_ROOT, false)
             .expect_err("not an array");
         assert_eq!(err.message, "Cannot index number with number");
     }
@@ -66599,11 +66639,16 @@ mod tests {
             start_key: Some(NumberKey::Literal(1.0, "1.0".into())),
             end_key: None,
         });
-        let err = delete_trie_array(OwnedValue::String("hi".into()), &trie, DELETE_TRIE_ROOT)
-            .expect_err("not an array");
+        let err = delete_trie_array(
+            OwnedValue::String("hi".into()),
+            &trie,
+            DELETE_TRIE_ROOT,
+            false,
+        )
+        .expect_err("not an array");
         assert_eq!(err.message, "Cannot delete fields from string");
 
-        let err = delete_trie_array(OwnedValue::Bool(true), &trie, DELETE_TRIE_ROOT)
+        let err = delete_trie_array(OwnedValue::Bool(true), &trie, DELETE_TRIE_ROOT, false)
             .expect_err("not an array");
         assert_eq!(err.message, "Cannot index boolean with object");
     }
@@ -67684,7 +67729,7 @@ mod tests {
         assert!(trie.root_is_terminal());
         // ... and the empty walk itself is still a clean no-op, not a panic:
         // `terminal` is never consulted by the node it sits on.
-        match delete_trie_apply(OwnedValue::Null, &trie, DELETE_TRIE_ROOT) {
+        match delete_trie_apply(OwnedValue::Null, &trie, DELETE_TRIE_ROOT, false) {
             Ok(OwnedValue::Null) => {}
             other => panic!("expected Ok(Null), got {other:?}"),
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20220,6 +20220,63 @@ fn test_del_field_and_index_key_noop_on_scalar_root_2106() -> Result<()> {
     Ok(())
 }
 
+/// #2106 (delpaths half): `delpaths()` is a completely separate
+/// implementation from `del()` (`delete_paths_sorted`/`delete_paths_under`/
+/// `delete_keys`, not `delete_at_path`/`delete_trie_*`), and the codebase's
+/// own comments treat the two as meant to share semantics -- fixing only
+/// `del()` would have left a fresh divergence (`del(.k0)` no-ops but
+/// `delpaths([["k0"]])` still errors, on the exact same input) where the two
+/// used to agree, if only by both being wrong.
+#[test]
+fn test_delpaths_noop_on_scalar_root_2106() -> Result<()> {
+    for scalar in ["2.5", "0", r#""a""#, "true", "false"] {
+        // Terminal single-component path (field-shaped key).
+        let (out, code) = run_yq_stdin(r#"delpaths([["k0"]])"#, scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "delpaths field key, scalar root {scalar}: {out}");
+        assert_eq!(
+            out.trim(),
+            scalar,
+            "delpaths field key, scalar root {scalar}"
+        );
+
+        // Terminal single-component path (index-shaped key).
+        let (out, code) = run_yq_stdin(r"delpaths([[0]])", scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "delpaths index key, scalar root {scalar}: {out}");
+        assert_eq!(
+            out.trim(),
+            scalar,
+            "delpaths index key, scalar root {scalar}"
+        );
+    }
+
+    // A mid-chain scalar (`delete_paths_under`'s own catch-all) no-ops the
+    // whole remaining path too, matching `del(.a.b)`'s equivalent shape.
+    let (out, code) = run_yq_stdin(
+        r#"delpaths([["a","b"]])"#,
+        r#"{"a": 5}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "delpaths nested field, scalar mid-chain: {out}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // An array root still errors, same as `del()`'s equivalent shape.
+    let (_out, code) = run_yq_stdin(r#"delpaths([["k0"]])"#, "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1, "array root must still error for delpaths");
+
+    // jq mode is unaffected -- real jq still errors here (confirmed live).
+    let (_output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").arg(r#"delpaths([["k0"]])"#);
+            command
+        },
+        Some(b"2.5"),
+    )?;
+    assert_eq!(code, 5, "jq mode must still error on a scalar root");
+
+    Ok(())
+}
+
 /// del()'s parent-key rule also applies when the resolved path fans out
 /// into more than one target (a top-level comma, or a computed key with
 /// multiple values) — the multi-path delete walk never sees the original

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20153,16 +20153,69 @@ fn test_1690_del_multi_branch_computed_key_over_scalar_root_2049() -> Result<()>
     }
 
     // Mixed key kinds (string + number): the field-group half of the trie
-    // walk still no-ops per the fix above, but the numeric key also
-    // populates the trie's *index* group, which then reaches
-    // `delete_trie_array`'s own pre-existing, deliberate non-array gate —
-    // a different, out-of-scope-for-#2049 typed-error path (real yq no-ops
-    // here too, but matching that is a broader change than removing this
-    // issue's `unreachable!()`). The fix's actual contract for this shape is
-    // narrower: no longer a process abort, exit 101 -> a catchable error.
+    // walk no-ops per the fix above, and the numeric key also populates the
+    // trie's *index* group, which used to reach `delete_trie_array`'s own
+    // non-array gate and raise a catchable error instead of the crash this
+    // test originally pinned -- #2106 closed that remaining gap too
+    // (`delete_trie_array` now threads `yq_mode` and no-ops there the same
+    // way, matching real yq's own no-op for this exact input, confirmed
+    // live).
     let (out, code) = run_yq_stdin(r#"del(.[("k0",0)])"#, "2.5", &["-o=json", "-I=0"])?;
-    assert_ne!(code, 101, "must not crash the process: {out}");
-    assert_eq!(code, 1, "expected a catchable error, got: {out}");
+    assert_eq!(code, 0, "must not crash or error: {out}");
+    assert_eq!(out.trim(), "2.5");
+
+    Ok(())
+}
+
+/// #2106: real yq no-ops `del()`'s field/index key against a genuine scalar
+/// root (number/string/bool) -- static, single-branch-computed, and
+/// multi-branch-computed alike -- while an *array* root still errors, same
+/// as a plain read. Live-verified against yq v4.53.3 for every shape below;
+/// `#2049` fixed the crash for the multi-branch-computed-field-key case but
+/// left the far more common static/single-computed/index shapes (and the
+/// multi-branch case's own *index* half) still raising a catchable error
+/// instead of no-oping.
+#[test]
+fn test_del_field_and_index_key_noop_on_scalar_root_2106() -> Result<()> {
+    for scalar in ["2.5", "0", r#""a""#, "true", "false"] {
+        // Static field key.
+        let (out, code) = run_yq_stdin("del(.k0)", scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "static field key, scalar root {scalar}: {out}");
+        assert_eq!(out.trim(), scalar, "static field key, scalar root {scalar}");
+
+        // Single computed field key.
+        let (out, code) = run_yq_stdin(r#"del(.["k0"])"#, scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "computed field key, scalar root {scalar}: {out}");
+        assert_eq!(
+            out.trim(),
+            scalar,
+            "computed field key, scalar root {scalar}"
+        );
+
+        // Index key.
+        let (out, code) = run_yq_stdin("del(.[0])", scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "index key, scalar root {scalar}: {out}");
+        assert_eq!(out.trim(), scalar, "index key, scalar root {scalar}");
+
+        // Multi-branch computed index key.
+        let (out, code) = run_yq_stdin("del(.[(0,1)])", scalar, &["-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 0,
+            "multi-branch index key, scalar root {scalar}: {out}"
+        );
+        assert_eq!(
+            out.trim(),
+            scalar,
+            "multi-branch index key, scalar root {scalar}"
+        );
+    }
+
+    // An array root still errors for a field key (matching real yq's
+    // "cannot index array with 'k0'", confirmed live) -- this predicate
+    // (`is_yq_field_index_noop_scalar`) deliberately excludes arrays, unlike
+    // every genuine scalar above.
+    let (_out, code) = run_yq_stdin("del(.k0)", "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1, "array root must still error for a field key");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Real yq (v4.53.3) no-ops `del()`'s field/index key against a genuine scalar (number/string/bool) root — static, single-branch computed, and multi-branch computed alike — returning the document unchanged rather than raising. An *array* root still correctly errors (matching real yq's own `cannot index array with 'k0'`).
- `#2049` fixed the crash for the narrower multi-branch-computed-*field*-on-scalar shape (an `unreachable!()` → catchable error), but left the far more common static/single-computed/index shapes, and the multi-branch shape's own *index* half, still raising instead of no-oping. Live-verified every shape against the pinned oracle before and after.
- Fix threads `yq_mode: bool` through `delete_at_path`'s `Field`/`Index` arms (both terminal and mid-chain) and through `delete_trie_apply`/`delete_trie_object`/`delete_trie_array` — `del()`'s own dedicated walkers, reached only *after* `resolve_node`'s earlier validation already succeeded. Deliberately does **not** touch the shared `resolve_node`/`eval_owned_fast_path`/`eval_generic.rs::eval_single` machinery `path()`/`=`/`|=`/plain reads also use — that's a much higher-blast-radius change, out of scope here (see #2125).
- Reuses `is_yq_field_index_noop_scalar`, the existing predicate assignment's own `#1181`/`#1920` yq no-op fix already established for exactly this scalar-vs-array distinction — no new predicate invented.
- Two shapes from the same investigation remain open, each filed separately since they need their own dedicated fix rather than an extension of this one: #2125 (a nested field behind a multi-branch computed key still errors — reaches `resolve_node`'s validation before `del()`'s own walkers ever run) and #2126 (`null`'s own materialization differs between dotted and bracket key syntax — an unrelated mechanism, not a scalar-type question at all).

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite — 3231 lib tests + every integration suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed every fixed shape's output against the pinned yq v4.53.3 oracle directly (static field key, single-computed field key, index key, mixed multi-branch key, pure-index multi-branch key — across number/string/bool/array roots)
- [x] Updated `test_1690_del_multi_branch_computed_key_over_scalar_root_2049`, which had explicitly pinned the old (now-fixed) catchable-error behavior for the mixed-key shape, to assert the new no-op instead
- [x] Added `test_del_field_and_index_key_noop_on_scalar_root_2106` covering all newly-fixed shapes across every scalar type, plus the array-still-errors regression check

Fixes #2106