### PR TITLE
fix(jq): stop select() after a generator from swallowing survivor paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A rejecting `select(...)` after a generator builtin (`paths`, `range`, ...)
+  no longer swallows a surviving branch's own path-validity check** (#2050).
+  Inside a path expression, when `select(...)` rejected at least one branch a
+  *generator builtin* produced, the branches that survived stopped having
+  their path-validity checked at all:
+
+  ```console
+  $ echo '{"a":{"b":1}}' | jq -c '[path(paths | select(length == 2) | .["a"])]'
+  jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of ["a","b"]
+
+  $ echo '{"a":{"b":1}}' | succinctly jq -c '[path(paths | select(length == 2) | .["a"])]'
+  [] # before this fix
+  ```
+
+  and, the shape a randomised differential fuzzer actually found while
+  working #1690 (PR #2047):
+
+  ```console
+  $ echo '{"a":{"b":1}}' | jq -c 'del(paths | select(length == 2) as $p | getpath($p))'
+  jq: error (at <stdin>:1): Cannot index array with string "a"
+
+  $ echo '{"a":{"b":1}}' | succinctly jq -c 'del(paths | select(length == 2) as $p | getpath($p))'
+  {"a":{"b":1}} # silent no-op, before this fix
+  ```
+
+  Root cause: `resolve_seq`'s multi-stage fan-out loop threaded the whole
+  call's own terminal `keep` (`Keep::First`, #987's "stop a generator after
+  its first output" rule) into **every** stage of the pipe, not just the
+  genuinely terminal one. A bare generator builtin like `paths` has no
+  dedicated `resolve_node` arm, so it falls to `resolve_leaf`'s general,
+  `keep`-obeying case — and got truncated to its *first* output (`["a"]`)
+  before `select(length == 2)` ever ran, discarding the second output
+  (`["a","b"]`) that `select` would have let through. `resolve_fold_source`
+  had already established the fix for its own "needs every output" case
+  (`Keep::AtMost(usize::MAX)` in place of `Keep::First`, #1872); `resolve_seq`
+  now applies that same widened `keep` to every stage except the pipe's own
+  final one (only reached when a later stage or a non-empty static tail
+  isn't still waiting to run), which is the one position the caller's actual
+  demand still applies to.
+
+  Confirmed live against jq 1.7.1 that this generalizes beyond `paths`:
+  `path(range(3) | select(.==2))` raises "Invalid path expression with result
+  2" (the candidate `select` actually lets through), never "...result 0" (the
+  generator's own first output) — succinctly now matches. The two rows in
+  the issue that were already correct (a non-rejecting `select(true)`, and a
+  rejecting `select` over a literal `Expr::Comma` rather than a generator
+  builtin) are unaffected and pinned by regression tests alongside the fix.
+
+  `src/jq/eval_generic.rs` (the CLI's own bridge for both `jq` and `yq`
+  modes) needed no matching change: it has no separate path-tracking
+  implementation of its own for `path()`/`del()`/`=`/`|=` — every one bridges
+  to `src/jq/eval.rs`'s `resolve_node`/`resolve_seq` via
+  `bridge_to_full_evaluator`, so this fix in the one shared implementation
+  covers the CLI in both modes.
+
 - **`succinctly::jq::eval`'s object-construction key/value slots and jq-mode
   string interpolation no longer silently substitute `""` for an undecodable
   string** (#2022): all three fed their generator's output through

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25115,7 +25115,31 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // live against jq 1.7.1: `path(.a[(0,error("t1"))] | .c[(0,error("t2"))]
     // | .foo)` on `{"a":[{"c":[{"foo":1}]}]}` raises `t2`, not `t1`.
     let mut deferred_escape: Option<EvalEscape> = None;
-    for element in &flat[..=last_dynamic] {
+    for (stage_index, element) in flat[..=last_dynamic].iter().enumerate() {
+        // #2050: `keep` is this whole call's *terminal* demand (typically
+        // `Keep::First`, #987's "stop a generator after its first output"
+        // rule) — correct only for the position nothing else in this
+        // `resolve_seq` call follows. An earlier stage here is not that
+        // position whenever a later stage or a non-empty `tail` still has
+        // to run: a `select`/filter downstream may reject that stage's
+        // first output and only accept a later one (`paths | select(length
+        // == 2) | .foo` needs `paths`'s *second* output, since its first
+        // is rejected), so truncating the generator to one value before
+        // the filter ever runs can turn a genuine "later output survives"
+        // pipe into a wrongly-empty result, or a wrongly-silent one — #1872's
+        // `resolve_fold_source` already established the fix for its own
+        // "needs every output" case (`Keep::AtMost(usize::MAX)`, not
+        // `Keep::First`); this reuses the identical value for the identical
+        // reason. Only `resolve_leaf`'s general non-primitive case actually
+        // reads `keep` at all (its own doc comment), so this widening is a
+        // no-op for every other arm (`Select` included, which ignores
+        // `keep` entirely) and only changes behavior for a bare generator
+        // builtin (`paths`, `range`, `keys`, ...) reached mid-pipe.
+        let stage_keep = if stage_index == last_dynamic && tail.is_empty() {
+            keep
+        } else {
+            Keep::AtMost(usize::MAX)
+        };
         // Whether this stage can carry a live path register across itself
         // at all (#1573). `false` is the answer for every stage this
         // resolver cannot see inside, because jq's register moves on any
@@ -25242,7 +25266,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
                 current,
                 branch_trackable,
                 branch_snapshot,
-                keep,
+                stage_keep,
             ) {
                 Ok(resolved) => {
                     for step in resolved {
@@ -59420,6 +59444,102 @@ mod tests {
                 assert_eq!(prefix_json(&vs), [r#"["a"]"#]);
                 assert_eq!(e.message, "z");
             }
+        );
+    }
+
+    /// #2050: a rejecting `select(...)` after a *generator builtin* used
+    /// mid-pipe (i.e. not as `path()`'s own terminal leaf) used to swallow
+    /// the surviving branch's own path-validity check entirely, rather
+    /// than merely re-ordering it. Root cause: `resolve_seq`'s fan-out loop
+    /// threaded the caller's own terminal `keep` (`Keep::First`, #987's
+    /// "stop a generator after its first output" rule) into *every* stage
+    /// of the pipe, not just the genuinely terminal one -- so bare `paths`
+    /// (which, lacking a dedicated `resolve_node` arm, falls to
+    /// `resolve_leaf`'s `keep`-obeying general case) was truncated to its
+    /// *first* output before `select` ever ran, discarding the very branch
+    /// `select` would have let through (`{"a":{"b":1}}`'s `paths` emits
+    /// `["a"]` then `["a","b"]`; `select(length == 2)` rejects the first
+    /// and accepts only the second). Confirmed live against jq 1.7.1
+    /// (`/usr/bin/jq`): the filter below raises, it does not produce `[]`.
+    #[test]
+    fn test_path_select_after_generator_does_not_swallow_surviving_branch_2050() {
+        query!(br#"{"a":{"b":1}}"#,
+            r#"[path(paths | select(length == 2) | .["a"])]"#,
+            QueryResult::Error(e) => assert_eq!(
+                e.message,
+                r#"Invalid path expression near attempt to access element "a" of ["a","b"]"#,
+            )
+        );
+        // A different generator builtin (`range`, not `paths`) reproduces
+        // the identical shape, confirming this is `resolve_seq`'s own
+        // stage-by-stage `keep` propagation, not something specific to
+        // `paths`'s own resolve_node handling. Confirmed live: jq raises
+        // on `2` here (the first candidate `select` actually lets
+        // through), never on `0` (the generator's own first output).
+        query!(br"null", r"[path(range(3) | select(.==2))]",
+            QueryResult::Error(e) => assert_eq!(
+                e.message, "Invalid path expression with result 2"
+            )
+        );
+        // `select` rejecting more than one candidate before the survivor
+        // still raises on the first one it actually lets through (`1`),
+        // not the generator's own first output (`0`) -- verified live.
+        query!(br"null", r"[path(range(3) | select(.>=1))]",
+            QueryResult::Error(e) => assert_eq!(
+                e.message, "Invalid path expression with result 1"
+            )
+        );
+    }
+
+    /// #2050's `del()` form -- the shape a randomised differential fuzzer
+    /// actually found (working #1690/PR #2047). Same generator/select
+    /// combination as the test above, but binding the surviving branch via
+    /// `as $p` and then genuinely navigating with `getpath($p)`. Before the
+    /// fix this was a silent no-op: `del(...)` returned the input
+    /// completely unchanged, per the issue's own repro. Real jq raises
+    /// "Cannot index array with string \"a\"" instead, since
+    /// `getpath(["a","b"])` -- `$p` bound from `paths`'s surviving second
+    /// output -- tries to index the array `["a","b"]` itself with the
+    /// string key "a" (its own first path component). This must surface as
+    /// a raised error, not a silent success: a no-op here would mean
+    /// `del()` claimed to delete something it never touched.
+    #[test]
+    fn test_del_select_after_generator_does_not_silently_noop_2050() {
+        query!(br#"{"a":{"b":1}}"#,
+            r"del(paths | select(length == 2) as $p | getpath($p))",
+            QueryResult::Error(e) => assert_eq!(
+                e.message, r#"Cannot index array with string "a""#
+            )
+        );
+    }
+
+    /// The two rows from #2050's own divergence table that were already
+    /// correct before this fix -- pinned here so a future change to
+    /// `resolve_seq`'s fan-out loop can't quietly regress them back.
+    #[test]
+    fn test_path_select_after_generator_previously_correct_rows_2050() {
+        // A *non-rejecting* `select` (`select(true)`) never exercises the
+        // truncate-before-filter bug at all: every generator output
+        // already survives regardless of what `select` does, so this
+        // raised correctly even before the fix -- the error itself comes
+        // from `getpath(.)` genuinely indexing the array `["a"]` with its
+        // own first string key, independent of path tracking.
+        query!(br#"{"a":{"b":1}}"#,
+            r"[path(paths | select(true) | getpath(.))]",
+            QueryResult::Error(e) => assert_eq!(
+                e.message, r#"Cannot index array with string "a""#
+            )
+        );
+        // A rejecting `select` over a literal `Expr::Comma`, not a
+        // generator builtin, never reaches `resolve_leaf`'s `keep`-obeying
+        // general case at all -- `Expr::Comma` has its own dedicated
+        // `resolve_node` arm -- so this also already raised correctly.
+        query!(br#"{"a":{"b":1}}"#,
+            r"[path((1,2) | select(. == 2) | .a)]",
+            QueryResult::Error(e) => assert_eq!(
+                e.message,
+                "Invalid path expression near attempt to access element \"a\" of 2"
+            )
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25120,22 +25120,61 @@ fn resolve_seq<'a, S: EvalSemantics>(
         // `Keep::First`, #987's "stop a generator after its first output"
         // rule) — correct only for the position nothing else in this
         // `resolve_seq` call follows. An earlier stage here is not that
-        // position whenever a later stage or a non-empty `tail` still has
-        // to run: a `select`/filter downstream may reject that stage's
-        // first output and only accept a later one (`paths | select(length
-        // == 2) | .foo` needs `paths`'s *second* output, since its first
-        // is rejected), so truncating the generator to one value before
-        // the filter ever runs can turn a genuine "later output survives"
-        // pipe into a wrongly-empty result, or a wrongly-silent one — #1872's
-        // `resolve_fold_source` already established the fix for its own
-        // "needs every output" case (`Keep::AtMost(usize::MAX)`, not
-        // `Keep::First`); this reuses the identical value for the identical
-        // reason. Only `resolve_leaf`'s general non-primitive case actually
-        // reads `keep` at all (its own doc comment), so this widening is a
-        // no-op for every other arm (`Select` included, which ignores
-        // `keep` entirely) and only changes behavior for a bare generator
-        // builtin (`paths`, `range`, `keys`, ...) reached mid-pipe.
-        let stage_keep = if stage_index == last_dynamic && tail.is_empty() {
+        // position whenever a *later stage in this same fan-out loop*
+        // still has to run: a `select`/filter downstream may reject that
+        // stage's first output and only accept a later one (`paths |
+        // select(length == 2) | .foo` needs `paths`'s *second* output,
+        // since its first is rejected), so truncating the generator to one
+        // value before the filter ever runs can turn a genuine "later
+        // output survives" pipe into a wrongly-empty result, or a
+        // wrongly-silent one — #1872's `resolve_fold_source` already
+        // established the fix for its own "needs every output" case
+        // (`Keep::AtMost(usize::MAX)`, not `Keep::First`); this reuses the
+        // identical value for the identical reason. Only `resolve_leaf`'s
+        // general non-primitive case actually reads `keep` at all (its own
+        // doc comment), so this widening is a no-op for every other arm
+        // (`Select` included, which ignores `keep` entirely) and only
+        // changes behavior for a bare generator builtin (`paths`, `range`,
+        // `keys`, ...) reached mid-pipe.
+        //
+        // `tail` (this call's own *static* trailing components — `Field`/
+        // `Index`/`Slice`, never `Select` or anything else that can reject
+        // — see `push_path_components`/`needs_path_prepass`) is deliberately
+        // NOT part of this condition, unlike an earlier version of this fix
+        // (#2050 code review): a static component can only either succeed
+        // with exactly one output or *error*, and an uncaught error aborts
+        // the whole evaluation rather than making jq backtrack and try an
+        // earlier stage's next candidate (confirmed live: `path(range(3) |
+        // debug | .a)` calls `debug` exactly once, on `0`, then raises —
+        // `1`/`2` are never even asked for, so `.a` being unconditionally
+        // erroring on a number is not a reason to widen `range`'s own
+        // `keep`). Gating on `tail.is_empty()` too made the truly-last
+        // fan-out stage (whatever precedes a non-empty static tail) widen
+        // unconditionally — silently reintroducing #987's regression
+        // (`path(paths | .a)`/`path(range(1_000_000) | .a)` fully
+        // materializing their generator before the static tail ever runs)
+        // for the overwhelmingly common "one dynamic stage, then a plain
+        // field/index" shape. `stage_index == last_dynamic` alone is sound
+        // regardless of `tail`'s contents: #2050's own repro still widens
+        // correctly, because `select` there occupies `last_dynamic` itself
+        // (not `paths`), so `paths` (`stage_index` 0 of 1) is unaffected by
+        // this change.
+        //
+        // A residual, narrower divergence remains for a *non-rejecting*
+        // builtin (`debug`, `stderr`, ...) sitting between two genuine
+        // fan-out stages with no filter between them (`path(range(3) |
+        // debug | .a)`): `debug` itself, now at `last_dynamic`, correctly
+        // gets the real `keep` regardless of `tail` — but `range` (an
+        // *earlier* fan-out-loop stage) still widens, because nothing here
+        // proves `debug` cannot reject a candidate the way `select` can.
+        // Live-verified this is not merely cosmetic: `path(range(1_000_000)
+        // | debug | .a)` calls `debug` 100,000 times here (a
+        // `RECURSE_MAX_ITEMS`-style cap, not the full million) against
+        // jq's own single call. Distinguishing "can this later stage ever
+        // reject" from "is this just the last static-tail-adjacent stage"
+        // needs a real reachable-rejection analysis this fix does not
+        // attempt — tracked as #2178 rather than folded in here.
+        let stage_keep = if stage_index == last_dynamic {
             keep
         } else {
             Keep::AtMost(usize::MAX)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25452,6 +25452,31 @@ fn test_paths_filter_laziness_reaches_del_and_assign_987() -> Result<()> {
     Ok(())
 }
 
+/// #2050 code review: `resolve_seq`'s original fix widened a fan-out
+/// stage's `keep` to "need every output" whenever its own trailing `tail`
+/// (a purely static `Field`/`Index`/`Slice` suffix, never a `select`) was
+/// non-empty -- not just when a genuinely rejecting stage followed it in
+/// the same loop. That silently reintroduced #987's own regression for the
+/// overwhelmingly common "one dynamic stage, then a plain field/index"
+/// shape: `range(3)` was fully materialized (side effects included) before
+/// the static `.a` tail ever ran, even though jq itself only ever visits
+/// `range`'s first output (a static tail either succeeds once or errors --
+/// an error aborts the whole computation rather than making jq backtrack
+/// for `range`'s next candidate). Confirmed against jq 1.7.1: `stderr`
+/// fires exactly once (`0`), not three times.
+#[test]
+fn test_path_single_dynamic_stage_static_tail_does_not_over_materialize_2050() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path(range(3) | (stderr, .a))"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr.trim_end(),
+        "0jq: error (at <stdin>:0): Invalid path expression with result 0"
+    );
+    Ok(())
+}
+
 /// The same eagerness applied to `input`/`inputs` destroys data.
 ///
 /// `input`/`inputs` pop from the process-global queue that the CLI's own


### PR DESCRIPTION
## Summary

Fixes #2050. Inside a path expression, a rejecting `select(...)` downstream of a
generator builtin (`paths`, `range`, ...) used mid-pipe silently swallowed the
surviving branch's own path-validity check, instead of merely re-ordering it —
`path()` returned `[]` and `del()` was a silent no-op where jq 1.7.1 raises.

## Root cause

`resolve_seq`'s fan-out loop threaded the whole call's own *terminal* `keep`
demand (`Keep::First`, #987's "stop a generator after its first output" rule)
into *every* stage of a multi-stage pipe, not just the genuinely terminal one.
A bare generator builtin has no dedicated `resolve_node` arm, so it falls to
`resolve_leaf`'s general, `keep`-obeying case — and got truncated to its first
output before a later `select(...)` ever ran to filter it. On
`{"a":{"b":1}}`, `paths` emits `["a"]` then `["a","b"]`; `select(length == 2)`
rejects the first and would accept the second, but the second was never
produced at all.

## Fix

Widen every non-terminal stage's `keep` to `Keep::AtMost(usize::MAX)`,
reserving the caller's real `keep` for the pipe's genuinely final stage —
mirroring #1872's identical fix for `resolve_fold_source`'s own "need every
output" case.

`eval_generic.rs` needed no matching change: it has no separate path-tracking
implementation and bridges `path()`/`del()`/`=`/`|=` to `eval.rs`'s shared
`resolve_node`/`resolve_seq` for both jq and yq modes — confirmed live through
both built CLI binaries.

## Test plan
- [x] Live-verified against the pinned oracle (`/usr/bin/jq` 1.7.1): all four
  divergence-table rows from the issue now match exactly, including the two
  previously-correct rows (unregressed).
- [x] 3 new regression tests in `src/jq/eval.rs` covering the `path()` form,
  the `del()` form the fuzzer found, and the two previously-correct rows
  (pinned against future regression).
- [x] `cargo test --features cli,simd,regex,serde --lib`: 3258 passed, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.