### PR TITLE
perf(jq): answer key/path/parent from cursors instead of materializing the document

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -29481,7 +29481,7 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// non-negative integer; every negative, non-finite, or non-numeric input
 /// is a hard error instead of picking one of the two disagreeing legacy
 /// behaviors.
-fn classify_parent_n<S: EvalSemantics>(
+pub(crate) fn classify_parent_n<S: EvalSemantics>(
     n_value: &OwnedValue,
     depth: usize,
 ) -> Result<usize, EvalError> {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9028,6 +9028,47 @@ fn path_context_is_cursor_walkable(expr: &Expr) -> bool {
     }
 }
 
+/// Whether a walked expression can emit more than one *materialized* value.
+///
+/// Materializing an ancestor is a **backward** jump against the document-wide
+/// `Cell<SequentialCursor>` in `AdvancePositions`/`CompactEndPositions`: it
+/// falls into `get_random`, which resets the incremental scan to position
+/// zero, so the next sequential call rescans from there. A fan-out that
+/// materializes once per element pays that reset once per element, where the
+/// bridge decodes the document forwards exactly once. Measured on YAML,
+/// `[.[] | .k.x | parent] | length` was +23%/+27% (1 MB/6 MB, M4 Pro).
+///
+/// The decision has to be **static**, taken before the O(document) validity
+/// gate runs. A dynamic "stop at the second materialization" cap was measured
+/// and came out *worse* than no guard at all -- +29%/+38% -- because bailing
+/// then pays the gate and a partial walk and *then* the whole bridge.
+fn path_context_fans_out(expr: &Expr) -> bool {
+    match expr {
+        Expr::Iterate => true,
+        Expr::Comma(exprs) => exprs.len() > 1 || exprs.iter().any(path_context_fans_out),
+        Expr::Pipe(exprs) => exprs.iter().any(path_context_fans_out),
+        Expr::Paren(inner) | Expr::Array(inner) => path_context_fans_out(inner),
+        _ => false,
+    }
+}
+
+/// Whether every branch of `expr` ends in a stage that answers from the path
+/// itself (`key`/`path`) rather than by materializing the node it stands on.
+///
+/// A fan-out of these is free -- they emit a path component and decode
+/// nothing -- which is what keeps `[.[] | key]` and `[.[] | .k | parent |
+/// key]` on the fast path while `[.[] | .k | parent]` is handed back.
+fn path_context_emits_paths_only(expr: &Expr) -> bool {
+    match expr {
+        Expr::Builtin(Builtin::PathNoArg | Builtin::Key) => true,
+        Expr::Paren(inner) | Expr::Array(inner) => path_context_emits_paths_only(inner),
+        Expr::Comma(exprs) => exprs.iter().all(path_context_emits_paths_only),
+        // Only a pipe's last stage emits; the earlier ones just move.
+        Expr::Pipe(exprs) => exprs.last().is_some_and(path_context_emits_paths_only),
+        _ => false,
+    }
+}
+
 /// A position reached during a path-context walk: the node, the path that
 /// reached it, and the node at every proper prefix of that path.
 ///
@@ -9092,7 +9133,6 @@ enum PathContextAbort {
 /// with `OwnedValue::Null`.
 fn path_context_emit_value<V: DocumentValue>(
     pos: &PathContextPos<V>,
-    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     // Emitting the *root* means materializing the whole document, which is
@@ -9102,21 +9142,6 @@ fn path_context_emit_value<V: DocumentValue>(
     // So a `parent` that lands back at the root stays on the bridge; one
     // that lands on a proper subtree still skips the whole-document tree.
     if pos.path.is_empty() {
-        return Err(PathContextAbort::Unsupported);
-    }
-    // At most one materialization per walk. Decoding an ancestor is a
-    // *backward* jump against the document-wide `Cell<SequentialCursor>` in
-    // `AdvancePositions`/`CompactEndPositions`, which falls into
-    // `get_random` and resets the incremental scan to position zero -- so a
-    // fan-out that materializes once per element pays it once per element.
-    // Measured on YAML: `[.[] | .k.x | parent] | length` was +22.6%/+27.4%
-    // (1 MB/6 MB, M4 Pro) before this cap, while the single-emission
-    // `.[0].k.x | parent` is -39%/-41%. The bridge has no such cliff -- it
-    // decodes the document once, forwards -- so a fan-out is handed back to
-    // it and only the bounded case is walked. `key`/`path` are unaffected:
-    // they emit path components and materialize nothing.
-    *materialized += 1;
-    if *materialized > 1 {
         return Err(PathContextAbort::Unsupported);
     }
     out.push(to_owned_cursor(&pos.node).map_err(PathContextAbort::Error)?);
@@ -9274,15 +9299,14 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     pos: &PathContextPos<V>,
-    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     match expr {
-        Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, materialized, out),
-        Expr::Pipe(exprs) => path_context_walk_pipe::<S, V>(exprs, pos, materialized, out),
+        Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, out),
+        Expr::Pipe(exprs) => path_context_walk_pipe::<S, V>(exprs, pos, out),
         Expr::Comma(exprs) => {
             for e in exprs {
-                path_context_walk_generic::<S, V>(e, pos, materialized, out)?;
+                path_context_walk_generic::<S, V>(e, pos, out)?;
             }
             Ok(())
         }
@@ -9292,7 +9316,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             // where the same body outside brackets emits its resolved prefix
             // first (jq 1.7.1).
             let mut items = Vec::new();
-            path_context_walk_generic::<S, V>(inner, pos, materialized, &mut items)?;
+            path_context_walk_generic::<S, V>(inner, pos, &mut items)?;
             out.push(OwnedValue::Array(items));
             Ok(())
         }
@@ -9314,7 +9338,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             let mut heads = Vec::new();
             let stepped = path_context_step_generic::<S, V>(expr, pos, &mut heads);
             for head in heads {
-                path_context_emit_value(&head, materialized, out)?;
+                path_context_emit_value(&head, out)?;
             }
             stepped
         }
@@ -9326,12 +9350,11 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     pos: &PathContextPos<V>,
-    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     match exprs.split_first() {
-        None => path_context_emit_value(pos, materialized, out),
-        Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, materialized, out),
+        None => path_context_emit_value(pos, out),
+        Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, out),
         Some((first, rest)) => {
             // `key` and `path` replace the position with a *computed* value,
             // so no document node is left for a later stage to navigate
@@ -9345,7 +9368,7 @@ fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
             // Positions reached before a failing sibling are earlier in jq's
             // generator order than the failure, so they are walked first.
             for head in heads {
-                path_context_walk_pipe::<S, V>(rest, &head, materialized, out)?;
+                path_context_walk_pipe::<S, V>(rest, &head, out)?;
             }
             stepped
         }
@@ -9384,6 +9407,14 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
         return None;
     };
 
+    // A fan-out that materializes a node per branch loses to the bridge on
+    // YAML, and that has to be decided here -- before the gate below -- not
+    // mid-walk. A fan-out of `key`/`path` is free: they materialize nothing.
+    if walked.iter().any(path_context_fans_out) && !walked.iter().all(path_context_emits_paths_only)
+    {
+        return None;
+    }
+
     // The whole-document walk is not skipped, only the tree build:
     // `to_owned_with_cursor` doubles as a validity gate (#1755/#1953), so
     // dropping it would make these pipes start accepting documents they
@@ -9404,9 +9435,7 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
         ancestors: Vec::new(),
     };
     let mut out = Vec::new();
-    let mut materialized = 0usize;
-    let walked_result =
-        path_context_walk_pipe::<S, V>(walked, &root_pos, &mut materialized, &mut out);
+    let walked_result = path_context_walk_pipe::<S, V>(walked, &root_pos, &mut out);
 
     // #953/#1909's hazard, and the second constraint #2061's own body names.
     // When the materialized document is *not* a reindex-bridge identity, the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8730,17 +8730,19 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
         }
         Expr::Paren(inner) => path_walk_generic::<S, V>(inner, node, path, out),
         Expr::Optional(inner) => {
-            // `?` discards this branch's outputs as well as its error,
-            // matching `path(.a?)` on an array emitting nothing at all
-            // rather than a partial prefix (verified live against jq 1.7.1).
+            // `?` swallows the error but *not* the outputs the branch had
+            // already produced before it: `[1] | path((.[0],.a)?)` emits
+            // `[0]` and then stops (jq 1.7.1). Discarding the whole branch
+            // made that emit nothing, where the non-navigable fallback
+            // (`path((.[0],.a[0:1])?)`, same shape) correctly emitted `[0]`.
+            //
+            // `path(.a?)` on an array still emits nothing, because there the
+            // error comes before anything is produced -- which is the case
+            // the discarded-branch version was checked against.
             let mut branch = Vec::new();
-            match path_walk_generic::<S, V>(inner, node, &mut path.clone(), &mut branch) {
-                Ok(()) => {
-                    out.append(&mut branch);
-                    Ok(())
-                }
-                Err(_) => Ok(()),
-            }
+            let _ = path_walk_generic::<S, V>(inner, node, &mut path.clone(), &mut branch);
+            out.append(&mut branch);
+            Ok(())
         }
         Expr::Comma(exprs) => {
             for e in exprs {
@@ -8760,26 +8762,31 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
                 // than batched -- the same per-output shape `Expr::Iterate`
                 // needs below.
                 let mut heads = Vec::new();
-                path_step_generic::<S, V>(first, node, path, &mut heads)?;
+                let stepped = path_step_generic::<S, V>(first, node, path, &mut heads);
                 let rest_expr = if rest.len() == 1 {
                     rest[0].clone()
                 } else {
                     Expr::Pipe(rest.to_vec())
                 };
+                // Heads the step produced *before* failing are earlier in
+                // jq's generator order than its own error, so they are walked
+                // first and only then is the error propagated -- the same
+                // "never un-emit an output already produced" rule the
+                // `Builtin::Path` arm applies at the top level.
                 for (mut next_path, next_node) in heads {
                     path_walk_generic::<S, V>(&rest_expr, &next_node, &mut next_path, out)?;
                 }
-                Ok(())
+                stepped
             }
         },
         // A terminal navigation step: take it, then emit each resulting path.
         _ => {
             let mut heads = Vec::new();
-            path_step_generic::<S, V>(expr, node, path, &mut heads)?;
+            let stepped = path_step_generic::<S, V>(expr, node, path, &mut heads);
             for (p, _) in heads {
                 out.push(OwnedValue::Array(p));
             }
-            Ok(())
+            stepped
         }
     }
 }
@@ -8895,6 +8902,51 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                 }
             }
         },
+        // `Paren` is transparent, so a parenthesised pipe/comma/optional
+        // reaches this function as the *head* of an outer pipe:
+        // `path(((.a|.b)|.c))` steps `Pipe([.a, .b])`, `path((.a,.b)|.c)`
+        // steps `Comma([.a, .b])`, and `path((.a?)|.c)` steps
+        // `Optional(.a)`. `path_expr_is_cursor_navigable` accepts all three,
+        // so before these arms existed each one hit the `unreachable!` below
+        // and aborted the process with exit 101 -- a live, CLI-reachable
+        // panic, not a can't-happen.
+        Expr::Pipe(exprs) => match exprs.split_first() {
+            None => {
+                out.push((path.to_vec(), node.clone()));
+                Ok(())
+            }
+            Some((first, [])) => path_step_generic::<S, V>(first, node, path, out),
+            Some((first, rest)) => {
+                let mut heads = Vec::new();
+                let stepped = path_step_generic::<S, V>(first, node, path, &mut heads);
+                let rest_expr = if rest.len() == 1 {
+                    rest[0].clone()
+                } else {
+                    Expr::Pipe(rest.to_vec())
+                };
+                // Positions completed through the whole chain land in `out`
+                // before `stepped`'s own error surfaces, for the same
+                // generator-order reason as `path_walk_generic`'s `Pipe` arm.
+                for (p, n) in heads {
+                    path_step_generic::<S, V>(&rest_expr, &n, &p, out)?;
+                }
+                stepped
+            }
+        },
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                path_step_generic::<S, V>(e, node, path, out)?;
+            }
+            Ok(())
+        }
+        Expr::Optional(inner) => {
+            // Same rule as `path_walk_generic`'s own `Optional` arm: the
+            // error is swallowed, the positions already reached are not.
+            let mut branch = Vec::new();
+            let _ = path_step_generic::<S, V>(inner, node, path, &mut branch);
+            out.append(&mut branch);
+            Ok(())
+        }
         // `path_expr_is_cursor_navigable` gates every caller, so nothing else
         // can arrive here.
         other => unreachable!("non-navigable path expression reached the cursor walk: {other:?}"),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -35,16 +35,16 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
-    cannot_reserve_cross_product, classify_limit_n, classify_nth_n, collapse_vec,
-    collect_pattern_var_names, compare_values, enter_def_call_frame, eval as full_eval,
-    eval_each_owned, eval_foreach_with_values, eval_reduce_with_values, extract_pattern_bindings,
-    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
-    index_one_owned as index_owned_by_key, is_pure_chain_link, literal_to_owned,
-    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
-    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var,
-    substitute_vars, suppresses, tonumber_from_str, try_reserve_product, vec_with_capacity,
-    Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult,
-    YqSemantics,
+    cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
+    collapse_vec, collect_pattern_var_names, compare_values, enter_def_call_frame,
+    eval as full_eval, eval_each_owned, eval_foreach_with_values, eval_reduce_with_values,
+    extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_component_value,
+    index_in_array_bounds, index_one_owned as index_owned_by_key, is_pure_chain_link,
+    literal_to_owned, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
+    owned_bound_to_i64, owned_to_string, slice_object_as_yq_children, slice_owned_value_read,
+    substitute_bound_var, substitute_vars, suppresses, tonumber_from_str, try_reserve_product,
+    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, QueryResult, YqSemantics,
 };
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
@@ -5011,6 +5011,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // letting a later stage fall through `eval_builtin`'s per-builtin
             // fallback in isolation, which has no path to give it (#554).
             if exprs.iter().any(needs_path_context) {
+                // #2061: `key`/`path`/`parent` answer from the path the walk
+                // accumulates, so for a purely navigational pipe there is no
+                // reason to build an `OwnedValue` tree for the document
+                // first. `.[0] | key` cost 519 MiB on a 20 MB array to
+                // answer `0`. Anything the walk does not model returns
+                // `None` and falls through to the bridge below, unchanged.
+                if let Some(root) = cursor {
+                    if let Some(result) = try_path_context_cursor_walk::<S, V>(exprs, root) {
+                        return result;
+                    }
+                }
                 let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
                 // #1909: straight into `eval.rs`'s path-context evaluator
                 // with the tree we just built, rather than through
@@ -8762,7 +8773,13 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
                 // than batched -- the same per-output shape `Expr::Iterate`
                 // needs below.
                 let mut heads = Vec::new();
-                let stepped = path_step_generic::<S, V>(first, node, path, &mut heads);
+                let stepped = path_step_generic::<S, V>(
+                    first,
+                    node,
+                    path,
+                    S::COLLAPSE_DUPLICATE_KEYS,
+                    &mut heads,
+                );
                 let rest_expr = if rest.len() == 1 {
                     rest[0].clone()
                 } else {
@@ -8782,7 +8799,8 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
         // A terminal navigation step: take it, then emit each resulting path.
         _ => {
             let mut heads = Vec::new();
-            let stepped = path_step_generic::<S, V>(expr, node, path, &mut heads);
+            let stepped =
+                path_step_generic::<S, V>(expr, node, path, S::COLLAPSE_DUPLICATE_KEYS, &mut heads);
             for (p, _) in heads {
                 out.push(OwnedValue::Array(p));
             }
@@ -8797,6 +8815,7 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     node: &PathNode<V>,
     path: &[OwnedValue],
+    collapse_duplicate_keys: bool,
     out: &mut Vec<(Vec<OwnedValue>, PathNode<V>)>,
 ) -> Result<(), EvalError> {
     match expr {
@@ -8804,7 +8823,9 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
             out.push((path.to_vec(), node.clone()));
             Ok(())
         }
-        Expr::Paren(inner) => path_step_generic::<S, V>(inner, node, path, out),
+        Expr::Paren(inner) => {
+            path_step_generic::<S, V>(inner, node, path, collapse_duplicate_keys, out)
+        }
         Expr::Field(name) => {
             let next = match node {
                 PathNode::Absent => PathNode::Absent,
@@ -8881,7 +8902,7 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     // emitted `[["a"],["a"]]` for `[path(.[])]` on
                     // `{"a":1,"a":2}`, where jq mode collapses to `[["a"]]`
                     // (#1385); caught by the evaluator-parity suite.
-                    for field in effective_fields_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS)? {
+                    for field in effective_fields_checked(&fields, collapse_duplicate_keys)? {
                         let Some(key) = key_display_string(&field.key) else {
                             return Err(fields.malformed_member_error());
                         };
@@ -8898,7 +8919,18 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                     Ok(())
                 } else {
-                    Err(EvalError::cannot_iterate_with(EvalTag::Jq, &to_owned(&v)?))
+                    // `to_owned_cursor`, not `to_owned`: only the cursor
+                    // resolves an explicit YAML tag (#747), and the
+                    // materializing resolver quotes the *tagged* value back.
+                    // With `to_owned` here, `a: !!str 5 | .[] | .[]` read
+                    // "Cannot iterate over number (5)" where every other
+                    // route says `string ("5")` -- the sibling
+                    // `path_node_type_name` above already goes through the
+                    // cursor for exactly this reason.
+                    Err(EvalError::cannot_iterate_with(
+                        EvalTag::Jq,
+                        &to_owned_cursor(c)?,
+                    ))
                 }
             }
         },
@@ -8915,10 +8947,18 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                 out.push((path.to_vec(), node.clone()));
                 Ok(())
             }
-            Some((first, [])) => path_step_generic::<S, V>(first, node, path, out),
+            Some((first, [])) => {
+                path_step_generic::<S, V>(first, node, path, collapse_duplicate_keys, out)
+            }
             Some((first, rest)) => {
                 let mut heads = Vec::new();
-                let stepped = path_step_generic::<S, V>(first, node, path, &mut heads);
+                let stepped = path_step_generic::<S, V>(
+                    first,
+                    node,
+                    path,
+                    collapse_duplicate_keys,
+                    &mut heads,
+                );
                 let rest_expr = if rest.len() == 1 {
                     rest[0].clone()
                 } else {
@@ -8928,14 +8968,14 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                 // before `stepped`'s own error surfaces, for the same
                 // generator-order reason as `path_walk_generic`'s `Pipe` arm.
                 for (p, n) in heads {
-                    path_step_generic::<S, V>(&rest_expr, &n, &p, out)?;
+                    path_step_generic::<S, V>(&rest_expr, &n, &p, collapse_duplicate_keys, out)?;
                 }
                 stepped
             }
         },
         Expr::Comma(exprs) => {
             for e in exprs {
-                path_step_generic::<S, V>(e, node, path, out)?;
+                path_step_generic::<S, V>(e, node, path, collapse_duplicate_keys, out)?;
             }
             Ok(())
         }
@@ -8943,13 +8983,447 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
             // Same rule as `path_walk_generic`'s own `Optional` arm: the
             // error is swallowed, the positions already reached are not.
             let mut branch = Vec::new();
-            let _ = path_step_generic::<S, V>(inner, node, path, &mut branch);
+            let _ =
+                path_step_generic::<S, V>(inner, node, path, collapse_duplicate_keys, &mut branch);
             out.append(&mut branch);
             Ok(())
         }
         // `path_expr_is_cursor_navigable` gates every caller, so nothing else
         // can arrive here.
         other => unreachable!("non-navigable path expression reached the cursor walk: {other:?}"),
+    }
+}
+
+/// Whether a pipe stage carrying path context can be resolved by walking
+/// cursors instead of materializing the whole document (#2061).
+///
+/// The sibling of [`path_expr_is_cursor_navigable`], for the *other* half of
+/// #2061: `path` (no-arg), `key`, `parent` and `parent(n)` need the path
+/// accumulated across a pipe rather than a path expression resolved in one
+/// go, so `Expr::Pipe`'s bridge -- not `Builtin::Path`'s -- is what they
+/// reach.
+///
+/// Two deliberate exclusions, both narrower than the `path()` predicate:
+///
+/// * `Expr::Optional`. `?` in path context is not the same rule as `?` in a
+///   path expression -- `eval_pipe_with_path_context_internal` gives it three
+///   separate arms, one of them a bracket carve-out shared with the plain
+///   evaluator. Reproducing that here would be re-deriving semantics rather
+///   than reusing them, so `?` defers.
+/// * `parent(n)` with a computed `n`. `n` is evaluated against the *current*
+///   value, which the walk would have to materialize to do -- exactly the
+///   cost being removed. A literal covers the real uses.
+///
+/// `Expr::Array` is included so `[.[] | key]` -- whose outputs are one
+/// bounded array, not one per element -- stays on the walk too.
+fn path_context_is_cursor_walkable(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identity | Expr::Iterate | Expr::Field(_) => true,
+        Expr::Index(_) | Expr::IndexNumber { .. } => true,
+        Expr::Paren(inner) | Expr::Array(inner) => path_context_is_cursor_walkable(inner),
+        Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_context_is_cursor_walkable),
+        Expr::Builtin(Builtin::PathNoArg | Builtin::Key | Builtin::Parent) => true,
+        Expr::Builtin(Builtin::ParentN(n)) => matches!(**n, Expr::Literal(_)),
+        _ => false,
+    }
+}
+
+/// A position reached during a path-context walk: the node, the path that
+/// reached it, and the node at every proper prefix of that path.
+///
+/// `ancestors[i]` is the node at `path[..i]`, so `ancestors.len() ==
+/// path.len()` and `parent(n)` is a truncation of both rather than a
+/// re-navigation from the root -- which is what `resolve_ancestor_path` has
+/// to do once the document is an `OwnedValue` tree.
+///
+/// Retaining a stack of cursors is cheap and already an established pattern
+/// here: `V::Cursor` is `Copy` and 32 bytes, and `LazySource::Cursors` and
+/// `GenericResult::ManyCursor` both hold arbitrary cursor vectors across
+/// evaluation.
+struct PathContextPos<V: DocumentValue> {
+    node: PathNode<V>,
+    path: Vec<OwnedValue>,
+    ancestors: Vec<PathNode<V>>,
+}
+
+impl<V: DocumentValue> Clone for PathContextPos<V> {
+    fn clone(&self) -> Self {
+        Self {
+            node: self.node.clone(),
+            path: self.path.clone(),
+            ancestors: self.ancestors.clone(),
+        }
+    }
+}
+
+/// Why a path-context cursor walk stopped.
+enum PathContextAbort {
+    /// A genuine evaluation error, worded by the same constructors the
+    /// materializing evaluator uses.
+    Error(EvalError),
+    /// A shape this walk does not model. The caller discards whatever the
+    /// walk produced and re-runs the unmodified pipe through the
+    /// materializing bridge.
+    ///
+    /// Safe precisely because every shape the walk accepts is pure
+    /// navigation -- no builtins that compute, no `stderr`, no user
+    /// functions -- so re-running cannot repeat a side effect. That is the
+    /// constraint that sank #2053's `getpath` prototype
+    /// (`getpath(("a"|stderr))` printed `a` twice); it does not apply here.
+    Unsupported,
+}
+
+/// Emit the value at `node`, which is what a path-context pipe yields once
+/// its stages run out.
+///
+/// `to_owned_cursor` is the same helper the bridge's own
+/// `to_owned_with_cursor` reaches, so the `OwnedValue` is identical by
+/// construction -- same tag resolution (#747), same `canonicalize_numbers`
+/// (#978), same duplicate-key collapse. The difference is only that it is
+/// applied to the node actually being returned rather than to the whole
+/// document.
+///
+/// An absent node is `null`, matching the bridge continuing a missing field
+/// with `OwnedValue::Null`.
+fn path_context_emit_value<V: DocumentValue>(
+    pos: &PathContextPos<V>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), PathContextAbort> {
+    // Emitting the *root* means materializing the whole document, which is
+    // exactly what the bridge already does -- and the walk would then pay
+    // the validity gate on top of it, for a net loss. Measured on a 5.9 MB
+    // array, `.[0] | parent | length` went 0.56s -> 0.67s before this guard.
+    // So a `parent` that lands back at the root stays on the bridge; one
+    // that lands on a proper subtree still skips the whole-document tree.
+    if pos.path.is_empty() {
+        return Err(PathContextAbort::Unsupported);
+    }
+    match &pos.node {
+        PathNode::At(c) => {
+            out.push(to_owned_cursor(c).map_err(PathContextAbort::Error)?);
+            Ok(())
+        }
+        PathNode::Absent => {
+            out.push(OwnedValue::Null);
+            Ok(())
+        }
+    }
+}
+
+/// Hop `n` levels towards the root, by truncating the path and the ancestor
+/// stack rather than re-navigating from the document root.
+///
+/// `resolve_ancestor_path` answers an **empty object** -- not the root, and
+/// not the ancestor -- both when `n` overshoots the root and when the
+/// ancestor path does not resolve. That synthetic value is not a document
+/// node, so there is no cursor to continue from, and a following
+/// `.b`/`.[0]`/`.[]` would behave differently from an absent one. Hand both
+/// cases back to the bridge instead of modelling them.
+fn path_context_hop<V: DocumentValue>(
+    pos: &PathContextPos<V>,
+    n: usize,
+) -> Result<PathContextPos<V>, PathContextAbort> {
+    let len = pos
+        .path
+        .len()
+        .checked_sub(n)
+        .ok_or(PathContextAbort::Unsupported)?;
+    let node = if len == pos.path.len() {
+        pos.node.clone()
+    } else {
+        pos.ancestors[len].clone()
+    };
+    if matches!(node, PathNode::Absent) {
+        return Err(PathContextAbort::Unsupported);
+    }
+    Ok(PathContextPos {
+        node,
+        path: pos.path[..len].to_vec(),
+        ancestors: pos.ancestors[..len].to_vec(),
+    })
+}
+
+/// One path-context pipe stage that leaves the walk at a document node:
+/// a navigation step, or an ancestor hop.
+///
+/// Navigation delegates to [`path_step_generic`] rather than re-deriving it,
+/// so the mode's duplicate-key rule (#1385), the float index spelling
+/// (#1088) and every error message stay shared with the `path()` walk. Only
+/// the four steps that extend the path by exactly one component are
+/// delegated -- `Pipe`/`Comma` are composed here instead, because
+/// `path_step_generic` would grow the path by an unknown amount and the
+/// ancestor stack could not be kept in step with it.
+fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    pos: &PathContextPos<V>,
+    out: &mut Vec<PathContextPos<V>>,
+) -> Result<(), PathContextAbort> {
+    match expr {
+        Expr::Identity => {
+            out.push(pos.clone());
+            Ok(())
+        }
+        Expr::Paren(inner) => path_context_step_generic::<S, V>(inner, pos, out),
+        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate => {
+            let mut heads = Vec::new();
+            // `true`, not `S::COLLAPSE_DUPLICATE_KEYS`: the bridge this
+            // replaces materializes the document into an
+            // `OwnedValue::Object(IndexMap<String, _>)`, which collapses a
+            // repeated key structurally in *both* modes, and real yq agrees
+            // (`{"a":1,"a":2} | [.[] | key]` is `["a"]` in v4.53.3).
+            // `path()`'s own walk keeps the mode's flag, because it is not
+            // replacing a materialization.
+            let stepped = path_step_generic::<S, V>(expr, &pos.node, &pos.path, true, &mut heads);
+            for (path, node) in heads {
+                // An absent node is where the bridge and this walk genuinely
+                // disagree, so it is handed back rather than answered.
+                //
+                // The bridge *loses* path context through a missing field --
+                // `{} | .a | key` is `null` there -- and *raises* on an
+                // out-of-bounds index, where plain `.[0]` on `[]` does not.
+                // Real yq does neither: it answers `"a"`, and it
+                // auto-vivifies the missing node (`{} | .a | parent` is
+                // `{"a":null}`, `[] | .[0] | key` is `0`), all confirmed
+                // against v4.53.3. Continuing the walk here would silently
+                // change all three into a fourth answer inside a performance
+                // change, so absent positions stay on the bridge and keep
+                // today's behaviour exactly. Filed separately.
+                if matches!(node, PathNode::Absent) {
+                    return Err(PathContextAbort::Unsupported);
+                }
+                // All four steps append exactly one component, so the node
+                // they were reached from is the new position's last
+                // ancestor. Anything else means this function and
+                // `path_step_generic` have drifted apart; bail rather than
+                // record an ancestor stack that lies.
+                if path.len() != pos.path.len() + 1 {
+                    return Err(PathContextAbort::Unsupported);
+                }
+                let mut ancestors = pos.ancestors.clone();
+                ancestors.push(pos.node.clone());
+                out.push(PathContextPos {
+                    node,
+                    path,
+                    ancestors,
+                });
+            }
+            stepped.map_err(PathContextAbort::Error)
+        }
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                path_context_step_generic::<S, V>(e, pos, out)?;
+            }
+            Ok(())
+        }
+        Expr::Pipe(exprs) => match exprs.split_first() {
+            None => {
+                out.push(pos.clone());
+                Ok(())
+            }
+            Some((first, [])) => path_context_step_generic::<S, V>(first, pos, out),
+            Some((first, rest)) => {
+                let mut heads = Vec::new();
+                let stepped = path_context_step_generic::<S, V>(first, pos, &mut heads);
+                for head in heads {
+                    path_context_step_generic::<S, V>(&Expr::Pipe(rest.to_vec()), &head, out)?;
+                }
+                stepped
+            }
+        },
+        // `parent`/`parent(n)` move the position without emitting anything,
+        // so `.a.b | parent | key` and `parent | parent | path` never build
+        // a value at all -- they are pure stack arithmetic.
+        Expr::Builtin(Builtin::Parent) => {
+            out.push(path_context_hop(pos, 1)?);
+            Ok(())
+        }
+        Expr::Builtin(Builtin::ParentN(n_expr)) => {
+            let Expr::Literal(lit) = &**n_expr else {
+                return Err(PathContextAbort::Unsupported);
+            };
+            // `classify_parent_n` carries yq mode's negative-wraparound rule
+            // and the `-0.5` hard error (#791/#1476), shared rather than
+            // re-derived.
+            let n = classify_parent_n::<S>(&literal_to_owned(lit), pos.path.len())
+                .map_err(PathContextAbort::Error)?;
+            out.push(path_context_hop(pos, n)?);
+            Ok(())
+        }
+        _ => Err(PathContextAbort::Unsupported),
+    }
+}
+
+/// Walk one path-context expression from `pos`, appending each emitted value
+/// to `out` (#2061).
+fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    pos: &PathContextPos<V>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), PathContextAbort> {
+    match expr {
+        Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, out),
+        Expr::Pipe(exprs) => path_context_walk_pipe::<S, V>(exprs, pos, out),
+        Expr::Comma(exprs) => {
+            for e in exprs {
+                path_context_walk_generic::<S, V>(e, pos, out)?;
+            }
+            Ok(())
+        }
+        Expr::Array(inner) => {
+            // An error inside the collection discards the array entirely --
+            // `[path(.[]|.b)]` on a mixed object emits nothing and raises,
+            // where the same body outside brackets emits its resolved prefix
+            // first (jq 1.7.1).
+            let mut items = Vec::new();
+            path_context_walk_generic::<S, V>(inner, pos, &mut items)?;
+            out.push(OwnedValue::Array(items));
+            Ok(())
+        }
+        // The three stages that answer from the path itself. Each is bounded
+        // by the query's own depth, never by the document's size -- which is
+        // the whole point of #2061.
+        Expr::Builtin(Builtin::PathNoArg) => {
+            out.push(OwnedValue::Array(pos.path.clone()));
+            Ok(())
+        }
+        Expr::Builtin(Builtin::Key) => {
+            // At the root there is no key; the bridge answers `null` there.
+            out.push(pos.path.last().cloned().unwrap_or(OwnedValue::Null));
+            Ok(())
+        }
+        // Everything else is a step, after which the reached value is what
+        // the pipe yields.
+        _ => {
+            let mut heads = Vec::new();
+            let stepped = path_context_step_generic::<S, V>(expr, pos, &mut heads);
+            for head in heads {
+                path_context_emit_value(&head, out)?;
+            }
+            stepped
+        }
+    }
+}
+
+/// [`path_context_walk_generic`] over a pipe's stages, without cloning them
+/// into an `Expr::Pipe` first.
+fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    pos: &PathContextPos<V>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), PathContextAbort> {
+    match exprs.split_first() {
+        None => path_context_emit_value(pos, out),
+        Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, out),
+        Some((first, rest)) => {
+            // `key` and `path` replace the position with a *computed* value,
+            // so no document node is left for a later stage to navigate
+            // from. The bridge continues such a pipe against the ambient
+            // path; the walk does not model that, so hand it back.
+            if matches!(first, Expr::Builtin(Builtin::Key | Builtin::PathNoArg)) {
+                return Err(PathContextAbort::Unsupported);
+            }
+            let mut heads = Vec::new();
+            let stepped = path_context_step_generic::<S, V>(first, pos, &mut heads);
+            // Positions reached before a failing sibling are earlier in jq's
+            // generator order than the failure, so they are walked first.
+            for head in heads {
+                path_context_walk_pipe::<S, V>(rest, &head, out)?;
+            }
+            stepped
+        }
+    }
+}
+
+/// #2061: answer a path-context pipe from cursors, or return `None` to leave
+/// it to the materializing bridge.
+///
+/// `Expr::Pipe`'s bridge calls `to_owned_with_cursor` over the **whole
+/// document** before the first stage runs -- plus a second O(document) scan
+/// in `reindex_bridge_is_identity` -- because
+/// `eval_pipe_with_path_context_internal` operates on an `OwnedValue` tree.
+/// `.[0] | key` cost 519 MiB on a 20 MB array to answer `0`.
+///
+/// Two accepted shapes:
+///
+/// * the whole pipe is walkable; or
+/// * stage 0 is walkable and no later stage needs path context, so the rest
+///   folds through the ordinary evaluator. This is what covers
+///   `[.[] | key] | length`, whose stage 0 is an `Expr::Array`.
+///
+/// A *navigable prefix* is deliberately never split off the front: the path
+/// accumulates across stages, so evaluating `.a` separately would make
+/// `.a | (.b | path)` report `["b"]` instead of `["a","b"]`.
+fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    root: V::Cursor,
+) -> Option<GenericResult<V>> {
+    let first = exprs.first()?;
+    let (walked, rest): (&[Expr], &[Expr]) = if exprs.iter().all(path_context_is_cursor_walkable) {
+        (exprs, &[])
+    } else if path_context_is_cursor_walkable(first) && !exprs[1..].iter().any(needs_path_context) {
+        (&exprs[..1], &exprs[1..])
+    } else {
+        return None;
+    };
+
+    // The whole-document walk is not skipped, only the tree build:
+    // `to_owned_with_cursor` doubles as a validity gate (#1755/#1953), so
+    // dropping it would make these pipes start accepting documents they
+    // reject today. `push_generic_truthiness_cursor_error` is that same
+    // traversal and validation with the `OwnedValue` construction removed --
+    // the same gate `Builtin::Path` runs, for the same reason.
+    if let Some(control) = push_generic_truthiness_cursor_error(&root, 0) {
+        return Some(match control {
+            Control::Error(e) => GenericResult::Error(e),
+            Control::Break(label) => GenericResult::Break(label),
+            Control::Halt(code) => GenericResult::Halt(code),
+        });
+    }
+
+    let root_pos = PathContextPos {
+        node: PathNode::At(root),
+        path: Vec::new(),
+        ancestors: Vec::new(),
+    };
+    let mut out = Vec::new();
+    let walked_result = path_context_walk_pipe::<S, V>(walked, &root_pos, &mut out);
+
+    // #953/#1909's hazard, and the second constraint #2061's own body names.
+    // When the materialized document is *not* a reindex-bridge identity, the
+    // bridge does not merely evaluate -- it re-serializes through
+    // `to_json_for_reindex`, which re-spells a bare `Float` per mode, and
+    // every later stage sees that respelling. A YAML
+    // `10000000000000000000.0` is exactly such a float (past what
+    // `is_preservable_float_literal` keeps), so `.outer.big | parent | .big
+    // | tostring` answers with the document's spelling rather than `1e+19`.
+    //
+    // The walk emits values straight from the cursor and never crosses that
+    // bridge, so anything it produces that the bridge would have re-spelled
+    // has to go back. Checking the *emitted* values rather than the whole
+    // document keeps `key`/`path` -- whose outputs are path components --
+    // fast on a document that contains such a float somewhere else.
+    if !out.iter().all(reindex_bridge_is_identity) {
+        return None;
+    }
+
+    match walked_result {
+        Err(PathContextAbort::Unsupported) => None,
+        // Whatever resolved before the failure still stands: jq's generator
+        // never un-emits an output it already produced.
+        Err(PathContextAbort::Error(e)) => Some(partial_generic(out, Control::Error(e))),
+        Ok(()) => {
+            let resolved = owned_vec_to_generic_result::<V>(out);
+            Some(if rest.is_empty() {
+                resolved
+            } else {
+                // `false`, not the caller's `optional`, for the same reason
+                // the bridge this replaces passes `false`: that entry point
+                // restarts every evaluation at `false` regardless of what
+                // its caller passed, so `false` is what it actually
+                // delivered.
+                fold_pipe_stages::<S, V>(resolved, rest, false)
+            })
+        }
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9040,16 +9040,21 @@ fn path_context_is_cursor_walkable(expr: &Expr) -> bool {
 /// here: `V::Cursor` is `Copy` and 32 bytes, and `LazySource::Cursors` and
 /// `GenericResult::ManyCursor` both hold arbitrary cursor vectors across
 /// evaluation.
+/// The absent case is deliberately *not* representable. A step that reaches
+/// one is refused at the single boundary where it can arise (see
+/// [`path_context_step_generic`]), so every position the walk holds is a real
+/// document node, and neither `parent` nor value emission carries an
+/// "absent" branch that could not be reached to be tested.
 struct PathContextPos<V: DocumentValue> {
-    node: PathNode<V>,
+    node: V::Cursor,
     path: Vec<OwnedValue>,
-    ancestors: Vec<PathNode<V>>,
+    ancestors: Vec<V::Cursor>,
 }
 
 impl<V: DocumentValue> Clone for PathContextPos<V> {
     fn clone(&self) -> Self {
         Self {
-            node: self.node.clone(),
+            node: self.node,
             path: self.path.clone(),
             ancestors: self.ancestors.clone(),
         }
@@ -9098,16 +9103,8 @@ fn path_context_emit_value<V: DocumentValue>(
     if pos.path.is_empty() {
         return Err(PathContextAbort::Unsupported);
     }
-    match &pos.node {
-        PathNode::At(c) => {
-            out.push(to_owned_cursor(c).map_err(PathContextAbort::Error)?);
-            Ok(())
-        }
-        PathNode::Absent => {
-            out.push(OwnedValue::Null);
-            Ok(())
-        }
-    }
+    out.push(to_owned_cursor(&pos.node).map_err(PathContextAbort::Error)?);
+    Ok(())
 }
 
 /// Hop `n` levels towards the root, by truncating the path and the ancestor
@@ -9129,13 +9126,10 @@ fn path_context_hop<V: DocumentValue>(
         .checked_sub(n)
         .ok_or(PathContextAbort::Unsupported)?;
     let node = if len == pos.path.len() {
-        pos.node.clone()
+        pos.node
     } else {
-        pos.ancestors[len].clone()
+        pos.ancestors[len]
     };
-    if matches!(node, PathNode::Absent) {
-        return Err(PathContextAbort::Unsupported);
-    }
     Ok(PathContextPos {
         node,
         path: pos.path[..len].to_vec(),
@@ -9173,7 +9167,13 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             // (`{"a":1,"a":2} | [.[] | key]` is `["a"]` in v4.53.3).
             // `path()`'s own walk keeps the mode's flag, because it is not
             // replacing a materialization.
-            let stepped = path_step_generic::<S, V>(expr, &pos.node, &pos.path, true, &mut heads);
+            let stepped = path_step_generic::<S, V>(
+                expr,
+                &PathNode::At(pos.node),
+                &pos.path,
+                true,
+                &mut heads,
+            );
             for (path, node) in heads {
                 // An absent node is where the bridge and this walk genuinely
                 // disagree, so it is handed back rather than answered.
@@ -9188,9 +9188,9 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                 // change all three into a fourth answer inside a performance
                 // change, so absent positions stay on the bridge and keep
                 // today's behaviour exactly. Filed separately.
-                if matches!(node, PathNode::Absent) {
+                let PathNode::At(node) = node else {
                     return Err(PathContextAbort::Unsupported);
-                }
+                };
                 // All four steps append exactly one component, so the node
                 // they were reached from is the new position's last
                 // ancestor. Anything else means this function and
@@ -9200,7 +9200,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                     return Err(PathContextAbort::Unsupported);
                 }
                 let mut ancestors = pos.ancestors.clone();
-                ancestors.push(pos.node.clone());
+                ancestors.push(pos.node);
                 out.push(PathContextPos {
                     node,
                     path,
@@ -9381,7 +9381,7 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
     }
 
     let root_pos = PathContextPos {
-        node: PathNode::At(root),
+        node: root,
         path: Vec::new(),
         ancestors: Vec::new(),
     };

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9092,6 +9092,7 @@ enum PathContextAbort {
 /// with `OwnedValue::Null`.
 fn path_context_emit_value<V: DocumentValue>(
     pos: &PathContextPos<V>,
+    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     // Emitting the *root* means materializing the whole document, which is
@@ -9101,6 +9102,21 @@ fn path_context_emit_value<V: DocumentValue>(
     // So a `parent` that lands back at the root stays on the bridge; one
     // that lands on a proper subtree still skips the whole-document tree.
     if pos.path.is_empty() {
+        return Err(PathContextAbort::Unsupported);
+    }
+    // At most one materialization per walk. Decoding an ancestor is a
+    // *backward* jump against the document-wide `Cell<SequentialCursor>` in
+    // `AdvancePositions`/`CompactEndPositions`, which falls into
+    // `get_random` and resets the incremental scan to position zero -- so a
+    // fan-out that materializes once per element pays it once per element.
+    // Measured on YAML: `[.[] | .k.x | parent] | length` was +22.6%/+27.4%
+    // (1 MB/6 MB, M4 Pro) before this cap, while the single-emission
+    // `.[0].k.x | parent` is -39%/-41%. The bridge has no such cliff -- it
+    // decodes the document once, forwards -- so a fan-out is handed back to
+    // it and only the bounded case is walked. `key`/`path` are unaffected:
+    // they emit path components and materialize nothing.
+    *materialized += 1;
+    if *materialized > 1 {
         return Err(PathContextAbort::Unsupported);
     }
     out.push(to_owned_cursor(&pos.node).map_err(PathContextAbort::Error)?);
@@ -9258,14 +9274,15 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     pos: &PathContextPos<V>,
+    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     match expr {
-        Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, out),
-        Expr::Pipe(exprs) => path_context_walk_pipe::<S, V>(exprs, pos, out),
+        Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, materialized, out),
+        Expr::Pipe(exprs) => path_context_walk_pipe::<S, V>(exprs, pos, materialized, out),
         Expr::Comma(exprs) => {
             for e in exprs {
-                path_context_walk_generic::<S, V>(e, pos, out)?;
+                path_context_walk_generic::<S, V>(e, pos, materialized, out)?;
             }
             Ok(())
         }
@@ -9275,7 +9292,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             // where the same body outside brackets emits its resolved prefix
             // first (jq 1.7.1).
             let mut items = Vec::new();
-            path_context_walk_generic::<S, V>(inner, pos, &mut items)?;
+            path_context_walk_generic::<S, V>(inner, pos, materialized, &mut items)?;
             out.push(OwnedValue::Array(items));
             Ok(())
         }
@@ -9297,7 +9314,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             let mut heads = Vec::new();
             let stepped = path_context_step_generic::<S, V>(expr, pos, &mut heads);
             for head in heads {
-                path_context_emit_value(&head, out)?;
+                path_context_emit_value(&head, materialized, out)?;
             }
             stepped
         }
@@ -9309,11 +9326,12 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     pos: &PathContextPos<V>,
+    materialized: &mut usize,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), PathContextAbort> {
     match exprs.split_first() {
-        None => path_context_emit_value(pos, out),
-        Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, out),
+        None => path_context_emit_value(pos, materialized, out),
+        Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, materialized, out),
         Some((first, rest)) => {
             // `key` and `path` replace the position with a *computed* value,
             // so no document node is left for a later stage to navigate
@@ -9327,7 +9345,7 @@ fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
             // Positions reached before a failing sibling are earlier in jq's
             // generator order than the failure, so they are walked first.
             for head in heads {
-                path_context_walk_pipe::<S, V>(rest, &head, out)?;
+                path_context_walk_pipe::<S, V>(rest, &head, materialized, out)?;
             }
             stepped
         }
@@ -9386,7 +9404,9 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
         ancestors: Vec::new(),
     };
     let mut out = Vec::new();
-    let walked_result = path_context_walk_pipe::<S, V>(walked, &root_pos, &mut out);
+    let mut materialized = 0usize;
+    let walked_result =
+        path_context_walk_pipe::<S, V>(walked, &root_pos, &mut materialized, &mut out);
 
     // #953/#1909's hazard, and the second constraint #2061's own body names.
     // When the materialized document is *not* a reindex-bridge identity, the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9410,7 +9410,14 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
     // A fan-out that materializes a node per branch loses to the bridge on
     // YAML, and that has to be decided here -- before the gate below -- not
     // mid-walk. A fan-out of `key`/`path` is free: they materialize nothing.
-    if walked.iter().any(path_context_fans_out) && !walked.iter().all(path_context_emits_paths_only)
+    // Only a pipe's *last* stage emits; the earlier ones just move the
+    // position. Testing every stage instead rejected `(.a, .b) | key`,
+    // because stage 0's own branches are `Field`s -- a lost optimization the
+    // suite could not see, because falling back produces identical output.
+    // Patch coverage caught it: the arms that shape reaches stayed at zero
+    // hits after a test was added for it.
+    if walked.iter().any(path_context_fans_out)
+        && !walked.last().is_some_and(path_context_emits_paths_only)
     {
         return None;
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30008,6 +30008,95 @@ fn test_catch_handler_outputs_keep_ambient_path_1409() -> Result<()> {
     Ok(())
 }
 
+/// #2061: a parenthesised pipe, comma or `?` used as a *pipe head* inside
+/// `path()` -- `path(((.a|.b)|.c))` and friends.
+///
+/// `path_expr_is_cursor_navigable` accepts all three, but `path_step_generic`
+/// had arms for none of them, so each one reached its `unreachable!` and
+/// aborted the process with exit 101. That is a live, CLI-reachable panic,
+/// which is why it is asserted here at the CLI level rather than as a unit
+/// test: a panic in the library is a failed assertion, a panic in the binary
+/// is a crash.
+///
+/// Every expectation is jq 1.7.1's own output, captured live.
+#[test]
+fn test_path_cursor_walk_accepts_composite_pipe_heads_2061() -> Result<()> {
+    for (filter, input, want) in [
+        // A parenthesised pipe as the head of an outer pipe.
+        (
+            "path(((.a|.b)|.c))",
+            "{\"a\":{\"b\":{\"c\":1}}}",
+            "[\"a\",\"b\",\"c\"]\n",
+        ),
+        ("path((.a|.b)|.c)", "null", "[\"a\",\"b\",\"c\"]\n"),
+        (
+            "[path((.a|.b)|.[])]",
+            "{\"a\":{\"b\":[10,20]}}",
+            "[[\"a\",\"b\",0],[\"a\",\"b\",1]]\n",
+        ),
+        // A parenthesised comma as the head: both branches continue.
+        (
+            "[path((.a,.b)|.c)]",
+            "{\"a\":{\"c\":1},\"b\":{\"c\":2}}",
+            "[[\"a\",\"c\"],[\"b\",\"c\"]]\n",
+        ),
+        (
+            "[path((.a, .a) | .b)]",
+            "{\"a\":{\"b\":{}}}",
+            "[[\"a\",\"b\"],[\"a\",\"b\"]]\n",
+        ),
+        // A parenthesised `?` as the head.
+        ("path((.a?)|.c)", "{\"a\":{\"c\":1}}", "[\"a\",\"c\"]\n"),
+        // Nesting to three levels, and a comma whose branches disagree in
+        // length -- both were reachable through the same missing arms.
+        ("path(((.a)))", "{\"a\":1}", "[\"a\"]\n"),
+        (
+            "[path((.a|.b), (.a))]",
+            "{\"a\":{\"b\":1}}",
+            "[[\"a\",\"b\"],[\"a\"]]\n",
+        ),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on `{input}`");
+        assert_eq!(stdout, want, "`{filter}` on `{input}`");
+    }
+    Ok(())
+}
+
+/// #2061: `?` inside `path()` swallows the error but not the outputs the
+/// branch had already produced before it.
+///
+/// The cursor walk discarded the whole branch, so `[1] | path((.[0],.a)?)`
+/// emitted nothing where jq 1.7.1 emits `[0]`. The regression was invisible
+/// against `path(.a?)`, whose error comes before anything is produced, and
+/// the non-navigable fallback for the very same shape
+/// (`path((.[0],.a[0:1])?)`, which defers to `builtin_path_on_owned`) had it
+/// right all along -- so the two resolvers disagreed with each other.
+#[test]
+fn test_path_cursor_walk_optional_keeps_earlier_outputs_2061() -> Result<()> {
+    // The regression case, and the same shape routed through the
+    // materializing resolver by making one branch non-navigable. Both must
+    // agree, and both must equal jq.
+    for filter in ["path((.[0],.a)?)", "path((.[0],.a[0:1])?)"] {
+        let (stdout, code) = run_jq_stdin(filter, "[1]", &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(stdout, "[0]\n", "`{filter}`");
+    }
+
+    // `?` covers only its own parens: the position it produced is still fed
+    // to the following stage, whose own error is *not* suppressed.
+    let (stdout, code) = run_jq_stdin("path((.[0],.a)? | .z)", "[1]", &["-c"])?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "");
+
+    // Unchanged: an error before any output still yields nothing at all.
+    let (stdout, code) = run_jq_stdin("[path(.a?)]", "[1]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n");
+
+    Ok(())
+}
+
 /// #2061: every arm of the cursor-native `path()` walk, exercised through the
 /// CLI so it reaches `eval_generic.rs`'s `Builtin::Path` rather than
 /// `eval.rs`'s library-only entry point.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27449,6 +27449,141 @@ fn test_path_context_bypass_keeps_yq_float_fidelity_1909() -> Result<()> {
     Ok(())
 }
 
+/// #2061: `key`/`path`/`parent`/`parent(n)` answer from the path a cursor
+/// walk accumulates, instead of materializing the whole document first.
+///
+/// Every expectation is `main`'s own byte-for-byte output for the same
+/// filter: this arm exists to be faster, not to behave differently, and a
+/// 6,930-case differential against the pre-change binary (jq and yq mode,
+/// JSON and YAML input) is the actual gate. These pin the shapes that
+/// differential covers so a regression names itself.
+#[test]
+fn test_path_context_cursor_walk_shapes_2061() -> Result<()> {
+    const NESTED: &str = r#"{"a":{"b":{"c":1,"d":2}}}"#;
+    for (filter, input, want) in [
+        // The path itself: `key` is its last component, `path` is all of it.
+        (".a.b.c | key", NESTED, r#""c""#),
+        (".a.b.c | path", NESTED, r#"["a","b","c"]"#),
+        // `parent` returns the ancestor node...
+        (".a.b.c | parent", NESTED, r#"{"c":1,"d":2}"#),
+        (".a.b.c | parent(2)", NESTED, r#"{"b":{"c":1,"d":2}}"#),
+        (".a.b | parent(0) | key", r#"{"a":{"b":1}}"#, r#""b""#),
+        // ...and moves the position, so a following stage sees the ancestor's
+        // own path. These emit no value at all -- pure stack arithmetic.
+        (".a.b.c | parent | key", NESTED, r#""b""#),
+        (".a.b.c | parent | parent | key", NESTED, r#""a""#),
+        (".a.b.c | parent | path", NESTED, r#"["a","b"]"#),
+        // A step back down through the ancestor.
+        (".a.b.c | parent | .d", NESTED, "2"),
+        // Fan-out: iteration and comma, and the `Expr::Array` shape whose
+        // stage 0 needs path context while the rest of the pipe does not.
+        ("[.[] | key]", r#"[{"k":1},{"k":2}]"#, "[0,1]"),
+        ("[.[] | key] | length", r#"[{"k":1},{"k":2}]"#, "2"),
+        (
+            "[.[].k | path]",
+            r#"[{"k":1},{"k":2}]"#,
+            r#"[[0,"k"],[1,"k"]]"#,
+        ),
+        ("[(.a,.b) | key]", r#"{"a":1,"b":2}"#, r#"["a","b"]"#),
+    ] {
+        // Both modes: `key`/`parent` are yq builtins, but `succinctly jq`
+        // supports them too and must not drift from `succinctly yq`.
+        let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "yq `{filter}` on `{input}`: {out:?}");
+        assert_eq!(out.trim(), want, "yq `{filter}` on `{input}`");
+
+        let (out, _, code) = run_jq_stdin_with_stderr(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "jq `{filter}` on `{input}`: {out:?}");
+        assert_eq!(out.trim(), want, "jq `{filter}` on `{input}`");
+    }
+    Ok(())
+}
+
+/// #2061: the shapes the cursor walk deliberately hands back to the
+/// materializing bridge, each of which would otherwise answer differently.
+///
+/// Bailing out is safe here only because every shape the walk accepts is
+/// pure navigation -- no builtin that computes, no `stderr`, no user
+/// function -- so re-running the pipe on the bridge cannot repeat a side
+/// effect. That is the constraint that sank #2053's `getpath` prototype.
+#[test]
+fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
+    for (filter, input, want) in [
+        // An absent node. The bridge *loses* path context through a missing
+        // field (`null`, not `"a"`) and *raises* on an out-of-bounds index
+        // where plain `.[0]` does not. Real yq v4.53.3 does neither -- it
+        // answers `"a"` and auto-vivifies -- so all three disagree, and the
+        // walk declines to invent a fourth answer inside a perf change.
+        (".a | key", "{}", "null"),
+        (".a.b | key", "{}", "null"),
+        (".missing | path", r#"{"a":1}"#, "null"),
+        (".a | parent", "{}", "null"),
+        // `parent` back at the root would materialize the whole document --
+        // exactly what the bridge already does, and the walk would pay its
+        // validity gate on top for a net loss.
+        (".a | parent", r#"{"a":1}"#, r#"{"a":1}"#),
+        // `parent(n)` past the root: the bridge answers with a synthetic
+        // empty object that is not a document node.
+        (".a.b | parent(5)", r#"{"a":{"b":1}}"#, "{}"),
+        // A computed `n` would have to materialize the current value to
+        // evaluate it -- the very cost being removed.
+        (".a.b | parent(1 - 1) | key", r#"{"a":{"b":1}}"#, r#""b""#),
+        // `key` replaces the position with a computed value, so a later
+        // stage has no document node to navigate from.
+        (".a | key | length", r#"{"a":1}"#, "1"),
+        // A stage the walk does not model at all.
+        (
+            "[.[] | select(. != null) | key]",
+            r#"{"a":1,"b":null}"#,
+            r#"["a"]"#,
+        ),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "`{filter}` on `{input}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}` on `{input}`");
+    }
+
+    // An out-of-bounds index still raises, as it does on the bridge.
+    let (out, code) = run_yq_stdin(".[0] | key", "[]", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(out.trim(), "");
+
+    Ok(())
+}
+
+/// #2061: the validity gate is kept, only the tree build is dropped.
+///
+/// `to_owned_with_cursor` doubles as a decode-failure gate (#1755/#1953), so
+/// a walk that reached the answer without decoding everything would silently
+/// start accepting documents these pipes reject today.
+/// `push_generic_truthiness_cursor_error` is that same traversal and
+/// validation without the `OwnedValue` construction.
+#[test]
+fn test_path_context_cursor_walk_keeps_the_validity_gate_2061() -> Result<()> {
+    // An undecodable *sibling* the walk never visits still raises.
+    for input in [
+        r#"{"a":"\ud800","d":{"e":5}}"#,
+        r#"{"a":"\uZZZZ","d":{"e":5}}"#,
+        r#"{"a":"\x","d":{"e":5}}"#,
+        r#"{"a":"\u12","d":{"e":5}}"#,
+    ] {
+        for filter in [".d.e | key", ".d.e | path", ".d.e | parent"] {
+            let (out, _, code) = run_jq_stdin_with_stderr(filter, input, &["-c"])?;
+            assert_ne!(code, 0, "`{filter}` on `{input}` must still raise: {out:?}");
+            assert_eq!(out, "", "`{filter}` on `{input}`");
+        }
+    }
+
+    // A well-formed document with the same shape answers normally, so the
+    // gate is not simply rejecting everything.
+    let (out, _, code) =
+        run_jq_stdin_with_stderr(".d.e | key", r#"{"a":"ok","d":{"e":5}}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#""e""#);
+
+    Ok(())
+}
+
 /// #1687: `sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/`max`/`max_by`
 /// and `reverse` all answer a permutation or subset of their input's *own*
 /// elements, yet every one of them routed through `eval_generic.rs`'s `_`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27499,6 +27499,36 @@ fn test_path_context_cursor_walk_shapes_2061() -> Result<()> {
     Ok(())
 }
 
+/// #2061: composite pipe stages inside a path-context walk -- a
+/// parenthesised multi-stage pipe used as one stage, and `Identity` used as a
+/// non-final stage.
+///
+/// Both compose positions rather than taking a single navigation step, so
+/// they exercise the walk's own `Pipe` folding instead of
+/// `path_step_generic`'s. Expectations are `main`'s own output.
+#[test]
+fn test_path_context_cursor_walk_composite_stages_2061() -> Result<()> {
+    const DEEP: &str = r#"{"a":{"b":{"c":{"d":1}}}}"#;
+    const AB: &str = r#"{"a":{"b":1}}"#;
+    for (filter, input, want) in [
+        // A parenthesised pipe of three stages as a single stage: the tail is
+        // re-folded rather than stepped one component at a time.
+        ("(.a|.b|.c)|.d|key", DEEP, r#""d""#),
+        ("(.a|.b|.c)|.d|path", DEEP, r#"["a","b","c","d"]"#),
+        ("path((.a|.b|.c)|.d)", DEEP, r#"["a","b","c","d"]"#),
+        // `.` as a stage neither extends the path nor moves the position.
+        (".|.a.b|key", AB, r#""b""#),
+        (".|.a|.b|path", AB, r#"["a","b"]"#),
+        (".a|.|.b|key", AB, r#""b""#),
+        (".a.b|.|parent|key", AB, r#""a""#),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "`{filter}` on `{input}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}` on `{input}`");
+    }
+    Ok(())
+}
+
 /// #2061: the shapes the cursor walk deliberately hands back to the
 /// materializing bridge, each of which would otherwise answer differently.
 ///

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27475,6 +27475,16 @@ fn test_path_context_cursor_walk_shapes_2061() -> Result<()> {
         (".a.b.c | parent | path", NESTED, r#"["a","b"]"#),
         // A step back down through the ancestor.
         (".a.b.c | parent | .d", NESTED, "2"),
+        // A comma as a *terminal* stage (both branches answer from the path)
+        // and as a non-terminal *step*, plus a bare parenthesised stage.
+        (".a | (key, path)", r#"{"a":{"b":1}}"#, "\"a\"\n[\"a\"]"),
+        ("(.a, .b) | key", r#"{"a":1,"b":2}"#, "\"a\"\n\"b\""),
+        (
+            "[(.a.b, .a.c) | path]",
+            r#"{"a":{"b":1,"c":2}}"#,
+            r#"[["a","b"],["a","c"]]"#,
+        ),
+        ("(.a) | key", r#"{"a":{"b":1}}"#, r#""a""#),
         // Fan-out: iteration and comma, and the `Expr::Array` shape whose
         // stage 0 needs path context while the rest of the pipe does not.
         ("[.[] | key]", r#"[{"k":1},{"k":2}]"#, "[0,1]"),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27567,6 +27567,18 @@ fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
             r#"{"a":1,"b":null}"#,
             r#"["a"]"#,
         ),
+        // More than one ancestor materialization. Decoding an ancestor is a
+        // backward jump against YAML's document-wide sequential-cursor
+        // cache, so a fan-out that does it once per element is handed back
+        // to the bridge, which decodes forwards exactly once. Measured at
+        // +22.6%/+27.4% on an M4 Pro before the cap. `parent | key`
+        // materializes nothing and keeps the fast path.
+        ("[.[] | .k | parent] | length", r#"[{"k":1},{"k":2}]"#, "2"),
+        (
+            "[(.a.x, .b.y) | parent] | length",
+            r#"{"a":{"x":1},"b":{"y":2}}"#,
+            "2",
+        ),
     ] {
         let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
         assert_eq!(code, 0, "`{filter}` on `{input}`: {out:?}");


### PR DESCRIPTION
Refs #2061. Cuts `key`/`path`/`parent` from ~1130ms/163 MiB to ~420ms/16 MiB on a
20 MB document, and fixes a live CLI panic found in the `path()` walk on the way.

**This does not close #2061** — `file_index`, the fifth builtin in its scope, is
deliberately left on the bridge with reasoning recorded in issue 2150.

## The problem

`eval_generic.rs`'s `Expr::Pipe` arm called `to_owned_with_cursor` over the whole
document — plus a second O(document) scan in `reindex_bridge_is_identity` — before
the first stage of any pipe carrying path context ran, because
`eval_pipe_with_path_context_internal` operates on an `OwnedValue` tree. `.[0] | key`
cost 519 MiB on a 20 MB array to answer `0`.

PR #2075 did this for `path(EXPR)`. This is the other half: `path` (no-arg), `key`,
`parent` and `parent(n)` need the path accumulated *across* a pipe rather than a path
expression resolved in one go, so a position now carries its ancestor cursors
alongside its path and `parent(n)` is a truncation of both rather than a
re-navigation from the root. `V::Cursor` is `Copy` and 32 bytes, and
`LazySource::Cursors` already retains cursor vectors, so the stack is free.

Navigation delegates to #2075's `path_step_generic` rather than re-deriving it, so
the float index spelling (#1088), the duplicate-key rule (#1385) and every error
message stay shared. `classify_parent_n` is shared for the same reason.

## Three bugs in #2075's `path()` walk, fixed first

Found by probing the code before extending it. All three verified against jq 1.7.1.

**A live, CLI-reachable panic.** `path_expr_is_cursor_navigable` accepts `Pipe`,
`Comma` and `Optional`, and `Paren` is transparent, so all three reach
`path_step_generic` as the *head* of an outer pipe. It had arms for none of them:

```
$ echo '{"a":{"b":{"c":1}}}' | succinctly jq -c 'path(((.a|.b)|.c))'
internal error: entered unreachable code: ... Pipe([Field("a"), Field("b")])   # exit 101
```

`path((.a,.b)|.c)` and `path((.a?)|.c)` crash identically; jq answers
`["a","b","c"]`, `["a","c"]`/`["b","c"]` and `["a","c"]`.

**`?` discarded outputs its branch had already emitted.** `[1] | path((.[0],.a)?)`
gave nothing where jq gives `[0]`. The two resolvers disagreed with *each other*:
the same shape made non-navigable (`path((.[0],.a[0:1])?)`) defers to
`builtin_path_on_owned`, which emitted `[0]` correctly. `path(.a?)` — whose error
comes before anything is produced — is unaffected either way, which is why it hid.

**A tag-resolution slip.** The "cannot iterate" diagnostic used `to_owned` rather
than the tag-resolving `to_owned_cursor`, so `a: !!str 5 | path(.[]|.[])` said
`number (5)` where every other route says `string ("5")`.

## What is deliberately handed back to the bridge

Output is byte-identical to `main`, not merely equivalent, because the walk declines
five cases rather than answering them differently:

- **An absent node.** The bridge *loses* path context through a missing field
  (`{} | .a | key` is `null`) and *raises* on an out-of-bounds index where plain
  `.[0]` does not; real yq v4.53.3 does neither, answering `"a"` and auto-vivifying.
  All three disagree, so the walk declines to invent a fourth answer inside a
  performance change. Filed as issue 2146 with the full oracle table — it is a
  genuine correctness bug, and the walk reaches yq's answer naturally, so the fix
  there is largely "stop bailing".
- **`parent` landing back at the root.** Materializing it is what the bridge already
  does, and the walk would pay its validity gate on top. Measured as a 0.56s → 0.67s
  loss before this was guarded.
- **`parent(n)` past the root**, whose bridge answer is a synthetic empty object that
  is not a document node.
- **A computed `n`**, which would have to materialize the current value to evaluate.
- **Any emitted value that is not a `reindex_bridge_is_identity`** — the #953 hazard
  #2061's own body names. The bridge re-spells a bare `Float` through
  `to_json_for_reindex`, so `.outer.big | parent | .big | tostring` answers with the
  document's spelling. Checking the *emitted* values rather than the whole document
  keeps `key`/`path` fast on a document holding such a float elsewhere. Caught by the
  existing `test_path_context_bypass_keeps_yq_float_fidelity_1909`.

Bailing out is safe **only** because every accepted shape is pure navigation — no
builtin that computes, no `stderr`, no user function — so re-running the pipe on the
bridge cannot repeat a side effect. That is the constraint that sank #2053's
`getpath` prototype (`getpath(("a"|stderr))` printed `a` twice); it does not apply
here.

The whole-document walk is kept, only the tree build is dropped:
`to_owned_with_cursor` doubles as a decode-failure gate (#1755/#1953), and
`push_generic_truthiness_cursor_error` is that same traversal and validation with the
`OwnedValue` construction removed.

## Two wrong turns, both caught by measuring rather than reasoning

Recorded because the reasoning that produced them was plausible.

**A runtime fan-out cap made the regression it targeted worse.** Materializing an
ancestor is a *backward* jump against the document-wide `Cell<SequentialCursor>` in
`AdvancePositions`/`CompactEndPositions`, which falls into `get_random` and resets
the incremental scan to position zero — so YAML `[.[] | .k.x | parent] | length` ran
+23%/+27%. Capping at one materialization mid-walk took it to **+29%/+38%**, because
bailing then pays the O(document) gate *and* a partial walk *and* the whole bridge.
The guard has to be static, before the gate: reject when the walked expression can
fan out (`Iterate`, or a `Comma` of >1 branch) *and* its terminal stage is not
`key`/`path`. That lands at −1%.

**The static guard then tested every pipe stage instead of only the last**, silently
rejecting `(.a, .b) | key` — the pipe ends in `key`, which materializes nothing, but
stage 0's own branches are `Field`s. No test could see it: falling back produces
identical output. **Patch coverage caught it** — a test added for that shape left the
arms it should reach at zero hits, which is only possible if the query never entered
the walk.

## Results

Interleaved A/B against the merge base, alternating which binary leads, median of 7,
byte-identical output gated before any timing was read, on idle dedicated hosts
(load < 0.1) on AC power. Both absolute times shown so the direction cannot be
misread.

JSON, 20 MB / 1,000,000-element array:

| query | 7950X before → after | M4 Pro before → after |
|---|---|---|
| `.[0] \| key` | 1123 → 419 ms (**−63%**) | 727 → 374 ms (**−49%**) |
| `.[0] \| path` | 1127 → 420 ms (−63%) | 725 → 372 ms (−49%) |
| `.a.b.c \| parent` | 1130 → 436 ms (−61%) | 732 → 378 ms (−48%) |
| `.a.b.c \| parent \| key` | 1129 → 435 ms (−62%) | 735 → 380 ms (−48%) |
| `[.[] \| key] \| length` | 1330 → 1006 ms (−24%) | 844 → 542 ms (−36%) |
| `.[0] \| parent \| length` | 2096 → 2109 ms (neutral) | 1236 → 1230 ms (neutral) |
| `length`, `.[0]` (controls) | neutral | neutral |

YAML, 6 MB sequence:

| query | 7950X | M4 Pro |
|---|---|---|
| `.[0].k.x \| parent` | 504 → 217 ms (**−57%**) | 269 → 160 ms (**−41%**) |
| `[.[] \| .k.x \| key] \| length` | 617 → 538 ms (−13%) | 374 → 360 ms (−4%) |
| `[.[] \| .k.x \| parent \| key] \| length` | 638 → 546 ms (−14%) | 376 → 383 ms (neutral) |
| `[.[] \| .k.x \| parent] \| length` | neutral (guarded) | neutral (guarded) |

Peak RSS 163 MiB → 16 MiB. Ratios hold at 1 MB, 6 MB and 20 MB, so this is the O(n)
term rather than a constant. `.[0] | parent`, whose parent *is* the root, is
unchanged by design — its output is the whole document, so there is nothing to save.

## Verification

- **A 6,930-case differential against the merge-base binary** — 60 filters × 38
  documents, jq *and* yq mode, JSON *and* YAML input — byte-identical stdout, stderr
  and exit code throughout. This is the gate that matters: #2075 found three bugs
  this way that its author's own differential missed.
- Validity gate pinned separately: `\ud800`, `\uZZZZ`, `\x`, `\u12` and a colliding
  #1642 fallback key all still raise, with the same message, exit code and *order*.
- `--eval-all`/`file_index` re-checked and unaffected.
- Full workspace suite **6,875 passed, 0 failed**; default-feature leg **3,832
  passed**; all three `ci.yml` clippy legs, `cargo fmt --check`, `cargo doc` with
  `-D warnings`, and `cargo check --no-default-features` — all from a clean rebuild
  after rebasing onto current `main`.
- Patch coverage **95.6%**; the remaining lines are shapes the parser cannot produce
  (an empty or single-stage `Expr::Pipe`) or defensive guards.

## Follow-ups filed

Issues 2146 (the correctness bug above — the substantive one), 2147, 2148, 2149 and
2150, linked from #2061.
