### PR TITLE
refactor(jq): fold IndexNumber/SliceNumber onto Index/Slice (#1401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`Expr::Index` and `Expr::Slice` now carry their own float-spelling keys** (#1401),
+  replacing the separate `Expr::IndexNumber`/`Expr::SliceNumber` variants that #1088 and
+  #1326 added beside them. `Expr::Index(i64)` is now
+  `Expr::Index { idx: i64, key: Option<NumberKey> }`, and `Expr::Slice` gains
+  `start_key`/`end_key`; both are breaking changes for callers that construct or match
+  these variants directly. The `Expr::index()` and `Expr::slice()` constructors are
+  unchanged.
+
+  Preserving a float literal's own spelling in `path()` output (`path(.[2.0])` is `[2.0]`)
+  behaves exactly as before — only the representation moved. The paired form required all
+  63 sites that ask "is this an index/a slice" to spell out both members of each pair, and
+  a site that forgot one got an `unreachable!()` instead of an answer, which is what
+  `delete_expr_array_paths` did from #1088 until #1326 closed it. One variant per family
+  makes that shape unrepresentable rather than merely tested for, and removes both
+  `Expr`-scrutinee `unreachable!()` fallbacks along with it. `size_of::<Expr>()` is
+  unchanged at 96 bytes and is now pinned by a test.
+
 ### Fixed
 
 - **`succinctly::jq::eval`'s object-construction key/value slots and jq-mode

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -449,10 +449,8 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
         // Expressions that don't contain sub-expressions - return as-is
         Expr::Identity
         | Expr::Field(_)
-        | Expr::Index(_)
-        | Expr::IndexNumber { .. }
+        | Expr::Index { .. }
         | Expr::Slice { .. }
-        | Expr::SliceNumber { .. }
         | Expr::Iterate
         | Expr::RecursiveDescent
         | Expr::Literal(_)
@@ -4345,10 +4343,7 @@ fn expr_is_cursor_transparent(expr: &jq::Expr) -> bool {
 /// can still be holding the root cursor.
 fn expr_descends(expr: &jq::Expr) -> bool {
     match expr {
-        jq::Expr::Field(_)
-        | jq::Expr::Index(_)
-        | jq::Expr::IndexNumber { .. }
-        | jq::Expr::Iterate => true,
+        jq::Expr::Field(_) | jq::Expr::Index { .. } | jq::Expr::Iterate => true,
         jq::Expr::Paren(inner) => expr_descends(inner),
         _ => false,
     }
@@ -4360,11 +4355,9 @@ fn expr_descends(expr: &jq::Expr) -> bool {
 /// have materialized it.
 fn expr_is_root_safe(expr: &jq::Expr) -> bool {
     match expr {
-        jq::Expr::Identity
-        | jq::Expr::Field(_)
-        | jq::Expr::Index(_)
-        | jq::Expr::IndexNumber { .. }
-        | jq::Expr::Iterate => true,
+        jq::Expr::Identity | jq::Expr::Field(_) | jq::Expr::Index { .. } | jq::Expr::Iterate => {
+            true
+        }
         // `debug` forwards its input untouched, so it is root-safe for the
         // same reason `.` is -- and it is the builtin #1653's own repro
         // (`.[] | debug`) is built from.

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3752,7 +3752,7 @@ fn can_use_m2_streaming(expr: &Expr) -> bool {
         // Core M2 expressions
         Expr::Identity => true,
         Expr::Field(_) => true,
-        Expr::Index(_) | Expr::IndexNumber { .. } => true,
+        Expr::Index { .. } => true,
         Expr::Iterate => true,
 
         // Chained navigation
@@ -6542,7 +6542,7 @@ mod tests {
         // .users | .[0] | .name
         let expr = Expr::Pipe(vec![
             Expr::Field("users".to_string()),
-            Expr::Index(0),
+            Expr::index(0),
             Expr::Field("name".to_string()),
         ]);
         let results = eval_yaml(yaml, &expr);

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1693,7 +1693,7 @@ pub fn collapsed_fields<F: DocumentFields>(
 
 /// [`collapsed_fields`], but skipped outright when the mode doesn't
 /// collapse (yq) -- the single guard the two positional `LazyKeys` arms
-/// (`Index`/`IndexNumber`, `Last`) both need before they can answer.
+/// (`Index`, `Last`) both need before they can answer.
 pub fn collapsed_fields_if<F: DocumentFields>(
     fields: &F,
     collapse: bool,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -982,9 +982,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         Expr::Field(name) => index_object_by_name::<W>(value, name, optional),
 
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-            index_array_by_position::<W>(value, *idx, optional)
-        }
+        Expr::Index { idx, .. } => index_array_by_position::<W>(value, *idx, optional),
 
         Expr::IndexExpr { target, key } => eval_index_expr::<W, S>(target, key, value, optional),
 
@@ -992,7 +990,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             eval_slice_expr::<W, S>(target, start, end, value, optional)
         }
 
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => match value {
+        Expr::Slice { start, end, .. } => match value {
             StandardJson::Array(elements) => {
                 // Fast path: full slice [:] / [0:] returns the original array unchanged
                 if matches!(start, None | Some(0)) && end.is_none() {
@@ -16212,7 +16210,12 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Targets::Borrowed(ts) => {
             for s in starts {
                 for e in &ends {
-                    let slice_expr = Expr::Slice { start: *s, end: *e };
+                    let slice_expr = Expr::Slice {
+                        start: *s,
+                        end: *e,
+                        start_key: None,
+                        end_key: None,
+                    };
                     for t in ts {
                         match eval_single::<W, S>(&slice_expr, t.clone(), optional) {
                             // #1943: to_owned_checked, not to_owned -- the
@@ -16490,8 +16493,8 @@ impl PathAssignOutcome {
 /// and a defensive terminal-shape check (not currently reachable: every
 /// leaf `push_path_components` can push is one of `needs_path_prepass`'s
 /// own static-classified variants, and the slice check above already
-/// excludes `Slice`/`SliceNumber`, so by this point `last` can only be
-/// `Field`/`Index`/`IndexNumber`/`Iterate` -- confirmed via patch-coverage
+/// excludes `Slice`, so by this point `last` can only be
+/// `Field`/`Index`/`Iterate` -- confirmed via patch-coverage
 /// output, not just assumed; kept as the one thing standing between a
 /// future new static-classified `Expr` variant and this function silently
 /// treating an unrelated shape as a valid no-op terminal).
@@ -16514,13 +16517,13 @@ fn yq_assign_classify(path: &Expr, root: &OwnedValue) -> PathAssignOutcome {
     }
     // Defensive, not currently reachable: every leaf `push_path_components`
     // can push here is one of `needs_path_prepass`'s own static-classified
-    // variants (`Field`/`Index`/`IndexNumber`/`Slice`/`SliceNumber`/
-    // `Iterate` -- `Identity` is dropped above, anything else fails the
+    // variants (`Field`/`Index`/`Slice`/`Iterate` -- `Identity` is
+    // dropped above, anything else fails the
     // caller's own `!needs_path_prepass` gate before ever reaching this
     // function), and the slice check just above already excludes
-    // `Slice`/`SliceNumber` wherever they appear, including as `last`. So
-    // by this point `last` can only be `Field`/`Index`/`IndexNumber`/
-    // `Iterate` -- confirmed via patch-coverage output (this arm's own
+    // `Slice` wherever it appears, including as `last`. So by this point
+    // `last` can only be `Field`/`Index`/`Iterate` -- confirmed via
+    // patch-coverage output (this arm's own
     // branch never fires), not just assumed. Kept rather than removed:
     // it's the one thing standing between a future new
     // static-classified `Expr` variant (added to `needs_path_prepass`
@@ -16528,7 +16531,7 @@ fn yq_assign_classify(path: &Expr, root: &OwnedValue) -> PathAssignOutcome {
     // an unrelated shape as a valid no-op terminal.
     if !matches!(
         unwrap_path_component(last).0,
-        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate
+        Expr::Field(_) | Expr::Index { .. } | Expr::Iterate
     ) {
         return PathAssignOutcome::NeedsRhs;
     }
@@ -16546,7 +16549,7 @@ fn yq_assign_classify(path: &Expr, root: &OwnedValue) -> PathAssignOutcome {
 /// a real container, instead of `navigate_read_only`'s own unconditional
 /// `Absent` for that case (#1432) -- a read-only, non-mutating dry run of
 /// [`set_path_steps`]'s own per-element `Iterate` recursion, restricted to
-/// the `Field`/`Index`/`IndexNumber`/`Iterate` step vocabulary that's all
+/// the `Field`/`Index`/`Iterate` step vocabulary that's all
 /// `yq_assign_classify`'s own slice/terminal-shape gates ever let through.
 /// `TotalNoop` whenever a fanned-into container is empty --
 /// [`set_path_steps`]'s own `Iterate` arm does nothing when there are no
@@ -16613,7 +16616,7 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
                 None => PathAssignOutcome::NeedsRhs,
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
+        Expr::Index { idx, .. } => match current {
             OwnedValue::Array(arr) => match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
                 Some(i) => classify_yq_assign_prefix(&arr[i], rest),
                 None => PathAssignOutcome::NeedsRhs,
@@ -16636,8 +16639,8 @@ fn classify_yq_assign_prefix(current: &OwnedValue, steps: &[Expr]) -> PathAssign
         },
         // Defensive, not currently reachable: `steps` only ever contains
         // `yq_assign_classify`'s own flattened `prefix`, whose every
-        // component is already provably one of `Field`/`Index`/
-        // `IndexNumber`/`Iterate` by the time it reaches here -- see that
+        // component is already provably one of `Field`/`Index`/`Iterate`
+        // by the time it reaches here -- see that
         // function's own identical "Defensive, not currently reachable"
         // comment on its terminal-component check, confirmed there via
         // patch-coverage output the same way this arm's own is (never
@@ -16958,7 +16961,7 @@ fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> bool {
                 },
                 _ => return false,
             },
-            Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match current {
+            Expr::Index { idx, .. } => match current {
                 OwnedValue::Array(arr) => {
                     match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
                         Some(i) => &arr[i],
@@ -18103,7 +18106,7 @@ fn set_path<S: EvalSemantics>(
                 ))
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, .. } => {
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
                 *write_index(arr, *idx)? = new_value;
@@ -18214,7 +18217,7 @@ fn set_path<S: EvalSemantics>(
         // an array — that is the whole reason jq has a separate sentence for
         // it. An out-of-range range clamps rather than erroring, unlike the
         // `Expr::Index` arm above: `[1,2,3] | .[5:9] = ["x"]` appends.
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => through_slice(
+        Expr::Slice { start, end, .. } => through_slice(
             root,
             *start,
             *end,
@@ -18264,13 +18267,7 @@ fn set_path<S: EvalSemantics>(
 fn is_atomic_path_component(expr: &Expr) -> bool {
     matches!(
         unwrap_path_component(expr).0,
-        Expr::Identity
-            | Expr::Field(_)
-            | Expr::Index(_)
-            | Expr::IndexNumber { .. }
-            | Expr::Iterate
-            | Expr::Slice { .. }
-            | Expr::SliceNumber { .. }
+        Expr::Identity | Expr::Field(_) | Expr::Index { .. } | Expr::Iterate | Expr::Slice { .. }
     )
 }
 
@@ -18420,8 +18417,7 @@ fn set_path_steps<S: EvalSemantics>(
                 // which the split-based walker also routed through
                 // catch-and-swallow -- delegates unchanged.
                 let (component, optional) = unwrap_path_component(last);
-                if let Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } = component
-                {
+                if let Expr::Slice { start, end, .. } = component {
                     return through_slice(
                         root,
                         *start,
@@ -18471,7 +18467,7 @@ fn set_path_steps<S: EvalSemantics>(
                     ));
                 }
             }
-            Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+            Expr::Index { idx, .. } => {
                 autovivify_array(root);
                 if let OwnedValue::Array(arr) = root {
                     // A still-negative index after counting back from the end
@@ -18581,7 +18577,7 @@ fn set_path_steps<S: EvalSemantics>(
                 ))
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, .. } => {
             let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
@@ -18664,7 +18660,7 @@ fn set_path_steps<S: EvalSemantics>(
         // `terminal_write` is always `false` here: `steps` is flat and this
         // is not its last element, so there is real path left after the
         // slice for `edit` to navigate (#1321).
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => through_slice(
+        Expr::Slice { start, end, .. } => through_slice(
             root,
             *start,
             *end,
@@ -19252,7 +19248,7 @@ fn update_path<S: EvalSemantics>(
                 Err(EvalError::cannot_index_with_field(owned_type_name(root), name).into())
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, .. } => {
             let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_array(root);
             if let OwnedValue::Array(arr) = root {
@@ -19527,7 +19523,7 @@ fn update_path<S: EvalSemantics>(
                             )
                         }
                     }
-                    Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+                    Expr::Index { idx, .. } => {
                         // #1428: see the `Field` arm above. `write_index` pads
                         // with `Null`s to reach a positive out-of-range index,
                         // so the undo restores the original length rather than
@@ -19625,7 +19621,7 @@ fn update_path<S: EvalSemantics>(
                     // target for every operator, live-verified
                     // (`.a[1:3][] |= . * 10` on `a: [1,2,3,4]` stays
                     // unchanged).
-                    Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
+                    Expr::Slice { start, end, .. } => {
                         through_slice(
                             root,
                             *start,
@@ -19662,7 +19658,7 @@ fn update_path<S: EvalSemantics>(
         // yq mode: real yq's container no-op (#1142) applies here too,
         // unconditional on the operator -- see the Pipe-chain arm's
         // matching comment above for the full rationale.
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => through_slice(
+        Expr::Slice { start, end, .. } => through_slice(
             root,
             *start,
             *end,
@@ -19738,10 +19734,8 @@ fn needs_path_prepass(expr: &Expr) -> bool {
     match expr {
         Expr::Identity
         | Expr::Field(_)
-        | Expr::Index(_)
-        | Expr::IndexNumber { .. }
+        | Expr::Index { .. }
         | Expr::Slice { .. }
-        | Expr::SliceNumber { .. }
         | Expr::Iterate => false,
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_prepass),
         Expr::Optional(inner) | Expr::Paren(inner) => needs_path_prepass(inner),
@@ -20030,7 +20024,7 @@ fn key_to_path_component(
         // Truncation toward zero, as in the value path.
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
             if scalar_noop {
-                return Ok(Expr::Index(0));
+                return Ok(Expr::Index { idx: 0, key: None });
             }
             // Null belongs with array: a write builds the array the index names,
             // so `null | .[nan] = 5` is the NaN complaint in jq too.
@@ -20065,9 +20059,9 @@ fn key_to_path_component(
 /// `NumberLiteral` to plain `Float` for exactly the same reason. A negative
 /// float arriving from *data* keeps its spelling in both.
 fn numeric_path_component(idx: i64, key: &OwnedValue) -> Expr {
-    match number_key_for(key) {
-        Some(key) => Expr::IndexNumber { idx, key },
-        None => Expr::Index(idx),
+    Expr::Index {
+        idx,
+        key: number_key_for(key),
     }
 }
 
@@ -20093,12 +20087,10 @@ fn number_key_for(v: &OwnedValue) -> Option<NumberKey> {
 /// key-detection half (#1326), for a genuinely dynamic bound
 /// (`.[$a:$b]`, `.[(1+1):]`) rather than a literal one.
 ///
-/// Unlike an index, a slice bound has no single `Expr` variant carrying
-/// both the resolved `i64` and its own key together -- [`Expr::SliceNumber`]
-/// carries each bound's key as an independent optional field, so this
-/// returns just the key half; the caller pairs it with the bound's own
-/// already-resolved `i64` (from [`owned_bound_to_i64`]) when constructing
-/// the path component.
+/// [`Expr::Slice`] carries each bound's key as an independent optional
+/// field, so this returns just the key half; the caller pairs it with the
+/// bound's own already-resolved `i64` (from [`owned_bound_to_i64`]) when
+/// constructing the path component.
 fn numeric_slice_bound_key(v: &OwnedValue) -> Option<NumberKey> {
     number_key_for(v)
 }
@@ -20127,7 +20119,7 @@ pub(crate) fn index_component_value(idx: i64, key: Option<&NumberKey>) -> OwnedV
 /// descriptor is reported as, one bound at a time -- the slice-bound sibling
 /// of [`index_component_value`] (#1326), shared by [`walk_path`] and
 /// [`navigation_element`]. `eval_pipe_with_path_context_internal` has no
-/// `Expr::Slice`/`Expr::SliceNumber` arm at all -- a slice there falls
+/// `Expr::Slice` arm at all -- a slice there falls
 /// through to that function's generic, path-context-losing fallback, a
 /// pre-existing gap #1326 doesn't touch.
 ///
@@ -20826,12 +20818,7 @@ fn resolve_node<'a, S: EvalSemantics>(
                 // expression carve-out above.
                 let bare_navigation_primitive = matches!(
                     inner.as_ref(),
-                    Expr::Field(_)
-                        | Expr::Index(_)
-                        | Expr::IndexNumber { .. }
-                        | Expr::Iterate
-                        | Expr::Slice { .. }
-                        | Expr::SliceNumber { .. }
+                    Expr::Field(_) | Expr::Index { .. } | Expr::Iterate | Expr::Slice { .. }
                 );
                 let branches = match resolve_node::<S>(inner, value, trackable, snapshot, keep) {
                     Ok(branches) => branches,
@@ -21892,7 +21879,13 @@ fn resolve_iterate_bounded<S: EvalSemantics>(
             .take(n)
             .map(|(i, v)| {
                 PathBranch::new(
-                    PathPrefix::extend(&root, Expr::Index(i as i64)),
+                    PathPrefix::extend(
+                        &root,
+                        Expr::Index {
+                            idx: i as i64,
+                            key: None,
+                        },
+                    ),
                     Cow::Borrowed(v),
                     true,
                 )
@@ -21928,13 +21921,18 @@ fn resolve_iterate_bounded<S: EvalSemantics>(
 fn navigation_element(component: &Expr) -> Option<OwnedValue> {
     match component {
         Expr::Field(name) => Some(OwnedValue::String(name.clone())),
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
-            Some(index_component_value(*idx, component.index_number_key()))
-        }
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
-            let (start_key, end_key) = component.slice_number_keys();
-            Some(slice_component_value(*start, start_key, *end, end_key))
-        }
+        Expr::Index { idx, key } => Some(index_component_value(*idx, key.as_ref())),
+        Expr::Slice {
+            start,
+            end,
+            start_key,
+            end_key,
+        } => Some(slice_component_value(
+            *start,
+            start_key.as_ref(),
+            *end,
+            end_key.as_ref(),
+        )),
         _ => None,
     }
 }
@@ -22005,12 +22003,7 @@ fn resolve_leaf<'a, S: EvalSemantics>(
     let is_primitive = trackable
         && matches!(
             expr,
-            Expr::Identity
-                | Expr::Field(_)
-                | Expr::Index(_)
-                | Expr::IndexNumber { .. }
-                | Expr::Slice { .. }
-                | Expr::SliceNumber { .. }
+            Expr::Identity | Expr::Field(_) | Expr::Index { .. } | Expr::Slice { .. }
         );
 
     if is_primitive {
@@ -22319,7 +22312,13 @@ fn push_recursive_branches<'a>(
     match value {
         OwnedValue::Array(items) => {
             for (i, item) in items.iter().enumerate() {
-                let path = PathPrefix::extend(prefix, Expr::Index(i as i64));
+                let path = PathPrefix::extend(
+                    prefix,
+                    Expr::Index {
+                        idx: i as i64,
+                        key: None,
+                    },
+                );
                 push_recursive_branches(&path, item, trackable, out);
             }
         }
@@ -22797,7 +22796,7 @@ impl FoldRegister {
 /// logic rather than re-deriving it.
 ///
 /// **Gated on `any_subexpr` finding an actual navigation step
-/// (`Field`/`Index`/`IndexNumber`/`Slice`/`SliceNumber`/`Iterate`)
+/// (`Field`/`Index`/`Slice`/`Iterate`)
 /// anywhere in `source`** -- only such a step can ever reach one of
 /// `resolve_node`'s own raising arms in the first place, so a source with
 /// none (`range(n)`, `keys`, a literal, and critically `input`/`inputs`)
@@ -22888,12 +22887,7 @@ fn resolve_fold_source<S: EvalSemantics>(
     let has_navigation = any_subexpr(source, &mut |e| {
         matches!(
             e,
-            Expr::Field(_)
-                | Expr::Index(_)
-                | Expr::IndexNumber { .. }
-                | Expr::Slice { .. }
-                | Expr::SliceNumber { .. }
-                | Expr::Iterate
+            Expr::Field(_) | Expr::Index { .. } | Expr::Slice { .. } | Expr::Iterate
         )
     });
     if !has_navigation {
@@ -24495,20 +24489,15 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
         for (e, e_key) in ends {
             // #1326: a genuinely dynamic bound (unlike a literal one, which
             // the parser's own `fold_slice_bound` handles at parse time)
-            // keeps its float spelling the same way -- `Expr::SliceNumber`
-            // only when at least one side actually has a key to preserve,
-            // so an all-integer/absent-bound dynamic slice still produces
-            // the plain `Expr::Slice` every other match site already
-            // expects, unchanged.
-            let slice_expr = if s_key.is_some() || e_key.is_some() {
-                Expr::SliceNumber {
-                    start: *s,
-                    end: *e,
-                    start_key: s_key.clone(),
-                    end_key: e_key.clone(),
-                }
-            } else {
-                Expr::Slice { start: *s, end: *e }
+            // keeps its float spelling the same way -- each bound's key is
+            // carried only when that side actually has one, so an
+            // all-integer/absent-bound dynamic slice produces a `Slice`
+            // with both key fields `None`, exactly as before.
+            let slice_expr = Expr::Slice {
+                start: *s,
+                end: *e,
+                start_key: s_key.clone(),
+                end_key: e_key.clone(),
             };
             for PathBranch {
                 path: components,
@@ -25989,21 +25978,16 @@ fn substitute_var_impl(
         Expr::Env => Expr::Env,
         Expr::Identity => Expr::Identity,
         Expr::Field(name) => Expr::Field(name.clone()),
-        Expr::Index(i) => Expr::Index(*i),
-        Expr::IndexNumber { idx, key } => Expr::IndexNumber {
+        Expr::Index { idx, key } => Expr::Index {
             idx: *idx,
             key: key.clone(),
         },
-        Expr::Slice { start, end } => Expr::Slice {
-            start: *start,
-            end: *end,
-        },
-        Expr::SliceNumber {
+        Expr::Slice {
             start,
             end,
             start_key,
             end_key,
-        } => Expr::SliceNumber {
+        } => Expr::Slice {
             start: *start,
             end: *end,
             start_key: start_key.clone(),
@@ -27203,7 +27187,7 @@ fn eval_owned_fast_path<S: EvalSemantics>(
                 name,
             )),
         }),
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => Some(match input {
+        Expr::Index { idx, .. } => Some(match input {
             OwnedValue::Array(items) => {
                 let resolved = if *idx < 0 {
                     items.len() as i64 + idx
@@ -30407,11 +30391,11 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 ))
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, key } => {
             // Extend path with index, as written rather than as resolved
             // (#1088) -- see `index_component_value`.
             let mut new_path = current_path.to_vec();
-            new_path.push(index_component_value(*idx, first.index_number_key()));
+            new_path.push(index_component_value(*idx, key.as_ref()));
 
             // Get the element value
             if let OwnedValue::Array(arr) = value {
@@ -32420,21 +32404,25 @@ fn walk_path<S: EvalSemantics>(
                 optional,
             )?;
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, key } => {
             step_into::<S>(
                 expr,
-                index_component_value(*idx, expr.index_number_key()),
+                index_component_value(*idx, key.as_ref()),
                 value,
                 current_path,
                 out,
                 optional,
             )?;
         }
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
-            let (start_key, end_key) = expr.slice_number_keys();
+        Expr::Slice {
+            start,
+            end,
+            start_key,
+            end_key,
+        } => {
             step_into::<S>(
                 expr,
-                slice_component_value(*start, start_key, *end, end_key),
+                slice_component_value(*start, start_key.as_ref(), *end, end_key.as_ref()),
                 value,
                 current_path,
                 out,
@@ -33861,6 +33849,27 @@ impl DeleteTrieBuilder {
         }
     }
 
+    /// Get or create the child of `parent` reached by one array step.
+    ///
+    /// Shared by [`Self::child_of`]'s `Index` and `Slice` arms, which put
+    /// both step kinds in the same bucket on purpose -- see that arm's own
+    /// comment for why.
+    fn array_child(&mut self, parent: u32, step: ArrayStep, optional: bool) -> u32 {
+        let map = &self.trie.nodes[parent as usize].indices;
+        match map.get(&step) {
+            Some(&id) => {
+                self.trie.nodes[id as usize].optional |= optional;
+                id
+            }
+            None => {
+                let slot = map.len();
+                let id = self.push_node(parent, slot, false, optional);
+                self.trie.nodes[parent as usize].indices.insert(step, id);
+                id
+            }
+        }
+    }
+
     /// Get or create the child of `parent` reached by one atomic path step.
     ///
     /// Rejects any component shape the pre-#1690 `delete_expr_paths_at`'s dispatch
@@ -33900,30 +33909,19 @@ impl DeleteTrieBuilder {
             // `delete_trie_array` funnels every terminal key into a single
             // `delete_keys` call, and that one batch is what makes
             // overlapping ranges union instead of compound.
-            Expr::Index(_)
-            | Expr::IndexNumber { .. }
-            | Expr::Slice { .. }
-            | Expr::SliceNumber { .. } => {
-                let step = match component {
-                    Expr::Index(idx) | Expr::IndexNumber { idx, .. } => ArrayStep::Index(*idx),
-                    Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
-                        ArrayStep::Slice(*start, *end)
-                    }
-                    _ => unreachable!("outer match admitted only Index/Slice shapes"),
-                };
-                let map = &self.trie.nodes[parent as usize].indices;
-                match map.get(&step) {
-                    Some(&id) => {
-                        self.trie.nodes[id as usize].optional |= optional;
-                        id
-                    }
-                    None => {
-                        let slot = map.len();
-                        let id = self.push_node(parent, slot, false, optional);
-                        self.trie.nodes[parent as usize].indices.insert(step, id);
-                        id
-                    }
-                }
+            //
+            // #1401: each arm binds its own step directly. While `Index`
+            // and `Slice` were each a *pair* of variants this had to be one
+            // combined arm over four of them plus an inner re-match with an
+            // `unreachable!()` fallback -- and that fallback is exactly what
+            // a float-spelled index reached, from #1088 until #1326 added
+            // the missing arm. Folding the pairs away removes the shape
+            // that made the gap possible; #1827's
+            // `test_multi_target_del_reaches_array_step_dispatch_1827` is
+            // the test that covers this site.
+            Expr::Index { idx, .. } => self.array_child(parent, ArrayStep::Index(*idx), optional),
+            Expr::Slice { start, end, .. } => {
+                self.array_child(parent, ArrayStep::Slice(*start, *end), optional)
             }
             // See `needs_fanout_pass`'s doc comment for why a bare
             // `Expr::Iterate` can never reach a comma-grouped `del()` path
@@ -34798,7 +34796,7 @@ fn delete_at_path(
                 name,
             )),
         },
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match root {
+        Expr::Index { idx, .. } => match root {
             OwnedValue::Array(arr) => {
                 if let Some(actual_idx) = resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
                     arr.remove(actual_idx);
@@ -34841,7 +34839,7 @@ fn delete_at_path(
         // silently empty rather than an error — unlike the `Expr::Index` arm
         // above, jq does not refuse an out-of-range slice, so `[1,2,3] |
         // del(.[5:9])` is `[1,2,3]`.
-        Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => match root {
+        Expr::Slice { start, end, .. } => match root {
             OwnedValue::Array(arr) => {
                 let range = SliceBounds::from_literals(*start, *end).resolve(arr.len());
                 arr.drain(range);
@@ -34912,7 +34910,7 @@ fn delete_at_path(
                             name,
                         )),
                     },
-                    Expr::Index(idx) | Expr::IndexNumber { idx, .. } => match root {
+                    Expr::Index { idx, .. } => match root {
                         OwnedValue::Array(arr) => {
                             match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
                                 Some(actual_idx) => {
@@ -35063,9 +35061,7 @@ fn delete_at_path(
                     // `=`/`|=` assignment, where a slice write auto-vivifies
                     // `null` instead of no-op'ing (a separate, documented
                     // divergence — see docs/compliance/jq/limitations.md).
-                    Expr::Slice { .. } | Expr::SliceNumber { .. }
-                        if matches!(root, OwnedValue::Null) =>
-                    {
+                    Expr::Slice { .. } if matches!(root, OwnedValue::Null) => {
                         delete_at_path_through_absent(&rest, optional, yq_mode)
                     }
                     // `scalar_noop`/`container_noop: false` — del()'s own
@@ -35154,7 +35150,7 @@ fn delete_at_path(
                     // auto-vivifying a `null` slice target through #1873's
                     // arm -- a semantics never oracle-verified for `del()`
                     // -- with nothing here to catch it.
-                    Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. } => {
+                    Expr::Slice { start, end, .. } => {
                         through_slice(
                             root,
                             *start,
@@ -41103,21 +41099,16 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // Recursively expand in all subexpressions
         Expr::Identity => Expr::Identity,
         Expr::Field(s) => Expr::Field(s.clone()),
-        Expr::Index(i) => Expr::Index(*i),
-        Expr::IndexNumber { idx, key } => Expr::IndexNumber {
+        Expr::Index { idx, key } => Expr::Index {
             idx: *idx,
             key: key.clone(),
         },
-        Expr::Slice { start, end } => Expr::Slice {
-            start: *start,
-            end: *end,
-        },
-        Expr::SliceNumber {
+        Expr::Slice {
             start,
             end,
             start_key,
             end_key,
-        } => Expr::SliceNumber {
+        } => Expr::Slice {
             start: *start,
             end: *end,
             start_key: start_key.clone(),
@@ -41556,21 +41547,16 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         Expr::Env => Expr::Env,
         Expr::Identity => Expr::Identity,
         Expr::Field(name) => Expr::Field(name.clone()),
-        Expr::Index(i) => Expr::Index(*i),
-        Expr::IndexNumber { idx, key } => Expr::IndexNumber {
+        Expr::Index { idx, key } => Expr::Index {
             idx: *idx,
             key: key.clone(),
         },
-        Expr::Slice { start, end } => Expr::Slice {
-            start: *start,
-            end: *end,
-        },
-        Expr::SliceNumber {
+        Expr::Slice {
             start,
             end,
             start_key,
             end_key,
-        } => Expr::SliceNumber {
+        } => Expr::Slice {
             start: *start,
             end: *end,
             start_key: start_key.clone(),
@@ -42693,15 +42679,15 @@ mod tests {
         );
     }
 
-    /// #1932: `eval_single`'s `Expr::Slice`/`Expr::SliceNumber` arm, in the
+    /// #1932: `eval_single`'s `Expr::Slice` arm, in the
     /// `StandardJson::Array` case, used an unchecked `to_owned` per element
     /// instead of `promote_borrowed_checked` -- the same #1755 bug shape
     /// already fixed for the adjacent `StandardJson::Object` arm a few
     /// lines below, missed on the array arm at the time. Exercised via
     /// `eval.rs`'s own library-API dispatch (`query!`), not the CLI, same as
     /// #1755's sort/unique family above (see that test's own comment) --
-    /// `eval_generic.rs` has no native arm for a bare `Expr::Slice`/
-    /// `Expr::SliceNumber` either, so its own catch-all fallback reaches
+    /// `eval_generic.rs` has no native arm for a bare `Expr::Slice`
+    /// either, so its own catch-all fallback reaches
     /// this exact function too, but only *after* first materializing the
     /// whole target via its own already-checked `to_owned_with_cursor` and
     /// re-serializing it to fresh JSON bytes (`eval_generic.rs`'s `_ =>` arm
@@ -42815,7 +42801,7 @@ mod tests {
     /// arm) only ever forwards `optional: true` *directly* into a callee for
     /// that one dynamic-bounds index/slice shape. Every other spelling of
     /// `?` -- including a literal-bounds slice like `.[0:1]?` (which folds
-    /// to `Expr::Slice`/`Expr::SliceNumber`, not `Expr::SliceExpr`, so it
+    /// to `Expr::Slice`, not `Expr::SliceExpr`, so it
     /// doesn't take that bypass either) and Assign/Update/SetPath/
     /// Combinations, none of which are Index/Slice at all -- instead
     /// evaluates its inner expression with the *ambient* `optional` and
@@ -42837,10 +42823,7 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        let slice_expr = Expr::Slice {
-            start: None,
-            end: None,
-        };
+        let slice_expr = Expr::slice(None, None);
         match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), true) {
             QueryResult::None => {}
             other => panic!("expected None, got {other:?}"),
@@ -42851,7 +42834,7 @@ mod tests {
         }
     }
 
-    /// #2001: `eval_single`'s `Expr::Slice`/`Expr::SliceNumber` `Array` arm
+    /// #2001: `eval_single`'s `Expr::Slice` `Array` arm
     /// (available in both jq and yq mode, unlike the `Object` arm above,
     /// which is yq-only -- this arm has no `S::TAG` gate at all) has the
     /// identical gap the `Object` arm's own #1953 fix already closed --
@@ -42868,10 +42851,7 @@ mod tests {
         let json_bytes: &[u8] = br#"[{"x":1,"y"},2,3]"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        let slice_expr = Expr::Slice {
-            start: None,
-            end: Some(1),
-        };
+        let slice_expr = Expr::slice(None, Some(1));
         match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), true) {
             QueryResult::None => {}
             other => panic!("expected None, got {other:?}"),
@@ -46536,7 +46516,9 @@ mod tests {
         let result = match expr {
             Expr::Identity => QueryResult::One(cursor.value()),
             Expr::Field(name) => index_object_by_name::<Vec<u64>>(cursor.value(), name, optional),
-            Expr::Index(idx) => index_array_by_position::<Vec<u64>>(cursor.value(), *idx, optional),
+            Expr::Index { idx, .. } => {
+                index_array_by_position::<Vec<u64>>(cursor.value(), *idx, optional)
+            }
             other => unreachable!("via_cursor only covers Identity/Field/Index, got {other:?}"),
         };
         match result {
@@ -46585,14 +46567,14 @@ mod tests {
             // Index: in bounds, negative-from-end, out of bounds (positive
             // and negative), on null, on a type that cannot be
             // position-indexed at all (with and without `?`).
-            (Expr::Index(1), arr(), false),
-            (Expr::Index(-1), arr(), false),
-            (Expr::Index(10), arr(), false),
-            (Expr::Index(-10), arr(), false),
-            (Expr::Index(0), OwnedValue::Null, false),
-            (Expr::Index(0), OwnedValue::String("x".to_string()), true),
-            (Expr::Index(0), OwnedValue::String("x".to_string()), false),
-            (Expr::Index(0), obj(), false),
+            (Expr::index(1), arr(), false),
+            (Expr::index(-1), arr(), false),
+            (Expr::index(10), arr(), false),
+            (Expr::index(-10), arr(), false),
+            (Expr::index(0), OwnedValue::Null, false),
+            (Expr::index(0), OwnedValue::String("x".to_string()), true),
+            (Expr::index(0), OwnedValue::String("x".to_string()), false),
+            (Expr::index(0), obj(), false),
         ];
 
         for (expr, input, optional) in cases {
@@ -62512,13 +62494,10 @@ mod tests {
         let steps = [
             Expr::Field("a".to_string()),
             Expr::Iterate,
-            Expr::Index(0),
+            Expr::index(0),
             Expr::Optional(Box::new(Expr::Iterate)),
             Expr::Field("b".to_string()),
-            Expr::Slice {
-                start: None,
-                end: None,
-            },
+            Expr::slice(None, None),
         ];
         let suffix = iterate_suffix_len(&steps);
         for cut in 0..=steps.len() {
@@ -62534,7 +62513,7 @@ mod tests {
         // what `usize::MAX` buys -- a sentinel no `rest.len()` can reach.
         let none = [
             Expr::Field("a".to_string()),
-            Expr::Index(0),
+            Expr::index(0),
             Expr::Field("b".to_string()),
         ];
         assert_eq!(iterate_suffix_len(&none), usize::MAX);
@@ -63117,12 +63096,12 @@ mod tests {
         );
 
         let mut root = OwnedValue::Null;
-        set_path::<JqSemantics>(&mut root, &Expr::Index(0), OwnedValue::Int(1), false, false)
+        set_path::<JqSemantics>(&mut root, &Expr::index(0), OwnedValue::Int(1), false, false)
             .unwrap();
         assert_eq!(root, OwnedValue::Array(vec![OwnedValue::Int(1)]));
 
         let mut root = OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
-        set_path::<JqSemantics>(&mut root, &Expr::Index(4), OwnedValue::Int(9), false, false)
+        set_path::<JqSemantics>(&mut root, &Expr::index(4), OwnedValue::Int(9), false, false)
             .unwrap();
         assert_eq!(
             root,
@@ -67315,8 +67294,8 @@ mod tests {
             }
         );
         // A whole-valued float bound *does* fold at parse time, exercising
-        // the static `Expr::SliceNumber` path instead -- both routes must
-        // agree.
+        // the static `Expr::Slice`-with-keys path instead -- both routes
+        // must agree.
         query!(br"[1,2,3,4,5]", r"path(.[1.0:3.0])",
             QueryResult::Owned(v) => {
                 assert_eq!(v.to_json(), r#"[{"start":1.0,"end":3.0}]"#);
@@ -67384,10 +67363,10 @@ mod tests {
         );
     }
 
-    /// #1326: `Expr::SliceNumber` needs a rebuild arm in every AST walker
-    /// that reconstructs a filter's body, the same way #1088 already added
-    /// one for `Expr::IndexNumber` -- `substitute_var` (`E as $x | body`),
-    /// `expand_func_calls` (inlining a `def`), and `substitute_func_param`
+    /// #1326: a slice's preserved bound keys need to survive every AST
+    /// walker that reconstructs a filter's body, the same way #1088's index
+    /// key already did -- `substitute_var` (`E as $x | body`),
+    /// `install_def_calls` (binding a `def`), and `substitute_func_param`
     /// (substituting a parameterized `def`'s own argument). Each jq-level
     /// case here is end-to-end correct (oracle-verified against real jq
     /// 1.7.1), but doesn't exercise these three functions' own rebuild
@@ -67414,16 +67393,18 @@ mod tests {
         );
     }
 
-    /// #1326: direct calls into `substitute_var`/`expand_func_calls`/
-    /// `substitute_func_param` with a hand-built `Expr::SliceNumber`,
-    /// pinning each walker's own rebuild arm regardless of whether any
-    /// particular jq-level construct happens to route through it today --
-    /// a `def`/`as`-bound body containing a bare `Expr::SliceNumber` is
-    /// exactly the shape each function's own doc comment describes
-    /// walking past.
+    /// #1326: direct calls into `substitute_var`/`install_def_calls`/
+    /// `substitute_func_param` with a hand-built key-carrying
+    /// [`Expr::Slice`], pinning each walker's own rebuild arm regardless of
+    /// whether any particular jq-level construct happens to route through
+    /// it today -- a `def`/`as`-bound body containing such a slice is
+    /// exactly the shape each function's own doc comment describes walking
+    /// past. #1401 folded the former `SliceNumber` into `Slice`, which is
+    /// why one arm now covers both spellings; the clone-through of
+    /// `start_key`/`end_key` is what this still pins.
     #[test]
     fn test_ast_rebuild_walkers_clone_slice_number_directly_1326() {
-        let slice_number = Expr::SliceNumber {
+        let slice_number = Expr::Slice {
             start: Some(1),
             end: Some(3),
             start_key: Some(NumberKey::Literal(1.5, "1.5".into())),
@@ -67455,7 +67436,7 @@ mod tests {
     /// `nth(n; expr)` always parses through `Builtin::NthStream` instead (see
     /// `eval_nth_expr_n_argument_propagates_halt`'s doc comment) -- so
     /// `install_def_calls`'s own rebuild arm for it can only be reached by a
-    /// direct call. Unlike `Expr::SliceNumber` above (a leaf `install_def_calls`
+    /// direct call. Unlike `Expr::Slice` above (a leaf `install_def_calls`
     /// just clones), `NthExpr` carries two sub-expressions it must actually
     /// recurse into: both `n` and `expr` need their own call to `f` rewritten
     /// to a `DefCall`, not silently left as an unresolvable `FuncCall`.
@@ -67539,34 +67520,36 @@ mod tests {
         builder.finish()
     }
 
-    /// #1326 review: adding `Expr::SliceNumber` alongside `Expr::Slice` in
-    /// the array walker's error-construction match exposed that
-    /// `Expr::IndexNumber` had no arm of its own there either -- a
-    /// pre-existing #1088 gap (a float-spelled index reaching this path
-    /// would have hit the catch-all `unreachable!()` instead of the same
-    /// error `Expr::Index` gets), closed as a byproduct rather than a
-    /// deliberate target. Called directly rather than through a jq query:
-    /// `5 | del(.[2.0])`-shaped repros exit through a different,
+    /// #1326 review: adding a sibling slice variant alongside `Expr::Slice`
+    /// in the array walker's error-construction match exposed that the
+    /// then-separate `Expr::IndexNumber` had no arm of its own there
+    /// either -- a pre-existing #1088 gap (a float-spelled index reaching
+    /// this path would have hit the catch-all `unreachable!()` instead of
+    /// the same error a plain index gets), closed as a byproduct rather
+    /// than a deliberate target. Called directly rather than through a jq
+    /// query: `5 | del(.[2.0])`-shaped repros exit through a different,
     /// higher-level dispatch before ever reaching this specific match.
+    ///
     /// (#1690 moved the match from `delete_expr_array_paths` to
-    /// `delete_trie_array`; the arm and its wording are unchanged, and
-    /// `ArrayStep` collapses the `Index`/`IndexNumber` pair into one key
-    /// before it, which is what this asserts.)
+    /// `delete_trie_array`. #1401 then folded the paired variants away, so
+    /// the missing-arm shape this guards can no longer be written -- what
+    /// stays asserted is that a float-spelled index still collapses to the
+    /// same `ArrayStep` key, and so reports the same error.)
     #[test]
     fn test_delete_expr_array_paths_reports_index_number_like_plain_index_1326() {
-        let trie = one_step_trie(Expr::IndexNumber {
+        let trie = one_step_trie(Expr::Index {
             idx: 2,
-            key: NumberKey::Literal(2.0, "2.0".into()),
+            key: Some(NumberKey::Literal(2.0, "2.0".into())),
         });
         let err = delete_trie_array(OwnedValue::Int(5), &trie, DELETE_TRIE_ROOT, false)
             .expect_err("not an array");
         assert_eq!(err.message, "Cannot index number with number");
     }
 
-    /// #1827: the sibling of `test_delete_expr_array_paths_reports_index_number_like_plain_index_1326`
-    /// for the `Slice`/`SliceNumber` pair -- the same match's two `Slice { .. }
-    /// | Expr::SliceNumber { .. }` arms (one `if`-gated on a `String` value, one
-    /// not) had no direct test coverage at all before this, for either sibling.
+    /// #1827: the slice-bound sibling of
+    /// `test_delete_expr_array_paths_reports_index_number_like_plain_index_1326`
+    /// -- the same match's two slice arms (one `if`-gated on a `String`
+    /// value, one not) had no direct test coverage at all before this.
     /// Same reachability caveat as #1326's own test: called directly, since a
     /// parsed `del(.[1.0:3], .[3])`-shaped query exits through a different,
     /// higher-level dispatch before ever reaching this specific match (verified
@@ -67574,7 +67557,7 @@ mod tests {
     /// asserted here).
     #[test]
     fn test_delete_expr_array_paths_reports_slice_number_like_plain_slice_1827() {
-        let trie = one_step_trie(Expr::SliceNumber {
+        let trie = one_step_trie(Expr::Slice {
             start: Some(1),
             end: Some(3),
             start_key: Some(NumberKey::Literal(1.0, "1.0".into())),
@@ -67604,15 +67587,12 @@ mod tests {
     /// treats as a hard arity error, not a no-op.
     #[test]
     fn test_delete_trie_array_yq_mode_noop_scoped_to_index_step_2106() {
-        let index_trie = one_step_trie(Expr::Index(0));
+        let index_trie = one_step_trie(Expr::index(0));
         let value = delete_trie_array(OwnedValue::Int(5), &index_trie, DELETE_TRIE_ROOT, true)
             .expect("index step scalar no-op in yq mode");
         assert_eq!(value, OwnedValue::Int(5));
 
-        let slice_trie = one_step_trie(Expr::Slice {
-            start: Some(1),
-            end: Some(3),
-        });
+        let slice_trie = one_step_trie(Expr::slice(Some(1), Some(3)));
         let err = delete_trie_array(OwnedValue::Int(5), &slice_trie, DELETE_TRIE_ROOT, true)
             .expect_err("slice step must still error even in yq mode");
         assert_eq!(err.message, "Cannot index number with object");

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3891,12 +3891,10 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // away, which is why the arm below still probes
         // (#1599 -- #1514 moved the probe off the guard, but
         // left this spelling paying it).
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted && *idx == 0 => {
-            match fields.uncons_key() {
-                Some((_, key_cursor, _)) => GenericResult::OneCursor(key_cursor),
-                None => GenericResult::Owned(OwnedValue::Null),
-            }
-        }
+        Expr::Index { idx, .. } if !sorted && *idx == 0 => match fields.uncons_key() {
+            Some((_, key_cursor, _)) => GenericResult::OneCursor(key_cursor),
+            None => GenericResult::Owned(OwnedValue::Null),
+        },
         // #1629: a negative index always has to walk the whole object
         // anyway (to normalize against its length), so the #1194 check
         // rides along for free -- same reasoning as `Expr::Iterate` above,
@@ -3909,7 +3907,7 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // bad member (verified live against pinned jq 1.7.1:
         // `{"a":1,"b":2,123:3} | keys_unsorted[0]` raises the same parse
         // error as `keys_unsorted[2]` would).
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted && *idx < 0 => {
+        Expr::Index { idx, .. } if !sorted && *idx < 0 => {
             match distinct_key_cursors_checked::<V>(&fields, collapse) {
                 Ok(cursors) => {
                     let target = usize::try_from(cursors.len() as i64 + idx).ok();
@@ -3930,7 +3928,7 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         // unchecked, same as `Builtin::First`/`.[0]` below -- see #1629's
         // own accounting of this tradeoff (its "Option 1") and
         // `docs/compliance/jq/limitations.md`.
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } if !sorted => {
+        Expr::Index { idx, .. } if !sorted => {
             let collapsed = collapsed_fields_if(&fields, collapse);
             if let Some(eff) = collapsed {
                 match eff.into_iter().nth(*idx as usize) {
@@ -4047,7 +4045,7 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
                 GenericResult::ManyOwned((0..len).map(|i| OwnedValue::Int(i as i64)).collect())
             }
         }
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, .. } => {
             // Same normalization/OOB-is-null semantics as
             // `LazyKeys`'s `Expr::Index` arm above.
             let target = if *idx < 0 {
@@ -4094,7 +4092,7 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
 /// arm (#1565); see [`fold_lazy_keys_stage`]'s own doc comment for why this
 /// split exists. `fold_pipe_stages_sink` intercepts `Expr::Iterate` before
 /// ever calling this function, but every *other* stage shape here --
-/// including `Expr::Builtin(Builtin::First) | Expr::Index(0)`'s own
+/// including `Expr::Builtin(Builtin::First) | Expr::index(0)`'s own
 /// pull-one-and-stop fast path -- is identical between the eager and
 /// demand-aware callers, since none of them fan out beyond the single `seq`
 /// they were already holding.
@@ -4195,7 +4193,23 @@ fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
         // don't affect the requested output, and an error on
         // a skipped element is one such element. Pinned by
         // `test_generic_lazy_seq_first_after_map_skips_later_error_725`.
-        Expr::Builtin(Builtin::First) | Expr::Index(0) => match seq.next() {
+        // #1401: `key: None` rather than `..` on purpose -- this arm is
+        // deliberately restricted to the *integer* spelling of `.[0]`.
+        //
+        // The fold that merged `IndexNumber` into `Index` would otherwise
+        // silently widen it: pre-fold this read `Expr::Index(0)`, which a
+        // float-spelled `.[0.0]` could not match, so `.[0.0]` fell through
+        // to the eager evaluator and *did* raise the later element's error
+        // (matching jq 1.7.1). Taking this path instead would suppress it,
+        // spreading the deliberate-but-divergent #725 skip to one more
+        // spelling -- the wrong direction under ADR-0018, which permits a
+        // divergence only where matching jq is impossible.
+        //
+        // That leaves `.[0]` and `.[0.0]` genuinely disagreeing here, which
+        // is the drift class #1401/#1827 exist to surface rather than one
+        // this refactor should quietly resolve either way -- filed as #2174.
+        // The real fix is to stop diverging on #725, not to diverge twice.
+        Expr::Builtin(Builtin::First) | Expr::Index { idx: 0, key: None } => match seq.next() {
             None => GenericResult::Owned(OwnedValue::Null),
             Some(Ok(LazyElem::Cursor(c))) => GenericResult::OneCursor(c),
             Some(Ok(LazyElem::Owned(o))) => GenericResult::Owned(o),
@@ -4849,7 +4863,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
-        Expr::Index(idx) | Expr::IndexNumber { idx, .. } => {
+        Expr::Index { idx, .. } => {
             if let Some(elements) = value.as_array() {
                 let len = elements.len();
                 let actual_idx = if *idx < 0 {
@@ -4874,7 +4888,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // No `optional`-guarded arm here (unlike `index_one_generic`,
                 // the computed-key sibling this literal `.[N]` form doesn't
                 // share code with): `.[N]?` parses straight to
-                // `Expr::Optional(Expr::Index(N))`, which isn't
+                // `Expr::Optional(Expr::index(N))`, which isn't
                 // `IndexExpr`/`SliceExpr`, so #693's dispatch never forces
                 // `optional = true` into this arm — it evaluates `Expr::
                 // Index` at the ambient `optional` (normally `false`) and
@@ -8681,7 +8695,7 @@ fn path_expr_is_cursor_navigable(expr: &Expr) -> bool {
         // A negative index needs no array length: `path(.[-1])` is `[-1]`
         // verbatim in both jq and succinctly today (verified live), so the
         // sign costs nothing here.
-        Expr::Index(_) | Expr::IndexNumber { .. } => true,
+        Expr::Index { .. } => true,
         Expr::Paren(inner) | Expr::Optional(inner) => path_expr_is_cursor_navigable(inner),
         Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_expr_is_cursor_navigable),
         _ => false,
@@ -8854,16 +8868,18 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
             out.push((p, next));
             Ok(())
         }
-        Expr::Index(_) | Expr::IndexNumber { .. } => {
+        Expr::Index { idx, key } => {
             // The component is reported with its own source spelling
-            // (`path(.[2.0])` is `[2.0]`, not `[2]` -- #1088), which only
-            // `IndexNumber` carries. `index_component_value` is `eval.rs`'s
-            // own renderer for exactly this, shared rather than re-derived.
-            let (idx, key) = match expr {
-                Expr::Index(i) => (*i, None),
-                Expr::IndexNumber { idx, key } => (*idx, Some(key)),
-                _ => unreachable!("guarded by the match arm above"),
-            };
+            // (`path(.[2.0])` is `[2.0]`, not `[2]` -- #1088), carried by
+            // `key` when the literal had one. `index_component_value` is
+            // `eval.rs`'s own renderer for exactly this, shared rather than
+            // re-derived.
+            //
+            // #1401: `idx`/`key` bind straight from the arm. While this was
+            // a *pair* of variants the arm could not bind them, so it
+            // re-matched over both with an `unreachable!()` fallback -- the
+            // same shape that let a missing arm slip through twice.
+            let (idx, key) = (*idx, key.as_ref());
             let next = match node {
                 PathNode::Absent => PathNode::Absent,
                 PathNode::At(c) => {
@@ -9022,7 +9038,7 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_is_cursor_walkable(expr: &Expr) -> bool {
     match expr {
         Expr::Identity | Expr::Iterate | Expr::Field(_) => true,
-        Expr::Index(_) | Expr::IndexNumber { .. } => true,
+        Expr::Index { .. } => true,
         Expr::Paren(inner) | Expr::Array(inner) => path_context_is_cursor_walkable(inner),
         Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_context_is_cursor_walkable),
         Expr::Builtin(Builtin::PathNoArg | Builtin::Key | Builtin::Parent) => true,
@@ -9202,7 +9218,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             Ok(())
         }
         Expr::Paren(inner) => path_context_step_generic::<S, V>(inner, pos, out),
-        Expr::Field(_) | Expr::Index(_) | Expr::IndexNumber { .. } | Expr::Iterate => {
+        Expr::Field(_) | Expr::Index { .. } | Expr::Iterate => {
             let mut heads = Vec::new();
             // `true`, not `S::COLLAPSE_DUPLICATE_KEYS`: the bridge this
             // replaces materializes the document into an
@@ -11024,7 +11040,7 @@ mod tests {
         let cursor = index.root(json);
         let value = cursor.value();
 
-        let result = eval(&Expr::Index(1), value);
+        let result = eval(&Expr::index(1), value);
         let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::Int(2));
@@ -12345,7 +12361,7 @@ mod tests {
     #[test]
     fn test_generic_lazy_seq_first_after_map_skips_later_error_725() {
         // Accepted, deliberate divergence from real jq (see the
-        // `Expr::Builtin(Builtin::First) | Expr::Index(0)` arm's own doc
+        // `Expr::Builtin(Builtin::First) | Expr::index(0)` arm's own doc
         // comment above `eval_single`'s `Pipe` fold): real jq's `map`
         // eagerly builds the whole array first, so `map(f)|first` errors if
         // *any* element fails, even ones past the first. `first`/`.[0]`'s
@@ -12563,7 +12579,7 @@ mod tests {
         // .users | .[0] | .name
         let expr = Expr::Pipe(vec![
             Expr::Field("users".to_string()),
-            Expr::Index(0),
+            Expr::index(0),
             Expr::Field("name".to_string()),
         ]);
 
@@ -13025,7 +13041,7 @@ mod tests {
             .expect("YAML document should have content");
         let value = seq_cursor.value();
 
-        let result = eval(&Expr::Index(1), value);
+        let result = eval(&Expr::index(1), value);
         let owned = result.into_owned().unwrap().unwrap();
 
         assert_eq!(owned, OwnedValue::Int(2));
@@ -13901,7 +13917,7 @@ mod tests {
         // .users | .[0] | .name
         let expr = Expr::Pipe(vec![
             Expr::Field("users".to_string()),
-            Expr::Index(0),
+            Expr::index(0),
             Expr::Field("name".to_string()),
         ]);
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -26,69 +26,59 @@ pub enum Expr {
     /// Field access: `.foo`
     Field(String),
 
-    /// Array index access: `.[0]` or `.[-1]`
-    Index(i64),
-
-    /// Array index access whose *original number* has to survive into
-    /// `path()` output: `.[2.0]`, `.[1.7]`, `.[1e10]`, `.[2.00]`.
+    /// Array index access: `.[0]`, `.[-1]`, `.[2.0]`.
+    ///
+    /// `idx` is what every step that *navigates* — reading, `setpath`,
+    /// `del` — actually uses (the truncation-toward-zero
+    /// `numeric_key_to_index` applies). `key` carries the number the
+    /// component reports itself as in `path()` output when that differs
+    /// from `idx`'s own rendering, and is `None` otherwise.
     ///
     /// jq appends the resolved key **verbatim** as the path component, so a
     /// number that still carries its own spelling keeps it —
     /// `path(.[2.0])` is `[2.0]` and `path(.[1e10])` is `[1E+10]`, not
-    /// `[2]`/`[10000000000]` (#1088). [`Expr::Index`]'s bare `i64` has
-    /// nowhere to put that, so a float-spelled key folds to this instead.
+    /// `[2]`/`[10000000000]` (#1088). An integer-*spelled* key renders
+    /// identically whether it goes out as `OwnedValue::Int` or as its own
+    /// literal, so it carries no `key` at all and the hot `.foo.bar[0]`
+    /// path is untouched. Nor does a negated one — see [`NumberKey`].
     ///
-    /// `idx` is exactly the `i64` [`Expr::Index`] would have carried (the
-    /// same truncation-toward-zero `numeric_key_to_index` applies), and
-    /// every step that *navigates* — reading, `setpath`, `del` — uses it
-    /// and behaves identically. Only the rendering of the component
-    /// differs, which is why nearly every match site pairs the two arms:
-    /// `Expr::Index(idx) | Expr::IndexNumber { idx, .. }`.
-    ///
-    /// An integer-*spelled* key never reaches here: `2` renders the same
-    /// whether it goes out as `OwnedValue::Int` or as its own literal, so
-    /// it keeps folding to [`Expr::Index`] and the hot `.foo.bar[0]` path
-    /// is untouched. Nor does a negated one — see [`NumberKey`].
-    IndexNumber {
+    /// **A key that needs preserving belongs in a field here, not in a
+    /// sibling variant.** #1088 originally added an `Expr::IndexNumber`
+    /// beside this one and #1326 repeated the shape for slices; every site
+    /// asking "is this an index component" then had to spell out both
+    /// members of the pair, and one that forgot got an `unreachable!()`
+    /// instead of an answer — twice. #1401 folded them back in, which is
+    /// what makes that failure mode unrepresentable rather than merely
+    /// tested for.
+    Index {
         /// The index every navigation step actually uses.
         idx: i64,
-        /// The number the component is reported as.
-        key: NumberKey,
+        /// The number the component is reported as, when it kept a spelling
+        /// of its own that `idx` cannot render.
+        key: Option<NumberKey>,
     },
 
-    /// Array slice: `.[2:5]` or `.[2:]` or `.[:5]`
+    /// Array slice: `.[2:5]`, `.[2:]`, `.[:5]`, `.[1.5:3.5]`.
+    ///
+    /// `start`/`end` are what every step that *navigates* — reading,
+    /// `setpath`, `del` — actually uses (`fold_slice_bound` folds each).
+    /// `start_key`/`end_key` carry the number each bound reports itself as
+    /// in `path()` output when that differs, independently: a slice with
+    /// one float-spelled bound and one absent/plain bound (`.[1.5:]`,
+    /// `.[1.5:3]`) carries a key for that bound only, never a synthesized
+    /// one for the other.
+    ///
+    /// jq appends each resolved bound **verbatim** as the path component,
+    /// so a bound that still carries its own spelling keeps it --
+    /// `path(.[1.5:3.5])` is `[{"start":1.5,"end":3.5}]`, not
+    /// `[{"start":1,"end":4}]` (#1326, following on from #1088). A slice
+    /// whose bounds are both integer-spelled or absent carries no key at
+    /// all, and the hot `.foo.bar[1:3]` path is untouched. Nor does a
+    /// negated bound (`.[-1.5:]`) — see [`NumberKey`].
+    ///
+    /// See [`Expr::Index`] for why these keys live here rather than in a
+    /// sibling `SliceNumber` variant (#1401).
     Slice {
-        start: Option<i64>,
-        end: Option<i64>,
-    },
-
-    /// Array slice whose *original number* has to survive into `path()`
-    /// output for at least one bound: `.[1.5:3.5]`, `.[1.0:3]`, `.[:3.00]`.
-    ///
-    /// The slice-bound sibling of [`Expr::IndexNumber`] (#1326, following
-    /// on from #1088): jq appends each resolved bound **verbatim** as the
-    /// path component, so a bound that still carries its own spelling keeps
-    /// it -- `path(.[1.5:3.5])` is `[{"start":1.5,"end":3.5}]`, not
-    /// `[{"start":1,"end":4}]`. [`Expr::Slice`]'s bare `Option<i64>` pair has
-    /// nowhere to put that, so a slice with at least one float-spelled bound
-    /// folds to this instead.
-    ///
-    /// `start`/`end` are exactly the `Option<i64>` pair [`Expr::Slice`]
-    /// would have carried (the same bound-folding `fold_slice_bound`
-    /// applies to each), and every step that *navigates* — reading,
-    /// `setpath`, `del` — uses them and behaves identically. Only the
-    /// rendering of the path component differs, which is why nearly every
-    /// match site pairs the two arms:
-    /// `Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. }`.
-    ///
-    /// A bound is only ever carried here when *its own* `NumberKey` is
-    /// `Some` — a slice with one float-spelled bound and one absent/plain
-    /// bound (`.[1.5:]`, `.[1.5:3]`) still reaches here with the other
-    /// key field `None`, not a synthesized one. A slice whose bounds are
-    /// *both* integer-spelled or absent never reaches here at all: it keeps
-    /// folding to plain [`Expr::Slice`], and the hot `.foo.bar[1:3]` path is
-    /// untouched. Nor does a negated bound (`.[-1.5:]`) — see [`NumberKey`].
-    SliceNumber {
         /// The start bound every navigation step actually uses.
         start: Option<i64>,
         /// The end bound every navigation step actually uses.
@@ -125,7 +115,8 @@ pub enum Expr {
     /// this errors at the source instead.
     ///
     /// A float key is *not* on that list any more: it keeps its own
-    /// spelling in `path()` output, via [`Expr::IndexNumber`] (#1088).
+    /// spelling in `path()` output, via [`Expr::Index`]'s own `key` field
+    /// (#1088).
     IndexExpr {
         /// The value being indexed — the postfix chain so far.
         target: Box<Self>,
@@ -143,9 +134,8 @@ pub enum Expr {
     /// [`Expr::Pipe`]. `S` is evaluated outer, `T` middle, `E` inner.
     ///
     /// A bound that fully folds to a constant never reaches here: the parser
-    /// keeps producing a static [`Expr::Slice`]/[`Expr::SliceNumber`]
-    /// whenever *both* present bounds are constant (#1326), so the existing
-    /// fast paths and every match site pairing those two are untouched.
+    /// keeps producing a static [`Expr::Slice`] whenever *both* present
+    /// bounds are constant (#1326), so the existing fast paths are untouched.
     SliceExpr {
         /// The value being sliced — the postfix chain so far.
         target: Box<Self>,
@@ -1470,7 +1460,8 @@ pub enum ObjectKey {
     Expr(Box<Expr>),
 }
 
-/// The number an [`Expr::IndexNumber`] component is reported as by `path()`.
+/// The number an [`Expr::Index`]/[`Expr::Slice`] component is reported as by
+/// `path()`, when it kept a spelling its own `i64` cannot render.
 ///
 /// jq's rule for a numeric path component is that there is no rule: the
 /// resolved key value is appended unchanged, so whatever spelling it still
@@ -1560,44 +1551,14 @@ pub enum Literal {
 }
 
 impl Expr {
-    /// The number this static array-index component reports itself as in
-    /// `path()` output, if it is anything other than its own `i64`.
+    /// Whether this is a static slice path component.
     ///
-    /// Exists so the `Expr::Index(idx) | Expr::IndexNumber { idx, .. }`
-    /// or-pattern stays a *single* arm at the three sites that render a
-    /// path component: they bind `idx` from the pattern and ask for the
-    /// spelling separately, instead of duplicating the body once per
-    /// variant (#1088).
-    pub(crate) fn index_number_key(&self) -> Option<&NumberKey> {
-        match self {
-            Self::IndexNumber { key, .. } => Some(key),
-            _ => None,
-        }
-    }
-
-    /// The numbers this static slice component's two bounds report
-    /// themselves as in `path()` output, if either is anything other than
-    /// its own `i64` -- the slice-bound sibling of [`Self::index_number_key`]
-    /// (#1326), for the same reason: keeps the
-    /// `Expr::Slice { start, end } | Expr::SliceNumber { start, end, .. }`
-    /// or-pattern a single arm at the sites that render a path component.
-    pub(crate) fn slice_number_keys(&self) -> (Option<&NumberKey>, Option<&NumberKey>) {
-        match self {
-            Self::SliceNumber {
-                start_key, end_key, ..
-            } => (start_key.as_ref(), end_key.as_ref()),
-            _ => (None, None),
-        }
-    }
-
-    /// Whether this is a slice path component, `Expr::Slice` or its
-    /// float-bound sibling `Expr::SliceNumber` (#1326) -- one definition for
-    /// the callers that only need "is this a slice", so a boolean-only check
-    /// doesn't hand-copy the two-variant or-pattern a match arm that also
-    /// needs `start`/`end` still has to spell out itself (CLAUDE.md:
-    /// "duplicated predicates diverge silently", #106).
+    /// One definition for the callers that only need "is this a slice", so
+    /// a boolean-only check doesn't hand-copy a pattern that the match arms
+    /// needing `start`/`end` spell out themselves (CLAUDE.md: "duplicated
+    /// predicates diverge silently", #106).
     pub(crate) fn is_slice(&self) -> bool {
-        matches!(self, Self::Slice { .. } | Self::SliceNumber { .. })
+        matches!(self, Self::Slice { .. })
     }
 
     /// Create an identity expression.
@@ -1612,7 +1573,7 @@ impl Expr {
 
     /// Create an index expression.
     pub fn index(i: i64) -> Self {
-        Self::Index(i)
+        Self::Index { idx: i, key: None }
     }
 
     /// Create an iterate expression.
@@ -1630,7 +1591,12 @@ impl Expr {
 
     /// Create a slice expression.
     pub fn slice(start: Option<i64>, end: Option<i64>) -> Self {
-        Self::Slice { start, end }
+        Self::Slice {
+            start,
+            end,
+            start_key: None,
+            end_key: None,
+        }
     }
 
     /// Create a computed-bounds slice expression: `target[start:end]`.
@@ -1846,56 +1812,92 @@ mod tests {
     fn test_expr_constructors() {
         assert_eq!(Expr::identity(), Expr::Identity);
         assert_eq!(Expr::field("foo"), Expr::Field("foo".into()));
-        assert_eq!(Expr::index(0), Expr::Index(0));
+        assert_eq!(Expr::index(0), Expr::Index { idx: 0, key: None });
         assert_eq!(Expr::iterate(), Expr::Iterate);
         assert_eq!(
             Expr::slice(Some(1), Some(3)),
             Expr::Slice {
                 start: Some(1),
-                end: Some(3)
+                end: Some(3),
+                start_key: None,
+                end_key: None,
             }
         );
     }
 
-    /// #1827: pins the three shared predicates' own classification of each
-    /// paired family's two members, so a future edit to `is_slice()`/
-    /// `index_number_key()`/`slice_number_keys()` cannot silently start
-    /// treating a plain/`*Number` pair differently. This alone does not
-    /// catch a *third* future paired variant, or a dispatch site elsewhere
-    /// that skips these predicates and pattern-matches the pair by hand
-    /// (most sites do, via the `Expr::Index(idx) | Expr::IndexNumber {
-    /// idx, .. }` or-pattern) — see
-    /// `test_index_and_slice_number_siblings_behave_identically_1827` in
-    /// `tests/jq_index_number_invariant_tests.rs` for the end-to-end
-    /// behavioral check that covers those sites instead.
+    /// #1827/#1401: pins that a float-spelled component is classified
+    /// exactly as its plain counterpart by every shared predicate, and that
+    /// the preserved spelling is the *only* thing that differs.
+    ///
+    /// Before #1401 this pinned two *pairs* of variants
+    /// (`Index`/`IndexNumber`, `Slice`/`SliceNumber`) against each other,
+    /// because a site could handle one member and forget the sibling — the
+    /// `delete_expr_array_paths` bug #1827 exists to catch. Folding the
+    /// keys onto the surviving variants made that unrepresentable, so what
+    /// is left to pin is the classification itself. The end-to-end
+    /// behavioural equivalence of the two spellings across the dispatch
+    /// sites lives in `tests/jq_index_number_invariant_tests.rs`.
     #[test]
-    fn test_index_and_slice_number_pairs_share_predicate_classification_1827() {
-        let index = Expr::Index(1);
-        let index_number = Expr::IndexNumber {
+    fn test_float_spelled_components_classify_as_plain_ones_1827() {
+        let index = Expr::Index { idx: 1, key: None };
+        let index_number = Expr::Index {
             idx: 1,
-            key: NumberKey::Literal(1.0, "1.0".into()),
+            key: Some(NumberKey::Literal(1.0, "1.0".into())),
         };
-        assert_eq!(index.index_number_key(), None);
-        assert!(matches!(index_number.index_number_key(), Some(k) if k.value() == 1.0));
         assert!(!index.is_slice());
         assert!(!index_number.is_slice());
+        assert!(matches!(index, Expr::Index { idx: 1, key: None }));
+        assert!(matches!(
+            &index_number,
+            Expr::Index { idx: 1, key: Some(k) } if k.value() == 1.0
+        ));
 
         let slice = Expr::Slice {
             start: Some(1),
             end: Some(3),
+            start_key: None,
+            end_key: None,
         };
-        let slice_number = Expr::SliceNumber {
+        let slice_number = Expr::Slice {
             start: Some(1),
             end: Some(3),
             start_key: Some(NumberKey::Literal(1.0, "1.0".into())),
             end_key: None,
         };
-        assert_eq!(slice.slice_number_keys(), (None, None));
-        let (start_key, end_key) = slice_number.slice_number_keys();
-        assert!(matches!(start_key, Some(k) if k.value() == 1.0));
-        assert_eq!(end_key, None);
         assert!(slice.is_slice());
         assert!(slice_number.is_slice());
+        // A bound only ever carries its *own* key: the plain `end` bound
+        // stays `None` rather than getting a synthesized spelling.
+        assert!(matches!(
+            &slice_number,
+            Expr::Slice { start_key: Some(k), end_key: None, .. } if k.value() == 1.0
+        ));
+    }
+
+    /// #1401: pins `Expr`'s footprint, so the next variant that grows it
+    /// has to say so in a diff rather than land unmeasured.
+    ///
+    /// #1088 and #1326 each added a variant that widened this enum, and the
+    /// cost only surfaced when #1401 went looking for it afterwards.
+    /// `Expr` is stored by value throughout (`Vec<Self>` in `Pipe`/`Comma`/
+    /// `FuncCall` args) and deep-cloned per binding by `substitute_var`, so
+    /// the width is paid by programs that never use the widening variant.
+    ///
+    /// 96 bytes is currently held jointly by `Slice` (16 + 16 + 32 + 32)
+    /// and `FuncDef` (24 + 24 + 8 + 8 + 24, since #2094's `bound` cache) —
+    /// so shrinking either one alone does not move this number. Re-measure
+    /// with `cargo +nightly rustc --features cli --lib -- -Zprint-type-sizes`
+    /// before changing it. Same 64-bit gate as `EvalError`'s own pin
+    /// (`src/jq/error.rs`), for the same reason.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_expr_size_is_pinned_1401() {
+        assert_eq!(
+            core::mem::size_of::<Expr>(),
+            96,
+            "size_of::<Expr>() moved -- every parsed program pays this, whether or not it \
+             uses the variant that grew. See #1401 before re-pinning."
+        );
     }
 
     #[test]

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -794,6 +794,8 @@ impl<'a> Parser<'a> {
                 return Ok(Bracket::Static(Expr::Slice {
                     start: None,
                     end: None,
+                    start_key: None,
+                    end_key: None,
                 }));
             }
 
@@ -850,17 +852,16 @@ impl<'a> Parser<'a> {
     }
 
     /// Decide whether a slice's bounds are both constant (the existing
-    /// [`Expr::Slice`]/[`Expr::SliceNumber`] fast path) or need runtime
+    /// [`Expr::Slice`] fast path) or need runtime
     /// evaluation ([`Expr::SliceExpr`], attached to a target by the caller —
     /// see [`Bracket::DynamicSlice`]). Each bound folds independently, so
     /// `.[1:.k]` (one literal, one dynamic) still becomes dynamic.
     ///
     /// #1326: a bound also carries its own `NumberKey` through
-    /// [`Self::fold_slice_bound`] when it's float-spelled -- if either
-    /// bound's fold produced one, the static result is
-    /// [`Expr::SliceNumber`] instead of plain [`Expr::Slice`], the same
-    /// per-bound-independence [`Self::fold_index_key`]'s own `IndexNumber`
-    /// fold established for indices (#1088).
+    /// [`Self::fold_slice_bound`] when it's float-spelled, into
+    /// [`Expr::Slice`]'s own `start_key`/`end_key` -- each bound
+    /// independently, the same rule [`Self::fold_index_key`] applies to an
+    /// index's own `key` (#1088).
     fn finish_slice(start: Option<Expr>, end: Option<Expr>) -> Bracket {
         let start_folded = start.as_ref().and_then(Self::fold_slice_bound);
         let end_folded = end.as_ref().and_then(Self::fold_slice_bound);
@@ -875,21 +876,12 @@ impl<'a> Parser<'a> {
         } else {
             let (start_i64, start_key) = start_folded.unzip();
             let (end_i64, end_key) = end_folded.unzip();
-            let start_key = start_key.flatten();
-            let end_key = end_key.flatten();
-            if start_key.is_some() || end_key.is_some() {
-                Bracket::Static(Expr::SliceNumber {
-                    start: start_i64,
-                    end: end_i64,
-                    start_key,
-                    end_key,
-                })
-            } else {
-                Bracket::Static(Expr::Slice {
-                    start: start_i64,
-                    end: end_i64,
-                })
-            }
+            Bracket::Static(Expr::Slice {
+                start: start_i64,
+                end: end_i64,
+                start_key: start_key.flatten(),
+                end_key: end_key.flatten(),
+            })
         }
     }
 
@@ -904,7 +896,7 @@ impl<'a> Parser<'a> {
         match key {
             Expr::Paren(inner) => Self::fold_index_key(inner),
             Expr::Literal(Literal::String(s)) => Some(Expr::Field(s.clone())),
-            Expr::Literal(Literal::Int(i)) => Some(Expr::Index(*i)),
+            Expr::Literal(Literal::Int(i)) => Some(Expr::Index { idx: *i, key: None }),
             // Every number written in filter source arrives as
             // `Literal::NumberLiteral` (#1035), so this one arm covers the
             // whole grammar; `Literal::Float`/`Literal::Int` are for
@@ -929,18 +921,18 @@ impl<'a> Parser<'a> {
             // the variant is. An `Int` repr still folds to a plain
             // [`Expr::Index`], since its own source text renders identically
             // to the `i64` and the hot `.foo.bar[0]` path must not move. A
-            // `Float` repr carries its spelling through
-            // [`Expr::IndexNumber`] instead, because jq echoes it back
-            // verbatim: `path(.[2.00])` is `[2.00]` and `path(.[1e10])` is
-            // `[1E+10]`. `idx` is the identical `i64` either way.
+            // `Float` repr carries its spelling in [`Expr::Index`]'s own
+            // `key` instead, because jq echoes it back verbatim:
+            // `path(.[2.00])` is `[2.00]` and `path(.[1e10])` is `[1E+10]`.
+            // `idx` is the identical `i64` either way.
             Expr::Literal(Literal::NumberLiteral(repr, text)) => match *repr {
-                NumberRepr::Int(i) => Some(Expr::Index(i)),
+                NumberRepr::Int(i) => Some(Expr::Index { idx: i, key: None }),
                 NumberRepr::Float(f)
                     if f.fract() == 0.0 && f >= i64::MIN as f64 && f < i64::MAX as f64 =>
                 {
-                    Some(Expr::IndexNumber {
+                    Some(Expr::Index {
                         idx: f as i64,
-                        key: NumberKey::Literal(f, text.as_str().into()),
+                        key: Some(NumberKey::Literal(f, text.as_str().into())),
                     })
                 }
                 NumberRepr::Float(_) => None,
@@ -956,7 +948,7 @@ impl<'a> Parser<'a> {
             // overflow `i64` -- not just for the float/exponent spelling of
             // `i64::MIN`'s magnitude (`2^63`, one past `i64::MAX`, so it
             // reaches here rather than folding directly), but for *any*
-            // producer of `Expr::Index(i64::MIN)`, including a bare
+            // producer of `Expr::index(i64::MIN)`, including a bare
             // `Literal::Int(i64::MIN)` on `right` (reachable from ordinary
             // jq source: `left` need not come from the negative-literal
             // split at all, just any `-1 * <literal>` spelling, and a
@@ -972,22 +964,26 @@ impl<'a> Parser<'a> {
                 right,
             } if matches!(**left, Expr::Literal(Literal::Int(-1))) => {
                 match Self::fold_index_key(right)? {
-                    Expr::Index(i) => i.checked_neg().map(Expr::Index),
-                    // #1088: negation is exactly the operation that destroys
-                    // jq's number-literal preservation, so the negated key
-                    // drops to a bare `f64` -- which is *why* `path(.[-1.0])`
-                    // is `[-1]` while `path(.[1.0])` is `[1.0]`. Nothing
-                    // index-specific is happening; `jq -n '-1.0'` already
-                    // prints `-1`. See [`NumberKey`]'s own doc comment.
-                    //
-                    // Negating the truncated `idx` and truncating the negated
-                    // value agree, because the truncation is toward zero.
-                    Expr::IndexNumber { idx, key } => {
-                        idx.checked_neg().map(|idx| Expr::IndexNumber {
-                            idx,
-                            key: NumberKey::Float(-key.value()),
-                        })
-                    }
+                    Expr::Index { idx, key } => idx.checked_neg().map(|idx| Expr::Index {
+                        idx,
+                        // #1088: negation is exactly the operation that
+                        // destroys jq's number-literal preservation, so a
+                        // key that got this far drops to a bare `f64` --
+                        // which is *why* `path(.[-1.0])` is `[-1]` while
+                        // `path(.[1.0])` is `[1.0]`. Nothing index-specific
+                        // is happening; `jq -n '-1.0'` already prints `-1`.
+                        // See [`NumberKey`]'s own doc comment.
+                        //
+                        // A key-*less* index stays key-less: `map` leaves
+                        // `None` alone rather than synthesizing a spelling
+                        // for a plain `.[-1]`. Keeping those two directions
+                        // distinct is the whole content of this arm.
+                        //
+                        // Negating the truncated `idx` and truncating the
+                        // negated value agree, because the truncation is
+                        // toward zero.
+                        key: key.map(|k| NumberKey::Float(-k.value())),
+                    }),
                     _ => None,
                 }
             }
@@ -998,19 +994,16 @@ impl<'a> Parser<'a> {
     /// Fold a slice bound to the `i64` every navigation step uses, seeing
     /// through parens -- and, alongside it, the [`NumberKey`] a
     /// float-spelled bound needs to keep its own spelling in `path()`
-    /// output (#1326, following #1088's identical rule for
-    /// [`Expr::IndexNumber`]).
+    /// output (#1326, following #1088's identical rule for an index's own
+    /// `key`).
     ///
-    /// [`Self::fold_index_key`]'s two number-bearing variants both count: an
-    /// [`Expr::Index`] contributes its `i64` with no key (the bound folds to
-    /// plain [`Expr::Slice`] the same as it always has), and an
-    /// [`Expr::IndexNumber`] contributes the identical `i64` *plus* the key
-    /// that needs preserving -- `finish_slice` builds
-    /// [`Expr::SliceNumber`] once either bound's fold carries one.
+    /// [`Self::fold_index_key`] answers both halves at once: the `i64` every
+    /// navigation step uses, and the key to preserve alongside it, which is
+    /// `None` for an integer-spelled bound. `finish_slice` hands each bound's
+    /// key straight to [`Expr::Slice`]'s matching field.
     fn fold_slice_bound(key: &Expr) -> Option<(i64, Option<NumberKey>)> {
         match Self::fold_index_key(key)? {
-            Expr::Index(i) => Some((i, None)),
-            Expr::IndexNumber { idx, key } => Some((idx, Some(key))),
+            Expr::Index { idx, key } => Some((idx, key)),
             _ => None,
         }
     }
@@ -5005,10 +4998,10 @@ mod tests {
 
     #[test]
     fn test_index() {
-        assert_eq!(parse(".[0]").unwrap(), Expr::Index(0));
-        assert_eq!(parse(".[42]").unwrap(), Expr::Index(42));
-        assert_eq!(parse(".[-1]").unwrap(), Expr::Index(-1));
-        assert_eq!(parse(".[ 0 ]").unwrap(), Expr::Index(0));
+        assert_eq!(parse(".[0]").unwrap(), Expr::index(0));
+        assert_eq!(parse(".[42]").unwrap(), Expr::index(42));
+        assert_eq!(parse(".[-1]").unwrap(), Expr::index(-1));
+        assert_eq!(parse(".[ 0 ]").unwrap(), Expr::index(0));
     }
 
     #[test]
@@ -5019,35 +5012,11 @@ mod tests {
 
     #[test]
     fn test_slice() {
-        assert_eq!(
-            parse(".[1:3]").unwrap(),
-            Expr::Slice {
-                start: Some(1),
-                end: Some(3)
-            }
-        );
-        assert_eq!(
-            parse(".[1:]").unwrap(),
-            Expr::Slice {
-                start: Some(1),
-                end: None
-            }
-        );
-        assert_eq!(
-            parse(".[:3]").unwrap(),
-            Expr::Slice {
-                start: None,
-                end: Some(3)
-            }
-        );
+        assert_eq!(parse(".[1:3]").unwrap(), Expr::slice(Some(1), Some(3)));
+        assert_eq!(parse(".[1:]").unwrap(), Expr::slice(Some(1), None));
+        assert_eq!(parse(".[:3]").unwrap(), Expr::slice(None, Some(3)));
         // `[:]` is a full slice (returns the whole array), not an iterate
-        assert_eq!(
-            parse(".[:]").unwrap(),
-            Expr::Slice {
-                start: None,
-                end: None
-            }
-        );
+        assert_eq!(parse(".[:]").unwrap(), Expr::slice(None, None));
     }
 
     #[test]
@@ -5133,7 +5102,7 @@ mod tests {
 
         assert_eq!(
             parse(".foo[0]").unwrap(),
-            Expr::Pipe(vec![Expr::Field("foo".into()), Expr::Index(0),])
+            Expr::Pipe(vec![Expr::Field("foo".into()), Expr::index(0),])
         );
 
         assert_eq!(
@@ -5141,7 +5110,7 @@ mod tests {
             Expr::Pipe(vec![
                 Expr::Field("foo".into()),
                 Expr::Field("bar".into()),
-                Expr::Index(0),
+                Expr::index(0),
                 Expr::Field("baz".into()),
             ])
         );
@@ -6034,29 +6003,29 @@ mod tests {
     /// produced, so the hot `.foo.bar[0]` path and every `Field`/`Index` match
     /// site are untouched by #360.
     ///
-    /// #1088 changed which *variant* a float-spelled key folds to, never
-    /// whether it folds: `.[1.0]` is still a static component, now carrying
-    /// the spelling `path()` has to report. An integer-spelled key is
-    /// untouched -- there is nothing for `IndexNumber` to preserve, and
-    /// `.[0]` staying `Expr::Index(0)` is what keeps the hot path hot.
+    /// #1088 changed what a float-spelled key *carries*, never whether it
+    /// folds: `.[1.0]` is still a static component, now with the spelling
+    /// `path()` has to report. An integer-spelled key is untouched -- there
+    /// is nothing to preserve, so its `key` stays `None`, and `.[0]`
+    /// staying `Expr::index(0)` is what keeps the hot path hot.
     #[test]
     fn test_index_key_constant_folding() {
-        assert_eq!(parse(".[0]").unwrap(), Expr::Index(0));
-        assert_eq!(parse(".[-1]").unwrap(), Expr::Index(-1));
+        assert_eq!(parse(".[0]").unwrap(), Expr::index(0));
+        assert_eq!(parse(".[-1]").unwrap(), Expr::index(-1));
         assert_eq!(
             parse(".[1.0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: 1,
-                key: NumberKey::Literal(1.0, "1.0".into()),
+                key: Some(NumberKey::Literal(1.0, "1.0".into())),
             }
         );
         // `1e0` is the same value spelled differently, and jq echoes the
         // spelling, so the two must not collapse onto one component.
         assert_eq!(
             parse(".[1e0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: 1,
-                key: NumberKey::Literal(1.0, "1e0".into()),
+                key: Some(NumberKey::Literal(1.0, "1e0".into())),
             }
         );
         assert_eq!(parse(".[\"a\"]").unwrap(), Expr::Field("a".into()));
@@ -6084,20 +6053,16 @@ mod tests {
     /// invisible unless a test writes the same constant on both sides.
     #[test]
     fn test_slice_bounds_accept_the_same_spellings() {
-        let expected = Expr::Slice {
-            start: Some(1),
-            end: Some(3),
-        };
+        let expected = Expr::slice(Some(1), Some(3));
         for src in [".[1:3]", ".[(1):3]", ".[1:(3)]"] {
             assert_eq!(parse(src).unwrap(), expected, "`{src}`");
         }
         // #1326: a float-spelled bound (even a whole-valued one) keeps its
-        // own spelling in `path()` output, so it folds to `Expr::SliceNumber`
-        // instead of the plain `Expr::Slice` above -- only the unaffected
-        // bound is `None`.
+        // own spelling in `path()` output, so it folds with that bound's
+        // key populated -- only the unaffected bound stays `None`.
         assert_eq!(
             parse(".[1.0:3]").unwrap(),
-            Expr::SliceNumber {
+            Expr::Slice {
                 start: Some(1),
                 end: Some(3),
                 start_key: Some(NumberKey::Literal(1.0, "1.0".into())),
@@ -6106,7 +6071,7 @@ mod tests {
         );
         assert_eq!(
             parse(".[1:3.0]").unwrap(),
-            Expr::SliceNumber {
+            Expr::Slice {
                 start: Some(1),
                 end: Some(3),
                 start_key: None,
@@ -6122,7 +6087,7 @@ mod tests {
             (".[-2:]", (Some(-2), None)),
         ] {
             let (start, end) = expected;
-            assert_eq!(parse(src).unwrap(), Expr::Slice { start, end }, "`{src}`");
+            assert_eq!(parse(src).unwrap(), Expr::slice(start, end), "`{src}`");
         }
 
         // A bound that does not fold to a literal becomes `Expr::SliceExpr`
@@ -6163,19 +6128,19 @@ mod tests {
         // why `path(.[-1.0])` is `[-1]` while `path(.[1.0])` is `[1.0]`.
         assert_eq!(
             parse(".[-1.0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: -1,
-                key: NumberKey::Float(-1.0),
+                key: Some(NumberKey::Float(-1.0)),
             }
         );
         assert_eq!(
             parse(".[-1e0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: -1,
-                key: NumberKey::Float(-1.0),
+                key: Some(NumberKey::Float(-1.0)),
             }
         );
-        // #1326: the slice-bound sibling of the `IndexNumber` case above --
+        // #1326: the slice-bound sibling of the index case above --
         // negation destroys the *literal spelling* the same way, but the
         // bound still keeps a `NumberKey::Float` rather than dropping to
         // plain `Expr::Slice` (`path(.[-3.0:-1.0])` is `[{"start":-3,
@@ -6184,7 +6149,7 @@ mod tests {
         // matching real jq exactly).
         assert_eq!(
             parse(".[-3.0:-1.0]").unwrap(),
-            Expr::SliceNumber {
+            Expr::Slice {
                 start: Some(-3),
                 end: Some(-1),
                 start_key: Some(NumberKey::Float(-3.0)),
@@ -6199,7 +6164,7 @@ mod tests {
 
     /// #1061: `i64::MAX as f64` rounds *up* to `2^63` (`i64::MAX` itself isn't
     /// exactly representable as `f64`), so a `<=` bound let `.[2^63]` fold to
-    /// `Expr::Index(i64::MAX)` -- silently one lower than what was written,
+    /// `Expr::index(i64::MAX)` -- silently one lower than what was written,
     /// with no error or truncation notice. The fix must reject the whole
     /// `[2^63, +inf)` range (both the nearest-representable spellings, since
     /// `9223372036854775807.0` and `9223372036854775808.0` round to the same
@@ -6226,20 +6191,26 @@ mod tests {
         ));
 
         // A value strictly below the boundary still takes the fast path
-        // (as `Expr::IndexNumber` since #1088 -- same `idx`, plus the
-        // spelling `path()` reports).
+        // (carrying a `key` since #1088 -- same `idx`, plus the spelling
+        // `path()` reports).
         assert_eq!(
             parse(".[9223372036854774784.0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: 9223372036854774784,
-                key: NumberKey::Literal(9223372036854774784.0, "9223372036854774784.0".into()),
+                key: Some(NumberKey::Literal(
+                    9223372036854774784.0,
+                    "9223372036854774784.0".into()
+                )),
             }
         );
         assert_eq!(
             parse(".[9223372036854774784e0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: 9223372036854774784,
-                key: NumberKey::Literal(9223372036854774784.0, "9223372036854774784e0".into()),
+                key: Some(NumberKey::Literal(
+                    9223372036854774784.0,
+                    "9223372036854774784e0".into()
+                )),
             }
         );
     }
@@ -6285,9 +6256,9 @@ mod tests {
         // etc.), so this only needs the one large-but-safe magnitude.
         assert_eq!(
             parse(".[-9223372036854774784.0]").unwrap(),
-            Expr::IndexNumber {
+            Expr::Index {
                 idx: -9223372036854774784,
-                key: NumberKey::Float(-9223372036854774784.0),
+                key: Some(NumberKey::Float(-9223372036854774784.0)),
             }
         );
     }
@@ -6542,7 +6513,7 @@ mod tests {
         // Kebab-case with array index
         assert_eq!(
             parse_with_mode(".my-key[0]", ParserMode::Yq).unwrap(),
-            Expr::Pipe(vec![Expr::Field("my-key".into()), Expr::Index(0),])
+            Expr::Pipe(vec![Expr::Field("my-key".into()), Expr::index(0),])
         );
 
         // Kebab-case with optional

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -411,10 +411,8 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // own grouping so the two stay comparable arm for arm.
         Expr::Identity
         | Expr::Field(_)
-        | Expr::Index(_)
-        | Expr::IndexNumber { .. }
+        | Expr::Index { .. }
         | Expr::Slice { .. }
-        | Expr::SliceNumber { .. }
         | Expr::Iterate
         | Expr::Literal(_)
         | Expr::RecursiveDescent

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -606,10 +606,8 @@ pub fn any_subexpr(expr: &Expr, pred: &mut dyn FnMut(&Expr) -> bool) -> bool {
         // Leaves: nothing nested to descend into.
         Expr::Identity
         | Expr::Field(_)
-        | Expr::Index(_)
-        | Expr::IndexNumber { .. }
+        | Expr::Index { .. }
         | Expr::Slice { .. }
-        | Expr::SliceNumber { .. }
         | Expr::Iterate
         | Expr::Literal(_)
         | Expr::RecursiveDescent

--- a/tests/jq_index_number_invariant_tests.rs
+++ b/tests/jq_index_number_invariant_tests.rs
@@ -1,27 +1,30 @@
-//! #1827: end-to-end behavioral equivalence between `Expr::Index`/`Expr::Slice`
-//! and their float-spelling-preserving siblings `Expr::IndexNumber`/
-//! `Expr::SliceNumber` (`src/jq/expr.rs`).
+//! #1827: end-to-end behavioral equivalence between an integer-spelled and
+//! a float-spelled static path component (`Expr::Index`/`Expr::Slice`,
+//! `src/jq/expr.rs`).
 //!
-//! `.[1]` folds to `Expr::Index(1)`; `.[1.0]` (same integer value, float
-//! spelling) folds to `Expr::IndexNumber { idx: 1, .. }` instead, so
-//! `path()` can report the component's own source spelling (#1088, #1326).
-//! The two must behave identically for navigation — reading, `del`,
-//! `setpath`/`=`/`|=`, `getpath` — with `path()`'s own component rendering
-//! the only place they're allowed to differ.
+//! `.[1]` folds to `Expr::Index { idx: 1, key: None }`; `.[1.0]` (same
+//! integer value, float spelling) folds to the same variant with `key`
+//! populated, so `path()` can report the component's own source spelling
+//! (#1088, #1326). The two must behave identically for navigation —
+//! reading, `del`, `setpath`/`=`/`|=`, `getpath` — with `path()`'s own
+//! component rendering the only place they're allowed to differ.
 //!
-//! This is the regression class #1088/#1326 already hit once:
-//! `delete_expr_array_paths`'s error-construction match had no
-//! `Expr::IndexNumber` arm at all from #1088 until #1326 added one as a
-//! byproduct, so a float-spelled index reaching it would have panicked via
-//! `unreachable!()`. `src/jq/eval.rs` has ~30 sites that pattern-match on
-//! this pair (or its `Slice`/`SliceNumber` sibling) — most via the shared
-//! predicates or an `Expr::Index(idx) | Expr::IndexNumber { idx, .. }`
-//! or-pattern, but nothing enforces that a *new* site does so, or that a
-//! *third* paired variant joining either family gets taught to every one of
-//! them. Running real filters through the full evaluator, as this file
-//! does, is what would have caught the #1088/#1326 gap: a missing arm
-//! panics or errors differently, not just "the wrong predicate returns
-//! false".
+//! This is the regression class #1088/#1326 already hit once. Each spelling
+//! used to be its *own* variant (`Expr::IndexNumber` beside `Expr::Index`,
+//! `Expr::SliceNumber` beside `Expr::Slice`), so every site had to spell
+//! out both members of the pair — and `delete_expr_array_paths`'s
+//! error-construction match had no `IndexNumber` arm at all from #1088
+//! until #1326 added one as a byproduct, so a float-spelled index reaching
+//! it would have panicked via `unreachable!()`.
+//!
+//! #1401 folded the keys onto the surviving variants, which makes a missing
+//! *sibling* arm unrepresentable — one variant per family, so the compiler
+//! sees every site. What this file still covers is the property that
+//! motivated the pairs in the first place, and that no type can enforce:
+//! that the two spellings actually reach the same behavior end to end,
+//! through the full evaluator, at every dispatch site a real filter can
+//! drive. A site that keyed off the spelling rather than `idx` would still
+//! be caught here.
 //!
 //! Every expectation below is pinned against jq-1.7.1 (the version in
 //! `tests/data/jq-golden/JQ_VERSION`).

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18866,7 +18866,7 @@ fn test_yq_scalar_target_noop_pre_last_component_1232() -> Result<()> {
 /// key chain (`.[$k1][$k2]`) that never touches a literal `Field`/`Index`
 /// node at all, falsifying "the no-op only needs to special-case a literal
 /// path component". `resolve_dynamic_indexes` folds `$k1`/`$k2` into
-/// concrete `Expr::IndexNumber` components before `get_path_mut` ever runs,
+/// concrete key-carrying `Expr::Index` components before `get_path_mut` runs,
 /// so the *write* itself exercises the exact same fixed arms as the
 /// literal-path tests above.
 ///


### PR DESCRIPTION
Closes #1401.

Folds the paired `Expr` variants that #1088 and #1326 added for float-spelling preservation
into a single variant per family — issue #1401's **option 1**, which turns out to subsume its
**option 3** as well. (Option 4 already shipped as #1827; option 2 is rejected below, on a
measurement.)

## The problem

```rust
Expr::Index(i64),                                    // .[0]
Expr::IndexNumber { idx: i64, key: NumberKey },      // .[2.0]  -- #1088
Expr::Slice { start, end },                          // .[1:3]
Expr::SliceNumber { start, end, start_key, end_key },// .[1.5:3.5] -- #1326
```

Every site that asks "is this an index / a slice component" had to spell out **both** members
of each pair, and nothing enforced it. `delete_expr_array_paths`'s error-construction match had
no `IndexNumber` arm at all from #1088 until #1326 added one incidentally — a float-spelled
index reaching it would have hit `unreachable!()`.

## The change

```rust
Expr::Index { idx: i64, key: Option<NumberKey> },
Expr::Slice { start, end, start_key, end_key },
```

One variant per family, so there is no sibling arm left to forget. **Deleting a variant is
compiler-enforced in a way adding one never was** — every one of the 63 dispatch sites was
enumerated by `cargo check`, including the four wildcard-fallback sites (`_ => true` /
`_ => false`) that would otherwise have drifted silently.

Both `Expr`-scrutinee `unreachable!()` fallbacks go with it, which is option 3 falling out for
free: `child_of` and `path_step_generic` each re-matched over the four variants *inside* a
combined arm purely because an or-pattern cannot bind fields. `child_of`'s shared body moves to
a new `array_child` helper so its two arms can bind directly.

## Corrections to the issue's own framing

Two of #1401's measured claims were re-measured and are stale. Both are recorded in the code
rather than only here.

| Issue claim | Verdict |
|---|---|
| `size_of::<Expr>()` went 72 → 96 when `SliceNumber` landed | **True** — reproduced at `05adafd3b^` (72) and HEAD (96) via `-Zprint-type-sizes` |
| `SliceNumber` is *the* size-determining variant | **Stale** — `FuncDef` independently reached 96 when #2094 gave it a `bound` cache. Boxing the keys (option 2) would buy ≤ 8 bytes while adding an allocation on the float path, so it is not done here |
| `expand_func_calls` deep-clones `Expr` per `def` evaluation | **False** — that function no longer exists; #1371/ADR-0020 replaced it with `DefCall`/`Shared(Rc<Expr>)` and memoizes substitution. Deep cloning survives only on the uncached `as`/`reduce`/`foreach` path |
| ~25 match sites; 89 `unreachable!` to audit | **63** sites in 39 functions; of `eval.rs`'s 91 `unreachable!` only 11 are wildcard arms and only **2** have an `Expr` scrutinee |

**So this is not a size win — it is size-neutral, and that is the honest claim.** `Expr` stays
96 bytes, now held jointly by `Slice` and `FuncDef`. A new `test_expr_size_is_pinned_1401`
pins it, following the existing `EvalError` / `GenericResult` precedent, so the next variant
that widens the enum has to say so in a diff instead of landing unmeasured — the thing #1401
says was missing.

## One arm deliberately not widened

`eval_generic`'s lazy `first`/`.[0]` fast path stays pinned to `key: None` rather than the
natural post-fold `{ idx: 0, .. }`. Widening it would make `.[0.0]` take the lazy path too and
suppress an error jq raises — spreading the deliberate-but-divergent #725 error-skip to one
more spelling, the wrong direction under ADR-0018. Verified empirically by rebuilding with the
widened arm, not assumed. That leaves `.[0]` and `.[0.0]` genuinely disagreeing there, which is
the drift class this issue exists to *surface*, not one a refactor should quietly resolve —
filed as **#2174**, with a comment at the site.

## Verification

- **Oracle**: 15 spellings byte-compared against pinned `/usr/bin/jq` 1.7.1, all matching —
  including the negation asymmetry the merged parser fold has to preserve (`path(.[1.0])` is
  `[1.0]`, `path(.[-1.0])` is `[-1]`; `key.map` leaves `None` alone rather than synthesizing a
  spelling). That merge was the riskiest edit in the change.
- **#1827's invariant net unweakened**: all 5 end-to-end tests pass untouched, including
  `test_multi_target_del_reaches_array_step_dispatch_1827`, the only one that reaches
  `child_of`. The predicate test is rewritten for the folded shape with the same assertion
  strength.
- `cargo test` 3865 passed / 0 failed; CLI + golden legs 2770 / 0; `--no-default-features`
  (no_std) on a cleaned cache 3831 / 0.
- `cargo fmt --check`; clippy clean on all three CI feature legs; `cargo doc` with
  `RUSTDOCFLAGS=-D warnings`.
- `-Zprint-type-sizes` confirms 96 bytes with `Slice` and `FuncDef` tied at the ceiling.
- Patch coverage **99.51%** (204/205). The one uncovered line is `fold_index_key`'s
  `Literal::Int` arm, which raw lcov shows at 0 hits while its siblings are at 494/51 — a
  pre-existing unreachable arm (its own comment explains that `Literal::Int` only arises from
  synthesized ASTs) inherited by re-spelling the line, not a new gap.

Net −20 lines across 12 files, and `Expr::index()` / `Expr::slice()` keep their signatures.
`Expr` is publicly re-exported, so the variant shapes are a breaking change for external
callers at 0.8.0 — noted in the CHANGELOG.
