### PR TITLE
perf(jq): thread path-context stages by borrow instead of deep-cloning the AST (#1510)

### DIFF
--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -33,6 +33,62 @@
 //! timed, so the reported cost isolates the write-path evaluator itself
 //! rather than being diluted by a constant per-sample index-build cost.
 //!
+//! # AST-shape groups (#1510)
+//!
+//! The groups above all vary *element count*: how many values the write walks
+//! over. The five `bench_path_*_ast` groups vary something else -- the size
+//! and shape of the **query** under path tracking, at a fixed element count --
+//! because that is the dimension `eval_stage_with_path_context`'s cost is
+//! charged on. Before #1510, every arm of the path-context evaluator that
+//! prepended a stage materialised `[stage] ++ rest` as an owned `Vec<Expr>`,
+//! and `Expr` is a recursive `Box`/`Vec` tree with a derived `Clone` -- so
+//! each of those was a deep copy of the whole remaining pipeline, paid once
+//! per `Comma` branch, once per `If` fan-out output, once per `Paren` stage,
+//! and once per recursion level of a `def`.
+//!
+//! Sweeping the query shape rather than the data is what makes that visible.
+//! Measured across these five groups on both an Apple M4 Pro and an AMD Ryzen
+//! 9 7950X (idle, interleaved base/fix within each rep, median of 3, #1510's
+//! parent commit as the baseline), every configuration improved on both, and
+//! the two agreed on every trend. Figures below are `ARM / x86`. The
+//! *direction* the ratio moves differs per group, and it is worth knowing
+//! which before reading a future run:
+//!
+//! - `paren_chain` is the group whose exponent changes, and its win grows with
+//!   `k`: -14/-11% at 1, -31/-25% at 4, -45/-51% at 16, -57/-60% at 64. Stage
+//!   `i` of `k` used to copy the `k - i` stages ahead of it, so the chain paid
+//!   O(k^2) node copies and now pays none.
+//! - `comma_rest` moves the *other* way (-15/-16% at one trailing stage, to
+//!   -0.4/-2% at sixty-four), and `recursive_def` likewise (-22/-23% at 1, to
+//!   -3/-5% at 64). The removed clone is linear in pipeline length, but the
+//!   navigation beside it is worse than linear -- each `Field` stage copies
+//!   the ambient `current_path`, which is itself growing -- so the clone's
+//!   *share* falls as the pipeline lengthens even though its absolute cost
+//!   rises.
+//! - `comma_width` and `if_fanout` are near-flat in their sweep (-12% to -7%
+//!   and -4% to -8% respectively, on both chips): clone and navigation both
+//!   scale linearly with fan-out, so widening alone does not separate them.
+//!
+//! The practical reading: this change pays best on short pipelines with heavy
+//! nesting or fan-out, and is progressively masked -- never reversed -- as
+//! per-stage navigation cost grows.
+//!
+//! **Every query in these groups ends in a bare `path`, and that is load-
+//! bearing, not decoration.** `eval_pipe_with_path_context_internal` is
+//! reached only when `needs_path_context` says so, and its trigger set is
+//! `path` (no argument), `key`, `parent`, `parent(n)` and `file_index` --
+//! *not* `path(f)`, which real jq's one-argument form maps to and which this
+//! crate resolves through the separate `resolve_node` walker instead. Written
+//! with `path(f)`, these five groups exercised that other machinery and left
+//! the code they exist to measure untouched: a counting global allocator put
+//! their allocation totals byte-for-byte identical before and after the
+//! change. Any future edit here must keep a trigger builtin in the pipeline,
+//! and is worth re-checking the same way rather than by timing alone.
+//!
+//! The expected paths asserted below were captured from the pinned jq 1.7.1
+//! oracle using the equivalent `path(f)` spelling of each query, which yields
+//! the same path values; only the routing differs.
+//!
 //! Run with:
 //! ```bash
 //! cargo bench --bench jq_write_path_bench
@@ -672,6 +728,331 @@ fn bench_del_shared_prefix_width(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// AST-shape groups (#1510). Element count is fixed; the query varies.
+// ---------------------------------------------------------------------------
+
+/// Elements the AST-shape groups fan out over. Fixed, so a sweep below moves
+/// only the query's own size -- large enough that per-element evaluator work
+/// dominates the one-off parse, small enough that the widest query shape
+/// still runs in reasonable time.
+const AST_ELEMS: usize = 100;
+
+/// Comma branches / `if` fan-out outputs / `def` recursion levels swept by the
+/// groups below.
+const AST_WIDTHS: &[usize] = &[2, 8, 32, 128];
+
+/// Trailing pipe stages after the fanning stage -- the `rest` whose AST used
+/// to be deep-copied once per branch.
+const AST_REST_STAGES: &[usize] = &[1, 4, 16, 64];
+
+/// A depth-`k` chain of `{"d": ...}` wrappers around `0`, so a query can
+/// navigate `k` trailing `.d` stages into it.
+fn nest_d(k: usize) -> String {
+    let mut out = String::from("0");
+    for _ in 0..k {
+        out = format!(r#"{{"d":{out}}}"#);
+    }
+    out
+}
+
+/// `k` trailing `.d` stages, pipe-separated -- the `rest` of the pipeline.
+fn rest_stages(k: usize) -> String {
+    core::iter::repeat(".d")
+        .take(k)
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// `{"foo": [ {"b0": NEST, ..., "b<w-1>": NEST} x AST_ELEMS ]}`.
+fn comma_doc(width: usize, depth: usize) -> Vec<u8> {
+    let nest = nest_d(depth);
+    let mut elem = String::from("{");
+    for j in 0..width {
+        if j > 0 {
+            elem.push(',');
+        }
+        elem.push_str(&format!(r#""b{j}":{nest}"#));
+    }
+    elem.push('}');
+    let mut out = String::from(r#"{"foo":["#);
+    for i in 0..AST_ELEMS {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&elem);
+    }
+    out.push_str("]}");
+    out.into_bytes()
+}
+
+/// `[path(.foo[] | (.b0, ..., .b<w-1>) | .d | ... | .d)]`.
+fn comma_query(width: usize, depth: usize) -> String {
+    let branches = (0..width)
+        .map(|j| format!(".b{j}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("[.foo[] | ({branches}) | {} | path]", rest_stages(depth))
+}
+
+/// The path `comma_query` must report for element `i`, branch `j`:
+/// `["foo", i, "b<j>", "d" x depth]`.
+fn expected_comma_path(i: usize, j: usize, depth: usize) -> OwnedValue {
+    let mut p = vec![
+        OwnedValue::String("foo".into()),
+        OwnedValue::Int(i as i64),
+        OwnedValue::String(format!("b{j}")),
+    ];
+    p.extend(core::iter::repeat(OwnedValue::String("d".into())).take(depth));
+    OwnedValue::Array(p)
+}
+
+/// Assert `comma_query`'s full output, then time it. Shared by the two comma
+/// groups, which differ only in which of `(width, depth)` they sweep -- the
+/// premise check is the same either way, and duplicating it is exactly the
+/// "duplicated predicates diverge silently" trap this repo warns about.
+fn bench_comma_shape(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    param: usize,
+    width: usize,
+    depth: usize,
+) {
+    let json = comma_doc(width, depth);
+    let expr = parse(&comma_query(width, depth)).expect("must parse");
+
+    // Guard the premise: one path per (element, branch), in that order, each
+    // naming the branch key and every trailing stage. A future bug that made
+    // the comma drop branches, or the trailing stages stop extending the
+    // path, would otherwise read here as a speedup.
+    let OwnedValue::Array(paths) = eval_one(&expr, &json) else {
+        panic!("width={width} depth={depth}: must produce an array");
+    };
+    assert_eq!(
+        paths.len(),
+        AST_ELEMS * width,
+        "width={width} depth={depth}: one path per element per branch"
+    );
+    for i in 0..AST_ELEMS {
+        for j in 0..width {
+            assert_eq!(
+                paths[i * width + j],
+                expected_comma_path(i, j, depth),
+                "width={width} depth={depth}: path ({i},{j}) mismatch"
+            );
+        }
+    }
+
+    let index = JsonIndex::build(&json);
+    group.throughput(Throughput::Elements((AST_ELEMS * width) as u64));
+    group.bench_with_input(BenchmarkId::from_parameter(param), &json, |b, json| {
+        b.iter(|| {
+            let cursor = index.root(black_box(json));
+            black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+        });
+    });
+}
+
+/// `Comma` under path tracking, sweeping **branch count** at a fixed trailing
+/// pipeline. This is the shape #1409 introduced and #1510 removes the cost
+/// of: the pre-#1510 `Comma` arm spliced `[branch] ++ rest` into an owned
+/// `Vec<Expr>` inside its own `for` loop, so a `w`-way comma deep-copied the
+/// whole trailing pipeline `w` times per element.
+fn bench_path_comma_width_ast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_ast_comma_width");
+    for &width in AST_WIDTHS {
+        bench_comma_shape(&mut group, width, width, 4);
+    }
+    group.finish();
+}
+
+/// The same shape, sweeping **trailing pipeline length** at a fixed branch
+/// count. Read the before/after ratio across the sweep rather than any single
+/// row: navigation and the removed clone are both linear in the number of
+/// trailing stages, so what identifies the clone is the ratio *growing* with
+/// pipeline size -- lost in the navigation at one stage, dominant at 64.
+fn bench_path_comma_rest_ast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_ast_comma_rest");
+    for &depth in AST_REST_STAGES {
+        bench_comma_shape(&mut group, depth, 8, depth);
+    }
+    group.finish();
+}
+
+/// A chain of parenthesised stages under path tracking -- `(.d) | (.d) | ...`.
+///
+/// The one group here whose *exponent* moves, not just its constant: the
+/// pre-#1510 `Paren` arm rebuilt `[inner] ++ rest` at every stage, so stage
+/// `i` of `k` copied the `k - i` stages still ahead of it and the chain cost
+/// O(k^2) node copies in total. It now borrows and copies none, so the sweep
+/// should flatten from quadratic to linear rather than merely shifting down.
+fn bench_path_paren_chain_ast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_ast_paren_chain");
+    for &k in AST_REST_STAGES {
+        let nest = nest_d(k);
+        let mut json = String::from(r#"{"foo":["#);
+        for i in 0..AST_ELEMS {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&nest);
+        }
+        json.push_str("]}");
+        let json = json.into_bytes();
+
+        let chain = core::iter::repeat("(.d)")
+            .take(k)
+            .collect::<Vec<_>>()
+            .join(" | ");
+        let expr = parse(&format!("[.foo[] | {chain} | path]")).expect("must parse");
+
+        // Guard the premise: one path per element, each descending all k
+        // stages -- a parenthesised stage that stopped extending the path
+        // would otherwise read as a speedup.
+        let OwnedValue::Array(paths) = eval_one(&expr, &json) else {
+            panic!("k={k}: must produce an array");
+        };
+        assert_eq!(paths.len(), AST_ELEMS, "k={k}: one path per element");
+        for (i, p) in paths.iter().enumerate() {
+            let mut expected = vec![OwnedValue::String("foo".into()), OwnedValue::Int(i as i64)];
+            expected.extend(core::iter::repeat(OwnedValue::String("d".into())).take(k));
+            assert_eq!(*p, OwnedValue::Array(expected), "k={k}: path {i} mismatch");
+        }
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(AST_ELEMS as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(k), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// `if` under path tracking with a *generating* condition, sweeping how many
+/// outputs that condition produces.
+///
+/// `if`'s branch evaluation runs once per condition output, and the pre-#1510
+/// arm built its `[branch] ++ probe` pair inside that closure -- so the taken
+/// branch was deep-copied once per output rather than once per `if`. Both
+/// arms are `.b` so the sweep moves only the fan-out width, never which
+/// branch is taken or how much navigation follows.
+fn bench_path_if_fanout_ast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_ast_if_fanout");
+    const DEPTH: usize = 4;
+    for &width in AST_WIDTHS {
+        let nest = nest_d(DEPTH);
+        let flags = core::iter::repeat("true")
+            .take(width)
+            .collect::<Vec<_>>()
+            .join(",");
+        let elem = format!(r#"{{"f":[{flags}],"b":{nest}}}"#);
+        let mut json = String::from(r#"{"foo":["#);
+        for i in 0..AST_ELEMS {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&elem);
+        }
+        json.push_str("]}");
+        let json = json.into_bytes();
+
+        let expr = parse(&format!(
+            "[.foo[] | if .f[] then .b else .b end | {} | path]",
+            rest_stages(DEPTH)
+        ))
+        .expect("must parse");
+
+        // Guard the premise: the condition really fans out `width` ways, and
+        // every output still carries the full path through `.b` and the
+        // trailing stages.
+        let OwnedValue::Array(paths) = eval_one(&expr, &json) else {
+            panic!("width={width}: must produce an array");
+        };
+        assert_eq!(
+            paths.len(),
+            AST_ELEMS * width,
+            "width={width}: one path per element per condition output"
+        );
+        for i in 0..AST_ELEMS {
+            let mut expected = vec![OwnedValue::String("foo".into()), OwnedValue::Int(i as i64)];
+            expected.push(OwnedValue::String("b".into()));
+            expected.extend(core::iter::repeat(OwnedValue::String("d".into())).take(DEPTH));
+            let expected = OwnedValue::Array(expected);
+            for j in 0..width {
+                assert_eq!(
+                    paths[i * width + j],
+                    expected,
+                    "width={width}: path ({i},{j}) mismatch"
+                );
+            }
+        }
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements((AST_ELEMS * width) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(width), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// A recursive `def` under path tracking, sweeping recursion depth.
+///
+/// Covers the `DefCall`/`Shared` arms -- item 1 of #2092, fixed by the same
+/// change. Those arms deref'd through the `Rc` that `BoundBody`/`Expr::Shared`
+/// exist to share and deep-copied the body back out, and since a recursive
+/// call rebuilds a fresh `DefCall` at every level, that copy was charged per
+/// level rather than once.
+fn bench_path_recursive_def_ast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_ast_recursive_def");
+    for &k in AST_REST_STAGES {
+        let nest = nest_d(k);
+        let mut json = String::from(r#"{"foo":["#);
+        for i in 0..AST_ELEMS {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&nest);
+        }
+        json.push_str("]}");
+        let json = json.into_bytes();
+
+        let expr = parse(&format!(
+            "def down(n): if n == 0 then . else .d | down(n - 1) end; \
+             [.foo[] | down({k}) | path]"
+        ))
+        .expect("must parse");
+
+        // Guard the premise: the recursion really descends k levels under
+        // path tracking. If `down` ever stopped being seen through by the
+        // path-context evaluator it would report a shorter path, not an error.
+        let OwnedValue::Array(paths) = eval_one(&expr, &json) else {
+            panic!("k={k}: must produce an array");
+        };
+        assert_eq!(paths.len(), AST_ELEMS, "k={k}: one path per element");
+        for (i, p) in paths.iter().enumerate() {
+            let mut expected = vec![OwnedValue::String("foo".into()), OwnedValue::Int(i as i64)];
+            expected.extend(core::iter::repeat(OwnedValue::String("d".into())).take(k));
+            assert_eq!(*p, OwnedValue::Array(expected), "k={k}: path {i} mismatch");
+        }
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(AST_ELEMS as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(k), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_del_array,
@@ -686,5 +1067,10 @@ criterion_group!(
     bench_del_filtered_descent_depth,
     bench_del_shared_prefix_depth,
     bench_del_shared_prefix_width,
+    bench_path_comma_width_ast,
+    bench_path_comma_rest_ast,
+    bench_path_paren_chain_ast,
+    bench_path_if_fanout_ast,
+    bench_path_recursive_def_ast,
 );
 criterion_main!(benches);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -29104,6 +29104,27 @@ fn path_probe_stage() -> Expr {
     ])))
 }
 
+/// The stages an isolating arm appends after the body it evaluates: a single
+/// [`path_probe_stage`] when the continuation needs each output's own path,
+/// and nothing otherwise.
+///
+/// Extracted for #1510, where eight arms (`FuncDef`, `Limit`, `FirstExpr`,
+/// `LastExpr`, `If`, `Try`, `Label`, and `eval_bind_with_path_context`) all
+/// stopped needing to build an owned `[body.clone(), probe]` pair once
+/// `eval_stage_with_path_context` let them pass the body by borrow. What is
+/// left is only the trailing probe, which is small, fixed, and -- unlike the
+/// body -- genuinely has to be constructed. Call it *outside* any loop or
+/// closure the arm runs, so a fan-out pays for one probe rather than one per
+/// output. `Vec::new()` does not allocate, so the unpaired case still costs
+/// nothing.
+fn probe_stages(paired: bool) -> Vec<Expr> {
+    if paired {
+        vec![path_probe_stage()]
+    } else {
+        Vec::new()
+    }
+}
+
 /// Split one [`path_probe_stage`] output back into `(path, value)`.
 ///
 /// `fallback_path` answers the shapes the probe never produces (anything
@@ -29804,6 +29825,7 @@ fn eval_bind_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // probe -- see `path_probe_stage` (#1409). Gated on `rest` actually
     // consulting path context so the common case pays nothing.
     let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+    let probe = probe_stages(paired);
     let mut all_results: Vec<OwnedValue> = Vec::new();
     let mut stopped = None;
     for bound_val in bound_values {
@@ -29813,20 +29835,15 @@ fn eval_bind_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // too -- reused rather than duplicating its exact `partial(...,
         // Control::Error(e))` wrapping by hand.
         let body_result = match substitute(&bound_val) {
-            Ok(substituted_body) => {
-                let mut body_stages = vec![substituted_body];
-                if paired {
-                    body_stages.push(path_probe_stage());
-                }
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &body_stages,
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                )
-            }
+            Ok(substituted_body) => eval_stage_with_path_context::<W, S>(
+                &substituted_body,
+                &probe,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            ),
             Err(e) => QueryResult::Error(e),
         };
         if let Some(stop) = accumulate_path_context_step(&mut all_results, body_result) {
@@ -29947,12 +29964,45 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     current_path: &[OwnedValue],
     optional: bool,
 ) -> QueryResult<'a, W> {
-    if exprs.is_empty() {
+    let Some((first, rest)) = exprs.split_first() else {
         return QueryResult::Owned(value.clone());
-    }
+    };
+    eval_stage_with_path_context::<W, S>(
+        first,
+        rest,
+        value,
+        root,
+        file_origin,
+        current_path,
+        optional,
+    )
+}
 
-    let (first, rest) = exprs.split_first().unwrap();
-
+/// One pipe stage, plus the stages that follow it, threaded by borrow.
+///
+/// Split out of `eval_pipe_with_path_context_internal` (#1510) so the arms
+/// that prepend a stage can pass the stage as `&Expr` instead of
+/// materialising `[stage] ++ rest` as an owned `Vec<Expr>`. `Expr` is a
+/// recursive `Box`/`Vec` tree with a derived `Clone`, so that splice was a
+/// deep copy of the whole remaining pipeline -- paid once per `Comma`
+/// branch, once per `If` fan-out output, and once per recursion level of a
+/// `DefCall`, in an evaluator whose `Shared(Rc<_>)`/`BoundBody` nodes exist
+/// precisely to make that tree cheap to share.
+///
+/// Splitting `(first, rest)` out of the slice is exact rather than
+/// approximate: nothing below reads `exprs` after `split_first`, so calling
+/// this with `(x, rest)` is by construction identical to calling
+/// `eval_pipe_with_path_context_internal` with `[x] ++ rest`.
+#[allow(clippy::too_many_arguments)]
+fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    first: &Expr,
+    rest: &[Expr],
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
     // Handle PathNoArg - return the current path. Position unchanged, so
     // `rest` continues against the ambient `root`/`current_path` (#1449:
     // routed through the shared helper #1445 already extracted for this
@@ -30285,28 +30335,19 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             }
         }
         Expr::Paren(inner) => {
-            // Parentheses don't change path, just evaluate inner
-            if rest.is_empty() {
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &[(**inner).clone()],
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                )
-            } else {
-                let mut combined = vec![(**inner).clone()];
-                combined.extend(rest.iter().cloned());
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &combined,
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                )
-            }
+            // Parentheses don't change path, just evaluate inner. Prepending
+            // the parenthesised stage to `rest` is a borrow, not a splice
+            // (#1510) -- the `rest.is_empty()` case needs no separate arm
+            // any more, since an empty `rest` is already the empty slice.
+            eval_stage_with_path_context::<W, S>(
+                inner,
+                rest,
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
         // `.[EXPR]?`/`.[S:E]?`: the same carve-out `eval_single` and
         // `eval_each` each already make for this shape (their matching arms
@@ -30438,20 +30479,39 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
                 )
             }
         }
-        Expr::Optional(inner) => {
-            let mut combined = vec![(**inner).clone()];
-            combined.extend(rest.iter().cloned());
-            eval_pipe_with_path_context_internal::<W, S>(
-                &combined,
-                value,
-                root,
-                file_origin,
-                current_path,
-                true,
-            )
-        }
+        Expr::Optional(inner) => eval_stage_with_path_context::<W, S>(
+            inner,
+            rest,
+            value,
+            root,
+            file_origin,
+            current_path,
+            true,
+        ),
+        // Flatten a nested pipe into this one. A `Pipe` prepends its whole
+        // stage list rather than a single stage, so it is the one arm the
+        // #1510 borrow cannot serve in general: `[i0..in] ++ rest` is two
+        // segments, and `rest: &[Expr]` holds one. See #2175 for making
+        // `rest` itself two-segment, which is what would retire the splice
+        // below.
+        //
+        // Only the empty-`rest` shape avoids it here. Earlier drafts also
+        // special-cased an empty and a one-stage inner pipe, both of which
+        // would be pure borrows -- but `parse_postfix` pops a length-1 chain
+        // instead of wrapping it (`if chain.len() == 1 { expr = chain.pop() }`),
+        // so the parser emits neither, and nothing else was found that feeds
+        // one to *this* evaluator. They are dropped rather than left as arms
+        // no test can reach; the splice below answers them correctly anyway,
+        // since `[] ++ rest` and `[only] ++ rest` are what it already builds.
+        Expr::Pipe(inner_exprs) if rest.is_empty() => eval_pipe_with_path_context_internal::<W, S>(
+            inner_exprs,
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
         Expr::Pipe(inner_exprs) => {
-            // Flatten nested pipe - combine inner pipe with rest
             let mut combined = inner_exprs.clone();
             combined.extend(rest.iter().cloned());
             eval_pipe_with_path_context_internal::<W, S>(
@@ -31013,10 +31073,14 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             Err(e) => QueryResult::Error(e),
             Ok(bound) => {
                 let _guard = enter_def_call_frame(*frames);
-                let mut stages = vec![(**bound).clone()];
-                stages.extend(rest.iter().cloned());
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &stages,
+                // The bound body stays behind its `Rc` (#1510). Deep-copying
+                // it out was self-defeating here above all: `BoundBody`'s
+                // whole point is to share one tree across calls, and a
+                // recursive `def` under path tracking rebuilds a fresh
+                // `DefCall` per level, so the clone was charged per level.
+                eval_stage_with_path_context::<W, S>(
+                    bound,
+                    rest,
                     value,
                     root,
                     file_origin,
@@ -31028,18 +31092,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // Transparent, for the same reason it is transparent to evaluation:
         // the argument this wraps is ordinary code, and it must keep the
         // caller's own path context when it runs.
-        Expr::Shared(inner) => {
-            let mut stages = vec![(**inner).clone()];
-            stages.extend(rest.iter().cloned());
-            eval_pipe_with_path_context_internal::<W, S>(
-                &stages,
-                value,
-                root,
-                file_origin,
-                current_path,
-                optional,
-            )
-        }
+        Expr::Shared(inner) => eval_stage_with_path_context::<W, S>(
+            inner,
+            rest,
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
         Expr::FuncDef {
             name,
             params,
@@ -31051,32 +31112,20 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
             let bound_then = bind_def(name, params, body, then, bound);
-            // #2094 review: the unpaired (common) case passes `bound_then`
-            // through as a one-element slice with no clone at all, so this
-            // arm keeps the full benefit of `bind_def`'s own cache -- only
-            // the paired case, which must append `path_probe_stage()`,
-            // needs an owned `Vec` (and so a clone of the cached tree) to
-            // build one.
-            let then_result = if paired {
-                let then_stages = [(*bound_then).clone(), path_probe_stage()];
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &then_stages,
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                )
-            } else {
-                eval_pipe_with_path_context_internal::<W, S>(
-                    core::slice::from_ref(&*bound_then),
-                    value,
-                    root,
-                    file_origin,
-                    current_path,
-                    optional,
-                )
-            };
+            // #2094 review kept `bound_then` clone-free in the unpaired
+            // (common) case so this arm keeps the full benefit of
+            // `bind_def`'s own cache; #1510 extends that to the paired case,
+            // which now carries the probe in `rest` rather than cloning the
+            // cached tree into an owned pair to put it next to.
+            let then_result = eval_stage_with_path_context::<W, S>(
+                &bound_then,
+                &probe_stages(paired),
+                value,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            );
             if rest.is_empty() {
                 then_result
             } else if paired {
@@ -31217,12 +31266,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let mut body_stages = vec![(**expr).clone()];
-            if paired {
-                body_stages.push(path_probe_stage());
-            }
-            let body_result = eval_pipe_with_path_context_internal::<W, S>(
-                &body_stages,
+            let body_result = eval_stage_with_path_context::<W, S>(
+                expr,
+                &probe_stages(paired),
                 value,
                 root,
                 file_origin,
@@ -31292,12 +31338,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             if needs_path_context(expr) || rest.iter().any(needs_path_context) =>
         {
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let mut body_stages = vec![(**expr).clone()];
-            if paired {
-                body_stages.push(path_probe_stage());
-            }
-            let body_result = eval_pipe_with_path_context_internal::<W, S>(
-                &body_stages,
+            let body_result = eval_stage_with_path_context::<W, S>(
+                expr,
+                &probe_stages(paired),
                 value,
                 root,
                 file_origin,
@@ -31357,12 +31400,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         // `QueryResult` variant set this evaluator ever produces.
         Expr::LastExpr(expr) if needs_path_context(expr) || rest.iter().any(needs_path_context) => {
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let mut body_stages = vec![(**expr).clone()];
-            if paired {
-                body_stages.push(path_probe_stage());
-            }
-            let body_result = eval_pipe_with_path_context_internal::<W, S>(
-                &body_stages,
+            let body_result = eval_stage_with_path_context::<W, S>(
+                expr,
+                &probe_stages(paired),
                 value,
                 root,
                 file_origin,
@@ -31714,14 +31754,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+            // Built once, outside the fan-out: the closure below runs per
+            // `cond` output, and this used to deep-clone the taken branch
+            // into an owned pair on every one of them (#1510).
+            let probe = probe_stages(paired);
             let branch_result = eval_fanout(cond_result, |truthy| {
                 let branch = if truthy { then_branch } else { else_branch };
-                let mut stages = vec![(**branch).clone()];
-                if paired {
-                    stages.push(path_probe_stage());
-                }
-                eval_pipe_with_path_context_internal::<W, S>(
-                    &stages,
+                eval_stage_with_path_context::<W, S>(
+                    branch,
+                    &probe,
                     value,
                     root,
                     file_origin,
@@ -31786,10 +31827,12 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // scoping stays intact.
             let mut branch_outputs = Vec::new();
             for sub_expr in exprs {
-                let mut combined = vec![sub_expr.clone()];
-                combined.extend(rest.iter().cloned());
-                let step = eval_pipe_with_path_context_internal::<W, S>(
-                    &combined,
+                // Combining is by borrow (#1510): the splice this replaces
+                // deep-copied the whole of `rest` once per branch, so a wide
+                // comma paid it as many times as it had branches.
+                let step = eval_stage_with_path_context::<W, S>(
+                    sub_expr,
+                    rest,
                     value,
                     root,
                     file_origin,
@@ -31809,13 +31852,10 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let with_probe = |e: &Expr| -> Vec<Expr> {
-                let mut v = vec![e.clone()];
-                if paired {
-                    v.push(path_probe_stage());
-                }
-                v
-            };
+            // One probe for the whole arm, shared by the body and by
+            // whichever catch handler runs -- the closure this replaces
+            // deep-cloned its argument on each of up to five calls (#1510).
+            let probe = probe_stages(paired);
             // Evaluate the try body (and catch handler) through the
             // path-context evaluator too, so `try select(file_index == 1)
             // catch ...` -- a natural `--eval-all` idiom -- resolves
@@ -31823,8 +31863,9 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // follow-up). Mirrors `eval_try`'s Error/Break/Partial handling
             // above, just routed through path context instead of
             // `eval_single`.
-            let result = eval_pipe_with_path_context_internal::<W, S>(
-                &with_probe(try_expr),
+            let result = eval_stage_with_path_context::<W, S>(
+                try_expr,
+                &probe,
                 value,
                 root,
                 file_origin,
@@ -31922,18 +31963,15 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let mut body_stages = vec![(**body).clone()];
-            if paired {
-                body_stages.push(path_probe_stage());
-            }
             // Evaluate the label body through the path-context evaluator
             // too, so `label $out | ... file_index ...` -- a natural (if
             // inert) wrapper -- resolves correctly instead of silently
             // falling back to the 0/null stub. Paired with the
             // `needs_path_context` fix for `Label`: one without the other
             // still drops path context silently (#715 follow-up).
-            let result = eval_pipe_with_path_context_internal::<W, S>(
-                &body_stages,
+            let result = eval_stage_with_path_context::<W, S>(
+                body,
+                &probe_stages(paired),
                 value,
                 root,
                 file_origin,
@@ -63981,6 +64019,48 @@ mod tests {
         assert_eq!(
             outputs(b"[10,20]", ".[] | (key, key)"),
             vec!["0", "0", "1", "1"]
+        );
+    }
+
+    /// #1510: `eval_stage_with_path_context`'s two `Expr::Pipe` arms. A
+    /// nested pipe is the one stage shape that still has to splice
+    /// `[i0..in] ++ rest` into an owned `Vec<Expr>`, because `rest:
+    /// &[Expr]` cannot hold two segments (#2175) -- but only when `rest` is
+    /// non-empty. Both arms have to keep threading the path, so `key` has
+    /// to name the *last* component reached, not the one the outer pipe was
+    /// at when it entered the parentheses.
+    ///
+    /// `parse_postfix` pops a length-1 chain rather than wrapping it, so
+    /// `(.a)` is an `Expr::Paren`, never a one-stage `Expr::Pipe` -- these
+    /// two are the only `Expr::Pipe` stage shapes reachable here.
+    #[test]
+    fn test_nested_pipe_stage_keeps_path_context_1510() {
+        // Non-empty `rest` (`| key` follows the parentheses): the splice arm.
+        assert_eq!(
+            outputs(br#"[{"a":{"b":1}}]"#, ".[] | (.a|.b) | key"),
+            vec!["\"b\""]
+        );
+        // Empty `rest` (nothing follows the parentheses): the borrow arm.
+        assert_eq!(
+            outputs(br#"[{"a":{"b":1}}]"#, ".[] | (.a | key)"),
+            vec!["\"a\""]
+        );
+    }
+
+    /// #1510 companion: the same two arms under a fan-out, pinning that the
+    /// path is rebuilt per element rather than shared across them. The
+    /// splice arm rebuilds `combined` on every element, so a regression that
+    /// hoisted or reused it would show up here as both elements reporting
+    /// the first one's index.
+    #[test]
+    fn test_nested_pipe_stage_paths_are_per_element_1510() {
+        assert_eq!(
+            outputs(br#"[{"a":{"b":1}},{"a":{"b":2}}]"#, ".[] | (.a|.b) | path"),
+            vec![r#"[0,"a","b"]"#, r#"[1,"a","b"]"#]
+        );
+        assert_eq!(
+            outputs(br#"[{"a":{"b":1}},{"a":{"b":2}}]"#, ".[] | (.a | path)"),
+            vec![r#"[0,"a"]"#, r#"[1,"a"]"#]
         );
     }
 


### PR DESCRIPTION
Closes #1510.

## What

`eval_pipe_with_path_context_internal` took the pipeline as one `&[Expr]`, so every arm
that prepended a stage had to materialise `[stage] ++ rest` as an owned `Vec<Expr>`.
`Expr` is a recursive `Box`/`Vec` tree with a derived `Clone`, so each of those was a
deep copy of the whole remaining pipeline.

Nothing in the body reads `exprs` after `split_first`, so calling a function with
`(first, rest)` is by construction identical to calling this one with `[first] ++ rest`.
Splitting the parameter in two — the new `eval_stage_with_path_context`, with the old
name kept as a thin wrapper so its ~44 callers are untouched — turns every single-stage
prepend into a borrow. **13 of the 14 clone sites in the region are removed.**

The issue names four sites; there were fourteen, and the two worst were inside loops:

| site | frequency |
|---|---|
| `Comma` | once per comma branch, in a loop |
| `If` | once per `cond` fan-out output, in a closure |
| `DefCall`, `Shared` | once per recursion level of a `def` |
| `Paren`, `Optional` | per invocation |
| 7 arms appending `path_probe_stage()` | per invocation (per output for `If`/`As`) |

`DefCall`/`Shared` are **item 1 of #2092**, fixed here as a side effect — both were
deref'ing through the very `Rc` that `BoundBody`/`Expr::Shared` exist to make cheap.
The other five items of #2092 are untouched, so it stays open.

## The one site left

`Expr::Pipe` prepends a whole stage list, and `[i0..in] ++ rest` is two segments where
`rest: &[Expr]` holds one. Only the empty-`rest` shape avoids the splice. An earlier
draft also special-cased an empty and a one-stage inner pipe — but `parse_postfix` pops
a length-1 chain rather than wrapping it, so the parser emits neither. Rather than ship
arms no test can reach, they were dropped; the splice answers both correctly anyway.
**#2175** tracks making `rest` itself two-segment.

## Measurements

Idle Apple M4 Pro and idle AMD Ryzen 9 7950X, interleaving base/fix within each rep
(per `docs/guides/benchmarking.md`), median of 3, baseline = this branch's merge-base.
All 20 configurations improved on both chips, and the two agreed on every trend.

| group | | | | |
|---|---|---|---|---|
| `paren_chain` | k=1 −14/−11% | k=4 −31/−25% | k=16 −45/−51% | k=64 **−57/−60%** |
| `recursive_def` | −23/−23% | −15/−17% | −6/−12% | −3/−4% |
| `comma_rest` | −15/−16% | −9/−10% | −5/−8% | −0/−2% |
| `comma_width` | −13/−12% | −8/−10% | −8/−9% | −7/−7% |
| `if_fanout` | −5/−4% | −6/−5% | −6/−7% | −7/−8% |

(ARM/x86. Baseline rep-to-rep spread 1.6–12% ARM, 0.3–10% x86.)

`paren_chain` is the group whose exponent changes — stage `i` of `k` used to copy the
`k − i` stages ahead of it, so the chain paid O(k²) node copies and now pays none. That
its win *grows* with `k` is the signature, and it is well clear of noise on both chips.

A counting global allocator corroborates deterministically: `paren_chain` k=64 drops
from 675,948 to 253,548 allocations (**−62.5%**), the comma shape from 99,040 to 88,340
(−10.8%).

## A trap worth flagging for review

My first benchmark shapes used `path(f)`, the obvious spelling. Allocation counts came
back **byte-for-byte identical** on both sides of the change — the queries never entered
the code being measured. `needs_path_context`'s trigger set is bare `path`/`key`/
`parent`/`parent(n)`/`file_index`, and **not** `path(f)`, which routes through the
separate `resolve_node` walker. Every query in the new groups therefore ends in a bare
`path`, and the module doc says so and why, so the next person does not repeat it.
Wall-clock alone would not have caught this; the identical allocation counts did.

That detour also turned up an unrelated quadratic on the `path(f)` DOM route, filed
separately with its attribution tables as **#2190**.

## Tests

Both surviving `Expr::Pipe` arms are pinned by new tests — `.[] | (.a|.b) | key` takes
the splice, `.[] | (.a | key)` takes the borrow — plus a per-element companion so a
regression that hoisted or reused `combined` shows up as a shared path.

Five new groups in `benches/jq_write_path_bench.rs` sweep query shape at a fixed element
count, since the existing groups all vary element count only. Each asserts its full
expected output outside the timed loop, with expected paths captured from the pinned jq
1.7.1 oracle.

## Verification

From a clean `cargo clean -p succinctly`, all green: `fmt --check`; `clippy
--all-targets --all-features` and the second CI feature set, both `-D warnings`;
`RUSTDOCFLAGS=-Dwarnings cargo doc`; `cargo test`; the CLI-gated leg (`jq_cli_tests`,
`jq_golden_tests`, `jq_computed_key_tests`, `jq_evaluator_parity_tests`,
`jq_recurse_depth_tests`, `jq_index_number_invariant_tests`, `jq_error_message_tests`,
`yq_cli_tests`, `yq_golden_tests`, `yq_path_consistency_tests`); `--no-default-features`
(no_std); and `--features simd`. `tests/data/jq-golden-known-failures.txt` and
`jq-error-known-divergences.txt` are unchanged.

refs #2092
