### PR TITLE
fix(jq): stop `?` from suppressing a later pipe stage's error under path context (#2073)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2784,6 +2784,14 @@ helper (the same one `Expr::Iterate`/`Builtin::Map` already use for this
 exact "keep the prefix, gate only the error" policy) instead of a bare
 `partial(...)` call.
 
+**The output above is unchanged since #2073, but the mechanism behind it
+moved.** That fix stopped `Expr::Optional` handing `rest` a forced
+`optional = true`, so `continue_rest_with_context`'s own `optional` gate no
+longer fires for this query -- the suppression now happens one level up, in
+`Expr::Optional`'s own structural catch of the isolated `recurse(...)`'s
+`Partial`. Nothing left in the path-context evaluator produces
+`optional == true` at all; see #2212.
+
 **One site remains unfixed**: `ParentN`'s own `n` argument (`parent((1,2))`
 still array-collapses `n` to `[1,2]`, then errors on the wrong type -- a
 narrower, lower-traffic case than the three arms fixed above, not attempted

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31627,44 +31627,39 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // `query_result_to_owned_values` convention (the Array arm discards
         // it instead, since a halted array never finished constructing).
         //
-        // Isolating `inner` this way only works when nothing downstream
-        // needs the per-output `current_path` `inner` would have produced
-        // had it continued straight into `rest` -- `Field`/`Index`/`Iterate`
-        // (and friends) only compute+thread an updated path when they have
-        // a non-empty `rest` to recurse into; evaluated with an empty
-        // `rest` for isolation, they just return bare values, so
-        // `continue_rest_with_context` below would fan them into `rest`
-        // using the *stale*, pre-`inner` `current_path` instead of each
-        // output's real one (`.a | (.[])? | key` would wrongly report every
-        // element's key as `"a"` instead of its index). This is a
-        // pre-existing limitation of the isolate-then-continue shape shared
-        // by the `Try`/`Label`/`If`/`FuncDef`/`Limit` arms elsewhere in this
-        // function. `Comma` escaped it by combining each branch with `rest`
-        // instead (#1509) -- a trick that doesn't carry over to constructs
-        // that scope something `rest` must stay outside of, since it would
-        // let `rest`'s own errors be caught by `try`'s handler or `label`'s
-        // break scope. Those arms instead keep isolating and append
-        // `path_probe_stage`'s `[path, .]` inside the isolated pipe
-        // (#1409), which would work here too -- but adopting it for
-        // `Optional` also stops `rest` inheriting this arm's suppression,
-        // an evaluator-wide model change #1826/#1869 both build on, so it
-        // is deliberately left for its own change -- #2073, which also
-        // records what that suppression currently costs: `.a | (.[])? |
-        // (key, error("boom"))` swallows an error real jq raises. This arm
-        // must not regress the path threading meanwhile, so it only takes
-        // the fast, isolated path when `rest` doesn't consult path context
-        // in the first place, and otherwise falls back to evaluating
-        // `[inner, ...rest]` combined under a forced `optional=true` (this
-        // arm's pre-#1335 behavior), which still threads `current_path`
-        // correctly because it never leaves the same recursive call `Field`/
-        // `Index`/`Iterate` build `new_path` inside of. That fallback still
-        // carries the narrower, pre-existing "rest inherits suppression"
-        // gap #1335 fixes in the common case (also tracked in #1409), but
-        // that's strictly no worse than `main`'s current behavior for this
-        // rarer combination.
-        Expr::Optional(inner) if rest.is_empty() || !rest.iter().any(needs_path_context) => {
-            let inner_result = eval_pipe_with_path_context_internal::<W, S>(
-                core::slice::from_ref(inner),
+        // Each output continues `rest` from its own path, not this arm's
+        // ambient one -- see `path_probe_stage` (#1409), the same technique
+        // `Try`/`Label`/`If`/`Limit`/`FirstExpr` use: appending `[path, .]`
+        // *inside* the isolated pipe (only when `rest` needs it, `paired`
+        // below) recovers each output's true `current_path` without ever
+        // leaving `inner`'s isolation, so `.a | (.[])? | key` still reports
+        // each element's own index (`0`, `1`, `2`) instead of one stale
+        // pre-`inner` path.
+        //
+        // `rest` always continues with the *ambient* `optional` this arm
+        // itself received, never a forced `true` (#2073). The arm used to
+        // fall back to evaluating `[inner, ...rest]` combined under a
+        // forced `optional=true` whenever `rest` needed path context (#1335's
+        // fix for the common, non-path-context case, extended no further)
+        // -- correct for path threading, since it never left the one
+        // recursive call `Field`/`Index`/`Iterate` build `new_path` inside
+        // of, but it also meant `optional=true` rode downstream as an
+        // ordinary parameter into the whole of `rest`'s evaluation tree, so
+        // any of that construct's own `if optional` leaf checks could
+        // swallow an error with nothing to do with this `?`: `.a | (.[])? |
+        // (key, error("boom"))` swallowed an error real jq raises. `Comma`
+        // could not have taken this isolating shape instead (combining each
+        // branch with `rest` is its own #1509 fix, since `,` genuinely
+        // distributes `rest` over every branch in real jq) but `?` is not
+        // `,` -- nothing about real jq's semantics has `rest` inherit a `?`
+        // several stages back. Isolating unconditionally, like `Try`/`Label`
+        // already do, removes the leak at its source instead of gating each
+        // leaf's self-check on where `optional` came from.
+        Expr::Optional(inner) => {
+            let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+            let inner_result = eval_stage_with_path_context::<W, S>(
+                inner,
+                &probe_stages(paired),
                 value,
                 root,
                 file_origin,
@@ -31679,27 +31674,27 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 other => other,
             };
             if rest.is_empty() {
-                caught
-            } else {
-                continue_rest_with_context::<W, S>(
+                return caught;
+            }
+            if paired {
+                return continue_rest_with_paths::<W, S>(
                     caught,
                     rest,
                     root,
                     file_origin,
                     current_path,
                     optional,
-                )
+                );
             }
+            continue_rest_with_context::<W, S>(
+                caught,
+                rest,
+                root,
+                file_origin,
+                current_path,
+                optional,
+            )
         }
-        Expr::Optional(inner) => eval_stage_with_path_context::<W, S>(
-            inner,
-            rest,
-            value,
-            root,
-            file_origin,
-            current_path,
-            true,
-        ),
         // Flatten a nested pipe into this one. A `Pipe` prepends its whole
         // stage list rather than a single stage, so it is the one arm the
         // #1510 borrow cannot serve in general: `[i0..in] ++ rest` is two

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30090,6 +30090,17 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 /// hand, makes that gap structurally impossible to reintroduce at a future
 /// call site.
 ///
+/// **`optional` is currently always `false` at every call site reachable from
+/// the path-context evaluator (#2212).** #2073 removed `Expr::Optional`'s
+/// combined-with-`rest` fallback, which was the last thing that produced an
+/// `optional == true` in there, so the three cells below that consult it are
+/// live only through this function's own unit test
+/// (`test_catch_error_under_optional_full_truth_table_1888`) -- which is
+/// therefore the sole load-bearing test for the truth table, not a
+/// belt-and-braces duplicate of an end-to-end one. Whether to delete the
+/// parameter or keep it as defence in depth is #2212's call; until then, do
+/// not cite these cells as evidence of live behaviour.
+///
 /// The prefix lives *inside* the matched `Partial` pattern, not in a
 /// separately-passed accumulator: `accumulate_path_context_step` already
 /// moved the caller's own `results` `Vec` into that `Partial` via
@@ -30138,9 +30149,10 @@ fn catch_error_under_optional<W>(
 /// result back out over `rest` the same way `Iterate` does above. Shared by
 /// `If`/`Try`/`Label` below to avoid re-deriving this fan-out loop at each
 /// call site (`Comma` used to as well, until #1409 moved it onto the
-/// combine-with-`rest` idiom `Optional`/`Pipe` already use, since threading
-/// one ambient `current_path` through every comma branch lost each
-/// branch's own per-output path).
+/// combine-with-`rest` idiom `Pipe` uses, since threading one ambient
+/// `current_path` through every comma branch lost each branch's own
+/// per-output path. `Optional` shared that idiom too until #2073 moved it
+/// onto the isolate-and-probe shape `Try`/`Label` use).
 fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     intermediate: QueryResult<'a, W>,
     rest: &[Expr],
@@ -31448,33 +31460,35 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // arm's existing (#1302/#1826) response to this exact ambient
             // shape.
             //
-            // That still isn't full jq parity for this exact query, and
-            // isn't meant to be: real jq's equivalent (`.a | .[] | if
-            // .==2 then error("boom") else . end` on `[1,2,3]`, confirmed
-            // live against jq 1.7.1) emits `1` then *errors*, whether or
-            // not an unrelated `?` sits earlier in the pipe, because `?`
-            // only catches an error raised *inside* what it directly
-            // wraps. Here, `(.a)?` only wraps `.a`; `.[] | ...` is a
-            // separate downstream stage `?` was never meant to reach. It
-            // reaches this arm's `optional=true` only because `key` makes
-            // `needs_path_context(rest)` true, routing through the
-            // `Expr::Optional` arm's slower "combine `[inner, ...rest]`,
-            // evaluate under a forced ambient `optional=true`" fallback a
-            // few arms below (rather than its faster, correct, isolated
-            // path) -- the same pre-existing #1335 "rest inherits
-            // suppression" gap already present, unchanged, in `Array`'s
-            // and `Map`'s own #1302/#1826 fixes (confirmed live: both
-            // `(.a)? | [.[] | if key==1 then error("boom") end]` and
-            // `(.a)? | map(if key==1 then error("boom") else key end)`
-            // also silently exit 0 with no error, on the same input).
-            // Closing that gap needs #1335's own architecture fix (a way
-            // to tell "there's a literal `?` right here" apart from
-            // "`optional` merely bled in from an unrelated earlier
-            // stage"), not another per-construct patch here -- this fix's
-            // job is only to make `Iterate`'s *response* to `optional`
-            // (however it arrived) consistent with every sibling arm's,
-            // not to independently re-litigate whether it should have
-            // arrived at all.
+            // #2073 has since closed the wider gap that repro depended on.
+            // The ambient `optional=true` only ever reached this arm
+            // because `key` made `needs_path_context(rest)` true, routing
+            // through the `Expr::Optional` arm's old "combine
+            // `[inner, ...rest]`, evaluate under a forced ambient
+            // `optional=true`" fallback a few arms below. That fallback is
+            // gone: `Expr::Optional` now isolates `inner` unconditionally,
+            // so `rest` continues with the ambient `optional` it entered
+            // with and never inherits a `?` several stages back. The same
+            // query now emits `0` and then *errors* (exit 5), which is full
+            // jq parity -- real jq's equivalent (`.a | .[] | if .==2 then
+            // error("boom") else . end` on `[1,2,3]`, confirmed live
+            // against jq 1.7.1) emits `1` then errors too, because `?` only
+            // catches an error raised *inside* what it directly wraps, and
+            // `(.a)?` only wraps `.a`. `Array`'s and `Map`'s own
+            // #1302/#1826 repros converged the same way (confirmed live
+            // post-#2073: both `(.a)? | [.[] | if key==1 then
+            // error("boom") end]` and `(.a)? | map(if key==1 then
+            // error("boom") else key end)` now exit 5 on the same input,
+            // where they used to exit 0 with no error).
+            //
+            // Consequence, tracked in #2212: with that fallback gone,
+            // nothing left in this evaluator produces `optional == true`,
+            // so this arm's force-`false` is a no-op and the catch below
+            // never takes its `optional` branch. The forcing is kept as
+            // defence in depth -- it is what makes the arm's response
+            // depend on its own structure rather than on an ambient flag --
+            // but do not read the `optional == true` cells below as live
+            // behaviour without re-checking #2212 first.
             //
             // Unlike `Array`/`Map`, `Iterate` is not a constructor -- there
             // is no atomic "discard the whole in-progress collection"
@@ -31486,11 +31500,13 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // `Halt` are never caught by this arm's ambient `optional` at
             // all, even when it's `true` -- unlike `Optional`'s own arm
             // (which only ever runs when there's a literal `?` right here,
-            // so unconditional catching is correct there), an ambient
-            // `optional` reaching `Iterate` can come from an *unrelated*
-            // enclosing `?` bleeding through `rest` (the same #1335 gap
-            // above), and a `break`'s label target is lexically scoped,
-            // never something an unrelated ancestor's `?` may intercept.
+            // so unconditional catching is correct there), this arm cannot
+            // tell a `?` that genuinely wraps it from one that merely sits
+            // somewhere above it, and a `break`'s label target is lexically
+            // scoped, never something an unrelated ancestor's `?` may
+            // intercept. #1335 was the route that made that distinction
+            // matter in practice; #2073 removed it, but the conservative
+            // rule stands on its own.
             // Both fall through `Some(other) => other` unchanged,
             // preserving whatever prefix `accumulate_path_context_step`
             // already attached (#400/#494).
@@ -43122,6 +43138,18 @@ mod tests {
         );
     }
 
+    /// Every `(atomic, optional)` cell of [`catch_error_under_optional`],
+    /// plus the bare-`Error` and `Break`/`Halt` shapes around them.
+    ///
+    /// Since #2073 this is the *only* test that reaches the helper's
+    /// `optional == true` cells at all: that fix removed
+    /// `Expr::Optional`'s combined-with-`rest` fallback, and with it the
+    /// last producer of an ambient `optional == true` anywhere inside the
+    /// path-context evaluator, so #1826's and #1869's own end-to-end tests
+    /// now exercise the `false` column instead (#2212 tracks whether the
+    /// parameter should survive at all). Deleting or weakening a row here
+    /// therefore removes the last check on that behaviour rather than a
+    /// duplicate of an integration test's.
     #[test]
     fn test_catch_error_under_optional_full_truth_table_1888() {
         type W = Vec<u64>;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8582,6 +8582,73 @@ fn test_optional_ambient_no_longer_suppresses_rest_error_2073() -> Result<()> {
     Ok(())
 }
 
+/// #2073 side effect, characterized rather than fixed: isolating `inner`
+/// unconditionally changes what a path-context `rest` sees after a
+/// *missing* field -- a shape with no error in it anywhere, so nothing about
+/// `?`'s own suppression applies.
+///
+/// `Expr::Field`'s missing-key arm returns `QueryResult::Owned(Null)`
+/// without running `rest` and without threading the `new_path` it just
+/// built. Under the old combined-with-`rest` route that early return
+/// swallowed the whole downstream pipe, so `| key` never ran and `.zz`'s own
+/// `null` leaked out as the final output. Under isolation the probe never
+/// runs either, so `split_probe_pair` takes its fallback branch and `rest`
+/// continues from the *stale*, pre-`inner` path -- reporting the parent's
+/// key.
+///
+/// Both answers are wrong: `path(.b.zz)` is `["b","zz"]` in succinctly and
+/// in real jq 1.7.1 alike, so `"zz"` is what all of these should say. The
+/// value pinned below is the one that makes `?` agree with the five sibling
+/// isolating constructs, which have reported the stale key since #1409 and
+/// are unaffected by #2073 -- checked here alongside it so a future fix for
+/// #2213 moves all six together or fails loudly.
+#[test]
+fn test_optional_missing_field_reports_stale_path_like_its_siblings_2213() -> Result<()> {
+    let input = r#"{"b":{"x":1}}"#;
+
+    // The `?` case #2073 moved: `null` (rest skipped) before, the stale
+    // parent key now.
+    let (stdout, _, code) = run_jq_full(&["-c", ".b | (.zz)? | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"b\"\n");
+
+    // `rest` genuinely runs now, where the old route dropped it entirely --
+    // the second output is what proves it, not just the changed first one.
+    let (stdout, _, code) = run_jq_full(&["-c", ".b | (.zz)? | (key, 1)"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"b\"\n1\n");
+
+    // The five sibling isolating constructs, unchanged by #2073 and already
+    // reporting the same stale key on `main`. A fix for #2213 should move
+    // every one of these to `"zz"` at once.
+    for query in [
+        ".b | (try .zz) | key",
+        ".b | (try .zz catch \"c\") | key",
+        ".b | (label $o | .zz) | key",
+        ".b | (if true then .zz else empty end) | key",
+        ".b | (first(.zz)) | key",
+    ] {
+        let (stdout, _, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(code, 0, "query: {query}");
+        assert_eq!(stdout, "\"b\"\n", "query: {query}");
+    }
+
+    // The plain pipe keeps the *other* wrong answer -- `.zz`'s own `null`,
+    // with `| key` never having run. Pinned so #2213's fix has to address
+    // this spelling too, not just the isolating ones.
+    let (stdout, _, code) = run_jq_full(&["-c", ".b | .zz | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "null\n");
+
+    // What all seven should agree on, and the reason `"zz"` is the target:
+    // the path itself is right, and matches real jq 1.7.1.
+    let (stdout, _, code) = run_jq_full(&["-c", "[path(.b.zz)]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"b\",\"zz\"]]\n");
+
+    Ok(())
+}
+
 /// `?` on a bare bracket guards only the final index/slice step, never the
 /// bracket's own key/bounds sub-expression -- in path-context evaluation too
 /// (#1410).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7801,79 +7801,86 @@ fn test_array_wrapped_path_context_builtin_optional_is_atomic_1302() -> Result<(
     Ok(())
 }
 
-/// #1826: `Builtin::Map(f)`'s path-context arm claimed the same
-/// array-construction atomicity `Expr::Array`'s arm above earns via #1302's
-/// fix, but never actually got it -- it passed the *ambient* `optional`
-/// straight into each element's own evaluation instead of forcing `false`
-/// and self-catching. An ambient `optional` (from an earlier `?` in the
-/// same pipe, still threaded downstream per this evaluator's model -- see
-/// `test_optional_dispatch_catches_atomically_not_broadcast_1335` below)
-/// let a genuine per-element error self-swallow into "no output for this
-/// element" before the array-level atomicity match ever saw it, silently
-/// *skipping* the erroring element instead of discarding the whole `map()`
-/// -- confirmed live pre-fix: `(.a)? | map(if key==1 then error("boom")
-/// else key end)` on `{"a":[1,2,3]}` produced `[0,2]`, where the
-/// structurally-identical `(.a)? | [.[] | if key==1 then error("boom") else
-/// key end]` already correctly produced nothing. Unlike #1302's own
-/// direct-`?`-on-the-construction repro, this one needs the *ambient*
-/// form (`?` on an earlier stage, `map(...)` unwrapped in `rest`) --
-/// `.a | map(...)?` (mirroring #1302's own test shape) does not reach the
-/// buggy code path at all, since that shape's `?` isolates with its own
-/// forced `false` via a different (already-correct) dispatch.
+/// #1826 originally found that `Builtin::Map(f)`'s path-context arm claimed
+/// the same array-construction atomicity `Expr::Array`'s arm above earns via
+/// #1302's fix, but never actually got it -- it passed the *ambient*
+/// `optional` straight into each element's own evaluation instead of
+/// forcing `false` and self-catching. Pre-#1826 that let a genuine
+/// per-element error self-swallow into "no output for this element" before
+/// the array-level atomicity match ever saw it, silently *skipping* the
+/// erroring element instead of discarding the whole `map()` -- confirmed
+/// live pre-fix: `(.a)? | map(if key==1 then error("boom") else key end)`
+/// on `{"a":[1,2,3]}` produced `[0,2]`.
+///
+/// #2073 then closed the wider gap #1826's own fix was built on top of: an
+/// ambient `optional` from an earlier `?` in the same pipe no longer
+/// threads into `rest`'s evaluation at all (`Expr::Optional`'s arm now
+/// isolates and catches `?`'s own `inner` unconditionally, exactly like
+/// `Try`/`Label`). So every "ambient `?`" case below no longer reaches
+/// `map`'s atomicity match under a suppressing `optional` in the first
+/// place -- `map`'s error now escapes as an ordinary hard error, same as
+/// the pre-existing "no ambient `?`" case already covered here. `map(f)`'s
+/// own atomicity (the #1302/#1826 fix this test originally pinned) still
+/// applies to its *direct*-attach shape, `map(...)?`, unaffected by #2073 --
+/// covered by `test_optional_dispatch_catches_atomically_not_broadcast_1335`
+/// below.
 #[test]
 fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
-    // Array target: the erroring element must discard the whole map, not
-    // just itself.
-    let (stdout, _, code) = run_jq_full(
+    // Array target: an earlier, unrelated `?` must not suppress `map`'s own
+    // error.
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | map(if key==1 then error(\"boom\") else key end)",
         ],
         Some(r#"{"a":[1,2,3]}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    // Object target: same atomicity, `key` reporting the string key instead
-    // of an index.
-    let (stdout, _, code) = run_jq_full(
+    // Object target: same shape, `key` reporting the string key instead of
+    // an index.
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | map(if key==\"y\" then error(\"boom\") else key end)",
         ],
         Some(r#"{"a":{"x":1,"y":2}}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     // The *first* element/entry erroring, not a later one: code review
     // caught that `partial()` (#400/#494) collapses an *empty* accumulated
     // prefix to a bare `Error`, not `Partial(_, Error)` -- a first-fix draft
     // matched only the `Partial` shape here, so this exact case (nothing
-    // accumulated yet when the error hits) fell through unguarded and still
-    // hard-errored instead of producing no output.
-    let (stdout, _, code) = run_jq_full(
+    // accumulated yet when the error hits) fell through unguarded.
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | map(if key==0 then error(\"boom\") else key end)",
         ],
         Some(r#"{"a":[1,2,3]}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    let (stdout, _, code) = run_jq_full(
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | map(if key==\"x\" then error(\"boom\") else key end)",
         ],
         Some(r#"{"a":{"x":1,"y":2}}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    // Without any ambient `?`, the same query still hard-errors -- the fix
-    // must not accidentally make every error inside `map()` vanish.
+    // Without any ambient `?`, the same query still hard-errors -- unchanged
+    // baseline this must agree with.
     let (_stdout, stderr, code) = run_jq_full(
         &[
             "-c",
@@ -7884,8 +7891,8 @@ fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
     assert_eq!(code, 5);
     assert!(stderr.contains("boom"), "stderr: {stderr}");
 
-    // Sibling positive case: a `map()` that never errors is unaffected by
-    // the ambient `optional`, and `rest` after it still runs normally.
+    // Sibling positive case: a `map()` that never errors is unaffected, and
+    // `rest` after it still runs normally.
     let (stdout, _, code) = run_jq_full(
         &["-c", "(.a)? | map(key) | length"],
         Some(r#"{"a":[1,2,3]}"#),
@@ -7896,59 +7903,69 @@ fn test_map_path_context_builtin_optional_is_atomic_1826() -> Result<()> {
     Ok(())
 }
 
-/// #1869: the identical bug class as #1826/#1302, but for `Expr::Iterate`'s
-/// own path-context arm (bare `.[]`, not `map(f)`). Confirmed live pre-fix:
-/// `(.a)? | .[] | if key==1 then error("boom") else key end` on
-/// `{"a":[1,2,3]}` produced `0`/`2` -- the erroring element (1) silently
-/// *skipped* rather than aborting the traversal, since the ambient
+/// #1869 originally found the identical bug class as #1826/#1302, but for
+/// `Expr::Iterate`'s own path-context arm (bare `.[]`, not `map(f)`).
+/// Confirmed live pre-fix: `(.a)? | .[] | if key==1 then error("boom") else
+/// key end` on `{"a":[1,2,3]}` produced `0`/`2` -- the erroring element (1)
+/// silently *skipped* rather than aborting the traversal, since the ambient
 /// `optional` reached each element's own recursive evaluation instead of
 /// being forced to `false` and self-caught at this arm's own level.
 ///
-/// Unlike `Array`/`Map`, `Iterate` is not a constructor -- there's no
-/// atomic in-progress collection to discard wholesale, so the fix keeps
-/// whatever prefix was already produced before the error (real jq's own
-/// `(1, 2, error("x"))?`-style "keep everything before the catch" model,
-/// #1335) rather than discarding it to nothing the way `map()`'s own fix
-/// does.
+/// #2073 then closed the wider gap #1869's own fix was built on top of: an
+/// ambient `optional` from an earlier `?` in the same pipe no longer
+/// threads into `rest`'s evaluation at all (`Expr::Optional`'s arm now
+/// isolates and catches `?`'s own `inner` unconditionally, exactly like
+/// `Try`/`Label`). So every "ambient `?`" case below no longer suppresses
+/// `.[]`'s error at all -- it now escapes as an ordinary hard error, same as
+/// the pre-existing "no ambient `?`" case already covered here. The
+/// *prefix-keeping* half of #1869's fix (unlike `Array`/`Map`, `Iterate` is
+/// not a constructor, so there's no atomic in-progress collection to
+/// discard wholesale) is unaffected by #2073 and still holds: real jq's own
+/// `(1, 2, error("x"))?`-style "keep everything before the catch" model
+/// applies just the same whether the error is ultimately caught by an
+/// enclosing `?` (uncommon here now) or escapes uncaught (every case below).
 #[test]
 fn test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869() -> Result<()> {
     // Array target: element 0 succeeds and is kept; element 1 errors and
-    // stops the traversal (element 2 must never run) -- not "skip 1, keep
-    // going to 2".
-    let (stdout, _, code) = run_jq_full(
+    // aborts the traversal (element 2 must never run) -- not "skip 1, keep
+    // going to 2". An earlier, unrelated `?` does not suppress this error.
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | .[] | if key==1 then error(\"boom\") else key end",
         ],
         Some(r#"{"a":[1,2,3]}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     // Object target: same shape, `key` reporting the string key.
-    let (stdout, _, code) = run_jq_full(
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | .[] | if key==\"y\" then error(\"boom\") else key end",
         ],
         Some(r#"{"a":{"x":1,"y":2,"z":3}}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "\"x\"\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     // The *first* element/entry erroring: `partial()` (#400/#494) collapses
-    // an empty accumulated prefix to a bare `Error`, which this arm's own
-    // `if optional` gate must still catch (not just the `Partial` shape) --
-    // #1826's review caught the same gap for `map()`.
-    let (stdout, _, code) = run_jq_full(
+    // an empty accumulated prefix to a bare `Error`, which this arm must
+    // still propagate correctly (not just the `Partial` shape) -- #1826's
+    // review caught the analogous gap for `map()`.
+    let (stdout, stderr, code) = run_jq_full(
         &[
             "-c",
             "(.a)? | .[] | if key==0 then error(\"boom\") else key end",
         ],
         Some(r#"{"a":[1,2,3]}"#),
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 5);
     assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     // Without any ambient `?`, the same query still hard-errors, keeping
     // the pre-error prefix on stdout -- matches real jq's own equivalent
@@ -8235,10 +8252,17 @@ fn test_string_interpolation_path_context_fanout_continues_rest_1403() -> Result
 
     // `?` wraps only the interpolation, with a downstream `| key` still
     // needing path context -- routes through the general `Expr::Optional`
-    // arm's *other* branch (rest non-empty, needs path context), which
-    // flattens and threads `optional=true` straight into this arm instead
-    // of catching externally the way the tail-position `?` cases above do.
-    // Exercises this arm's own `optional`-gated catch directly.
+    // arm's `paired` branch (#2073): the interpolation is isolated and
+    // evaluated with `optional` forced to `false`, so its own `if optional`
+    // swallow-gate (`StringInterpolation`'s own arm) no longer fires -- the
+    // interior error now escapes as a `Partial(out, Error)` instead, caught
+    // structurally by `Expr::Optional`'s own arm one level up (not by an
+    // ambient `optional` reaching this arm's internal gate, the pre-#2073
+    // mechanism). Same already-built prefix (`out`) either way, still paired
+    // with the *fresh, empty* path a built string always continues `rest`
+    // from (`continue_rest_with_fresh_root` -- a string is not a document
+    // node), so `key` after the `?` still resolves against that empty path
+    // and still yields `null`, matching the tail-position `?` cases above.
     let (stdout, _, code) = run_jq_full(
         &["-c", ".a | (\"\\(key, error(\"boom\"))\")? | key"],
         Some(r#"{"a":1}"#),
@@ -8529,6 +8553,31 @@ fn test_optional_wrapped_navigation_still_threads_path_into_rest_1335() -> Resul
     let (stdout, _, code) = run_jq_full(&["-c", ".a | .[] | key"], Some(r#"{"a":[10,20,30]}"#))?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "0\n1\n2");
+
+    Ok(())
+}
+
+/// #2073's own repro: `?` must suppress only the expression it directly
+/// wraps, never a *later* pipe stage's own error -- even when that later
+/// stage needs path context, the one case `Expr::Optional`'s arm got wrong.
+/// Before the fix, `rest` needing path context (here, `key`) routed through
+/// a combined-with-`rest` fallback under a forced `optional=true`, so
+/// `error("boom")` -- several stages downstream of the `?`, and entirely
+/// unrelated to it -- self-swallowed via `Comma`'s own `if optional` check:
+/// confirmed live pre-fix this printed `0` and exited 0. Real jq prints `0`
+/// then hard-errors, exit 5 (`?` only wraps `(.[])`, not the comma after
+/// it) -- matching `test_optional_wrapped_navigation_still_threads_path_into_rest_1335`
+/// above, which pins that the *path threading* this fix depends on
+/// (`path_probe_stage`, #1409) still works for this exact shape.
+#[test]
+fn test_optional_ambient_no_longer_suppresses_rest_error_2073() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".a | (.[])? | (key, error(\"boom\"))"],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert_eq!(stdout, "0\n");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
 
     Ok(())
 }
@@ -14025,17 +14074,18 @@ fn test_parent_n_argument_still_swallows_ordinary_error_under_optional() -> Resu
 }
 
 /// Same swallow as the test above, but with a trailing `| key` that still
-/// needs path context, so `optional=true` threads straight into `ParentN`'s
-/// own `n` evaluation (`eval_owned_expr_opt`) instead of being caught by an
-/// external `Expr::Optional` wrapper (the `rest.is_empty()` case the test
-/// above exercises). `error(...)`'s own evaluation (`eval_error`) already
-/// self-swallows to `QueryResult::None` whenever the ambient `optional` is
-/// true -- before the error ever reaches `eval_owned_expr_opt`'s own
-/// `Err(EvalEscape::Error(_)) if optional` guard -- so this still confirms
-/// the observable swallow-through-rest behavior, even though (per
-/// investigation) that specific guard line appears unreachable today: no
-/// error-raising path in this evaluator currently propagates an `Err` all
-/// the way up while `optional` is `true`.
+/// needs path context. Before #2073, `optional=true` threaded straight into
+/// `ParentN`'s own `n` evaluation (`eval_owned_expr_opt`) via this arm's old
+/// combined-with-`rest` fallback, rather than being caught by an isolated
+/// `Expr::Optional` wrapper (the `rest.is_empty()` case the test above
+/// exercises). #2073 removed that fallback -- `Expr::Optional` now isolates
+/// `inner` (`parent(has(error("x")))`) unconditionally with `optional`
+/// forced `false`, so the error inside it escapes as a genuine `Err`/
+/// `QueryResult::Error` and is caught structurally by `Expr::Optional`'s own
+/// arm instead, one level up from `ParentN`'s own match. The observable
+/// result is unchanged (still empty output, no error) since the error
+/// originates *inside* what the `?` directly wraps either way -- only the
+/// mechanism moved.
 #[test]
 fn test_parent_n_argument_error_swallow_threaded_through_rest() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -22402,13 +22452,18 @@ fn test_path_context_parent_n_argument_wrong_type_optional_1280() -> Result<()> 
     Ok(())
 }
 
-/// Same `Ok(Some(_)) if optional` swallow as the test above, but reached
-/// via `Expr::Optional`'s *other* routing branch: `key` after the `?`
-/// still needs path context, so `optional=true` threads straight into
-/// `ParentN`'s own match instead of being caught by an external wrapper
-/// (mirrors `test_string_interpolation_path_context_fanout_continues_rest_1403`'s
+/// Same `Ok(Some(_)) if optional` swallow as the test above, but reached via
+/// `Expr::Optional`'s `paired` routing (`key` after the `?` needs path
+/// context). Before #2073 this arm's old combined-with-`rest` fallback
+/// threaded `optional=true` straight into `ParentN`'s own match; #2073
+/// removed that fallback, so `ParentN`'s `n` argument now evaluates with
+/// `optional` forced `false` and its type mismatch escapes as a genuine
+/// error instead, caught structurally by `Expr::Optional`'s own arm one
+/// level up (mirrors
+/// `test_string_interpolation_path_context_fanout_continues_rest_1403`'s
 /// identical `? | key`-shaped case for the sibling `StringInterpolation`
-/// arm).
+/// arm). Same observable swallow-to-empty either way, since the type
+/// mismatch is inside what the `?` directly wraps.
 #[test]
 fn test_path_context_parent_n_argument_wrong_type_optional_threaded_through_rest_1280() -> Result<()>
 {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1521,17 +1521,22 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
 /// lives in `eval_pipe_with_path_context_internal`, generic over
 /// `EvalSemantics` and shared verbatim by both modes -- `key` (a jq-mode
 /// path-context builtin) reaches it in yq mode too, once gated open via
-/// `--jq-extensions`. Confirms the same fixed behavior here: the erroring
-/// element (1) stops the traversal and keeps the pre-error prefix, rather
-/// than the pre-fix bug's silent skip-and-continue.
+/// `--jq-extensions`. #2073 then closed the wider gap #1869's own fix was
+/// built on top of (see the jq-mode test's own updated doc comment): an
+/// ambient `?` from an earlier stage no longer threads into `rest`'s
+/// evaluation at all, so the erroring element's error now escapes as an
+/// ordinary hard error instead of being swallowed. The prefix-keeping half
+/// of #1869's fix is unaffected and still holds here: the erroring element
+/// (1) still stops the traversal and keeps the pre-error prefix.
 #[test]
 fn test_yq_iterate_path_context_ambient_optional_keeps_prefix_1869() -> Result<()> {
-    let (stdout, code) = run_yq_stdin(
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
         "(.a)? | .[] | if key==1 then error(\"boom\") else key end",
         "a:\n  - 1\n  - 2\n  - 3\n",
         &["--jq-extensions", "-o", "json"],
     )?;
-    assert_eq!(code, 0);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
     assert_eq!(stdout, "0\n");
     Ok(())
 }
@@ -1561,6 +1566,26 @@ fn test_yq_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "\"a\"");
+
+    Ok(())
+}
+
+/// #2073's own repro, yq-mode twin of jq_cli_tests.rs's own
+/// `test_optional_ambient_no_longer_suppresses_rest_error_2073` -- the fixed
+/// arm lives in `eval_pipe_with_path_context_internal`, generic over
+/// `EvalSemantics` and shared verbatim by both modes. Before the fix this
+/// printed `0` and exited 0, silently suppressing `error("boom")` even
+/// though it is several stages downstream of the `?`, not inside it.
+#[test]
+fn test_yq_optional_ambient_no_longer_suppresses_rest_error_2073() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
+        r#".a | (.[])? | (key, error("boom"))"#,
+        "a:\n  - 1\n  - 2\n  - 3\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert_eq!(stdout, "0\n");
 
     Ok(())
 }
@@ -24361,17 +24386,23 @@ fn test_yq_string_interpolation_path_context_control_flow_is_atomic_1403() -> Re
 }
 
 /// `?` wraps only the interpolation, with a downstream `| key` still
-/// needing path context -- flattens through the general `Expr::Optional`
-/// arm's rest-non-empty branch, threading `optional=true` straight into
-/// this yq-only match, exercising its own `if optional` arm directly.
-/// Unlike the jq-mode counterpart
+/// needing path context. Before #2073, this routed through the general
+/// `Expr::Optional` arm's old combined-with-`rest` fallback, threading
+/// `optional=true` straight into this yq-only match's own `if optional`
+/// arm, which returns `QueryResult::None` as the whole match arm's result --
+/// `rest` (the flattened-in `key`) never ran at all, since there is no
+/// separate rest-continuation step here the way `continue_rest_with_fresh_root`
+/// gives the jq-mode path. #2073 removed that fallback: `Expr::Optional` now
+/// isolates the interpolation unconditionally with `optional` forced
+/// `false`, so this yq-only match's second slot (`error("boom")`) now
+/// propagates a genuine `QueryResult::Error` instead of self-swallowing, and
+/// `Expr::Optional`'s own arm catches it structurally one level up -- with
+/// nothing produced to feed into `rest`, `key` still never runs against a
+/// real value. Same empty output either way (confirmed live that the query
+/// below is empty, not `null`, unlike the jq-mode counterpart
 /// (`test_string_interpolation_path_context_fanout_continues_rest_1403`'s
-/// final case, which still runs `| key` against the fanned-out result),
-/// this arm's `if optional` catch returns `QueryResult::None` as the whole
-/// match arm's result -- `rest` (the flattened-in `key`) never runs at
-/// all, since there is no separate rest-continuation step here the way
-/// `continue_rest_with_fresh_root` gives the jq-mode path: confirmed live
-/// that the query below is empty, not `null`.
+/// final case), since yq mode's `StringInterpolation` arm has no
+/// `continue_rest_with_fresh_root`-style path to fall back to.
 #[test]
 fn test_yq_string_interpolation_path_context_optional_threaded_through_rest_1403() -> Result<()> {
     let (output, code) = run_yq_stdin(


### PR DESCRIPTION
## Summary

- `Expr::Optional`'s path-context arm (`eval_pipe_with_path_context_internal`) fell back to evaluating `[inner, ...rest]` combined under a forced `optional=true` whenever `rest` needed path context (`key`/`parent`/...), so the flag rode downstream as an ordinary parameter into `rest`'s whole evaluation tree and could swallow an error with nothing to do with the `?` several stages earlier (`.a | (.[])? | (key, error("boom"))` silently swallowed the error; real jq hard-errors, exit 5).
- Isolates `inner` unconditionally instead, exactly like the `Try`/`Label` arms already do, using `path_probe_stage` (#1409) to keep per-output path threading correct. `rest` now always continues with the *ambient* `optional` the arm itself received, never a forced one.
- Follow-up commit addresses review findings: retires now-dead ambient-optional machinery (`optional` is provably always `false` inside the path-context evaluator post-fix), fixes stale doc comments describing the removed mechanism, and records/files three deferred follow-ups (#2212, #2213, #2214) rather than silently expanding this fix's scope.

## Test plan

- [x] `test_map_path_context_builtin_optional_is_atomic_1826` / `test_iterate_path_context_ambient_optional_keeps_prefix_not_skip_1869` (+ yq twin) updated to oracle-verified (jq 1.7.1) post-fix values
- [x] New regression tests pin the issue's own repro directly, jq and yq modes
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests`: 1277 + 1368 passed
- [x] `cargo test --features cli,simd,regex,serde --lib`: 3314 passed
- [x] `cargo test` (default features) and `cargo test --no-default-features` (no_std): passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] Live-verified the issue's own repro now hard-errors (exit 5) with correct partial output, and existing path-threading coverage (`.a | (.[])? | key`) is unregressed

Closes #2073.