### PR TITLE
fix(jq): let reestablishes_register cover a still-trackable branch (#2044)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -555,15 +555,24 @@ is the revert that established what the other one costs.
    (`path(. as $x \| (def f: 5; f) \| $x)` — resolving a call to its body is not something a
    syntactic predicate can do from a name). All three are refuse-only.
 
-   A fourth refusal is the `null`/`false` half of `register_identical` applied one stage
-   earlier than succinctly reaches: `path(.a \| null)` on `{"a":null}` and `path(.a \| false)`
-   on `{"a":false}` are `["a"]` in jq — the literal never moved the register, and a `null` is
-   `jv_identical` to a `null` whatever node it came from — while succinctly refuses, because
-   `reestablishes_register` only re-establishes a branch that is *already* untracked and a
-   stage sitting directly on a trackable one never gets there. Pre-existing (it predates the
-   register threading), refuse-only, and closing it is a widening that needs its own live
-   matrix; tracked as [#2044](https://github.com/rust-works/succinctly/issues/2044), which
-   carries the same root cause under its own repro (`path(null \| .a)` on `null`).
+   A fourth case, the `null`/`false` half of `register_identical` applied one stage earlier
+   than succinctly used to reach — `path(.a \| null)` on `{"a":null}` and `path(.a \| false)`
+   on `{"a":false}` are `["a"]` in jq, because the literal never moved the register and a
+   `null` is `jv_identical` to a `null` whatever node it came from — is now closed for jq
+   mode: [#2044](https://github.com/rust-works/succinctly/issues/2044) widened
+   `reestablishes_register` to also cover a still-trackable branch's own step, sourcing the
+   register from what `resolve_leaf` records on the exact transition that drops
+   trackability. **yq mode deliberately keeps the pre-#2044 refuse-only behavior for this
+   shape** rather than gaining the same widening: real yq no-ops a field/index access
+   against a scalar (#1181's convention) instead of navigating through it, a rule this
+   widening doesn't know about and that isn't consulted at this call site yet for a *plain*,
+   non-computed key
+   ([#2107](https://github.com/rust-works/succinctly/issues/2107)) — applying jq's own
+   write-through answer to yq mode here would silently corrupt data (confirmed live against
+   yq v4.53.3: `(null \| .a) = 5` on `null` is a no-op, not the write jq's own `{"a":5}`
+   answer would become) rather than merely refuse, which is the direction ADR-0018 never
+   permits. Refuse-only for yq mode remains pre-existing and tracked the same way the three
+   shapes above are.
 
    Separately, a variable bound from a *navigated* position (`.a as $y`) still carries no
    marker at all, because `substitute_var_tracked` remains gated on

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -565,9 +565,10 @@ is the revert that established what the other one costs.
    trackability. **yq mode deliberately keeps the pre-#2044 refuse-only behavior for this
    shape** rather than gaining the same widening: real yq no-ops a field/index access
    against a scalar (#1181's convention) instead of navigating through it, a rule this
-   widening doesn't know about and that isn't consulted at this call site yet for a *plain*,
-   non-computed key
-   ([#2107](https://github.com/rust-works/succinctly/issues/2107)) — applying jq's own
+   widening doesn't know about — the `resolve_leaf` fallback this call site ultimately
+   reaches for a literal is part of the "dynamic-prepass" family
+   [#1419](https://github.com/rust-works/succinctly/issues/1419) already tracks as having
+   no yq-mode exception anywhere — so applying jq's own
    write-through answer to yq mode here would silently corrupt data (confirmed live against
    yq v4.53.3: `(null \| .a) = 5` on `null` is a no-op, not the write jq's own `{"a":5}`
    answer would become) rather than merely refuse, which is the direction ADR-0018 never

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1029,6 +1029,16 @@ narrower, already-fixed-write case where only the RHS-discard *optimization* is 
 (`0 as $k | .[$k] = error("boom")` on a scalar root still raises `boom` where real yq no-ops
 silently, even though the write itself — `.[$k] = 99` — already correctly no-ops).
 
+A pipe-literal reaches the same `resolve_leaf` fallback, not just a computed key or
+`Comma`-grouped LHS: `(null | .a) = 5` on `null` errors "Invalid path expression near
+attempt to access element \"a\" of null" in `succinctly yq`, where real yq no-ops to `null`
+unchanged (live-verified against yq v4.53.3, [#2044](https://github.com/rust-works/succinctly/issues/2044)).
+
+```bash
+$ printf 'null\n' | yq            '(null | .a) = 5'   # null, no-op
+$ printf 'null\n' | succinctly yq '(null | .a) = 5'   # Error: Invalid path expression near attempt to access element "a" of null
+```
+
 **Fixed by [#1298](https://github.com/rust-works/succinctly/issues/1298):** `get_path_mut`
 (the walker #1232 widened) used to have no `Expr::Iterate` arm at all, so a mid-chain `.[]`
 under plain `=` (`.a[].b = 99`) always errored "invalid path component" — in both jq and yq

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24567,12 +24567,9 @@ struct StepRegisterFacts {
 /// All four confirmed live against jq 1.7.1, along with the rest of the
 /// matrix on #1573.
 ///
-/// The five preconditions are each load-bearing (the first four ride
+/// The four preconditions are each load-bearing (all but the last ride
 /// [`StepRegisterFacts`]):
 ///
-/// - `!branch_trackable` — a trackable branch needs no re-establishing, and
-///   its `Expr::TrackedVar` arm already certifies against the ambient value
-///   directly (which *is* the register while trackable).
 /// - `!navigated` — the step contributed no path components. A step that
 ///   navigated reached a genuinely new position, and `trackable` already
 ///   answers for it; re-pointing it at `prefix` would report the wrong path.
@@ -24584,6 +24581,21 @@ struct StepRegisterFacts {
 /// - [`register_identical`] — the whole rule, shared with the fold register
 ///   so the two cannot drift.
 ///
+/// `branch_trackable` is **not** a precondition here (#2044): a trackable
+/// branch that this stage drops out of trackability (a computed, non-
+/// navigating value — the caller's own `step_trackable` already went
+/// `false`) can still land back on the register by this exact rule, the
+/// same as an already-untracked branch can. jq's `INDEX`/`PATH_END` run
+/// `jv_identical` against the register on *every* step regardless of
+/// whether the resolver here still considers the branch trackable —
+/// confirmed live: `path(null | .a)` on `null` input is `["a"]`, because a
+/// freshly computed `null` is `jv_identical` to a `null` register exactly
+/// like an already-untracked one would be. The caller sources `register`
+/// from `step_register` (not `carried_register`) for this case, since
+/// `carried_register` is only ever populated once already-untracked
+/// (`resolve_leaf` records the ambient value as `step_register` on the
+/// very transition that drops trackability — see [`carry_register`]).
+///
 /// This only ever turns a refusal into an answer, so getting it *wrong*
 /// costs an accepted path jq refuses — the dangerous direction, and why
 /// every clause above is a conjunct rather than a heuristic.
@@ -24592,8 +24604,7 @@ fn reestablishes_register(
     register: Option<&OwnedValue>,
     resulting: &OwnedValue,
 ) -> bool {
-    !facts.branch_trackable
-        && !facts.navigated
+    !facts.navigated
         && facts.stage_preserves_register
         && register.is_some_and(|reg| register_identical(reg, resulting, facts.step_snapshot))
 }
@@ -24836,8 +24847,19 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     stage_preserves_register,
                     step_snapshot,
                 };
-                let reestablished =
-                    reestablishes_register(facts, carried_register.as_deref(), &resulting);
+                // The register entering this step (#2044): while the branch
+                // was still trackable, the register was `current` itself,
+                // and `resolve_leaf` records that value as `step_register`
+                // on exactly the transition that drops trackability --
+                // `carried_register` is only ever populated once already
+                // untracked (see `reestablishes_register`'s own doc
+                // comment).
+                let register_entering = if branch_trackable {
+                    step_register.as_deref()
+                } else {
+                    carried_register.as_deref()
+                };
+                let reestablished = reestablishes_register(facts, register_entering, &resulting);
                 let path = if reestablished {
                     Rc::clone(&prefix)
                 } else {
@@ -70285,6 +70307,46 @@ mod tests {
         query!(br#"{"a":{"b":1}}"#, r"path(.a as $y | .a | $y)",
             QueryResult::Error(e) => {
                 assert!(e.is_invalid_path_expression());
+            }
+        );
+    }
+
+    /// #2044: `reestablishes_register`'s `!branch_trackable` conjunct
+    /// excluded the *plain-pipe* case (no variable at all) from the same
+    /// `jv_identical` default-arm rule `register_identical` already applies
+    /// once already-untracked -- a *freshly computed* `null`/`true`/`false`
+    /// reached from a still-trackable position (the document root here) is
+    /// `jv_identical` to a matching register too, exactly like jq's own
+    /// `INDEX`/`PATH_END` opcodes see it. Live-verified against jq 1.7.1:
+    /// `path(null | .a)` on `null` input is `["a"]`.
+    #[test]
+    fn test_path_reestablishes_register_from_trackable_branch_2044() {
+        query!(b"null", r"path(null | .a)",
+            QueryResult::Owned(OwnedValue::Array(path)) => {
+                assert_eq!(path, vec![OwnedValue::String("a".to_string())]);
+            }
+        );
+
+        // A non-null/bool value reached the same way is *not* covered by
+        // `register_identical`'s default arm (jq's own `jv_identical` only
+        // takes that unconditional path for null/true/false) -- still
+        // refuses, same as the pre-#2044 behavior. `Field`/`Index` against
+        // an untracked value raises the "near attempt to access element"
+        // wording (`ErrorKind::UntrackedNavigation`), not the "with result"
+        // one `is_invalid_path_expression` checks -- see
+        // `invalid_path_expression_near_access`'s own doc comment.
+        query!(b"null", r"path(true | .a)",
+            QueryResult::Error(e) => {
+                assert!(e.is_untracked_navigation_error());
+            }
+        );
+
+        // The issue's own second repro: a `$var` snapshot combined with the
+        // same trackable-branch null re-establishment, live-verified
+        // against jq 1.7.1 as `[0]`.
+        query!(b"null", r"path((try . catch 1) as $v | null | .[0] | $v)",
+            QueryResult::Owned(OwnedValue::Array(path)) => {
+                assert_eq!(path, vec![OwnedValue::Int(0)]);
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24526,12 +24526,14 @@ fn apply_static_tail<'a, S: EvalSemantics>(
 
 /// The register-relevant facts about one resolved step (#1573), bundled so
 /// the two rules below cannot be handed different subsets of them — and
-/// because four independent `bool`s at a call site is exactly what clippy's
-/// `fn_params_excessive_bools` is for (same reasoning as `SliceEditFlags`).
+/// because three independent `bool`s at a call site is exactly what
+/// clippy's `fn_params_excessive_bools` is for (same reasoning as
+/// `SliceEditFlags`). Does *not* carry `branch_trackable` (#2044): that's
+/// now a per-call eligibility decision (`trackable_step_register_eligible`)
+/// computed once by the caller and threaded through, not a fact bundled
+/// alongside these three.
 #[derive(Clone, Copy)]
 struct StepRegisterFacts {
-    /// Was the branch entering this stage still sitting on the register?
-    branch_trackable: bool,
     /// Did this step contribute path components of its own?
     navigated: bool,
     /// Can the stage's *expression* be proven not to have moved jq's own
@@ -24543,9 +24545,9 @@ struct StepRegisterFacts {
 }
 
 /// Whether a still-trackable branch's own step -- one that itself drops out
-/// of trackability, per [`StepRegisterFacts::branch_trackable`] being `true`
-/// entering it -- is eligible to have that step's `resolve_leaf`-recorded
-/// register (#2044) consulted for re-establishment or carried forward to
+/// of trackability, per its own `branch_trackable` being `true` entering it
+/// -- is eligible to have that step's `resolve_leaf`-recorded register
+/// (#2044) consulted for re-establishment or carried forward to
 /// the next stage. Shared by [`reestablishes_register`]'s own consultation
 /// and [`carry_register`]'s forwarding decision so the mode gate cannot
 /// independently drift between the two the way this file's history already
@@ -24556,9 +24558,11 @@ struct StepRegisterFacts {
 ///
 /// jq mode only: real yq no-ops a field/index access against a scalar
 /// (#1181's convention) rather than navigating through it, a rule neither
-/// call site knows about and that isn't consulted at either one yet for a
-/// *plain*, non-computed key (#2107's own, separately-tracked gap) — so yq
-/// mode treats a still-trackable branch's own step as ineligible
+/// call site knows about — this resolver's `resolve_leaf` fallback (what
+/// `resolve_seq` ultimately reaches for a literal like the `null` here) is
+/// part of the "dynamic-prepass" family #1419 already tracks as having no
+/// yq-mode exception anywhere — so yq mode treats a still-trackable
+/// branch's own step as ineligible
 /// unconditionally, leaving it exactly as refuse-only as it was pre-#2044
 /// in both the single-step (`reestablishes_register`) and carried-forward,
 /// multi-step (`carry_register`) shapes. Both confirmed live against yq
@@ -24670,26 +24674,29 @@ fn reestablishes_register(
 /// common case where the register is never consulted again; the borrow
 /// `resolve_leaf` records today costs nothing. Kept as `Cow` deliberately.
 ///
-/// The "trackable again" arm is gated by [`trackable_step_register_eligible`]
-/// (#2044), the same jq-only eligibility [`reestablishes_register`]'s own
-/// caller checks — carrying `step_register` forward here for an ineligible
-/// (yq-mode) transition would let a *later* already-untracked step
-/// reestablish from it despite [`reestablishes_register`]'s own call site
-/// never being eligible to use it directly, reopening the exact data-
-/// corruption gap that mode gate exists to close, just one step later
-/// (confirmed live: `(null | null | .a) = 5` in yq mode). When ineligible,
-/// `carried` is `None` by construction anyway (a still-trackable branch
-/// never had anything carried), so this still answers `None`, matching
-/// pre-#2044 behavior exactly.
-fn carry_register<'a, S: EvalSemantics>(
+/// The "trackable again" arm is gated by `trackable_step_eligible` (#2044,
+/// [`trackable_step_register_eligible`]) — the caller computes this once
+/// and passes it in, the same jq-only eligibility its own
+/// `reestablishes_register` check already used for this exact step, rather
+/// than this function re-deriving it independently. Carrying
+/// `step_register` forward for an ineligible (yq-mode) transition would let
+/// a *later* already-untracked step reestablish from it despite
+/// `reestablishes_register`'s own call site never being eligible to use it
+/// directly, reopening the exact data-corruption gap that mode gate exists
+/// to close, just one step later (confirmed live: `(null | null | .a) = 5`
+/// in yq mode). When ineligible, `carried` is `None` by construction anyway
+/// (a still-trackable branch never had anything carried), so this still
+/// answers `None`, matching pre-#2044 behavior exactly.
+fn carry_register<'a>(
     facts: StepRegisterFacts,
     reestablished: bool,
+    trackable_step_eligible: bool,
     carried: &Option<Cow<'a, OwnedValue>>,
     step_register: Option<Cow<'a, OwnedValue>>,
 ) -> Option<Cow<'a, OwnedValue>> {
     if reestablished || facts.navigated || !facts.stage_preserves_register {
         None
-    } else if trackable_step_register_eligible::<S>(facts.branch_trackable) {
+    } else if trackable_step_eligible {
         step_register
     } else {
         carried.clone()
@@ -24885,7 +24892,6 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     register: step_register,
                 } = step;
                 let facts = StepRegisterFacts {
-                    branch_trackable,
                     navigated: components.depth() > 0,
                     stage_preserves_register,
                     step_snapshot,
@@ -24895,9 +24901,15 @@ fn resolve_seq<'a, S: EvalSemantics>(
                 // and `resolve_leaf` records that value as `step_register`
                 // on exactly the transition that drops trackability --
                 // `carried_register` is only ever populated once already
-                // untracked. See `trackable_step_register_eligible` for the
-                // jq-only mode gate this shares with `carry_register` below.
-                let register_entering = if trackable_step_register_eligible::<S>(branch_trackable) {
+                // untracked. Computed once and threaded into both this
+                // check and `carry_register` below, rather than each
+                // re-deriving it, so the jq-only mode gate
+                // (`trackable_step_register_eligible`) cannot drift between
+                // the two the way this file's own history already shows it
+                // can.
+                let trackable_step_eligible =
+                    trackable_step_register_eligible::<S>(branch_trackable);
+                let register_entering = if trackable_step_eligible {
                     step_register.as_deref()
                 } else {
                     carried_register.as_deref()
@@ -24909,9 +24921,10 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     PathPrefix::extend_many(&prefix, components.to_vec())
                 };
                 PathBranch {
-                    register: carry_register::<S>(
+                    register: carry_register(
                         facts,
                         reestablished,
+                        trackable_step_eligible,
                         &carried_register,
                         step_register,
                     ),
@@ -70407,11 +70420,12 @@ mod tests {
     /// still-trackable branch must stay jq-mode-only. Real yq no-ops a
     /// field/index access against a scalar (#1181's convention) rather than
     /// navigating through it -- that convention isn't consulted at this
-    /// particular site yet (#2107's own, separately-tracked gap for a
-    /// *plain*, non-computed key), so applying jq's own "write through a
-    /// freshly-computed null" answer to yq mode too would silently corrupt
-    /// data instead of either erroring (this resolver's own pre-#2044
-    /// behavior) or no-oping (what real yq actually does). Live-verified
+    /// particular site yet (#1419's own, separately-tracked "dynamic-
+    /// prepass family has no yq-mode exception anywhere" gap), so applying
+    /// jq's own "write through a freshly-computed null" answer to yq mode
+    /// too would silently corrupt data instead of either erroring (this
+    /// resolver's own pre-#2044 behavior) or no-oping (what real yq
+    /// actually does). Live-verified
     /// against yq v4.53.3: `(null | .a) = 5` on `null` is a no-op (`null`
     /// unchanged), not a write.
     #[test]
@@ -70439,6 +70453,22 @@ mod tests {
     #[test]
     fn test_reestablishes_register_stays_jq_mode_only_multi_step_2044() {
         yq_query!(b"null", r"(null | null | .a) = 5",
+            QueryResult::Error(e) => {
+                assert!(e.is_untracked_navigation_error());
+            }
+        );
+    }
+
+    /// #2044 code review: the two tests above only exercise the mode gate
+    /// through an assignment's write-target resolution -- `path()` itself
+    /// reaches the identical `resolve_seq`/`reestablishes_register` code
+    /// (there's no `--jq-extensions` gate on `path` in yq mode), so pin the
+    /// bare read form too. Live-verified against yq v4.53.3: `path(null |
+    /// .a)` on `null` still refuses, matching the pre-#2044 behavior this
+    /// gate is meant to preserve for yq mode.
+    #[test]
+    fn test_reestablishes_register_stays_jq_mode_only_read_2044() {
+        yq_query!(b"null", r"path(null | .a)",
             QueryResult::Error(e) => {
                 assert!(e.is_untracked_navigation_error());
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22422,14 +22422,16 @@ fn cannot_move_register(expr: &Expr) -> bool {
 /// the same filter with `false` on `{"a":false}` both answer `["a"]`, while
 /// `false` against `{"a":true}` raises).
 ///
-/// jq applies that same `null`/`bool` arm one step earlier than succinctly
-/// does: `path(.a | null)` on `{"a":null}` is `["a"]` in jq, because the
-/// literal never moved the register and `null` is identical to it — while
-/// succinctly refuses, since `reestablishes_register` only re-establishes a
-/// branch that is *already* untracked and a stage sitting directly on a
-/// trackable one never gets there. Refuse-only, pre-existing, and recorded
-/// in `docs/compliance/jq/limitations.md`; do not read the arm below as
-/// claiming that shape works.
+/// jq applies that same `null`/`bool` arm regardless of whether the branch
+/// reaching it was already untracked or is only just now stepping off a
+/// still-trackable one: `path(.a | null)` on `{"a":null}` is `["a"]` in jq,
+/// because the literal never moved the register and `null` is identical to
+/// it. `reestablishes_register`'s jq-mode call site handles both cases
+/// (#2044 widened it to also cover a still-trackable branch's own step,
+/// which used to be excluded and refuse this shape).
+///
+/// yq mode does **not** get this widening — see
+/// [`trackable_step_register_eligible`] for why.
 ///
 /// So a value is identical to the register when it equals it *and* is
 /// either
@@ -22437,12 +22439,6 @@ fn cannot_move_register(expr: &Expr) -> bool {
 /// - a frozen `as`-binding snapshot (`PathBranch::snapshot`) — a value jq is
 ///   still holding by the very same pointer, never rebuilt — or
 /// - a `null`/`true`/`false`.
-///
-/// A *trackable* branch never needs this: it navigated to a real path, and
-/// its caller places it directly. Both callers keep their own separate
-/// `trackable` precondition (a dead register can never match anything)
-/// rather than folding it in here, so this stays a pure statement about the
-/// two values.
 ///
 /// Kept as one function precisely because it is now consulted from two
 /// unrelated places: a second, hand-inlined copy of this rule would be free
@@ -24546,6 +24542,36 @@ struct StepRegisterFacts {
     step_snapshot: bool,
 }
 
+/// Whether a still-trackable branch's own step -- one that itself drops out
+/// of trackability, per [`StepRegisterFacts::branch_trackable`] being `true`
+/// entering it -- is eligible to have that step's `resolve_leaf`-recorded
+/// register (#2044) consulted for re-establishment or carried forward to
+/// the next stage. Shared by [`reestablishes_register`]'s own consultation
+/// and [`carry_register`]'s forwarding decision so the mode gate cannot
+/// independently drift between the two the way this file's history already
+/// shows it can ("#1573's register re-establishment had already been fixed
+/// in the `Ok` arm alone once before the `Err` arm's identical omission was
+/// noticed" — the same class of bug, here between two different functions
+/// rather than two arms of one).
+///
+/// jq mode only: real yq no-ops a field/index access against a scalar
+/// (#1181's convention) rather than navigating through it, a rule neither
+/// call site knows about and that isn't consulted at either one yet for a
+/// *plain*, non-computed key (#2107's own, separately-tracked gap) — so yq
+/// mode treats a still-trackable branch's own step as ineligible
+/// unconditionally, leaving it exactly as refuse-only as it was pre-#2044
+/// in both the single-step (`reestablishes_register`) and carried-forward,
+/// multi-step (`carry_register`) shapes. Both confirmed live against yq
+/// v4.53.3: `(null | .a) = 5` and `(null | null | .a) = 5` are both no-ops
+/// on `null` input, never the write jq's own `{"a":5}` answer would become
+/// if either call site treated this as eligible in yq mode — silently
+/// corrupting data is a worse outcome than the refusal it would replace.
+/// The already-untracked case (this function's `false` branch) is
+/// unaffected by the mode gate in either direction.
+fn trackable_step_register_eligible<S: EvalSemantics>(branch_trackable: bool) -> bool {
+    branch_trackable && S::TAG == EvalTag::Jq
+}
+
 /// Whether one pipe stage's output re-establishes the path register, and so
 /// is trackable again despite arriving on an already-untracked branch
 /// (#1573).
@@ -24596,6 +24622,11 @@ struct StepRegisterFacts {
 /// (`resolve_leaf` records the ambient value as `step_register` on the
 /// very transition that drops trackability — see [`carry_register`]).
 ///
+/// **jq mode only for the still-trackable case** — the caller gates which
+/// `register` it passes in through [`trackable_step_register_eligible`];
+/// see that function's own doc comment for why yq mode stays refuse-only
+/// here.
+///
 /// This only ever turns a refusal into an answer, so getting it *wrong*
 /// costs an accepted path jq refuses — the dangerous direction, and why
 /// every clause above is a conjunct rather than a heuristic.
@@ -24638,7 +24669,19 @@ fn reestablishes_register(
 /// cost an allocation at *every* recording, including the overwhelmingly
 /// common case where the register is never consulted again; the borrow
 /// `resolve_leaf` records today costs nothing. Kept as `Cow` deliberately.
-fn carry_register<'a>(
+///
+/// The "trackable again" arm is gated by [`trackable_step_register_eligible`]
+/// (#2044), the same jq-only eligibility [`reestablishes_register`]'s own
+/// caller checks — carrying `step_register` forward here for an ineligible
+/// (yq-mode) transition would let a *later* already-untracked step
+/// reestablish from it despite [`reestablishes_register`]'s own call site
+/// never being eligible to use it directly, reopening the exact data-
+/// corruption gap that mode gate exists to close, just one step later
+/// (confirmed live: `(null | null | .a) = 5` in yq mode). When ineligible,
+/// `carried` is `None` by construction anyway (a still-trackable branch
+/// never had anything carried), so this still answers `None`, matching
+/// pre-#2044 behavior exactly.
+fn carry_register<'a, S: EvalSemantics>(
     facts: StepRegisterFacts,
     reestablished: bool,
     carried: &Option<Cow<'a, OwnedValue>>,
@@ -24646,7 +24689,7 @@ fn carry_register<'a>(
 ) -> Option<Cow<'a, OwnedValue>> {
     if reestablished || facts.navigated || !facts.stage_preserves_register {
         None
-    } else if facts.branch_trackable {
+    } else if trackable_step_register_eligible::<S>(facts.branch_trackable) {
         step_register
     } else {
         carried.clone()
@@ -24852,9 +24895,9 @@ fn resolve_seq<'a, S: EvalSemantics>(
                 // and `resolve_leaf` records that value as `step_register`
                 // on exactly the transition that drops trackability --
                 // `carried_register` is only ever populated once already
-                // untracked (see `reestablishes_register`'s own doc
-                // comment).
-                let register_entering = if branch_trackable {
+                // untracked. See `trackable_step_register_eligible` for the
+                // jq-only mode gate this shares with `carry_register` below.
+                let register_entering = if trackable_step_register_eligible::<S>(branch_trackable) {
                     step_register.as_deref()
                 } else {
                     carried_register.as_deref()
@@ -24866,7 +24909,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
                     PathPrefix::extend_many(&prefix, components.to_vec())
                 };
                 PathBranch {
-                    register: carry_register(
+                    register: carry_register::<S>(
                         facts,
                         reestablished,
                         &carried_register,
@@ -70347,6 +70390,57 @@ mod tests {
         query!(b"null", r"path((try . catch 1) as $v | null | .[0] | $v)",
             QueryResult::Owned(OwnedValue::Array(path)) => {
                 assert_eq!(path, vec![OwnedValue::Int(0)]);
+            }
+        );
+
+        // The same reestablishment through an assignment's write-target
+        // resolution, not just `path()` -- live-verified against jq 1.7.1:
+        // `(null | .a) = 5` on `null` is `{"a":5}`.
+        query!(b"null", r"(null | .a) = 5",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("a"), Some(&OwnedValue::Int(5)));
+            }
+        );
+    }
+
+    /// #2044 code review: widening `reestablishes_register` for a
+    /// still-trackable branch must stay jq-mode-only. Real yq no-ops a
+    /// field/index access against a scalar (#1181's convention) rather than
+    /// navigating through it -- that convention isn't consulted at this
+    /// particular site yet (#2107's own, separately-tracked gap for a
+    /// *plain*, non-computed key), so applying jq's own "write through a
+    /// freshly-computed null" answer to yq mode too would silently corrupt
+    /// data instead of either erroring (this resolver's own pre-#2044
+    /// behavior) or no-oping (what real yq actually does). Live-verified
+    /// against yq v4.53.3: `(null | .a) = 5` on `null` is a no-op (`null`
+    /// unchanged), not a write.
+    #[test]
+    fn test_reestablishes_register_stays_jq_mode_only_2044() {
+        yq_query!(b"null", r"(null | .a) = 5",
+            QueryResult::Error(e) => {
+                assert!(e.is_untracked_navigation_error());
+            }
+        );
+    }
+
+    /// #2044 code review, second round: a *pre-existing* bug (reproduces
+    /// identically on `main` before this PR touched anything) found while
+    /// verifying the fix above -- `carry_register`'s own `branch_trackable`
+    /// arm carried a still-trackable step's `step_register` forward
+    /// unconditionally, so an already-untracked *later* step's own
+    /// `reestablishes_register` check (which was never gated by mode at
+    /// all, pre-#2044) could reestablish from the leaked value one step
+    /// after the direct site. Same underlying mechanism as the test above,
+    /// just delayed by one pipe stage -- fixed by extending
+    /// `trackable_step_register_eligible`'s mode gate to `carry_register`
+    /// too rather than leaving it as a second, independently-drifting copy
+    /// of the same eligibility rule. Live-verified against yq v4.53.3:
+    /// `(null | null | .a) = 5` on `null` is a no-op, not a write.
+    #[test]
+    fn test_reestablishes_register_stays_jq_mode_only_multi_step_2044() {
+        yq_query!(b"null", r"(null | null | .a) = 5",
+            QueryResult::Error(e) => {
+                assert!(e.is_untracked_navigation_error());
             }
         );
     }


### PR DESCRIPTION
## Summary

\`path()\` refused to navigate off a computed \`null\`/\`false\`/\`true\` that is \`jv_identical\` to the path register, where jq navigates it happily — but only when reached from a **still-trackable** position (no variable involved, the plain pipe).

\`reestablishes_register\`'s \`!branch_trackable\` conjunct excluded exactly this case from the same \`jv_identical\` default-arm rule \`register_identical\` already applied once a branch was already untracked. jq's own \`INDEX\`/\`PATH_END\` opcodes run \`jv_identical\` against the register on *every* step regardless of whether this resolver still considers the branch trackable — a freshly computed \`null\` is identical to a \`null\` register exactly the same way whether we arrived there via navigation or a literal.

```console
$ echo null | succinctly jq -c 'path(null | .a)'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null   # was
["a"]                                                                                            # real jq
```

## Fix

- Drop \`reestablishes_register\`'s \`!branch_trackable\` conjunct.
- Source the register to check from \`step_register\` (what \`resolve_leaf\` records on the exact transition that drops trackability) instead of \`carried_register\` (only ever populated once already untracked) when the incoming branch was trackable.

## Verification

- Both repros from the issue, live-verified against jq 1.7.1:
  - \`path(null | .a)\` on \`null\` → \`["a"]\`
  - \`path((try . catch 1) as $v | null | .[0] | $v)\` on \`null\` → \`[0]\`
- Negative control unaffected: \`path(true | .a)\` (a non-null/bool value the fuzzer's own matrix confirmed still refuses) still refuses.
- Re-ran the full \`#1573\` precedent matrix from \`reestablishes_register\`'s own doc comment — all match jq 1.7.1, including the deliberately-still-refused \`test_path_navigated_binding_still_refused_pending_gate_1573\` case (a separate, documented gap this fix doesn't touch).
- Broader manual oracle sweep (7 more null/bool/mixed shapes) — all match.

Fixes #2044.

## Test plan
- [x] New unit test \`test_path_reestablishes_register_from_trackable_branch_2044\` pinning both of the issue's own repros plus the non-null/bool negative control
- [x] \`cargo test --features cli,simd,regex,serde\` (full suite, 0 failures) — existing \`#1573\`/\`#1440\` register-machinery tests all still pass unchanged
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\`
- [x] \`cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only\` clean