### PR TITLE
fix(jq): raise on undecodable string in object construction and string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Object construction's key/value slots and jq-mode string interpolation no
+  longer silently substitute `""` for an undecodable string** (#2022): all
+  three fed their generator's output through `stream_outputs` (bare
+  `to_owned`, via `collect_owned`) instead of the already-existing
+  `stream_outputs_checked`, so `{(.a): 1}`/`{"k": .a}`/`"\(.a)"` on an
+  undecodable `.a` silently produced `{"":1}`/`{"k":""}`/`""` instead of
+  raising — the same #1746/#1972 bug shape this codebase has closed at ~15-20
+  other call sites (#1934's tracked lineage), just not yet at these three.
+  Found during #1989's classification pass. Two related call sites
+  (`fanout_arg`/`fanout_two_args`'s own argument materialization) were
+  investigated but left unfixed pending their own dedicated verification —
+  see #2165.
+
 - **Self-recursive and branching user-defined `def`s now evaluate** (#1371). `def
   sum_to(n): if n == 0 then 0 else n + sum_to(n-1) end; sum_to(100)` returns `5050`, and
   `sum_to(10000)` returns `50005000`, both matching jq 1.7.1; naive `fib` works where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Object construction's key/value slots and jq-mode string interpolation no
-  longer silently substitute `""` for an undecodable string** (#2022): all
-  three fed their generator's output through `stream_outputs` (bare
-  `to_owned`, via `collect_owned`) instead of the already-existing
-  `stream_outputs_checked`, so `{(.a): 1}`/`{"k": .a}`/`"\(.a)"` on an
-  undecodable `.a` silently produced `{"":1}`/`{"k":""}`/`""` instead of
-  raising — the same #1746/#1972 bug shape this codebase has closed at ~15-20
-  other call sites (#1934's tracked lineage), just not yet at these three.
-  Found during #1989's classification pass. Two related call sites
-  (`fanout_arg`/`fanout_two_args`'s own argument materialization) were
-  investigated but left unfixed pending their own dedicated verification —
-  see #2165.
+- **`succinctly::jq::eval`'s object-construction key/value slots and jq-mode
+  string interpolation no longer silently substitute `""` for an undecodable
+  string** (#2022): all three fed their generator's output through
+  `stream_outputs` (bare `to_owned`, via `collect_owned`) instead of the
+  already-existing `stream_outputs_checked`, so `{(.a): 1}`/`{"k": .a}`/
+  `"\(.a)"` on an undecodable `.a` silently produced `{"":1}`/`{"k":""}`/`""`
+  instead of raising — the same #1746/#1972 bug shape this codebase has
+  closed at ~15-20 other call sites (#1934's tracked lineage), just not yet
+  at these three. Found during #1989's classification pass.
+
+  Reachable only through the public `succinctly::jq::eval` library API, the
+  same as #1755's original finding for this bug family — the bundled CLI is
+  unaffected either way: `Expr::Object`/`Expr::StringInterpolation` have no
+  dedicated arm in `eval_generic.rs` (the CLI's own bridge), so both fall to
+  its wildcard arm, which already runs the *entire current value* through a
+  checked conversion before this function is ever reached, regardless of
+  whether the undecodable field is one the query actually touches.
+
+  A related call site, `fanout_two_args`'s own argument materialization, was
+  investigated but left unfixed pending its own dedicated verification — see
+  #2165 (also corrects an earlier belief that `fanout_arg` was still open;
+  it was already fixed by #2023).
 
 - **Self-recursive and branching user-defined `def`s now evaluate** (#1371). `def
   sum_to(n): if n == 0 then 0 else n + sum_to(n-1) end; sum_to(100)` returns `5050`, and

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1669,14 +1669,17 @@ fn build_object_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let (keys, key_trailing) = match &entry.key {
         ObjectKey::Literal(s) => (vec![OwnedValue::String(s.clone())], None),
         ObjectKey::Expr(key_expr) => {
-            stream_outputs(eval_single::<W, S>(key_expr, value.clone(), optional))
+            // #2022: checked, not `stream_outputs` -- an undecodable computed
+            // key must raise, not silently materialize as `""`.
+            stream_outputs_checked(eval_single::<W, S>(key_expr, value.clone(), optional))
         }
     };
     let sole = sole && keys.len() == 1;
 
     for key in keys {
+        // #2022: same fix as the key slot above, for the value slot.
         let (vals, val_trailing) =
-            stream_outputs(eval_single::<W, S>(&entry.value, value.clone(), optional));
+            stream_outputs_checked(eval_single::<W, S>(&entry.value, value.clone(), optional));
         let sole = sole && vals.len() == 1;
 
         for val in vals {
@@ -9834,14 +9837,18 @@ fn owned_to_json_bytes<S: EvalSemantics>(value: &OwnedValue) -> Vec<u8> {
 /// Materialize a `\(...)` slot's own outputs as rendered strings, plus a
 /// deferred escape if its generator terminates in an error/break/halt.
 ///
-/// Reuses [`stream_outputs`] (already fully general -- it just unpacks a
-/// `QueryResult` into `(Vec<OwnedValue>, Option<Control>)` with no
+/// Reuses [`stream_outputs_checked`] (already fully general -- it just
+/// unpacks a `QueryResult` into `(Vec<OwnedValue>, Option<Control>)` with no
 /// object-specific coupling) and stringifies each output the same way a
 /// single-valued slot already did (`owned_to_string`).
+///
+/// #2022: checked, not the bare [`stream_outputs`] this used before -- an
+/// undecodable `\(...)` slot value must raise, not silently interpolate as
+/// `""`, matching the yq-mode single-value fast path #1972 already fixed.
 fn string_part_outputs<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     result: QueryResult<'_, W>,
 ) -> (Vec<String>, Option<Control>) {
-    let (values, control) = stream_outputs(result);
+    let (values, control) = stream_outputs_checked(result);
     (values.iter().map(owned_to_string::<S>).collect(), control)
 }
 
@@ -43624,6 +43631,72 @@ mod tests {
             br#"[1,2,"ok",4]"#,
             ".[:] == .[:]",
             QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        );
+    }
+
+    /// #2022: object construction's computed-key slot fed its key generator's
+    /// output through `stream_outputs` (bare `to_owned`, via `collect_owned`),
+    /// silently substituting `""` for an undecodable key instead of raising --
+    /// the same #1746/#1972 shape already fixed at the sibling call sites
+    /// above, unreachable here only because `stream_outputs` (not
+    /// `stream_outputs_checked`) was doing the folding.
+    #[test]
+    fn test_object_construction_key_raises_on_decode_failure_2022() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "{(.a): 1}",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        // Positive control: valid data is unaffected.
+        query!(
+            br#"{"a": "ok"}"#,
+            "{(.a): 1}",
+            QueryResult::Owned(OwnedValue::Object(map)) => {
+                assert_eq!(map.get("ok"), Some(&OwnedValue::Int(1)));
+            }
+        );
+    }
+
+    /// #2022 sibling: object construction's value slot had the identical bug
+    /// -- `{"k": .a}` on an undecodable `.a` silently produced `{"k":""}`.
+    #[test]
+    fn test_object_construction_value_raises_on_decode_failure_2022() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "{\"k\": .a}",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            br#"{"a": "ok"}"#,
+            "{\"k\": .a}",
+            QueryResult::Owned(OwnedValue::Object(map)) => {
+                assert_eq!(map.get("k"), Some(&OwnedValue::String("ok".into())));
+            }
+        );
+    }
+
+    /// #2022 sibling: jq-mode string interpolation (`string_part_outputs`,
+    /// distinct from the yq-mode single-value fast path #1972 already fixed
+    /// below) had the same bug for a multi-output `\(...)` slot.
+    #[test]
+    fn test_jq_string_interpolation_raises_on_slot_decode_failure_2022() {
+        query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            r#""\(.a)""#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+        query!(
+            br#"{"a": "ok"}"#,
+            r#""\(.a)""#,
+            QueryResult::Owned(OwnedValue::String(s)) => {
+                assert_eq!(s, "ok");
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1575,11 +1575,17 @@ fn stream_outputs<W: Clone + AsRef<[u64]>>(
 /// cannot preserve; `eval_foreach`'s INIT `Halt` arm must win unconditionally
 /// over an already-pending `input_control`, which this fold's uniform
 /// `Option::or` reconciliation downstream would get backwards). Verified by
-/// hand, not assumed, that the four sites this *is* applied to have no such
-/// wrinkle: each already routes an empty converted prefix through
+/// hand, not assumed, that the *bound-value-materialization* sites this
+/// consolidation targets (`eval_as`, `eval_reduce`'s INIT, `eval_as_pattern`,
+/// plus one more) have no such wrinkle: each already routes an empty
+/// converted prefix through
 /// [`owned_vec_to_result`]/[`partial`]/[`finish_fork`], which already
 /// collapse to the exact same `QueryResult` the hand-rolled early return
-/// upstream produced.
+/// upstream produced. Since consolidated, this function has also picked up
+/// unrelated one-shot generator-conversion callers with no such ordering
+/// concern at all (object construction's key/value slots and jq-mode string
+/// interpolation, #2022; `fanout_arg`, #2023) -- the count above is about
+/// this one bound-value shape specifically, not a total call-site census.
 fn stream_outputs_checked<W: Clone + AsRef<[u64]>>(
     result: QueryResult<'_, W>,
 ) -> (Vec<OwnedValue>, Option<Control>) {
@@ -43676,6 +43682,27 @@ mod tests {
             QueryResult::Owned(OwnedValue::Object(map)) => {
                 assert_eq!(map.get("k"), Some(&OwnedValue::String("ok".into())));
             }
+        );
+    }
+
+    /// #2022 sibling: `build_object_entries` is shared, unconditional code --
+    /// no `EvalTag` gate -- so the fix applies equally in yq mode. Same
+    /// library-API-only caveat as the jq-mode tests above: this decode
+    /// failure shape has no real-syntax reachable analog to check against a
+    /// live oracle (raw invalid UTF-8 is rejected at YAML parse time, before
+    /// evaluation ever runs), so this only confirms the fix is applied
+    /// uniformly across both `EvalSemantics`, not a jq/yq-parity claim.
+    #[test]
+    fn test_yq_object_construction_raises_on_decode_failure_2022() {
+        yq_query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "{(.a): 1}",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
+        );
+        yq_query!(
+            b"{\"a\": \"\xff\xfe\"}",
+            "{\"k\": .a}",
+            QueryResult::Error(e) if e.is_decode_failure() => {}
         );
     }
 


### PR DESCRIPTION
## Summary

Object construction's key/value slots and jq-mode string interpolation fed their generator's output through `stream_outputs` (bare `to_owned` via `collect_owned`) instead of the already-existing `stream_outputs_checked`, so an undecodable string silently materialized as `""` instead of raising — the same #1746/#1972 bug shape already fixed at ~15-20 other call sites in this codebase (#1934's tracked lineage).

Found during #1989's classification pass (fresh audit of bare `to_owned` sites in `src/jq/eval.rs`).

## What changed

- `build_object_entries`'s key-expression and value-expression evaluation (object construction, `{(.a): 1}` / `{"k": .a}`) now use `stream_outputs_checked`.
- `string_part_outputs` (jq-mode `"\(...)"` string interpolation) now uses `stream_outputs_checked`.

Both are drop-in swaps: `stream_outputs_checked` has the identical `(Vec<OwnedValue>, Option<Control>)` signature as `stream_outputs`, differing only in raising a decode failure instead of silently substituting.

## What was investigated but not changed

Two related call sites (`fanout_arg`/`fanout_two_args`'s own argument materialization) were investigated but left unfixed — a live probe using `. as $var`-mediated access showed both **already raise correctly today**, because `. as $var` bindings are themselves materialized via `stream_outputs_checked` upstream (per #1902/#1934), so the check already happens before the argument expression runs in the common (navigational) case. Blindly swapping these anyway risks turning jq-matching *lossy* behavior (a runtime-computed invalid-UTF-8 string, e.g. via `@base64d` — live-verified that real jq itself does **not** raise there) into a new divergence. Filed as #2165 for their own dedicated per-site verification, along with two more `stream_outputs` call sites found during the fresh audit (regex `sub`/`gsub` replacement, regex flags argument).

## Testing

- New regression tests: `test_object_construction_key_raises_on_decode_failure_2022`, `test_object_construction_value_raises_on_decode_failure_2022`, `test_jq_string_interpolation_raises_on_slot_decode_failure_2022` — each confirmed to fail before the fix and pass after, using this bug family's established `query!` macro test methodology (raw invalid-UTF-8 bytes embedded directly in a `JsonIndex`-built fixture, matching #1746/#1755/#1790/#1832/#1902/#1932/#1943/#1972's own precedent — this bypasses the CLI's own upfront document-sanitization pass, which is why these are library-API-level tests rather than live CLI reproductions).
- Full test suite (`cargo test --features cli,simd,regex,serde`): all passing, no regressions.
- `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings`: clean.
- `cargo fmt --check`: clean.

Fixes #2022