### PR TITLE
perf(jq): stop getpath materializing the document twice

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12843,6 +12843,46 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_owned: OwnedValue,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #1755/#1953: to_owned, not to_owned_lossy -- an undecodable root
+    // value must raise, not silently become "" and get walked as if it were
+    // the real value. A genuine decode failure (a #1642 collision counts as
+    // one) is unconditional regardless of `optional` (that flag only
+    // governs the path-shape check below, never a decode failure); a #1194
+    // malformed-member error is ordinary like any other and
+    // `suppress_or_raise` lets `optional` suppress it instead.
+    let root = match to_owned(value) {
+        Ok(v) => v,
+        Err(e) => return suppress_or_raise(e, optional),
+    };
+    getpath_walk_owned::<W, S>(&root, path_owned, optional)
+}
+
+/// [`getpath_one_path`]'s walk once its root value is already resolved and
+/// decode-validated -- everything that function does after its own
+/// `to_owned` call.
+///
+/// Split out for #2053 so `eval_generic`'s generic evaluator can reach it
+/// with the `OwnedValue` it has *already* materialized (its own validity
+/// gate, #1755/#1953 -- see that call site's own comment for why it cannot
+/// be skipped), instead of going through `eval_generic::eval_on_owned`'s
+/// reindex bridge (serialize to JSON, `JsonIndex::build`, re-enter `eval`,
+/// `to_owned` a *second* time here) only to decode the very same
+/// document over again. Mirrors [`builtin_path_on_owned`]'s identical
+/// relationship to `builtin_path`.
+///
+/// `root` is only ever read, never mutated, so the walk borrows through
+/// every step instead of cloning the whole tree up front — the only clone
+/// paid at each step is the child actually reached, exactly as the original
+/// single-function version already did once its first move-in from
+/// `to_owned` was spent. That is what lets a generator path
+/// (`getpath((["a"],["b"]))`) call this once per resolved path against one
+/// shared `root: &OwnedValue`, instead of re-materializing the document per
+/// call the way `getpath_one_path` used to.
+pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    root: &OwnedValue,
+    path_owned: OwnedValue,
+    optional: bool,
+) -> QueryResult<'a, W> {
     let OwnedValue::Array(path) = path_owned else {
         return if optional {
             QueryResult::None
@@ -12851,33 +12891,25 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     };
 
-    // #1755/#1953: to_owned, not to_owned_lossy -- an undecodable root
-    // value must raise, not silently become "" and get walked as if it were
-    // the real value. A genuine decode failure (a #1642 collision counts as
-    // one) is unconditional regardless of `optional` (that flag only
-    // governs the path-shape check above, never a decode failure); a #1194
-    // malformed-member error is ordinary like any other and
-    // `suppress_or_raise` lets `optional` suppress it instead.
-    let mut current = match to_owned(value) {
-        Ok(v) => v,
-        Err(e) => return suppress_or_raise(e, optional),
-    };
+    let mut current: Cow<'_, OwnedValue> = Cow::Borrowed(root);
 
     for segment in path {
-        match (&current, &segment) {
+        match (current.as_ref(), &segment) {
             // jq: null | getpath(["a"]) => null
             (OwnedValue::Null, _) => {
                 return QueryResult::Owned(OwnedValue::Null);
             }
             (OwnedValue::Object(obj), OwnedValue::String(key)) => {
-                current = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
+                current = Cow::Owned(obj.get(key).cloned().unwrap_or(OwnedValue::Null));
             }
             (
                 OwnedValue::Array(arr),
                 OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
             ) => {
-                current = resolve_read_index(&segment, arr.len())
-                    .map_or(OwnedValue::Null, |i| arr[i].clone());
+                current = Cow::Owned(
+                    resolve_read_index(&segment, arr.len())
+                        .map_or(OwnedValue::Null, |i| arr[i].clone()),
+                );
             }
             // An object segment is jq's slice, `{"start":s,"end":e}`. jq
             // checks the *container* first — an object or a scalar reports
@@ -12889,7 +12921,7 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     Err(_) if optional => return QueryResult::None,
                     Err(e) => return e.into(),
                 };
-                current = OwnedValue::Array(arr[range].to_vec());
+                current = Cow::Owned(OwnedValue::Array(arr[range].to_vec()));
             }
             (OwnedValue::String(s), OwnedValue::Object(desc)) => {
                 let range = match SliceBounds::from_descriptor(desc) {
@@ -12897,7 +12929,7 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     Err(_) if optional => return QueryResult::None,
                     Err(e) => return e.into(),
                 };
-                current = OwnedValue::String(slice::slice_str(s, range));
+                current = Cow::Owned(OwnedValue::String(slice::slice_str(s, range)));
             }
             // yq mode only (#1102): completes the `getpath(path(x)) == x`
             // round trip for an object-slice descriptor -- without this,
@@ -12913,7 +12945,7 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     Err(_) if optional => return QueryResult::None,
                     Err(e) => return e.into(),
                 };
-                current = slice_object_children_at(map, range);
+                current = Cow::Owned(slice_object_children_at(map, range));
             }
             _ if optional => return QueryResult::None,
             _ => {
@@ -12922,7 +12954,7 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    QueryResult::Owned(current)
+    QueryResult::Owned(current.into_owned())
 }
 
 // =============================================================================

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10374,6 +10374,76 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
 
+        // #2053: mirrors `Builtin::Path`'s #1909 treatment above -- the `_`
+        // fallback below pays a materialize + re-serialize + re-index round
+        // trip of `value` *and* a second whole-document decode inside
+        // `eval::getpath_one_path`'s own `to_owned`, just to answer
+        // a single node lookup. Unlike `Path`, `getpath`'s root
+        // materialization is not waste to begin with (#1755/#1953): it is
+        // the exact same validity gate `to_owned_with_cursor` below already
+        // pays for -- `{"a":"\ud800","d":5} | getpath(["d"])` must still
+        // raise even though the walk never reaches `.a`, where `.d`/`keys`/
+        // `length` on the same document do not. Only the *second* decode
+        // and the reindex round trip go, not the first.
+        //
+        // The bypass-vs-fallback decision below is made purely from
+        // `owned`'s own shape (`reindex_bridge_is_identity`), *before*
+        // `path_expr` is touched at all. A withdrawn earlier attempt at
+        // this fix (PR #2045) instead probed `path_expr`'s output shape and
+        // fell back to a second, full re-evaluation when the probe didn't
+        // fit a recognized pattern, which fired any side effect inside
+        // `path_expr` twice: `getpath(("a"|stderr))` printed `aa` instead
+        // of jq's `a`. `fanout_arg_generic` is the fix for that shape
+        // (#1687, already used by `limit`/`nth`/`has` above): it drives
+        // `path_expr` lazily, exactly once, against the *original* cursor
+        // `value` -- so a `path_expr` that never touches `.` (the
+        // overwhelmingly common `getpath([0])`/`getpath(["a","b"])` shape)
+        // costs nothing extra beyond evaluating a small literal, and one
+        // that does touch `.` reads it through the same cheap cursor
+        // navigation any other builtin's argument already gets, rather than
+        // a second reindex of the whole document.
+        //
+        // Each resolved path then walks `owned` -- already materialized
+        // above -- directly via `getpath_walk_owned`, which is
+        // `eval::getpath_one_path`'s own walk with its `to_owned`
+        // call lifted out (mirrors `builtin_path_on_owned`'s identical
+        // relationship to `builtin_path`). `optional` is threaded through
+        // for real here, unlike `Path`/`Key`/`Parent`/`FileIndex`'s
+        // hardcoded `false` above -- `getpath_walk_owned` uses it to decide
+        // whether an indexing failure partway through a path raises or
+        // suppresses, so hardcoding it would be a real correctness risk if
+        // dispatch ever changed to reach here with `optional = true`.
+        // Review found no such reachable path today (`Expr::Optional`'s
+        // catch-all evaluates its inner expression at the *ambient*
+        // `optional`, same as the already-documented `Map`/`Select`
+        // precedent at `test_generic_plain_map_optional_on_non_container_is_unreachable_via_parser_725`,
+        // so `getpath(P)?` never actually forces `optional = true` into
+        // this arm) -- confirmed by swapping in a hardcoded `false` here
+        // and finding it byte-identical across the full `getpath` test
+        // suite. Threading it for real costs nothing and removes the
+        // dependency on that reachability analysis staying true, so it
+        // stays -- but it is defensive, not currently load-bearing.
+        Builtin::GetPath(path_expr) => {
+            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            if reindex_bridge_is_identity(&owned) {
+                return fanout_arg_generic::<S, V, _>(
+                    path_expr,
+                    value.clone(),
+                    optional,
+                    cursor,
+                    |path_owned| {
+                        query_result_to_generic::<V>(crate::jq::eval::getpath_walk_owned::<
+                            Vec<u64>,
+                            S,
+                        >(
+                            &owned, path_owned, optional
+                        ))
+                    },
+                );
+            }
+            eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
+        }
+
         Builtin::Empty => GenericResult::None,
 
         Builtin::ToString => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26473,6 +26473,22 @@ fn test_getpath_non_array_path_suppressed_by_optional_2053() -> Result<()> {
     Ok(())
 }
 
+/// #2053: the same non-array-path guard's *unsuppressed* sibling branch --
+/// without `?`, the same malformed path argument still raises through the
+/// native bypass arm, matching jq's own "Path must be specified as an
+/// array" message. Verified against jq 1.7.1.
+#[test]
+fn test_getpath_non_array_path_raises_without_optional_2053() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"getpath("x")"#], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
+    assert!(
+        stderr.contains("Path must be specified as an array"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1531: a generator argument must be pulled lazily, so `body` runs against
 /// argument value N *before* value N+1 is evaluated. Once `body` fails, jq
 /// never evaluates the rest of the argument -- side effects included.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26461,6 +26461,18 @@ fn test_getpath_generator_path_shares_one_materialization_2053() -> Result<()> {
     Ok(())
 }
 
+/// #2053: `getpath_walk_owned`'s own non-array-path guard, reached through
+/// the native bypass arm (an all-`Int` document is `reindex_bridge_is_identity`)
+/// -- `?` suppresses a malformed (non-array) path argument the same way it
+/// suppresses any other `getpath` error. Verified against jq 1.7.1.
+#[test]
+fn test_getpath_non_array_path_suppressed_by_optional_2053() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(r#"getpath("x")?"#, r#"{"a":1}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+    Ok(())
+}
+
 /// #1531: a generator argument must be pulled lazily, so `body` runs against
 /// argument value N *before* value N+1 is evaluated. Once `body` fails, jq
 /// never evaluates the rest of the argument -- side effects included.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -26364,6 +26364,103 @@ fn test_jq_getpath_fanout_all_outputs_still_resolve_1532() -> Result<()> {
     Ok(())
 }
 
+/// #2053: `eval_generic.rs`'s new native `Builtin::GetPath` bypass arm still
+/// materializes and validates the whole document exactly once before ever
+/// walking a path -- the same rule `test_path_still_raises_on_an_
+/// undecodable_sibling_2061` pins for `path()`. `getpath(["d"])` never
+/// reaches `.a`, but a `\uXXXX`-family decode failure anywhere in the
+/// document still raises, matching real jq's own eager whole-document parse
+/// (#1755/#1953) -- unlike plain navigation (`.d`, `keys`, `length`), which
+/// only decode what they touch and succeed on this same document. This is
+/// the whole-document validity gate the issue's fix explicitly could not
+/// drop: a naive cursor walk straight to `.d` would silently accept a
+/// document both real jq and `main` currently reject.
+#[test]
+fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
+    for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
+        let input = format!("{{\"a\":\"{bad}\",\"d\":5}}");
+        let (stdout, stderr, code) = run_jq_stdin_streams("getpath([\"d\"])", &input, &["-c"])?;
+        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "", "{bad}");
+    }
+
+    // The raise above is `getpath`-specific, not a blanket rejection of the
+    // document -- plain navigation over the same input still succeeds.
+    let (stdout, code) = run_jq_stdin(".d", r#"{"a":"\ud800","d":5}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "5");
+
+    Ok(())
+}
+
+/// #2053, constraint 2 from the issue that split this fix off from #1909:
+/// `path_expr` must be evaluated exactly once, on *both* branches
+/// `eval_generic.rs`'s new native `Builtin::GetPath` arm can take -- the
+/// `reindex_bridge_is_identity`-gated bypass, and the pre-existing
+/// reindex-round-trip fallback kept for its numeric edge cases. A withdrawn
+/// earlier attempt at this fix (PR #2045) probed `path_expr`'s output shape
+/// and, on a shape it didn't recognise, discarded the probe and fell back to
+/// evaluating the whole unmodified expression a second time -- firing any
+/// side effect inside it twice (`getpath(("a"|stderr))` printed `aa` instead
+/// of jq's `a`). `MARK2053|stderr` plays that same role here: it must appear
+/// on stderr exactly once, matching real jq, regardless of which branch
+/// answers the call.
+#[test]
+fn test_getpath_path_expr_evaluated_exactly_once_2053() -> Result<()> {
+    // Bypass branch: every value in the document is a bare `Int`, so
+    // `reindex_bridge_is_identity` admits it and the new native arm answers
+    // the call directly.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams(r#"getpath(("MARK2053"|stderr))"#, r#"{"a":1}"#, &["-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stderr.matches("MARK2053").count(), 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("Path must be specified as an array"),
+        "stderr: {stderr:?}"
+    );
+
+    // Fallback branch: a `NumberLiteral` past `REINDEX_LITERAL_LEN_CAP`
+    // (256 chars) anywhere in the document makes `reindex_bridge_is_identity`
+    // return `false`, sending this call through the pre-existing
+    // reindex-round-trip path (`eval_on_owned` -> `eval::builtin_getpath` ->
+    // `fanout_arg`) instead -- the other place this property has to hold,
+    // since that path's own single evaluation of `path_expr` was left
+    // untouched by this fix.
+    let long_literal = "0.".to_string() + &"0".repeat(300) + "1";
+    let input = format!(r#"{{"a":1,"big":{long_literal}}}"#);
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams(r#"getpath(("MARK2053"|stderr))"#, &input, &["-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stderr.matches("MARK2053").count(), 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("Path must be specified as an array"),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
+/// #2053: a generator path (`getpath((["a"],["b"],["a"]))`) resolves every
+/// branch correctly off the *same* materialized root -- the native bypass
+/// arm's `owned: &OwnedValue` is shared (borrowed via `Cow`, never mutated)
+/// across every one of `fanout_arg_generic`'s per-path calls into
+/// `eval::getpath_walk_owned`, rather than re-materialized per path the way
+/// `eval::getpath_one_path` used to. Revisiting the same path twice (`["a"]`
+/// here) is a regression check for that sharing: nothing about walking it
+/// once should leave the shared root in a state where walking it again
+/// produces something different.
+#[test]
+fn test_getpath_generator_path_shares_one_materialization_2053() -> Result<()> {
+    let (stdout, code) = run_jq_stdin(
+        r#"[getpath((["a"],["b"],["a"]))]"#,
+        r#"{"a":{"x":1},"b":2}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"[{"x":1},2,{"x":1}]"#);
+    Ok(())
+}
+
 /// #1531: a generator argument must be pulled lazily, so `body` runs against
 /// argument value N *before* value N+1 is evaluated. Once `body` fails, jq
 /// never evaluates the rest of the argument -- side effects included.


### PR DESCRIPTION
## Summary
- \`getpath(P)\` had no native dispatch arm in \`eval_generic.rs\` and fell into the wildcard fallback: materialize the whole input, re-serialize it to JSON, rebuild a \`JsonIndex\`, re-enter \`eval.rs\`, and materialize the same document a *second* time inside \`getpath_one_path\`. Issue #1909 removed this exact double materialization for \`path\`/\`key\`/\`parent\`/\`file_index\`, but \`getpath\` was left out because two constraints a naive port breaks were only found partway through that fix (commit \`97d4af28c\`): the whole-document materialization is a *validity gate* (an undecodable value elsewhere in the document must still raise, even on a path that never reaches it), and \`path_expr\` must be evaluated *exactly once* (a probe-then-fallback shape double-fires side effects).
- Adds a native \`Builtin::GetPath\` arm mirroring \`Builtin::Path\`'s existing #1909 fix: materialize once via \`to_owned_with_cursor\`, decide bypass-vs-fallback purely from \`reindex_bridge_is_identity\` on the already-materialized root -- before \`path_expr\` is ever touched -- then evaluate \`path_expr\` exactly once via \`fanout_arg_generic\` (the existing #1687 primitive already used by \`limit\`/\`nth\`/\`has\`) against the one materialized document.
- Splits \`getpath_one_path\` into the validity-gate check plus a new \`getpath_walk_owned\` taking an already-decoded root by reference (a \`Cow\`, so a generator path shares one materialization instead of paying for one per output), mirroring \`builtin_path_on_owned\`'s identical relationship to \`builtin_path\`.
- Unlike \`Path\`/\`Key\`/\`Parent\`/\`FileIndex\`'s hardcoded \`optional = false\` (sound only there since \`eval_on_owned\`'s own \`optional\` is a documented no-op for those builtins), \`getpath\`'s \`optional\` is threaded through for real, since it controls whether a mid-path indexing failure raises or suppresses. Review confirmed via fault injection that no real query today actually forces \`optional = true\` into this dispatch point (matching the already-documented \`Map\`/\`Select\` precedent) -- the threading is defensive/future-proofing rather than closing a currently-observable divergence, and the code comment says so explicitly now.
- Deliberately scoped to the "cheap and safe" half only, per the issue's own framing ("two independent halves; either is useful alone") -- the "full win" (relaxing the whole-document validity gate itself, e.g. an allocation-free scan) is a separate, harder, out-of-scope follow-up.

## Test plan
- [x] Constraint 1 (validity gate): \`{"a":"\ud800","d":5} | getpath(["d"])\` still raises, matching real jq's own rejection, even though the path never touches \`.a\`.
- [x] Constraint 2 (single evaluation): a \`stderr\`-side-effect-bearing \`path_expr\` fires exactly once, matching jq, verified through both the bypass branch and the numeric-edge-case fallback branch.
- [x] \`optional\` threading verified live against jq for several mid-path-failure shapes, with and without \`?\`, including a generator path with a partial failure (prefix preserved, later branch suppressed).
- [x] 3 new CLI tests: \`test_getpath_still_raises_on_an_undecodable_sibling_2053\`, \`test_getpath_path_expr_evaluated_exactly_once_2053\`, \`test_getpath_generator_path_shares_one_materialization_2053\` -- these pin the two hard constraints (verified via fault injection that they'd catch the exact regression the withdrawn PR #2045 attempt hit) rather than discriminating old-vs-new output, since the fix removes redundant work, not incorrect output; the pre-existing #1164/#1953 tests plus a deliberate fault-injection pass (an intentionally-broken \`getpath_walk_owned\` was caught by the new tests and #1164's existing one) are what actually exercise the changed code's correctness. (Note: the pre-existing \`#1532\`-tagged \`getpath\` tests exercise a structurally separate code path -- \`resolve_node\`'s own path/assignment-context \`GetPath\` arm -- and don't touch anything this PR changes; not cited as coverage for this fix.)
- [x] Full test suite: \`cargo test --features cli,simd,regex,serde --no-fail-fast\` -- 0 failures, independently re-run twice (mine + review).
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo fmt --check\` -- clean.
- [x] Performance (interleaved A/B, \`scripts/ab-cli.py\`, output-identity-gated): \`getpath([0])\` on 300k/1M-element arrays: -46%/-50% time, -54%/-55% peak memory (independently re-measured in review: -57% time on a 300k array); a 5-path generator query: -61% to -80%, confirming the per-output re-materialization is also gone. \`.[0]\` control unaffected in both runs (within noise).

Fixes #2053