### PR TITLE
fix(jq): route push_owned_values's unsafe call sites through the checked sibling

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2271,7 +2271,7 @@ where
         }
         let mut out: Vec<OwnedValue> = Vec::new();
         for arg in args {
-            if let Some(control) = push_owned_values(body(arg), &mut out) {
+            if let Some(control) = push_owned_values_checked(body(arg), &mut out) {
                 return partial(out, control);
             }
         }
@@ -2303,7 +2303,7 @@ where
             Ok(v) => v,
             Err(e) => {
                 if let Some(previous) = pending_first.take() {
-                    if let Some(control) = push_owned_values(previous, &mut out) {
+                    if let Some(control) = push_owned_values_checked(previous, &mut out) {
                         body_control = Some(control);
                         return Demand::Stop;
                     }
@@ -2313,7 +2313,7 @@ where
             }
         };
         if let Some(previous) = pending_first.take() {
-            if let Some(control) = push_owned_values(previous, &mut out) {
+            if let Some(control) = push_owned_values_checked(previous, &mut out) {
                 body_control = Some(control);
                 return Demand::Stop;
             }
@@ -2324,14 +2324,14 @@ where
         // or an escaping first result would be parked and the sink would ask
         // for another value anyway -- which is the bug this arm exists to fix.
         if result.is_escape() {
-            if let Some(control) = push_owned_values(result, &mut out) {
+            if let Some(control) = push_owned_values_checked(result, &mut out) {
                 body_control = Some(control);
             }
             return Demand::Stop;
         }
         if out.is_empty() && pending_first.is_none() {
             pending_first = Some(result);
-        } else if let Some(control) = push_owned_values(result, &mut out) {
+        } else if let Some(control) = push_owned_values_checked(result, &mut out) {
             body_control = Some(control);
             return Demand::Stop;
         }
@@ -2358,7 +2358,7 @@ where
         // of it.
         Flow::Escaped(control) => {
             if let Some(previous) = pending_first.take() {
-                if let Some(body_control) = push_owned_values(previous, &mut out) {
+                if let Some(body_control) = push_owned_values_checked(previous, &mut out) {
                     return partial(out, body_control);
                 }
             }
@@ -2499,7 +2499,7 @@ fn fanout_two_args<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
 
         for i in inners {
-            if let Some(control) = push_owned_values(body(o.clone(), i), &mut out) {
+            if let Some(control) = push_owned_values_checked(body(o.clone(), i), &mut out) {
                 return partial(out, control);
             }
         }
@@ -2587,7 +2587,7 @@ where
                 Ok(v) => v,
                 Err(demand) => return demand,
             };
-            match push_owned_values(body(o.clone(), i), &mut out) {
+            match push_owned_values_checked(body(o.clone(), i), &mut out) {
                 Some(control) => {
                     escape = Some(control);
                     Demand::Stop
@@ -27977,7 +27977,16 @@ fn limit_with_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 result
             } else {
                 let mut prefix = Vec::new();
-                push_owned_values(result, &mut prefix);
+                // #2024: a decode failure discovered while materializing the
+                // pre-escape prefix describes a value the generator already
+                // produced *before* its own terminator fired, so it outranks
+                // that terminator's control -- the same precedence
+                // `fanout_arg`'s own flush-then-stop arms give a flushed
+                // `pending_first`'s decode failure over the argument's
+                // trailing control.
+                if let Some(decode_control) = push_owned_values_checked(result, &mut prefix) {
+                    return partial(prefix, decode_control);
+                }
                 partial(prefix, control)
             }
         }
@@ -46223,6 +46232,57 @@ mod tests {
         yq_query!(
             b"{\"a\":1,\"b\":\"\xff\xfe\"}",
             r"has(.b)",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #2024: `fanout_arg`'s lazy (`ArgFanout::All`) sink pushed `body`'s own
+    /// *result* through bare `push_owned_values`, not `_checked` -- a
+    /// different gap from #2023's (which fixed the *argument*-decoding side
+    /// of this same function). `[1,"\xff\xfe"] | nth((0,1))` isolates it:
+    /// `nth`'s `body` is `.[n]`, so `n=0` decodes cleanly (`1`, buffered as
+    /// `pending_first`) while `n=1` indexes the undecodable array element --
+    /// flushing the buffered `1` first (line ~2307, the `pending_first`
+    /// flush, itself already safe -- an `Int` never fails `to_owned_checked`)
+    /// then reaching the `else` push at line ~2325, this fix's target.
+    /// Pre-fix this gave `ManyOwned([Int(1), String("")])` (silent `""`
+    /// substitution for the second, undecodable element); post-fix it raises
+    /// instead, keeping the already-flushed `1` as the `Partial` prefix.
+    #[test]
+    fn test_fanout_arg_lazy_sink_body_result_raises_decode_failure_2024() {
+        query!(
+            b"[1,\"\xff\xfe\"]",
+            r"nth((0,1))",
+            QueryResult::Partial(vs, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #2024: `limit_with_n`'s `Flow::Escaped` arm (fewer than `n` outputs
+    /// produced before the generator's own terminator fired) converted its
+    /// pre-escape prefix via bare `push_owned_values` too, discarding
+    /// whatever control the conversion itself raised. `limit(3; (.a,
+    /// error("x")))` on `{"a":"<bad>"}` collects the single undecodable `.a`
+    /// into `taken` before `error("x")` fires (`satisfied` is false, since
+    /// `1 < 3`), then converts that one-item prefix to owned values while
+    /// building the result. Pre-fix this silently substituted `""` into the
+    /// prefix and reported the generator's own `"x"` error (`Error(e)` with
+    /// `e.message == "x"`, the empty-prefix collapse in `partial`); post-fix
+    /// the undecodable value's own decode failure is raised instead --
+    /// `.a`'s value was already produced *before* `error("x")` fired, so it
+    /// outranks that later control, the same precedence
+    /// `fanout_arg`'s flush-then-stop arms already give a flushed
+    /// `pending_first`'s decode failure over the argument's own trailing
+    /// control.
+    #[test]
+    fn test_eval_limit_escaped_prefix_no_silent_substitution_2024() {
+        query!(
+            b"{\"a\":\"\xff\xfe\"}",
+            r#"limit(3; (.a, error("x")))"#,
             QueryResult::Error(e) if e.is_decode_failure() => {
                 assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4458,6 +4458,42 @@ fn items_to_result<'a, W: Clone + AsRef<[u64]>>(items: Vec<Item<'a, W>>) -> Quer
     owned_vec_to_result(items.into_iter().map(Item::into_owned).collect())
 }
 
+/// Fallible twin of [`items_to_result`] (#2024 code review): the
+/// all-`Borrowed` fast path is unchanged (it defers decoding rather than
+/// doing any itself, so there's nothing to check yet -- the eventual
+/// consumer, e.g. [`push_owned_values_checked`], is what raises), but the
+/// mixed/owned branch converted every item through bare [`Item::into_owned`]
+/// unconditionally, silently substituting `""` for an undecodable item
+/// instead of raising -- the #1746-shaped bug one layer upstream of
+/// [`limit_with_n`]'s own fix just below: `limit(2; 1, .a)` on an
+/// undecodable `.a` mixes an `Owned` literal (`1`) with a `Borrowed` `.a`,
+/// so it never reaches the all-`Borrowed` fast path at all. Stops at the
+/// first undecodable item, keeping whatever prefix already converted
+/// cleanly -- the same partial-prefix contract every other `_checked`
+/// sibling in this file gives.
+fn items_to_result_checked<'a, W: Clone + AsRef<[u64]>>(
+    items: Vec<Item<'a, W>>,
+) -> QueryResult<'a, W> {
+    if items.iter().all(|i| matches!(i, Item::Borrowed(_))) {
+        let borrowed: Vec<StandardJson<'a, W>> = items
+            .into_iter()
+            .map(|i| match i {
+                Item::Borrowed(v) => v,
+                Item::Owned(_) => unreachable!("checked above"),
+            })
+            .collect();
+        return borrowed_vec_to_result(borrowed);
+    }
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        match item.into_owned_checked() {
+            Ok(v) => out.push(v),
+            Err(e) => return partial(out, Control::Error(e)),
+        }
+    }
+    owned_vec_to_result(out)
+}
+
 /// Pull at most one output, then stop the generator — jq's
 /// `def first(f): label $out | (f, break $out);`.
 ///
@@ -27961,7 +27997,12 @@ fn limit_with_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // and fired their side effects (#820).
     let (taken, flow) = each_take_n::<W, S>(expr, value, optional, n);
     let satisfied = taken.len() >= n;
-    let result = items_to_result(taken);
+    // #2024: `items_to_result_checked`, not `items_to_result` -- the mainline
+    // `Stopped`/`Exhausted` arms return `result` straight through, so a
+    // mixed `Owned`/`Borrowed` `taken` batch (e.g. `limit(2; 1, .a)`, a
+    // literal alongside a field navigation) must already be decode-checked
+    // by the time it gets here, not just the `!satisfied` branch below.
+    let result = items_to_result_checked(taken);
     match flow {
         // Stopped because `n` outputs arrived: jq's own `foreach ... break
         // $out` fires here, so nothing past that point is ever reached and a
@@ -27977,17 +28018,27 @@ fn limit_with_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 result
             } else {
                 let mut prefix = Vec::new();
-                // #2024: a decode failure discovered while materializing the
+                // A decode failure discovered while materializing the
                 // pre-escape prefix describes a value the generator already
                 // produced *before* its own terminator fired, so it outranks
-                // that terminator's control -- the same precedence
-                // `fanout_arg`'s own flush-then-stop arms give a flushed
-                // `pending_first`'s decode failure over the argument's
-                // trailing control.
-                if let Some(decode_control) = push_owned_values_checked(result, &mut prefix) {
-                    return partial(prefix, decode_control);
-                }
-                partial(prefix, control)
+                // that terminator's control -- `fanout_arg`'s own doc
+                // comment's rule 3 already establishes that precedence for
+                // `halt`/`break` specifically ("body's own error can outrank
+                // a trailing halt"; `setpath((1, halt_error(6)); 1)` exits 5,
+                // never reaching the halt), and it holds here too: a decode
+                // failure can only originate from a raw, not-yet-decoded
+                // document byte span (`StandardJson::String`, never a
+                // query-constructed `OwnedValue::String`), so a document
+                // containing the bytes that trigger one would already have
+                // failed real jq's own UTF-8-validating parser before any
+                // `halt`/`break` in the same query could fire -- the same
+                // precedence `fanout_arg`'s own flush-then-stop arms give a
+                // flushed `pending_first`'s decode failure over the
+                // argument's trailing control, and the same shape `eval_as`'s
+                // own bound-control-vs-fallback match already uses.
+                let final_control =
+                    push_owned_values_checked(result, &mut prefix).unwrap_or(control);
+                partial(prefix, final_control)
             }
         }
     }
@@ -46283,6 +46334,47 @@ mod tests {
         query!(
             b"{\"a\":\"\xff\xfe\"}",
             r#"limit(3; (.a, error("x")))"#,
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #2024 code review: the fix above only exercised `Flow::Escaped`'s
+    /// `!satisfied` branch, but the far more common case -- `n` outputs
+    /// actually reached (`Flow::Stopped`) -- returned `items_to_result`'s
+    /// (not `_checked`) output straight through, completely unguarded.
+    /// `limit(2; 1, .a)` mixes an `Owned` literal (`1`) with a `Borrowed`
+    /// `.a`, which routes `items_to_result`/`_checked` through the
+    /// mixed-batch branch (`items.iter().all(Borrowed)` is false), the one
+    /// that actually converts eagerly -- unlike the all-`Borrowed` fast path,
+    /// which just defers. Pre-fix this gave `ManyOwned([Int(1),
+    /// String("")])` (silent `""` substitution for `.a`, `n=2` reached
+    /// cleanly, no error at all); post-fix it raises, keeping the
+    /// successfully-converted `1` as the `Partial` prefix.
+    #[test]
+    fn test_eval_limit_stopped_mixed_batch_raises_decode_failure_2024() {
+        query!(
+            b"{\"a\":\"\xff\xfe\"}",
+            r"limit(2; 1, .a)",
+            QueryResult::Partial(vs, Control::Error(e)) if e.is_decode_failure() => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #2024 code review: pins the halt/break-vs-decode-failure precedence
+    /// `limit_with_n`'s `Flow::Escaped` arm now has (see its own comment,
+    /// citing `fanout_arg`'s rule 3) -- a decode failure discovered while
+    /// materializing the pre-escape prefix outranks even a `halt_error`,
+    /// since the failure describes a value the generator already produced
+    /// *before* the halt fired.
+    #[test]
+    fn test_eval_limit_escaped_prefix_decode_failure_outranks_halt_2024() {
+        query!(
+            b"{\"a\":\"\xff\xfe\"}",
+            r"limit(3; (.a, halt_error(6)))",
             QueryResult::Error(e) if e.is_decode_failure() => {
                 assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4444,33 +4444,26 @@ fn eval_each_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `eval_comma`'s borrowed/owned promotion (#353): stay borrowed while every
 /// item is, and the moment one owned item appears promote the whole ordered
 /// batch, so no operand's position is lost.
-fn items_to_result<'a, W: Clone + AsRef<[u64]>>(items: Vec<Item<'a, W>>) -> QueryResult<'a, W> {
-    if items.iter().all(|i| matches!(i, Item::Borrowed(_))) {
-        let borrowed: Vec<StandardJson<'a, W>> = items
-            .into_iter()
-            .map(|i| match i {
-                Item::Borrowed(v) => v,
-                Item::Owned(_) => unreachable!("checked above"),
-            })
-            .collect();
-        return borrowed_vec_to_result(borrowed);
-    }
-    owned_vec_to_result(items.into_iter().map(Item::into_owned).collect())
-}
-
-/// Fallible twin of [`items_to_result`] (#2024 code review): the
-/// all-`Borrowed` fast path is unchanged (it defers decoding rather than
-/// doing any itself, so there's nothing to check yet -- the eventual
-/// consumer, e.g. [`push_owned_values_checked`], is what raises), but the
-/// mixed/owned branch converted every item through bare [`Item::into_owned`]
+///
+/// The all-`Borrowed` fast path defers decoding rather than doing any
+/// itself, so there's nothing to check yet there -- the eventual consumer,
+/// e.g. [`push_owned_values_checked`], is what raises. But the mixed/owned
+/// branch used to convert every item through bare [`Item::into_owned`]
 /// unconditionally, silently substituting `""` for an undecodable item
-/// instead of raising -- the #1746-shaped bug one layer upstream of
-/// [`limit_with_n`]'s own fix just below: `limit(2; 1, .a)` on an
-/// undecodable `.a` mixes an `Owned` literal (`1`) with a `Borrowed` `.a`,
-/// so it never reaches the all-`Borrowed` fast path at all. Stops at the
-/// first undecodable item, keeping whatever prefix already converted
-/// cleanly -- the same partial-prefix contract every other `_checked`
-/// sibling in this file gives.
+/// instead of raising (#2024 code review) -- the #1746-shaped bug one layer
+/// upstream of [`limit_with_n`]'s own fix, its sole production caller:
+/// `limit(2; 1, .a)` on an undecodable `.a` mixes an `Owned` literal (`1`)
+/// with a `Borrowed` `.a`, so it never reaches the all-`Borrowed` fast path
+/// at all. Now stops at the first undecodable item, keeping whatever prefix
+/// already converted cleanly -- the same partial-prefix contract every
+/// other `_checked` sibling in this file gives. Named `_checked` rather
+/// than renaming this function outright since an unchecked, `to_owned`-only
+/// twin was the pre-fix shape reviewers had to compare against; nothing
+/// else in this file still needs that unchecked twin (its only other
+/// caller, the test-only `collect_each` below, was switched to this
+/// function too -- neither the all-`Borrowed` fast path nor the ordinary,
+/// decodable-content test data it exercises change behavior under the
+/// stricter check).
 fn items_to_result_checked<'a, W: Clone + AsRef<[u64]>>(
     items: Vec<Item<'a, W>>,
 ) -> QueryResult<'a, W> {
@@ -4484,7 +4477,7 @@ fn items_to_result_checked<'a, W: Clone + AsRef<[u64]>>(
             .collect();
         return borrowed_vec_to_result(borrowed);
     }
-    let mut out = Vec::with_capacity(items.len());
+    let mut out = vec_with_capacity(items.len());
     for item in items {
         match item.into_owned_checked() {
             Ok(v) => out.push(v),
@@ -27997,11 +27990,12 @@ fn limit_with_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // and fired their side effects (#820).
     let (taken, flow) = each_take_n::<W, S>(expr, value, optional, n);
     let satisfied = taken.len() >= n;
-    // #2024: `items_to_result_checked`, not `items_to_result` -- the mainline
-    // `Stopped`/`Exhausted` arms return `result` straight through, so a
-    // mixed `Owned`/`Borrowed` `taken` batch (e.g. `limit(2; 1, .a)`, a
-    // literal alongside a field navigation) must already be decode-checked
-    // by the time it gets here, not just the `!satisfied` branch below.
+    // #2024: the mainline `Stopped`/`Exhausted` arms below return `result`
+    // straight through, so a mixed `Owned`/`Borrowed` `taken` batch (e.g.
+    // `limit(2; 1, .a)`, a literal alongside a field navigation) must
+    // already be decode-checked by the time it gets here, not just the
+    // `!satisfied` branch below -- see `items_to_result_checked`'s own doc
+    // comment for why its unchecked predecessor didn't cover this.
     let result = items_to_result_checked(taken);
     match flow {
         // Stopped because `n` outputs arrived: jq's own `foreach ... break
@@ -41960,7 +41954,7 @@ mod tests {
             items.push(item);
             Demand::Continue
         });
-        let result = items_to_result(items);
+        let result = items_to_result_checked(items);
         match flow {
             Flow::Exhausted | Flow::Stopped { .. } => result,
             Flow::Escaped(control) => {


### PR DESCRIPTION
## Summary

- `fanout_arg`'s eager (non-`All`) branch and lazy (`ArgFanout::All`) sink,
  `fanout_two_args`'s eager loop, and `fanout_two_args_lazy`'s inner sink
  all pushed a `body` result's value through bare `push_owned_values`
  (unchecked `to_owned`) instead of `push_owned_values_checked`, silently
  substituting `""` for an undecodable string in the output instead of
  raising a decode failure -- the #1746-shaped bug, on the *body-result*
  side this time (#2023 already fixed the *argument*-decoding side of
  these same functions).
- `limit_with_n`'s `Flow::Escaped` arm (fewer than `n` outputs produced
  before the generator's own terminator fired) had the identical gap on
  its pre-escape prefix, and additionally discarded whatever `Control`
  the checked conversion itself raised in favor of the generator's own
  trailing control. Fixed so a decode failure discovered while
  materializing that prefix -- describing a value the generator already
  produced *before* its own terminator fired -- now takes precedence,
  matching the flush-then-stop precedence `fanout_arg`'s own sinks
  already give a buffered `pending_first`'s decode failure over the
  argument's trailing control.
- The two callers the issue names as already safe (`negate_fanout_core`,
  `eval_owned_multi_keep_partial`) are left untouched.

## Repro

`[1,"\xff\xfe"] | nth((0,1))` (forces `nth`'s multi-value fan-out
through `fanout_arg`'s lazy sink): pre-fix `ManyOwned([Int(1),
String("")])`, post-fix raises a decode failure with `Partial([Int(1)],
...)`.

`limit(3; (.a, error("x")))` on `{"a":"<bad>"}`: pre-fix
`Partial([String("")], Error("x"))` (silent substitution, wrong error
reported); post-fix raises the decode failure directly.

Both verified fail-without-fix / pass-with-fix.

Fixes #2024

## Test plan

- [x] New regression tests: `test_fanout_arg_lazy_sink_body_result_raises_decode_failure_2024`, `test_eval_limit_escaped_prefix_no_silent_substitution_2024` -- both confirmed to fail against the pre-fix code and pass with the fix
- [x] `cargo test --features cli,simd,regex,serde` (full suite): all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`: clean
- [x] `cargo test --no-default-features --verbose` (no_std): clean
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings): clean