### PR TITLE
refactor(jq): name and debug-assert the owned-only sink protocol (#2025)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3136,6 +3136,45 @@ impl<W: Clone + AsRef<[u64]>> Item<'_, W> {
         }
     }
 
+    /// Materialize an item pushed by a producer whose sink protocol only ever
+    /// carries [`Item::Owned`], where the `Borrowed` arm is therefore dead
+    /// code (#2025).
+    ///
+    /// Three collecting sinks are in this position, and each is fed by exactly
+    /// one `sink(...)` call in its producer's whole body, all three passing
+    /// `Item::Owned`: [`binary_fanout_core`] (from `binary_fanout_each`, whose
+    /// only push is `combine`'s own result -- the *operands* are separately
+    /// routed through [`Self::into_owned_checked`] by `checked_fanout_operand`,
+    /// #1972), [`builtin_paths_filter`] (from `each_paths_filter`, whose only
+    /// push is a path array built over an already-[`to_owned_checked`]
+    /// document, #1829), and [`builtin_inputs`] (from `each_inputs`, whose only
+    /// push is a queued `OwnedValue`). Neither [`Self::into_owned`] nor
+    /// [`Self::into_owned_checked`] can therefore differ observably at any of
+    /// them.
+    ///
+    /// Spelled as its own method rather than a bare [`Self::into_owned`] for
+    /// two reasons. #2025 was filed against exactly these three sites on the
+    /// theory that they were unchecked materializations of document-sourced
+    /// strings, and closed only after the sink protocol above was re-derived by
+    /// hand; a classification pass that greps for the call *shape* (#1989) has
+    /// no way to see that argument otherwise, so the name carries it. And if a
+    /// producer ever starts pushing `Item::Borrowed` into one of these sinks,
+    /// the debug assertion fails in CI's debug test run rather than silently
+    /// substituting `""` for an undecodable string -- #1746's bug shape, which
+    /// is precisely what this would become.
+    ///
+    /// Release behaviour is [`Self::into_owned`]'s, unchanged: the assertion
+    /// documents and guards an invariant, it does not add a new failure mode to
+    /// a path that has none today.
+    fn into_owned_from_owned_producer(self) -> OwnedValue {
+        debug_assert!(
+            matches!(self, Item::Owned(_)),
+            "a producer pushed Item::Borrowed into a sink whose protocol is \
+             owned-only; see Item::into_owned_from_owned_producer (#2025)"
+        );
+        self.into_owned()
+    }
+
     /// Fallible twin of [`Self::into_owned`], raising
     /// [`EvalError::decode_failure`] on an undecodable borrowed string
     /// instead of silently substituting `""` (#1972) -- used where the
@@ -4790,7 +4829,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
         optional,
         combine,
         &mut |item: Item<'a, W>| {
-            out.push(item.into_owned());
+            out.push(item.into_owned_from_owned_producer());
             Demand::Continue
         },
     );
@@ -33071,7 +33110,7 @@ fn builtin_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut paths = Vec::new();
     let flow = each_paths_filter::<W, S>(filter, value, optional, &mut |item| {
-        paths.push(item.into_owned());
+        paths.push(item.into_owned_from_owned_producer());
         Demand::Continue
     });
     match flow {
@@ -35667,7 +35706,7 @@ fn each_inputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn builtin_inputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>() -> QueryResult<'a, W> {
     let mut docs: Vec<OwnedValue> = Vec::new();
     match each_inputs::<W, S>(&mut |item| {
-        docs.push(item.into_owned());
+        docs.push(item.into_owned_from_owned_producer());
         Demand::Continue
     }) {
         // A `Continue`-only sink never stops, but the arm costs nothing and

--- a/tests/jq_owned_only_sink_invariant_test.rs
+++ b/tests/jq_owned_only_sink_invariant_test.rs
@@ -1,0 +1,78 @@
+//! Drives the three sinks whose protocol `Item::into_owned_from_owned_producer`
+//! documents as owned-only (#2025), so that method's `debug_assert!` actually
+//! runs against each of them in a debug test build.
+//!
+//! The subject of these tests is the assertion, not the outputs -- every output
+//! asserted here is already covered elsewhere. What is *not* covered elsewhere
+//! is the claim the method's own doc comment makes: that `binary_fanout_each`,
+//! `each_paths_filter` and `each_inputs` push nothing but `Item::Owned`. That
+//! claim was re-derived by hand when #2025 was closed, and nothing but review
+//! stops a later edit from pushing a borrowed item into one of these sinks --
+//! at which point an undecodable string would silently materialize as `""`
+//! (#1746's bug shape) instead of raising. With this file in place, that edit
+//! fails here first.
+//!
+//! Driven through the library's own `eval` entry point rather than the CLI:
+//! `binary_fanout_core` is `eval.rs`'s eager collecting wrapper, and reaching
+//! it from filter text alone depends on which arms `eval_generic` currently
+//! handles natively -- a detail that has moved before (#607, #1607) and is not
+//! what these tests are pinning.
+//!
+//! Kept to its own test binary for `seed_remaining_inputs`'s sake: seeding is
+//! thread-local and, once seeded, `input_queue_is_active()` stays true for the
+//! rest of that thread's life, so it must not leak into another file's shared
+//! process (same reasoning as `jq_eval_using_input_queue_gate_test.rs`).
+
+#![cfg(feature = "std")]
+
+use succinctly::jq::{eval, parse, seed_remaining_inputs, JqSemantics, OwnedValue};
+use succinctly::json::JsonIndex;
+
+fn eval_to_json(json: &[u8], filter: &str) -> Vec<String> {
+    let index = JsonIndex::build(json);
+    let cursor = index.root(json);
+    let expr = parse(filter).expect("parse failed");
+    eval::<_, JqSemantics>(&expr, cursor)
+        .collect_owned()
+        .iter()
+        .map(OwnedValue::to_json)
+        .collect()
+}
+
+/// `binary_fanout_core`'s sink, fed by `binary_fanout_each`'s single
+/// `sink(Item::Owned(v))` -- `combine`'s own result. Two-by-two so the sink is
+/// pushed to more than once, and jq's right-outer/left-inner order is visible.
+#[test]
+fn test_binary_fanout_core_sink_carries_only_owned_items_2025() {
+    assert_eq!(
+        eval_to_json(br"null", "(1,2) + (10,20)"),
+        vec!["11", "12", "21", "22"],
+    );
+}
+
+/// `builtin_paths_filter`'s sink, fed by `each_paths_filter`'s single
+/// `sink(Item::Owned(path.clone()))`. A nested match so the pushed path array
+/// has more than one component.
+#[test]
+fn test_builtin_paths_filter_sink_carries_only_owned_items_2025() {
+    assert_eq!(
+        eval_to_json(
+            br#"{"a": 1, "b": {"c": 2}, "d": "x"}"#,
+            r#"paths(type == "number")"#
+        ),
+        vec![r#"["a"]"#, r#"["b","c"]"#],
+    );
+}
+
+/// `builtin_inputs`'s sink, fed by `each_inputs`'s single
+/// `sink(Item::Owned(doc))`. Two queued documents so the sink is pushed to more
+/// than once; `[inputs]` (not `inputs`) to reach the eager collecting face.
+#[test]
+fn test_builtin_inputs_sink_carries_only_owned_items_2025() {
+    seed_remaining_inputs(
+        vec![(OwnedValue::Int(42), 0, 1), (OwnedValue::Int(43), 0, 2)],
+        None,
+    );
+
+    assert_eq!(eval_to_json(br#"{"a":1}"#, "[inputs]"), vec!["[42,43]"]);
+}


### PR DESCRIPTION
## What

Gives the owned-only sink protocol at three `Item::into_owned` call sites a
name, a doc comment, and a `debug_assert!` — plus a test file that drives all
three so the assertion actually runs.

No behaviour change: in release this is `into_owned`, unchanged.

## Why

#2025 flagged `binary_fanout_core`, `builtin_paths_filter` and `builtin_inputs`
as unchecked materializations of document-sourced strings (#1746's shape: an
undecodable string silently becomes `""`). It closed as not-a-bug, because
each is fed by exactly one `sink(...)` call in its producer's whole body and
all three pass `Item::Owned`:

| Consumer | Producer | Its only `sink(…)` |
|---|---|---|
| `binary_fanout_core` | `binary_fanout_each` | `sink(Item::Owned(v))` — `combine`'s result; operands separately go through `into_owned_checked` (#1972) |
| `builtin_paths_filter` | `each_paths_filter` | `sink(Item::Owned(path.clone()))` — over an already-`to_owned_checked` document (#1829) |
| `builtin_inputs` | `each_inputs` | `sink(Item::Owned(doc))` — a queued `OwnedValue` |

So the `Borrowed` arm the checked and unchecked methods differ on is dead code
there. But that argument lived only in a closed issue: a classification pass
that greps for the call shape (#1989) re-files these three, and an edit that
starts pushing a borrowed item into one of these sinks reintroduces the real
bug with nothing to catch it. This encodes the argument where the code is.

## Verification

- Each new test provably reaches the guarded method: temporarily inverted the
  assertion to always-fail, confirmed all three tests fail, restored it and
  confirmed all three pass.
- Full workspace suite (`--features cli,simd,regex,serde`): **6935 passed, 0
  failed**.
- `cargo fmt --check`; `cargo clippy --all-targets --all-features -D warnings`
  and the second clippy leg; `cargo test` default features; `cargo test
  --no-default-features` (no_std); the CLI test list from `ci.yml`; `cargo doc
  --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — all pass.

## Notes

Type-level narrowing (a sink typed `OwnedValue` instead of `Item`) isn't
available: all three producers are *also* called from `eval_each`'s own arms,
which pass its generic `Item` sink.

While auditing this, the `Item::into_owned` sub-family was swept end to end (7
sites, probe + full suite + 400 randomized runs, zero substitution events) —
results posted on #1989. #2173 came out of the same pass and is unrelated to
this PR.

Refs #1989, #2025
