### PR TITLE
fix(jq): raise on an undecodable event leaf in fromstream(f)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1120,6 +1120,19 @@ coverage differs:
   `Error`/`Partial` arms across these same three functions' `input`/INIT streams didn't
   exclude a genuine decode failure from `optional`'s suppression the way `finish_fork`
   already does — an internal-consistency fix, not a further widening of this policy).
+- **#2188 fixed `fromstream(f)`'s own event-collecting fallback.** `collect_owned`'s
+  `One`/`Many` arms use unchecked `to_owned`, so `builtin_fromstream`'s
+  `result.collect_owned()` fallback silently substituted `""` for an undecodable event leaf
+  instead of raising — found via a research audit for #1989 that classified every bare
+  `to_owned(` call site in this file. Fixed by routing through the pre-existing
+  `stream_outputs_checked` (already had the exact `(Vec<OwnedValue>, Option<Control>)` shape
+  the call site destructures into) rather than adding a new function.
+  `builtin_truncate_stream` has the identical `collect_owned` call shape but is safe by
+  construction, not just untested: its `stream_expr` is evaluated against the same ambient
+  value that also becomes `depth`, and any value complex enough for `stream_expr` to reach a
+  nested undecodable string through is necessarily non-scalar, which always outranks an `Int`
+  path length in jq's ordering — so every event is unconditionally dropped before a corrupted
+  leaf could reach output.
 - **The #1677 malformed-`,`/`:`-delimiter check is the narrower gap.**
   `to_owned_checked_at_depth` itself never calls `key_delimiter_ok`/`value_delimiter_ok`, so
   every builtin routed through it still misses this one check. `Builtin::Keys` (`keys`/

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32958,7 +32958,17 @@ fn builtin_fromstream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // instead of halting (#791).
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         QueryResult::Partial(vs, control) => (vs, Some(control)),
-        result => (result.collect_owned(), None),
+        // #2188: `stream_outputs_checked`, not bare `collect_owned` --
+        // `collect_owned`'s `One`/`Many` arms use unchecked `to_owned`,
+        // silently substituting `""` for an undecodable event leaf instead
+        // of raising, the same #1746-shaped bug this whole family has
+        // already been fixed for elsewhere. `stream_outputs_checked` gives
+        // the identical `(Vec<OwnedValue>, Option<Control>)` shape this
+        // match already destructures into, so no call-site restructuring is
+        // needed -- its own `Error`/`Break`/`Halt`/`Partial` arms are simply
+        // unreachable here, since this match's own arms above already
+        // intercept those variants before `result` can carry one.
+        result => stream_outputs_checked(result),
     };
 
     let mut outputs = Vec::new();
@@ -33039,6 +33049,20 @@ fn builtin_truncate_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // See the matching arm in `builtin_fromstream`.
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         QueryResult::Partial(vs, control) => (vs, Some(control)),
+        // #2188 audit: unlike `builtin_fromstream`'s identical shape, bare
+        // `collect_owned` here is safe by construction, not just untested --
+        // `stream_expr` is evaluated against this same `value`, which also
+        // becomes `depth` a few lines up. Any `value` complex enough for
+        // `stream_expr` to reach a nested undecodable string through it is
+        // necessarily a container (object/array), and a container always
+        // sorts above any `Int` path length in jq's ordering (`compare_values`
+        // just below) -- so `path_len > depth` is provably false for every
+        // event whenever `depth` is non-scalar, meaning every event is
+        // dropped before an undecodable leaf's silently-substituted `""`
+        // could ever reach `outputs`. `stream_expr` has no other source of
+        // document-backed (as opposed to literal/computed) content to draw
+        // an undecodable value from, so this holds for any `stream_expr`,
+        // not just one that reads `value` directly.
         result => (result.collect_owned(), None),
     };
 
@@ -46692,6 +46716,26 @@ mod tests {
         query!(
             b"{\"a\":\"\xff\xfe\"}",
             r"limit(3; (.a, halt_error(6)))",
+            QueryResult::Error(e) if e.is_decode_failure() => {
+                assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
+            }
+        );
+    }
+
+    /// #2188 (found during the #1989 audit): `builtin_fromstream`'s
+    /// `collect_owned`-based fallback arm used bare `to_owned` for the
+    /// events it collects, silently substituting `""` for an undecodable
+    /// event leaf instead of raising. `{"events":[[[],"<bad>"]]}` gives
+    /// `.events[]` a single tostream-shaped `[path, leaf]` event with an
+    /// empty path (a top-level-leaf marker) and an undecodable leaf --
+    /// `fromstream` treats an empty path as immediately-complete, so this
+    /// isolates the `collect_owned` conversion itself rather than anything
+    /// in the accumulator loop.
+    #[test]
+    fn test_fromstream_raises_on_undecodable_event_leaf_2188() {
+        query!(
+            b"{\"events\":[[[],\"\xff\xfe\"]]}",
+            r"fromstream(.events[])",
             QueryResult::Error(e) if e.is_decode_failure() => {
                 assert!(e.message.contains("invalid UTF-8"), "message: {}", e.message);
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33052,12 +33052,14 @@ fn builtin_truncate_stream<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #2188 audit: unlike `builtin_fromstream`'s identical shape, bare
         // `collect_owned` here is safe by construction, not just untested --
         // `stream_expr` is evaluated against this same `value`, which also
-        // becomes `depth` a few lines up. Any `value` complex enough for
-        // `stream_expr` to reach a nested undecodable string through it is
-        // necessarily a container (object/array), and a container always
-        // sorts above any `Int` path length in jq's ordering (`compare_values`
+        // becomes `depth` a few lines up. `value` itself being an undecodable
+        // `String` is not `depth`'s only non-scalar-in-effect case either:
+        // whether `value` is a container reachable via a nested field/index,
+        // or is directly the undecodable string, `depth` ends up either a
+        // container or a `String` -- and a `String`/container both always
+        // sort above any `Int` path length in jq's ordering (`compare_values`
         // just below) -- so `path_len > depth` is provably false for every
-        // event whenever `depth` is non-scalar, meaning every event is
+        // event whenever `depth` is non-numeric, meaning every event is
         // dropped before an undecodable leaf's silently-substituted `""`
         // could ever reach `outputs`. `stream_expr` has no other source of
         // document-backed (as opposed to literal/computed) content to draw


### PR DESCRIPTION
## Summary

- `builtin_fromstream`'s `collect_owned`-based fallback arm used bare
  `collect_owned`, whose `One`/`Many` arms call unchecked `to_owned` --
  silently substituting `""` for an undecodable event leaf instead of
  raising, the same #1746-shaped bug this family has already been fixed
  for elsewhere (#1972/#2023/#2024). Found via a research audit for #1989
  (enumerating/classifying every bare `to_owned(` call site in `eval.rs`
  as that issue's own precondition before any mechanical rename).
- Fixed by routing through the existing `stream_outputs_checked` instead
  of writing a new function -- it already has the exact
  `(Vec<OwnedValue>, Option<Control>)` shape this match already
  destructures into.
- `builtin_truncate_stream` has the identical `collect_owned` shape at
  its own call site but is safe by construction, not just untested:
  `stream_expr` is evaluated against the same `value` that also becomes
  `depth`, and any `value` complex enough for `stream_expr` to reach a
  nested undecodable string through it is necessarily a container, which
  always sorts above any `Int` path length in jq's ordering -- so every
  event is unconditionally dropped before a corrupted leaf could ever
  reach output. Documented inline rather than fixed, since there's
  nothing to fix; this re-derives (rather than just trusts) the #1989
  audit's own live-repro finding for this site.

Fixes #2188

## Repro (library API, `\ud800`/raw-invalid-UTF8 methodology per this
## repo's established pattern for this bug family)

`{"events":[[[],"<bad>"]]}` | `fromstream(.events[])`:
pre-fix `Owned(String(""))` (silent substitution, no error);
post-fix raises a decode failure.

## Test plan

- [x] New regression test `test_fromstream_raises_on_undecodable_event_leaf_2188`, confirmed to fail against the pre-fix code and pass with the fix
- [x] Full test suite (`cli,simd,regex,serde`): all green
- [x] Both clippy legs (clean `cargo clean -p` rebuild each): clean
- [x] `cargo test --no-default-features` (no_std): clean
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings): clean