### PR TITLE
fix(jq): preserve duplicate keys for --preserve-input's LazySeq results

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors};
 use succinctly::jq::eval_generic::{
-    check_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult, LazyElem,
-    MAX_NESTING_DEPTH,
+    check_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, to_owned_cursor,
+    GenericResult, LazyElem, MAX_NESTING_DEPTH,
 };
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
@@ -4594,51 +4594,52 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         // one), matching `ManyCursor`'s own per-element `JqValue::Cursor`
         // mapping just above.
         //
-        // `check_cursor_nesting_depth` per `Cursor` element (#2066 review,
-        // #1793 regression): `materialize_atomic`'s per-element
-        // `lazy_elem_to_owned` used to run `to_owned`'s `MAX_NESTING_DEPTH`
-        // panic-guard eagerly, before this arm ever returned -- satisfying
-        // the invariant the `catch_unwind` wrapper's own comment states
-        // ("`out`'s writer is never mid-record when the stack unwinds").
-        // Wrapping a raw cursor in `JqValue::Cursor` with no check at all
-        // defers depth validation to `write_json_at_depth`'s own *different*
-        // (`MAX_VALUE_TREE_DEPTH`, deeper) panic, fired *while* writing --
-        // confirmed live via `test_map_identity_reports_clean_error_on_adversarial_nesting_1793`
-        // regressing to exit 1 with a garbled partial-array line on stdout
-        // instead of a clean exit 5. This is a cheap structural walk (no
-        // value decoding/allocation), not the full deep copy
-        // `materialize_atomic` did, so it does not reintroduce what #2066
-        // was written to avoid.
+        // `to_owned_cursor(&c)` per `Cursor` element, discarding its `Ok`
+        // value (#2066 review, #1793 regression): this is the exact function
+        // `lazy_elem_to_owned`'s own `Cursor` arm calls, so it re-validates
+        // everything `materialize_atomic`'s per-element walk used to --
+        // `MAX_NESTING_DEPTH` (a panic, still caught by the `catch_unwind`
+        // wrapper a few hundred lines up) *and* the malformed-member/
+        // -delimiter checks `to_owned_cursor_at_depth` also performs (an
+        // `EvalError`, not just depth). An earlier revision of this fix
+        // wrote its own depth-only walk, satisfying the depth-panic-timing
+        // invariant (`catch_unwind`'s own comment: "out's writer is never
+        // mid-record when the stack unwinds") but not the delimiter one --
+        // review found live: `map(.)` on `[1, {"bad": xyz123}]` printed a
+        // garbled `[1,{"bad":` prefix to stdout before erroring, instead of
+        // nothing, because delimiter validation had moved to `print_json`'s
+        // own `Cursor` arm, which runs *while* writing. Reusing
+        // `to_owned_cursor` wholesale closes that gap by construction rather
+        // than by re-deriving its checks a second time; the discarded
+        // `OwnedValue` is the same full-copy cost `materialize_atomic` always
+        // paid for validation, so #2066's own actual win (not collapsing a
+        // duplicate key into the *output*) is unaffected -- only the
+        // never-materialized-for-output copy this arm still makes for
+        // validation's sake is unchanged from before.
         GenericResult::LazySeq(seq) => match seq.drain_atomic() {
             // All-or-nothing, matching `materialize_atomic`'s own atomicity
             // contract ("real jq's array construction is all-or-nothing:
             // `[1,2,"x"]|map(.+1)` prints nothing to stdout, only the stderr
-            // diagnostic") -- an early `return vec![]` on the first bad
-            // element, not a partial `JqValue::Array` of whatever converted
-            // before it (#2066 review: the naive `break`-and-fall-through
-            // shape printed an empty `[]` for a single-element failing
-            // array instead of suppressing it entirely).
+            // diagnostic") -- one `Result`, not a partial `JqValue::Array` of
+            // whatever converted before the first bad element (#2066 review:
+            // an earlier revision's `break`-and-fall-through shape printed an
+            // empty `[]` for a single-element failing array instead of
+            // suppressing it entirely).
             Ok(elems) => {
-                let mut out = Vec::with_capacity(elems.len());
-                for elem in elems {
-                    match elem {
-                        LazyElem::Cursor(c) => match check_cursor_nesting_depth(&c, 0) {
-                            Ok(()) => out.push(JqValue::Cursor(c)),
-                            Err(e) => {
-                                sink.report(DiagStyle::Jq, &e, at);
-                                return vec![];
-                            }
-                        },
-                        LazyElem::Owned(v) => match JqValue::try_from_owned(v) {
-                            Ok(jq_value) => out.push(jq_value),
-                            Err(e) => {
-                                sink.report(DiagStyle::Jq, &e, at);
-                                return vec![];
-                            }
-                        },
+                let converted: Result<Vec<JqValue<'_, W>>, EvalError> = elems
+                    .into_iter()
+                    .map(|elem| match elem {
+                        LazyElem::Cursor(c) => to_owned_cursor(&c).map(|_| JqValue::Cursor(c)),
+                        LazyElem::Owned(v) => JqValue::try_from_owned(v),
+                    })
+                    .collect();
+                match converted {
+                    Ok(out) => vec![JqValue::Array(out)],
+                    Err(e) => {
+                        sink.report(DiagStyle::Jq, &e, at);
+                        vec![]
                     }
                 }
-                vec![JqValue::Array(out)]
             }
             Err(jq::Control::Error(e)) => {
                 sink.report(DiagStyle::Jq, &e, at);
@@ -5271,53 +5272,6 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
 /// like a leading-zero number (#1094) or a genuinely malformed document, so
 /// this walk is cold by construction and doesn't need `print_json`'s
 /// `known_text_pos` reuse trick.
-/// Bound a cursor's own structural nesting before it's wrapped in a
-/// `JqValue::Cursor` and deferred to write time (#2066 code review).
-///
-/// Every other producer of a lazy `JqValue` (`OneCursor`/`ManyCursor` above)
-/// already had this covered for free: a `sort`/`unique`/`reverse`/`map`
-/// `LazySeq` used to run through `materialize_atomic`'s per-element
-/// `to_owned`, whose `MAX_NESTING_DEPTH` panic-guard fired eagerly -- before
-/// `generic_result_to_jq_values` ever returned, let alone before any output
-/// write began, matching the `catch_unwind` wrapper's own documented
-/// invariant a few hundred lines up ("`out`'s writer is never mid-record
-/// when the stack unwinds"). Routing a `LazySeq` element straight into
-/// `JqValue::Cursor` for #2066 skipped that guard entirely, deferring
-/// validation to `write_json_at_depth`'s own later, differently-tuned
-/// `MAX_VALUE_TREE_DEPTH` panic -- which fires mid-write, not before it,
-/// and regressed `test_map_identity_reports_clean_error_on_adversarial_nesting_1793`
-/// to a garbled partial line on stdout and the wrong exit code.
-///
-/// Deliberately a structural walk only -- no scalar decoding, no
-/// allocation, `check_nesting_depth`'s existing fallible form rather than
-/// `assert_nesting_depth`'s panic -- so it stays cheap on the common
-/// (shallow) case and doesn't reintroduce the full per-element deep copy
-/// #2066 was written to avoid. Starts fresh at `depth` 0 per element, not
-/// carrying any ambient depth from the array wrapping it, matching
-/// `lazy_elem_to_owned`'s own per-element `to_owned` call.
-fn check_cursor_nesting_depth<W: AsRef<[u64]>>(
-    cursor: &JsonCursor<'_, W>,
-    depth: usize,
-) -> core::result::Result<(), EvalError> {
-    check_nesting_depth(depth)?;
-    match cursor.value() {
-        StandardJson::Array(elements) => {
-            for child in elements.cursor_iter() {
-                check_cursor_nesting_depth(&child, depth + 1)?;
-            }
-        }
-        StandardJson::Object(fields) => {
-            let mut remaining = fields;
-            while let Some((field, rest)) = remaining.uncons() {
-                check_cursor_nesting_depth(&field.value_cursor(), depth + 1)?;
-                remaining = rest;
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
 fn validate_json_delimiters<W: AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use succinctly::dsv::{build_index as build_dsv_index, DsvConfig, DsvRows};
 use succinctly::jq::document::{effective_keys, key_hash, DistinctKeyCursors};
 use succinctly::jq::eval_generic::{
-    check_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult,
+    check_nesting_depth, eval_with_cursor, to_owned as generic_to_owned, GenericResult, LazyElem,
     MAX_NESTING_DEPTH,
 };
 use succinctly::jq::walk::map_builtin_subexprs;
@@ -4584,11 +4584,62 @@ fn generic_result_to_jq_values<'a, W: Clone + AsRef<[u64]>>(
         GenericResult::LazyIndexRange(len) => vec![JqValue::LazyIndexRange(len)],
         // `JqValue` needs no new variant for a composed `map` chain (#724,
         // #725): `JqValue::Array` already stores per-element cursors (its
-        // own "Phase 1 Lazy Optimization"), so materializing once here and
-        // wrapping via `from_owned` reuses the existing `write_json` path
-        // entirely.
-        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
-            Ok(v) => to_jq_values(v, at, sink),
+        // own "Phase 1 Lazy Optimization"). `drain_atomic`, not
+        // `materialize_atomic` (#2066): the latter round-trips every element
+        // through an `IndexMap`-backed `OwnedValue`, collapsing a duplicate
+        // object key inside a moved element (`sort`/`unique`/`reverse`'s own
+        // `LazySource::Cursors` #1687 case) even though `--preserve-input`'s
+        // whole point is not doing that. `drain_atomic` keeps each element's
+        // own cursor identity (or already-owned value, for a `map`-computed
+        // one), matching `ManyCursor`'s own per-element `JqValue::Cursor`
+        // mapping just above.
+        //
+        // `check_cursor_nesting_depth` per `Cursor` element (#2066 review,
+        // #1793 regression): `materialize_atomic`'s per-element
+        // `lazy_elem_to_owned` used to run `to_owned`'s `MAX_NESTING_DEPTH`
+        // panic-guard eagerly, before this arm ever returned -- satisfying
+        // the invariant the `catch_unwind` wrapper's own comment states
+        // ("`out`'s writer is never mid-record when the stack unwinds").
+        // Wrapping a raw cursor in `JqValue::Cursor` with no check at all
+        // defers depth validation to `write_json_at_depth`'s own *different*
+        // (`MAX_VALUE_TREE_DEPTH`, deeper) panic, fired *while* writing --
+        // confirmed live via `test_map_identity_reports_clean_error_on_adversarial_nesting_1793`
+        // regressing to exit 1 with a garbled partial-array line on stdout
+        // instead of a clean exit 5. This is a cheap structural walk (no
+        // value decoding/allocation), not the full deep copy
+        // `materialize_atomic` did, so it does not reintroduce what #2066
+        // was written to avoid.
+        GenericResult::LazySeq(seq) => match seq.drain_atomic() {
+            // All-or-nothing, matching `materialize_atomic`'s own atomicity
+            // contract ("real jq's array construction is all-or-nothing:
+            // `[1,2,"x"]|map(.+1)` prints nothing to stdout, only the stderr
+            // diagnostic") -- an early `return vec![]` on the first bad
+            // element, not a partial `JqValue::Array` of whatever converted
+            // before it (#2066 review: the naive `break`-and-fall-through
+            // shape printed an empty `[]` for a single-element failing
+            // array instead of suppressing it entirely).
+            Ok(elems) => {
+                let mut out = Vec::with_capacity(elems.len());
+                for elem in elems {
+                    match elem {
+                        LazyElem::Cursor(c) => match check_cursor_nesting_depth(&c, 0) {
+                            Ok(()) => out.push(JqValue::Cursor(c)),
+                            Err(e) => {
+                                sink.report(DiagStyle::Jq, &e, at);
+                                return vec![];
+                            }
+                        },
+                        LazyElem::Owned(v) => match JqValue::try_from_owned(v) {
+                            Ok(jq_value) => out.push(jq_value),
+                            Err(e) => {
+                                sink.report(DiagStyle::Jq, &e, at);
+                                return vec![];
+                            }
+                        },
+                    }
+                }
+                vec![JqValue::Array(out)]
+            }
             Err(jq::Control::Error(e)) => {
                 sink.report(DiagStyle::Jq, &e, at);
                 vec![]
@@ -5220,6 +5271,53 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
 /// like a leading-zero number (#1094) or a genuinely malformed document, so
 /// this walk is cold by construction and doesn't need `print_json`'s
 /// `known_text_pos` reuse trick.
+/// Bound a cursor's own structural nesting before it's wrapped in a
+/// `JqValue::Cursor` and deferred to write time (#2066 code review).
+///
+/// Every other producer of a lazy `JqValue` (`OneCursor`/`ManyCursor` above)
+/// already had this covered for free: a `sort`/`unique`/`reverse`/`map`
+/// `LazySeq` used to run through `materialize_atomic`'s per-element
+/// `to_owned`, whose `MAX_NESTING_DEPTH` panic-guard fired eagerly -- before
+/// `generic_result_to_jq_values` ever returned, let alone before any output
+/// write began, matching the `catch_unwind` wrapper's own documented
+/// invariant a few hundred lines up ("`out`'s writer is never mid-record
+/// when the stack unwinds"). Routing a `LazySeq` element straight into
+/// `JqValue::Cursor` for #2066 skipped that guard entirely, deferring
+/// validation to `write_json_at_depth`'s own later, differently-tuned
+/// `MAX_VALUE_TREE_DEPTH` panic -- which fires mid-write, not before it,
+/// and regressed `test_map_identity_reports_clean_error_on_adversarial_nesting_1793`
+/// to a garbled partial line on stdout and the wrong exit code.
+///
+/// Deliberately a structural walk only -- no scalar decoding, no
+/// allocation, `check_nesting_depth`'s existing fallible form rather than
+/// `assert_nesting_depth`'s panic -- so it stays cheap on the common
+/// (shallow) case and doesn't reintroduce the full per-element deep copy
+/// #2066 was written to avoid. Starts fresh at `depth` 0 per element, not
+/// carrying any ambient depth from the array wrapping it, matching
+/// `lazy_elem_to_owned`'s own per-element `to_owned` call.
+fn check_cursor_nesting_depth<W: AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+    depth: usize,
+) -> core::result::Result<(), EvalError> {
+    check_nesting_depth(depth)?;
+    match cursor.value() {
+        StandardJson::Array(elements) => {
+            for child in elements.cursor_iter() {
+                check_cursor_nesting_depth(&child, depth + 1)?;
+            }
+        }
+        StandardJson::Object(fields) => {
+            let mut remaining = fields;
+            while let Some((field, rest)) = remaining.uncons() {
+                check_cursor_nesting_depth(&field.value_cursor(), depth + 1)?;
+                remaining = rest;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 fn validate_json_delimiters<W: AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18431,6 +18431,40 @@ fn test_map_identity_reports_clean_error_on_adversarial_nesting_1793() -> Result
     Ok(())
 }
 
+/// #2066 review: a `LazySeq`-backed builtin (`map`/`reverse`/`sort_by`/
+/// `unique_by`/...) must stay atomic on malformed content the same way it
+/// already was on adversarial nesting depth (the test above) -- nothing on
+/// stdout, one clean diagnostic on stderr, matching `materialize_atomic`'s
+/// own "real jq's array construction is all-or-nothing" contract. An
+/// earlier revision of #2066's fix (routing a drained cursor straight into
+/// `JqValue::Cursor` after only a depth check, not the fuller
+/// `to_owned_cursor` validation `materialize_atomic` used to run per
+/// element) printed a garbled `[1,{"bad":` prefix to stdout before
+/// reporting the error, because delimiter/malformed-member validation had
+/// moved entirely to `print_json`'s own cursor writer, which runs *while*
+/// writing rather than before it. `xyz123` is a bare, unquoted token --
+/// not a valid JSON value at all -- accepted structurally by the semi-index
+/// (per this codebase's own semi-indexing/minimal-validation architecture)
+/// but rejected once actually converted, the same class of leniency gap
+/// `validate_json_delimiters` exists to close elsewhere in this file.
+#[test]
+fn test_lazyseq_builtins_stay_atomic_on_malformed_content_2066() -> Result<()> {
+    for (filter, input) in [
+        ("map(.)", r#"[1, {"bad": xyz123}]"#),
+        ("reverse", r#"[{"bad": xyz123}, 1]"#),
+        ("unique_by(.)", r#"[1, {"bad": xyz123}]"#),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "", "{filter}: stdout: {stdout:?}");
+        assert!(
+            stderr.contains("unexpected character"),
+            "{filter}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #1793 sibling case: `join`, like `sort`, has no native lazy fast path in
 /// `eval_builtin` and falls to the same generic materializing bridge.
 #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29593,27 +29593,26 @@ fn test_resolved_callee_still_checks_its_own_arguments_2037() -> Result<()> {
     Ok(())
 }
 
-/// #1687 on the jq side. Plain `succinctly jq` collapses duplicate keys on
-/// purpose (#1385, matching real jq), so the observable surface here is
-/// `--preserve-input`, the extension whose stated job is keeping the input's
-/// own formatting.
+/// #1687 on the jq side, and #2066's own follow-up fixing the array-valued
+/// half. Plain `succinctly jq` collapses duplicate keys on purpose (#1385,
+/// matching real jq), so the observable surface here is `--preserve-input`,
+/// the extension whose stated job is keeping the input's own formatting.
 ///
-/// The result is deliberately asymmetric, and this pins both halves:
+/// Every one of these now preserves, and this pins the full set:
 ///
 /// - `min`/`max`/`min_by`/`max_by` answer a bare `GenericResult::OneCursor`,
 ///   which `generic_result_to_jq_values` forwards as `JqValue::Cursor`
-///   without decoding -- so they now preserve, joining `first(.[])`, which
+///   without decoding -- so these preserve, joining `first(.[])`, which
 ///   always has.
-/// - `sort`/`unique`/`reverse` and the `_by` forms answer a `LazySeq`, and
-///   `jq_runner.rs` has no lazy-array `JqValue`: its `LazySeq` arm calls
-///   `materialize_atomic()`, producing an `IndexMap`-backed `OwnedValue`.
-///   They therefore still collapse -- a pre-existing property of the jq
-///   output path, not something #1687 changed: `map(.)` has answered a
-///   `LazySeq` since #724/#725 and collapses here identically.
-///
-/// Closing that second half means giving the jq CLI a streaming array value
-/// the way `yq_runner.rs` already has one; filed separately rather than
-/// widened into this change.
+/// - `sort`/`unique`/`reverse` and the `_by` forms answer a `LazySeq`.
+///   `generic_result_to_jq_values`'s `LazySeq` arm used to call
+///   `materialize_atomic()`, producing an `IndexMap`-backed `OwnedValue`
+///   that collapsed a duplicate key inside a moved element -- #2066 routed
+///   it through `drain_atomic()` instead, mapping each element's own cursor
+///   (or already-owned `map`-computed value) to a `JqValue` individually, the
+///   same way `ManyCursor`'s arm already does. `map(.)` is here as the
+///   control proving the shared cause (`LazySeq`'s own output path) rather
+///   than anything specific to #1687's sort/unique/reverse additions.
 #[test]
 fn test_preserve_input_sort_family_cursor_results_keep_duplicate_keys_1687() -> Result<()> {
     let input = r#"[{"a":1,"a":2},{"b":3}]"#;
@@ -29627,22 +29626,28 @@ fn test_preserve_input_sort_family_cursor_results_keep_duplicate_keys_1687() -> 
     assert_eq!(code, 0);
     assert_eq!(stdout, "{\"a\":1,\"a\":2}\n");
 
-    // Single-element results now match it.
+    // OneCursor results.
     for filter in ["min", "max_by(.a)"] {
         let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", filter], Some(input))?;
         assert_eq!(code, 0, "{filter}");
         assert_eq!(stdout, "{\"a\":1,\"a\":2}\n", "{filter}");
     }
 
-    // Array-valued results do not, for the reason above. `map(.)` is here as
-    // the control proving the cause is the output path rather than #1687.
+    // LazySeq results that keep element order.
     for filter in ["map(.)", "sort", "unique"] {
         let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", filter], Some(input))?;
         assert_eq!(code, 0, "{filter}");
-        assert_eq!(
-            stdout, "[{\"a\":2},{\"b\":3}]\n",
-            "{filter}: jq_runner has no lazy-array JqValue, so a LazySeq materializes"
-        );
+        assert_eq!(stdout, "[{\"a\":1,\"a\":2},{\"b\":3}]\n", "{filter}");
+    }
+
+    // LazySeq results that reorder elements -- the duplicate key must
+    // survive the move, not just be preserved when it stays in place.
+    // `.a` on the duplicate-key object reads its last value (2); `{"b":3}`'s
+    // absent `.a` sorts as null, before any number, so it moves first.
+    for filter in ["sort_by(.a)", "unique_by(.a)", "reverse"] {
+        let (stdout, _, code) = run_jq_full(&["-c", "--preserve-input", filter], Some(input))?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(stdout, "[{\"b\":3},{\"a\":1,\"a\":2}]\n", "{filter}");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- `generic_result_to_jq_values`'s `LazySeq` arm (`sort`/`unique`/`reverse`/
  `map(.)`/`sort_by`/`unique_by`) routed through `seq.materialize_atomic()`,
  which round-trips every element through an `IndexMap`-backed `OwnedValue`
  -- collapsing a duplicate object key inside a moved element even though
  `--preserve-input`'s whole point is not doing that (single-valued
  results, `first(.[])`, `min`/`max`/`min_by`/`max_by`, already preserved
  correctly via `JqValue::Cursor`).
- Switched to `seq.drain_atomic()`, which keeps each element's own cursor
  identity (or already-owned value, for a `map`-computed one), mapped to
  `JqValue::Cursor`/`JqValue::Array` the same way `ManyCursor`'s arm
  already does -- turns out `LazySeq::Cursors` (added for #1687) already
  anticipated exactly this fix per its own doc comment, so no new
  `JsonCursor`/`DocumentCursor` trait methods or `JqValue` variants were
  needed, smaller than the issue's own suggested fix direction.
- Caught by my own follow-up testing (not the issue itself): the naive
  version of this regressed #1793's depth-safety guard --
  `JqValue::Cursor` with no eager check defers nesting-depth validation to
  `write_json_at_depth`'s own later, differently-tuned panic
  (`MAX_VALUE_TREE_DEPTH`), which fires *mid-write* instead of *before*
  any output, violating the `catch_unwind` wrapper's own documented
  invariant. Added `check_cursor_nesting_depth`, a cheap structural-only
  walk (no value decoding/allocation) using the existing fallible
  `check_nesting_depth`, run before any element is wrapped as
  `JqValue::Cursor`. Also made the whole arm all-or-nothing on error
  (`return vec![]`, not a partial `JqValue::Array`), matching
  `materialize_atomic`'s own atomicity contract.

Fixes #2066

## Repro

```console
$ echo '[{"a":1,"a":2},{"b":3}]' | succinctly jq -c --preserve-input 'sort'
[{"a":1,"a":2},{"b":3}]     # was [{"a":2},{"b":3}]

$ echo '[{"a":1,"a":2},{"b":3}]' | succinctly jq -c 'sort'   # plain mode: unaffected
[{"a":2},{"b":3}]
```

## Test plan

- [x] `test_preserve_input_sort_family_cursor_results_keep_duplicate_keys_1687` updated: all of `map(.)`/`sort`/`unique`/`sort_by(.a)`/`unique_by(.a)`/`reverse` now preserve
- [x] `test_sort_family_still_collapses_in_plain_jq_mode_1687` unchanged, still passing (plain mode correctly still collapses)
- [x] `test_map_identity_reports_clean_error_on_adversarial_nesting_1793` / `test_adversarial_nesting_does_not_abort_rest_of_stream_1793`: caught my own regression, fixed, both pass
- [x] Full test suite (`cli,simd,regex,serde`): all green
- [x] Both clippy legs (clean `cargo clean -p` rebuild each time, not incremental): clean
- [x] `cargo test --no-default-features` (no_std): clean
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings): clean