### PR TITLE
perf(jq): memoize FuncDef's def-call installation per node

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -17,8 +17,8 @@ use succinctly::jq::eval_generic::{
 };
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
-    self, format_number_jq_compat, nonfinite_display_string, EvalError, Expr, JqSemantics, JqValue,
-    OwnedValue, Program, UnresolvedCall, MAX_VALUE_TREE_DEPTH,
+    self, format_number_jq_compat, nonfinite_display_string, BoundBody, EvalError, Expr,
+    JqSemantics, JqValue, OwnedValue, Program, UnresolvedCall, MAX_VALUE_TREE_DEPTH,
 };
 use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -158,6 +158,7 @@ impl ModuleLoader {
                 params,
                 body: Box::new(body),
                 then: Box::new(expr),
+                bound: BoundBody::default(),
             };
         }
 
@@ -171,6 +172,7 @@ impl ModuleLoader {
                     params,
                     body: Box::new(body),
                     then: Box::new(expr),
+                    bound: BoundBody::default(),
                 };
             }
         }
@@ -189,6 +191,7 @@ impl ModuleLoader {
                     params,
                     body: Box::new(body),
                     then: Box::new(expr),
+                    bound: BoundBody::default(),
                 };
             }
         }
@@ -258,11 +261,13 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             params,
             body,
             then,
+            ..
         } => Expr::FuncDef {
             name,
             params,
             body: Box::new(rewrite_namespaced_calls(*body)),
             then: Box::new(rewrite_namespaced_calls(*then)),
+            bound: BoundBody::default(),
         },
         Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
             op,
@@ -470,6 +475,7 @@ fn extract_func_defs(expr: &Expr) -> Vec<(String, Vec<String>, Expr)> {
             params,
             body,
             then,
+            ..
         } = expr
         {
             defs.push((name.clone(), params.clone(), (**body).clone()));

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -17,7 +17,7 @@ use succinctly::jq::eval_generic::{
 };
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
-    self, format_number_jq_compat, nonfinite_display_string, BoundBody, EvalError, Expr,
+    self, format_number_jq_compat, nonfinite_display_string, EvalError, Expr, FuncDefBound,
     JqSemantics, JqValue, OwnedValue, Program, UnresolvedCall, MAX_VALUE_TREE_DEPTH,
 };
 use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
@@ -158,7 +158,7 @@ impl ModuleLoader {
                 params,
                 body: Box::new(body),
                 then: Box::new(expr),
-                bound: BoundBody::default(),
+                bound: FuncDefBound::default(),
             };
         }
 
@@ -172,7 +172,7 @@ impl ModuleLoader {
                     params,
                     body: Box::new(body),
                     then: Box::new(expr),
-                    bound: BoundBody::default(),
+                    bound: FuncDefBound::default(),
                 };
             }
         }
@@ -191,7 +191,7 @@ impl ModuleLoader {
                     params,
                     body: Box::new(body),
                     then: Box::new(expr),
-                    bound: BoundBody::default(),
+                    bound: FuncDefBound::default(),
                 };
             }
         }
@@ -267,7 +267,7 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             params,
             body: Box::new(rewrite_namespaced_calls(*body)),
             then: Box::new(rewrite_namespaced_calls(*then)),
-            bound: BoundBody::default(),
+            bound: FuncDefBound::default(),
         },
         Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
             op,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -298,8 +298,8 @@ impl EvalSemantics for YqSemantics {
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 
 use super::expr::{
-    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefData, Literal,
-    MergeFlags, NumberKey, ObjectEntry, ObjectKey, Pattern, StringPart,
+    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefBound, FuncDefData,
+    Literal, MergeFlags, NumberKey, ObjectEntry, ObjectKey, Pattern, StringPart,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -3397,7 +3397,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             bound,
         } => {
             let bound_then = bind_def(name, params, body, then, bound);
-            eval_each::<W, S>(bound_then, value, optional, sink)
+            eval_each::<W, S>(&bound_then, value, optional, sink)
         }
 
         // #1371: a bound call needs its own arm here for the same reason the
@@ -26322,7 +26322,7 @@ fn substitute_var_impl(
                 )),
                 // Rebuilt above (`body`/`then` may have changed), so any
                 // cache computed against the old node is stale (#2094).
-                bound: BoundBody::default(),
+                bound: FuncDefBound::default(),
             }
         }
         Expr::FuncCall { name, args } => Expr::FuncCall {
@@ -31088,18 +31088,32 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
             let bound_then = bind_def(name, params, body, then, bound);
-            let mut then_stages = vec![(**bound_then).clone()];
-            if paired {
-                then_stages.push(path_probe_stage());
-            }
-            let then_result = eval_pipe_with_path_context_internal::<W, S>(
-                &then_stages,
-                value,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            );
+            // #2094 review: the unpaired (common) case passes `bound_then`
+            // through as a one-element slice with no clone at all, so this
+            // arm keeps the full benefit of `bind_def`'s own cache -- only
+            // the paired case, which must append `path_probe_stage()`,
+            // needs an owned `Vec` (and so a clone of the cached tree) to
+            // build one.
+            let then_result = if paired {
+                let then_stages = [(*bound_then).clone(), path_probe_stage()];
+                eval_pipe_with_path_context_internal::<W, S>(
+                    &then_stages,
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                )
+            } else {
+                eval_pipe_with_path_context_internal::<W, S>(
+                    core::slice::from_ref(&*bound_then),
+                    value,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                )
+            };
             if rest.is_empty() {
                 then_result
             } else if paired {
@@ -40490,12 +40504,12 @@ fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     params: &[String],
     body: &Expr,
     then: &Expr,
-    bound: &BoundBody,
+    bound: &FuncDefBound,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
     let bound_then = bind_def(name, params, body, then, bound);
-    eval_single::<W, S>(bound_then, value, optional)
+    eval_single::<W, S>(&bound_then, value, optional)
 }
 
 /// Ambient "how many frames deep is the recursion the caller is already
@@ -40579,32 +40593,34 @@ mod ambient_frame_depth {
 ///
 /// Memoized on `bound` (#2094): a `def` declared *inside* a loop body (`.[] |
 /// (def add1: . + 1; add1)`) reaches this same node once per element, and
-/// installation is a pure function of `(name, params, body, then)` -- the
-/// same reasoning [`BoundBody`] itself documents for `DefCall`. Infallible,
-/// unlike [`bind_def_call`], so there is no failure case to leave uncached.
+/// installation is a pure function of `(name, params, body, then, depth)` --
+/// the same reasoning [`BoundBody`] documents for `DefCall`, plus the
+/// current ambient depth (baked into the installed `DefCall`s' own `frames`
+/// fields). Infallible, unlike [`bind_def_call`], so there is no failure
+/// case to leave uncached.
 ///
-/// Safe to cache `ambient_frame_depth::get()`'s value (baked into the
-/// installed `DefCall`s' own `frames` fields) along with the rest: nothing
-/// between two evaluations of the *same* `FuncDef` node can change the
-/// ambient depth without also rebuilding that node first. The depth only
-/// moves inside an [`enter_def_call_frame`] guard scoped to one `DefCall`'s
-/// own bound-body evaluation, and every substitution pass that could place
-/// this `FuncDef` node inside a different `DefCall`'s recursion also
-/// rebuilds the node (and resets `bound`) as part of that same substitution.
-pub(crate) fn bind_def<'e>(
+/// **Not safe to treat the depth as constant across repeat reaches of the
+/// same node** -- see [`FuncDefBound`]'s own doc comment for why (`Expr::
+/// Shared` can carry the identical node, unrebuilt, into a call site at a
+/// different real recursion depth) -- so [`FuncDefBound::get_or_init_at`]
+/// recomputes whenever the depth this call observes doesn't match what
+/// produced the cached answer, rather than trusting any cached answer at
+/// all like [`BoundBody`] does.
+pub(crate) fn bind_def(
     name: &str,
     params: &[String],
     body: &Expr,
     then: &Expr,
-    bound: &'e BoundBody,
-) -> &'e Rc<Expr> {
-    bound.get_or_init(|| {
+    bound: &FuncDefBound,
+) -> Rc<Expr> {
+    let depth = ambient_frame_depth::get();
+    bound.get_or_init_at(depth, || {
         let def = Rc::new(FuncDefData {
             name: name.to_string(),
             params: params.to_vec(),
             body: body.clone(),
         });
-        Rc::new(install_def_calls(then, &def, ambient_frame_depth::get()))
+        Rc::new(install_def_calls(then, &def, depth))
     })
 }
 
@@ -41078,7 +41094,7 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                     // is stale (#2094) -- the shadowed branch above instead
                     // clones `expr` wholesale, correctly carrying its cache
                     // (if any) through untouched.
-                    bound: BoundBody::default(),
+                    bound: FuncDefBound::default(),
                 }
             }
         }
@@ -41509,7 +41525,7 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                 body: Box::new(subst_unless_shadowed(body_shadowed, body, param, arg)),
                 then: Box::new(subst_unless_shadowed(then_shadowed, then, param, arg)),
                 // Rebuilt above, so any cache is stale (#2094).
-                bound: BoundBody::default(),
+                bound: FuncDefBound::default(),
             }
         }
         Expr::FuncCall { name, args } => {
@@ -41700,22 +41716,22 @@ mod tests {
         };
 
         let first = bind_def(&name, &params, &body, &then, &bound);
-        let first_ptr = Rc::as_ptr(first);
+        let first_ptr = Rc::as_ptr(&first);
         let second = bind_def(&name, &params, &body, &then, &bound);
         assert!(
-            Rc::ptr_eq(first, second),
-            "a second call sharing the same BoundBody must reuse the first's cached Rc \
-             (same pointer), not recompute install_def_calls from scratch"
+            Rc::ptr_eq(&first, &second),
+            "a second call at the same depth sharing the same FuncDefBound must reuse the \
+             first's cached Rc (same pointer), not recompute install_def_calls from scratch"
         );
-        assert_eq!(Rc::as_ptr(second), first_ptr);
+        assert_eq!(Rc::as_ptr(&second), first_ptr);
 
         // An independent node's own cache cell is untouched by the one
         // above -- confirms the cache is keyed per-node, not global.
-        let fresh_cache = BoundBody::default();
+        let fresh_cache = FuncDefBound::default();
         let third = bind_def(&name, &params, &body, &then, &fresh_cache);
         assert!(
-            !Rc::ptr_eq(first, third),
-            "a different BoundBody must compute its own Rc, not see another node's cache"
+            !Rc::ptr_eq(&first, &third),
+            "a different FuncDefBound must compute its own Rc, not see another node's cache"
         );
     }
 
@@ -41733,18 +41749,18 @@ mod tests {
             panic!("expected a top-level FuncDef");
         };
 
-        // Each call below gets its own fresh `BoundBody` (#2094): they
-        // simulate three *independent* reaches of a `def name: ...` node at
-        // different ambient depths, which in the real evaluator can only
-        // happen across a rebuild that itself resets the cache (see
-        // `bind_def`'s own doc comment) -- reusing one cache cell across all
-        // three would make the 2nd/3rd calls return the 1st's stale result
-        // and defeat what this test checks.
+        // One cache cell reused across all three calls below, simulating
+        // three reaches of the identical `def name: ...` node at different
+        // ambient depths with no rebuild in between -- exactly the
+        // `Expr::Shared`-threaded shape `FuncDefBound::get_or_init_at`
+        // exists to keep correct (#2094): each call below observes a
+        // different depth than the one that produced whatever's currently
+        // cached, so each recomputes rather than returning a stale answer.
+        let cache = FuncDefBound::default();
 
         // No ambient depth entered yet: a fresh top-level `def` still seeds
         // from `0`, matching every evaluator's actual call site.
-        let cache1 = BoundBody::default();
-        match &**bind_def(&name, &params, &body, &then, &cache1) {
+        match &*bind_def(&name, &params, &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
@@ -41756,8 +41772,7 @@ mod tests {
         // FuncDef node.
         {
             let _guard = enter_def_call_frame(MAX_EVAL_FRAMES - 1);
-            let cache2 = BoundBody::default();
-            match &**bind_def(&name, &params, &body, &then, &cache2) {
+            match &*bind_def(&name, &params, &body, &then, &cache) {
                 Expr::DefCall { frames, .. } => assert_eq!(*frames, MAX_EVAL_FRAMES - 1),
                 other => panic!("expected DefCall, got {other:?}"),
             }
@@ -41767,11 +41782,67 @@ mod tests {
         // `def` reached *after* the nested call returns -- a sibling, not
         // something nested inside it -- does not inherit a depth that no
         // longer applies to it.
-        let cache3 = BoundBody::default();
-        match &**bind_def(&name, &params, &body, &then, &cache3) {
+        match &*bind_def(&name, &params, &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
+    }
+
+    /// #2094 review: two independent finder agents confirmed, by direct
+    /// experiment against this exact API, that reusing one `BoundBody`-style
+    /// write-once cache across reaches at different ambient depths silently
+    /// returns the *first* reach's stale, too-shallow `frames` -- reachable
+    /// in practice through `Expr::Shared`, which both `install_def_calls`
+    /// and `substitute_func_param` deliberately leave unrebuilt: pass a
+    /// self-recursive `def` as a function-valued argument, and the same
+    /// underlying node (and cache cell) is reached again, unrebuilt, from
+    /// inside a deeper recursive call. `FuncDefBound::get_or_init_at`
+    /// closes this by keying the cache on depth too, invalidating instead
+    /// of trusting a cached answer computed at a different depth -- this
+    /// pins that behavior directly against `bind_def`, the same way the
+    /// test above pins the fresh-node case.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_bind_def_recomputes_when_ambient_depth_changes_2094() {
+        let Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+            ..
+        } = parse("def inner: 1; inner").unwrap()
+        else {
+            panic!("expected a top-level FuncDef");
+        };
+
+        let cache = FuncDefBound::default();
+
+        let first = bind_def(&name, &params, &body, &then, &cache);
+        let first_frames = match &*first {
+            Expr::DefCall { frames, .. } => *frames,
+            other => panic!("expected DefCall, got {other:?}"),
+        };
+        assert_eq!(first_frames, 0);
+
+        // Same cache cell, no rebuild -- simulates the identical `FuncDef`
+        // node being reached again through an `Expr::Shared` wrapper
+        // threaded into a deeper recursive `DefCall`'s substituted body.
+        let _guard = enter_def_call_frame(500);
+        let second = bind_def(&name, &params, &body, &then, &cache);
+        let second_frames = match &*second {
+            Expr::DefCall { frames, .. } => *frames,
+            other => panic!("expected DefCall, got {other:?}"),
+        };
+        assert_eq!(
+            second_frames, 500,
+            "bind_def must recompute at the new depth (500), not return the first reach's \
+             stale frames (0) -- a write-once cache here would silently undercount how deep \
+             this reach actually is, weakening the MAX_EVAL_FRAMES guard (#1098/#1016)"
+        );
+        assert!(
+            !Rc::ptr_eq(&first, &second),
+            "a depth change must produce a freshly computed Rc, not the first reach's cached one"
+        );
     }
 
     /// Companion to the test above: confirms the ambient floor it pins is
@@ -41799,14 +41870,14 @@ mod tests {
         };
 
         let _guard = enter_def_call_frame(MAX_EVAL_FRAMES);
-        let cache = BoundBody::default();
+        let cache = FuncDefBound::default();
         let bound_then = bind_def(&name, &params, &body, &then, &cache);
         let Expr::DefCall {
             def,
             args,
             frames,
             bound,
-        } = &**bound_then
+        } = &*bound_then
         else {
             panic!("expected DefCall");
         };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1293,7 +1293,8 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             params,
             body,
             then,
-        } => eval_func_def::<W, S>(name, params, body, then, value, optional),
+            bound,
+        } => eval_func_def::<W, S>(name, params, body, then, bound, value, optional),
         Expr::FuncCall { name, args } => eval_func_call::<W>(name, args, value, optional),
 
         // #1371: a call already bound to its definition. Unlike `FuncCall`
@@ -3393,9 +3394,10 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             params,
             body,
             then,
+            bound,
         } => {
-            let bound_then = bind_def(name, params, body, then);
-            eval_each::<W, S>(&bound_then, value, optional, sink)
+            let bound_then = bind_def(name, params, body, then, bound);
+            eval_each::<W, S>(bound_then, value, optional, sink)
         }
 
         // #1371: a bound call needs its own arm here for the same reason the
@@ -26295,6 +26297,7 @@ fn substitute_var_impl(
             params,
             body,
             then,
+            ..
         } => {
             // Check if any parameter shadows the var_name
             let shadowed = params.contains(&var_name.to_string());
@@ -26317,6 +26320,9 @@ fn substitute_var_impl(
                     replacement,
                     mark_trackable,
                 )),
+                // Rebuilt above (`body`/`then` may have changed), so any
+                // cache computed against the old node is stale (#2094).
+                bound: BoundBody::default(),
             }
         }
         Expr::FuncCall { name, args } => Expr::FuncCall {
@@ -31076,12 +31082,13 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             params,
             body,
             then,
+            bound,
         } => {
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let bound_then = bind_def(name, params, body, then);
-            let mut then_stages = vec![bound_then];
+            let bound_then = bind_def(name, params, body, then, bound);
+            let mut then_stages = vec![(**bound_then).clone()];
             if paired {
                 then_stages.push(path_probe_stage());
             }
@@ -40483,11 +40490,12 @@ fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     params: &[String],
     body: &Expr,
     then: &Expr,
+    bound: &BoundBody,
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let bound_then = bind_def(name, params, body, then);
-    eval_single::<W, S>(&bound_then, value, optional)
+    let bound_then = bind_def(name, params, body, then, bound);
+    eval_single::<W, S>(bound_then, value, optional)
 }
 
 /// Ambient "how many frames deep is the recursion the caller is already
@@ -40568,13 +40576,36 @@ mod ambient_frame_depth {
 /// demand-driven `eval_each`, the path-context one, and `eval_generic`'s —
 /// and all four need exactly this before continuing into their own
 /// evaluation of `then`.
-pub(crate) fn bind_def(name: &str, params: &[String], body: &Expr, then: &Expr) -> Expr {
-    let def = Rc::new(FuncDefData {
-        name: name.to_string(),
-        params: params.to_vec(),
-        body: body.clone(),
-    });
-    install_def_calls(then, &def, ambient_frame_depth::get())
+///
+/// Memoized on `bound` (#2094): a `def` declared *inside* a loop body (`.[] |
+/// (def add1: . + 1; add1)`) reaches this same node once per element, and
+/// installation is a pure function of `(name, params, body, then)` -- the
+/// same reasoning [`BoundBody`] itself documents for `DefCall`. Infallible,
+/// unlike [`bind_def_call`], so there is no failure case to leave uncached.
+///
+/// Safe to cache `ambient_frame_depth::get()`'s value (baked into the
+/// installed `DefCall`s' own `frames` fields) along with the rest: nothing
+/// between two evaluations of the *same* `FuncDef` node can change the
+/// ambient depth without also rebuilding that node first. The depth only
+/// moves inside an [`enter_def_call_frame`] guard scoped to one `DefCall`'s
+/// own bound-body evaluation, and every substitution pass that could place
+/// this `FuncDef` node inside a different `DefCall`'s recursion also
+/// rebuilds the node (and resets `bound`) as part of that same substitution.
+pub(crate) fn bind_def<'e>(
+    name: &str,
+    params: &[String],
+    body: &Expr,
+    then: &Expr,
+    bound: &'e BoundBody,
+) -> &'e Rc<Expr> {
+    bound.get_or_init(|| {
+        let def = Rc::new(FuncDefData {
+            name: name.to_string(),
+            params: params.to_vec(),
+            body: body.clone(),
+        });
+        Rc::new(install_def_calls(then, &def, ambient_frame_depth::get()))
+    })
 }
 
 /// Widens the ambient frame-depth floor (see [`ambient_frame_depth`]) to
@@ -40694,11 +40725,28 @@ pub(crate) fn bind_def_call<'e>(
                 def.params.len()
             )));
         }
-        let mut body = def.body.clone();
-        for (param, arg) in def.params.iter().zip(args.iter()) {
-            body = substitute_func_param(&body, param, &Expr::Shared(Rc::new(arg.clone())));
-        }
-        Ok(Rc::new(install_def_calls(&body, def, frames + 1)))
+        // #2094: `def.body` needs to become an owned `Expr` before
+        // `install_def_calls` below only when at least one parameter
+        // substitution actually rebuilds it -- `substitute_func_param`
+        // already deep-clones/rebuilds the whole tree on its own first
+        // call, so seeding the loop with a separate `def.body.clone()`
+        // wasted one O(body size) allocation per bound call (i.e. once per
+        // recursion level, since this whole function is gated by `bound`).
+        // A zero-parameter `def` needs no substitution at all, so it skips
+        // straight to installing over `&def.body` with no clone whatsoever.
+        let mut params_and_args = def.params.iter().zip(args.iter());
+        let installed_body = match params_and_args.next() {
+            Some((param, arg)) => {
+                let mut body =
+                    substitute_func_param(&def.body, param, &Expr::Shared(Rc::new(arg.clone())));
+                for (param, arg) in params_and_args {
+                    body = substitute_func_param(&body, param, &Expr::Shared(Rc::new(arg.clone())));
+                }
+                install_def_calls(&body, def, frames + 1)
+            }
+            None => install_def_calls(&def.body, def, frames + 1),
+        };
+        Ok(Rc::new(installed_body))
     })
 }
 
@@ -41001,6 +41049,7 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
             params: inner_params,
             body: inner_body,
             then,
+            ..
         } => {
             // #1376: shadowing needs the *same arity*, not just the same
             // name -- see the `FuncCall` arm above for why arity
@@ -41025,6 +41074,11 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                     params: inner_params.clone(),
                     body: Box::new(install_def_calls(inner_body, def, frames + 1)),
                     then: Box::new(install_def_calls(then, def, frames + 1)),
+                    // Rebuilt above, so any cache from the pre-install node
+                    // is stale (#2094) -- the shadowed branch above instead
+                    // clones `expr` wholesale, correctly carrying its cache
+                    // (if any) through untouched.
+                    bound: BoundBody::default(),
                 }
             }
         }
@@ -41436,6 +41490,7 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
             params,
             body,
             then,
+            ..
         } => {
             // #2077 defect B: a nested `def` of the same name *and arity*
             // (zero, matching how a function parameter is referenced --
@@ -41453,6 +41508,8 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                 params: params.clone(),
                 body: Box::new(subst_unless_shadowed(body_shadowed, body, param, arg)),
                 then: Box::new(subst_unless_shadowed(then_shadowed, then, param, arg)),
+                // Rebuilt above, so any cache is stale (#2094).
+                bound: BoundBody::default(),
             }
         }
         Expr::FuncCall { name, args } => {
@@ -41630,6 +41687,39 @@ mod tests {
     /// under `no_std` (see its own module doc comment) -- there is no
     /// no_std variant of this mechanism to test.
     #[test]
+    fn test_bind_def_memoizes_per_node_2094() {
+        let Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+            bound,
+        } = parse("def f: 1; f").unwrap()
+        else {
+            panic!("expected a top-level FuncDef");
+        };
+
+        let first = bind_def(&name, &params, &body, &then, &bound);
+        let first_ptr = Rc::as_ptr(first);
+        let second = bind_def(&name, &params, &body, &then, &bound);
+        assert!(
+            Rc::ptr_eq(first, second),
+            "a second call sharing the same BoundBody must reuse the first's cached Rc \
+             (same pointer), not recompute install_def_calls from scratch"
+        );
+        assert_eq!(Rc::as_ptr(second), first_ptr);
+
+        // An independent node's own cache cell is untouched by the one
+        // above -- confirms the cache is keyed per-node, not global.
+        let fresh_cache = BoundBody::default();
+        let third = bind_def(&name, &params, &body, &then, &fresh_cache);
+        assert!(
+            !Rc::ptr_eq(first, third),
+            "a different BoundBody must compute its own Rc, not see another node's cache"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "std")]
     fn test_bind_def_seeds_defcall_frames_from_ambient_depth_1371() {
         let Expr::FuncDef {
@@ -41637,15 +41727,25 @@ mod tests {
             params,
             body,
             then,
+            ..
         } = parse("def f: f; f").unwrap()
         else {
             panic!("expected a top-level FuncDef");
         };
 
+        // Each call below gets its own fresh `BoundBody` (#2094): they
+        // simulate three *independent* reaches of a `def name: ...` node at
+        // different ambient depths, which in the real evaluator can only
+        // happen across a rebuild that itself resets the cache (see
+        // `bind_def`'s own doc comment) -- reusing one cache cell across all
+        // three would make the 2nd/3rd calls return the 1st's stale result
+        // and defeat what this test checks.
+
         // No ambient depth entered yet: a fresh top-level `def` still seeds
         // from `0`, matching every evaluator's actual call site.
-        match bind_def(&name, &params, &body, &then) {
-            Expr::DefCall { frames, .. } => assert_eq!(frames, 0),
+        let cache1 = BoundBody::default();
+        match &**bind_def(&name, &params, &body, &then, &cache1) {
+            Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
 
@@ -41656,8 +41756,9 @@ mod tests {
         // FuncDef node.
         {
             let _guard = enter_def_call_frame(MAX_EVAL_FRAMES - 1);
-            match bind_def(&name, &params, &body, &then) {
-                Expr::DefCall { frames, .. } => assert_eq!(frames, MAX_EVAL_FRAMES - 1),
+            let cache2 = BoundBody::default();
+            match &**bind_def(&name, &params, &body, &then, &cache2) {
+                Expr::DefCall { frames, .. } => assert_eq!(*frames, MAX_EVAL_FRAMES - 1),
                 other => panic!("expected DefCall, got {other:?}"),
             }
         }
@@ -41666,8 +41767,9 @@ mod tests {
         // `def` reached *after* the nested call returns -- a sibling, not
         // something nested inside it -- does not inherit a depth that no
         // longer applies to it.
-        match bind_def(&name, &params, &body, &then) {
-            Expr::DefCall { frames, .. } => assert_eq!(frames, 0),
+        let cache3 = BoundBody::default();
+        match &**bind_def(&name, &params, &body, &then, &cache3) {
+            Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
     }
@@ -41690,22 +41792,25 @@ mod tests {
             params,
             body,
             then,
+            ..
         } = parse("def f: f; f").unwrap()
         else {
             panic!("expected a top-level FuncDef");
         };
 
         let _guard = enter_def_call_frame(MAX_EVAL_FRAMES);
+        let cache = BoundBody::default();
+        let bound_then = bind_def(&name, &params, &body, &then, &cache);
         let Expr::DefCall {
             def,
             args,
             frames,
             bound,
-        } = bind_def(&name, &params, &body, &then)
+        } = &**bound_then
         else {
             panic!("expected DefCall");
         };
-        let err = bind_def_call(&def, &args, frames, &bound)
+        let err = bind_def_call(def, args, *frames, bound)
             .expect_err("ambient depth at the ceiling must refuse the call, not run it");
         assert!(
             err.message.contains("exceeded maximum recursion depth"),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -47,7 +47,7 @@ use super::eval::{
     YqSemantics,
 };
 #[cfg(test)]
-use super::expr::BoundBody;
+use super::expr::FuncDefBound;
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
 use super::value::{owned_value_eq, NumberRepr, OwnedValue};
@@ -5719,7 +5719,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             bound,
         } => {
             let bound_then = bind_def(name, params, body, then, bound);
-            eval_each_generic::<S, V>(bound_then, value, optional, cursor, sink)
+            eval_each_generic::<S, V>(&bound_then, value, optional, cursor, sink)
         }
 
         // #1371: mirrors `eval.rs`'s own `DefCall`/`Shared` pair -- see there
@@ -17528,10 +17528,10 @@ mod tests {
         };
 
         let _guard = enter_def_call_frame(crate::jq::eval::MAX_EVAL_FRAMES);
-        let cache = BoundBody::default();
+        let cache = FuncDefBound::default();
         let defcall = bind_def(&name, &params, &body, &then, &cache);
         assert!(
-            matches!(&**defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
+            matches!(&*defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
             "expected bind_def to seed frames from the ambient depth"
         );
 
@@ -17540,7 +17540,8 @@ mod tests {
         let cursor = index.root(json);
 
         let mut on_value = |_item: GenericResult<_>| true;
-        let control = eval_each_with_cursor_using::<JqSemantics, _>(defcall, cursor, &mut on_value);
+        let control =
+            eval_each_with_cursor_using::<JqSemantics, _>(&defcall, cursor, &mut on_value);
 
         match control {
             Some(Control::Error(err)) => assert!(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -46,6 +46,8 @@ use super::eval::{
     Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, QueryResult,
     YqSemantics,
 };
+#[cfg(test)]
+use super::expr::BoundBody;
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
 use super::slice::{slice_str, SliceBounds};
 use super::value::{owned_value_eq, NumberRepr, OwnedValue};
@@ -5714,9 +5716,10 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             params,
             body,
             then,
+            bound,
         } => {
-            let bound_then = bind_def(name, params, body, then);
-            eval_each_generic::<S, V>(&bound_then, value, optional, cursor, sink)
+            let bound_then = bind_def(name, params, body, then, bound);
+            eval_each_generic::<S, V>(bound_then, value, optional, cursor, sink)
         }
 
         // #1371: mirrors `eval.rs`'s own `DefCall`/`Shared` pair -- see there
@@ -17518,15 +17521,17 @@ mod tests {
             params,
             body,
             then,
+            ..
         } = parse("def f: f; f").unwrap()
         else {
             panic!("expected a top-level FuncDef");
         };
 
         let _guard = enter_def_call_frame(crate::jq::eval::MAX_EVAL_FRAMES);
-        let defcall = bind_def(&name, &params, &body, &then);
+        let cache = BoundBody::default();
+        let defcall = bind_def(&name, &params, &body, &then, &cache);
         assert!(
-            matches!(&defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
+            matches!(&**defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
             "expected bind_def to seed frames from the ambient depth"
         );
 
@@ -17535,8 +17540,7 @@ mod tests {
         let cursor = index.root(json);
 
         let mut on_value = |_item: GenericResult<_>| true;
-        let control =
-            eval_each_with_cursor_using::<JqSemantics, _>(&defcall, cursor, &mut on_value);
+        let control = eval_each_with_cursor_using::<JqSemantics, _>(defcall, cursor, &mut on_value);
 
         match control {
             Some(Control::Error(err)) => assert!(

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -2120,6 +2120,40 @@ mod tests {
         );
     }
 
+    /// Same invariant as [`test_bound_body_is_invisible_to_eq_and_debug_1371`],
+    /// for [`FuncDefBound`] (#2094) -- and additionally covers that a
+    /// *depth-mismatched* cache entry is just as invisible as an empty one,
+    /// since `FuncDefBound` (unlike `BoundBody`) can hold a populated-but-
+    /// stale entry rather than only empty-or-fresh.
+    #[test]
+    fn test_func_def_bound_is_invisible_to_eq_and_debug_2094() {
+        let def = |bound| Expr::FuncDef {
+            name: "f".into(),
+            params: Vec::new(),
+            body: Box::new(Expr::Identity),
+            then: Box::new(Expr::Identity),
+            bound,
+        };
+        let cold = def(FuncDefBound::default());
+
+        let warm_bound = FuncDefBound::default();
+        let _ = warm_bound.get_or_init_at(0, || Rc::new(Expr::Identity));
+        let warm = def(warm_bound);
+
+        let stale_bound = FuncDefBound::default();
+        let _ = stale_bound.get_or_init_at(99, || Rc::new(Expr::Identity));
+        let stale = def(stale_bound);
+
+        for (label, other) in [("warm", &warm), ("stale", &stale)] {
+            assert_eq!(cold, *other, "the cache must not affect equality ({label})");
+            assert_eq!(
+                format!("{cold:?}"),
+                format!("{other:?}"),
+                "the cache must not affect Debug output ({label})"
+            );
+        }
+    }
+
     /// Helper: `Vec<String>` from string literals, without repeating the
     /// `to_string` dance at each call site.
     fn alloc_vec<const N: usize>(names: [&str; N]) -> Vec<String> {

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -570,12 +570,12 @@ pub enum Expr {
 /// carrying the old node's, since a cache keyed on arguments that just
 /// changed is exactly a stale one.
 ///
-/// Write-once by design (see [`Self::get_or_try_init`]/[`Self::get_or_init`]
-/// below) — safe *only* because `DefCall.frames` is a plain field, frozen
-/// once by whichever `install_def_calls` pass built this specific node, and
-/// never re-read from ambient state at call time. [`Expr::FuncDef`]'s own
-/// cache (#2094) needs a different shape for exactly that reason: see
-/// [`FuncDefBound`]'s own doc comment.
+/// Write-once by design (see [`Self::get_or_try_init`] below) — safe *only*
+/// because `DefCall.frames` is a plain field, frozen once by whichever
+/// `install_def_calls` pass built this specific node, and never re-read from
+/// ambient state at call time. [`Expr::FuncDef`]'s own cache (#2094) needs a
+/// different shape for exactly that reason: see [`FuncDefBound`]'s own doc
+/// comment.
 #[derive(Clone, Default)]
 pub struct BoundBody(core::cell::OnceCell<Rc<Expr>>);
 
@@ -620,9 +620,9 @@ impl core::fmt::Debug for BoundBody {
 ///
 /// Computed on first evaluation and reused afterwards -- unlike
 /// [`BoundBody`], keyed additionally by the ambient frame depth
-/// ([`super::eval::ambient_frame_depth`]) it was computed at, and
-/// recomputed (not just left stale) whenever that depth differs from what
-/// produced the cached answer.
+/// (`eval::ambient_frame_depth`, private to that module) it was computed
+/// at, and recomputed (not just left stale) whenever that depth differs
+/// from what produced the cached answer.
 ///
 /// The naive `OnceCell`-style write-once cache `BoundBody` uses is unsound
 /// here: installing a `def` bakes the *current* ambient depth into every

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -412,13 +412,14 @@ pub enum Expr {
         /// Expression where this function is in scope
         then: Box<Self>,
         /// `then`, with this def's own calls installed -- computed on first
-        /// evaluation of this node and reused afterwards (#2094), the same
-        /// way `DefCall`'s own `bound` field works. Every substitution pass
-        /// that rebuilds this node's `body`/`then`/`params` must reset this
-        /// to `BoundBody::default()`; a pass that merely clones the node
-        /// through unchanged (nothing here was substituted into) may carry
-        /// the cached value along.
-        bound: BoundBody,
+        /// evaluation of this node and reused afterwards (#2094). See
+        /// [`FuncDefBound`]'s own doc comment for why this needs a different
+        /// cache shape than `DefCall`'s own `bound` field. Every
+        /// substitution pass that rebuilds this node's `body`/`then`/`params`
+        /// must reset this to `FuncDefBound::default()`; a pass that merely
+        /// clones the node through unchanged (nothing here was substituted
+        /// into) may carry the cached value along.
+        bound: FuncDefBound,
     },
 
     /// Function call: `name` or `name(args)`
@@ -568,6 +569,13 @@ pub enum Expr {
 /// must reset this** — they construct a fresh `BoundBody` rather than
 /// carrying the old node's, since a cache keyed on arguments that just
 /// changed is exactly a stale one.
+///
+/// Write-once by design (see [`Self::get_or_try_init`]/[`Self::get_or_init`]
+/// below) — safe *only* because `DefCall.frames` is a plain field, frozen
+/// once by whichever `install_def_calls` pass built this specific node, and
+/// never re-read from ambient state at call time. [`Expr::FuncDef`]'s own
+/// cache (#2094) needs a different shape for exactly that reason: see
+/// [`FuncDefBound`]'s own doc comment.
 #[derive(Clone, Default)]
 pub struct BoundBody(core::cell::OnceCell<Rc<Expr>>);
 
@@ -588,15 +596,6 @@ impl BoundBody {
         let bound = bind()?;
         Ok(self.0.get_or_init(|| bound))
     }
-
-    /// The bound body, computing it with an infallible `bind` on first call.
-    ///
-    /// For a cache site whose `bind` can never fail (#2094's `FuncDef`
-    /// installation, unlike `DefCall`'s own recursion-depth-guarded bind) --
-    /// see [`Self::get_or_try_init`] for the fallible counterpart.
-    pub fn get_or_init(&self, bind: impl FnOnce() -> Rc<Expr>) -> &Rc<Expr> {
-        self.0.get_or_init(bind)
-    }
 }
 
 /// Two `DefCall`s are equal when their definition, arguments and frame count
@@ -613,6 +612,71 @@ impl PartialEq for BoundBody {
 impl core::fmt::Debug for BoundBody {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("BoundBody")
+    }
+}
+
+/// An [`Expr::FuncDef`]'s "`then`, with this def's own calls installed" cache
+/// (#2094).
+///
+/// Computed on first evaluation and reused afterwards -- unlike
+/// [`BoundBody`], keyed additionally by the ambient frame depth
+/// ([`super::eval::ambient_frame_depth`]) it was computed at, and
+/// recomputed (not just left stale) whenever that depth differs from what
+/// produced the cached answer.
+///
+/// The naive `OnceCell`-style write-once cache `BoundBody` uses is unsound
+/// here: installing a `def` bakes the *current* ambient depth into every
+/// nested `DefCall`'s own `frames` field (`bind_def`'s doc comment covers
+/// why that's normally safe to treat as constant across repeat evaluations
+/// of one node). But `Expr::Shared` sharing an `Rc<Expr>` unchanged across
+/// substitution passes (by design, for #1371/#2077/#2096 hygiene) means the
+/// *same* `FuncDef` node -- same `Rc`, same cache cell -- can genuinely be
+/// reached at two different real depths without ever being rebuilt: pass a
+/// self-recursive `def` as a function-valued argument, evaluate it once
+/// directly (shallow) and once inside a deeper recursive call (e.g. `def
+/// each(n; f): if n <= 0 then empty else (f, each(n - 1; f)) end`). A
+/// write-once cache would freeze the shallow reach's `frames` baseline and
+/// silently reuse it for the deep reach too, undercounting how close that
+/// deep call actually is to `MAX_EVAL_FRAMES` -- exactly the unbounded
+/// native-recursion gap #1098/#1016 exist to close.
+///
+/// Falling back to recomputing whenever the depth moves keeps the *common*
+/// case (a `def` inline in a loop body, reached repeatedly at one constant
+/// depth) fully cached, and only pays install cost again in the rarer
+/// cross-depth-reuse shape above -- trading a little of that shape's own
+/// performance for keeping the recursion guard sound in all cases.
+#[derive(Clone, Default)]
+pub struct FuncDefBound(core::cell::RefCell<Option<(u32, Rc<Expr>)>>);
+
+impl FuncDefBound {
+    /// The installed body for the given ambient `depth`, computing it fresh
+    /// via `bind` if nothing is cached yet or the cached answer was computed
+    /// at a different depth.
+    pub fn get_or_init_at(&self, depth: u32, bind: impl FnOnce() -> Rc<Expr>) -> Rc<Expr> {
+        if let Some((cached_depth, tree)) = self.0.borrow().as_ref() {
+            if *cached_depth == depth {
+                return Rc::clone(tree);
+            }
+        }
+        let tree = bind();
+        *self.0.borrow_mut() = Some((depth, Rc::clone(&tree)));
+        tree
+    }
+}
+
+/// Two `FuncDef`s are equal when their name/params/body/then are — whether
+/// either has been evaluated yet, or at what depth, is derived state, not
+/// identity (mirrors [`BoundBody`]'s own `PartialEq`).
+impl PartialEq for FuncDefBound {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+/// Deliberately opaque, for the same reason as [`BoundBody`]'s own `Debug`.
+impl core::fmt::Debug for FuncDefBound {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("FuncDefBound")
     }
 }
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -411,6 +411,14 @@ pub enum Expr {
         body: Box<Self>,
         /// Expression where this function is in scope
         then: Box<Self>,
+        /// `then`, with this def's own calls installed -- computed on first
+        /// evaluation of this node and reused afterwards (#2094), the same
+        /// way `DefCall`'s own `bound` field works. Every substitution pass
+        /// that rebuilds this node's `body`/`then`/`params` must reset this
+        /// to `BoundBody::default()`; a pass that merely clones the node
+        /// through unchanged (nothing here was substituted into) may carry
+        /// the cached value along.
+        bound: BoundBody,
     },
 
     /// Function call: `name` or `name(args)`
@@ -579,6 +587,15 @@ impl BoundBody {
         }
         let bound = bind()?;
         Ok(self.0.get_or_init(|| bound))
+    }
+
+    /// The bound body, computing it with an infallible `bind` on first call.
+    ///
+    /// For a cache site whose `bind` can never fail (#2094's `FuncDef`
+    /// installation, unlike `DefCall`'s own recursion-depth-guarded bind) --
+    /// see [`Self::get_or_try_init`] for the fallible counterpart.
+    pub fn get_or_init(&self, bind: impl FnOnce() -> Rc<Expr>) -> &Rc<Expr> {
+        self.0.get_or_init(bind)
     }
 }
 

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -102,8 +102,8 @@ pub use eval::{
 // `false` without `std`), so `eval_generic` can consult it unconditionally.
 pub use eval::input_queue_is_active;
 pub use expr::{
-    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefData, Import,
-    Include, Literal, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
+    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefBound, FuncDefData,
+    Import, Include, Literal, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
     PatternEntry, Program, StringPart,
 };
 pub use lazy::JqValue;

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -34,9 +34,9 @@ use alloc::collections::BTreeMap;
 use std::collections::BTreeMap;
 
 use super::expr::{
-    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal,
-    MergeFlags, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry,
-    Program, StringPart,
+    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefBound, Import, Include,
+    Literal, MergeFlags, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
+    PatternEntry, Program, StringPart,
 };
 use super::value::{parse_i64_or_f64, NumberRepr};
 
@@ -2148,7 +2148,7 @@ impl<'a> Parser<'a> {
             params,
             body: Box::new(body),
             then: Box::new(then),
-            bound: BoundBody::default(),
+            bound: FuncDefBound::default(),
         })
     }
 
@@ -4548,7 +4548,7 @@ impl<'a> Parser<'a> {
                 params,
                 body: Box::new(body),
                 then: Box::new(result),
-                bound: BoundBody::default(),
+                bound: FuncDefBound::default(),
             };
         }
 

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -34,9 +34,9 @@ use alloc::collections::BTreeMap;
 use std::collections::BTreeMap;
 
 use super::expr::{
-    ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal, MergeFlags,
-    MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry, Program,
-    StringPart,
+    ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, Import, Include, Literal,
+    MergeFlags, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern, PatternEntry,
+    Program, StringPart,
 };
 use super::value::{parse_i64_or_f64, NumberRepr};
 
@@ -2148,6 +2148,7 @@ impl<'a> Parser<'a> {
             params,
             body: Box::new(body),
             then: Box::new(then),
+            bound: BoundBody::default(),
         })
     }
 
@@ -4547,6 +4548,7 @@ impl<'a> Parser<'a> {
                 params,
                 body: Box::new(body),
                 then: Box::new(result),
+                bound: BoundBody::default(),
             };
         }
 

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -514,6 +514,7 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
             params,
             body,
             then,
+            ..
         } => {
             let outer = scope.len();
             scope.push((name.clone(), params.len()));

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -21,6 +21,8 @@
 
 use alloc::boxed::Box;
 
+#[cfg(test)]
+use super::BoundBody;
 use super::{Builtin, Expr, ObjectKey, StringPart};
 
 /// The sub-expressions a [`Builtin`] owns, in source order.
@@ -924,6 +926,7 @@ mod tests {
             params: Vec::new(),
             body: Box::new(Expr::Builtin(Builtin::Input)),
             then: Box::new(program.expr),
+            bound: BoundBody::default(),
         };
         assert!(uses_input_builtins(&expanded));
     }

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -22,7 +22,7 @@
 use alloc::boxed::Box;
 
 #[cfg(test)]
-use super::BoundBody;
+use super::FuncDefBound;
 use super::{Builtin, Expr, ObjectKey, StringPart};
 
 /// The sub-expressions a [`Builtin`] owns, in source order.
@@ -926,7 +926,7 @@ mod tests {
             params: Vec::new(),
             body: Box::new(Expr::Builtin(Builtin::Input)),
             then: Box::new(program.expr),
-            bound: BoundBody::default(),
+            bound: FuncDefBound::default(),
         };
         assert!(uses_input_builtins(&expanded));
     }


### PR DESCRIPTION
## Summary

Fixes #2094.

`Expr::DefCall` already memoizes its substituted body via `BoundBody` (#1371/ADR-0020), but `Expr::FuncDef` had no equivalent — every one of its four evaluation arms (the plain evaluator, `eval_each`, the path-context evaluator, and `eval_generic`'s) unconditionally rebuilt the whole `then` subtree via `install_def_calls` on every evaluation of that node. A `def` declared *inside* a loop body re-paid that full-tree substitution on every iteration — the same per-call regression class ADR-0020 measured for `DefCall` before `BoundBody` existed.

**This PR's first commit had a critical, review-caught bug** (see "Code review outcome" below) — the initial cache design was unsound for a def passed as a higher-order function argument. Fixed in a follow-up commit; the description below covers the corrected design.

## Change

- Added `bound: FuncDefBound` to `Expr::FuncDef` — a purpose-built cache (not `DefCall`'s `BoundBody`, see "Why FuncDef needs a different cache" below) that additionally keys on the ambient recursion depth it was computed at, recomputing whenever a later reach observes a different depth than what produced the cached answer.
- Every site that **rebuilds** a `FuncDef` node's `body`/`then`/`params` resets the new field to `FuncDefBound::default()` (`substitute_func_param`, `substitute_var_impl`, `install_def_calls`'s "different def" arm, the CLI's module/import/auto-load wrapping in `jq_runner.rs`, and `rewrite_namespaced_calls`). The one site that clones a `FuncDef` node through **unchanged** (`install_def_calls`'s "shadowed, same name+arity" arm) carries the cache along instead.
- `bind_def` now takes the node's `&FuncDefBound` and returns an owned `Rc<Expr>`, reading the current ambient depth once and passing it to `FuncDefBound::get_or_init_at`.
- Folded in the issue's own "related, minor" fix: `bind_def_call`'s initial `def.body.clone()` was redundant whenever at least one parameter substitution ran, and even the zero-parameter case never needed to clone before `install_def_calls` (which takes `&Expr`). Both paths now seed directly from `&def.body`.
- `eval_pipe_with_path_context_internal`'s `FuncDef` arm passes the cached tree through as a one-element slice with no clone in the common (unpaired) case — only the paired case, which must append `path_probe_stage()`, clones to build its `Vec`.

## Why `FuncDef` needs a different cache shape than `DefCall`'s `BoundBody`

This is the thing the first commit got wrong. `bind_def`'s result bakes in the *current* ambient recursion depth (installed into the resulting `DefCall`s' own `frames` fields, which feed the `MAX_EVAL_FRAMES` guard). A write-once cache is only sound if the same node can't be reached at two genuinely different depths without an intervening rebuild — true for `DefCall`'s own `BoundBody` (its `frames` field is frozen once, at install time, never re-read from ambient state at call time), but **false** for `FuncDef`: `Expr::Shared` is deliberately opaque to every substitution pass (`install_def_calls` and `substitute_func_param` both just `Rc::clone` through it, by design, for #1371/#2077/#2096 hygiene), so a `def` passed as a function-valued argument and referenced both directly and inside a deeper recursive call reaches the *identical* node — same `Rc`, same cache cell — at two different real depths with no rebuild in between:

```jq
def each_level(n; f): if n <= 0 then empty else (f, each_level(n - 1; f)) end;
each_level(N; def inner: <self-recursive>; inner)
```

A write-once cache freezes the shallow reach's depth and silently reuses it for the deep reach too, undercounting how close that deep call actually is to `MAX_EVAL_FRAMES` — reopening the unbounded-native-recursion gap #1098/#1016 exist to close. `FuncDefBound` closes this by storing `(depth, Rc<Expr>)` and recomputing whenever the observed depth doesn't match, keeping the common case (a `def` inline in a loop, reached repeatedly at one constant depth) fully cached while staying sound in the rarer cross-depth-reuse shape above.

## Code review outcome

Ran the mandatory `/code-review` pass twice.

**First pass** caught the critical bug above — five of six finder agents independently converged on the identical finding (a write-once cache going stale across `Expr::Shared`-threaded recursion), one of them empirically confirming it via a direct unit-level repro (`bind_def` called twice on one cache cell at ambient depths 0 and 500 with no rebuild in between; the second call returned the stale `frames = 0` instead of `500`). Also flagged and fixed: the path-context evaluator's clone (addressed above), and `BoundBody`'s doc comment not mentioning it was becoming a two-variant-shared type (reverted — `FuncDef` now has its own type instead, so that generalization is no longer needed).

One finder agent, while investigating, ran `git checkout -- src/jq/eval.rs` mid-review to "clean up" its own temporary probe test — which discarded ~112 lines of not-yet-committed review-response fixes along with it. Recovered by treating `cargo build`'s error list as a checklist and reconstructing every site from scratch, verified against a fresh `Read` before each edit this time. No functional loss, but worth naming here for the commit-history reviewer: the two commits after the first aren't "extra polish," they're closing a real, review-caught soundness gap plus recovering from an unrelated tooling incident.

**Second pass** (post-fix): clean.

## Verification

- Full lib + integration suite green (56 test binaries, 3243 lib tests, 0 failures), both required clippy feature combinations clean, `--no-default-features` no_std check green.
- New tests: `test_bind_def_memoizes_per_node_2094` (two calls at the same depth share one cached `Rc`), `test_bind_def_recomputes_when_ambient_depth_changes_2094` (pins the fixed behavior directly — same cache cell, depth 0 then 500, must return 500 not stale 0), `test_func_def_bound_is_invisible_to_eq_and_debug_2094` (mirrors `BoundBody`'s own `PartialEq`/`Debug`-opacity test, plus a depth-mismatched-but-populated case `BoundBody` could never have).
- Live end-to-end checks: a `def` passed as a higher-order argument through recursion (both directly and via a further self-recursive inner `def`) runs without error or crash at moderate depth; deep nested-def-under-recursion constructions matched `main`'s pre-existing (unrelated) behavior exactly.
- Differential testing against `/usr/bin/jq` 1.7.1: loop-iterated inline defs, `$`-param-shorthand nested defs match.
- Interleaved A/B on a def-inside-a-loop workload (500K elements): ~2x (930ms → 430ms on 5 interleaved reps each, re-confirmed after the depth-aware fix), byte-identical output against the pre-change binary.

## Test plan

- [x] `cargo test --lib --features cli,regex` (3243 passed)
- [x] `cargo test --features cli,regex,serde` (full suite, all 56 binaries green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo test --no-default-features --verbose` (no_std doctests)
- [x] Interleaved A/B benchmark + output-identity diff against pre-change binary
- [x] Differential testing against pinned `/usr/bin/jq` 1.7.1
- [x] Two full `/code-review` passes, second one clean
