### PR TITLE
refactor(jq): BoundBody::get_or_try_init uses set, not get_or_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invariant, flagged in `map_subexprs`'s own doc comment for follow-up
   rather than silently changed here.
 
+- **`BoundBody::get_or_try_init` now uses `OnceCell::set` instead of
+  `get_or_init` to populate its cache** (#2092, finding #6). In this
+  single-threaded, non-reentrant-by-design cache, the cell cannot
+  legitimately already hold a value by the time `bind` finishes — `set`
+  makes that invariant self-checking (a panic if it's ever violated)
+  instead of `get_or_init`'s silent "discard my freshly-bound value, return
+  whatever's already there." No behavior change on any currently-reachable
+  path.
+
+  #2092's other finding in this area — a duplicated `Shared`/`DefCall`
+  passthrough block between `substitute_func_param` and
+  `substitute_var_impl` (finding #5) — turned out to already be resolved as
+  a side effect of #2095's `map_subexprs` refactor above: both functions'
+  `DefCall` arms now fall through to `map_subexprs`'s single shared default
+  arm rather than each carrying their own copy, closing the exact
+  `bound`-reset drift risk finding #5 described. Only the one-line
+  `Expr::Shared` arm remains duplicated between them, which #2095's own doc
+  comment explains is deliberately kept explicit in each caller rather than
+  folded. #2092's four remaining findings (##1-4) are real algorithmic
+  inefficiencies on the `def` recursive-call hot path, but each needs
+  interleaved hardware A/B benchmark evidence before landing per this
+  project's benchmarking discipline — split out to #2194 rather than
+  bundled into this refactor-only change.
+
 ### Fixed
 
 - **`IN(s)`/`IN(src; s)` now forward the real ambient `optional` instead of

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -584,7 +584,16 @@ impl BoundBody {
             return Ok(cached);
         }
         let bound = bind()?;
-        Ok(self.0.get_or_init(|| bound))
+        // `set`, not `get_or_init`: this cache is write-once by design (see
+        // the struct's own doc comment) because `bind` is not reentrant in
+        // this single-threaded evaluator. `set` makes that invariant
+        // self-checking -- a concurrent/reentrant write panics here instead
+        // of `get_or_init` silently discarding `bound` and returning
+        // whatever the other write raced in with.
+        self.0
+            .set(bound)
+            .expect("BoundBody set twice: bind() must not be reentrant");
+        Ok(self.0.get().expect("just set"))
     }
 }
 
@@ -2120,6 +2129,37 @@ mod tests {
             format!("{warm:?}"),
             "the cache must not affect Debug output"
         );
+    }
+
+    /// #2092 (finding #6): a second `get_or_try_init` call on an
+    /// already-populated `BoundBody` must return the cached value without
+    /// re-invoking `bind` -- confirms the early `self.0.get()` return still
+    /// holds after switching the populate path from `get_or_init` to `set`.
+    #[test]
+    fn test_bound_body_second_call_returns_cached_without_rebinding_2092() {
+        let bound = BoundBody::default();
+        let mut bind_calls = 0usize;
+        let first = bound
+            .get_or_try_init(|| {
+                bind_calls += 1;
+                Ok::<_, ()>(Rc::new(Expr::Identity))
+            })
+            .expect("first bind succeeds");
+        assert_eq!(**first, Expr::Identity);
+        assert_eq!(bind_calls, 1);
+
+        let second = bound
+            .get_or_try_init(|| {
+                bind_calls += 1;
+                Ok::<_, ()>(Rc::new(Expr::RecursiveDescent))
+            })
+            .expect("cached read succeeds");
+        assert_eq!(
+            **second,
+            Expr::Identity,
+            "must return the first bind's cached value, not re-bind"
+        );
+        assert_eq!(bind_calls, 1, "bind must not run a second time");
     }
 
     /// Same invariant as [`test_bound_body_is_invisible_to_eq_and_debug_1371`],


### PR DESCRIPTION
## Summary

Fixes #2092 (finding #6; findings #1-4 split out to #2194 as they need hardware A/B benchmark evidence; finding #5 turned out to already be resolved as a side effect of #2095's `map_subexprs` refactor, explained below).

- **`BoundBody::get_or_try_init` now uses `OnceCell::set` instead of `get_or_init`** to populate its cache. In this single-threaded, non-reentrant-by-design cache, the cell cannot legitimately already hold a value by the time `bind` finishes — `set` makes that invariant self-checking (a panic if it's ever violated) instead of `get_or_init`'s silent "discard my freshly-bound value, return whatever's already there." No behavior change on any currently-reachable path — verified with a new test confirming a second `get_or_try_init` call still returns the cached value without re-invoking `bind`.

- **Finding #5 (duplicated `Shared`/`DefCall` passthrough block between `substitute_func_param`/`substitute_var_impl`) is already closed**, discovered while investigating this issue: #2095's `map_subexprs` refactor moved both functions' `DefCall` arms to fall through to `map_subexprs`'s single shared default arm rather than each carrying their own copy — exactly resolving the `bound`-reset drift risk finding #5 described (forgetting to reset `bound` in one copy but not the other). Only the one-line `Expr::Shared` arm remains duplicated between the two functions, which #2095's own doc comment explains is deliberately kept explicit in each caller (each carries its own hazard-specific rationale comment) rather than folded.

- **Findings #1-4 split out to #2194**: real algorithmic inefficiencies on the `def` recursive-call hot path (deep-clone in the path-context evaluator, per-parameter clone in `bind_def_call`, `OnceCell` overhead on the recursive path, uncached `any_subexpr` walk on `Shared` nodes) — each needs interleaved hardware A/B benchmark evidence per this project's benchmarking discipline before landing, so they're tracked separately rather than bundled into this refactor-only change.

## Test plan

- [x] New test: `test_bound_body_second_call_returns_cached_without_rebinding_2092` — confirms the populate-once-then-cache behavior is unchanged after switching `get_or_init` → `set`.
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --features cli,simd,regex,serde -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Patch coverage 88% (22/25) — the 3 uncovered lines are the never-meant-to-execute second closure body in the new test itself, proving the cache short-circuits correctly