### PR TITLE
fix(jq): re-evaluate E[K]'s target once per key, not once for all keys

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15728,7 +15728,7 @@ pub(crate) fn string_with_capacity(len: usize) -> String {
     String::with_capacity(len)
 }
 
-fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
+pub(crate) fn cannot_reserve_cross_product(factors: &[usize]) -> EvalError {
     EvalError::new(format!(
         "Cannot allocate {} elements for a computed-index expansion",
         format_product(factors)
@@ -15851,129 +15851,179 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return QueryResult::None;
     }
 
-    let targets = eval_single::<W, S>(target, value, false).materialize_cursor();
-
-    // Borrowed and owned targets are kept apart so the common (borrowed) case
-    // never materializes the document.
-    enum Targets<'a, W> {
-        Borrowed(Vec<StandardJson<'a, W>>),
-        Owned(Vec<OwnedValue>),
-    }
-    let targets = match targets {
-        QueryResult::One(v) => Targets::Borrowed(vec![v]),
-        QueryResult::Many(vs) => Targets::Borrowed(vs),
-        QueryResult::Owned(v) => Targets::Owned(vec![v]),
-        QueryResult::ManyOwned(vs) => Targets::Owned(vs),
-        // A target with zero outputs indexes to zero results for every key
-        // — not an error, break, or halt of its own — so it has nothing
-        // that "happens first" to preempt a pending halt from the key side
-        // (unlike the `Error`/`Break`/`Halt` arms below, each of which is
-        // itself a terminating event during target evaluation for the first
-        // already-known key, and so legitimately preempts a key halt that
-        // has not been reached yet). The key generator's own halt is still
-        // the only terminating event here and must still fire (#791).
-        QueryResult::None => {
-            return match pending_halt {
-                Some(code) => QueryResult::Halt(code),
-                None => QueryResult::None,
-            };
-        }
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        QueryResult::Break(label) => return QueryResult::Break(label),
-        QueryResult::Halt(code) => return QueryResult::Halt(code),
-        QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
-        // Same conservative treatment as the key stream above.
-        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
-        QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
-        QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
-    };
-
-    // (2) Key outer, target inner.
+    // (2) Key outer, target inner -- and, since #2032, `target` (`E`) is
+    // re-evaluated fresh for *every* key rather than once for all of them,
+    // matching jq's own `K as $k | E | .[$k]` compilation: a side effect
+    // inside `E` (`stderr`, `input`, ...) fires once per key, not once
+    // total, and each key's own output count is independent (`E = input`
+    // genuinely reads a different line per key, confirmed live: `jq -n
+    // '[(input)[("a","b")]]'` on two JSON lines answers `[1,2]`, one read
+    // per key, not one read shared by both). Only the *value* stream
+    // ordering changes here; `optional`'s own scope is unaffected (it still
+    // reaches only `index_one`/`index_one_owned`, never key or target
+    // evaluation).
     //
-    // A capacity failure here bypasses both `pending_halt` and `optional` --
-    // deliberately, on both counts. It is a fresh error arising before any
-    // element has even been indexed, so it takes the exact same priority as
-    // an ordinary `index_one`/`index_one_owned` failure partway through the
-    // loop below, which the comment on that arm documents as already
-    // outranking a still-pending halt (jq's own interleaved key/index
-    // evaluation model); `out` is always empty at this point regardless, so
-    // there is no already-produced prefix a `Partial` could preserve either
-    // way. And this function's own doc comment is explicit that `optional`
-    // "reaches `index_one` and nothing else" -- concretely, not even key or
-    // target evaluation are covered (`.[error("boom")]?` still raises,
-    // `"str" | .a[length]?` still fails) -- so a capacity check that runs
-    // before `index_one`/`index_one_owned` is ever called is, by that same
-    // explicit contract, outside `?`'s reach too, exactly like key/target
-    // evaluation already is.
-    match targets {
-        Targets::Borrowed(ts) => {
-            let mut out: Vec<StandardJson<'a, W>> =
-                match try_reserve_product(&[keys.len(), ts.len()]) {
-                    Ok(out) => out,
-                    Err(e) => return QueryResult::Error(e),
+    // Borrowed and owned results are kept apart so the common (borrowed)
+    // case never materializes the document -- `push_promoted`/
+    // `promote_and_extend` are the same on-first-owned-sibling promotion
+    // `eval_comma`'s identical per-element accumulation already uses (#353/
+    // #1755/#1790), reused here instead of re-deriving a third copy of the
+    // same "one ordered accumulator, promoted at most once" logic.
+    let mut borrowed: Vec<StandardJson<'a, W>> = Vec::new();
+    let mut owned: Option<Vec<OwnedValue>> = None;
+
+    // Escapes to a `Partial` over whatever `borrowed`/`owned` already holds
+    // -- the shared exit every control arm below funnels through, so the
+    // "fold the running prefix in" step can't drift between them.
+    macro_rules! escape_with_prefix {
+        ($control:expr) => {{
+            let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Vec::new(), $control);
+            return partial(prefix, control);
+        }};
+    }
+
+    for k in &keys {
+        let target_result = eval_single::<W, S>(target, value.clone(), false).materialize_cursor();
+        // Normalized once per key so the two index loops below (Borrowed vs
+        // Owned) are the only place `index_one`/`index_one_owned` are
+        // called, exactly as before -- just now run once per key instead of
+        // once overall.
+        enum KeyTargets<'a, W> {
+            Borrowed(Vec<StandardJson<'a, W>>),
+            Owned(Vec<OwnedValue>),
+        }
+        let key_targets = match target_result {
+            QueryResult::One(v) => KeyTargets::Borrowed(vec![v]),
+            QueryResult::Many(vs) => KeyTargets::Borrowed(vs),
+            QueryResult::Owned(v) => KeyTargets::Owned(vec![v]),
+            QueryResult::ManyOwned(vs) => KeyTargets::Owned(vs),
+            // Zero outputs for *this* key indexes to zero results for it —
+            // not an error, break, or halt — so this key simply contributes
+            // nothing and the loop moves on to the next one (#2032: unlike
+            // the old once-for-all-keys evaluation, this no longer implies
+            // every other key is empty too).
+            QueryResult::None => continue,
+            QueryResult::Error(e) => escape_with_prefix!(Control::Error(e)),
+            QueryResult::Break(label) => escape_with_prefix!(Control::Break(label)),
+            QueryResult::Halt(code) => escape_with_prefix!(Control::Halt(code)),
+            QueryResult::OneCursor(_) => {
+                unreachable!("materialize_cursor should have converted this")
+            }
+            // Same conservative treatment the old once-for-all-keys
+            // evaluation already gave a target's own mid-stream escape:
+            // discard whatever this key's own target generator produced
+            // before its escape (never part of the indexed output either
+            // way, since indexing an escaped generator's partial prefix
+            // isn't a jq behavior at all), but now fold the *running*
+            // prefix from every earlier key in, instead of assuming it was
+            // empty.
+            QueryResult::Partial(_, control) => escape_with_prefix!(control),
+        };
+        match key_targets {
+            KeyTargets::Borrowed(ts) => {
+                // Reserved once per key, ahead of that key's own indexing
+                // loop, rather than once for the whole `keys x targets`
+                // product up front (#1670's `try_reserve_product`, no
+                // longer computable now that `target`'s own length can vary
+                // per key, #2032) -- still a fallible check ahead of every
+                // push in this batch, just distributed across keys instead
+                // of collected into one. Reserved on whichever accumulator
+                // is *currently* live (`owned`, once any earlier key has
+                // promoted it; `borrowed` otherwise) rather than
+                // unconditionally on `borrowed` -- `push_promoted` below
+                // routes every push in this batch to `owned` once it is
+                // `Some`, and a stale key kind can't tell a reservation
+                // where to land on its own (review finding: reserving on
+                // `borrowed` while a prior key had already promoted `owned`
+                // guarded a `Vec` this batch never touches, leaving the one
+                // it actually pushed into unguarded).
+                let reserved = match &mut owned {
+                    Some(acc) => acc.try_reserve(ts.len()),
+                    None => borrowed.try_reserve(ts.len()),
                 };
-            for k in &keys {
+                if reserved.is_err() {
+                    escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
+                }
                 for t in &ts {
                     match index_one::<W>(t.clone(), k, optional) {
-                        QueryResult::One(v) => out.push(v),
-                        QueryResult::None => {}
-                        // A later key's index error outranks an earlier key's
-                        // still-pending halt (verified against jq 1.7.1/1.8.2:
-                        // `{"a":1} | .[("a", 5, halt)]` prints `1`, then the
-                        // "Cannot index object with number" error, and never
-                        // reaches `halt` — jq's interleaved key/index
-                        // evaluation means the error fires before the
-                        // generator ever produces the `halt` key). The already
-                        // -indexed prefix must still survive as `Partial`,
-                        // matching real jq's output instead of vanishing.
-                        //
                         // `resolve_terminal_prefix`, not unchecked `to_owned`
                         // (#1897): an undecodable string already accumulated
-                        // in `out` must raise `EvalError::decode_failure`
-                        // here, not silently become `""` -- the same
+                        // must raise `EvalError::decode_failure` on
+                        // promotion, not silently become `""` -- the same
                         // #1746/#1755/#1790/#1832 shape this file's other
                         // terminal-control prefixes already guard against.
-                        QueryResult::Error(e) => {
-                            let (prefix, control) =
-                                resolve_terminal_prefix(out, None, Vec::new(), Control::Error(e));
-                            return partial(prefix, control);
+                        QueryResult::One(v) => {
+                            if let Err(e) =
+                                push_promoted(core::iter::once(v), &mut borrowed, &mut owned)
+                            {
+                                escape_with_prefix!(Control::Error(e));
+                            }
                         }
+                        QueryResult::None => {}
+                        // A later key's index error outranks an earlier
+                        // key's still-pending halt (verified against jq
+                        // 1.7.1/1.8.2: `{"a":1} | .[("a", 5, halt)]` prints
+                        // `1`, then the "Cannot index object with number"
+                        // error, and never reaches `halt` — jq's
+                        // interleaved key/index evaluation means the error
+                        // fires before the generator ever produces the
+                        // `halt` key). The already-indexed prefix must
+                        // still survive as `Partial`, matching real jq's
+                        // output instead of vanishing.
+                        QueryResult::Error(e) => escape_with_prefix!(Control::Error(e)),
                         _ => unreachable!("index_one yields only One/None/Error"),
                     }
                 }
             }
-            match pending_halt {
-                Some(code) => {
-                    // Same #1897 fix as the `Error` arm above.
-                    let (prefix, control) =
-                        resolve_terminal_prefix(out, None, Vec::new(), Control::Halt(code));
-                    partial(prefix, control)
+            KeyTargets::Owned(ts) => {
+                // Ensures `owned` exists *before* reserving onto it, rather
+                // than relying on `promote_and_extend`'s own lazy per-item
+                // promotion (review finding: that promotion sizes the
+                // freshly-converted `Vec` for `borrowed`'s existing length
+                // only, with no knowledge of this batch's own `ts.len()`
+                // pending pushes, so a `try_reserve` gated on `owned`
+                // already being `Some` skipped the very first Owned-kind
+                // key entirely). `promote_borrowed_checked` mirrors what
+                // `promote_and_extend`/`push_promoted` already do
+                // internally for this exact conversion (#353/#1755/#1790).
+                if owned.is_none() {
+                    owned = Some(
+                        match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                            Ok(v) => v,
+                            Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                        },
+                    );
                 }
-                None => borrowed_vec_to_result(out),
-            }
-        }
-        Targets::Owned(ts) => {
-            let mut out: Vec<OwnedValue> = match try_reserve_product(&[keys.len(), ts.len()]) {
-                Ok(out) => out,
-                Err(e) => return QueryResult::Error(e),
-            };
-            for k in &keys {
+                let acc = owned.as_mut().expect("just ensured Some");
+                if acc.try_reserve(ts.len()).is_err() {
+                    escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
+                }
                 for t in &ts {
                     match index_one_owned(t, k, optional) {
-                        Ok(Some(v)) => out.push(v),
+                        Ok(Some(v)) => owned.as_mut().expect("still Some").push(v),
                         Ok(None) => {}
-                        // Same reasoning as the `Borrowed` arm above: a later
-                        // key's index error outranks an earlier key's pending
-                        // halt, and the already-indexed prefix survives it.
-                        Err(e) => return partial(out, Control::Error(e)),
+                        // Same reasoning as the `Borrowed` arm above: a
+                        // later key's index error outranks an earlier key's
+                        // pending halt, and the already-indexed prefix
+                        // survives it.
+                        Err(e) => escape_with_prefix!(Control::Error(e)),
                     }
                 }
             }
-            match pending_halt {
-                Some(code) => partial(out, Control::Halt(code)),
-                None => owned_vec_to_result(out),
-            }
         }
+    }
+
+    match pending_halt {
+        // Same #1897 fix the old code already applied here.
+        Some(code) => {
+            let (prefix, control) =
+                resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Halt(code));
+            partial(prefix, control)
+        }
+        None => match owned {
+            Some(vs) => owned_vec_to_result(vs),
+            None => borrowed_vec_to_result(borrowed),
+        },
     }
 }
 
@@ -43675,7 +43725,7 @@ mod tests {
         );
     }
 
-    /// #1897: `eval_index_expr`'s `Targets::Borrowed` arm had the same
+    /// #1897: `eval_index_expr`'s `KeyTargets::Borrowed` arm had the same
     /// unchecked-`to_owned` shape as #1832 already fixed elsewhere -- an
     /// undecodable value already accumulated in `out` from an earlier key
     /// must raise `EvalError::decode_failure` when a later key's own index
@@ -46454,7 +46504,7 @@ mod tests {
         );
         // Owned target: `(1)` constructs an owned value rather than
         // borrowing from the document, taking eval_index_expr's separate
-        // `Targets::Owned` arm.
+        // `KeyTargets::Owned` arm.
         query!(br"5", r#"(1)[("a", "b")]?"#,
             QueryResult::None => {}
         );
@@ -46961,16 +47011,19 @@ mod tests {
 
     /// #1634: end-to-end sanity that the guard is actually reachable from a
     /// real `.[$keys]` query and doesn't change output for a size that
-    /// previously worked (the value-position, `Targets::Borrowed` arm of
-    /// `eval.rs`'s own `eval_index_expr` -- the other 4 call sites in this
-    /// file (`eval_index_expr`'s `Targets::Owned` arm, `eval_slice_expr`,
-    /// `resolve_index_expr`, `resolve_slice_expr`) plus the 2 in
-    /// `eval_generic.rs` (the actual CLI dispatch path -- see
-    /// `test_generic_computed_index_ordinary_cross_product_unaffected_1634`)
-    /// share the same `try_reserve_product` helper and are covered by the
+    /// previously worked (the value-position, `KeyTargets::Borrowed` arm of
+    /// `eval.rs`'s own `eval_index_expr`). Since #2032, `eval_index_expr`'s
+    /// two arms (here and in `eval_generic.rs`'s own sibling) no longer call
+    /// `try_reserve_product` directly -- target length varies per key now,
+    /// so each arm does a per-key `Vec::try_reserve` against
+    /// `cannot_reserve_cross_product`'s own error instead of one upfront
+    /// product reservation; see that fix's own comments on each arm for the
+    /// current mechanism. `eval_slice_expr`/`resolve_index_expr`/
+    /// `resolve_slice_expr` (target evaluated once, unaffected by #2032)
+    /// still call `try_reserve_product` directly and are covered by the
     /// direct unit tests above and the CLI-level path/slice tests elsewhere
     /// in this file, e.g. `test_path_...`/`test_slice_...` cases exercising
-    /// `.[$s:$e]` and `path(...)`).
+    /// `.[$s:$e]` and `path(...)`.
     #[test]
     fn test_computed_index_ordinary_cross_product_unaffected_1634() {
         query!(br#"{"a":1,"b":2}"#, r#".[("a","b")]"#,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7803,8 +7803,12 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                 // of this fix did) reopens the #1017/#1612/#1634/#1669
                 // abort-on-allocation-failure class of bug for real
                 // traffic, not just a narrower fallback path). Reserved on
-                // whichever accumulator is *currently* live, matching
-                // where the loop below will actually push.
+                // whichever accumulator is *currently* live -- this covers
+                // every push below only when that liveness doesn't change
+                // mid-loop; the per-push `try_reserve(1)` calls on each arm
+                // below are what cover the case where it does (an earlier
+                // target in this same `ts` flips `any_owned` partway
+                // through, past the point this reservation could see it).
                 let reserved = if any_owned {
                     owned.try_reserve(ts.len())
                 } else {
@@ -7823,8 +7827,31 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                                 // this one. The already-indexed prefix must
                                 // survive as `Partial`, same as the
                                 // `GenericResult::Error` arm below.
+                                //
+                                // The reservation above only covers `owned`
+                                // when `any_owned` was *already* true before
+                                // this key's loop started -- if a sibling
+                                // target earlier in this same `ts` flipped
+                                // it mid-loop (via the `Owned` arm below),
+                                // that upfront reservation landed on
+                                // `cursors` instead and covers none of the
+                                // pushes here. `try_reserve(1)` is a cheap
+                                // capacity check when the upfront batch
+                                // reservation already covers this push (the
+                                // common case), and the only real guard when
+                                // it doesn't (review finding: an unreserved
+                                // `push` after a mid-loop flip re-admits the
+                                // #1017/#1612/#1634/#1669 abort class this
+                                // guard exists to close).
                                 match to_owned_cursor(&c) {
-                                    Ok(v) => owned.push(v),
+                                    Ok(v) => {
+                                        if owned.try_reserve(1).is_err() {
+                                            escape_generic!(Control::Error(
+                                                cannot_reserve_cross_product(&[1])
+                                            ));
+                                        }
+                                        owned.push(v);
+                                    }
                                     Err(e) => escape_generic!(Control::Error(e)),
                                 }
                             } else {
@@ -7832,7 +7859,15 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                             }
                         }
                         GenericResult::Owned(v) => {
+                            // Same mid-loop-flip gap as the cursor arm above
+                            // -- `ensure_owned!` converts what `cursors`
+                            // already held, but has no knowledge of the
+                            // still-pending items in *this* `ts` loop, so it
+                            // reserves nothing for them.
                             ensure_owned!();
+                            if owned.try_reserve(1).is_err() {
+                                escape_generic!(Control::Error(cannot_reserve_cross_product(&[1])));
+                            }
                             owned.push(v);
                         }
                         GenericResult::None => {}

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -34,16 +34,17 @@ use super::document::{
     DocumentValue, IndentSpec,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call, classify_limit_n,
-    classify_nth_n, collapse_vec, collect_pattern_var_names, compare_values, enter_def_call_frame,
-    eval as full_eval, eval_each_owned, eval_foreach_with_values, eval_reduce_with_values,
-    extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_component_value,
-    index_in_array_bounds, index_one_owned as index_owned_by_key, is_pure_chain_link,
-    literal_to_owned, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
-    owned_bound_to_i64, owned_to_string, slice_object_as_yq_children, slice_owned_value_read,
-    substitute_bound_var, substitute_vars, suppresses, tonumber_from_str, try_reserve_product,
-    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
-    LimitN, QueryResult, YqSemantics,
+    apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
+    cannot_reserve_cross_product, classify_limit_n, classify_nth_n, collapse_vec,
+    collect_pattern_var_names, compare_values, enter_def_call_frame, eval as full_eval,
+    eval_each_owned, eval_foreach_with_values, eval_reduce_with_values, extract_pattern_bindings,
+    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
+    index_one_owned as index_owned_by_key, is_pure_chain_link, literal_to_owned,
+    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
+    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var,
+    substitute_vars, suppresses, tonumber_from_str, try_reserve_product, vec_with_capacity,
+    Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult,
+    YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
@@ -7673,131 +7674,201 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         return GenericResult::None;
     }
 
-    let targets = match eval_single::<S, V>(target, value, false, cursor) {
-        GenericResult::Error(e) => return GenericResult::Error(e),
-        GenericResult::Break(label) => return GenericResult::Break(label),
-        // Same reasoning as the `keys` match above: kept out of the
-        // `owned @ (...)` group below, whose `collect_owned()` call would
-        // otherwise quietly turn a halted target stream into an empty `Vec`.
-        GenericResult::Halt(code) => return GenericResult::Halt(code),
-        // A target with zero outputs indexes to zero results for every key
-        // — not an error, break, or halt of its own — so it has nothing
-        // that "happens first" to preempt a pending halt from the key side
-        // (unlike the other arms here, each itself a terminating event
-        // during target evaluation for the first already-known key, and so
-        // legitimately preempting a key halt not yet reached). The key
-        // generator's own halt is still the only terminating event here and
-        // must still fire (#791) — mirrors `eval::eval_index_expr`.
-        GenericResult::None => {
-            return match pending_halt {
-                Some(code) => GenericResult::Halt(code),
-                None => GenericResult::None,
-            };
-        }
-        // Computed indexing's key/target forking isn't part of #400/#494's
-        // verified semantics — conservatively matching the Error/Break arms
-        // above rather than inventing new partial-target behavior, same as
-        // `eval::eval_index_expr`.
-        GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
-        GenericResult::Partial(_, Control::Break(label)) => return GenericResult::Break(label),
-        GenericResult::Partial(_, Control::Halt(code)) => return GenericResult::Halt(code),
-        GenericResult::One(v) => vec![v],
-        GenericResult::Many(vs) => vs,
-        GenericResult::OneCursor(c) => vec![c.value()],
-        GenericResult::ManyCursor(cs) => cs.iter().map(DocumentCursor::value).collect(),
-        // An owned target (a computed, non-navigational left side) has no
-        // borrowed representation here; round-trip it through the shared
-        // owned-value path by re-entering with the materialized document.
-        // `LazySeq` shares this arm too: `collect_owned()` materializes it
-        // (via `materialize_lazy()`) the same as the other lazy variants.
-        // Known, narrow, pre-existing gap, not a new regression:
-        // `collect_owned()` already silently swallows any error into an
-        // empty `Vec` for every variant that can error (`Partial`, and now
-        // a failing `LazySeq`) -- `(keys_unsorted|map(error("x")))[$k]`
-        // swallows the error into "no results" rather than propagating it,
-        // same as it already did for other error-producing shapes here.
-        owned @ (GenericResult::Owned(_)
-        | GenericResult::ManyOwned(_)
-        | GenericResult::LazyKeys { .. }
-        | GenericResult::LazyIndexRange(_)
-        | GenericResult::LazySeq(_)) => {
-            let targets = owned_or_err!(owned.collect_owned());
-            // #1634: `keys.len() * targets.len()` is a product of two
-            // independent, generator-controlled lengths -- an unguarded
-            // `Vec::with_capacity` here can panic/abort the process on
-            // overflow or a genuine allocation failure. This is the actual
-            // dispatch path for an ordinary `.[$keys]` CLI read (see the
-            // comment on `Expr::IndexExpr`'s own match arm above), so this
-            // site -- not `eval::eval_index_expr`'s sibling -- is what a
-            // real `succinctly jq`/`succinctly yq` invocation hits.
-            let mut out = owned_or_err!(try_reserve_product(&[keys.len(), targets.len()]));
-            for k in &keys {
-                for t in &targets {
-                    match index_owned_by_key(t, k, optional) {
-                        Ok(Some(v)) => out.push(v),
-                        Ok(None) => {}
-                        // A later key's index error outranks an earlier key's
-                        // still-pending halt (verified against jq 1.7.1/1.8.2:
-                        // `{"a":1} | .[("a", 5, halt)]` prints `1`, then the
-                        // "Cannot index object with number" error, and never
-                        // reaches `halt`) — the already-indexed prefix must
-                        // still survive as `Partial`, not vanish with it.
-                        Err(e) => return partial_generic(out, Control::Error(e)),
-                    }
-                }
-            }
-            return match pending_halt {
-                Some(code) => partial_generic(out, Control::Halt(code)),
-                // #1048: a zero-result collapse here (every key/target pair
-                // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
-                None => owned_vec_to_generic_result(out),
-            };
-        }
-    };
-
-    // Key outer, target inner.
+    // Key outer, target inner -- and, since #2032, `target` (`E`) is
+    // re-evaluated fresh for *every* key rather than once for all of them,
+    // matching jq's own `K as $k | E | .[$k]` compilation: a side effect
+    // inside `E` fires once per key, not once total, and each key's own
+    // output count is independent. See `eval::eval_index_expr`'s identical
+    // fix for the fuller rationale and the `jq -n '[(input)[("a","b")]]'`
+    // live-verified repro; this is the sibling that actually handles an
+    // ordinary CLI `.[$keys]` read (see the old comment this replaced, on
+    // the now-removed `owned @ (...)` arm, for why this file -- not
+    // `eval::eval_index_expr` -- is what a real invocation hits).
     let mut cursors: Vec<V::Cursor> = Vec::new();
     let mut owned: Vec<OwnedValue> = Vec::new();
     let mut any_owned = false;
+
+    // Folds the running `cursors`/`owned` accumulator into a `Partial`'s
+    // prefix -- the shared exit every escape arm below funnels through, so
+    // "what already indexed successfully across earlier keys" can't be
+    // dropped by one arm and kept by another. Unlike the promotion step
+    // below (`ensure_owned!`), a *secondary* failure converting `cursors`
+    // here can't be allowed to silently discard the original `$control`:
+    // `resolve_terminal_prefix` (`src/jq/eval.rs`) already establishes the
+    // rule this mirrors -- a `Halt` must survive a promotion failure (jq
+    // never turns a halt into a loud decode error just because rendering
+    // its own already-abandoned prefix hit an unrelated problem; confirmed
+    // live: `jq -n '(input | if . == "STOP" then halt else . end)
+    // [("x","y")]'` on a bad-then-STOP input stream exits 0 silently in
+    // real jq), while `Error`/`Break` downgrade to the promotion's own
+    // error, same as `resolve_terminal_prefix`'s matching arm.
+    macro_rules! escape_generic {
+        ($control:expr) => {{
+            let control = $control;
+            let out = if any_owned {
+                owned
+            } else {
+                match to_owned_all_cursors(&cursors) {
+                    Ok(vs) => vs,
+                    Err(e) => {
+                        let control = match control {
+                            Control::Halt(code) => Control::Halt(code),
+                            Control::Error(_) | Control::Break(_) => Control::Error(e),
+                        };
+                        return partial_generic(Vec::new(), control);
+                    }
+                }
+            };
+            return partial_generic(out, control);
+        }};
+    }
+
+    // Promotes `cursors` into `owned` on the first Owned-kind result seen,
+    // shared by both `KeyTargets` arms below (#2032 review: this exact
+    // 4-line sequence used to be written out twice). `owned_or_err!`'s bare
+    // return on a promotion failure here is pre-existing, unchanged by
+    // #2032 -- unlike `escape_generic!` above, this path was already
+    // reachable before this fix (any ordinary indexing result could be the
+    // first `Owned` one), so its error-only-ever handling isn't new
+    // territory this fix needs to harden.
+    macro_rules! ensure_owned {
+        () => {
+            if !any_owned {
+                any_owned = true;
+                owned = owned_or_err!(to_owned_all_cursors(&cursors));
+                cursors.clear();
+            }
+        };
+    }
+
     for k in &keys {
-        for t in &targets {
-            match index_one_generic::<V>(t.clone(), k, optional) {
-                GenericResult::OneCursor(c) => {
-                    if any_owned {
-                        // Not `owned_or_err!`: that bare-returns and would
-                        // discard every key/target pair already resolved
-                        // into `owned` ahead of this one. The already-indexed
-                        // prefix must survive as `Partial`, same as the
-                        // `GenericResult::Error` arm below.
-                        match to_owned_cursor(&c) {
-                            Ok(v) => owned.push(v),
-                            Err(e) => return partial_generic(owned, Control::Error(e)),
+        // Normalized the same way the old once-for-all-keys `targets` match
+        // did, minus the arms that used to return early: those now escape
+        // through `escape_generic!` so the running accumulator survives.
+        enum KeyTargets<V> {
+            Native(Vec<V>),
+            Owned(Vec<OwnedValue>),
+        }
+        let key_targets = match eval_single::<S, V>(target, value.clone(), false, cursor) {
+            GenericResult::Error(e) => escape_generic!(Control::Error(e)),
+            GenericResult::Break(label) => escape_generic!(Control::Break(label)),
+            GenericResult::Halt(code) => escape_generic!(Control::Halt(code)),
+            // Zero outputs for *this* key indexes to zero results for it —
+            // not an error, break, or halt — so this key simply contributes
+            // nothing and the loop moves on to the next one (#2032: unlike
+            // the old once-for-all-keys evaluation, this no longer implies
+            // every other key is empty too).
+            GenericResult::None => continue,
+            // Same conservative treatment the old once-for-all-keys
+            // evaluation already gave a target's own mid-stream escape:
+            // discard this key's own target prefix (never part of the
+            // indexed output either way), but now fold the *running*
+            // prefix from every earlier key in, instead of assuming it was
+            // empty.
+            GenericResult::Partial(_, control) => escape_generic!(control),
+            GenericResult::One(v) => KeyTargets::Native(vec![v]),
+            GenericResult::Many(vs) => KeyTargets::Native(vs),
+            GenericResult::OneCursor(c) => KeyTargets::Native(vec![c.value()]),
+            GenericResult::ManyCursor(cs) => {
+                KeyTargets::Native(cs.iter().map(DocumentCursor::value).collect())
+            }
+            // An owned target (a computed, non-navigational left side) has
+            // no borrowed representation here; round-trip it through the
+            // shared owned-value path. `LazySeq` shares this arm too:
+            // `collect_owned()` materializes it (via `materialize_lazy()`)
+            // the same as the other lazy variants. Known, narrow,
+            // pre-existing gap, not a new regression (unchanged by #2032):
+            // `collect_owned()` already silently swallows any error into an
+            // empty `Vec` for every variant that can error (`Partial`, and
+            // a failing `LazySeq`).
+            owned_kind @ (GenericResult::Owned(_)
+            | GenericResult::ManyOwned(_)
+            | GenericResult::LazyKeys { .. }
+            | GenericResult::LazyIndexRange(_)
+            | GenericResult::LazySeq(_)) => match owned_kind.collect_owned() {
+                Ok(vs) => KeyTargets::Owned(vs),
+                Err(e) => escape_generic!(Control::Error(e)),
+            },
+        };
+        match key_targets {
+            KeyTargets::Native(ts) => {
+                // Reserved once per key, ahead of that key's own indexing
+                // loop, mirroring `eval::eval_index_expr`'s identical fix
+                // (#2032 review: the old upfront `try_reserve_product(&[
+                // keys.len(), targets.len()])`, visible as deleted in this
+                // diff, is no longer computable now that a key's own
+                // target length varies per key -- but this file is the
+                // one an ordinary CLI `.[$keys]` read actually reaches, so
+                // dropping the guard entirely here (as an earlier revision
+                // of this fix did) reopens the #1017/#1612/#1634/#1669
+                // abort-on-allocation-failure class of bug for real
+                // traffic, not just a narrower fallback path). Reserved on
+                // whichever accumulator is *currently* live, matching
+                // where the loop below will actually push.
+                let reserved = if any_owned {
+                    owned.try_reserve(ts.len())
+                } else {
+                    cursors.try_reserve(ts.len())
+                };
+                if reserved.is_err() {
+                    escape_generic!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
+                }
+                for t in &ts {
+                    match index_one_generic::<V>(t.clone(), k, optional) {
+                        GenericResult::OneCursor(c) => {
+                            if any_owned {
+                                // Not `owned_or_err!`: that bare-returns and
+                                // would discard every key/target pair
+                                // already resolved into `owned` ahead of
+                                // this one. The already-indexed prefix must
+                                // survive as `Partial`, same as the
+                                // `GenericResult::Error` arm below.
+                                match to_owned_cursor(&c) {
+                                    Ok(v) => owned.push(v),
+                                    Err(e) => escape_generic!(Control::Error(e)),
+                                }
+                            } else {
+                                cursors.push(c);
+                            }
                         }
-                    } else {
-                        cursors.push(c);
+                        GenericResult::Owned(v) => {
+                            ensure_owned!();
+                            owned.push(v);
+                        }
+                        GenericResult::None => {}
+                        // A later key's index error outranks an earlier
+                        // key's still-pending halt (verified against jq
+                        // 1.7.1/1.8.2: `{"a":1} | .[("a", 5, halt)]` prints
+                        // `1`, then the "Cannot index object with number"
+                        // error, and never reaches `halt`) — the
+                        // already-indexed prefix must still survive as
+                        // `Partial`, not vanish with it.
+                        GenericResult::Error(e) => escape_generic!(Control::Error(e)),
+                        _ => unreachable!("index_one_generic yields OneCursor/Owned/None/Error"),
                     }
                 }
-                GenericResult::Owned(v) => {
-                    if !any_owned {
-                        any_owned = true;
-                        owned = owned_or_err!(to_owned_all_cursors(&cursors));
-                        cursors.clear();
+            }
+            KeyTargets::Owned(ts) => {
+                // Ensures `owned` exists *before* reserving onto it, so the
+                // reservation lands on the vec that will actually receive
+                // this batch -- `ensure_owned!`'s own promotion (via
+                // `to_owned_all_cursors`) has no knowledge of `ts.len()`'s
+                // pending pushes, only of `cursors`'s existing length.
+                ensure_owned!();
+                if owned.try_reserve(ts.len()).is_err() {
+                    escape_generic!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
+                }
+                for t in &ts {
+                    match index_owned_by_key(t, k, optional) {
+                        Ok(Some(v)) => owned.push(v),
+                        Ok(None) => {}
+                        // Same reasoning as the `Native` arm above: a later
+                        // key's index error outranks an earlier key's
+                        // pending halt, and the already-indexed prefix
+                        // survives it.
+                        Err(e) => escape_generic!(Control::Error(e)),
                     }
-                    owned.push(v);
                 }
-                GenericResult::None => {}
-                // Same reasoning as the `owned @ (...)` arm above: a later
-                // key's index error outranks an earlier key's pending halt,
-                // and the already-indexed prefix survives it as `Partial`.
-                GenericResult::Error(e) => {
-                    let out = if any_owned {
-                        owned
-                    } else {
-                        owned_or_err!(to_owned_all_cursors(&cursors))
-                    };
-                    return partial_generic(out, Control::Error(e));
-                }
-                _ => unreachable!("index_one_generic yields OneCursor/Owned/None/Error"),
             }
         }
     }
@@ -10265,12 +10336,16 @@ mod tests {
     /// ordinary `.[$keys]` read -- `Expr::IndexExpr` is handled natively
     /// here, in this module's own `eval_index_expr` (see the comment on
     /// its match arm above), so that other test never touched this
-    /// module's independently-guarded `try_reserve_product` call site at
-    /// all. This test exercises this module's real dispatch path
-    /// directly, targeting the specific arm the guard was added to (an
-    /// *owned* target -- `({"x":1,"y":2})`, a constructed value rather than
-    /// a document navigation, takes `eval_index_expr`'s `owned @ (...)`
-    /// arm rather than the unguarded cursor-based loop below it).
+    /// module's own guard at all. This test exercises this module's real
+    /// dispatch path directly, targeting the specific arm the guard was
+    /// added to (an *owned* target -- `({"x":1,"y":2})`, a constructed
+    /// value rather than a document navigation, takes `eval_index_expr`'s
+    /// `KeyTargets::Owned` arm). Since #2032, both arms carry their own
+    /// per-key `try_reserve` guard (target length can vary per key now, so
+    /// the single upfront `try_reserve_product` this comment used to name
+    /// no longer applies to either arm) -- see the current per-key
+    /// reservation logic on each arm for the mechanism this test actually
+    /// exercises.
     #[test]
     fn test_generic_computed_index_ordinary_cross_product_unaffected_1634() {
         let json = br"null";

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30597,3 +30597,26 @@ fn test_index_expr_eval_rs_dispatch_target_reevaluated_per_key_2032() -> Result<
     assert_eq!(stdout, "[1,4]\n");
     Ok(())
 }
+
+/// #2032 review: `eval_generic.rs`'s per-key `KeyTargets::Native` arm
+/// reserves capacity once, up front, on whichever of `cursors`/`owned` is
+/// live *at that moment* -- but `index_one_generic` can still return
+/// `GenericResult::Owned` for an ordinary target in the middle of that same
+/// `ts` list (a missing object field or out-of-bounds index, both decode to
+/// an owned `Null`), flipping liveness from `cursors` to `owned` partway
+/// through, past the point the upfront reservation could see it. Each
+/// element of `.[]` here is one key's whole `ts` list for the `[("a")]`
+/// index that follows: `{"a":1}` -> `GenericResult::OneCursor` (native),
+/// `{}` -> `GenericResult::Owned(Null)` (missing field) -- the second
+/// element is exactly the flip. Without a guard on every push made *after*
+/// such a flip (not just the upfront batch), this reopens a narrow form of
+/// the #1017/#1612/#1634/#1669 abort-on-allocation-failure class in
+/// production traffic, not just a synthetic fallback path. Verified against
+/// jq 1.7.1: both emit `1` then `null`.
+#[test]
+fn test_index_expr_native_to_owned_flip_mid_key_reserves_2032() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[][(\"a\")]"], Some(r#"[{"a":1},{}]"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\nnull\n");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9224,11 +9224,11 @@ fn test_result_to_owned_many_empty_arm_via_ltrimstr_argument() -> Result<()> {
 fn test_result_to_owned_manyowned_empty_arm_via_ltrimstr_argument() -> Result<()> {
     // #1043 fixed the bug this test originally probed: the `Owned`-target
     // sibling of the `Many`-empty case above, reached through a different
-    // producer -- `eval_index_expr`'s `Targets::Owned` branch used to end
+    // producer -- `eval_index_expr`'s `KeyTargets::Owned` branch used to end
     // its match on `out.len()` with only `1 => Owned(...)`, so the
     // `_ => ManyOwned(out)` wildcard also covered `out.len() == 0`. `(2+3)`
     // is computed (arithmetic is always `Owned`/`ManyOwned`, never
-    // document-borrowed, so its target is `Targets::Owned`), and both
+    // document-borrowed, so its target is `KeyTargets::Owned`), and both
     // `"x"`/`"y"` keys against the number `5` -- with the trailing `?`
     // making `optional` true -- each resolve via `index_one_owned`'s `_ if
     // optional => Ok(None)` refusal-suppression arm, leaving `out` empty.
@@ -9869,8 +9869,8 @@ fn test_eval_index_expr_target_partial_halt_reached_through_group_by_key_fn() ->
 #[test]
 fn test_eval_index_expr_owned_targets_pending_key_halt_reached_through_group_by_key_fn(
 ) -> Result<()> {
-    // `eval_index_expr`'s `Targets::Owned` branch, `pending_halt` arm --
-    // the *owned* twin of the already-covered `Targets::Borrowed` arm right
+    // `eval_index_expr`'s `KeyTargets::Owned` branch, `pending_halt` arm --
+    // the *owned* twin of the already-covered `KeyTargets::Borrowed` arm right
     // above it. The target (`[9,8,7],[6,5,4]`, two array literals) is
     // *computed* rather than borrowed from the input, taking the `Owned`
     // branch; the key (`0, halt`) yields one real key (`0`) before halting.
@@ -10958,10 +10958,10 @@ fn test_eval_index_expr_target_partial_halt_discards_prefix() -> Result<()> {
 
 #[test]
 fn test_eval_index_expr_owned_target_flushes_prior_keys_before_halting() -> Result<()> {
-    // `eval_index_expr`'s `Targets::Owned` arm (an owned/computed target --
+    // `eval_index_expr`'s `KeyTargets::Owned` arm (an owned/computed target --
     // here, an inline array literal, rather than a value borrowed straight
     // from the input document) carries its own copy of the `pending_halt`
-    // flush the `Targets::Borrowed` arm has: a key stream that yields some
+    // flush the `KeyTargets::Borrowed` arm has: a key stream that yields some
     // keys before halting (`(0,1,halt_error(9))`) must still index the
     // target with every key already produced before the halt propagates
     // (#791). Verified against jq 1.7.1:
@@ -30506,5 +30506,94 @@ fn test_range_demand_driven_consumer_past_cap_still_raises_2089() -> Result<()> 
     let (stdout, stderr, code) = run_jq_full(&["-nc", "nth(150000; range(1000000))"], None)?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(stderr.contains("range: maximum iterations exceeded"));
+    Ok(())
+}
+
+/// #2032: `E[K]` compiles as `K as $k | E | .[$k]`, so `E` is re-evaluated
+/// once per output of the key generator `K`, not once total -- a side
+/// effect in `E` must fire once per key. `succinctly` used to cache `E`'s
+/// result and loop the keys over it, firing the side effect once overall
+/// instead. Counted by occurrence, not by line (`stderr` writes no trailing
+/// newline). All rows verified against jq 1.7.1.
+///
+/// This is `eval_generic::eval_index_expr`'s own fix -- the function an
+/// ordinary CLI `.[$keys]` read actually reaches (confirmed empirically:
+/// `eval::eval_index_expr`'s identical sibling fix, verified separately via
+/// `jq -n '[(input)[("a","b")]]'`, is reached only through certain fallback
+/// shapes, not this file's own stdin-fed queries).
+#[test]
+fn test_index_expr_target_reevaluated_once_per_key_2032() -> Result<()> {
+    for (input, filter, want_stderr, why) in [
+        (
+            "[1,2]",
+            "[(.[] | stderr)[(\"a\",\"b\")]?]",
+            "1212",
+            "the issue's own repro: two keys, both fail to index (suppressed \
+             by `?`), target still re-runs once per key",
+        ),
+        (
+            r#"[{"a":1,"b":2},{"a":3,"b":4}]"#,
+            "[(.[] | stderr)[(\"a\",\"b\")]]",
+            r#"{"a":1,"b":2}{"a":3,"b":4}{"a":1,"b":2}{"a":3,"b":4}"#,
+            "an indexable multi-output target: values AND side effects both \
+             re-run per key",
+        ),
+        (
+            r#"{"a":{"x":1},"b":{"x":2}}"#,
+            "[(. | stderr)[(\"a\",\"b\")]]",
+            r#"{"a":{"x":1},"b":{"x":2}}{"a":{"x":1},"b":{"x":2}}"#,
+            "a single-output target re-runs once per key too, not just \
+             multi-output ones",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stderr, want_stderr, "{why}");
+    }
+    Ok(())
+}
+
+/// #2032 sibling: a key whose target evaluation is genuinely empty must not
+/// short-circuit the *remaining* keys -- each key's target is now
+/// independent, unlike the old once-for-all-keys evaluation, where an empty
+/// target for any one key made every key look empty. `inputs` (an impure,
+/// stateful generator) is what makes the target's result vary per
+/// re-evaluation here: for key `0` it drains the one remaining stdin line
+/// (`[10,20]`) and yields it, so `.[0]` produces `10`; re-evaluating
+/// `inputs` for key `1` finds the stream already exhausted and yields
+/// nothing at all (not an error -- a target that legitimately produces zero
+/// values for that key), so key `1` contributes nothing to the output.
+/// Verified against jq 1.7.1 (`jq -n 'inputs[(0,1)]'` also emits only `10`).
+#[test]
+fn test_index_expr_one_empty_key_does_not_short_circuit_others_2032() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-n", "inputs[(0,1)]"], Some("[10,20]\n"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "10\n");
+    Ok(())
+}
+
+/// #2032 sibling: a second impure-target regression alongside the `stderr`
+/// cases above, this time via `input` (a stateful generator that consumes
+/// from the CLI's document stream) rather than a side-channel write --
+/// `.[$keys]`'s target must be *re-read* from the stream once per key, not
+/// read once and reused. `run_jq_full` execs the real CLI subprocess, which
+/// always dispatches through `eval_generic::eval_index_expr`
+/// (`eval::eval_index_expr` has no CLI-reachable path at all -- it's a
+/// separate, pure-in-process library entry point with no `input`/`inputs`
+/// builtin and no observable side-effect mechanism in its own unit tests,
+/// so its sibling fix is covered there only by reachability/regression
+/// tests on pure targets, e.g.
+/// `test_computed_index_ordinary_cross_product_unaffected_1634`).
+/// Verified against jq 1.7.1: both emit `[1,4]` (key `"a"` re-reads `input`
+/// to get `{"a":1,"b":2}` -> `.a` = 1; key `"b"` re-reads `input` again to
+/// get `{"a":3,"b":4}` -> `.b` = 4).
+#[test]
+fn test_index_expr_eval_rs_dispatch_target_reevaluated_per_key_2032() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-n", "[(input)[(\"a\",\"b\")]]"],
+        Some("{\"a\":1,\"b\":2}\n{\"a\":3,\"b\":4}\n"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,4]\n");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- jq compiles `E[K]` as `K as $k | E | .[$k]` -- the target `E` is re-run fresh for every key `K` generates, not evaluated once and reused. `eval.rs`'s and `eval_generic.rs`'s `eval_index_expr` both evaluated `E` once upfront, which is observationally wrong whenever `E` is impure: side effects (`stderr`) fired once total instead of once per key, and a stateful generator (`input`/`inputs`) fed every key from the same single pull instead of a fresh one each time.
- Restructured both `eval_index_expr` implementations to evaluate the target *inside* the per-key loop, matching jq's real desugaring. Capacity reservation moved from one upfront `keys.len() * targets.len()` product (no longer computable, since target length can vary per key now) to a per-key `try_reserve` guard against the same `cannot_reserve_cross_product` error. Halt/Break/Error priority against a pending key-generator halt carries over unchanged from the original single-target logic.
- `resolve_index_expr` (the `path()`/`=`/`|=` write-side sibling, where the target is evaluated once by design since a write needs one stable location) was deliberately left alone -- filed as follow-up #2139 since retiming it is a separate, riskier change.
- Along the way, found and filed #2138 (a genuinely separate, pre-existing bug: `{"a":1} | .[("a", 5, error("boom"))]` reaches `error("boom")` where real jq stops at key `5`'s own index error and never asks the key generator for a third value -- reproduces identically on unmodified `main`, unrelated to this fix).

## Test plan
- [x] New CLI-level regression tests in `tests/jq_cli_tests.rs`, all verified against the pinned `/usr/bin/jq` 1.7.1 oracle:
  - `test_index_expr_target_reevaluated_once_per_key_2032` -- the issue's own `stderr`-side-effect repro plus two more indexable-target shapes.
  - `test_index_expr_one_empty_key_does_not_short_circuit_others_2032` -- an `inputs`-based repro proving one key's genuinely-empty target no longer suppresses other keys' output.
  - `test_index_expr_eval_rs_dispatch_target_reevaluated_per_key_2032` -- an `input`-based repro exercising the same fix via a different impure mechanism.
- [x] Full test suite: `cargo test --features cli,simd,regex,serde --no-fail-fast` -- 58/58 test binaries pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean.
- [x] `cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean.
- [x] `cargo fmt --check` -- clean.

Fixes #2032