### PR TITLE
fix(jq): give first(f)/last(f) a path-context arm (#2074)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31341,9 +31341,7 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 QueryResult::Error(e) => QueryResult::Error(e),
                 QueryResult::Break(label) => QueryResult::Break(label),
                 QueryResult::Halt(code) => QueryResult::Halt(code),
-                QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
-                QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
-                QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
+                QueryResult::Partial(_, control) => control_to_result(control),
                 QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
                     unreachable!(
                         "eval_pipe_with_path_context_internal only ever produces \

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -807,13 +807,12 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
-        // No `Expr::FirstExpr`/`Expr::LastExpr` arm, and no matching arm in
-        // `eval_pipe_with_path_context_internal` either, so `first(key)` and
-        // `last(key)` silently answer `null` where the sibling
-        // `limit(1; key)` answers correctly (#2074). Both halves are needed
-        // to close it -- the same pairing `Label` (#715) and `FuncDef`
-        // (#1306) each required -- so it is tracked rather than half-fixed
-        // here.
+        // `first(expr)`/`last(expr)` (#2074): same reasoning as `Limit`
+        // above -- whatever the wrapped expression needs, the wrapper
+        // needs too. Paired with matching arms in
+        // `eval_pipe_with_path_context_internal` below, the same pairing
+        // `Label` (#715) and `FuncDef` (#1306) each required.
+        Expr::FirstExpr(inner) | Expr::LastExpr(inner) => needs_path_context(inner),
         Expr::Comma(exprs) => exprs.iter().any(needs_path_context),
         // `[key]`/`[parent]`/`[file_index]` (#1302): an array literal is
         // still just "collect this inner expression's outputs", the same
@@ -31237,6 +31236,133 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
             continue_rest_with_context::<W, S>(
                 limited,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        // `first(expr)` (#2074): the same shape as `Expr::Limit { n: 1,
+        // expr }` above -- eagerly evaluate `expr` through this evaluator
+        // (trading #820's stop-early optimization for correctness, same
+        // accepted cost as `Limit`'s own arm), then take the first output.
+        // A `Partial` with at least one output already reached is still
+        // satisfied (first can short-circuit once satisfied, same as
+        // `Limit`'s `n=1` case), matching `each_take_first`'s semantics.
+        Expr::FirstExpr(expr)
+            if needs_path_context(expr) || rest.iter().any(needs_path_context) =>
+        {
+            let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+            let mut body_stages = vec![(**expr).clone()];
+            if paired {
+                body_stages.push(path_probe_stage());
+            }
+            let body_result = eval_pipe_with_path_context_internal::<W, S>(
+                &body_stages,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let first = match body_result {
+                QueryResult::Owned(v) => QueryResult::Owned(v),
+                QueryResult::ManyOwned(mut vs) => {
+                    vs.truncate(1);
+                    owned_vec_to_result(vs)
+                }
+                QueryResult::None => QueryResult::None,
+                QueryResult::Error(e) => QueryResult::Error(e),
+                QueryResult::Break(label) => QueryResult::Break(label),
+                QueryResult::Halt(code) => QueryResult::Halt(code),
+                QueryResult::Partial(mut vs, control) => {
+                    if !vs.is_empty() {
+                        vs.truncate(1);
+                        owned_vec_to_result(vs)
+                    } else {
+                        partial(vs, control)
+                    }
+                }
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!(
+                        "eval_pipe_with_path_context_internal only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Partial"
+                    )
+                }
+            };
+            if paired {
+                return continue_rest_with_paths::<W, S>(
+                    first,
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+            }
+            continue_rest_with_context::<W, S>(
+                first,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
+        }
+        // `last(expr)` (#2074): same shape as `first(expr)` above, but
+        // takes the LAST output instead of truncating to the first --
+        // mirrors `eval_last_expr`'s own semantics (empty stream -> null;
+        // `Partial` always drops its prefix and surfaces the control since
+        // `last` cannot short-circuit -- verified `last(1,2,error("x"))`
+        // raises, it does not answer `2`), restricted to the narrower
+        // `QueryResult` variant set this evaluator ever produces.
+        Expr::LastExpr(expr) if needs_path_context(expr) || rest.iter().any(needs_path_context) => {
+            let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+            let mut body_stages = vec![(**expr).clone()];
+            if paired {
+                body_stages.push(path_probe_stage());
+            }
+            let body_result = eval_pipe_with_path_context_internal::<W, S>(
+                &body_stages,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
+            let last = match body_result {
+                QueryResult::Owned(v) => QueryResult::Owned(v),
+                QueryResult::ManyOwned(vs) => match vs.into_iter().next_back() {
+                    Some(last) => QueryResult::Owned(last),
+                    None => QueryResult::Owned(OwnedValue::Null),
+                },
+                QueryResult::None => QueryResult::Owned(OwnedValue::Null),
+                QueryResult::Error(e) => QueryResult::Error(e),
+                QueryResult::Break(label) => QueryResult::Break(label),
+                QueryResult::Halt(code) => QueryResult::Halt(code),
+                QueryResult::Partial(_, Control::Error(e)) => QueryResult::Error(e),
+                QueryResult::Partial(_, Control::Break(label)) => QueryResult::Break(label),
+                QueryResult::Partial(_, Control::Halt(code)) => QueryResult::Halt(code),
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!(
+                        "eval_pipe_with_path_context_internal only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Partial"
+                    )
+                }
+            };
+            if paired {
+                return continue_rest_with_paths::<W, S>(
+                    last,
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                );
+            }
+            continue_rest_with_context::<W, S>(
+                last,
                 rest,
                 root,
                 file_origin,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7428,6 +7428,45 @@ fn test_first_last_expr_path_context_resolves_2074() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "[null]");
 
+    // `paired` + `QueryResult::Partial` (the body itself produces some
+    // outputs before a terminating control): `first` can short-circuit
+    // once satisfied, so it answers from the already-taken output's own
+    // path, same as `first(1, error("x"))` = `1` in the non-path-context
+    // case. `last` cannot short-circuit and surfaces the control instead
+    // (verified live: `last(1,2,error("x"))` raises, doesn't answer `2`).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | first((.[], error(\"boom\"))) | key"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | last((.[], error(\"boom\"))) | key"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("boom"));
+
+    // Same shape with `halt` instead of `error` -- exercises
+    // `accumulate_path_context_step`'s `Halt` arm specifically (a
+    // different `Control` variant than the `Error` case above, taking a
+    // separate branch through `control_to_result`/`partial`).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | first((.[], halt)) | key"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | last((.[], halt)) | key"],
+        Some(r#"{"a":[1,2]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty(), "halt should suppress all output");
+
     // The common case (no path-context builtin in the body) is unaffected.
     let (stdout, _, code) = run_jq_full(&["-c", "[first(.[])]"], Some(r"[1,2,3]"))?;
     assert_eq!(code, 0);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7467,6 +7467,73 @@ fn test_first_last_expr_path_context_resolves_2074() -> Result<()> {
     assert_eq!(code, 0);
     assert!(stdout.trim().is_empty(), "halt should suppress all output");
 
+    // The body producing a *bare* Error/Break/Halt/None -- not wrapped in
+    // a `Partial` -- is a structurally distinct case from the
+    // Comma-accumulation shapes above: the very first (only) body stage
+    // itself terminates before any output is ever collected, so
+    // `eval_pipe_with_path_context_internal` never reaches
+    // `accumulate_path_context_step` at all for this pipe.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | first(empty) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | first(error(\"x\")) | key"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains('x'));
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | first(halt) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | (.a | first(break $out) | key)"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    // `Partial` with an *empty* prefix (the very first comma branch is
+    // what terminates, before any output was ever collected) -- `first`
+    // has nothing satisfying to fall back on here, so it surfaces the
+    // control just like `last` always does.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | first((error(\"x\"), 1)) | key"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains('x'));
+
+    // Same bare-terminator cases for `last`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | last(empty) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    // Empty body -> `null` (#1521), continuing `rest` from the fallback
+    // (ambient) path since no real navigation happened -- `key` there
+    // answers the *enclosing* container's own key, `"a"`, not a fabricated
+    // one.
+    assert_eq!(stdout.trim(), "\"a\"");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".a | last(error(\"x\")) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains('x'));
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | last(halt) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | (.a | last(break $out) | key)"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
     // The common case (no path-context builtin in the body) is unaffected.
     let (stdout, _, code) = run_jq_full(&["-c", "[first(.[])]"], Some(r"[1,2,3]"))?;
     assert_eq!(code, 0);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7378,6 +7378,67 @@ fn test_limit_path_context_resolves_1765() -> Result<()> {
     Ok(())
 }
 
+/// #2074: `Expr::FirstExpr`/`Expr::LastExpr` had no arm in either
+/// `needs_path_context` or `eval_pipe_with_path_context_internal`, so
+/// `first(key)`/`last(key)` silently answered `null` where the sibling
+/// `limit(1; key)` (tested above) answered correctly.
+#[test]
+fn test_first_last_expr_path_context_resolves_2074() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [first(key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[\"a\"]");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [last(key)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[\"a\"]");
+
+    // `first`/`last` distinguish which output they take, unlike `limit(1;
+    // ...)` above -- confirms the path threaded through matches the actual
+    // output picked, not just any one of them.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [first(.[] | key)]"],
+        Some(r#"{"a":[10,20,30]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[0]");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | [last(.[] | key)]"],
+        Some(r#"{"a":[10,20,30]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[2]");
+
+    // The `rest`-continues-from-the-taken-output's-own-path shape from the
+    // issue's own repro: `key` sits *after* `first(...)`/`last(...)` in the
+    // pipe, not inside it, so this exercises the `path_probe_stage`/
+    // `continue_rest_with_paths` pairing, not just the body-evaluation arm.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | first(.[]) | key"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | last(.[]) | key"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2");
+
+    // `last(empty)` still answers `null`, not nothing (#1521) -- the
+    // path-context arm must preserve that, not just the ordinary one.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | [last(empty)]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[null]");
+
+    // The common case (no path-context builtin in the body) is unaffected.
+    let (stdout, _, code) = run_jq_full(&["-c", "[first(.[])]"], Some(r"[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1]");
+    let (stdout, _, code) = run_jq_full(&["-c", "[last(.[])]"], Some(r"[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[3]");
+
+    Ok(())
+}
+
 /// #1964 (found in review of the `Expr::Limit` path-context fix above, then
 /// fixed by #1964 itself): `eval_pipe_with_path_context_internal`'s
 /// `Expr::Comma` arm routes every branch through this same evaluator,


### PR DESCRIPTION
## Summary

`Expr::FirstExpr`/`Expr::LastExpr` had no arm in `needs_path_context` or
`eval_pipe_with_path_context_internal`, so a `key`/`parent`/`file_index`
inside or after `first(f)`/`last(f)` silently stubbed to `null` where the
sibling `limit(1; key)` already resolved correctly:

```console
$ echo '{"a":[1,2,3]}' | succinctly jq -c '.a | first(key)'
null            # was; should be "a"
$ echo '{"a":[1,2,3]}' | succinctly jq -c '.a | first(.[]) | key'
"a"             # was; jq 'path(.a | first(.[]))' confirms it should be 0
```

- `first(f)` mirrors `Expr::Limit { n: 1, expr: f }`'s existing arm exactly (eager evaluation, take-first, same accepted #820 short-circuit tradeoff for a `Partial` that's already satisfied).
- `last(f)` mirrors `eval_last_expr`'s own semantics (empty stream → `null` per #1521; `Partial` always drops its prefix and surfaces the control since `last` cannot short-circuit — verified live `last(1,2,error("x"))` raises rather than answering `2`), restricted to the narrower `QueryResult` variant set `eval_pipe_with_path_context_internal` ever produces.
- Both are guarded the same way `Limit`'s arm is (`needs_path_context(expr) || rest.iter().any(needs_path_context)`), and both use the existing `path_probe_stage`/`continue_rest_with_paths` machinery for the "`rest` continues from the taken output's own path" shape, so `.a | first(.[]) | key` routes `key` through the correct per-output path rather than the ambient one.

Fixes #2074.

## Test plan
- [x] Live-verified against the repro cases in the issue, plus `path()` cross-checks against the pinned jq 1.7.1 oracle (`key` itself isn't a real jq builtin, so the path-index values are cross-checked via `path(.a | first(.[]))` etc.)
- [x] New regression test `test_first_last_expr_path_context_resolves_2074` in `tests/jq_cli_tests.rs`, modeled on the existing `test_limit_path_context_resolves_1765`
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Edge-case regression check against the oracle: `first(empty)`, `last(empty)`, `first(1,2,error("x"))`, plain `first(.[])`/`last(.[])` — all unchanged, matching jq 1.7.1
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` clean