### PR TITLE
fix(jq): range() raises instead of silently truncating past MAX_RANGE

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2511,6 +2511,58 @@ discard no write, and cannot crash the process -- so per rule 4 it is recorded h
 still-open gap rather than an accepted-forever divergence. Tracked in
 [#2111](https://github.com/rust-works/succinctly/issues/2111).
 
+### `range`'s own accumulation cap (#2089): a resource-exhaustion guard, now raising instead of silently truncating
+
+`MAX_RANGE` (`src/jq/eval.rs`, `100000`, shared by `eval_range_values` and
+`eval_range_values_f64`) caps how many values a single `(from, to, step)`
+combination will accumulate before raising, mirroring
+`REDUCE_FOREACH_MAX_STEPS`'s own resource-exhaustion rationale two sections
+above -- real jq's `range` is bounded only by memory, and a single
+materializing call (`[range(1e18)]`, `reduce range(1e18) as $x (0;.+$x)`)
+could otherwise try to allocate an unbounded `Vec` in one shot.
+
+```console
+$ echo null | jq -c '[range(100001)] | length'             # jq 1.7.1
+100001
+$ echo null | succinctly jq -c '[range(100001)] | length'
+jq: error (at <stdin>:1): range: maximum iterations exceeded    # exit 5
+```
+
+Before this fix, exceeding the cap silently returned the truncated prefix as
+a **success** (`100000`, wrong, exit 0, empty stderr) instead of raising --
+the one guard in this file that chose that failure mode, found auditing
+#2079's own fix. `range: maximum iterations exceeded` now matches the
+`until`/`while`/`reduce`/`foreach`/`repeat` wording convention. Accepted
+under ADR-0018 rule 4c, same as `REDUCE_FOREACH_MAX_STEPS`.
+
+**The cap is per-combination and demand-aware, not a hard ceiling on
+`range`'s total output**: whether truncation actually raises depends on
+whether the *consumer* still wanted more once the capped batch was
+delivered. `first`/`limit`/`nth`'s own early stop never sees it —
+`first(range(1e18))` still returns `0` instantly, no error, because the
+consumer stopped asking within the first few (well under `100000`) values
+`each_range`'s sink was ever offered. A demand-driven consumer that *does*
+ask past the cap (`[limit(200000; range(1000000))]`, `nth(150000;
+range(1000000))`) raises just like the eager materializing shapes above —
+real jq answers `200000`/`150000` for both (confirmed live), so these are
+genuine, if narrower, instances of the same pre-existing divergence #2089's
+own repro table didn't happen to list, not new ones introduced by this fix.
+
+**Two known gaps this fix doesn't close, found reviewing it:**
+
+- `range(...)?`/`try range(...)` still lets the truncated prefix through as
+  ordinary output (`[range(100001)?] | length` => `100000`, exit 0) — `?`
+  suppresses the raised error, but `drain_result` has already delivered the
+  capped batch to the sink before `emit` decides whether to raise, so
+  nothing distinguishes it from a genuine result once the error itself is
+  swallowed. Not specific to `range` (`[while(true;.+1)?]` shows the same
+  pattern for `WHILE_UNTIL_MAX_STEPS`), so tracked as a general evaluator
+  question rather than here: [#2132](https://github.com/rust-works/succinctly/issues/2132).
+- `eval_range_values`'s integer stepping (`i += step`) has no overflow
+  guard — pre-existing, reproduces identically before this fix too, and
+  needs its own oracle verification before choosing a direction. Tracked as
+  [#2131](https://github.com/rust-works/succinctly/issues/2131).
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4157,29 +4157,49 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
-    let mut escape: Option<Control> = None;
+    // `Cell`, not a plain `Option`, because `emit` below and the
+    // `from`/`to`/`step` closures that call it are separate closures live
+    // at the same time -- each needs to *set* an escape it discovers on its
+    // own, which a shared `&mut Option<Control>` can't give more than one
+    // of simultaneously (#2089: `emit` gained its own write here once
+    // `eval_range_values`/`_f64` could raise on `MAX_RANGE`).
+    let escape: core::cell::Cell<Option<Control>> = core::cell::Cell::new(None);
     let mut sink_stopped = false;
 
     // One (from, to, step) combination's values, forwarded to the wrapping
     // `sink`. Reuses `eval_range_values`/`_f64` and `drain_result` verbatim
-    // -- `MAX_RANGE` is unaffected: each combination still eagerly builds
-    // one capped `Vec` exactly as the eager path does (#1556 is scoped to
-    // the bound expressions, not that pre-existing cap).
+    // -- each combination still eagerly builds one `MAX_RANGE`-capped `Vec`
+    // exactly as before (#1556 is scoped to the bound expressions, not that
+    // pre-existing cap). #2089: whether truncation should actually raise
+    // depends on what `sink` does with the capped batch, not merely on
+    // whether it happened -- `eval_range`'s own sink (used by `[range(...)]`,
+    // `reduce`, ...) always answers `Continue`, so for it `Flow::Exhausted`
+    // means "delivered everything I had and the caller still wants more",
+    // exactly the silent-wrong-data case this issue is about. A
+    // demand-driven sink (`first`, `limit`, ...) that stops partway through
+    // the capped batch never reaches that branch at all -- confirmed live:
+    // `first(range(1e18))` still returns `0` instantly, no error, while
+    // `[range(1e18)]`/`reduce range(1e18) as $x (0;.+$x)` now raise instead
+    // of silently returning a 100000-element/-sum prefix.
     let mut emit = |from_val: RangeNum, to_val: RangeNum, step_val: RangeNum| -> Demand {
-        let one = match (from_val, to_val, step_val) {
+        let (one, truncated) = match (from_val, to_val, step_val) {
             (RangeNum::Int(f), RangeNum::Int(t), RangeNum::Int(st)) => {
                 eval_range_values::<W>(f, t, st)
             }
             (f, t, st) => eval_range_values_f64::<W>(f.as_f64(), t.as_f64(), st.as_f64()),
         };
         match drain_result(one, sink) {
+            Flow::Exhausted if truncated => {
+                escape.set(Some(Control::Error(range_max_exceeded_error())));
+                Demand::Stop
+            }
             Flow::Exhausted => Demand::Continue,
             Flow::Stopped { .. } => {
                 sink_stopped = true;
                 Demand::Stop
             }
-            // `owned_vec_to_result` only ever yields `None`/`Owned`/
-            // `ManyOwned`, so `drain_result` can only answer `Exhausted` or
+            // `owned_vec_to_result` never yields `Error`/`Break`/`Halt`/
+            // `Partial`, so `drain_result` can only answer `Exhausted` or
             // `Stopped { pending: None }` here.
             Flow::Escaped(_) => unreachable!(
                 "eval_range_values(_f64) never produces an Error/Break/Halt/Partial result"
@@ -4191,7 +4211,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         let from_val = match range_num(&item_to_owned(from_item)) {
             Ok(n) => n,
             Err(e) => {
-                escape = Some(Control::Error(e));
+                escape.set(Some(Control::Error(e)));
                 return Demand::Stop;
             }
         };
@@ -4213,7 +4233,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let to_val = match range_num(&item_to_owned(to_item)) {
                 Ok(n) => n,
                 Err(e) => {
-                    escape = Some(Control::Error(e));
+                    escape.set(Some(Control::Error(e)));
                     return Demand::Stop;
                 }
             };
@@ -4226,7 +4246,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             let step_val = match range_num(&item_to_owned(step_item)) {
                                 Ok(n) => n,
                                 Err(e) => {
-                                    escape = Some(Control::Error(e));
+                                    escape.set(Some(Control::Error(e)));
                                     return Demand::Stop;
                                 }
                             };
@@ -4236,7 +4256,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         Flow::Exhausted => Demand::Continue,
                         Flow::Stopped { .. } => Demand::Stop,
                         Flow::Escaped(control) => {
-                            escape = Some(control);
+                            escape.set(Some(control));
                             Demand::Stop
                         }
                     }
@@ -4248,7 +4268,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Flow::Exhausted => Demand::Continue,
             Flow::Stopped { .. } => Demand::Stop,
             Flow::Escaped(control) => {
-                escape = Some(control);
+                escape.set(Some(control));
                 Demand::Stop
             }
         }
@@ -4257,7 +4277,7 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     if sink_stopped {
         return Flow::Stopped { pending: None };
     }
-    match escape {
+    match escape.into_inner() {
         Some(control) => Flow::Escaped(control),
         None => from_flow,
     }
@@ -28316,15 +28336,45 @@ fn eval_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// shared by [`eval_range_values`] and [`eval_range_values_f64`] (#1029: was
 /// two independent `const MAX_RANGE` copies, the structural twin of the
 /// `MAX_ITEMS` triplication #1023 fixed for the recurse family).
+///
+/// Real jq's `range` is bounded only by memory; this exists purely as a
+/// resource-exhaustion guard against a single materializing call
+/// (`[range(1e18)]`, `reduce range(1e18) as $x (0; .+$x)`, ...) trying to
+/// allocate an unbounded `Vec` in one shot, the same reasoning
+/// [`REDUCE_FOREACH_MAX_STEPS`]/[`WHILE_UNTIL_MAX_STEPS`] already establish
+/// for their own guards. Kept at the same magnitude as
+/// `REDUCE_FOREACH_MAX_STEPS` rather than re-derived, so the three share one
+/// "how much may a single eager accumulation hold" answer.
+///
+/// Exhausting it now *raises*, matching every sibling guard in this file --
+/// #2089 found it silently truncating to a wrong, unflagged answer at exit 0
+/// instead, the one guard in the file that chose that failure mode. See
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md)
+/// for the recorded divergence (real jq has no such cap at all).
 const MAX_RANGE: usize = 100000;
 
-/// Helper to generate range values.
+/// The error [`each_range`]'s `emit` raises once a caller that actually
+/// wanted every value (its sink kept answering [`Demand::Continue`]) hits a
+/// [`MAX_RANGE`]-truncated batch -- shared so callers can't drift in wording.
+fn range_max_exceeded_error() -> EvalError {
+    EvalError::new("range: maximum iterations exceeded")
+}
+
+/// Helper to generate range values, capped at [`MAX_RANGE`] per call.
+///
+/// Returns whether the cap actually cut the range short (`true`) or the
+/// range finished naturally within it (`false`) -- deliberately *not* an
+/// error here: this has no visibility into whether the caller's own sink
+/// would have stopped asking before the cap anyway (`first`/`limit`'s
+/// demand-driven early exit, #2089), only [`each_range`]'s `emit` does, so
+/// the truncation verdict is reported back rather than acted on locally.
 fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
     from: i64,
     to: i64,
     step: i64,
-) -> QueryResult<'a, W> {
+) -> (QueryResult<'a, W>, bool) {
     let mut values: Vec<OwnedValue> = Vec::new();
+    let mut truncated = false;
 
     if step > 0 {
         let mut i = from;
@@ -28332,18 +28382,22 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
             values.push(OwnedValue::Int(i));
             i += step;
         }
+        truncated = i < to;
     } else if step < 0 {
         let mut i = from;
         while i > to && values.len() < MAX_RANGE {
             values.push(OwnedValue::Int(i));
             i += step;
         }
+        truncated = i > to;
     }
 
-    owned_vec_to_result(values)
+    (owned_vec_to_result(values), truncated)
 }
 
-/// Helper to generate range values over floats.
+/// Helper to generate range values over floats, capped at [`MAX_RANGE`] per
+/// call -- see [`eval_range_values`]'s own doc comment for why truncation is
+/// reported rather than raised here.
 ///
 /// Accumulates by repeated addition of `step` (jq semantics), so results carry
 /// the same floating-point drift as jq (e.g. `range(0;1;0.3)` ends at
@@ -28352,24 +28406,32 @@ fn eval_range_values_f64<'a, W: Clone + AsRef<[u64]>>(
     from: f64,
     to: f64,
     step: f64,
-) -> QueryResult<'a, W> {
+) -> (QueryResult<'a, W>, bool) {
     let mut values: Vec<OwnedValue> = Vec::new();
+    let mut truncated = false;
 
+    // The cap check rides in the loop's own compound condition, not a
+    // `break` inside it, so the float comparison is never clippy's sole
+    // `while` condition (`while_float` fires on that shape specifically,
+    // not on one ANDed with another term) -- matching how the pre-#2089
+    // version of this loop already avoided the lint by coincidence.
     if step > 0.0 {
         let mut i = from;
         while i < to && values.len() < MAX_RANGE {
             values.push(OwnedValue::Float(i));
             i += step;
         }
+        truncated = i < to;
     } else if step < 0.0 {
         let mut i = from;
         while i > to && values.len() < MAX_RANGE {
             values.push(OwnedValue::Float(i));
             i += step;
         }
+        truncated = i > to;
     }
 
-    owned_vec_to_result(values)
+    (owned_vec_to_result(values), truncated)
 }
 
 /// Builtin: recurse (recurse(.[]))

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30260,3 +30260,84 @@ fn test_optional_comma_sibling_prune_still_correct_for_path_and_del_2124() -> Re
     assert_eq!(stdout, "{\"c\":1}\n");
     Ok(())
 }
+
+/// #2089: `range`'s `MAX_RANGE` accumulation cap used to truncate silently
+/// (a success, exit 0, wrong data) instead of raising -- the one guard in
+/// `eval.rs` that chose that failure mode, unlike its
+/// `until`/`while`/`reduce`/`foreach` siblings. All rows verified against
+/// jq 1.7.1, which has no such cap at all (bounded only by memory).
+#[test]
+fn test_range_max_exceeded_raises_instead_of_truncating_2089() -> Result<()> {
+    for (filter, why) in [
+        ("[range(100001)] | length", "the issue's own minimal repro"),
+        (
+            "reduce range(150000) as $x (0; . + $x)",
+            "an aggregation is exactly where a silent truncation is most \
+             dangerous -- a plausible-looking wrong number, not a crash",
+        ),
+        ("[range(0;200000)] | length", "the two-argument form"),
+        (
+            "[range(0;200000;1)] | length",
+            "the three-argument integer form",
+        ),
+        (
+            "[range(0;-200000;-1)] | length",
+            "a descending integer range",
+        ),
+        ("[range(0;200000;0.5)] | length", "a float step"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 5, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "", "{why}");
+        assert!(
+            stderr.contains("range: maximum iterations exceeded"),
+            "{why} -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2089 boundary: landing exactly on the cap must not raise -- only
+/// genuinely exceeding it should. Verified against jq 1.7.1 (`100000`).
+#[test]
+fn test_range_at_max_exactly_does_not_raise_2089() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "[range(100000)] | length"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "100000\n");
+    Ok(())
+}
+
+/// #2089 sibling: the fix must not regress the demand-driven fast path a
+/// consumer that stops well short of the cap already relied on --
+/// `each_range`'s `emit` only raises when the sink is still asking for more
+/// once a capped batch is exhausted, never when the sink stops early on its
+/// own. Verified against jq 1.7.1: both return instantly, no error, no hang.
+#[test]
+fn test_range_early_stop_consumer_unaffected_by_cap_2089() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "first(range(1000000000))"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "0\n");
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "[limit(3; range(200000))]"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0,1,2]\n");
+    Ok(())
+}
+
+/// #2089 sibling: a demand-driven consumer that *does* ask past the cap
+/// (unlike the early-stop cases above) must still raise -- this was already
+/// silently wrong before #2089 (returning a truncated 100000-element/-index
+/// answer at exit 0), just not the shape the issue's own repro table
+/// happened to list. Verified against jq 1.7.1: `200000`/`150000`, no cap.
+#[test]
+fn test_range_demand_driven_consumer_past_cap_still_raises_2089() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", "[limit(200000; range(1000000))] | length"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("range: maximum iterations exceeded"));
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "nth(150000; range(1000000))"], None)?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("range: maximum iterations exceeded"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`range(from;to;step)` stopped accumulating at 100,000 values (`MAX_RANGE`)
and returned what it had as a **success** — exit 0, empty stderr — the one
guard in `eval.rs` that chose silent truncation over raising, unlike its
`until`/`while`/`reduce`/`foreach`/`repeat` siblings. Real jq has no such
cap at all (bounded only by memory), and every row in the issue's own
repro table exits 0 with a plausible-looking wrong number.

`eval_range_values`/`eval_range_values_f64` now report whether they
truncated (`(QueryResult, bool)`) instead of deciding unilaterally, and
`each_range`'s `emit` closure only raises when the wrapping sink was still
asking for more (`Flow::Exhausted`) once a capped batch was delivered —
never when the sink already stopped on its own (`Flow::Stopped`). This
matters: a demand-driven consumer that only needs a few values from an
effectively-infinite range must not error just because the underlying
range is theoretically huge — `first(range(1e9))` still returns `0`
instantly, no error — while `[range(1e9)]`/`reduce range(1e9) as $x
(0;.+$x)` now raise, and so do demand-driven consumers that genuinely ask
*past* the cap (`[limit(200000; range(1000000))]`, `nth(150000;
range(1000000))`) — the same pre-existing bug via a shape the issue's own
repro table didn't happen to list.

Accepted under ADR-0018 rule 4c (resource-exhaustion guard, not matching
real jq's memory-only bound), matching `REDUCE_FOREACH_MAX_STEPS`'s own
rationale, and recorded in `docs/compliance/jq/limitations.md`.

**Two follow-ups filed from review, out of this fix's scope:**
- #2131 — `eval_range_values`'s integer stepping has no i64 overflow guard
  (pre-existing, reproduces identically before this fix).
- #2132 — `range(...)?`/`try range(...)` still lets the truncated prefix
  through as output (not range-specific: `while(...)?`shows the same
  pattern for `WHILE_UNTIL_MAX_STEPS`).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] All repros verified against `/usr/bin/jq` 1.7.1: the issue's own
      6-row table, the exact-100000 boundary (must not raise), early-stop
      demand-driven consumers (must not raise), and demand-driven
      consumers that ask past the cap (must raise)
- [x] New regression tests in `tests/jq_cli_tests.rs` covering all of the
      above

Fixes #2089