### PR TITLE
fix(jq): forward real optional into IN(s)/IN(src;s) instead of false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`IN(s)`/`IN(src; s)` now forward the real ambient `optional` instead of
+  hardcoding `false`** (#2015). Both builtins are defined in terms of
+  `any(...)` (`IN(s)` is `any(s == .; .)`, `IN(src; s)` is
+  `any(src == s; .)`), and `any`/`all`'s own shared implementation,
+  `any_all_gen_cond`, already threads a live, used `optional` parameter
+  through its root-value conversion and its generator's own error handling
+  (#2001) — but `builtin_upper_in`/`builtin_upper_in_src` never picked up
+  the matching update: the former called `to_owned_checked` unconditionally
+  (its own `optional` parameter was `_`-prefixed and unused), and the latter
+  passed a literal `false` into `any_all_gen_cond` regardless of its own
+  (also unused) `optional` parameter.
+
+  Found during review of issue #2015, which asked whether this was a
+  genuine gap or a principled exemption matching `builtin_recurse_f`'s own
+  (real jq's `recurse` has no internal optional-suppression concept, so its
+  `optional` is deliberately left unused — see that function's own doc
+  comment). It is not: unlike `recurse`, `IN`'s own doc comments describe it
+  as delegating its fanout machinery to the *already-correct* `any`/`all`
+  implementation, and no comment anywhere claimed a principled reason for
+  `IN` to diverge from that sibling. Confirmed live against jq 1.7.1 that
+  `IN`, `any`, and `recurse` all get caught uniformly by the outer `?` for
+  an *ordinary* raised error (real jq has no internal suppression concept
+  for any of the three, so it gives no signal either way); the actual
+  distinguishing gap is entirely internal to this codebase's
+  `optional`-threading discipline, in the same family as #1953/#2001/#2010.
+
+  Not reachable via any live `?`/`try` syntax today — like every one of
+  #2001's five sites, `Expr::Optional`'s own dispatch evaluates its inner
+  expression with the *ambient* `optional` and lets the outer `eval_try`
+  catch the result independently of what the callee does internally, so
+  this closes an internal-consistency gap (and a possible future-caller
+  trap) rather than a user-observable regression. A genuine decode failure
+  (invalid UTF-8) is unaffected either way — that class is never suppressed
+  by `optional`, with or without this fix.
+
 - **A rejecting `select(...)` after a generator builtin (`paths`, `range`, ...)
   no longer swallows a surviving branch's own path-validity check** (#2050).
   Inside a path expression, when `select(...)` rejected at least one branch a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -54139,6 +54139,29 @@ mod tests {
         );
     }
 
+    /// #2015 code review: this fix's own `optional`-threading discipline is
+    /// shared, unconditional code (`builtin_upper_in`/`builtin_upper_in_src`
+    /// have no `S::TAG` branch), but the original PR's own tests were all
+    /// `query!` (jq-mode) -- per this repo's own "a jq-scoped fix to a
+    /// shared builtin needs a dual-mode check" rule, pin the yq-mode
+    /// counterpart here too. `IN`/`IN(src;s)` are gated behind
+    /// `--jq-extensions` for the real CLI, but `yq_query!` always parses
+    /// with extensions enabled (`ParserMode::Yq`, `true`), so this exercises
+    /// the same `YqSemantics` evaluator path a real `--jq-extensions` CLI
+    /// invocation would.
+    #[test]
+    fn test_builtin_upper_in_and_src_suppress_ordinary_error_under_optional_yq_2015() {
+        yq_query!(br"1", r#"IN(error("boom"))?"#,
+            QueryResult::None => {}
+        );
+        yq_query!(br"1", r#"IN(1; error("boom"))?"#,
+            QueryResult::None => {}
+        );
+        yq_query!(br"1", r#"IN(error("boom"); 1)?"#,
+            QueryResult::None => {}
+        );
+    }
+
     /// #910: an earlier match short-circuits before a *later* candidate's
     /// error is ever consulted -- confirmed against real jq 1.7.1,
     /// `IN(2, error("boom"))` on `2` is `true`, not an error. When no

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7173,7 +7173,7 @@ fn builtin_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     s: &Expr,
     value: StandardJson<'a, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'a, W> {
     // #932: `IN(s)` is jq's `any(s == .; .)`, so it stops at the first equal
     // candidate rather than evaluating every one and then testing the
@@ -7186,13 +7186,23 @@ fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // review) rather than silently falling back to widening equality.
     //
     // #1755: to_owned_checked, not to_owned -- an undecodable input must
-    // raise, not silently compare as "".
-    let current = match to_owned_checked(&value) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
+    // raise, not silently compare as "". #2015: `..._or_suppress`, not
+    // unconditional `to_owned_checked` -- `IN(s)` is literally `any(s ==
+    // .; .)` (see this function's own doc comment), and `any`/`all`'s own
+    // `any_all_gen_cond` already treats a non-decode-failure error here as
+    // respecting `optional` (#2001); hardcoding this one sibling builtin to
+    // always raise was an accidental miss at #2001 time, not a deliberate
+    // divergence -- there is no doc comment anywhere claiming `IN(s)` has a
+    // principled reason to differ from `any`/`all`'s own already-fixed
+    // behavior (contrast `builtin_recurse_f`'s own doc comment, which does
+    // give one for *its* unused `optional`).
+    let current = to_owned_checked_or_suppress!(&value, optional);
     let mut found = false;
-    let flow = eval_each_owned::<S>(s, &current, false, &mut |candidate| {
+    // #2015: `optional`, not hardcoded `false` -- `s`'s own generator
+    // errors are `any_all_gen_cond`'s `gen` in `IN(s)`'s own `any(s ==
+    // .; .)` terms, and that sibling already threads the real ambient
+    // `optional` into its own `gen` evaluation for exactly this reason.
+    let flow = eval_each_owned::<S>(s, &current, optional, &mut |candidate| {
         if owned_value_eq::<S>(&candidate, &current) {
             found = true;
             Demand::Stop
@@ -7255,14 +7265,25 @@ fn builtin_upper_in_src<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     src: &Expr,
     s: &Expr,
     value: StandardJson<'a, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'a, W> {
     let gen = Expr::Compare {
         op: CompareOp::Eq,
         left: Box::new(src.clone()),
         right: Box::new(s.clone()),
     };
-    any_all_gen_cond::<W, S>(&gen, &Expr::Identity, value, false, true)
+    // #2015: forward the real ambient `optional`, not hardcoded `false` --
+    // `any_all_gen_cond`'s own `optional` parameter is live and used
+    // throughout its body (#2001; see its doc comment on the root-value
+    // conversion above), and `builtin_any_cond`/`builtin_all_cond` (the
+    // `any`/`all` builtins this function's own doc comment says `IN(src;
+    // s)` delegates its fanout machinery to) both forward their real
+    // ambient `optional` unmodified. Hardcoding `false` here silently
+    // dropped that consistency for this one caller; there is no doc
+    // comment anywhere claiming `IN(src; s)` has a principled reason to
+    // differ (contrast `builtin_recurse_f`'s doc comment, which gives one
+    // for *its* unused `optional`).
+    any_all_gen_cond::<W, S>(&gen, &Expr::Identity, value, optional, true)
 }
 
 /// Builtin: select(condition)
@@ -43616,6 +43637,104 @@ mod tests {
         }
     }
 
+    /// #2015: `builtin_upper_in` (`IN(s)`) hardcoded `_optional` unused and
+    /// called `to_owned_checked` unconditionally, unlike its sibling `any`/
+    /// `all` (`any_all_gen_cond`, fixed by #2001 immediately above) despite
+    /// `IN(s)`'s own doc comment defining it as literally `any(s == .; .)`.
+    /// Verified against real jq 1.7.1 that `IN`/`any`/`recurse` all just get
+    /// caught uniformly by the outer `?` for an *ordinary* raised error --
+    /// real jq gives no signal distinguishing "principled exemption" from
+    /// "accidental gap" here, since jq's own builtins have no internal
+    /// suppression concept at all (`?`/`try` always catches from the
+    /// outside). The distinguishing test in *this* codebase is `optional`'s
+    /// own doc-comment-promised, live-and-used-elsewhere criterion
+    /// (`suppress_or_raise`'s doc comment) -- `IN(s)` has no comment
+    /// claiming a principled reason to differ from `any`/`all`, unlike
+    /// `builtin_recurse_f`'s. See #2015 for the full investigation.
+    #[test]
+    fn test_builtin_upper_in_respects_optional_for_malformed_member_error_2015() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let s_expr = Expr::Identity;
+        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2015: a genuine decode failure must still survive `optional` here
+    /// too -- `IN(s)`'s fix routes through `to_owned_checked_or_suppress!`,
+    /// which (like every other site sharing that macro) never suppresses
+    /// `is_decode_failure()`, only the #1194 malformed-member class above.
+    #[test]
+    fn test_builtin_upper_in_decode_failure_survives_optional_2015() {
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let index = JsonIndex::build(decode_failure_bytes);
+        let cursor = index.root(decode_failure_bytes);
+        let s_expr = Expr::Identity;
+        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+    }
+
+    /// #2015: `builtin_upper_in_src` (`IN(src; s)`) had the identical gap --
+    /// it hardcoded `false` into its `any_all_gen_cond` call regardless of
+    /// its own (unused, `_`-prefixed) `optional` parameter. See
+    /// `test_builtin_upper_in_respects_optional_for_malformed_member_error_2015`'s
+    /// doc comment for the full reasoning.
+    #[test]
+    fn test_builtin_upper_in_src_respects_optional_for_malformed_member_error_2015() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let src_expr = Expr::Identity;
+        let s_expr = Expr::Identity;
+        match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
+            &src_expr,
+            &s_expr,
+            cursor.value(),
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
+            &src_expr,
+            &s_expr,
+            cursor.value(),
+            false,
+        ) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2015: a genuine decode failure must still survive `optional` for
+    /// `IN(src; s)` too, same reasoning as `IN(s)`'s matching test above.
+    #[test]
+    fn test_builtin_upper_in_src_decode_failure_survives_optional_2015() {
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let index = JsonIndex::build(decode_failure_bytes);
+        let cursor = index.root(decode_failure_bytes);
+        let src_expr = Expr::Identity;
+        let s_expr = Expr::Identity;
+        match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
+            &src_expr,
+            &s_expr,
+            cursor.value(),
+            true,
+        ) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+    }
+
     /// #2001: `builtin_contains`'s own root-value conversion had the same
     /// gap. See
     /// `test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953`'s
@@ -53992,6 +54111,31 @@ mod tests {
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "boom");
             }
+        );
+    }
+
+    /// #2015: `?` suppresses an ordinary raised error from `IN`/`IN(src;
+    /// s)` the same way it does for every other jq construct -- confirmed
+    /// live against real jq 1.7.1: `1 | IN(error("boom"))?` and
+    /// `1 | IN(error("boom"); 1)?`/`1 | IN(1; error("boom"))?` are all
+    /// empty (`[]` under `[...]`), not an error, same as
+    /// `[1,2] | recurse(error("x"))?`'s partial-then-suppressed shape and
+    /// `1 | any(error("x"); .)?`'s empty shape. This was already correct
+    /// before the #2015 fix (the outer `Expr::Optional`/`eval_try` boundary
+    /// catches an ordinary `Error` regardless of what a callee does with
+    /// its own `optional` parameter internally, same as every #1953/#2001
+    /// site) -- pinned here so it stays correct now that `optional` is also
+    /// threaded internally.
+    #[test]
+    fn test_builtin_upper_in_and_src_suppress_ordinary_error_under_optional_2015() {
+        query!(br"1", r#"IN(error("boom"))?"#,
+            QueryResult::None => {}
+        );
+        query!(br"1", r#"IN(1; error("boom"))?"#,
+            QueryResult::None => {}
+        );
+        query!(br"1", r#"IN(error("boom"); 1)?"#,
+            QueryResult::None => {}
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -43667,6 +43667,38 @@ mod tests {
         }
     }
 
+    /// #2015 code review: `test_builtin_upper_in_respects_optional_for_malformed_member_error_2015`
+    /// above exercises only the *first* of `builtin_upper_in`'s two
+    /// `optional`-wiring points -- its malformed root `value` makes
+    /// `to_owned_checked_or_suppress!` return before `s` (the identity
+    /// expression there) is ever evaluated by `eval_each_owned`, so a
+    /// revert of that second call's `optional` argument back to hardcoded
+    /// `false` still passes every `_2015` test above (verified by hand:
+    /// reverting it and rerunning `cargo test --lib
+    /// jq::eval::tests::test_builtin_upper_in` leaves all of them green).
+    /// This test instead gives `s` itself a reason to error independent of
+    /// `value`'s own decodability -- a decodable root (`5`, a number) fed
+    /// through `s = .foo` (`Expr::Field`), which unconditionally errors
+    /// ("Cannot index number with string \"foo\"") on a non-object/null
+    /// target -- so it can only be suppressed if `eval_each_owned`'s own
+    /// `optional` argument is the real ambient one, not a hardcoded
+    /// `false`.
+    #[test]
+    fn test_builtin_upper_in_respects_optional_for_type_mismatch_inside_s_2015() {
+        let json_bytes: &[u8] = b"5";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let s_expr = Expr::field("foo");
+        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), true) {
+            QueryResult::Owned(OwnedValue::Bool(false)) => {}
+            other => panic!("expected Bool(false) (suppressed), got {other:?}"),
+        }
+        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
     /// #2015: a genuine decode failure must still survive `optional` here
     /// too -- `IN(s)`'s fix routes through `to_owned_checked_or_suppress!`,
     /// which (like every other site sharing that macro) never suppresses


### PR DESCRIPTION
## Summary

Fixes #2015. `builtin_upper_in` (`IN(s)`) and `builtin_upper_in_src` (`IN(src;
s)`) never picked up #2001's `any_all_gen_cond` fix: the former called
`to_owned_checked` unconditionally (ignoring its own `_optional` parameter),
and the latter hardcoded `false` into its `any_all_gen_cond` call regardless
of the real ambient `optional` — despite both builtins' own doc comments
defining them in terms of `any(s == .; .)`, whose shared fanout machinery
already threads a live, used `optional` (#2001).

## Investigation

Verified live against jq 1.7.1 that `IN`, `any`, and `recurse` are all caught
uniformly by the outer `?`/`try` for an ordinary raised error — real jq has
no internal per-construct suppression concept for any of them, so jq's own
behavior gives no signal distinguishing a principled exemption (like
`recurse`'s, which has its own doc comment explaining why its `optional` is
legitimately unused) from an accidental gap:

```console
$ echo '1' | jq -c '[IN(error("boom"))?]'
[]
$ echo '1' | jq -c '[IN(1; error("boom"))?]'
[]
$ echo '1' | jq -c '[IN(error("boom"); 1)?]'
[]
$ echo '[1,2]' | jq -c '[recurse(error("x"))?]'
[[1,2]]
$ echo '1' | jq -c '[any(error("x"); .)?]'
[]
```

No doc comment anywhere claims `IN`/`IN(src;s)` has a principled reason to
diverge from `any`/`all`'s own already-fixed behavior — this is a genuine
accidental gap in the same family as #2001's five confirmed sites, not a
deliberate exemption. Not reachable via live `?`/`try` syntax today (same as
every one of #2001's sites), so this closes an internal-consistency gap
rather than a user-observable regression — a defensive fix against a future
caller reaching either builtin with `optional: true`.

## Changes

- `builtin_upper_in`: `_optional` → `optional`; routes through
  `to_owned_checked_or_suppress!` instead of unconditional `to_owned_checked`;
  forwards `optional` into its own `eval_each_owned` call instead of `false`.
- `builtin_upper_in_src`: `_optional` → `optional`; forwards `optional` into
  `any_all_gen_cond` instead of hardcoded `false`.

## Test plan
- [x] Live-verified against the pinned oracle (`/usr/bin/jq` 1.7.1) — see
  investigation section above.
- [x] 5 new regression tests: malformed-member/`optional` pairs for both
  builtins (matching the #2001 pattern), decode-failure-survives-`optional`
  pins for both, and a `query!`-level test confirming `IN(...)?`/
  `IN(...;...)?` still suppress an ordinary error, matching live jq.
- [x] `cargo test --features cli,simd,regex,serde --lib`: 3268 passed, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.