### PR TITLE
fix(jq): let a fold's UPDATE/EXTRACT re-establish path tracking off $var

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -512,42 +512,63 @@ used to be a third, narrower gap, found reviewing
 `resolve_reduce`/`resolve_foreach` arms to `resolve_node` (`src/jq/eval.rs`) modeling jq's
 own `(path, value_at_path)` register, derived empirically since real jq has no fold-specific
 path machinery at all (`reduce`/`foreach` are sugar over the same variable-binding primitive
-every other construct uses). Three narrower shapes remain open, **all of them refuse-only**
-— succinctly declines a filter jq accepts, visibly (exit 5) and without touching any
-document. There used to be a fourth that ran the other way, accepting a filter jq rejects so
+every other construct uses). Three narrower shapes were tracked below; #2046 closed the
+headline example of the first, leaving a smaller residue in its place. Every remaining piece
+across all three is **refuse-only** — succinctly declines a filter jq accepts, visibly
+(exit 5) and without touching any document. There used to be a fourth that ran the other
+way, accepting a filter jq rejects so
 that `=`/`|=`/`del()` wrote where jq raises;
 [#1466](https://github.com/rust-works/succinctly/issues/1466) closed it, and shape #3 below
 is the price it paid. Refusing is the safe direction: [#985](https://github.com/rust-works/succinctly/issues/985)
 is the revert that established what the other one costs.
 
-1. **Variable-rooted navigation off a mismatched accumulator** —
-   `path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))` on `{"a":{"b":1},"c":2}` is
-   `["a","b"]` ×2 in jq; succinctly refuses.
+1. **Variable-rooted navigation off a mismatched accumulator** — **closed by
+   [#2046](https://github.com/rust-works/succinctly/issues/2046)** for the shape that gave
+   this entry its name: `path(. as $x \| foreach (1,2) as $i (0; $x.a; .b))` on
+   `{"a":{"b":1},"c":2}` now answers `["a","b"]` ×2, matching jq, instead of refusing.
 
-   The *plain-pipe* half of this shape is closed.
+   The *plain-pipe* half of this shape closed first.
    [#1573](https://github.com/rust-works/succinctly/issues/1573) established that jq carries
    a `(path, value_at_path)` **register** which only navigation advances — a literal never
    moves it, so a `$var` frozen from where it still points steps back onto it — and
-   `resolve_seq` now threads that register (`PathBranch::register`,
-   `reestablishes_register`, `src/jq/eval.rs`). `path(. as $x \| 5 \| $x.a)` on `{"a":1}`,
-   which this list previously recorded as refusing, answers `["a"]` like jq.
+   `resolve_seq` threads that register (`PathBranch::register`,
+   `reestablishes_register`, `src/jq/eval.rs`). `path(. as $x \| 5 \| $x.a)` on `{"a":1}`
+   answers `["a"]` like jq. [`FoldRegister`](../../../src/jq/eval.rs) (the fold's *own*
+   register) had no way to reach that same mechanism, because it is seeded from *outside*
+   any one `resolve_seq` call — `FoldRegister::resolve` had nothing to hand `resolve_seq` to
+   seed its first stage from. #2046 added exactly that: `resolve_seq` takes an extra
+   `register: Option<&'a OwnedValue>` parameter, consulted only when seeding its own fan-out
+   loop's first branch (mirroring how it already seeds `trackable`/`snapshot`), and
+   `FoldRegister::resolve` supplies `self.value` there whenever `UPDATE`/`EXTRACT` is (under
+   any wrapping `Paren`) an `Expr::Pipe` — the shape `$x.a`, `$x.a.b`, `$x[0]`, `5 \| $x.a`,
+   ... all parse into. Once seeded, the *existing*, already-oracle-verified stage-to-stage
+   carrying (`reestablishes_register`/`carry_register`, both from #1573/#2041/#2044) takes
+   over unchanged — #2046 adds a new *source* for the carried register, not a new rule for
+   recognising it. A bare `$var` with nothing chained after it needed none of this: it was
+   already reestablishing directly through `FoldRegister::relocate`'s own `identical()` check.
 
-   What remains here is that [`FoldRegister`](../../../src/jq/eval.rs) does not seed *its*
-   register into the resolution of its own `UPDATE`/`EXTRACT`: the accumulator (`0`) is
-   resolved with tracking already off and no register to compare against, so `$x.a` cannot
-   re-establish the way it does in a plain pipe. Closing it means threading the register
-   into `resolve_node`/`resolve_leaf` as a parameter rather than carrying it on the branch,
-   which is a materially larger change across that function's ~20-call-site dispatch graph.
+   **Scope limit, deliberately not closed**: the register is threaded only as far as
+   `resolve_seq`'s own seed — a `$var` reference nested *inside* `if`/`try`/`select`/an
+   alternative/a construction at UPDATE or EXTRACT's own top level still refuses, because
+   `resolve_node`'s own recursive dispatch (the ~20-call-site graph the original design note
+   here estimated threading through) was deliberately left untouched. Confirmed live:
+   `path(. as $x \| foreach (1) as $i (0; if true then $x.a else 1 end; .))` on
+   `{"a":{"b":1},"c":2}` is `["a"]` in jq; succinctly still refuses. Widening this further
+   would mean the fuller ~20-call-site threading the original note described, with its own
+   oracle matrix per arm — left for a follow-up rather than attempted alongside the
+   already-substantial change above.
 
    The register is also carried **only across stages this resolver can prove did not move
-   it** (`cannot_move_register`, `src/jq/eval.rs`). jq's register advances on any `INDEX`
-   its own bytecode executes, which includes the ones hidden inside a jq-*defined* builtin
-   (`first` is `.[0]`, `add` is `reduce .[] as $x ...`) or a user function body — stages
-   that reach the resolver as one opaque computed value. Assuming those left the register
-   alone made `path(. as $x \| ([.a]\|first) \| $x)` answer `[]` where jq refuses, and
-   `=`/`|=`/`del()` then wrote through the fabricated path, so the allowlist is deliberately
-   narrow and everything outside it drops the register. Three shapes jq answers therefore
-   refuse here: a construction or interpolation that itself navigates
+   it** (`cannot_move_register`, `src/jq/eval.rs`) — the same allowlist now gates both
+   `resolve_seq`'s plain-pipe carrying *and* #2046's fold-seeded carrying, since both reach
+   the identical stage-to-stage machinery. jq's register advances on any `INDEX` its own
+   bytecode executes, which includes the ones hidden inside a jq-*defined* builtin (`first`
+   is `.[0]`, `add` is `reduce .[] as $x ...`) or a user function body — stages that reach
+   the resolver as one opaque computed value. Assuming those left the register alone made
+   `path(. as $x \| ([.a]\|first) \| $x)` answer `[]` where jq refuses, and `=`/`|=`/`del()`
+   then wrote through the fabricated path, so the allowlist is deliberately narrow and
+   everything outside it drops the register. Three shapes jq answers therefore refuse here:
+   a construction or interpolation that itself navigates
    (`path(. as $x \| [.a] \| $x)`, `{k:.a}`, `"\(.a)"` — excluded because jq *also* raises
    for a `.a` applied to a computed value, which this resolver never sees inside a
    construction: `path(. as $x \| {k:.a} \| [.a] \| $x)` raises in jq on the second `.a`),
@@ -574,6 +595,25 @@ is the revert that established what the other one costs.
    answer would become) rather than merely refuse, which is the direction ADR-0018 never
    permits. Refuse-only for yq mode remains pre-existing and tracked the same way the three
    shapes above are.
+
+   **#2046 review finding, also closed**: `FoldRegister::advance` — which builds `foreach`'s
+   per-step `EXTRACT` register from `UPDATE`'s own output — carried its *pre-UPDATE* register
+   forward unconditionally whenever `UPDATE`'s own branch ended untracked, without checking
+   whether `UPDATE`'s own expression could have moved jq's real register along the way. That
+   was already live on `main`, reachable through `FoldRegister::relocate`'s pre-existing
+   `identical()` check without needing #2046's own new register-seeding at all — differential
+   fuzzing found it independently on a pre-#2046 build (1, 3 and 4 fabrications across three
+   4,000-shape seeds, always the same shape): `path(. as $x \| foreach (1,2,3) as $k (null;
+   try $x.c catch 1; select(true) \| $x))` on `{"a":"s","c":"s"}` printed `[]` three times
+   where jq raises "Invalid path expression with result {\"a\":\"s\",\"c\":\"s\"}" — `try
+   $x.c catch 1` attempts (and jq's real bytecode executes) a genuine `INDEX` on `$x` before
+   the error is caught, which moves jq's real `value_at_path` regardless of the `catch`.
+   Fixed by gating `advance`'s carry-forward on `cannot_move_register(update_expr)`, the same
+   allowlist described above — bundled with #2046 rather than filed separately since it sits
+   in the exact function #2046's own fix required understanding in full, and #2046's own
+   verification requirement (a direction-classified differential fuzz showing zero new
+   accept-where-jq-refuses cases) would not have been satisfiable while leaving a *known*
+   instance of exactly that class in the same subsystem.
 
    Separately, a variable bound from a *navigated* position (`.a as $y`) still carries no
    marker at all, because `substitute_var_tracked` remains gated on

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20704,7 +20704,9 @@ fn resolve_node<'a, S: EvalSemantics>(
     keep: Keep,
 ) -> PathResolveResult<'a> {
     match expr {
-        Expr::Pipe(exprs) => resolve_seq::<S>(exprs, value, trackable, snapshot, keep),
+        // `None`: an ordinary pipe has no externally-known register to
+        // inject (#2046) — see `resolve_seq`'s own doc comment.
+        Expr::Pipe(exprs) => resolve_seq::<S>(exprs, value, trackable, snapshot, keep, None),
         Expr::Paren(inner) => resolve_node::<S>(inner, value, trackable, snapshot, keep),
 
         // #1371: `path(f)` has to see *through* a call to whatever its body
@@ -22722,6 +22724,31 @@ impl FoldRegister {
     /// `relocate` (a freshly-built object, no snapshot, no path) could
     /// still make this step's own bare `.` look genuinely trackable,
     /// reopening #1466's bug class through this second call site.
+    ///
+    /// **#2046**: when `expr` is (under any wrapping `Paren`) an
+    /// `Expr::Pipe`, this dispatches straight to [`resolve_seq`] with
+    /// `self.value` threaded in as its externally-known register — rather
+    /// than through the ordinary `resolve_against_cow`/`resolve_node`
+    /// route, which has no parameter for one at all. That register is what
+    /// lets a `$var` bound *outside* this fold (substituted in as
+    /// `Expr::TrackedVar`, wherever it appears in UPDATE/EXTRACT) still
+    /// navigate — `path(. as $x | reduce (1) as $i (0; $x.a))` needs `.a`
+    /// to reestablish against `self.value`, the fold's own persistent
+    /// register, not the transient accumulator `tr`/`snapshot` already
+    /// describe. `tr` alone cannot express this: it says whether the
+    /// accumulator *itself* is currently sitting at the register, which
+    /// `INIT = 0` here already answered `false` — exactly the case
+    /// [`resolve_seq`]'s own carried-register mechanism (#1573/#2041)
+    /// exists to recover from, just never wired to a fold's register until
+    /// now. A bare `$var` (no chain after it) needs none of this: it
+    /// resolves to a single untracked, snapshot-marked branch that
+    /// `relocate`'s own `identical()` check below already recognises
+    /// directly, register or not. Every other shape a `$var` might be
+    /// nested inside here — `if`/`try`/`select`/a construction/... — falls
+    /// to the unmodified `resolve_node` call, exactly as before #2046: a
+    /// known, syntactic scope limit (not every arm of `resolve_node`
+    /// threads this register), costing a refusal rather than risking a
+    /// wrong acceptance. See issue #2046.
     fn resolve<'a, S: EvalSemantics>(
         &self,
         expr: &Expr,
@@ -22731,7 +22758,32 @@ impl FoldRegister {
         keep: Keep,
     ) -> PathResolveResult<'a> {
         let tr = self.trackable && at_register;
-        match resolve_against_cow::<S>(expr, Cow::Owned(input), tr, snapshot, keep) {
+        let resolved = if let Expr::Pipe(exprs) = unwrap_paren(expr) {
+            resolve_seq::<S>(
+                exprs,
+                &input,
+                tr,
+                snapshot,
+                keep,
+                self.trackable.then_some(&self.value),
+            )
+        } else {
+            resolve_node::<S>(expr, &input, tr, snapshot, keep)
+        };
+        let owned = match resolved {
+            Ok(branches) => Ok(branches
+                .into_iter()
+                .map(PathBranch::into_owned_value)
+                .collect()),
+            Err((prefix, e)) => Err((
+                prefix
+                    .into_iter()
+                    .map(PathBranch::into_owned_value)
+                    .collect(),
+                e,
+            )),
+        };
+        match owned {
             Ok(branches) => Ok(self.relocate(branches)),
             Err((prefix, e)) => Err((self.relocate(prefix), e)),
         }
@@ -22785,26 +22837,71 @@ impl FoldRegister {
     /// "re-entry" boundary between them, unlike the reset between source
     /// elements — see this type's own doc comment).
     ///
-    /// An untracked UPDATE branch leaves the register unchanged (not
-    /// reset to untracked) — a computed UPDATE result doesn't erase where
-    /// the register already was, mirroring `enter`'s identical "computed
-    /// doesn't move the register" rule for INIT. Confirmed live:
-    /// `path(. as $x | foreach (1) as $i (0; 5; $x))` is `[]` — UPDATE=`5`
-    /// never navigates, so the register EXTRACT sees is still wherever it
-    /// was before UPDATE ran (the document root, from `enter`'s untracked
-    /// branch), letting `$x` (bound from that same root) match.
-    fn advance(&self, branch: &PathBranch<'_>) -> Self {
+    /// An untracked UPDATE branch *whose own expression is provably unable
+    /// to have moved jq's register* ([`cannot_move_register`]) leaves the
+    /// register unchanged (not reset to untracked) — a computed UPDATE
+    /// result doesn't erase where the register already was, mirroring
+    /// `enter`'s identical "computed doesn't move the register" rule for
+    /// INIT. Confirmed live: `path(. as $x | foreach (1) as $i (0; 5;
+    /// $x))` is `[]` — UPDATE=`5` never navigates, so the register EXTRACT
+    /// sees is still wherever it was before UPDATE ran (the document root,
+    /// from `enter`'s untracked branch), letting `$x` (bound from that same
+    /// root) match.
+    ///
+    /// **#2046 review finding — pre-existing on `main`, not a consequence of
+    /// #2046's own change**: an untracked UPDATE branch is not the same
+    /// thing as an UPDATE that never navigated — `try $x.c catch 1` ends
+    /// untracked (the `catch` branch, a plain literal) but its own body did
+    /// attempt (and jq's real bytecode did execute) a genuine `INDEX` on
+    /// `$x` before the error was caught, which moves jq's real
+    /// `value_at_path` regardless of the `catch`. Before this gate, this
+    /// function carried `self` (wherever the register was *before* UPDATE
+    /// ran) forward unconditionally whenever `branch` was untracked, and
+    /// that was already reachable through [`FoldRegister::relocate`]'s own
+    /// pre-existing `identical()` check — which consults exactly `self`
+    /// (this type's own `value`/`trackable`, i.e. `advance`'s own return
+    /// value threaded in as `extract_reg`) once EXTRACT's own resolution
+    /// finishes, with no dependency on #2046's own `resolve_seq` register
+    /// injection at all. Differential fuzzing against jq 1.7.1, run against
+    /// a build *without* #2046's own change as a baseline check, still
+    /// found it: `path(. as $x | foreach (1,2,3) as $k (null; try $x.c
+    /// catch 1; select(true) | $x))` on `{"a":"s","c":"s"}` answered `[]`
+    /// three times here where jq raises "Invalid path expression with
+    /// result {...}" (`select(true)` also drops the register itself,
+    /// `cannot_move_register(Select)` being `false`, but the fabrication
+    /// originates one step earlier, at this function, independent of that).
+    /// Reusing [`cannot_move_register`] — already the exact, oracle-verified
+    /// allowlist [`resolve_seq`]'s own stage-to-stage carrying uses for this
+    /// identical question — is what closes it: only a
+    /// syntactically-provable-safe UPDATE (a literal, `$var`, arithmetic
+    /// over safe operands, ...) still carries `self` forward; anything else
+    /// (including a `try`/`select`/`reduce`/call that *might* have
+    /// navigated, caught or not) loses the register entirely. Losing it
+    /// only costs a refusal; keeping it risks the accept-where-jq-refuses
+    /// class #1466 closed. Bundled with #2046 rather than filed separately:
+    /// it lives in the exact function #2046's own fix required
+    /// understanding in full, and #2046's own verification requirement (a
+    /// direction-classified differential fuzz showing zero
+    /// accept-where-jq-refuses cases) is not satisfiable while a known
+    /// instance of that exact class sits live in the same subsystem.
+    fn advance(&self, branch: &PathBranch<'_>, update_expr: &Expr) -> Self {
         if branch.trackable {
             Self {
                 path: Rc::clone(&branch.path),
                 value: branch.value.clone().into_owned(),
                 trackable: true,
             }
-        } else {
+        } else if cannot_move_register(update_expr) {
             Self {
                 path: Rc::clone(&self.path),
                 value: self.value.clone(),
                 trackable: self.trackable,
+            }
+        } else {
+            Self {
+                path: PathPrefix::root(),
+                value: OwnedValue::Null,
+                trackable: false,
             }
         }
     }
@@ -23415,7 +23512,7 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                         aborted = Some(control);
                         break 'input;
                     }
-                    let extract_reg = active_reg.advance(update_branch);
+                    let extract_reg = active_reg.advance(update_branch, substituted_update);
                     // `update_branch` is itself already relocated (it's
                     // `active_reg.resolve()`'s own output above), and
                     // `advance()` built `extract_reg` from this same
@@ -25005,12 +25102,30 @@ fn carry_register<'a>(
 /// *its* position, which is the document root only when it sits at the top of
 /// the path. `path(.x | .a[.k])` resolves `.k` against `.x`, giving
 /// `["x","a","a"]`.
+///
+/// `register` (#2046) is an *externally known* path register, distinct from
+/// the one this function's own fan-out loop already carries stage-to-stage
+/// via each [`PathBranch`]'s own `register` field (#1573/#2041) — this
+/// parameter is what seeds that mechanism in the first place, for the one
+/// caller that has a register from *outside* this call to inject:
+/// [`FoldRegister::resolve`], which has no other way to make a fold's own
+/// persistent register visible to a `$var` reference chained inside
+/// UPDATE/EXTRACT (`. as $x | reduce ... (0; $x.a; ...)` — see that
+/// function's own doc comment). `resolve_node`'s ordinary `Expr::Pipe` arm
+/// passes `None`: an ordinary pipe has no such outside register, only
+/// whatever it establishes for itself.
+///
+/// Only ever consulted at the seed branch below, mirroring `trackable`/
+/// `snapshot`: once seeded, `reestablishes_register`/`carry_register`'s
+/// already-tested stage-to-stage rules take over unchanged, so this adds one
+/// new *source* for the carried register, not a new rule for recognising it.
 fn resolve_seq<'a, S: EvalSemantics>(
     exprs: &[Expr],
     value: &'a OwnedValue,
     trackable: bool,
     snapshot: bool,
     keep: Keep,
+    register: Option<&'a OwnedValue>,
 ) -> PathResolveResult<'a> {
     let mut flat = Vec::new();
     for e in exprs {
@@ -25114,12 +25229,26 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // The seed also inherits this call's own ambient `snapshot` (#1591), for
     // the identical reason it inherits `trackable`: it is `value` itself,
     // unchanged, before the first stage below ever runs.
+    //
+    // `register` (#2046) is attached the same way `PathBranch::with_register`
+    // always requires: only while `!trackable`, since a trackable seed's
+    // register is its own value at its own path and needs no second copy —
+    // `with_register` would otherwise `debug_assert!`. This is the one spot
+    // an externally-supplied register (from `FoldRegister::resolve`) enters
+    // the stage-to-stage carrying mechanism below; every subsequent stage
+    // reads it as `carried_register`, exactly as it already would for a
+    // register `resolve_leaf` established from inside this same call.
     let mut branches: Vec<PathBranch<'a>> = vec![PathBranch::passthrough(
         PathPrefix::root(),
         Cow::Borrowed(value),
         trackable,
         snapshot,
-    )];
+    )
+    .with_register(if trackable {
+        None
+    } else {
+        register.map(Cow::Borrowed)
+    })];
     // Set the first time any stage's branch escapes, and overwritten by any
     // later stage's own escape (#1013) — mirroring the pre-existing "a later
     // step's own failure outranks an earlier deferred one" rule this
@@ -72408,25 +72537,25 @@ mod tests {
     /// `trackable`), so nothing ever exercised what happens when `f`
     /// *itself* fails to navigate from one. Both sides still refuse (exit
     /// 5, no output either way — `reduce` only ever emits its final
-    /// accumulator, so there is no partial prefix to lose either) — only
-    /// the wording differs. jq reports the ordinary `#530` "with result"
-    /// message naming the value `f` produced (`1`, from `.a` on `$x`'s
-    /// value), where succinctly reports `#843`'s "near attempt to access
-    /// element" message instead, since `resolve_leaf`'s own untracked-Field
-    /// guard fires before `resolve_recurse`'s per-node `trackable`
-    /// propagation is ever consulted. Left as a follow-up rather than
-    /// chased here: both messages already say "refused," so there is no
-    /// silent-acceptance risk, only a wording mismatch in an edge case that
-    /// needed this fix's own guard change to become reachable at all.
+    /// accumulator, so there is no partial prefix to lose either).
+    ///
+    /// **Closed by #2046**, incidentally rather than deliberately: `$x |
+    /// recurse(.a?)` is `Expr::Pipe([TrackedVar, RecurseF(...)])`, exactly
+    /// the shape `FoldRegister::resolve` now threads its register into (see
+    /// that function's own doc comment). `$x` reestablishes against the
+    /// fold's register (the document root), so `recurse(.a?)` now runs with
+    /// genuine `trackable: true` instead of hitting `resolve_leaf`'s
+    /// untracked-`Field` guard before `resolve_recurse` is ever reached —
+    /// and *that* is what produces jq's own `#530` "with result 1" wording
+    /// (`.a` on `$x`'s value, `1`, is not itself a further path-shaped
+    /// value) instead of `#843`'s "near attempt" message. Confirmed live
+    /// against jq 1.7.1: byte-identical message and exit code.
     #[test]
     fn test_resolve_recurse_field_navigation_into_snapshot_wording_gap_1591() {
         query!(br#"{"a":1}"#,
             "path(. as $x | reduce (1) as $i (0; $x | recurse(.a?)))",
             QueryResult::Error(e) => {
-                assert_eq!(
-                    e.message,
-                    r#"Invalid path expression near attempt to access element "a" of {"a":1}"#
-                );
+                assert_eq!(e.message, r"Invalid path expression with result 1");
             }
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30896,3 +30896,162 @@ fn test_reduce_source_navigation_does_not_clobber_persistent_register_2031() -> 
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     Ok(())
 }
+
+/// #2046's own primary repro: `FoldRegister` knew where its own register
+/// was but never exposed it to UPDATE/EXTRACT's own resolution -- `$x`
+/// (bound *outside* the fold, via `. as $x`) is substituted in as
+/// `Expr::TrackedVar`, but `$x.a`'s own `.a` step had no register to
+/// reestablish against, so it raised `#843`'s "near attempt" error instead
+/// of navigating. The equivalent plain pipe already worked since #2041
+/// (`path(. as $x | 5 | $x.a)` is `["a"]`); this is the fold-specific half.
+/// Verified against jq 1.7.1: `["a","b"]` printed twice (one per `foreach`
+/// element), exit 0.
+#[test]
+fn test_foreach_update_reestablishes_outer_bound_register_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(. as $x | foreach (1,2) as $i (0; $x.a; .b))"],
+        Some(r#"{"a":{"b":1},"c":2}"#),
+    )?;
+    assert_eq!(
+        stdout, "[\"a\",\"b\"]\n[\"a\",\"b\"]\n",
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2046 negative control: a *bare* `$x` (nothing chained after it)
+/// referenced inside a fold's UPDATE already resolved correctly before
+/// #2046, via `FoldRegister::relocate`'s own direct `identical()` check --
+/// this guards that #2046's new `resolve_seq`-based dispatch for `$x.a`-
+/// style chains didn't regress that pre-existing, unrelated path. Verified
+/// against jq 1.7.1: `[]` printed twice, exit 0 (the register never leaves
+/// the document root, since `INIT = 0` is a literal and `$x` itself is the
+/// whole document).
+#[test]
+fn test_foreach_bare_trackedvar_inside_fold_still_tracks_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(. as $x | foreach (1,2) as $i (0; $x))"],
+        Some(r#"{"a":{"b":1},"c":2}"#),
+    )?;
+    assert_eq!(stdout, "[]\n[]\n", "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2046 negative control, the dangerous direction: `SOURCE`'s own
+/// navigation (`.a` then `.c`) moves the fold's persistent register onto
+/// `.c`'s own position each iteration -- `$x` is still frozen at the
+/// document *root*, a value that is structurally equal to neither `.a` nor
+/// `.c`'s own subtree here, so nothing should reestablish. This is the
+/// fold-context analogue of #2041's own `path(.a as $y | .c | $y)`
+/// counter-example (equal *value*, different *node*, refused by real jq
+/// because `jv_identical` is pointer identity, not structural equality) --
+/// #2046 must not widen acceptance into that same accept-where-jq-refuses
+/// class just because it now threads a register through `resolve_seq` for
+/// fold UPDATE/EXTRACT. Verified against jq 1.7.1: raises "Invalid path
+/// expression with result {"a":{"b":1},"c":{"b":1}}", exit 5 -- the
+/// assertion below only checks the message's first 11 bytes since
+/// succinctly's own `dump_truncated` (`DUMP_KEEP`, `src/jq/error.rs`)
+/// truncates this particular message shape far sooner than real jq does
+/// (a separate, pre-existing wording-length gap unrelated to this fix,
+/// filed as #2179).
+#[test]
+fn test_foreach_extract_equal_value_different_node_still_refuses_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(. as $x | foreach (1,2) as $i (.a; .c; $x))"],
+        Some(r#"{"a":{"b":1},"c":{"b":1}}"#),
+    )?;
+    assert_eq!(stdout, "", "must not emit a path: stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"Invalid path expression with result {"a":{"b":1"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2046's `reduce` companion to the primary `foreach` repro: `reduce`'s
+/// own persistent register moves onto `.a`'s own path after the first
+/// iteration's `$x.a` navigates there (the accumulator becomes `{"b":1}`,
+/// itself now sitting *at* the register), so the *second* iteration's
+/// `$x.a` compares the frozen `$x` (still the whole document root) against
+/// the *current* register position (`.a`, value `{"b":1}`) -- not equal,
+/// so it correctly raises rather than reestablishing a second time. This
+/// pins the distinction between `FoldRegister::resolve`'s injected
+/// register (`self.value`, fixed at INIT time) and `resolve_leaf`'s own
+/// ambient-value recording (the accumulator's *current* position, used
+/// whenever the incoming step is already `tr == true`) -- #2046's fix
+/// composes with the existing per-step mechanism instead of overriding it.
+/// Verified against jq 1.7.1: raises "Invalid path expression with result
+/// {\"b\":1}" on the second iteration, exit 5.
+#[test]
+fn test_reduce_second_iteration_register_moved_by_first_still_refuses_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(. as $x | reduce (1,2) as $i (0; $x.a))"],
+        Some(r#"{"a":{"b":1},"c":2}"#),
+    )?;
+    assert_eq!(stdout, "", "must not emit a path: stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"Invalid path expression with result {"b":1}"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2046 write-side companion: once `path()` can resolve `$x.a` inside a
+/// fold's UPDATE, `=`/`|=`/`del()` all route through the same resolver, so
+/// this exercises the actual document write rather than just `path()`'s
+/// own report. Verified against jq 1.7.1: `{"a":{"b":99},"c":2}`, exit 0.
+#[test]
+fn test_foreach_update_reestablished_register_supports_a_write_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "(. as $x | foreach (1,2) as $i (0; $x.a; .b)) = 99"],
+        Some(r#"{"a":{"b":1},"c":2}"#),
+    )?;
+    assert_eq!(stdout, "{\"a\":{\"b\":99},\"c\":2}\n", "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2046 review finding, closed alongside the primary fix (not a
+/// consequence of it): an UPDATE branch ending *untracked* is not the same
+/// thing as an UPDATE that never navigated -- `try $x.c catch 1` attempts
+/// (and jq's real bytecode executes) a genuine `INDEX` on `$x` before the
+/// error is caught, which moves jq's real `value_at_path` regardless of the
+/// `catch`. `FoldRegister::advance` used to carry the pre-UPDATE register
+/// forward unconditionally whenever UPDATE's own branch was untracked --
+/// already reachable on `main` *before* #2046, through
+/// `FoldRegister::relocate`'s own pre-existing `identical()` check (no
+/// register-seeding from #2046 required): the differential fuzzer this
+/// issue's own verification requires found this exact shape fabricating on
+/// a pre-#2046 build across three separate 4,000-shape seeds (1, 3 and 4
+/// occurrences respectively), always this same root cause. Fixed by gating
+/// `advance`'s carry-forward on `cannot_move_register(update_expr)`, the
+/// same oracle-verified allowlist `resolve_seq`'s own stage-to-stage
+/// carrying already uses. Verified against jq 1.7.1: raises "Invalid path
+/// expression with result {"a":"s","c":"s"}", exit 5 -- `main` (both
+/// before and after #2046's own register-seeding change, absent this
+/// guard) printed `[]` three times, exit 0. The assertion below only
+/// checks the message's first 11 bytes since succinctly's own
+/// `dump_truncated` (`DUMP_KEEP`, `src/jq/error.rs`) truncates this
+/// particular message shape far sooner than real jq does (a separate,
+/// pre-existing wording-length gap unrelated to this fix, filed as #2179).
+#[test]
+fn test_foreach_advance_does_not_carry_register_past_a_caught_navigation_2046() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "path(. as $x | foreach (1,2,3) as $k (null; try $x.c catch 1; select(true) | $x))",
+        ],
+        Some(r#"{"a":"s","c":"s"}"#),
+    )?;
+    assert_eq!(stdout, "", "must not emit a path: stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"Invalid path expression with result {"a":"s","c"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Real jq's \`path()\` carries a single register that only navigation moves. A \`\$var\` frozen at a point where the register is still live can re-establish trackability later if code navigates back onto it -- already true for a plain pipe (#2041), but not inside a \`reduce\`/\`foreach\` fold: \`FoldRegister\` knew where its own register was but never exposed it to \`UPDATE\`/\`EXTRACT\`'s own resolution, so \`\$x.a\` inside a fold always refused where the equivalent plain pipe already worked.
- \`resolve_seq\` gains a \`register: Option<&OwnedValue>\` parameter, consulted only when building its fan-out loop's seed branch -- a new *source* for the existing #1573/#2041/#2044 register-carrying machinery, not a new recognition rule. \`FoldRegister::resolve\` now dispatches an \`UPDATE\`/\`EXTRACT\` expression that is (under any wrapping parens) a pipe straight to \`resolve_seq\`, threading its own register in. Everything else -- a \`\$var\` referenced inside \`if\`/\`try\`/\`select\`/an alternative/a construction at \`UPDATE\`/\`EXTRACT\`'s own top level -- still falls through to \`resolve_node\` unmodified: a deliberate, safe-direction scope limit (confirmed live against jq 1.7.1, several variations tested in review) rather than the full ~20-call-site threading the issue's own text originally estimated.
- \`FoldRegister::advance\` (\`foreach\`'s \`UPDATE\`-to-\`EXTRACT\` register handoff) also gains a \`cannot_move_register\` gate, closing a pre-existing bug this work's own differential fuzzing found independently: \`advance\` carried the pre-\`UPDATE\` register forward unconditionally whenever \`UPDATE\`'s own branch was untracked, even when \`UPDATE\`'s body genuinely attempted-and-caught a navigation (\`try \$x.c catch 1\`) that moves jq's real register.
- Filed #2179 for an unrelated, pre-existing message-truncation-length divergence found while writing tests -- not fixed inline, out of scope.

## Test plan
- [x] New CLI-level regression tests in \`tests/jq_cli_tests.rs\`: the primary repro, a bare-\`\$x\` negative control, an equal-value-different-node refusal control (the #2041-precedent danger direction), a \`reduce\` companion, a write-side (\`=\`) test, and the \`advance()\` regression guard. All verified to discriminate against a pre-fix binary in review (4/6 fail on revert as expected; the other 2 are intentional negative controls).
- [x] Fresh differential fuzzer (\`.ai/scratch/sweep-path-fold-register-update-extract.py\`, gitignored) against jq 1.7.1: 8 FABRICATE divergences (jq errors, we wrongly succeeded) across an initial 3-seed/4000-shape sample pre-fix, all the same \`advance()\` root cause; 0 FABRICATE and 0 MISMATCH post-fix across a 10-seed/40,000-shape run. Independently re-run in review (8,000 more shapes across 2 more seeds) with the same result.
- [x] The \`advance()\` "pre-existing bug" claim was independently verified via \`git stash\`-based A/B binary testing in review, not just static reasoning -- confirmed reachable and real with the new register-threading absent.
- [x] Scope-limit safety (a \`\$var\` nested inside \`if\`/\`try\`/\`select\`/alternative/construction still safely refuses rather than fabricating) verified against jq 1.7.1 with several constructions in review, all matching the safe direction.
- [x] Full test suite: \`cargo test --features cli,simd,regex,serde --no-fail-fast\` -- 0 failures, run repeatedly across implementation, my own independent verification, review, and after rebasing onto a \`main\` commit that also touches \`resolve_seq\`.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo fmt --check\` -- clean.
- [x] \`docs/compliance/jq/limitations.md\` updated to record what's fixed and the deliberate scope limit.

Fixes #2046