### PR TITLE
fix(jq): until/while's step budget no longer caps ordinary loops at 10,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   string-accumulation gap against real jq's own near-linear cost, filed
   as #2086).
 
+- **`while`/`until`'s own step budget (`WHILE_UNTIL_MAX_STEPS`, #534, above)
+  no longer refuses an ordinary loop over more than 10,000 iterations**
+  (#2087): the identical bug shape #2079 (above) fixed for
+  `reduce`/`foreach` — a flat count charged once per state visited,
+  regardless of genuine backtracking fanout vs. an ordinary non-forking
+  loop — so `0 | until(. >= 50000; . + 1)` refused with `until: maximum
+  iterations exceeded` where real jq returns `50000`. Fixed the same way:
+  raised `WHILE_UNTIL_MAX_STEPS` 10x, `10000` to `100_000`, 2x above this
+  issue's own 50,000-iteration repro. See
+  [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md)
+  for the same superlinear-cost-body caveat #2079/#2086 already
+  established, measured again here for `while`/`until`'s own evaluation
+  path rather than assumed to carry over unchanged.
+
 - **A decode failure (invalid UTF-8, or a structurally malformed value) now
   raises instead of silently materializing as `null`, `""`, or a dropped
   field**, on nearly every route that turns lazily-indexed JSON/YAML into an

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2321,6 +2321,54 @@ pathological-body worst case in the single-digit seconds (measured, not
 extrapolated) rather than the tens of minutes a further 10x would cost at
 the same pathological shape.
 
+### `while`/`until`'s own step budget (#534/#2087): the identical bug #2079 already fixed for `reduce`/`foreach`
+
+`WHILE_UNTIL_MAX_STEPS` (`src/jq/eval.rs`) is a shared step budget for
+`while`/`until`'s backtracking-generator evaluation, decremented once per
+state visited across the whole recursion tree regardless of branching --
+[#534](https://github.com/rust-works/succinctly/issues/534) introduced it
+(originally `10000`) as the same class of resource-exhaustion guard
+`REDUCE_FOREACH_MAX_STEPS` was introduced for (previous section): without
+it, a multi-output `cond`/`update` forks the rest of the loop per output,
+and a genuinely all-forking loop is unbounded.
+
+Exactly the same degeneration [#2079](https://github.com/rust-works/succinctly/issues/2079)
+found for `reduce`/`foreach` applies here unchanged: a flat count charged
+once per state visited, regardless of whether the visit came from genuine
+branching or an ordinary single-output loop, collapses into a plain cap on
+iteration count for the overwhelmingly common non-forking case -- not the
+fanout explosion #534 was actually guarding against, and not something real
+jq caps at all. [#2087](https://github.com/rust-works/succinctly/issues/2087)
+found the original `10000` refusing an everyday counting loop as a result:
+
+```console
+$ echo 'null' | jq -c '0 | until(. >= 50000; . + 1)'
+50000
+$ echo 'null' | succinctly jq -c '0 | until(. >= 50000; . + 1)'
+jq: error (at <stdin>:1): until: maximum iterations exceeded
+```
+
+**Fix**: raised `WHILE_UNTIL_MAX_STEPS` 10x, `10000` to `100000`, matching
+#2079's own precedent exactly -- same 2x-headroom-over-the-repro reasoning,
+same "flat count over a true fanout-product bound" tradeoff (a product
+bound wouldn't change the single-fork ceiling this issue is about, only
+when a genuinely multi-fork case is rejected), same ADR-0018 rule 4c
+acceptance (bounding a resource-exhaustion vector, not matching real jq's
+own memory-only bound).
+
+**The same superlinear-cost caveat #2079/#2086 already found for
+`reduce`/`foreach` applies here too, via the identical underlying
+mechanism** (`OwnedValue` string-append reallocates the whole accumulator
+per step): `[0,""] | until(.[0] >= N; [.[0]+1, .[1] + "x"]) | .[1] | length`
+measures ~15-16s at N approaching the new `100000` ceiling in this build,
+against real jq's own apparently-linear ~0.1-0.2s at the same N (confirmed
+live) -- somewhat higher than #2086's own ~7.8s figure for the analogous
+`reduce` shape (both walk the same O(N²) string-append path; the gap
+between the two isn't attributed further here), but the same accepted
+tradeoff: not chased down as part of this fix, since #2086 already tracks
+the underlying performance gap and a second, until/while-flavoured report
+would just be the same root cause observed through a different builtin.
+
 ### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
 
 [#1906](https://github.com/rust-works/succinctly/issues/1906)/PR #1933 added `Expr::Repeat`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27870,8 +27870,19 @@ fn eval_nth_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Total recursive fork budget for `while`/`until` (#534): shared across the
 /// whole backtracking tree (decremented once per state visited, regardless
 /// of branching), not per-branch, so the common non-forking case bounds
-/// total work to the same 10000-step cap the old flat loop used.
-const WHILE_UNTIL_MAX_STEPS: usize = 10000;
+/// total work to the same step cap the old flat loop used.
+///
+/// #2087: originally `10000`, which -- the identical bug shape
+/// [`REDUCE_FOREACH_MAX_STEPS`] had before #2079 -- degenerated into a
+/// plain cap on ordinary iteration count for the overwhelmingly common
+/// non-forking case, rather than the genuine backtracking-fanout explosion
+/// #534 introduced this guard for; real jq has no such cap at all. Raised
+/// 10x, matching #2079's own precedent exactly (same rationale: 2x
+/// headroom over the reporting issue's own repro, worst-case CPU for a
+/// superlinear-cost cond/update body kept in the single-digit seconds,
+/// measured rather than assumed). Full rationale:
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md).
+const WHILE_UNTIL_MAX_STEPS: usize = 100_000;
 
 /// Evaluate `until(cond; update)` - apply update until cond is true.
 ///
@@ -55992,6 +56003,26 @@ mod tests {
                 assert!(prefix.iter().all(|v| *v == OwnedValue::Int(1)));
                 assert!(e.message.contains("while: maximum iterations exceeded"));
             }
+        );
+    }
+
+    #[test]
+    fn test_2087_until_ordinary_loop_over_50000_iterations_succeeds() {
+        // #2087: a single-output, non-forking `until` loop is ordinary
+        // iteration, not the backtracking fanout WHILE_UNTIL_MAX_STEPS
+        // exists to bound -- before the fix, this refused with "until:
+        // maximum iterations exceeded" where real jq (1.7.1) answers
+        // 50000 (confirmed live against the pinned oracle).
+        assert_eq!(outputs(b"null", r"0 | until(. >= 50000; . + 1)"), ["50000"]);
+    }
+
+    #[test]
+    fn test_2087_while_ordinary_loop_over_50000_iterations_succeeds() {
+        // #2087: `while`'s own non-forking shape has the identical bug --
+        // real jq's `[0 | while(. < 50000; . + 1)] | length` is `50000`.
+        assert_eq!(
+            outputs(b"null", r"[0 | while(. < 50000; . + 1)] | length"),
+            ["50000"]
         );
     }
 


### PR DESCRIPTION
## Summary

- `WHILE_UNTIL_MAX_STEPS` has the identical bug shape #2079 already fixed for `reduce`/`foreach`'s `REDUCE_FOREACH_MAX_STEPS`: a flat count charged once per state visited, regardless of whether the visit came from genuine backtracking fanout (`#534`'s original guard target) or an ordinary, non-forking loop — so `0 | until(. >= 50000; . + 1)` refused with `until: maximum iterations exceeded` where real jq returns `50000`. Confirmed live against the pinned oracle (jq 1.7.1) before and after.
- Fixed the same way #2079 fixed the analogous `reduce`/`foreach` bug: raised `WHILE_UNTIL_MAX_STEPS` 10x, `10000` → `100_000` — 2x headroom over this issue's own 50,000-iteration repro, same margin #2079 used. `while`/`until`'s genuine-fanout case (`#534`'s own motivating example) still errors, just at a no-longer-accidentally-reachable-by-ordinary-use ceiling.
- Measured the same superlinear-cost-body caveat #2079/#2086 already documented for `reduce`/`foreach` — via the identical `OwnedValue` string-append mechanism, a pathological `until`/`while` body measures ~15-16s at the new ceiling against jq's own ~0.1-0.2s. Not a new performance gap: the same root cause #2086 already tracks, now confirmed to reach `until`/`while` too rather than assumed to.
- Both existing `test_until_budget_exceeded_errors`/`test_while_budget_exceeded_errors` tests reference `WHILE_UNTIL_MAX_STEPS` symbolically and adapt to the new ceiling automatically — no update needed, verified they still pass.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite — 3234 lib tests + every integration suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Live-verified the issue's own repro against the pinned oracle before and after the fix
- [x] Added `test_2087_until_ordinary_loop_over_50000_iterations_succeeds` and `test_2087_while_ordinary_loop_over_50000_iterations_succeeds`, both live-verified against jq 1.7.1
- [x] Measured the pathological-body worst-case cost at the new ceiling directly (release build), not assumed to carry over from #2086's `reduce` measurement

Fixes #2087