### PR TITLE
fix(jq): degrade gracefully on eval-thread spawn failure, close a test gap

### DIFF
--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1375,7 +1375,7 @@ fn main() -> Result<()> {
     let child = std::thread::Builder::new()
         .stack_size(EVAL_STACK_SIZE)
         .spawn(run_main)
-        .expect("failed to spawn the evaluation thread");
+        .context("failed to spawn the evaluation thread")?;
     match child.join() {
         Ok(result) => result,
         Err(panic) => std::panic::resume_unwind(panic),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17770,6 +17770,55 @@ fn test_thickly_wrapped_self_recursive_def_errors_without_aborting_1371() -> Res
     Ok(())
 }
 
+/// #2093 (code review of #1371/#2090): the sibling test above pins that
+/// exceeding `MAX_EVAL_FRAMES` stays catchable, but its own wrapping shape
+/// (array constructors) also grows the *output value*'s nesting past
+/// `MAX_VALUE_TREE_DEPTH` (384) at the same query -- so it can't tell
+/// whether a regression to a plain per-call counter (unsafe for exactly the
+/// structural-nesting shape `MAX_EVAL_FRAMES`'s own doc comment describes)
+/// would go uncaught, since either guard alone already explains the error.
+///
+/// `if true then <body> end` nesting charges the same cumulative structural
+/// frame cost per level (confirmed: this shape hits the guard at a
+/// depth×width product in the tens of thousands, matching the array-wrapped
+/// shape's own order of magnitude) while the *value* never grows at all --
+/// an always-true condition just threads `.` straight through every level
+/// unchanged, so the returned value is `null` whether the call succeeds or
+/// the guard fires. That isolates the frame guard: a flat per-call counter
+/// would let this succeed at any depth (nothing about call *count* alone
+/// exceeds a few thousand here), where the real structural-frame guard
+/// correctly refuses it.
+#[test]
+fn test_deeply_nested_conditional_wrapping_hits_frame_guard_without_growing_value_2093(
+) -> Result<()> {
+    let wrap_open = "if true then ".repeat(100);
+    let wrap_close = " end".repeat(100);
+
+    // 100 levels × 300 recursive steps ≈ 30,000 frames -- safely under
+    // MAX_EVAL_FRAMES (40,000) and nowhere near MAX_VALUE_TREE_DEPTH, since
+    // the value never nests. Matches jq 1.7.1 byte for byte (confirmed live).
+    let query = format!(
+        "def deep(m): if m == 0 then . else ({wrap_open}deep(m-1){wrap_close}) end; deep(300)"
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "null");
+
+    // 100 levels × 1,500 recursive steps ≈ 150,000 frames -- well past
+    // MAX_EVAL_FRAMES, refused as a catchable error rather than a stack
+    // overflow (#1016/#1098) -- the invariant this whole guard exists for.
+    let query = format!(
+        "def deep(m): if m == 0 then . else ({wrap_open}deep(m-1){wrap_close}) end; deep(1500)"
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1371: the depth guard has to be reachable from every evaluator, not just
 /// the plain one, and each reports it differently. A runaway recursion under a
 /// *truncating* consumer goes through `eval_each`'s own `DefCall` arm, and one


### PR DESCRIPTION
## Summary

#2093 tracked four smaller follow-ups from #1371/#2090's code review:

1. **Frame under-count for a `DefCall` reached through a builtin argument** — already fixed on `main` (`install_def_calls_in_builtin` already charges `depth + 1`, with a doc comment explaining exactly why). No change needed; verified by direct code reading.
2. **Doc comment citing a nonexistent `MAX_CALL_DEPTH` constant** — already fixed on `main` (now correctly cites `MAX_EVAL_FRAMES` and its ~13,000-level figure). No change needed.
3. **Evaluation-thread spawn `.expect()`s instead of degrading gracefully** — fixed: `.context(...)?` instead of `.expect(...)`, so a stack-reservation failure (a restrictive `ulimit -v`, some CI sandboxes) produces the crate's normal CLI error output instead of an unconditional panic on *every* invocation, including `--help`.
4. **No regression test distinguishes `MAX_EVAL_FRAMES`'s structural-frame guard from `MAX_VALUE_TREE_DEPTH`'s output-value-depth check** — the existing test's own wrapping shape (array constructors) grows both simultaneously, so a regression to an unsafe flat per-call counter wouldn't necessarily be caught. Added `test_deeply_nested_conditional_wrapping_hits_frame_guard_without_growing_value_2093`: a nested `if true then ... end` wrapping shape charges the same cumulative frame cost per level while the returned value never nests at all (an always-true condition just threads `.` straight through every level), isolating the two guards.

**Investigating #4 surfaced a separate, more serious bug**: a *wide-but-flat* pipe/comma sibling list isn't charged cumulatively by `install_def_calls` the way genuine nesting is — every sibling in one `Expr::Pipe`/`Expr::Comma` vec receives the same `frames + 1`, regardless of how many siblings there are. A sufficiently wide-and-deep recursive body can therefore hold real native stack cost per recursive level that `MAX_EVAL_FRAMES` never counts, overflowing the stack for real (confirmed: real jq handles the same input cleanly, `exit 0`; succinctly aborts, `exit 134`). Filed separately as #2135 rather than folded into this PR — fixing the charging model itself needs its own re-calibration against #2080's crash-floor bisection, a materially larger and riskier change than this follow-up batch.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite — 3232 lib tests + every integration suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified findings #1/#2 are already resolved by reading the current code directly (not assumed)
- [x] Added `test_deeply_nested_conditional_wrapping_hits_frame_guard_without_growing_value_2093`, live-verified both halves (within-bounds success matches jq 1.7.1 byte-for-byte; over-bounds failure is a catchable error, not a crash) against the pinned oracle before writing the assertions

Fixes #2093