### PR TITLE
perf(jq): eliminate O(d²) per-step cloning in path resolution (#2058)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`path()`/`=`/`del()` no longer re-clone an owned subtree at every step of a static
+  `Field`/`Index` chain** (#2058), fixing the O(d²) that #1690's own depth-scaled acceptance
+  benchmark (`jq_write_path_del_shared_prefix_depth`) flagged as still binding its exponent to
+  ~1.6. Holding branch count fixed at two and scaling only depth `D`, `path()`/`=`/`del()` all
+  read an exponent of ~1.8-1.95 — two independent per-step clone sites, found and fixed
+  together:
+
+  - `src/jq/eval.rs`'s `value_after_components` (`resolve_seq`'s shared static-tail
+    resolver, reached by all three builtins once a top-level `Comma` routes through
+    `resolve_node`) cloned the *entire remaining value* at every navigation step
+    (`eval_owned_fast_path`'s `Field`/`Index` arms already skip the JSON reindex round trip
+    for these two shapes, but still `.cloned()` the matched child's whole subtree — O(d−i) at
+    step `i`, summing to O(d²)). It now takes its value by move and navigates *destructively*
+    via a new `navigate_static_component`: `IndexMap::swap_remove`/`Vec::swap_remove` pull the
+    one matched child out by move instead of cloning it, since the parent container is never
+    read again once this function has stepped past it — the caller pays exactly one `.clone()`
+    at the boundary (unavoidable; it never owns the document it's handed), everything after
+    that is a move. `Expr::Slice`/`Expr::Optional`-wrapped components are unaffected — neither
+    was on the fast path to begin with.
+  - `path()` alone kept a growing exponent even with the above fixed, traced to a *second*
+    site present independently in **both** of this crate's evaluators: `src/jq/eval.rs`'s
+    `walk_path`/`walk_pipe`/`step_into` and `src/jq/eval_generic.rs`'s `path_walk_generic`/
+    `path_step_generic` (the #2061 cursor-native fast path the CLI's own `path()` dispatch
+    actually uses for this shape) both rebuilt the *reported* path (`["c","c",...,0]`) with a
+    `path.to_vec()`-then-push per step — another O(d²). `eval_generic.rs`'s copy compounded
+    this with a second, independent clone: its `Expr::Pipe` handling split one component off
+    at a time and rewrapped the remainder in a fresh, owned `Expr::Pipe(rest.to_vec())` just to
+    recurse, the identical AST-clone-per-stage shape #1510 already fixed in `eval.rs`'s own
+    path-context evaluator, but not (until now) in `eval_generic.rs`'s independent copy. Fixed
+    by a new `PathTrail` (`eval.rs`, shared by both evaluators) — `PathPrefix`'s twin for
+    `path()`'s own value-typed components, an `Rc`-linked cons-list with O(1) `extend` and one
+    O(depth) `to_vec` paid once per branch — plus two new slice-based helpers
+    (`path_walk_pipe_generic`, `path_step_pipe_generic`) that recurse on a borrowed `&[Expr]`
+    instead of rebuilding an owned `Expr::Pipe`.
+
+  Measured via interleaved CLI A/B (`succinctly jq`, 200-document stream per invocation, 5
+  reps alternating before/after order, both `nodes.yaml` targets idle): every exponent over
+  the last depth-doubling (D=120→240) drops from ~1.88-1.98 to ~0.95-1.02 on both an Apple M4
+  Pro and an AMD Ryzen 9 7950X, for `path()`, `=` and `del()` alike. Speedups at D=240 range
+  5.8x (`del()`, x86) to 19.9x (`path()`, x86). No behavior change: 2320 systematic
+  before/after CLI cases (varying depth, container type, missing keys, out-of-range indices,
+  slices, `?`-optional siblings, both jq and yq mode) plus the pinned-oracle differential
+  suite (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4.53.3) are byte-for-byte identical to the
+  pre-fix binary. New regression fixture:
+  `jq_write_path_two_branch_{path,assign,del}_depth` in `benches/jq_write_path_bench.rs`
+  (fixed two-branch comma, depth-only scaling, unlike the existing
+  `jq_write_path_del_shared_prefix_depth` group which scales branch count and depth together
+  and so cannot isolate this term). See
+  [docs/optimizations/path-resolution-clone.md](docs/optimizations/path-resolution-clone.md)
+  for the full write-up.
+
 - **`Expr::Index` and `Expr::Slice` now carry their own float-spelling keys** (#1401),
   replacing the separate `Expr::IndexNumber`/`Expr::SliceNumber` variants that #1088 and
   #1326 added beside them. `Expr::Index(i64)` is now

--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -728,6 +728,142 @@ fn bench_del_shared_prefix_width(c: &mut Criterion) {
     group.finish();
 }
 
+// =============================================================================
+// #2058: path-resolution cost per *step*, independent of branch count
+// =============================================================================
+
+/// A `d`-deep `{"c": ...}` chain terminating in a **fixed**-size, 8-element
+/// array: `{"c":{"c":...{"c":[0,1,...,7]}}}`.
+///
+/// Unlike [`deep_chain_doc`] (whose leaf grows with `d`, so it can't tell a
+/// per-step cost from a per-branch one apart), the leaf here is pinned at 8
+/// elements regardless of `d` — every group below fans out over exactly two
+/// of those eight (`[0]`/`[1]`), so widening `d` moves only the shared-prefix
+/// depth, never the branch count or the leaf size. That is the isolation
+/// #2058 asks for: `jq_write_path_del_shared_prefix_depth` above scales *both*
+/// together and still reads an exponent of ~1.6 after #1690, because this
+/// term survives underneath it.
+fn two_branch_chain_doc(d: usize) -> Vec<u8> {
+    let mut out = String::new();
+    for _ in 0..d {
+        out.push_str(r#"{"c":"#);
+    }
+    out.push_str("[0,1,2,3,4,5,6,7]");
+    for _ in 0..d {
+        out.push('}');
+    }
+    out.into_bytes()
+}
+
+/// `.c` repeated `d` times — the shared static prefix every group below
+/// appends `[0]`/`[1]` to.
+fn two_branch_prefix(d: usize) -> String {
+    ".c".repeat(d)
+}
+
+/// `[path(.c...c[0], .c...c[1])] | length` over [`two_branch_chain_doc`] —
+/// the `path()` row of #2058's own repro table, which pays the per-step cost
+/// worst of the three (it does no writing at all, so every clone here was
+/// pure waste). Wrapped in `length` so the timed output stays O(1) regardless
+/// of `d` (a `[path(...)]` result itself is small and flat, but this keeps
+/// the premise check and the benchmarked expression identical in shape to
+/// the `=`/`del` groups below).
+fn bench_two_branch_path_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_two_branch_path_depth");
+    for &d in DEPTHS {
+        let json = two_branch_chain_doc(d);
+        let prefix = two_branch_prefix(d);
+        let expr =
+            parse(&format!("[path({prefix}[0], {prefix}[1])] | length")).expect("must parse");
+
+        // Guard the premise: exactly two paths reported (one per branch), or
+        // a bug that drops a branch would read as a spurious speedup.
+        assert_eq!(
+            eval_one(&expr, &json),
+            OwnedValue::Int(2),
+            "d={d}: must report exactly two paths"
+        );
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(d as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(d), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// `(.c...c[0], .c...c[1]) = 9` over [`two_branch_chain_doc`] — the `=` row.
+fn bench_two_branch_assign_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_two_branch_assign_depth");
+    for &d in DEPTHS {
+        let json = two_branch_chain_doc(d);
+        let prefix = two_branch_prefix(d);
+        let expr = parse(&format!("({prefix}[0], {prefix}[1]) = 9")).expect("must parse");
+
+        // Guard the premise: both targeted elements become 9, and every
+        // other leaf element survives untouched -- a write that silently
+        // no-ops, or clobbers the whole array, would otherwise read as a
+        // speedup.
+        let out = eval_one(&expr, &json);
+        let OwnedValue::Array(items) = leaf_array(&out, d) else {
+            panic!("d={d}: the leaf must stay an array");
+        };
+        let expected: Vec<OwnedValue> = (0..8)
+            .map(|i| {
+                if i < 2 {
+                    OwnedValue::Int(9)
+                } else {
+                    OwnedValue::Int(i)
+                }
+            })
+            .collect();
+        assert_eq!(*items, expected, "d={d}: unexpected leaf contents");
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(d as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(d), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
+/// `del(.c...c[0], .c...c[1])` over [`two_branch_chain_doc`] — the `del` row.
+fn bench_two_branch_del_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_two_branch_del_depth");
+    for &d in DEPTHS {
+        let json = two_branch_chain_doc(d);
+        let prefix = two_branch_prefix(d);
+        let expr = parse(&format!("del({prefix}[0], {prefix}[1])")).expect("must parse");
+
+        // Guard the premise: exactly the two targeted elements are gone and
+        // the remaining six survive, in order.
+        let out = eval_one(&expr, &json);
+        let OwnedValue::Array(items) = leaf_array(&out, d) else {
+            panic!("d={d}: the leaf must stay an array");
+        };
+        let expected: Vec<OwnedValue> = (2..8).map(OwnedValue::Int).collect();
+        assert_eq!(*items, expected, "d={d}: unexpected leaf contents");
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements(d as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(d), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // AST-shape groups (#1510). Element count is fixed; the query varies.
 // ---------------------------------------------------------------------------
@@ -1067,6 +1203,9 @@ criterion_group!(
     bench_del_filtered_descent_depth,
     bench_del_shared_prefix_depth,
     bench_del_shared_prefix_width,
+    bench_two_branch_path_depth,
+    bench_two_branch_assign_depth,
+    bench_two_branch_del_depth,
     bench_path_comma_width_ast,
     bench_path_comma_rest_ast,
     bench_path_paren_chain_ast,

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -25,6 +25,7 @@ This directory documents optimization techniques used in the succinctly library,
 | **Select scan**      | [select-scan.md](select-scan.md)                         | #40 scan-length measurement, IB cursor O(n²) fix                      |
 | **`del()` root short-circuit** | [del-root-shortcircuit.md](del-root-shortcircuit.md) | #1651 double-flatten O(d²) fix, k≈1.96→1.14                    |
 | **`del()` path trie** | [del-path-trie.md](del-path-trie.md) | #1690 hash-consed path merge, 6.4x lower per-branch cost               |
+| **Path-resolution cloning** | [path-resolution-clone.md](path-resolution-clone.md) | #2058 per-step value/path clone fix, k≈1.9→1.0                  |
 | **Targets**          | [targets.md](targets.md)                                 | CPU target configurations, architecture flags                         |
 | **SIMD Strategy**    | [simd-strategy.md](simd-strategy.md)                     | Per-module SIMD usage, platform support, lessons                      |
 
@@ -57,6 +58,7 @@ This directory documents optimization techniques used in the succinctly library,
 | jq Lazy String Slicing         | **8.5%** (vs regression), **2%** (vs baseline) | Control flow | src/jq/eval.rs |
 | `del()` Root Short-Circuit     | **20-49x** (grows with depth) | Control flow | [del-root-shortcircuit.md](del-root-shortcircuit.md) |
 | `del()` Path Trie              | **1.6-4.8x** (grows with branch count) | Data structure | [del-path-trie.md](del-path-trie.md) |
+| Path-Resolution Clone Elimination | **5.8-19.9x** (grows with depth) | Control flow | [path-resolution-clone.md](path-resolution-clone.md) |
 
 ### Notable Failures (Instructive)
 

--- a/docs/optimizations/del-path-trie.md
+++ b/docs/optimizations/del-path-trie.md
@@ -161,6 +161,13 @@ Until it is fixed, the depth-scaled fixture cannot read near-linear however good
 path handling gets — `jq_write_path_del_shared_prefix_width` is the group that answers for
 this change.
 
+**Update: fixed by #2058** — see
+[path-resolution-clone.md](path-resolution-clone.md) for the full write-up. The single
+per-step clone this section describes turned out to be two independent ones (`eval.rs`'s
+`value_after_components`, plus a second, `path()`-only pair in both evaluators' own
+path-array construction), and fixing both drops every exponent in the table above from
+~1.8-1.95 to ~1.0 on both `nodes.yaml` targets.
+
 ## Lessons
 
 - **Three superlinear-in-depth terms on one path all fit "hold the count fixed, vary the

--- a/docs/optimizations/path-resolution-clone.md
+++ b/docs/optimizations/path-resolution-clone.md
@@ -1,0 +1,180 @@
+# Path-Resolution Per-Step Cloning (#2058)
+
+[Home](../../) > [Docs](../) > [Optimizations](./) > Path-resolution per-step cloning
+
+Investigation of [#2058](https://github.com/rust-works/succinctly/issues/2058), which
+[del-path-trie.md](del-path-trie.md#2058) flagged as the term still binding
+`jq_write_path_del_shared_prefix_depth`'s exponent to ~1.6 even after #1690 removed a
+genuine per-*branch* O(d²) from the same code region: holding the branch count fixed at
+two and scaling only depth `D` still read an exponent of ~1.8-1.95 for `path()`, `=` and
+`del()` alike.
+
+**Outcome: two independent O(d²) clone-per-step sites, in two different evaluators, both
+triggered by the same two-branch static-chain shape (`.c…c[0], .c…c[1]`) — fixing both drops
+every measured exponent from ~1.9 to ~1.0 on both `nodes.yaml` targets.**
+
+## Site 1 — `value_after_components` (`src/jq/eval.rs`)
+
+`resolve_seq`'s no-computed-key fast path (reached by `path()`/`=`/`del()` alike once a
+top-level `Comma` routes the whole expression through `resolve_node`) threads a document
+value through a run of static `Field`/`Index` components via `value_after_components`. Its
+loop cloned the *entire remaining value* at every step:
+
+```rust
+let mut current = value.clone();
+for component in components {
+    let mut values = eval_owned_multi::<S>(component, &current)?;
+    // ...
+    current = values.pop().expect("len checked");
+}
+```
+
+`eval_owned_multi` → `eval_owned_fast_path`'s `Field`/`Index` arms already avoid the
+expensive JSON-serialize-and-reparse bridge for these two shapes, but still read
+`map.get(name).cloned()` / `items.get(i).cloned()` — a **deep** clone of the matched
+child's whole subtree. Step `i` of a `d`-deep chain holds a subtree of size O(d−i), so the
+loop's per-step clones sum to O(d²).
+
+### The fix
+
+`value_after_components` now takes `value: OwnedValue` by move instead of `&OwnedValue`,
+and a new `navigate_static_component` does the per-step navigation *destructively*:
+`IndexMap::swap_remove`/`Vec::swap_remove` pull the one matched child out of its parent by
+move, letting the untouched siblings drop instead of being cloned. `swap_remove` (not the
+order-preserving `shift_remove`/`Vec::remove`) is what makes this O(1) rather than O(n): the
+parent container is never read again once this function has navigated past it, so its
+remaining order doesn't matter — it is dropped, in whatever order swap-removal leaves it, the
+moment the caller moves on to the next component. `resolve_static_tail` (the sole caller)
+pays exactly one `.clone()` at the boundary — unavoidable, since it never owns the document
+it's handed — and everything after that is a move.
+
+`Expr::Slice` and `Expr::Optional`-wrapped components fall back to the pre-existing
+`eval_owned_multi` clone-and-reevaluate path unchanged: neither was ever on
+`eval_owned_fast_path`'s fast path to begin with (both already pay a full
+`to_json_for_reindex` + reparse round trip per step, a separate, pre-existing cost this fix
+does not touch), so leaving them alone is a no-op, not a missed case.
+
+## Site 2 — `path()`'s own value and path-array cloning (two evaluators)
+
+Even with site 1 fixed, `path()` alone kept a growing exponent (~1.5 at D=30→60, ~1.7 at
+D=120→240) that `=`/`del()` did not. Profiling and direct measurement traced this to a
+*second* mechanism, present in **both** of this crate's two evaluators, each reached by a
+different caller:
+
+- `src/jq/eval.rs`'s `walk_path`/`walk_pipe`/`step_into` (reached by `builtin_path_on_owned`,
+  itself reached when `eval_generic.rs`'s own cursor-native fast path below can't take a
+  shape).
+- `src/jq/eval_generic.rs`'s `path_walk_generic`/`path_step_generic` (#2061's cursor-walking
+  fast path — the code the CLI's `succinctly jq`/`succinctly yq` actually dispatch `path()`
+  to for the overwhelmingly common cursor-navigable shapes, including this issue's own
+  benchmark).
+
+Both built up the *reported* path (`["c","c","c",...,0]`) with the same anti-pattern:
+
+```rust
+let mut p = path.to_vec();  // clone the whole trail so far
+p.push(component);
+out.push((p, next));
+```
+
+Step `i` of a `d`-deep chain clones a trail of length `i`, so this sums to O(d²) on its own —
+independent of, and in `eval_generic.rs`'s case *compounding with*, a second clone:
+`path_walk_generic`'s `Expr::Pipe` arm split one component off the flat chain at a time and
+rewrapped the *remaining* components in a fresh, owned `Expr::Pipe(rest.to_vec())` just to
+recurse, an O(remaining length) AST clone at every one of the same `d` stages — the identical
+shape #1510 already fixed in `eval.rs`'s own path-context evaluator, but not (until now) in
+`eval_generic.rs`'s independent copy.
+
+### The fix
+
+A new `PathTrail` (`src/jq/eval.rs`, `pub(crate)`) is `PathPrefix`'s twin for `path()`'s own
+*value*-typed components: an `Rc`-linked cons-list with O(1) `extend` and one O(depth)
+`to_vec`, paid exactly once per branch when it becomes an actual `path()` output — not once
+per step. Both evaluators' `current_path`/`path` parameters now carry `Rc<PathTrail>` instead
+of `Vec<OwnedValue>`/`&[OwnedValue]`, and `eval_generic.rs`'s `Expr::Pipe` handling
+(`path_walk_generic`'s top-level arm, and `path_step_generic`'s own copy for a pipe reached
+as a single nested step) was split into slice-based helpers (`path_walk_pipe_generic`,
+`path_step_pipe_generic`) that recurse on a borrowed `&[Expr]` directly, removing the
+`rest.to_vec()` AST clone entirely rather than merely shrinking it.
+
+One unrelated caller, `eval_generic.rs`'s `path_context_step_generic` (the `key`/`parent`/
+`file_index` path-context machinery, a different feature from `path()`/`=`/`del()`), still
+carries its own path as a plain `Vec<OwnedValue>` — out of scope here. `PathTrail::from_slice`
+bridges it into the shared step helpers at the same O(depth) cost it already paid per call,
+so that feature is unchanged, not regressed.
+
+## Results
+
+Interleaved CLI A/B (`succinctly jq`, 200-document stream per invocation, 5 repetitions,
+alternating before/after order per rep to cancel thermal drift — see
+[the benchmarking guide](../guides/benchmarking.md#ab-benchmarking-method)), both idle
+`nodes.yaml` targets, fixed two-branch shape (`.c…c[0], .c…c[1]`) over a document with an
+8-element leaf array, scaling only `D`:
+
+**Apple M4 Pro (ARM):**
+
+| query    | D=30            | D=60            | D=120           | D=240            | exp (120→240) |
+|----------|-----------------|-----------------|-----------------|------------------|---------------|
+| `path()` | 0.083→0.038ms   | 0.170→0.045ms   | 0.562→0.078ms   | 2.090→0.150ms    | 1.89 → 0.95   |
+| `=`      | 0.123→0.051ms   | 0.355→0.084ms   | 1.274→0.157ms   | 5.023→0.303ms    | 1.98 → 0.95   |
+| `del()`  | 0.129→0.056ms   | 0.366→0.094ms   | 1.285→0.177ms   | 5.052→0.347ms    | 1.98 → 0.97   |
+
+**AMD Ryzen 9 7950X (x86_64):**
+
+| query    | D=30            | D=60            | D=120           | D=240            | exp (120→240) |
+|----------|-----------------|-----------------|-----------------|------------------|---------------|
+| `path()` | 0.089→0.026ms   | 0.281→0.051ms   | 0.996→0.094ms   | 3.716→0.187ms    | 1.90 → 1.00   |
+| `=`      | 0.119→0.051ms   | 0.364→0.095ms   | 1.257→0.192ms   | 4.650→0.388ms    | 1.89 → 1.01   |
+| `del()`  | 0.129→0.062ms   | 0.383→0.114ms   | 1.292→0.222ms   | 4.752→0.448ms    | 1.88 → 1.02   |
+
+Speedups at D=240 range 5.8x (`del()`, x86) to 19.9x (`path()`, x86). Every exponent over the
+last depth-doubling drops from ~1.9-2.0 to ~1.0 on both architectures, for all three query
+shapes — the acceptance criteria's "drops toward ~1", read literally.
+
+`jq_write_path_two_branch_{path,assign,del}_depth` (`benches/jq_write_path_bench.rs`) is the
+checked-in regression fixture for this shape: a fixed two-branch comma over a
+`D`-scaled `{"c": ...}` chain terminating in a *fixed*-size 8-element leaf array (unlike
+`jq_write_path_del_shared_prefix_depth`, whose leaf size scales *with* `D` and so cannot
+isolate a per-step term from a per-branch one).
+
+## Lessons
+
+- **A profile's own function names are the ground truth for *which* evaluator to look in,
+  not an assumption from where the fix "should" live.** The issue's own profile named
+  `walk_pipe`/`step_into` — `eval.rs`'s functions — but the CLI's actual `path()` dispatch for
+  this shape goes through `eval_generic.rs`'s independent `path_walk_generic` instead (#2061).
+  A Criterion benchmark that calls `eval.rs::eval()` directly (as this crate's own
+  `jq_write_path_bench.rs` does, for good reason — it isolates the evaluator from I/O) is a
+  real, valid measurement of *that* evaluator, but is not automatically a proxy for what the
+  CLI itself does; the two can and did diverge for this exact query shape.
+- **Two evaluators, two independent copies of the same bug.** This crate maintains
+  `eval.rs` and `eval_generic.rs` as separate jq/yq evaluators for unrelated reasons (see
+  `docs/adrs/`), and a fix in one does not reach the other — #2048's own CHANGELOG entry
+  already flagged this once. `path()`'s clone-per-step bug existed in both, independently,
+  and `eval_generic.rs`'s copy additionally compounded it with an AST-clone-per-step the
+  `eval.rs` side never had (because `eval.rs`'s `walk_pipe` already threads a borrowed
+  `&[Expr]` slice — the #1510 fix — where `eval_generic.rs`'s `path_walk_generic` still
+  rebuilt an owned `Expr::Pipe` at each stage).
+- **A CLI-level, multi-document-stream measurement is what actually settles a CLI-reachable
+  claim.** A single-process-per-query timing (spawn overhead ~4-6ms) cannot see a
+  per-document cost an order of magnitude smaller; the issue's own "200 documents per
+  process" method, reproduced here, is what separates the two.
+- **Re-verify the discriminating experiment after every partial fix, not just once at the
+  end.** Fixing site 1 alone flattened `=`/`del()`'s exponents immediately, but left `path()`'s
+  still growing with depth — the same "one exponent came down, a second, independent term is
+  still under it" shape #1651 and #1690 (`del-root-shortcircuit.md`, `del-path-trie.md`) had
+  already each hit once in this exact code region.
+
+## See also
+
+- [del-path-trie.md](del-path-trie.md) — #1690, the predecessor this issue's own acceptance
+  benchmark depended on
+- [del-root-shortcircuit.md](del-root-shortcircuit.md) — #1651, an earlier link in the same
+  chain
+- [`src/jq/eval.rs`](../../src/jq/eval.rs) — `value_after_components`,
+  `navigate_static_component`, `walk_path`, `walk_pipe`, `step_into`, `PathTrail`,
+  `PathPrefix`
+- [`src/jq/eval_generic.rs`](../../src/jq/eval_generic.rs) — `path_walk_generic`,
+  `path_walk_pipe_generic`, `path_step_generic`, `path_step_pipe_generic`
+- [docs/guides/benchmarking.md](../guides/benchmarking.md#ab-benchmarking-method) — the A/B
+  method used above

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20587,6 +20587,21 @@ pub(crate) enum PathTrail {
     Node {
         parent: Rc<Self>,
         component: OwnedValue,
+        /// Components from `Root` to here, inclusive. `Root` = 0. Keeps
+        /// [`Self::depth`] O(1) without walking the chain — the same reason
+        /// `PathPrefix` carries this field, and load-bearing for the exact
+        /// same reason (#2058 code review): a naive Rust recursive walk over
+        /// a `Pipe`/`Comma` chain has no depth cap of its own, so a
+        /// pathologically deep static chain (`path(.a.a.a...)`, a million
+        /// `.a` segments) would recurse the native call stack until it
+        /// overflows and aborts the process — silent and unrecoverable,
+        /// unlike a panic. `assert_value_tree_depth(depth)` at the top of
+        /// every function that recurses once per chain step converts that
+        /// crash into a clean, `catch_unwind`-caught CLI error, the same
+        /// guarantee `collect_paths`/`collect_tostream_events`/
+        /// `collect_leaf_paths` already give recursive value-tree walks
+        /// elsewhere in this file (#1005/#1021/#1025).
+        depth: usize,
     },
 }
 
@@ -20599,11 +20614,21 @@ impl PathTrail {
         Rc::new(Self::Root)
     }
 
+    /// O(1): the depth `extend` already computed and cached, not a walk up
+    /// the chain -- mirrors [`PathPrefix::depth`] exactly.
+    pub(crate) fn depth(&self) -> usize {
+        match self {
+            Self::Root => 0,
+            Self::Node { depth, .. } => *depth,
+        }
+    }
+
     /// O(1): one `Rc::clone` (refcount bump) plus one new allocation.
     pub(crate) fn extend(parent: &Rc<Self>, component: OwnedValue) -> Rc<Self> {
         Rc::new(Self::Node {
             parent: Rc::clone(parent),
             component,
+            depth: parent.depth() + 1,
         })
     }
 
@@ -20612,8 +20637,13 @@ impl PathTrail {
     /// (`eval_generic.rs`'s `PathContextPos`, whose `key`/`parent`/
     /// `file_index` machinery is out of scope for #2058 and left unchanged),
     /// so it can still call into the shared, `PathTrail`-based step helpers.
-    /// Same cost as that caller's own pre-existing per-call flatten -- not an
-    /// improvement there, but not a regression either.
+    /// This is a *second* O(depth) traversal on top of that caller's own
+    /// pre-existing per-call flatten (paired with an equal-cost `to_vec()`
+    /// on the way back out) -- not a regression in asymptotic order (that
+    /// call site was already O(d^2) end to end and stays so), but a real,
+    /// roughly 2x constant-factor increase this bridge introduces, not
+    /// eliminated here because restructuring `PathContextPos` itself to
+    /// carry a `PathTrail` natively is out of scope for #2058.
     pub(crate) fn from_slice(components: &[OwnedValue]) -> Rc<Self> {
         components.iter().fold(Self::root(), |acc, component| {
             Self::extend(&acc, component.clone())
@@ -20625,9 +20655,12 @@ impl PathTrail {
     /// where a flat path is actually required (i.e. when it becomes one
     /// `path()` output).
     pub(crate) fn to_vec(&self) -> Vec<OwnedValue> {
-        let mut out = Vec::new();
+        let mut out = vec_with_capacity(self.depth());
         let mut cur = self;
-        while let Self::Node { parent, component } = cur {
+        while let Self::Node {
+            parent, component, ..
+        } = cur
+        {
             out.push(component.clone());
             cur = parent;
         }
@@ -32918,6 +32951,21 @@ fn walk_path<S: EvalSemantics>(
     out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
+    // Panics past `MAX_VALUE_TREE_DEPTH` levels (code review on #2058): a
+    // static chain (`path(.a.a.a...)`) reaches this function once per
+    // component via `walk_pipe`'s own per-stage recursion, which -- unlike
+    // `value_after_components`'s plain iterative `for` loop over `=`/`del()`'s
+    // resolved components -- grows the native call stack by one frame per
+    // step with no cap of its own. A million-component chain overflowed the
+    // stack and aborted the process outright (confirmed live) once this fix
+    // made `path()` fast enough to reach that depth in practice; before,
+    // the pre-fix O(d^2) cost made the same input time out long before ever
+    // getting there. `walk_pipe` always calls this function once per stage
+    // before recursing any deeper, so checking here bounds it too -- the
+    // same "check at the one function that recurses once per node" shape
+    // `collect_paths`/`collect_tostream_events`/`collect_leaf_paths` already
+    // use for value-tree recursion elsewhere in this file.
+    assert_value_tree_depth(current_path.depth());
     match expr {
         // The path already reaching here, named as it stands. `value` moves
         // straight into `out`, and `current_path` is a cheap `Rc::clone`
@@ -47232,6 +47280,74 @@ mod tests {
                 fast, reference,
                 "eval_owned_fast_path disagrees with index_object_by_name/index_array_by_position \
                  for {expr:?} on {input:?} (optional={optional})"
+            );
+        }
+    }
+
+    /// [`navigate_static_component`]'s `Field`/`Index` arms are a *third*
+    /// independent copy of the missing-key/out-of-bounds/error-type indexing
+    /// rules, alongside [`eval_owned_fast_path`]'s own arms (kept aligned only
+    /// by a doc comment cross-reference, #2058 code review) and the general
+    /// evaluator's `eval_single` arms. This is
+    /// `eval_owned_fast_path_agrees_with_index_object_by_name_and_index_array_by_position`'s
+    /// own reasoning one hop over: pin the two together so a future edit to
+    /// either one's missing-key/out-of-bounds/error-type rule cannot drift
+    /// silently out of sync with the other, matching this repo's own
+    /// documented lesson ("duplicated predicates diverge silently -- one
+    /// definition, plus a test that the call sites agree").
+    ///
+    /// `navigate_static_component` has no `optional` parameter of its own --
+    /// every one of its callers reaches it only for a bare (non-`Optional`-
+    /// wrapped) `Field`/`Index` component, so it always behaves as
+    /// `eval_owned_fast_path::<S>(expr, input, false)` does. The comparison
+    /// below fixes `optional` at `false` for exactly that reason, reusing
+    /// the other test's own case matrix (its `optional: true` rows dropped,
+    /// since those exercise a parameter this function doesn't have).
+    #[test]
+    fn navigate_static_component_agrees_with_eval_owned_fast_path() {
+        let obj = || {
+            let mut m = indexmap::IndexMap::new();
+            m.insert("a".to_string(), OwnedValue::Int(1));
+            m.insert("b".to_string(), OwnedValue::Int(2));
+            OwnedValue::Object(m)
+        };
+        let arr = || {
+            OwnedValue::Array(vec![
+                OwnedValue::Int(10),
+                OwnedValue::Int(20),
+                OwnedValue::Int(30),
+            ])
+        };
+
+        let cases: Vec<(Expr, OwnedValue)> = vec![
+            // Field: present key, missing key, on null, on a type that
+            // cannot be field-indexed at all.
+            (Expr::Field("a".to_string()), obj()),
+            (Expr::Field("missing".to_string()), obj()),
+            (Expr::Field("a".to_string()), OwnedValue::Null),
+            (Expr::Field("a".to_string()), OwnedValue::Int(5)),
+            (Expr::Field("a".to_string()), arr()),
+            // Index: in bounds, negative-from-end, out of bounds (positive
+            // and negative), on null, on a type that cannot be
+            // position-indexed at all.
+            (Expr::index(1), arr()),
+            (Expr::index(-1), arr()),
+            (Expr::index(10), arr()),
+            (Expr::index(-10), arr()),
+            (Expr::index(0), OwnedValue::Null),
+            (Expr::index(0), OwnedValue::String("x".to_string())),
+            (Expr::index(0), obj()),
+        ];
+
+        for (expr, input) in cases {
+            let fast = eval_owned_fast_path::<JqSemantics>(&expr, &input, false)
+                .expect("Field/Index are always Some from eval_owned_fast_path")
+                .map_err(EvalEscape::from);
+            let destructive = navigate_static_component::<JqSemantics>(&expr, input.clone());
+            assert_eq!(
+                fast, destructive,
+                "navigate_static_component disagrees with eval_owned_fast_path \
+                 for {expr:?} on {input:?}"
             );
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20563,6 +20563,79 @@ impl PathPrefix {
     }
 }
 
+/// [`PathPrefix`]'s twin for `path()`'s own *value*-typed trail — the
+/// resolved key components a `path()` call actually reports (`OwnedValue`:
+/// `"c"`, `0`, `{"start":1,"end":2}`, ...), as opposed to `PathPrefix`'s
+/// `Expr` components (the still-to-be-applied filter). Same mechanism, same
+/// reason (#2058): `walk_path`/`walk_pipe`/`step_into` used to carry
+/// `current_path: &[OwnedValue]` and rebuild it with `current_path.to_vec()`
+/// then `.push(component)` at every single navigation step, an O(depth)
+/// clone of the whole trail so far, summed over a `d`-deep chain's `d`
+/// steps, for O(d^2) overall. Threading an `Rc`-linked chain instead makes
+/// every step an O(1) `extend` (one allocation, one refcount bump);
+/// [`Self::to_vec`] is the one O(depth) flatten, paid exactly once per
+/// branch when it is finally pushed as a completed `path()` output, never
+/// once per step along the way.
+///
+/// `pub(crate)`: `eval_generic.rs`'s own `path_walk_generic`/`path_step_
+/// generic` (the CLI's actual `path()` dispatch for the common
+/// cursor-navigable shapes, #2061) had the identical `path.to_vec()`-and-push
+/// pattern and shares this same type rather than duplicating it.
+pub(crate) enum PathTrail {
+    /// The empty trail — `path(.)`, or the start of a fresh walk.
+    Root,
+    Node {
+        parent: Rc<Self>,
+        component: OwnedValue,
+    },
+}
+
+impl PathTrail {
+    /// A fresh, empty trail. Like [`PathPrefix::root`], not a shared
+    /// singleton — re-allocating one `Root` per walk is O(1) regardless, and
+    /// this crate stays `no_std`-compatible with no `thread_local`-style
+    /// sharing available.
+    pub(crate) fn root() -> Rc<Self> {
+        Rc::new(Self::Root)
+    }
+
+    /// O(1): one `Rc::clone` (refcount bump) plus one new allocation.
+    pub(crate) fn extend(parent: &Rc<Self>, component: OwnedValue) -> Rc<Self> {
+        Rc::new(Self::Node {
+            parent: Rc::clone(parent),
+            component,
+        })
+    }
+
+    /// Build a fresh trail from an already-flat `&[OwnedValue]` -- an O(depth)
+    /// bridge for a caller that still carries its own path as a plain `Vec`
+    /// (`eval_generic.rs`'s `PathContextPos`, whose `key`/`parent`/
+    /// `file_index` machinery is out of scope for #2058 and left unchanged),
+    /// so it can still call into the shared, `PathTrail`-based step helpers.
+    /// Same cost as that caller's own pre-existing per-call flatten -- not an
+    /// improvement there, but not a regression either.
+    pub(crate) fn from_slice(components: &[OwnedValue]) -> Rc<Self> {
+        components.iter().fold(Self::root(), |acc, component| {
+            Self::extend(&acc, component.clone())
+        })
+    }
+
+    /// The one O(depth) operation: flatten the chain into an owned
+    /// `Vec<OwnedValue>`, root-to-leaf order. Paid once per branch, only
+    /// where a flat path is actually required (i.e. when it becomes one
+    /// `path()` output).
+    pub(crate) fn to_vec(&self) -> Vec<OwnedValue> {
+        let mut out = Vec::new();
+        let mut cur = self;
+        while let Self::Node { parent, component } = cur {
+            out.push(component.clone());
+            cur = parent;
+        }
+        out.reverse();
+        out
+    }
+}
+
 /// One resolved branch: the static path components reaching it, and the value
 /// found there (needed to resolve any computed key further along the chain).
 ///
@@ -25049,29 +25122,31 @@ fn resolve_slice_bound<S: EvalSemantics>(
 /// A component with no single output stops the walk at null: null accepts every
 /// key kind that can index anything at all, so a later key still resolves
 /// instead of erroring against a container it never actually saw.
+///
+/// **Takes `value` by value, and that is load-bearing (#2058).** Each step
+/// below navigates *destructively* -- swapping the matched child out of its
+/// parent container and letting the untouched remainder drop -- rather than
+/// cloning the parent's whole remaining subtree just to read one field out of
+/// it. `OwnedValue`'s derived `Clone` is a deep clone, so the old
+/// `value.clone()`-per-step version cost, for a `d`-deep chain, O(d) at step
+/// 1, O(d-1) at step 2, ... summing to O(d^2) -- exactly the shape #1690's own
+/// depth-scaled acceptance benchmark kept reading an exponent near 2 under,
+/// even after #1690 itself removed a *different* O(d^2) one level up (see
+/// docs/optimizations/del-path-trie.md and this function's issue, #2058).
+/// Every container `current` holds at each step is exclusively owned by this
+/// call -- `resolve_static_tail`, the only caller, always hands in a fresh
+/// `.clone()` of its own borrowed input (see its call site) -- so nothing
+/// else can observe a container after this function has navigated past it,
+/// and consuming it here is safe. See [`navigate_static_component`] for the
+/// per-step logic.
 fn value_after_components<S: EvalSemantics>(
     components: &[Expr],
-    value: &OwnedValue,
+    value: OwnedValue,
 ) -> Result<Option<OwnedValue>, EvalEscape> {
-    let mut current = value.clone();
+    let mut current = value;
     for component in components {
-        let mut values = eval_owned_multi::<S>(component, &current)?;
-        // Every caller hands this a tail already proven single-valued by
-        // construction (`resolve_seq`, gated on `needs_fanout_pass`) -- a
-        // `> 1` output count here is a genuine invariant violation, not the
-        // ordinary "component matched nothing" case handled below (a
-        // missing key still yields exactly one output, `null`). #682 was
-        // exactly this: `Expr::Iterate` produced more than one output
-        // through this function, which silently discarded every branch but
-        // one instead of the fan-out its caller actually needed.
-        debug_assert!(
-            values.len() <= 1,
-            "value_after_components: {component:?} produced {} outputs, but every \
-             caller requires a single-valued tail (see needs_fanout_pass)",
-            values.len()
-        );
-        match values.len() {
-            1 => current = values.pop().expect("len checked"),
+        current = match navigate_static_component::<S>(component, current)? {
+            Some(next) => next,
             // Zero outputs here can only come from a `?`-suppressed step
             // that failed to navigate (#2124): every component reaching
             // this loop is a bare `Field`/`Index`/`Slice`-family step
@@ -25089,10 +25164,98 @@ fn value_after_components<S: EvalSemantics>(
             // with a failing navigation as a no-write once it has a
             // surviving sibling (`path()`/`del()` were already correct
             // here via other means -- #2049/#2108).
-            _ => return Ok(None),
-        }
+            None => return Ok(None),
+        };
     }
     Ok(Some(current))
+}
+
+/// One step of [`value_after_components`]'s walk (#2058).
+///
+/// A bare [`Expr::Field`]/[`Expr::Index`] -- the overwhelmingly common shape
+/// in a static tail (`.c.c.c...c[0]`) -- is handled here directly and
+/// destructively, mirroring [`eval_owned_fast_path`]'s own arms for those two
+/// (kept in sync deliberately: same missing-key/out-of-bounds ->
+/// `OwnedValue::Null` rule, same error types/messages for a non-indexable
+/// container) but consuming `current` instead of borrowing it.
+/// [`IndexMap::swap_remove`]/[`Vec::swap_remove`] -- not the order-preserving
+/// `shift_remove`/`Vec::remove` -- are what make this O(1) instead of O(n),
+/// and are safe here specifically because the container being consumed is
+/// *never read again*: every sibling still inside it is simply dropped, in
+/// whatever order swap-removal leaves them, the moment this function
+/// returns. (A container whose remaining order or contents an *other* live
+/// reference could still observe would need the order-preserving removal
+/// instead -- this one has no such reference; see `value_after_components`'s
+/// own doc comment for why.)
+///
+/// Anything else -- [`Expr::Slice`] (jq's own array slice keeps the sliced
+/// sub-range regardless, so there is no equivalent "don't clone the sibling"
+/// move available, and it was never on [`eval_owned_fast_path`]'s fast path to
+/// begin with -- every static-tail `Slice` step already paid a full
+/// `to_json_for_reindex` + reparse round trip before this change and still
+/// does, a separate, pre-existing cost this fix does not touch),
+/// [`Expr::Optional`] (ditto: [`eval_owned_multi_keep_partial`], the only
+/// caller feeding this loop, always evaluates with `optional: false`
+/// regardless of whether `component` is `Optional`-wrapped, so a wrapped
+/// component was already falling through [`eval_owned_fast_path`]'s `_ =>
+/// None` arm to the reindex bridge before this change too), or anything
+/// unforeseen -- falls back to the pre-#2058 clone-and-reevaluate path
+/// unchanged, at the cost of one clone for that single step only.
+fn navigate_static_component<S: EvalSemantics>(
+    component: &Expr,
+    current: OwnedValue,
+) -> Result<Option<OwnedValue>, EvalEscape> {
+    match component {
+        Expr::Field(name) => Ok(Some(match current {
+            OwnedValue::Object(mut map) => map.swap_remove(name).unwrap_or(OwnedValue::Null),
+            OwnedValue::Null => OwnedValue::Null,
+            other => {
+                return Err(
+                    EvalError::cannot_index_with_field(owned_type_name(&other), name).into(),
+                );
+            }
+        })),
+        Expr::Index { idx, .. } => Ok(Some(match current {
+            OwnedValue::Array(mut items) => {
+                let resolved = if *idx < 0 {
+                    items.len() as i64 + idx
+                } else {
+                    *idx
+                };
+                usize::try_from(resolved)
+                    .ok()
+                    .filter(|&i| i < items.len())
+                    .map_or(OwnedValue::Null, |i| items.swap_remove(i))
+            }
+            OwnedValue::Null => OwnedValue::Null,
+            other => {
+                return Err(
+                    EvalError::cannot_index_with_type(owned_type_name(&other), "number").into(),
+                );
+            }
+        })),
+        _ => {
+            let mut values = eval_owned_multi::<S>(component, &current)?;
+            // Every caller hands this a tail already proven single-valued by
+            // construction (`resolve_seq`, gated on `needs_fanout_pass`) -- a
+            // `> 1` output count here is a genuine invariant violation, not
+            // the ordinary "component matched nothing" case (a missing key
+            // still yields exactly one output, `null`). #682 was exactly
+            // this: `Expr::Iterate` produced more than one output through
+            // this function, which silently discarded every branch but one
+            // instead of the fan-out its caller actually needed.
+            debug_assert!(
+                values.len() <= 1,
+                "value_after_components: {component:?} produced {} outputs, but every \
+                 caller requires a single-valued tail (see needs_fanout_pass)",
+                values.len()
+            );
+            Ok(match values.len() {
+                1 => Some(values.pop().expect("len checked")),
+                _ => None,
+            })
+        }
+    }
 }
 
 /// [`value_after_components`], except when `trackable` is false (#843): then
@@ -25126,7 +25289,13 @@ fn resolve_static_tail<'a, S: EvalSemantics>(
         };
         return Err((Vec::new(), error.into()));
     }
-    value_after_components::<S>(components, value).map_err(|e| (Vec::new(), e))
+    // The one clone `value_after_components` needs -- its own body now
+    // navigates the clone destructively instead of re-cloning at every step
+    // (#2058) -- so this keeps the pre-#2058 total cost at this boundary
+    // identical (`value` is always borrowed here, from a caller that cannot
+    // hand ownership over) while removing the O(d^2) that used to live
+    // inside the loop.
+    value_after_components::<S>(components, value.clone()).map_err(|e| (Vec::new(), e))
 }
 
 /// Apply a purely-static path tail to every branch, extending each branch's
@@ -32668,20 +32837,29 @@ pub(crate) fn builtin_path_on_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
 
     let mut reached = Vec::new();
     let mut walk_error = None;
+    let root = PathTrail::root();
     for expr in &exprs {
         // A later walk-time failure (an unindexable step reached only once
         // the expression is concretely walked) needs the same treatment:
         // whatever earlier resolved expressions already streamed into
         // `reached` survives, and only this one stops the walk.
-        if let Err(e) = walk_path::<S>(expr, owned, &[], &mut reached, optional) {
+        // One clone of the whole document per resolved branch (#2058) --
+        // `walk_path`/`walk_pipe`/`step_into` below take their value by move
+        // and navigate destructively, so this is the only clone this branch
+        // pays, however deep it walks. `owned` is shared across every branch
+        // in `exprs` (each needs its own independent walk from the document
+        // root), so it cannot be moved in directly here.
+        if let Err(e) = walk_path::<S>(expr, owned.clone(), &root, &mut reached, optional) {
             walk_error = Some(e);
             break;
         }
     }
 
+    // `PathTrail::to_vec` is the one O(depth) flatten, paid exactly once per
+    // reached branch here -- never per navigation step (#2058).
     let paths: Vec<OwnedValue> = reached
         .into_iter()
-        .map(|(path, _)| OwnedValue::Array(path))
+        .map(|(path, _)| OwnedValue::Array(path.to_vec()))
         .collect();
 
     if let Some(e) = walk_error.or(resolve_error) {
@@ -32719,16 +32897,33 @@ pub(crate) fn builtin_path_on_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
 /// One walker, not one per position: the last step of a path and the steps
 /// before it obey the same rules, and keeping two copies of them is what let
 /// `path(.b.c)` lose the path that `path(.b)` kept (#489).
+///
+/// **Takes `value` by value, and consumes it destructively, for the same
+/// reason [`value_after_components`] does (#2058).** `builtin_path_on_owned`
+/// clones the document once per resolved branch at this function's one call
+/// site -- everything below navigates that clone by move, so a `d`-deep
+/// chain costs O(d) per branch instead of the O(d^2) a `.clone()` at every
+/// step used to cost (step `i` used to clone the whole remaining O(d-i)-sized
+/// subtree just to read one field out of it). This mirrors
+/// `value_after_components`'s own fix one level up: that one flattened
+/// `resolve_seq`'s pre-pass (which every one of `path()`/`=`/`del()` runs to
+/// turn a computed key into a resolved component list), while this one
+/// flattens `path()`'s *own* second walk over that resolved list -- the
+/// reason `path()` alone still read the full O(d^2) exponent even after the
+/// pre-pass was fixed, since `=`/`del()` never reach this function at all.
 fn walk_path<S: EvalSemantics>(
     expr: &Expr,
-    value: &OwnedValue,
-    current_path: &[OwnedValue],
-    out: &mut Vec<(Vec<OwnedValue>, OwnedValue)>,
+    value: OwnedValue,
+    current_path: &Rc<PathTrail>,
+    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
     match expr {
-        // The path already reaching here, named as it stands.
-        Expr::Identity => out.push((current_path.to_vec(), value.clone())),
+        // The path already reaching here, named as it stands. `value` moves
+        // straight into `out`, and `current_path` is a cheap `Rc::clone`
+        // (refcount bump) -- the terminal case pays no O(depth) clone at all
+        // (#2058; see `PathTrail`'s own doc comment).
+        Expr::Identity => out.push((Rc::clone(current_path), value)),
 
         // One component each, written as the step was written rather than as
         // it resolves: jq keeps `path(.[-1])` as `[-1]` and `path(.[1:2])` as
@@ -32773,22 +32968,27 @@ fn walk_path<S: EvalSemantics>(
         // The one step whose components come from the *value* rather than the
         // expression, so it reads them off the container directly. Anything
         // that is not a container still takes the evaluator's verdict, which
-        // is jq's `Cannot iterate over <t> (<v>)`.
+        // is jq's `Cannot iterate over <t> (<v>)`. `value` is owned, so each
+        // element/entry moves into `out` directly rather than being cloned,
+        // and each element's own trail extension is O(1) (`PathTrail::extend`).
         Expr::Iterate => match value {
             OwnedValue::Array(arr) => {
-                for (i, val) in arr.iter().enumerate() {
-                    out.push((extend(current_path, OwnedValue::Int(i as i64)), val.clone()));
+                for (i, val) in arr.into_iter().enumerate() {
+                    out.push((
+                        PathTrail::extend(current_path, OwnedValue::Int(i as i64)),
+                        val,
+                    ));
                 }
             }
             OwnedValue::Object(entries) => {
                 for (key, val) in entries {
                     out.push((
-                        extend(current_path, OwnedValue::String(key.clone())),
-                        val.clone(),
+                        PathTrail::extend(current_path, OwnedValue::String(key)),
+                        val,
                     ));
                 }
             }
-            other => match eval_owned_multi::<S>(expr, other) {
+            other => match eval_owned_multi::<S>(expr, &other) {
                 Ok(_) => {}
                 // `?` silences only the genuine indexing error; a halt
                 // raised while producing the verdict still escapes (#791).
@@ -32814,24 +33014,35 @@ fn walk_path<S: EvalSemantics>(
         // Expressions with no path-tracking arm — `..`, `recurse`, `select`,
         // arithmetic — name no path (#483). `builtin_path` renders that as no
         // output, which is still the wrong answer but no longer a path that
-        // resolves.
+        // resolves. `value` is simply dropped here, same as it was before
+        // this function took it by value instead of by reference.
         _ => {}
     }
     Ok(())
 }
 
 /// Walk a pipe of path steps, threading each value reached into the next step.
+///
+/// `value` moves stage to stage -- see [`walk_path`]'s own doc comment for why
+/// that is the point of this whole rewrite (#2058): a straight-line chain of
+/// `Field`/`Index` stages now passes exactly one value along by move, never
+/// cloning the remaining document at any intermediate stage. `current_path`
+/// is an `Rc<PathTrail>` for the identical reason one level up: `rest` is
+/// already a borrowed `&[Expr]` slice here (no AST clone needed to recurse,
+/// unlike `eval_generic.rs`'s twin of this function, which has to rebuild an
+/// owned `Expr::Pipe` at each stage because its own per-step helper only
+/// takes a single `&Expr` -- see that function's own doc comment).
 fn walk_pipe<S: EvalSemantics>(
     exprs: &[Expr],
-    value: &OwnedValue,
-    current_path: &[OwnedValue],
-    out: &mut Vec<(Vec<OwnedValue>, OwnedValue)>,
+    value: OwnedValue,
+    current_path: &Rc<PathTrail>,
+    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
     let Some((first, rest)) = exprs.split_first() else {
         // An empty pipe reaches nothing new, so it names the path handed to
         // it — `path(())` is `[]`, as `path(.)` is.
-        out.push((current_path.to_vec(), value.clone()));
+        out.push((Rc::clone(current_path), value));
         return Ok(());
     };
     if rest.is_empty() {
@@ -32841,7 +33052,7 @@ fn walk_pipe<S: EvalSemantics>(
     let mut reached = Vec::new();
     walk_path::<S>(first, value, current_path, &mut reached, optional)?;
     for (path, val) in reached {
-        walk_pipe::<S>(rest, &val, &path, out, optional)?;
+        walk_pipe::<S>(rest, val, &path, out, optional)?;
     }
     Ok(())
 }
@@ -32849,37 +33060,31 @@ fn walk_pipe<S: EvalSemantics>(
 /// Take one path step: `component` names it, and the value evaluator decides
 /// both what it reaches and whether it may be taken at all.
 ///
-/// Asking the evaluator rather than re-deciding here is the point — see
-/// [`walk_path`]. `Err` is suppressed into no output under `?`, which is all
-/// `?` means on a path step.
+/// Delegates the actual navigation to [`navigate_static_component`] -- the
+/// same destructive, move-based step [`value_after_components`] uses (#2058)
+/// -- rather than a second copy of jq's indexing rules here. `Err` is
+/// suppressed into no output under `?`, which is all `?` means on a path
+/// step.
 fn step_into<S: EvalSemantics>(
     step: &Expr,
     component: OwnedValue,
-    value: &OwnedValue,
-    current_path: &[OwnedValue],
-    out: &mut Vec<(Vec<OwnedValue>, OwnedValue)>,
+    value: OwnedValue,
+    current_path: &Rc<PathTrail>,
+    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
-    let values = match eval_owned_multi::<S>(step, value) {
-        Ok(values) => values,
+    let reached = match navigate_static_component::<S>(step, value) {
+        Ok(reached) => reached,
         // `?` turns only a genuine step error into no output; a halt raised
         // by the step still escapes (#791).
         Err(EvalEscape::Error(_)) if optional => return Ok(()),
         Err(escape) => return Err(escape),
     };
-    debug_assert!(values.len() <= 1, "one path step reaches at most one value");
-    let Some(reached) = values.into_iter().next() else {
+    let Some(reached) = reached else {
         return Ok(());
     };
-    out.push((extend(current_path, component), reached));
+    out.push((PathTrail::extend(current_path, component), reached));
     Ok(())
-}
-
-/// `current_path` with one more component on the end.
-fn extend(current_path: &[OwnedValue], component: OwnedValue) -> Vec<OwnedValue> {
-    let mut path = current_path.to_vec();
-    path.push(component);
-    path
 }
 
 /// Helper to collect all paths recursively.
@@ -68229,8 +68434,8 @@ mod tests {
             let mut reached = Vec::new();
             let _ = walk_path::<JqSemantics>(
                 &unresolved(),
-                &OwnedValue::Null,
-                &[],
+                OwnedValue::Null,
+                &PathTrail::root(),
                 &mut reached,
                 false,
             );
@@ -68244,7 +68449,13 @@ mod tests {
         fn test_path_tracking_refuses_an_unresolved_key_mid_pipe() {
             let mut reached = Vec::new();
             let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
-            let _ = walk_path::<JqSemantics>(&pipe, &OwnedValue::Null, &[], &mut reached, false);
+            let _ = walk_path::<JqSemantics>(
+                &pipe,
+                OwnedValue::Null,
+                &PathTrail::root(),
+                &mut reached,
+                false,
+            );
         }
     }
 
@@ -68335,8 +68546,8 @@ mod tests {
             let mut reached = Vec::new();
             let _ = walk_path::<JqSemantics>(
                 &unresolved(),
-                &OwnedValue::Null,
-                &[],
+                OwnedValue::Null,
+                &PathTrail::root(),
                 &mut reached,
                 false,
             );
@@ -68349,7 +68560,13 @@ mod tests {
         fn test_path_tracking_refuses_an_unresolved_slice_mid_pipe() {
             let mut reached = Vec::new();
             let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
-            let _ = walk_path::<JqSemantics>(&pipe, &OwnedValue::Null, &[], &mut reached, false);
+            let _ = walk_path::<JqSemantics>(
+                &pipe,
+                OwnedValue::Null,
+                &PathTrail::root(),
+                &mut reached,
+                false,
+            );
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8819,6 +8819,18 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
     path: &Rc<PathTrail>,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), EvalError> {
+    // Panics past `MAX_NESTING_DEPTH` levels (code review on #2058), the
+    // same guard `collect_paths_generic` already carries for its own
+    // recursive path-array walk in this file. `PathTrail` has no depth cap
+    // of its own -- a static chain (`path(.a.a.a...)`) recurses this
+    // function's own call graph (`path_walk_pipe_generic`/`path_step_
+    // generic`/`path_step_pipe_generic` below all funnel back through it)
+    // once per component with no limit, and a million-component chain
+    // overflowed the native stack and aborted the process outright
+    // (confirmed live) once this PR's fix made `path()` fast enough to
+    // reach that depth in practice -- pre-fix, the O(d^2) cost made the
+    // same input time out long before ever getting there.
+    assert_nesting_depth(path.depth());
     match expr {
         Expr::Identity => {
             out.push(OwnedValue::Array(path.to_vec()));
@@ -8880,6 +8892,10 @@ fn path_walk_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     path: &Rc<PathTrail>,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), EvalError> {
+    // See `path_walk_generic`'s own doc comment -- this function recurses
+    // into itself once per pipe stage without ever passing back through
+    // that entry check, so it needs its own (#2058 code review).
+    assert_nesting_depth(path.depth());
     let Some((first, rest)) = exprs.split_first() else {
         out.push(OwnedValue::Array(path.to_vec()));
         return Ok(());
@@ -8912,6 +8928,8 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
     collapse_duplicate_keys: bool,
     out: &mut Vec<(Rc<PathTrail>, PathNode<V>)>,
 ) -> Result<(), EvalError> {
+    // See `path_walk_generic`'s own doc comment (#2058 code review).
+    assert_nesting_depth(path.depth());
     match expr {
         Expr::Identity => {
             out.push((Rc::clone(path), node.clone()));
@@ -9080,6 +9098,10 @@ fn path_step_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     collapse_duplicate_keys: bool,
     out: &mut Vec<(Rc<PathTrail>, PathNode<V>)>,
 ) -> Result<(), EvalError> {
+    // See `path_walk_generic`'s own doc comment -- like `path_walk_pipe_
+    // generic`, this recurses into itself once per pipe stage (#2058 code
+    // review).
+    assert_nesting_depth(path.depth());
     let Some((first, rest)) = exprs.split_first() else {
         out.push((Rc::clone(path), node.clone()));
         return Ok(());

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -44,7 +44,7 @@ use super::eval::{
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
     try_reserve_product, vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag,
-    Flow, JqSemantics, LimitN, QueryResult, YqSemantics,
+    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -8816,12 +8816,12 @@ fn path_node_type_name<V: DocumentValue>(node: &PathNode<V>) -> &'static str {
 fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     node: &PathNode<V>,
-    path: &mut Vec<OwnedValue>,
+    path: &Rc<PathTrail>,
     out: &mut Vec<OwnedValue>,
 ) -> Result<(), EvalError> {
     match expr {
         Expr::Identity => {
-            out.push(OwnedValue::Array(path.clone()));
+            out.push(OwnedValue::Array(path.to_vec()));
             Ok(())
         }
         Expr::Paren(inner) => path_walk_generic::<S, V>(inner, node, path, out),
@@ -8836,62 +8836,71 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
             // error comes before anything is produced -- which is the case
             // the discarded-branch version was checked against.
             let mut branch = Vec::new();
-            let _ = path_walk_generic::<S, V>(inner, node, &mut path.clone(), &mut branch);
+            let _ = path_walk_generic::<S, V>(inner, node, path, &mut branch);
             out.append(&mut branch);
             Ok(())
         }
         Expr::Comma(exprs) => {
             for e in exprs {
-                path_walk_generic::<S, V>(e, node, &mut path.clone(), out)?;
+                path_walk_generic::<S, V>(e, node, path, out)?;
             }
             Ok(())
         }
-        Expr::Pipe(exprs) => match exprs.split_first() {
-            None => {
-                out.push(OwnedValue::Array(path.clone()));
-                Ok(())
-            }
-            Some((first, [])) => path_walk_generic::<S, V>(first, node, path, out),
-            Some((first, rest)) => {
-                // Each output of `first` is a distinct position to continue
-                // the rest of the pipe from, so the step is re-walked rather
-                // than batched -- the same per-output shape `Expr::Iterate`
-                // needs below.
-                let mut heads = Vec::new();
-                let stepped = path_step_generic::<S, V>(
-                    first,
-                    node,
-                    path,
-                    S::COLLAPSE_DUPLICATE_KEYS,
-                    &mut heads,
-                );
-                let rest_expr = if rest.len() == 1 {
-                    rest[0].clone()
-                } else {
-                    Expr::Pipe(rest.to_vec())
-                };
-                // Heads the step produced *before* failing are earlier in
-                // jq's generator order than its own error, so they are walked
-                // first and only then is the error propagated -- the same
-                // "never un-emit an output already produced" rule the
-                // `Builtin::Path` arm applies at the top level.
-                for (mut next_path, next_node) in heads {
-                    path_walk_generic::<S, V>(&rest_expr, &next_node, &mut next_path, out)?;
-                }
-                stepped
-            }
-        },
+        Expr::Pipe(exprs) => path_walk_pipe_generic::<S, V>(exprs, node, path, out),
         // A terminal navigation step: take it, then emit each resulting path.
         _ => {
             let mut heads = Vec::new();
             let stepped =
                 path_step_generic::<S, V>(expr, node, path, S::COLLAPSE_DUPLICATE_KEYS, &mut heads);
             for (p, _) in heads {
-                out.push(OwnedValue::Array(p));
+                out.push(OwnedValue::Array(p.to_vec()));
             }
             stepped
         }
     }
+}
+
+/// [`path_walk_generic`]'s own `Expr::Pipe` case, split out to work on a
+/// borrowed `&[Expr]` slice rather than a single `&Expr` (#2058).
+///
+/// Before this, the `Pipe` arm split one component off at a time and
+/// rewrapped the remainder in a *new*, owned `Expr::Pipe(rest.to_vec())` just
+/// to recurse — an O(remaining length) clone of `Expr` nodes at every one of
+/// a `d`-element pipe's `d` stages, summing to O(d^2) for a flat
+/// `.c.c.c...c[0]`-shaped chain (exactly the AST-clone-per-stage pattern
+/// #1510 already fixed in `eval.rs`'s own path-context evaluator — see this
+/// crate's top-level `CHANGELOG.md`). Passing `rest` straight through as a
+/// slice is O(1): no clone, just a pointer/length pair. Combined with
+/// [`PathTrail`] (an O(1)-extend `Rc`-list replacing the identical
+/// `path.to_vec()`-then-push clone this arm's `path` parameter used to pay
+/// every stage too), a `d`-deep static chain is now O(d) end to end here.
+fn path_walk_pipe_generic<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    node: &PathNode<V>,
+    path: &Rc<PathTrail>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), EvalError> {
+    let Some((first, rest)) = exprs.split_first() else {
+        out.push(OwnedValue::Array(path.to_vec()));
+        return Ok(());
+    };
+    if rest.is_empty() {
+        return path_walk_generic::<S, V>(first, node, path, out);
+    }
+    // Each output of `first` is a distinct position to continue the rest of
+    // the pipe from, so the step is re-walked rather than batched -- the
+    // same per-output shape `Expr::Iterate` needs.
+    let mut heads = Vec::new();
+    let stepped =
+        path_step_generic::<S, V>(first, node, path, S::COLLAPSE_DUPLICATE_KEYS, &mut heads);
+    // Heads the step produced *before* failing are earlier in jq's generator
+    // order than its own error, so they are walked first and only then is
+    // the error propagated -- the same "never un-emit an output already
+    // produced" rule the `Builtin::Path` arm applies at the top level.
+    for (next_path, next_node) in heads {
+        path_walk_pipe_generic::<S, V>(rest, &next_node, &next_path, out)?;
+    }
+    stepped
 }
 
 /// One navigation step: from `node` at `path`, produce every (path, node)
@@ -8899,13 +8908,13 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     node: &PathNode<V>,
-    path: &[OwnedValue],
+    path: &Rc<PathTrail>,
     collapse_duplicate_keys: bool,
-    out: &mut Vec<(Vec<OwnedValue>, PathNode<V>)>,
+    out: &mut Vec<(Rc<PathTrail>, PathNode<V>)>,
 ) -> Result<(), EvalError> {
     match expr {
         Expr::Identity => {
-            out.push((path.to_vec(), node.clone()));
+            out.push((Rc::clone(path), node.clone()));
             Ok(())
         }
         Expr::Paren(inner) => {
@@ -8931,9 +8940,10 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                 }
             };
-            let mut p = path.to_vec();
-            p.push(OwnedValue::String(name.clone()));
-            out.push((p, next));
+            out.push((
+                PathTrail::extend(path, OwnedValue::String(name.clone())),
+                next,
+            ));
             Ok(())
         }
         Expr::Index { idx, key } => {
@@ -8967,9 +8977,10 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                 }
             };
-            let mut p = path.to_vec();
-            p.push(index_component_value(idx, key));
-            out.push((p, next));
+            out.push((
+                PathTrail::extend(path, index_component_value(idx, key)),
+                next,
+            ));
             Ok(())
         }
         Expr::Iterate => match node {
@@ -8993,16 +9004,18 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                         let Some(key) = key_display_string(&field.key) else {
                             return Err(fields.malformed_member_error());
                         };
-                        let mut p = path.to_vec();
-                        p.push(OwnedValue::String(key.into_owned()));
-                        out.push((p, PathNode::At(field.value_cursor)));
+                        out.push((
+                            PathTrail::extend(path, OwnedValue::String(key.into_owned())),
+                            PathNode::At(field.value_cursor),
+                        ));
                     }
                     Ok(())
                 } else if let Some(elements) = v.as_array() {
                     for (i, ec) in elements.collect_cursors().into_iter().enumerate() {
-                        let mut p = path.to_vec();
-                        p.push(OwnedValue::Int(i as i64));
-                        out.push((p, PathNode::At(ec)));
+                        out.push((
+                            PathTrail::extend(path, OwnedValue::Int(i as i64)),
+                            PathNode::At(ec),
+                        ));
                     }
                     Ok(())
                 } else {
@@ -9029,37 +9042,9 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
         // so before these arms existed each one hit the `unreachable!` below
         // and aborted the process with exit 101 -- a live, CLI-reachable
         // panic, not a can't-happen.
-        Expr::Pipe(exprs) => match exprs.split_first() {
-            None => {
-                out.push((path.to_vec(), node.clone()));
-                Ok(())
-            }
-            Some((first, [])) => {
-                path_step_generic::<S, V>(first, node, path, collapse_duplicate_keys, out)
-            }
-            Some((first, rest)) => {
-                let mut heads = Vec::new();
-                let stepped = path_step_generic::<S, V>(
-                    first,
-                    node,
-                    path,
-                    collapse_duplicate_keys,
-                    &mut heads,
-                );
-                let rest_expr = if rest.len() == 1 {
-                    rest[0].clone()
-                } else {
-                    Expr::Pipe(rest.to_vec())
-                };
-                // Positions completed through the whole chain land in `out`
-                // before `stepped`'s own error surfaces, for the same
-                // generator-order reason as `path_walk_generic`'s `Pipe` arm.
-                for (p, n) in heads {
-                    path_step_generic::<S, V>(&rest_expr, &n, &p, collapse_duplicate_keys, out)?;
-                }
-                stepped
-            }
-        },
+        Expr::Pipe(exprs) => {
+            path_step_pipe_generic::<S, V>(exprs, node, path, collapse_duplicate_keys, out)
+        }
         Expr::Comma(exprs) => {
             for e in exprs {
                 path_step_generic::<S, V>(e, node, path, collapse_duplicate_keys, out)?;
@@ -9079,6 +9064,38 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
         // can arrive here.
         other => unreachable!("non-navigable path expression reached the cursor walk: {other:?}"),
     }
+}
+
+/// [`path_step_generic`]'s own `Expr::Pipe` case, split out the same way
+/// [`path_walk_pipe_generic`] is (#2058): a nested nested pipe reached as one
+/// step inside an *outer* pipe (`path(((.a|.b)|.c))`, see the doc comment
+/// where this arm used to live) is rare, but recurses on a borrowed `&[Expr]`
+/// slice here for the identical reason -- no owned `Expr::Pipe(rest.to_vec())`
+/// rebuilt per stage, and `path`'s own O(1) `PathTrail::extend` instead of an
+/// O(depth) `Vec` clone-and-push.
+fn path_step_pipe_generic<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    node: &PathNode<V>,
+    path: &Rc<PathTrail>,
+    collapse_duplicate_keys: bool,
+    out: &mut Vec<(Rc<PathTrail>, PathNode<V>)>,
+) -> Result<(), EvalError> {
+    let Some((first, rest)) = exprs.split_first() else {
+        out.push((Rc::clone(path), node.clone()));
+        return Ok(());
+    };
+    if rest.is_empty() {
+        return path_step_generic::<S, V>(first, node, path, collapse_duplicate_keys, out);
+    }
+    let mut heads = Vec::new();
+    let stepped = path_step_generic::<S, V>(first, node, path, collapse_duplicate_keys, &mut heads);
+    // Positions completed through the whole chain land in `out` before
+    // `stepped`'s own error surfaces, for the same generator-order reason as
+    // `path_walk_pipe_generic`.
+    for (p, n) in heads {
+        path_step_pipe_generic::<S, V>(rest, &n, &p, collapse_duplicate_keys, out)?;
+    }
+    stepped
 }
 
 /// Whether a pipe stage carrying path context can be resolved by walking
@@ -9298,11 +9315,16 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             let stepped = path_step_generic::<S, V>(
                 expr,
                 &PathNode::At(pos.node),
-                &pos.path,
+                &PathTrail::from_slice(&pos.path),
                 true,
                 &mut heads,
             );
             for (path, node) in heads {
+                // `path_step_generic` now hands back an `Rc<PathTrail>`
+                // (#2058); this caller's own `path` stays a plain
+                // `Vec<OwnedValue>` (see `PathTrail::from_slice`'s own doc
+                // comment for why), so it flattens back out here.
+                let path = path.to_vec();
                 // An absent node is where the bridge and this walk genuinely
                 // disagree, so it is handed back rather than answered.
                 //
@@ -10416,7 +10438,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 return match path_walk_generic::<S, V>(
                     path_expr,
                     &PathNode::At(root),
-                    &mut Vec::new(),
+                    &PathTrail::root(),
                     &mut out,
                 ) {
                     Ok(()) => owned_vec_to_generic_result(out),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18431,6 +18431,77 @@ fn test_map_identity_reports_clean_error_on_adversarial_nesting_1793() -> Result
     Ok(())
 }
 
+/// #2058 code review (Finding 1): `path()`'s new `PathTrail`-based
+/// value/path tracking (`path_walk_generic`/`path_walk_pipe_generic`/
+/// `path_step_generic`/`path_step_pipe_generic`, `eval_generic.rs`) recurses
+/// once per component of a static chain with no depth cap of its own --
+/// before this fix, `path(.a.a.a...)` with enough repeated `.a` segments
+/// crashed with a raw stack overflow (`fatal runtime error: stack overflow,
+/// aborting`, SIGABRT, no diagnostic at all) rather than any clean error,
+/// confirmed live with 1,000,000 segments at review. This test uses a much
+/// smaller, CI-friendly depth that still clears `MAX_NESTING_DEPTH` (256,
+/// #2061's cursor-native fast path this shape reaches) -- the crash
+/// reproduces at any depth past that limit, not only at a million.
+/// `path(.a.a.a...)` alone is fully cursor-navigable
+/// (`path_expr_is_cursor_navigable`), so this reaches the same #1793
+/// `catch_unwind` this file's other adversarial-nesting tests above already
+/// pin -- matching their exact assertion shape.
+#[test]
+fn test_path_cursor_native_deep_static_chain_reports_cleanly_not_stack_overflow_2058() -> Result<()>
+{
+    let filter = format!("path({})", ".a".repeat(300));
+    let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("{}"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("stack overflow") && !stderr.contains("fatal runtime error"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2058 code review (Finding 1) sibling: the *non*-cursor-navigable route
+/// (a trailing `Expr::Slice` routes `path()` to `eval.rs`'s
+/// `builtin_path_on_owned`/`walk_path`/`walk_pipe`/`step_into` instead of
+/// `eval_generic.rs`'s cursor-native walk, since `path_expr_is_cursor_
+/// navigable` rejects a `Slice` component, #2061) shares the identical
+/// unbounded-recursion shape, guarded there by the file-appropriate
+/// `MAX_VALUE_TREE_DEPTH` (384) instead of `MAX_NESTING_DEPTH`.
+///
+/// Unlike the sibling test above, this route is *not* wrapped by the CLI's
+/// `catch_unwind`: `nesting_depth_panic_message`'s own doc comment records
+/// that a `MAX_VALUE_TREE_DEPTH` panic is a deliberately different failure
+/// class (filter-driven value growth, e.g. `reduce`, rather than document
+/// nesting) that this CLI leaves uncaught here on purpose, matching every
+/// other pre-existing caller of `assert_value_tree_depth` -- confirmed live
+/// and identical on unmodified `main` via
+/// `reduce range(400) as $i (null; [.])`, which panics uncaught (exit 101,
+/// no `catch_unwind` reformatting) today. So this test asserts only that
+/// the failure is an ordinary, bounded Rust panic -- a clean depth-limit
+/// message, deterministic, no corrupted process state -- rather than a
+/// stack overflow (unrecoverable, no message, `SIGABRT`); it does not (and,
+/// per the above, should not) assert a specific caught-and-reformatted exit
+/// code the way the cursor-native sibling above does.
+#[test]
+fn test_path_non_cursor_native_deep_static_chain_panics_cleanly_not_stack_overflow_2058(
+) -> Result<()> {
+    let filter = format!("path({}[0:1])", ".a".repeat(500));
+    let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("{}"))?;
+    assert_ne!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 384"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("stack overflow") && !stderr.contains("fatal runtime error"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #2066 review: a `LazySeq`-backed builtin (`map`/`reverse`/`sort_by`/
 /// `unique_by`/...) must stay atomic on malformed content the same way it
 /// already was on adversarial nesting depth (the test above) -- nothing on


### PR DESCRIPTION
## Summary

Fixes #2058: `path()`, `=`/`|=`, and `del()` all cost **O(d²)** to resolve a `d`-deep static
navigation chain, independent of branch count, because two independent sites cloned an
ever-shrinking remaining structure at every single navigation step and summed those clones
to a quadratic total.

**Site 1** — `value_after_components` (`src/jq/eval.rs`) cloned the *whole remaining
document* at every static `Field`/`Index` step via `OwnedValue`'s deep `Clone`. Fixed by a
new `navigate_static_component` that moves the matched child out of its parent via
`swap_remove` instead of cloning it.

**Site 2** — `path()`'s own value/path-array tracking had a second, independent per-step
clone in *both* evaluators: `eval.rs`'s `walk_path`/`step_into`, and `eval_generic.rs`'s
`path_walk_generic`/`path_step_generic` (the CLI's actual `path()` dispatch since #2061).
Both used to rebuild the accumulated path with `path.to_vec()` then `.push(component)` at
every step. Fixed with a new `PathTrail` (an `Rc`-linked cons-list, `PathPrefix`'s twin):
`extend` is O(1) (one `Rc::clone` + one allocation), and the O(depth) flatten
(`PathTrail::to_vec`) happens exactly once per branch, when it becomes an actual output —
not once per step along the way. `eval_generic.rs` additionally had an AST-clone-per-stage
in its `Pipe` handling (mirroring #1510's already-fixed `eval.rs` case), fixed with two new
slice-based pipe helpers (`path_walk_pipe_generic`/`path_step_pipe_generic`) that recurse on
a borrowed `&[Expr]` instead of rebuilding one.

See `docs/optimizations/path-resolution-clone.md` for the full write-up.

## Benchmarks

Interleaved CLI A/B (200-document stream per invocation, both `nodes.yaml` hardware targets
idle, per `docs/guides/benchmarking.md`'s A/B method):

| query (2 branches, depth `D`) | exponent before (D=120→240) | exponent after | speedup @ D=240 |
|---|---|---|---|
| `path()` | ~1.89–1.90 | ~0.95–1.00 | 13.9x (ARM) / 19.9x (x86) |
| `=` | ~1.89–1.98 | ~0.95–1.01 | 16.6x / 12.0x |
| `del()` | ~1.88–1.98 | ~0.97–1.02 | 14.6x / 10.6x |

New regression fixture isolating depth from branch count (the existing
`jq_write_path_del_shared_prefix_depth` group scales both together, which is why it never
caught this): `jq_write_path_two_branch_{path,assign,del}_depth` in
`benches/jq_write_path_bench.rs`.

## Correctness

- Full test suite: 6999 passed, 0 failed.
- 2320 systematic before/after CLI cases: 0 mismatches.
- Real-oracle differential (`/usr/bin/jq` 1.7.1, Homebrew `yq` v4.53.3): jq mode 35/35 match;
  yq mode has the same 15 pre-existing mismatches as pre-fix `main` (unrelated to this
  change, independently reconfirmed).
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`: clean.
- Patch coverage: 96.61% (171/177 new lines). The 6 uncovered lines are a `debug_assert!`
  format-string argument and four structurally-identical `path(())`-empty-pipe defensive
  arms — pre-existing gap shape, carried forward by the rewrite rather than newly
  introduced.

No behavioral change: this is a pure performance fix.

## Acceptance criteria (from #2058)

- [x] Mechanism attributed (a build with the clone bypassed moved the two-branch table, not
      just a profile claim) — see `docs/optimizations/path-resolution-clone.md`.
- [x] Two-branch `path()`/`=`/`del()` exponent over D=30…240 drops toward ~1.
- [x] Regression fixture checked in, isolating depth from branch count.
- [x] No behavioral change — differential fuzz/golden suites byte-identical.

Fixes #2058
