### PR TITLE
fix(jq): share yq --argjson's leniency retry with jq's own

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2936,13 +2936,15 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// first place. Worth revisiting if a third leniency shows up (#2012 code
 /// review, altitude angle).
 ///
-/// `pub(crate)`: also called from `yq_runner::parse_json_value` (#2051) --
-/// `succinctly yq --argjson`/`--jsonargs` has its own, separate parser with
-/// no oracle-fidelity obligation to match jq's leniency (real mikefarah/yq
-/// has no `--argjson` flag at all), but sharing this one function keeps the
-/// two CLI modes from silently re-diverging on the same input the way they
-/// did between #1094/#2012 landing here and yq's copy not getting either
-/// fix.
+/// `pub(crate)`: as of #2051, called from three sites total --
+/// `parse_json_value` and `seq_value_is_valid` in this file, plus
+/// `yq_runner::parse_json_value` (yq mode has only `--argjson`, no
+/// `--jsonargs`/positional args at all -- see `yq_runner::build_args_var`).
+/// yq's own `--argjson` has no oracle-fidelity obligation to match jq's
+/// leniency (real mikefarah/yq has no `--argjson` flag at all), but sharing
+/// this one function keeps the two CLI modes from silently re-diverging on
+/// the same input the way they did between #1094/#2012 landing here and
+/// yq's copy not getting either fix.
 pub(crate) fn normalize_json_leniently(s: &str) -> String {
     normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s))
 }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2935,7 +2935,15 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// (`1e400`, #1095) that motivated using `serde_json::Value` here in the
 /// first place. Worth revisiting if a third leniency shows up (#2012 code
 /// review, altitude angle).
-fn normalize_json_leniently(s: &str) -> String {
+///
+/// `pub(crate)`: also called from `yq_runner::parse_json_value` (#2051) --
+/// `succinctly yq --argjson`/`--jsonargs` has its own, separate parser with
+/// no oracle-fidelity obligation to match jq's leniency (real mikefarah/yq
+/// has no `--argjson` flag at all), but sharing this one function keeps the
+/// two CLI modes from silently re-diverging on the same input the way they
+/// did between #1094/#2012 landing here and yq's copy not getting either
+/// fix.
+pub(crate) fn normalize_json_leniently(s: &str) -> String {
     normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s))
 }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3611,14 +3611,33 @@ fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> St
 /// `to_owned_canonicalizing_numbers`). Adding fidelity only here would make
 /// `--argjson` *inconsistent* with that established convention rather than
 /// fix a real divergence.
+///
+/// On the initial strict parse's failure, retries against
+/// `jq_runner::normalize_json_leniently`'s output (#1094's leading zero,
+/// #2012's lone low surrogate) -- the same two leniencies `succinctly jq`
+/// already accepts, shared from one definition rather than a second,
+/// independently-maintained copy (#2051: before this, the two modes had
+/// silently drifted apart on this exact input). Reparsing the *normalized*
+/// text directly (not the original, unlike `jq_runner`'s retry) is
+/// sufficient here precisely because this function already discards number
+/// fidelity -- there is no original spelling left to preserve.
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {
         return Ok(OwnedValue::Null);
     }
-    let value: serde_json::Value =
-        serde_json::from_str(s).with_context(|| format!("invalid JSON: {s}"))?;
-    Ok(serde_json_to_owned(&value))
+    match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(value) => Ok(serde_json_to_owned(&value)),
+        Err(e) => {
+            let normalized = crate::jq_runner::normalize_json_leniently(s);
+            if normalized != s {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&normalized) {
+                    return Ok(serde_json_to_owned(&value));
+                }
+            }
+            Err(e).with_context(|| format!("invalid JSON: {s}"))
+        }
+    }
 }
 
 /// Convert a `serde_json::Value` into an `OwnedValue`.

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3614,30 +3614,40 @@ fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> St
 ///
 /// On the initial strict parse's failure, retries against
 /// `jq_runner::normalize_json_leniently`'s output (#1094's leading zero,
-/// #2012's lone low surrogate) -- the same two leniencies `succinctly jq`
-/// already accepts, shared from one definition rather than a second,
-/// independently-maintained copy (#2051: before this, the two modes had
-/// silently drifted apart on this exact input). Reparsing the *normalized*
-/// text directly (not the original, unlike `jq_runner`'s retry) is
-/// sufficient here precisely because this function already discards number
-/// fidelity -- there is no original spelling left to preserve.
+/// #2012's lone low surrogate) -- the same two leniencies `succinctly jq`'s
+/// own `--argjson` already accepts (yq mode has no `--jsonargs` at all, see
+/// `build_args_var` below), shared from one definition rather than a
+/// second, independently-maintained copy (#2051: before this, the two
+/// modes had silently drifted apart on this exact input). Reparsing the
+/// *normalized* text directly (not the original, unlike `jq_runner`'s
+/// retry) is sufficient here precisely because this function already
+/// discards number fidelity -- there is no original spelling left to
+/// preserve. That includes *magnitude*, not just cosmetic spelling, for an
+/// integer too large for `f64` to represent exactly: stripping a leading
+/// zero from `0099999999999999999999999` now reaches the same lossy
+/// `serde_json_to_owned` path a plain `99999999999999999999999` (no
+/// leading zero) already went through before this fix, and already
+/// materializes as `1e+23` there too (#978's own established, deliberate
+/// convention) -- this leniency retry does not introduce a new precision
+/// class, it makes a leading-zero-prefixed integer behave exactly as if
+/// the leading zero were never there, consistent with every other digit
+/// string this function accepts.
 fn parse_json_value(s: &str) -> Result<OwnedValue> {
     let s = s.trim();
     if s.is_empty() {
         return Ok(OwnedValue::Null);
     }
-    match serde_json::from_str::<serde_json::Value>(s) {
-        Ok(value) => Ok(serde_json_to_owned(&value)),
-        Err(e) => {
-            let normalized = crate::jq_runner::normalize_json_leniently(s);
-            if normalized != s {
-                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&normalized) {
-                    return Ok(serde_json_to_owned(&value));
-                }
-            }
-            Err(e).with_context(|| format!("invalid JSON: {s}"))
-        }
+    // A no-op normalization reparses byte-identical text and fails
+    // identically -- no `normalized != s` guard needed before retrying.
+    let e = match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(value) => return Ok(serde_json_to_owned(&value)),
+        Err(e) => e,
+    };
+    let normalized = crate::jq_runner::normalize_json_leniently(s);
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&normalized) {
+        return Ok(serde_json_to_owned(&value));
     }
+    Err(e).with_context(|| format!("invalid JSON: {s}"))
 }
 
 /// Convert a `serde_json::Value` into an `OwnedValue`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9026,6 +9026,40 @@ fn test_argjson_shares_jq_leniency_2051() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "{\"x\":[7,\"\u{fffd}\"]}");
 
+    // A leading-zero integer too large for f64 to represent exactly must
+    // materialize *identically* to its non-leading-zero counterpart --
+    // yq's --argjson already discards integer-magnitude fidelity beyond
+    // f64's exact range (#978), and this leniency retry deliberately makes
+    // the leading zero invisible to that existing behavior rather than
+    // carving out a magnitude-preserving exception just for values that
+    // happen to need the leniency retry (code review on #2051).
+    let (with_zero, code) = run_yq_stdin(
+        ".x = $x",
+        "{}",
+        &[
+            "--argjson",
+            "x",
+            "0099999999999999999999999",
+            "-o=json",
+            "-I=0",
+        ],
+    )?;
+    assert_eq!(code, 0);
+    let (without_zero, code) = run_yq_stdin(
+        ".x = $x",
+        "{}",
+        &[
+            "--argjson",
+            "x",
+            "99999999999999999999999",
+            "-o=json",
+            "-I=0",
+        ],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(with_zero.trim(), without_zero.trim());
+    assert_eq!(with_zero.trim(), r#"{"x":1e+23}"#);
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8995,6 +8995,40 @@ fn test_argjson_bare_negative_number_1150() -> Result<()> {
     Ok(())
 }
 
+/// #2051: `succinctly yq --argjson` had its own, separate parser with no
+/// leniency retry, so it silently drifted from `succinctly jq` once #1094
+/// (leading zero) and #2012 (lone low surrogate) gave jq mode's `--argjson`
+/// that leniency and yq mode's copy never got the fix. Both diverged inputs,
+/// plus needing both leniencies in the same value at once.
+#[test]
+fn test_argjson_shares_jq_leniency_2051() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".n = $n",
+        "{}",
+        &["--argjson", "n", "007", "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"n":7}"#);
+
+    let (output, code) = run_yq_stdin(
+        ".s = $s",
+        "{}",
+        &["--argjson", "s", r#""\udc00""#, "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{\"s\":\"\u{fffd}\"}");
+
+    let (output, code) = run_yq_stdin(
+        ".x = $x",
+        "{}",
+        &["--argjson", "x", r#"[007,"\udc00"]"#, "-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{\"x\":[7,\"\u{fffd}\"]}");
+
+    Ok(())
+}
+
 #[test]
 fn test_arg_hyphen_prefixed_string_value_1150() -> Result<()> {
     let (output, code) = run_yq_stdin("$n", "a: 1", &["--arg", "n", "-hello"])?;


### PR DESCRIPTION
## Summary
- `succinctly yq --argjson` had its own, separate `parse_json_value` (`src/bin/succinctly/yq_runner.rs`) with no retry on strict-parse failure — so #1094's leading-zero leniency and #2012's lone-low-surrogate leniency landed for `succinctly jq`'s `--argjson` but never for `succinctly yq`'s, silently diverging two originally-identical parsers on the same input.
- Widened `jq_runner::normalize_json_leniently` to `pub(crate)` and called it directly from `yq_runner::parse_json_value`'s new retry path, rather than duplicating the leading-zero/lone-surrogate normalization logic a second time — single source of truth, matching this crate's own documented lesson that duplicated logic like this diverges silently (see CLAUDE.md's optimization-history key insights).
- yq's retry reparses the *normalized* text directly (unlike jq's original-bytes materialization dance) — yq's `--argjson` already discards number-literal fidelity on purpose (#978, `to_owned_canonicalizing_numbers`), so there's no original spelling left to preserve; jq mode's byte-preserving behavior is untouched.
- Confirmed `--jsonargs` doesn't exist for yq mode at all (no such flag, per `build_args_var`'s own doc comment) — `--argjson` is the only call site of `parse_json_value` in `yq_runner.rs`, so this fix covers the issue's full scope.

Fixes #2051

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New regression test `test_argjson_shares_jq_leniency_2051` (`tests/yq_cli_tests.rs`) — leading-zero, lone-low-surrogate, and both needed at once in the same value
- [x] Existing `--argjson` tests (`test_argjson_invalid_value_errors`, `test_argjson_bare_negative_number_1150`, `test_argjson_variable`) still pass — genuinely invalid JSON still errors
- [x] Manually verified `succinctly jq --argjson`'s existing behavior is unaffected (byte-preserving number spelling, error messages)
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` clean