### PR TITLE
refactor(jq): unify install_def_calls/substitute_func_param/substitute_var_impl via map_subexprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Expr`-scrutinee `unreachable!()` fallbacks along with it. `size_of::<Expr>()` is
   unchanged at 96 bytes and is now pinned by a test.
 
+- **`eval.rs`'s three `Expr`-substitution passes now share one generic tree
+  walk** (#2095): `install_def_calls`, `substitute_func_param` and
+  `substitute_var_impl` each used to hand-write a full ~40-arm match over
+  every `Expr` variant, identical except at a handful of binder/leaf/opaque
+  arms, so adding a new `Expr` variant meant three synchronized edits — and
+  missing one next to a wildcard would compile cleanly while silently
+  dropping that variant from whichever pass forgot it. `map_subexprs`
+  (`src/jq/walk.rs`) generalizes `map_builtin_subexprs` one level up the
+  tree: it owns every variant whose recursive-structural-child handling is
+  identical across all three callers, and each caller now matches only its
+  own special-cased arms (shadow checks, opaque `Shared`/`DefCall`
+  handling, `FuncDef`, `Builtin`) before falling through to it. Both
+  `map_subexprs` and `map_builtin_subexprs` deliberately have no wildcard
+  arm, so a future `Expr`/`Builtin` variant is a compile error in one place
+  rather than a silent gap in three.
+
+  Behavior-preserving refactor, not a fix: verified by reading all three
+  functions' arms side by side before folding any of them, and every
+  existing `jq`/`yq` test still passes unchanged. `Expr::Shared` and
+  `Expr::Error` turned out to be handled identically across all three
+  callers too, but are kept as explicit per-function arms rather than
+  folded — `Shared`'s opacity is architecturally load-bearing (#1371,
+  #2077, #2096) and each caller's own comment documents a different
+  concrete hazard, and `Expr::Error`'s non-recursion into its message looks
+  like a pre-existing latent gap (`error($x)` referencing a variable a pass
+  is substituting doesn't get substituted) rather than a deliberate
+  invariant, flagged in `map_subexprs`'s own doc comment for follow-up
+  rather than silently changed here.
+
 ### Fixed
 
 - **`IN(s)`/`IN(src; s)` now forward the real ambient `optional` instead of

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -42,7 +42,7 @@ use super::document::{
     DocumentFields,
 };
 use super::slice::{self, SliceBounds};
-use super::walk::{any_subexpr, map_builtin_subexprs};
+use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
 
 /// Which `EvalSemantics` implementor a value carries, as a runtime tag.
 ///
@@ -26188,25 +26188,6 @@ fn substitute_var_impl(
         // would also re-walk every argument from every level below on each
         // binding, which is the O(depth^2) traversal this design removes.
         Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
-        // A `DefCall`'s arguments are ordinary caller-scope code and must
-        // stay reachable: the call site can sit inside an `as` that has not
-        // been evaluated yet, so this is the pass that binds `$x` in
-        // `1 as $x | f($x)`. The definition itself is not descended into --
-        // it was captured with every variable in scope at its own definition
-        // site already substituted, and its body is a fresh scope per call.
-        Expr::DefCall {
-            def, args, frames, ..
-        } => Expr::DefCall {
-            def: Rc::clone(def),
-            args: args
-                .iter()
-                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
-                .collect(),
-            frames: *frames,
-            // Fresh: `args` just changed, so anything cached against the old
-            // ones would be stale.
-            bound: BoundBody::default(),
-        },
         Expr::Var(name) if name == var_name => {
             if mark_trackable {
                 Expr::TrackedVar(Rc::new(replacement.clone()))
@@ -26214,245 +26195,9 @@ fn substitute_var_impl(
                 owned_to_expr(replacement)
             }
         }
-        Expr::Var(_) => expr.clone(),
-        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
-        Expr::Loc { line } => Expr::Loc { line: *line },
-        Expr::Env => Expr::Env,
-        Expr::Identity => Expr::Identity,
-        Expr::Field(name) => Expr::Field(name.clone()),
-        Expr::Index { idx, key } => Expr::Index {
-            idx: *idx,
-            key: key.clone(),
-        },
-        Expr::Slice {
-            start,
-            end,
-            start_key,
-            end_key,
-        } => Expr::Slice {
-            start: *start,
-            end: *end,
-            start_key: start_key.clone(),
-            end_key: end_key.clone(),
-        },
-        Expr::Iterate => Expr::Iterate,
-        // Must recurse into `key`: variables are resolved by substitution, so
-        // skipping it would leave `$k` in `.[$k]` unbound at eval time.
-        Expr::IndexExpr { target, key } => Expr::IndexExpr {
-            target: Box::new(substitute_var_impl(
-                target,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            key: Box::new(substitute_var_impl(
-                key,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        // Same reasoning as `IndexExpr`: `$a`/`$b` in `.[$a:$b]` must resolve.
-        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
-            target: Box::new(substitute_var_impl(
-                target,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            start: start.as_deref().map(|e| {
-                Box::new(substitute_var_impl(
-                    e,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                ))
-            }),
-            end: end.as_deref().map(|e| {
-                Box::new(substitute_var_impl(
-                    e,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                ))
-            }),
-        },
-        Expr::RecursiveDescent => Expr::RecursiveDescent,
-        Expr::Optional(e) => Expr::Optional(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::Pipe(exprs) => Expr::Pipe(
-            exprs
-                .iter()
-                .map(|e| substitute_var_impl(e, var_name, replacement, mark_trackable))
-                .collect(),
-        ),
-        Expr::Comma(exprs) => Expr::Comma(
-            exprs
-                .iter()
-                .map(|e| substitute_var_impl(e, var_name, replacement, mark_trackable))
-                .collect(),
-        ),
-        Expr::Array(e) => Expr::Array(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::Object(entries) => {
-            Expr::Object(
-                entries
-                    .iter()
-                    .map(|entry| {
-                        let new_key =
-                            match &entry.key {
-                                ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                                ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(
-                                    substitute_var_impl(e, var_name, replacement, mark_trackable),
-                                )),
-                            };
-                        ObjectEntry {
-                            key: new_key,
-                            value: substitute_var_impl(
-                                &entry.value,
-                                var_name,
-                                replacement,
-                                mark_trackable,
-                            ),
-                        }
-                    })
-                    .collect(),
-            )
-        }
-        Expr::Literal(lit) => Expr::Literal(lit.clone()),
-        Expr::Paren(e) => Expr::Paren(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
-            op: *op,
-            left: Box::new(substitute_var_impl(
-                left,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            right: Box::new(substitute_var_impl(
-                right,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::Negate(operand) => Expr::Negate(Box::new(substitute_var_impl(
-            operand,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::Compare { op, left, right } => Expr::Compare {
-            op: *op,
-            left: Box::new(substitute_var_impl(
-                left,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            right: Box::new(substitute_var_impl(
-                right,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::And(l, r) => Expr::And(
-            Box::new(substitute_var_impl(
-                l,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            Box::new(substitute_var_impl(
-                r,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        ),
-        Expr::Or(l, r) => Expr::Or(
-            Box::new(substitute_var_impl(
-                l,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            Box::new(substitute_var_impl(
-                r,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        ),
-        Expr::Not => Expr::Not,
-        Expr::Alternative(l, r) => Expr::Alternative(
-            Box::new(substitute_var_impl(
-                l,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            Box::new(substitute_var_impl(
-                r,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        ),
-        Expr::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => Expr::If {
-            cond: Box::new(substitute_var_impl(
-                cond,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            then_branch: Box::new(substitute_var_impl(
-                then_branch,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            else_branch: Box::new(substitute_var_impl(
-                else_branch,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::Try { expr, catch } => Expr::Try {
-            expr: Box::new(substitute_var_impl(
-                expr,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            catch: catch.as_ref().map(|e| {
-                Box::new(substitute_var_impl(
-                    e,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                ))
-            }),
-        },
+        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
+        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
+        // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
         Expr::Builtin(b) => Expr::Builtin(substitute_var_in_builtin(
             b,
@@ -26460,290 +26205,85 @@ fn substitute_var_impl(
             replacement,
             mark_trackable,
         )),
-        Expr::StringInterpolation(parts) => Expr::StringInterpolation(
-            parts
-                .iter()
-                .map(|p| match p {
-                    StringPart::Literal(s) => StringPart::Literal(s.clone()),
-                    StringPart::Expr(e) => StringPart::Expr(Box::new(substitute_var_impl(
-                        e,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    ))),
-                })
-                .collect(),
-        ),
-        Expr::Format(f) => Expr::Format(f.clone()),
         // Phase 8 expressions
-        Expr::As { expr, var, body } => {
-            // Don't substitute if this `as` binds the same variable (shadowing)
-            if var == var_name {
-                Expr::As {
-                    expr: Box::new(substitute_var_impl(
-                        expr,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    var: var.clone(),
-                    body: body.clone(), // Don't substitute in body - shadowed
-                }
-            } else {
-                Expr::As {
-                    expr: Box::new(substitute_var_impl(
-                        expr,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    var: var.clone(),
-                    body: Box::new(substitute_var_impl(
-                        body,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                }
-            }
-        }
+        // Don't substitute if this `as` binds the same variable (shadowing)
+        Expr::As { expr, var, body } if var == var_name => Expr::As {
+            expr: Box::new(substitute_var_impl(
+                expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            var: var.clone(),
+            body: body.clone(), // Don't substitute in body - shadowed
+        },
+        // Shadowed if *any* alternative pattern binds var_name (#1201,
+        // #1365; mirrors `Expr::AsPattern`'s own `pattern_binds_var`
+        // shadow check just above, since a bare `$var` binding is just
+        // the single-variable, single-alternative case of this same
+        // question).
         Expr::Reduce {
             input,
             patterns,
             init,
             update,
-        } => {
-            // Shadowed if *any* alternative pattern binds var_name (#1201,
-            // #1365; mirrors `Expr::AsPattern`'s own `pattern_binds_var`
-            // shadow check just above, since a bare `$var` binding is just
-            // the single-variable, single-alternative case of this same
-            // question).
-            if patterns.iter().any(|p| pattern_binds_var(p, var_name)) {
-                Expr::Reduce {
-                    input: Box::new(substitute_var_impl(
-                        input,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    patterns: patterns.clone(),
-                    init: Box::new(substitute_var_impl(
-                        init,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    update: update.clone(), // shadowed
-                }
-            } else {
-                Expr::Reduce {
-                    input: Box::new(substitute_var_impl(
-                        input,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    patterns: patterns.clone(),
-                    init: Box::new(substitute_var_impl(
-                        init,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    update: Box::new(substitute_var_impl(
-                        update,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                }
-            }
-        }
+        } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::Reduce {
+            input: Box::new(substitute_var_impl(
+                input,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            patterns: patterns.clone(),
+            init: Box::new(substitute_var_impl(
+                init,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            update: update.clone(), // shadowed
+        },
         Expr::Foreach {
             input,
             patterns,
             init,
             update,
             extract,
-        } => {
-            if patterns.iter().any(|p| pattern_binds_var(p, var_name)) {
-                Expr::Foreach {
-                    input: Box::new(substitute_var_impl(
-                        input,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    patterns: patterns.clone(),
-                    init: Box::new(substitute_var_impl(
-                        init,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    update: update.clone(),
-                    extract: extract.clone(),
-                }
-            } else {
-                Expr::Foreach {
-                    input: Box::new(substitute_var_impl(
-                        input,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    patterns: patterns.clone(),
-                    init: Box::new(substitute_var_impl(
-                        init,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    update: Box::new(substitute_var_impl(
-                        update,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                    extract: extract.as_ref().map(|e| {
-                        Box::new(substitute_var_impl(
-                            e,
-                            var_name,
-                            replacement,
-                            mark_trackable,
-                        ))
-                    }),
-                }
-            }
-        }
-        Expr::Limit { n, expr } => Expr::Limit {
-            n: Box::new(substitute_var_impl(
-                n,
+        } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::Foreach {
+            input: Box::new(substitute_var_impl(
+                input,
                 var_name,
                 replacement,
                 mark_trackable,
             )),
-            expr: Box::new(substitute_var_impl(
-                expr,
+            patterns: patterns.clone(),
+            init: Box::new(substitute_var_impl(
+                init,
                 var_name,
                 replacement,
                 mark_trackable,
             )),
-        },
-        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::LastExpr(e) => Expr::LastExpr(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::NthExpr { n, expr } => Expr::NthExpr {
-            n: Box::new(substitute_var_impl(
-                n,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            expr: Box::new(substitute_var_impl(
-                expr,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::Until { cond, update } => Expr::Until {
-            cond: Box::new(substitute_var_impl(
-                cond,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            update: Box::new(substitute_var_impl(
-                update,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::While { cond, update } => Expr::While {
-            cond: Box::new(substitute_var_impl(
-                cond,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            update: Box::new(substitute_var_impl(
-                update,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::Repeat(e) => Expr::Repeat(Box::new(substitute_var_impl(
-            e,
-            var_name,
-            replacement,
-            mark_trackable,
-        ))),
-        Expr::Range { from, to, step } => Expr::Range {
-            from: Box::new(substitute_var_impl(
-                from,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            to: to.as_ref().map(|e| {
-                Box::new(substitute_var_impl(
-                    e,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                ))
-            }),
-            step: step.as_ref().map(|e| {
-                Box::new(substitute_var_impl(
-                    e,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                ))
-            }),
+            update: update.clone(),
+            extract: extract.clone(),
         },
         // Phase 9: Variables & Definitions
+        // Shadowed if *any* alternative binds var_name -- the body's scope
+        // has to treat the name consistently across every alternative it
+        // might actually run under (#720).
         Expr::AsPattern {
             expr,
             patterns,
             body,
-        } => {
-            // Shadowed if *any* alternative binds var_name -- the body's
-            // scope has to treat the name consistently across every
-            // alternative it might actually run under (#720).
-            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, var_name));
-            Expr::AsPattern {
-                expr: Box::new(substitute_var_impl(
-                    expr,
-                    var_name,
-                    replacement,
-                    mark_trackable,
-                )),
-                patterns: patterns.clone(),
-                body: if shadowed {
-                    body.clone()
-                } else {
-                    Box::new(substitute_var_impl(
-                        body,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    ))
-                },
-            }
-        }
+        } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::AsPattern {
+            expr: Box::new(substitute_var_impl(
+                expr,
+                var_name,
+                replacement,
+                mark_trackable,
+            )),
+            patterns: patterns.clone(),
+            body: body.clone(),
+        },
         Expr::FuncDef {
             name,
             params,
@@ -26777,102 +26317,23 @@ fn substitute_var_impl(
                 bound: FuncDefBound::default(),
             }
         }
-        Expr::FuncCall { name, args } => Expr::FuncCall {
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
-                .collect(),
-        },
-        Expr::NamespacedCall {
-            namespace,
-            name,
-            args,
-        } => Expr::NamespacedCall {
-            namespace: namespace.clone(),
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|a| substitute_var_impl(a, var_name, replacement, mark_trackable))
-                .collect(),
-        },
-        // Assignment operators
-        Expr::Assign { path, value } => Expr::Assign {
-            path: Box::new(substitute_var_impl(
-                path,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            value: Box::new(substitute_var_impl(
-                value,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::Update { path, filter } => Expr::Update {
-            path: Box::new(substitute_var_impl(
-                path,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            filter: Box::new(substitute_var_impl(
-                filter,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
-            op: *op,
-            path: Box::new(substitute_var_impl(
-                path,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            value: Box::new(substitute_var_impl(
-                value,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-        Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
-            path: Box::new(substitute_var_impl(
-                path,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-            value: Box::new(substitute_var_impl(
-                value,
-                var_name,
-                replacement,
-                mark_trackable,
-            )),
-        },
-
         // Label-break
-        Expr::Label { name, body } => {
-            // Don't substitute if the label shadows our variable
-            if name == var_name {
-                expr.clone()
-            } else {
-                Expr::Label {
-                    name: name.clone(),
-                    body: Box::new(substitute_var_impl(
-                        body,
-                        var_name,
-                        replacement,
-                        mark_trackable,
-                    )),
-                }
-            }
-        }
-        Expr::Break(name) => Expr::Break(name.clone()),
+        // Don't substitute if the label shadows our variable
+        Expr::Label { name, .. } if name == var_name => expr.clone(),
+
+        // #2095: every remaining variant's recursive-structural-child
+        // handling here is identical to `install_def_calls`'s and
+        // `substitute_func_param`'s own -- apply this substitution to each
+        // `Expr`-typed child and rebuild the node, nothing else -- so it
+        // lives once in `map_subexprs` (`src/jq/walk.rs`) instead of being
+        // hand-repeated in all three. See that function's own doc comment
+        // for the full variant-by-variant justification, including the five
+        // arms (`Shared`, `Error`, `Builtin`, `FuncDef`, and
+        // `install_def_calls`'s own `DefCall` policy) that stay explicit
+        // above/in each caller instead of ever reaching it.
+        _ => map_subexprs(expr, &mut |sub| {
+            substitute_var_impl(sub, var_name, replacement, mark_trackable)
+        }),
     }
 }
 
@@ -41363,212 +40824,11 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                 bound: BoundBody::default(),
             }
         }
-        // Recursively expand in all subexpressions
-        Expr::Identity => Expr::Identity,
-        Expr::Field(s) => Expr::Field(s.clone()),
-        Expr::Index { idx, key } => Expr::Index {
-            idx: *idx,
-            key: key.clone(),
-        },
-        Expr::Slice {
-            start,
-            end,
-            start_key,
-            end_key,
-        } => Expr::Slice {
-            start: *start,
-            end: *end,
-            start_key: start_key.clone(),
-            end_key: end_key.clone(),
-        },
-        Expr::Iterate => Expr::Iterate,
-        Expr::IndexExpr { target, key } => Expr::IndexExpr {
-            target: Box::new(install_def_calls(target, def, frames + 1)),
-            key: Box::new(install_def_calls(key, def, frames + 1)),
-        },
-        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
-            target: Box::new(install_def_calls(target, def, frames + 1)),
-            start: start
-                .as_deref()
-                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
-            end: end
-                .as_deref()
-                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
-        },
-        Expr::RecursiveDescent => Expr::RecursiveDescent,
-        Expr::Optional(e) => Expr::Optional(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::Pipe(exprs) => Expr::Pipe(
-            exprs
-                .iter()
-                .map(|e| install_def_calls(e, def, frames + 1))
-                .collect(),
-        ),
-        Expr::Comma(exprs) => Expr::Comma(
-            exprs
-                .iter()
-                .map(|e| install_def_calls(e, def, frames + 1))
-                .collect(),
-        ),
-        Expr::Array(e) => Expr::Array(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::Object(entries) => Expr::Object(
-            entries
-                .iter()
-                .map(|entry| {
-                    let new_key = match &entry.key {
-                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                        ObjectKey::Expr(e) => {
-                            ObjectKey::Expr(Box::new(install_def_calls(e, def, frames + 1)))
-                        }
-                    };
-                    ObjectEntry {
-                        key: new_key,
-                        value: install_def_calls(&entry.value, def, frames + 1),
-                    }
-                })
-                .collect(),
-        ),
-        Expr::Literal(lit) => Expr::Literal(lit.clone()),
-        Expr::Paren(e) => Expr::Paren(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
-            op: *op,
-            left: Box::new(install_def_calls(left, def, frames + 1)),
-            right: Box::new(install_def_calls(right, def, frames + 1)),
-        },
-        Expr::Negate(operand) => {
-            Expr::Negate(Box::new(install_def_calls(operand, def, frames + 1)))
-        }
-        Expr::Compare { op, left, right } => Expr::Compare {
-            op: *op,
-            left: Box::new(install_def_calls(left, def, frames + 1)),
-            right: Box::new(install_def_calls(right, def, frames + 1)),
-        },
-        Expr::And(l, r) => Expr::And(
-            Box::new(install_def_calls(l, def, frames + 1)),
-            Box::new(install_def_calls(r, def, frames + 1)),
-        ),
-        Expr::Or(l, r) => Expr::Or(
-            Box::new(install_def_calls(l, def, frames + 1)),
-            Box::new(install_def_calls(r, def, frames + 1)),
-        ),
-        Expr::Not => Expr::Not,
-        Expr::Alternative(l, r) => Expr::Alternative(
-            Box::new(install_def_calls(l, def, frames + 1)),
-            Box::new(install_def_calls(r, def, frames + 1)),
-        ),
-        Expr::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => Expr::If {
-            cond: Box::new(install_def_calls(cond, def, frames + 1)),
-            then_branch: Box::new(install_def_calls(then_branch, def, frames + 1)),
-            else_branch: Box::new(install_def_calls(else_branch, def, frames + 1)),
-        },
-        Expr::Try { expr, catch } => Expr::Try {
-            expr: Box::new(install_def_calls(expr, def, frames + 1)),
-            catch: catch
-                .as_ref()
-                .map(|c| Box::new(install_def_calls(c, def, frames + 1))),
-        },
+        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
+        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
+        // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
         Expr::Builtin(b) => Expr::Builtin(install_def_calls_in_builtin(b, def, frames + 1)),
-        Expr::StringInterpolation(parts) => Expr::StringInterpolation(
-            parts
-                .iter()
-                .map(|p| match p {
-                    StringPart::Literal(s) => StringPart::Literal(s.clone()),
-                    StringPart::Expr(e) => {
-                        StringPart::Expr(Box::new(install_def_calls(e, def, frames + 1)))
-                    }
-                })
-                .collect(),
-        ),
-        Expr::Format(f) => Expr::Format(f.clone()),
-        Expr::Var(v) => Expr::Var(v.clone()),
-        // Genuinely reachable, not just a totality formality: this
-        // function re-runs on every `Expr::FuncDef` *evaluation* (its own
-        // call site inlines `def`s at the point they execute, not once at
-        // parse time), and a `def`'s own body can already contain a
-        // `TrackedVar` from an enclosing `as`-binding -- confirmed live,
-        // `. as $x | def f: $x | .b; path(f)` reaches this arm. `v.clone()`
-        // is an O(1) `Rc` refcount bump, not a deep copy of the frozen
-        // snapshot, so re-inlining a `def` that closes over a large
-        // passthrough-bound value on every call stays cheap (#844).
-        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
-        Expr::Loc { line } => Expr::Loc { line: *line },
-        Expr::Env => Expr::Env,
-        Expr::As {
-            expr,
-            var,
-            body: as_body,
-        } => Expr::As {
-            expr: Box::new(install_def_calls(expr, def, frames + 1)),
-            var: var.clone(),
-            body: Box::new(install_def_calls(as_body, def, frames + 1)),
-        },
-        Expr::Reduce {
-            input,
-            patterns,
-            init,
-            update,
-        } => Expr::Reduce {
-            input: Box::new(install_def_calls(input, def, frames + 1)),
-            patterns: patterns.clone(),
-            init: Box::new(install_def_calls(init, def, frames + 1)),
-            update: Box::new(install_def_calls(update, def, frames + 1)),
-        },
-        Expr::Foreach {
-            input,
-            patterns,
-            init,
-            update,
-            extract,
-        } => Expr::Foreach {
-            input: Box::new(install_def_calls(input, def, frames + 1)),
-            patterns: patterns.clone(),
-            init: Box::new(install_def_calls(init, def, frames + 1)),
-            update: Box::new(install_def_calls(update, def, frames + 1)),
-            extract: extract
-                .as_ref()
-                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
-        },
-        Expr::Limit { n, expr } => Expr::Limit {
-            n: Box::new(install_def_calls(n, def, frames + 1)),
-            expr: Box::new(install_def_calls(expr, def, frames + 1)),
-        },
-        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::LastExpr(e) => Expr::LastExpr(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::NthExpr { n, expr } => Expr::NthExpr {
-            n: Box::new(install_def_calls(n, def, frames + 1)),
-            expr: Box::new(install_def_calls(expr, def, frames + 1)),
-        },
-        Expr::Until { cond, update } => Expr::Until {
-            cond: Box::new(install_def_calls(cond, def, frames + 1)),
-            update: Box::new(install_def_calls(update, def, frames + 1)),
-        },
-        Expr::While { cond, update } => Expr::While {
-            cond: Box::new(install_def_calls(cond, def, frames + 1)),
-            update: Box::new(install_def_calls(update, def, frames + 1)),
-        },
-        Expr::Repeat(e) => Expr::Repeat(Box::new(install_def_calls(e, def, frames + 1))),
-        Expr::Range { from, to, step } => Expr::Range {
-            from: Box::new(install_def_calls(from, def, frames + 1)),
-            to: to
-                .as_ref()
-                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
-            step: step
-                .as_ref()
-                .map(|e| Box::new(install_def_calls(e, def, frames + 1))),
-        },
-        Expr::AsPattern {
-            expr,
-            patterns,
-            body: pattern_body,
-        } => Expr::AsPattern {
-            expr: Box::new(install_def_calls(expr, def, frames + 1)),
-            patterns: patterns.clone(),
-            body: Box::new(install_def_calls(pattern_body, def, frames + 1)),
-        },
         Expr::FuncDef {
             name: inner_name,
             params: inner_params,
@@ -41607,54 +40867,6 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                 }
             }
         }
-        Expr::FuncCall { name, args } => {
-            // Reached for a different function name entirely, or (#1376)
-            // a same-name call whose arity doesn't match this occurrence
-            // -- either way, not this pass's call to resolve, so just
-            // expand in arguments and leave the call itself untouched.
-            Expr::FuncCall {
-                name: name.clone(),
-                args: args
-                    .iter()
-                    .map(|a| install_def_calls(a, def, frames + 1))
-                    .collect(),
-            }
-        }
-        Expr::NamespacedCall {
-            namespace,
-            name,
-            args,
-        } => Expr::NamespacedCall {
-            namespace: namespace.clone(),
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|a| install_def_calls(a, def, frames + 1))
-                .collect(),
-        },
-        Expr::Assign { path, value } => Expr::Assign {
-            path: Box::new(install_def_calls(path, def, frames + 1)),
-            value: Box::new(install_def_calls(value, def, frames + 1)),
-        },
-        Expr::Update { path, filter } => Expr::Update {
-            path: Box::new(install_def_calls(path, def, frames + 1)),
-            filter: Box::new(install_def_calls(filter, def, frames + 1)),
-        },
-        Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
-            op: *op,
-            path: Box::new(install_def_calls(path, def, frames + 1)),
-            value: Box::new(install_def_calls(value, def, frames + 1)),
-        },
-        Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
-            path: Box::new(install_def_calls(path, def, frames + 1)),
-            value: Box::new(install_def_calls(value, def, frames + 1)),
-        },
-
-        // Label-break
-        Expr::Label { name, body: lbody } => Expr::Label {
-            name: name.clone(),
-            body: Box::new(install_def_calls(lbody, def, frames + 1)),
-        },
         // #1371: opaque. A `Shared` holds an argument that was captured at
         // call time, after every enclosing substitution had run and after
         // this same installer had already visited it -- so there is nothing
@@ -41707,7 +40919,16 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
             // node before it has been evaluated).
             bound: BoundBody::default(),
         },
-        Expr::Break(name) => Expr::Break(name.clone()),
+        // Reached for a different function name entirely, or (#1376)
+        // a same-name call whose arity doesn't match this occurrence
+        // -- either way, not this pass's call to resolve, so just
+        // expand in arguments and leave the call itself untouched. Shared
+        // with every other uniform structural variant below (#2095) via
+        // `map_subexprs` (`src/jq/walk.rs`) -- see that function's own doc
+        // comment for the full variant-by-variant justification, including
+        // the arms above that stay explicit here instead of ever reaching
+        // it.
+        _ => map_subexprs(expr, &mut |sub| install_def_calls(sub, def, frames + 1)),
     }
 }
 
@@ -41742,28 +40963,18 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
 /// (`shadowed` means some binder between here and `e` already rebinds
 /// `param`, so nothing further down can still be `param`'s substituted
 /// argument -- see each call site's own shadow condition). Collapses the
-/// "binder shadows `param` -> clone; otherwise recurse" idiom shared by
-/// `substitute_func_param`'s `As`/`Reduce`/`Foreach`/`AsPattern`/`FuncDef`
-/// arms below (#2096 review).
+/// "binder shadows `param` -> clone; otherwise recurse" idiom `FuncDef`'s
+/// own arm below needs for its two *independent* `body`/`then` shadow
+/// conditions (#2096 review). `As`/`Reduce`/`Foreach`/`AsPattern` used to
+/// share this too, before #2095 hoisted each of their single shadow
+/// conditions to a match guard instead, so their own non-shadowed case could
+/// fall through to [`map_subexprs`]'s (`src/jq/walk.rs`) shared,
+/// unconditional-recursion arm rather than calling back in here.
 fn subst_unless_shadowed(shadowed: bool, e: &Expr, param: &str, arg: &Expr) -> Expr {
     if shadowed {
         e.clone()
     } else {
         substitute_func_param(e, param, arg)
-    }
-}
-
-/// Like [`subst_unless_shadowed`], for `Foreach`'s optional `extract` slot.
-fn subst_unless_shadowed_opt(
-    shadowed: bool,
-    e: &Option<Box<Expr>>,
-    param: &str,
-    arg: &Expr,
-) -> Option<Expr> {
-    if shadowed {
-        e.as_deref().cloned()
-    } else {
-        e.as_deref().map(|e| substitute_func_param(e, param, arg))
     }
 }
 
@@ -41782,229 +40993,51 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
         // from being substituted *into the first argument*: arguments live in
         // the caller's scope and cannot mention the callee's own parameters.
         Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
-        // A nested call's arguments, by contrast, are code in *this* body's
-        // scope and can mention this parameter -- `def outer(n): inner(n);`
-        // binds `n` here, through the inner call. Reached whenever an outer
-        // definition was installed over a body before this one's parameters
-        // were bound, which is the ordinary case for two sibling `def`s.
-        Expr::DefCall {
-            def, args, frames, ..
-        } => Expr::DefCall {
-            def: Rc::clone(def),
-            args: args
-                .iter()
-                .map(|a| substitute_func_param(a, param, arg))
-                .collect(),
-            frames: *frames,
-            // Fresh, for the reason `substitute_var_impl`'s own arm gives.
-            bound: BoundBody::default(),
-        },
         // A variable reference to the parameter becomes the argument expression
         Expr::Var(name) if name == param => arg.clone(),
-        Expr::Var(_) => expr.clone(),
-        // Genuinely reachable, not just a totality formality: called from
-        // `expand_func_calls` to bind a `def`'s own `$`-parameters at every
-        // call site, and the `def`'s body can already contain a
-        // `TrackedVar` from an enclosing `as`-binding unrelated to `param`
-        // -- see `expand_func_calls`'s own `Expr::TrackedVar` arm for the
-        // confirmed repro. `v.clone()` is an `Rc` refcount bump, not a
-        // deep copy (#844).
-        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
-        Expr::Loc { line } => Expr::Loc { line: *line },
-        Expr::Env => Expr::Env,
-        Expr::Identity => Expr::Identity,
-        Expr::Field(name) => Expr::Field(name.clone()),
-        Expr::Index { idx, key } => Expr::Index {
-            idx: *idx,
-            key: key.clone(),
-        },
-        Expr::Slice {
-            start,
-            end,
-            start_key,
-            end_key,
-        } => Expr::Slice {
-            start: *start,
-            end: *end,
-            start_key: start_key.clone(),
-            end_key: end_key.clone(),
-        },
-        Expr::Iterate => Expr::Iterate,
-        Expr::IndexExpr { target, key } => Expr::IndexExpr {
-            target: Box::new(substitute_func_param(target, param, arg)),
-            key: Box::new(substitute_func_param(key, param, arg)),
-        },
-        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
-            target: Box::new(substitute_func_param(target, param, arg)),
-            start: start
-                .as_deref()
-                .map(|e| Box::new(substitute_func_param(e, param, arg))),
-            end: end
-                .as_deref()
-                .map(|e| Box::new(substitute_func_param(e, param, arg))),
-        },
-        Expr::RecursiveDescent => Expr::RecursiveDescent,
-        Expr::Optional(e) => Expr::Optional(Box::new(substitute_func_param(e, param, arg))),
-        Expr::Pipe(exprs) => Expr::Pipe(
-            exprs
-                .iter()
-                .map(|e| substitute_func_param(e, param, arg))
-                .collect(),
-        ),
-        Expr::Comma(exprs) => Expr::Comma(
-            exprs
-                .iter()
-                .map(|e| substitute_func_param(e, param, arg))
-                .collect(),
-        ),
-        Expr::Array(e) => Expr::Array(Box::new(substitute_func_param(e, param, arg))),
-        Expr::Object(entries) => Expr::Object(
-            entries
-                .iter()
-                .map(|entry| {
-                    let new_key = match &entry.key {
-                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                        ObjectKey::Expr(e) => {
-                            ObjectKey::Expr(Box::new(substitute_func_param(e, param, arg)))
-                        }
-                    };
-                    ObjectEntry {
-                        key: new_key,
-                        value: substitute_func_param(&entry.value, param, arg),
-                    }
-                })
-                .collect(),
-        ),
-        Expr::Literal(lit) => Expr::Literal(lit.clone()),
-        Expr::Paren(e) => Expr::Paren(Box::new(substitute_func_param(e, param, arg))),
-        Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
-            op: *op,
-            left: Box::new(substitute_func_param(left, param, arg)),
-            right: Box::new(substitute_func_param(right, param, arg)),
-        },
-        Expr::Negate(operand) => Expr::Negate(Box::new(substitute_func_param(operand, param, arg))),
-        Expr::Compare { op, left, right } => Expr::Compare {
-            op: *op,
-            left: Box::new(substitute_func_param(left, param, arg)),
-            right: Box::new(substitute_func_param(right, param, arg)),
-        },
-        Expr::And(l, r) => Expr::And(
-            Box::new(substitute_func_param(l, param, arg)),
-            Box::new(substitute_func_param(r, param, arg)),
-        ),
-        Expr::Or(l, r) => Expr::Or(
-            Box::new(substitute_func_param(l, param, arg)),
-            Box::new(substitute_func_param(r, param, arg)),
-        ),
-        Expr::Not => Expr::Not,
-        Expr::Alternative(l, r) => Expr::Alternative(
-            Box::new(substitute_func_param(l, param, arg)),
-            Box::new(substitute_func_param(r, param, arg)),
-        ),
-        Expr::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => Expr::If {
-            cond: Box::new(substitute_func_param(cond, param, arg)),
-            then_branch: Box::new(substitute_func_param(then_branch, param, arg)),
-            else_branch: Box::new(substitute_func_param(else_branch, param, arg)),
-        },
-        Expr::Try { expr, catch } => Expr::Try {
-            expr: Box::new(substitute_func_param(expr, param, arg)),
-            catch: catch
-                .as_ref()
-                .map(|c| Box::new(substitute_func_param(c, param, arg))),
-        },
+        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
+        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
+        // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
         Expr::Builtin(b) => Expr::Builtin(substitute_func_param_in_builtin(b, param, arg)),
-        Expr::StringInterpolation(parts) => Expr::StringInterpolation(
-            parts
-                .iter()
-                .map(|p| match p {
-                    StringPart::Literal(s) => StringPart::Literal(s.clone()),
-                    StringPart::Expr(e) => {
-                        StringPart::Expr(Box::new(substitute_func_param(e, param, arg)))
-                    }
-                })
-                .collect(),
-        ),
-        Expr::Format(f) => Expr::Format(f.clone()),
-        Expr::As { expr, var, body } => Expr::As {
+        Expr::As { expr, var, body } if var == param => Expr::As {
             expr: Box::new(substitute_func_param(expr, param, arg)),
             var: var.clone(),
-            body: Box::new(subst_unless_shadowed(var == param, body, param, arg)),
+            body: body.clone(),
         },
         Expr::Reduce {
             input,
             patterns,
             init,
             update,
-        } => {
-            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, param));
-            Expr::Reduce {
-                input: Box::new(substitute_func_param(input, param, arg)),
-                patterns: patterns.clone(),
-                init: Box::new(substitute_func_param(init, param, arg)),
-                update: Box::new(subst_unless_shadowed(shadowed, update, param, arg)),
-            }
-        }
+        } if patterns.iter().any(|p| pattern_binds_var(p, param)) => Expr::Reduce {
+            input: Box::new(substitute_func_param(input, param, arg)),
+            patterns: patterns.clone(),
+            init: Box::new(substitute_func_param(init, param, arg)),
+            update: update.clone(),
+        },
         Expr::Foreach {
             input,
             patterns,
             init,
             update,
             extract,
-        } => {
-            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, param));
-            Expr::Foreach {
-                input: Box::new(substitute_func_param(input, param, arg)),
-                patterns: patterns.clone(),
-                init: Box::new(substitute_func_param(init, param, arg)),
-                update: Box::new(subst_unless_shadowed(shadowed, update, param, arg)),
-                extract: subst_unless_shadowed_opt(shadowed, extract, param, arg).map(Box::new),
-            }
-        }
-        Expr::Limit { n, expr } => Expr::Limit {
-            n: Box::new(substitute_func_param(n, param, arg)),
-            expr: Box::new(substitute_func_param(expr, param, arg)),
-        },
-        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(substitute_func_param(e, param, arg))),
-        Expr::LastExpr(e) => Expr::LastExpr(Box::new(substitute_func_param(e, param, arg))),
-        Expr::NthExpr { n, expr } => Expr::NthExpr {
-            n: Box::new(substitute_func_param(n, param, arg)),
-            expr: Box::new(substitute_func_param(expr, param, arg)),
-        },
-        Expr::Until { cond, update } => Expr::Until {
-            cond: Box::new(substitute_func_param(cond, param, arg)),
-            update: Box::new(substitute_func_param(update, param, arg)),
-        },
-        Expr::While { cond, update } => Expr::While {
-            cond: Box::new(substitute_func_param(cond, param, arg)),
-            update: Box::new(substitute_func_param(update, param, arg)),
-        },
-        Expr::Repeat(e) => Expr::Repeat(Box::new(substitute_func_param(e, param, arg))),
-        Expr::Range { from, to, step } => Expr::Range {
-            from: Box::new(substitute_func_param(from, param, arg)),
-            to: to
-                .as_ref()
-                .map(|e| Box::new(substitute_func_param(e, param, arg))),
-            step: step
-                .as_ref()
-                .map(|e| Box::new(substitute_func_param(e, param, arg))),
+        } if patterns.iter().any(|p| pattern_binds_var(p, param)) => Expr::Foreach {
+            input: Box::new(substitute_func_param(input, param, arg)),
+            patterns: patterns.clone(),
+            init: Box::new(substitute_func_param(init, param, arg)),
+            update: update.clone(),
+            extract: extract.clone(),
         },
         Expr::AsPattern {
             expr,
             patterns,
             body,
-        } => {
-            let shadowed = patterns.iter().any(|p| pattern_binds_var(p, param));
-            Expr::AsPattern {
-                expr: Box::new(substitute_func_param(expr, param, arg)),
-                patterns: patterns.clone(),
-                body: Box::new(subst_unless_shadowed(shadowed, body, param, arg)),
-            }
-        }
+        } if patterns.iter().any(|p| pattern_binds_var(p, param)) => Expr::AsPattern {
+            expr: Box::new(substitute_func_param(expr, param, arg)),
+            patterns: patterns.clone(),
+            body: body.clone(),
+        },
         Expr::FuncDef {
             name,
             params,
@@ -42032,57 +41065,21 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
                 bound: FuncDefBound::default(),
             }
         }
-        Expr::FuncCall { name, args } => {
-            // In jq, function parameters are bare identifiers that parse as zero-arg FuncCalls
-            // Check if this is a reference to the parameter
-            if name == param && args.is_empty() {
-                arg.clone()
-            } else {
-                Expr::FuncCall {
-                    name: name.clone(),
-                    args: args
-                        .iter()
-                        .map(|a| substitute_func_param(a, param, arg))
-                        .collect(),
-                }
-            }
+        Expr::FuncCall { name, args } if name == param && args.is_empty() => {
+            // In jq, function parameters are bare identifiers that parse as
+            // zero-arg FuncCalls. This is a reference to the parameter.
+            arg.clone()
         }
-        Expr::NamespacedCall {
-            namespace,
-            name,
-            args,
-        } => Expr::NamespacedCall {
-            namespace: namespace.clone(),
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|a| substitute_func_param(a, param, arg))
-                .collect(),
-        },
-        Expr::Assign { path, value } => Expr::Assign {
-            path: Box::new(substitute_func_param(path, param, arg)),
-            value: Box::new(substitute_func_param(value, param, arg)),
-        },
-        Expr::Update { path, filter } => Expr::Update {
-            path: Box::new(substitute_func_param(path, param, arg)),
-            filter: Box::new(substitute_func_param(filter, param, arg)),
-        },
-        Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
-            op: *op,
-            path: Box::new(substitute_func_param(path, param, arg)),
-            value: Box::new(substitute_func_param(value, param, arg)),
-        },
-        Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
-            path: Box::new(substitute_func_param(path, param, arg)),
-            value: Box::new(substitute_func_param(value, param, arg)),
-        },
 
-        // Label-break
-        Expr::Label { name, body } => Expr::Label {
-            name: name.clone(),
-            body: Box::new(substitute_func_param(body, param, arg)),
-        },
-        Expr::Break(name) => Expr::Break(name.clone()),
+        // #2095: every remaining variant's recursive-structural-child
+        // handling here is identical to `install_def_calls`'s and
+        // `substitute_var_impl`'s own -- apply this substitution to each
+        // `Expr`-typed child and rebuild the node, nothing else -- so it
+        // lives once in `map_subexprs` (`src/jq/walk.rs`) instead of being
+        // hand-repeated in all three. See that function's own doc comment
+        // for the full variant-by-variant justification, including the arms
+        // above that stay explicit here instead of ever reaching it.
+        _ => map_subexprs(expr, &mut |sub| substitute_func_param(sub, param, arg)),
     }
 }
 

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -20,10 +20,14 @@
 //! its sub-expressions are declared, and every caller picks the fix up at once.
 
 use alloc::boxed::Box;
+#[cfg(not(test))]
+use alloc::rc::Rc;
+#[cfg(test)]
+use std::rc::Rc;
 
 #[cfg(test)]
-use super::FuncDefBound;
-use super::{Builtin, Expr, ObjectKey, StringPart};
+use super::FuncDefData;
+use super::{BoundBody, Builtin, Expr, FuncDefBound, ObjectEntry, ObjectKey, StringPart};
 
 /// The sub-expressions a [`Builtin`] owns, in source order.
 ///
@@ -567,6 +571,373 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         Builtin::GsubFlags(a, b, c) => {
             Builtin::GsubFlags(Box::new(f(a)), Box::new(f(b)), Box::new(f(c)))
         }
+    }
+}
+
+/// The mapping twin of [`any_subexpr`].
+///
+/// Generalizes [`map_builtin_subexprs`] one level up the tree (#2095):
+/// rebuilds `expr` with each of its direct `Expr`-typed children replaced by
+/// `f`'s answer for it.
+///
+/// Before this existed, `eval.rs` had three separate ~40-arm matches over
+/// every `Expr` variant -- `install_def_calls`, `substitute_func_param` and
+/// `substitute_var_impl` -- structurally identical except at a handful of
+/// binder/leaf/opaque arms, so adding a new `Expr` variant meant three
+/// synchronized hand-edits. Missing one next to a wildcard would compile
+/// cleanly and silently drop that variant from whichever pass forgot it --
+/// the same failure mode [`builtin_kids`]'s own doc comment describes, one
+/// level up.
+///
+/// **Not every variant below is a shared, unconditional shape.** Several
+/// carry per-caller logic -- a shadow check that must skip recursing into a
+/// bound-scope child, opacity, frame-accounting specific to one caller --
+/// that this function does not and cannot reproduce generically. Every
+/// `eval.rs` caller that needs one matches that variant explicitly, with its
+/// own condition, *before* ever falling through to this function for
+/// whatever remains uniform -- mirroring how each already special-cases
+/// `Expr::Builtin` ahead of its own `_in_builtin` sibling rather than
+/// somehow folding builtin dispatch in here too. Concretely, verified by
+/// reading all three functions' arms side by side (#2095 review):
+///
+/// - `Expr::As`/`Reduce`/`Foreach`/`AsPattern`/`Label`: `install_def_calls`
+///   has no shadow concept for these (a `def`-name substitution is never
+///   shadowed by a `$var`/pattern binder) and recurses into every child
+///   unconditionally -- exactly this function's own arm below. Both
+///   `substitute_var_impl` and `substitute_func_param` must *not* recurse
+///   into the bound-scope child when their own binder shadows the name being
+///   substituted, so both intercept these variants with their own guarded
+///   arm first and never reach this function for them.
+/// - `Expr::Var`/`Expr::FuncCall`: `install_def_calls` (for `Var`) and
+///   `substitute_var_impl` (for `FuncCall`) have no special case at all --
+///   exactly this function's leaf-clone / clone-name-and-map-args arms.
+///   `substitute_var_impl`/`substitute_func_param` (for `Var`) and
+///   `install_def_calls`/`substitute_func_param` (for `FuncCall`) intercept
+///   the name/arity match explicitly and fall through to this function only
+///   for the non-matching case.
+/// - `Expr::DefCall`: shared verbatim by `substitute_var_impl` and
+///   `substitute_func_param` (`def` opaque, `frames` unchanged, `args`
+///   walked, `bound` reset -- see the arm below). `install_def_calls` needs a
+///   *different* `frames` policy (the larger of its own stale count and the
+///   ambient depth this pass is walking at) and keeps its own explicit arm.
+/// - `Expr::Shared`: opaque (no recursion at all) in all three, for the
+///   architectural reasons #1371/#2077/#2096 give -- descending would redo
+///   already-finished substitution and could recapture a caller's variable.
+///   Kept explicit in all three rather than folded here, despite being
+///   identical across them, because each function's own comment on this arm
+///   documents a different concrete hazard worth reading in place.
+/// - `Expr::Error`: also identical across all three (`msg.clone()`, no
+///   recursion into the message) -- and also kept explicit in all three
+///   rather than folded, but for the opposite reason from `Shared`: unlike
+///   `Shared`'s opacity, this one is not obviously a deliberate invariant.
+///   `error($x)` referencing a variable, parameter, or def-call the
+///   enclosing pass is substituting would not get substituted by any of the
+///   three today. Preserved as-is (behavior-preserving refactor, not a
+///   bugfix) but flagged here for follow-up.
+/// - `Expr::Builtin`: always delegates to [`map_builtin_subexprs`], but
+///   `install_def_calls_in_builtin` charges its own sub-expressions an extra
+///   frame relative to every other structural descent (see its own doc
+///   comment) -- so all three callers keep their existing explicit
+///   `Expr::Builtin(b) => Expr::Builtin(..._in_builtin(b, ...))` arm rather
+///   than reaching this function's own arm for it.
+/// - `Expr::FuncDef`: genuinely different in all three, not just in
+///   *whether* something is shadowed but in what "shadowed" even means
+///   (`install_def_calls`: same name and arity, and the fully-shadowed
+///   branch clones the whole node, preserving its cache; `substitute_func_param`:
+///   two independent conditions, one for `body` and one for `then`;
+///   `substitute_var_impl`: one condition, for `body` only, with `then`
+///   always recursed) -- no shared unconditional shape exists to fall back
+///   to, so all three keep their own complete arm and never reach this
+///   function's own arm for it.
+///
+/// The five arms named above (`Shared`, `Error`, `Builtin`, `FuncDef`, and
+/// `install_def_calls`'s own `DefCall` policy) are therefore never actually
+/// exercised by any of today's three callers -- but this function still
+/// implements them, with a reasoned default, rather than reaching for a
+/// wildcard: the whole point of matching exhaustively is that a *future*
+/// `Expr` variant is a compile error here until it is categorized, and a
+/// wildcard on these five would quietly extend to that future variant too,
+/// recreating exactly the silent-drop risk this function exists to close.
+///
+/// **Deliberately has no wildcard arm**, for the same reason
+/// [`map_builtin_subexprs`] doesn't.
+///
+/// `&mut dyn FnMut`, not a generic `F`, for the same reason
+/// [`map_builtin_subexprs`] and [`any_subexpr`] both give: this recurses, so
+/// a generic parameter would monomorphise the whole traversal per call site.
+pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
+    match expr {
+        // --- Leaves: no `Expr` child, nothing for `f` to see -----------------
+        Expr::Identity => Expr::Identity,
+        Expr::Field(name) => Expr::Field(name.clone()),
+        Expr::Index { idx, key } => Expr::Index {
+            idx: *idx,
+            key: key.clone(),
+        },
+        Expr::Slice {
+            start,
+            end,
+            start_key,
+            end_key,
+        } => Expr::Slice {
+            start: *start,
+            end: *end,
+            start_key: start_key.clone(),
+            end_key: end_key.clone(),
+        },
+        Expr::Iterate => Expr::Iterate,
+        Expr::Literal(lit) => Expr::Literal(lit.clone()),
+        Expr::RecursiveDescent => Expr::RecursiveDescent,
+        Expr::Not => Expr::Not,
+        Expr::Format(fmt) => Expr::Format(fmt.clone()),
+        Expr::Var(name) => Expr::Var(name.clone()),
+        // Genuinely reachable, not just a totality formality: `install_def_calls`
+        // re-runs on every `Expr::FuncDef` *evaluation* (its own call site
+        // inlines `def`s at the point they execute, not once at parse time),
+        // and a `def`'s own body can already contain a `TrackedVar` from an
+        // enclosing `as`-binding -- confirmed live, `. as $x | def f: $x |
+        // .b; path(f)` reaches this arm. `substitute_func_param` reaches it
+        // for the same underlying reason: it binds a `def`'s own
+        // `$`-parameters at every call site, and the `def`'s body can
+        // already contain a `TrackedVar` unrelated to the parameter being
+        // bound. `v.clone()` is an O(1) `Rc` refcount bump, not a deep copy
+        // of the frozen snapshot, so re-inlining a `def` that closes over a
+        // large passthrough-bound value on every call stays cheap (#844).
+        Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
+        Expr::Loc { line } => Expr::Loc { line: *line },
+        Expr::Env => Expr::Env,
+        Expr::Break(name) => Expr::Break(name.clone()),
+
+        // --- One `Expr` child -----------------------------------------------
+        Expr::Optional(e) => Expr::Optional(Box::new(f(e))),
+        Expr::Array(e) => Expr::Array(Box::new(f(e))),
+        Expr::Paren(e) => Expr::Paren(Box::new(f(e))),
+        Expr::Negate(e) => Expr::Negate(Box::new(f(e))),
+        Expr::FirstExpr(e) => Expr::FirstExpr(Box::new(f(e))),
+        Expr::LastExpr(e) => Expr::LastExpr(Box::new(f(e))),
+        Expr::Repeat(e) => Expr::Repeat(Box::new(f(e))),
+
+        // --- `Vec<Expr>` children ---------------------------------------------
+        Expr::Pipe(exprs) => Expr::Pipe(exprs.iter().map(&mut f).collect()),
+        Expr::Comma(exprs) => Expr::Comma(exprs.iter().map(&mut f).collect()),
+
+        // --- Two unconditional `Expr` children --------------------------------
+        Expr::IndexExpr { target, key } => Expr::IndexExpr {
+            target: Box::new(f(target)),
+            key: Box::new(f(key)),
+        },
+        Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
+            op: *op,
+            left: Box::new(f(left)),
+            right: Box::new(f(right)),
+        },
+        Expr::Compare { op, left, right } => Expr::Compare {
+            op: *op,
+            left: Box::new(f(left)),
+            right: Box::new(f(right)),
+        },
+        Expr::And(l, r) => Expr::And(Box::new(f(l)), Box::new(f(r))),
+        Expr::Or(l, r) => Expr::Or(Box::new(f(l)), Box::new(f(r))),
+        Expr::Alternative(l, r) => Expr::Alternative(Box::new(f(l)), Box::new(f(r))),
+        Expr::Limit { n, expr } => Expr::Limit {
+            n: Box::new(f(n)),
+            expr: Box::new(f(expr)),
+        },
+        Expr::NthExpr { n, expr } => Expr::NthExpr {
+            n: Box::new(f(n)),
+            expr: Box::new(f(expr)),
+        },
+        Expr::Until { cond, update } => Expr::Until {
+            cond: Box::new(f(cond)),
+            update: Box::new(f(update)),
+        },
+        Expr::While { cond, update } => Expr::While {
+            cond: Box::new(f(cond)),
+            update: Box::new(f(update)),
+        },
+        Expr::Assign { path, value } => Expr::Assign {
+            path: Box::new(f(path)),
+            value: Box::new(f(value)),
+        },
+        Expr::Update { path, filter } => Expr::Update {
+            path: Box::new(f(path)),
+            filter: Box::new(f(filter)),
+        },
+        Expr::CompoundAssign { op, path, value } => Expr::CompoundAssign {
+            op: *op,
+            path: Box::new(f(path)),
+            value: Box::new(f(value)),
+        },
+        Expr::AlternativeAssign { path, value } => Expr::AlternativeAssign {
+            path: Box::new(f(path)),
+            value: Box::new(f(value)),
+        },
+
+        // --- One required child plus optional siblings ------------------------
+        Expr::SliceExpr { target, start, end } => Expr::SliceExpr {
+            target: Box::new(f(target)),
+            start: start.as_deref().map(|e| Box::new(f(e))),
+            end: end.as_deref().map(|e| Box::new(f(e))),
+        },
+        Expr::Range { from, to, step } => Expr::Range {
+            from: Box::new(f(from)),
+            to: to.as_deref().map(|e| Box::new(f(e))),
+            step: step.as_deref().map(|e| Box::new(f(e))),
+        },
+        Expr::Try { expr, catch } => Expr::Try {
+            expr: Box::new(f(expr)),
+            catch: catch.as_deref().map(|c| Box::new(f(c))),
+        },
+
+        // --- Three unconditional `Expr` children -------------------------------
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => Expr::If {
+            cond: Box::new(f(cond)),
+            then_branch: Box::new(f(then_branch)),
+            else_branch: Box::new(f(else_branch)),
+        },
+
+        // --- Structured collections --------------------------------------------
+        Expr::Object(entries) => Expr::Object(
+            entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
+                        ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(f(e))),
+                    };
+                    ObjectEntry {
+                        key,
+                        value: f(&entry.value),
+                    }
+                })
+                .collect(),
+        ),
+        Expr::StringInterpolation(parts) => Expr::StringInterpolation(
+            parts
+                .iter()
+                .map(|part| match part {
+                    StringPart::Literal(s) => StringPart::Literal(s.clone()),
+                    StringPart::Expr(e) => StringPart::Expr(Box::new(f(e))),
+                })
+                .collect(),
+        ),
+
+        // --- Calls: clone the name, map every argument through `f` -------------
+        // The shape a non-matching call already falls back to in every one of
+        // the three `eval.rs` callers below -- each that needs to intercept a
+        // *particular* name/arity (installing a `DefCall`, binding a
+        // `$`-parameter reference) does so with its own guarded arm first and
+        // reaches this one only once that guard has already failed.
+        Expr::FuncCall { name, args } => Expr::FuncCall {
+            name: name.clone(),
+            args: args.iter().map(&mut f).collect(),
+        },
+        Expr::NamespacedCall {
+            namespace,
+            name,
+            args,
+        } => Expr::NamespacedCall {
+            namespace: namespace.clone(),
+            name: name.clone(),
+            args: args.iter().map(&mut f).collect(),
+        },
+
+        // --- Binders: unconditional recursion into every child, including the
+        // bound-scope one -- see this function's own doc comment for which
+        // callers rely on this arm and which intercept the variant themselves
+        // instead.
+        Expr::As { expr, var, body } => Expr::As {
+            expr: Box::new(f(expr)),
+            var: var.clone(),
+            body: Box::new(f(body)),
+        },
+        Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } => Expr::Reduce {
+            input: Box::new(f(input)),
+            patterns: patterns.clone(),
+            init: Box::new(f(init)),
+            update: Box::new(f(update)),
+        },
+        Expr::Foreach {
+            input,
+            patterns,
+            init,
+            update,
+            extract,
+        } => Expr::Foreach {
+            input: Box::new(f(input)),
+            patterns: patterns.clone(),
+            init: Box::new(f(init)),
+            update: Box::new(f(update)),
+            extract: extract.as_deref().map(|e| Box::new(f(e))),
+        },
+        Expr::AsPattern {
+            expr,
+            patterns,
+            body,
+        } => Expr::AsPattern {
+            expr: Box::new(f(expr)),
+            patterns: patterns.clone(),
+            body: Box::new(f(body)),
+        },
+        Expr::Label { name, body } => Expr::Label {
+            name: name.clone(),
+            body: Box::new(f(body)),
+        },
+
+        // --- `DefCall`: the shape shared by `substitute_var_impl` and
+        // `substitute_func_param` -- see this function's own doc comment.
+        // `install_def_calls` needs a different `frames` policy and keeps its
+        // own explicit arm instead of reaching this one.
+        //
+        // `args` are code in the *caller's* scope, not the resolved `def`'s
+        // own, and can still mention a variable or parameter this pass is
+        // substituting -- `def outer(n): inner(n);` binds `n` here, through
+        // the inner call, whenever an outer definition was installed over a
+        // body before this one's own binder had run (the ordinary case for
+        // two sibling `def`s). `def` itself is not descended into: it was
+        // captured with everything in its own scope already substituted.
+        Expr::DefCall {
+            def,
+            args,
+            frames,
+            bound: _,
+        } => Expr::DefCall {
+            def: Rc::clone(def),
+            args: args.iter().map(&mut f).collect(),
+            frames: *frames,
+            bound: BoundBody::default(),
+        },
+
+        // --- Never reached by any of today's three `eval.rs` callers -- see
+        // this function's own doc comment for why each keeps its own
+        // explicit arm instead. Implemented anyway, exhaustively, so a
+        // hypothetical new caller gets a reasoned default instead of a
+        // temptation to add a wildcard.
+        Expr::Shared(inner) => Expr::Shared(Rc::new(f(inner))),
+        Expr::Error(msg) => Expr::Error(msg.as_deref().map(|m| Box::new(f(m)))),
+        Expr::Builtin(b) => Expr::Builtin(map_builtin_subexprs(b, f)),
+        Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+            bound: _,
+        } => Expr::FuncDef {
+            name: name.clone(),
+            params: params.clone(),
+            body: Box::new(f(body)),
+            then: Box::new(f(then)),
+            bound: FuncDefBound::default(),
+        },
     }
 }
 
@@ -1123,5 +1494,282 @@ mod tests {
                 "field order/identity not preserved for {filter:?}"
             );
         }
+    }
+
+    /// #2095: exercises [`map_subexprs`]'s two-child arms with the same
+    /// "identity closure, distinct field values, full equality against the
+    /// original" technique [`map_builtin_subexprs_preserves_field_order`]
+    /// uses -- a reconstruction that transposed two fields would still pass
+    /// a same-value or "count only" check, but fails `assert_eq!` here
+    /// because each case's two fields hold genuinely different values.
+    #[test]
+    fn map_subexprs_preserves_field_order_two_children() {
+        let cases = [
+            "1 + 2",       // Arithmetic(Add, 1, 2)
+            "1 == 2",      // Compare(Eq, 1, 2)
+            "1 and 2",     // And(1, 2)
+            "1 or 2",      // Or(1, 2)
+            "1 // 2",      // Alternative(1, 2)
+            "limit(1; 2)", // Limit(n, expr)
+            "nth(1; 2)",   // NthExpr(n, expr)
+            "until(1; 2)", // Until(cond, update)
+            "while(1; 2)", // While(cond, update)
+            ".a[.b]",      // IndexExpr(target, key)
+        ];
+        for filter in cases {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, 2, "expected exactly 2 sub-expressions in {filter:?}");
+            assert_eq!(
+                result, expr,
+                "field order/identity not preserved for {filter:?}"
+            );
+        }
+    }
+
+    /// Three-and-more-child arms, plus the optional-sibling ones
+    /// (`SliceExpr`/`Range`/`Try`) in both their fully-populated and
+    /// partially-`None` shapes.
+    #[test]
+    fn map_subexprs_preserves_field_order_three_or_more_children() {
+        let cases = [
+            "if .a then .b else .c end", // If(cond, then, else)
+            "range(.a; .b; .c)",         // Range(from, to, step) -- both present
+            ".[.a:.b]",                  // SliceExpr(target, start, end) -- both present
+        ];
+        for filter in cases {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, 3, "expected exactly 3 sub-expressions in {filter:?}");
+            assert_eq!(
+                result, expr,
+                "field order/identity not preserved for {filter:?}"
+            );
+        }
+
+        // `SliceExpr`/`Range` with only one optional sibling present -- the
+        // `None` slot must round-trip as `None`, not be skipped or coerced.
+        for (filter, expected_calls) in [
+            (".[.a:]", 2),          // SliceExpr(target, Some(start), None)
+            (".[:.a]", 2),          // SliceExpr(target, None, Some(end))
+            ("range(.a)", 2), // Range(from=0 literal, Some(to), None) -- `range(n)` desugars to `range(0; n)`
+            ("range(.a; .b)", 2), // Range(from, Some(to), None)
+            ("try .a", 1),    // Try(expr, None)
+            ("try .a catch .b", 2), // Try(expr, Some(catch))
+        ] {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, expected_calls, "call count mismatch for {filter:?}");
+            assert_eq!(
+                result, expr,
+                "field order/identity not preserved for {filter:?}"
+            );
+        }
+    }
+
+    /// `Vec<Expr>` and structured-collection arms (`Pipe`/`Comma`/`Object`/
+    /// `StringInterpolation`/`FuncCall`/`NamespacedCall`), confirming every
+    /// element is visited (not just the first/last) and non-`Expr` payload
+    /// (literal object keys, string literal parts) is left alone.
+    #[test]
+    fn map_subexprs_visits_every_element_of_a_collection() {
+        for (filter, expected_calls) in [
+            ("1,2,3", 3),             // Comma
+            ("1|2|3", 3),             // Pipe
+            ("{a: .b, (.c): .d}", 3), // Object: literal key (0) + expr key (1) + value (1)
+            (r#""x\(.a)y""#, 1),      // StringInterpolation: one Expr part
+            ("module::f(.a; .b)", 2), // NamespacedCall args
+        ] {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, expected_calls, "call count mismatch for {filter:?}");
+            assert_eq!(result, expr, "identity round-trip failed for {filter:?}");
+        }
+    }
+
+    /// The generic (unconditional-recursion) binder arms -- `As`/`Reduce`/
+    /// `Foreach`/`AsPattern`/`Label` -- as reached directly through
+    /// `map_subexprs` itself (no shadow check, since that lives in the three
+    /// `eval.rs` callers, not here). `patterns.clone()`/`var.clone()`/
+    /// `name.clone()` fields must also survive the round trip untouched.
+    #[test]
+    fn map_subexprs_binders_recurse_unconditionally() {
+        for (filter, expected_calls) in [
+            (".a as $x | .b", 2),                 // As
+            ("reduce .a as $x (.b; .c)", 3),      // Reduce
+            ("foreach .a as $x (.b; .c; .d)", 4), // Foreach
+            (". as [$a] ?// {b:$b} | .c", 2),     // AsPattern
+            ("label $out | .a", 1),               // Label
+        ] {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, expected_calls, "call count mismatch for {filter:?}");
+            assert_eq!(result, expr, "identity round-trip failed for {filter:?}");
+        }
+    }
+
+    /// Assignment-family arms (`Assign`/`Update`/`CompoundAssign`/
+    /// `AlternativeAssign`), which all share the same "path + value/filter"
+    /// two-child shape.
+    #[test]
+    fn map_subexprs_assignment_family() {
+        for filter in [".a = .b", ".a |= .b", ".a += .b", ".a //= .b"] {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let result = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                e.clone()
+            });
+            assert_eq!(calls, 2, "expected exactly 2 sub-expressions in {filter:?}");
+            assert_eq!(
+                result, expr,
+                "field order/identity not preserved for {filter:?}"
+            );
+        }
+    }
+
+    /// `Expr::Builtin` still delegates to [`map_builtin_subexprs`] when
+    /// reached through `map_subexprs` directly (dead code from the three
+    /// `eval.rs` callers today, which all special-case `Builtin` themselves
+    /// -- see `map_subexprs`'s own doc comment -- but this function must
+    /// still behave sensibly if something else ever does reach it here).
+    #[test]
+    fn map_subexprs_builtin_delegates_to_map_builtin_subexprs() {
+        let expr = parse("map(.a)").expect("filter should parse");
+        let mut calls = 0usize;
+        let result = map_subexprs(&expr, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 1);
+        assert_eq!(result, expr);
+    }
+
+    /// `Expr::Error`'s default arm recurses into the message (unlike any of
+    /// today's three `eval.rs` callers, which all keep their own
+    /// non-recursing `Expr::Error(msg) => Expr::Error(msg.clone())` arm
+    /// instead of reaching this one -- see this function's own doc comment
+    /// for why). Confirms both the `Some` and `None` message shapes.
+    #[test]
+    fn map_subexprs_error_default_recurses_into_message() {
+        let with_msg = parse("error(.a)").expect("filter should parse");
+        let mut calls = 0usize;
+        let result = map_subexprs(&with_msg, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 1);
+        assert_eq!(result, with_msg);
+
+        let bare = Expr::Error(None);
+        let mut calls = 0usize;
+        let result = map_subexprs(&bare, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 0);
+        assert_eq!(result, bare);
+    }
+
+    /// `Expr::Shared`'s default arm recurses into the wrapped expression
+    /// (dead code from the three `eval.rs` callers today, which all keep
+    /// `Shared` opaque -- see this function's own doc comment).
+    #[test]
+    fn map_subexprs_shared_default_recurses() {
+        let inner = Expr::Builtin(Builtin::Length);
+        let shared = Expr::Shared(Rc::new(inner.clone()));
+        let mut calls = 0usize;
+        let result = map_subexprs(&shared, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 1);
+        assert_eq!(result, shared);
+    }
+
+    /// `Expr::DefCall`'s default arm -- the shape shared by
+    /// `substitute_var_impl` and `substitute_func_param` (`def` opaque via
+    /// `Rc::clone`, `args` mapped through `f`, `frames` unchanged, `bound`
+    /// reset). `install_def_calls` never reaches this arm (it keeps its own
+    /// explicit one with a different `frames` policy), so this test
+    /// exercises the arm directly.
+    #[test]
+    fn map_subexprs_defcall_default_maps_args_and_resets_bound() {
+        let def = Rc::new(FuncDefData {
+            name: "f".into(),
+            params: vec!["x".into()],
+            body: Expr::Identity,
+        });
+        let original = Expr::DefCall {
+            def: Rc::clone(&def),
+            args: vec![Expr::Field("a".into()), Expr::Field("b".into())],
+            frames: 7,
+            bound: BoundBody::default(),
+        };
+        let mut calls = 0usize;
+        let result = map_subexprs(&original, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 2, "expected exactly one call per arg");
+        match result {
+            Expr::DefCall {
+                def: result_def,
+                args,
+                frames,
+                bound: _,
+            } => {
+                assert!(
+                    Rc::ptr_eq(&result_def, &def),
+                    "`def` must stay opaque (Rc::clone)"
+                );
+                assert_eq!(
+                    args,
+                    vec![Expr::Field("a".into()), Expr::Field("b".into())],
+                    "args must be mapped in order"
+                );
+                assert_eq!(
+                    frames, 7,
+                    "frames must be unchanged (install_def_calls-only policy)"
+                );
+            }
+            other => panic!("expected DefCall, got {other:?}"),
+        }
+    }
+
+    /// `Expr::FuncDef`'s default arm (unconditional recursion into both
+    /// `body` and `then`, bound reset) -- dead code from all three
+    /// `eval.rs` callers today, each of which keeps its own complete,
+    /// genuinely different arm (see this function's own doc comment).
+    #[test]
+    fn map_subexprs_funcdef_default_recurses_body_and_then() {
+        let expr = parse("def f: .a; .b").expect("filter should parse");
+        let mut calls = 0usize;
+        let result = map_subexprs(&expr, &mut |e| {
+            calls += 1;
+            e.clone()
+        });
+        assert_eq!(calls, 2, "expected exactly one call each for body and then");
+        assert_eq!(result, expr);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2095.

`src/jq/eval.rs` had three ~40-arm hand-written matches over every `Expr` variant (`install_def_calls`, `substitute_func_param`, `substitute_var_impl`), structurally identical except at a handful of binder/leaf/opaque arms. Adding a new `Expr` variant meant three synchronized hand-edits, and missing one next to a wildcard would compile cleanly while silently dropping that variant from whichever pass forgot it.

- Adds `map_subexprs` to `src/jq/walk.rs`, generalizing the existing `map_builtin_subexprs` (`Builtin`-level) pattern one level up to `Expr` itself: a single exhaustive match applying a closure to every direct `Expr`-typed child and rebuilding the node. No wildcard arm, so a future `Expr` variant is a compile error here until categorized.
- Refactors all three `eval.rs` functions down to just their genuinely special arms (shadow checks, opaque `Shared`/`DefCall` handling, `FuncDef`, `Builtin`) plus a single fallthrough to `map_subexprs`.
- Removes the now-dead `subst_unless_shadowed_opt` helper.
- Adds `map_subexprs` unit tests in `walk.rs` mirroring `map_builtin_subexprs`'s field-order/identity checks.

Behavior-preserving refactor only — every arm was verified side-by-side across all three functions before folding (see `map_subexprs`'s own doc comment for the full per-variant reasoning).

**Flagged, not fixed** (pre-existing, all three functions agree): none of the three currently recurses into `Expr::Error`'s message, so `error($x)` referencing a variable/parameter being substituted wouldn't get that substitution. Preserved as-is per the behavior-preservation scope of this PR; documented in `map_subexprs`'s doc comment and CHANGELOG.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite green (3280+ unit tests, jq/yq golden conformance included)
- [x] `cargo test --no-default-features` — no_std build green
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean
- [x] New `map_subexprs` unit tests added and passing