### PR TITLE
fix(jq): thread path context through computed brackets

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31398,45 +31398,23 @@ fn eval_slice_bound_with_path_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>
     Ok((converted, escape))
 }
 
-/// [`eval_slice_expr`]'s path-context twin (#2100): reproduces its actual
-/// coded shape exactly (`S` outer / `T` middle / `E`=target inner; target
-/// evaluated *once* for the whole `(s,e)` cross-product, not once per pair
-/// -- confirmed by reading `eval_slice_expr` itself, not its own doc
-/// comment's more aspirational "E inner" phrasing) with path threading
-/// added: each successful `(s, e, target-output)` triple extends
-/// `current_path` by a `{"start":s,"end":e}` component -- built via the
-/// same `slice_component_value`/`numeric_slice_bound_key` pair `walk_path`/
-/// `navigation_element` already use for the *literal* slice case (#1326) --
-/// before continuing `rest`.
+/// [`eval_slice_expr`]'s path-context twin (#2100): reproduces its current
+/// coded shape (`S` outer, resolved once; `T`=`end` re-evaluated fresh for
+/// every `s`, #2225; `E`=`target` re-evaluated fresh for every `(s, e)`
+/// pair, #2143) with path threading added: each successful
+/// `(s, e, target-output)` triple extends `current_path` by a
+/// `{"start":s,"end":e}` component -- built via the same
+/// `slice_component_value`/`numeric_slice_bound_key` pair `walk_path`/
+/// `navigation_element`/the literal `Expr::Slice` path-context arm (#2215)
+/// already use -- before continuing `rest`.
 ///
-/// **This arm has no literal-slice counterpart, and that asymmetry is
-/// visible.** `eval_pipe_with_path_context_internal` has arms for
-/// `Expr::Identity`/`Field`/`Index`/`Iterate` but none for a literal
-/// `Expr::Slice`, which still falls to the catch-all and leaves
-/// `current_path` unextended. Before #2100 both spellings agreed (both
-/// lost the component); now the computed one is right -- it matches the
-/// `{"start":..,"end":..}` component `walk_path`/`path(.a[0:3])` already
-/// produce -- and the literal one is the outlier, so which answer you get
-/// depends on whether the parser happened to fold the bounds:
-///
-/// ```text
-/// .a | .[0:3]         | path  =>  ["a"]                          (folded to Expr::Slice)
-/// .a | .[(0,1):(3)]   | path  =>  ["a",{"start":0,"end":3}], ...  (stays Expr::SliceExpr)
-/// .a | .[(1.7):(2.2)] | path  =>  ["a",{"start":1.7,"end":2.2}]   (floats don't fold)
-/// ```
-///
-/// Fixing the literal arm is the follow-up (#2215) rather than part of
-/// this change: it belongs next to `Field`/`Index` in the pipe evaluator,
-/// not here, and unlike them it has no owned-value navigation helper to
-/// reuse yet.
-///
-/// A mid-loop `Err` from [`slice_owned_value_read`] discards whatever this
-/// call already accumulated and returns the bare error immediately --
-/// matching `eval_slice_expr`'s own `return e.into()`/`return
-/// QueryResult::Error(e)` arms exactly. This is *not* symmetric with
-/// [`eval_index_expr_with_path_context`]'s own keep-the-prefix behavior on a
-/// mid-loop error; that asymmetry already exists between the two plain
-/// evaluators and this fix preserves it rather than papering over it.
+/// A mid-loop `Err` from [`slice_owned_value_read`] keeps whatever this call
+/// already accumulated and folds it in as the escape's prefix, exactly like
+/// [`eval_index_expr_with_path_context`]'s own keep-the-prefix rule on a
+/// later key's index error -- matching `eval_slice_expr`'s own #2143-review
+/// fix, which eliminated the asymmetry an earlier version of this function
+/// used to preserve deliberately (a mid-loop slice error used to discard
+/// the prefix outright; both plain evaluator and this twin now keep it).
 #[allow(clippy::too_many_arguments)]
 fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     target: &Expr,
@@ -31467,97 +31445,91 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             Some(control) => partial(Vec::new(), control),
         };
     }
-    let (ends, ends_escape) = match eval_slice_bound_with_path_context::<W, S>(
-        end,
-        value,
-        root,
-        file_origin,
-        current_path,
-        f64::ceil,
-    ) {
-        Ok(v) => v,
-        Err(control) => return partial(Vec::new(), control),
-    };
-    let ends_escaped = ends_escape.is_some();
-    let bounds_escape = ends_escape.or(starts_escape);
-    if ends.is_empty() {
-        return match bounds_escape {
-            None => QueryResult::None,
-            Some(control) => partial(Vec::new(), control),
-        };
-    }
-    let starts_len = if ends_escaped { 1 } else { starts.len() };
-    let starts = &starts[..starts_len];
 
     let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-    let target_result = eval_stage_with_path_context::<W, S>(
-        target,
-        &probe_stages(paired),
-        value,
-        root,
-        file_origin,
-        current_path,
-        false,
-    );
-    let target_outputs = match target_result {
-        QueryResult::Owned(v) => vec![v],
-        QueryResult::ManyOwned(vs) => vs,
-        QueryResult::None => return QueryResult::None,
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        QueryResult::Break(label) => return QueryResult::Break(label),
-        QueryResult::Halt(code) => return QueryResult::Halt(code),
-        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
-        QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
-        QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
-        QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => unreachable!(
-            "eval_stage_with_path_context only ever produces \
-             Owned/ManyOwned/None/Error/Break/Halt/Partial"
-        ),
-    };
-    // `Some` exactly when `paired`, for the same reason
-    // [`eval_index_expr_with_path_context`] pairs its own target outputs
-    // that way: the unpaired case has no per-output path to carry, so it
-    // borrows the ambient `current_path` rather than copying it once per
-    // target output and then again per `(s, e, t)` triple below.
-    let target_pairs: Vec<(Option<Vec<OwnedValue>>, OwnedValue)> = target_outputs
-        .into_iter()
-        .map(|probed| {
-            if paired {
-                let (path, value) = split_probe_pair(probed, current_path);
-                (Some(path), value)
-            } else {
-                (None, probed)
-            }
-        })
-        .collect();
-
     let mut results: Vec<OwnedValue> = Vec::new();
-    for (s_raw, s) in starts {
+
+    for (s_raw, s) in &starts {
+        // #2225: `end` re-evaluated fresh for this `s`. An empty stream for
+        // this `s` contributes nothing and moves on to the next `s` --
+        // achieved here simply by the inner `for e in &ends` loop below not
+        // iterating, same as `eval_slice_expr`'s own equivalent.
+        let (ends, ends_escape) = match eval_slice_bound_with_path_context::<W, S>(
+            end,
+            value,
+            root,
+            file_origin,
+            current_path,
+            f64::ceil,
+        ) {
+            Ok(v) => v,
+            Err(control) => return partial(core::mem::take(&mut results), control),
+        };
         for (e_raw, e) in &ends {
-            for (target_path, t) in &target_pairs {
-                match slice_owned_value_read::<S>(t, *s, *e, bracket_optional) {
+            // #2143: `target` re-evaluated fresh for this `(s, e)` pair.
+            let target_result = eval_stage_with_path_context::<W, S>(
+                target,
+                &probe_stages(paired),
+                value,
+                root,
+                file_origin,
+                current_path,
+                false,
+            );
+            let target_outputs = match target_result {
+                QueryResult::Owned(v) => vec![v],
+                QueryResult::ManyOwned(vs) => vs,
+                // Zero outputs for *this* pair contributes nothing -- not
+                // every other pair is empty too (mirrors
+                // `eval_index_expr_with_path_context`'s identical
+                // per-key/per-pair treatment).
+                QueryResult::None => continue,
+                // Any target-level escape discards *this pair's* own target
+                // output and escapes immediately with whatever earlier
+                // pairs already accumulated.
+                QueryResult::Error(e) => {
+                    return partial(core::mem::take(&mut results), Control::Error(e));
+                }
+                QueryResult::Break(label) => {
+                    return partial(core::mem::take(&mut results), Control::Break(label));
+                }
+                QueryResult::Halt(code) => {
+                    return partial(core::mem::take(&mut results), Control::Halt(code));
+                }
+                QueryResult::Partial(_, control) => {
+                    return partial(core::mem::take(&mut results), control);
+                }
+                QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => {
+                    unreachable!(
+                        "eval_stage_with_path_context only ever produces \
+                         Owned/ManyOwned/None/Error/Break/Halt/Partial"
+                    )
+                }
+            };
+
+            for probed in target_outputs {
+                let (target_path, t) = if paired {
+                    split_probe_pair(probed, current_path)
+                } else {
+                    (current_path.to_vec(), probed)
+                };
+                match slice_owned_value_read::<S>(&t, *s, *e, bracket_optional) {
                     Ok(Some(v)) => {
-                        // The clone is genuinely needed in the paired case
-                        // -- `target_pairs` is reused across every `(s, e)`
-                        // pair, so the component can't be pushed in place --
-                        // but it is now charged only where something reads
-                        // it, not to the whole `S x E x T` product.
-                        let new_path = target_path.as_ref().map(|path| {
-                            let mut path = path.clone();
-                            path.push(slice_component_value(
+                        let mut new_path = target_path;
+                        if paired {
+                            new_path.push(slice_component_value(
                                 *s,
                                 numeric_slice_bound_key(s_raw).as_ref(),
                                 *e,
                                 numeric_slice_bound_key(e_raw).as_ref(),
                             ));
-                            path
-                        });
+                        }
                         let step = eval_pipe_with_path_context_internal::<W, S>(
                             rest,
                             &v,
                             root,
                             file_origin,
-                            new_path.as_deref().unwrap_or(current_path),
+                            &new_path,
                             rest_optional,
                         );
                         if let Some(stop) = accumulate_path_context_step(&mut results, step) {
@@ -31565,16 +31537,25 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                         }
                     }
                     Ok(None) => {}
-                    // Matches `eval_slice_expr`'s own mid-loop `Err` arms:
-                    // discards whatever this call already accumulated,
-                    // rather than `eval_index_expr`'s keep-the-prefix rule
-                    // -- see this function's own doc comment.
-                    Err(e) => return QueryResult::Error(e),
+                    // #2143 (review, mirrored): a later `(s, e)` pair's/
+                    // target's slice-application error must not discard
+                    // values already produced -- keeps the prefix, exactly
+                    // `eval_index_expr_with_path_context`'s identical rule
+                    // for a later key's index error.
+                    Err(e) => {
+                        return partial(core::mem::take(&mut results), Control::Error(e));
+                    }
                 }
             }
         }
+        // #2225: this `s`'s own `end` evaluation may have escaped after
+        // producing some values -- fold the running prefix in, same as
+        // every other per-iteration escape above.
+        if let Some(control) = ends_escape {
+            return partial(results, control);
+        }
     }
-    match bounds_escape {
+    match starts_escape {
         None => owned_vec_to_result(results),
         Some(control) => partial(results, control),
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31164,6 +31164,422 @@ fn eval_expr_needing_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     }
 }
 
+/// Classify a `QueryResult` already restricted to the
+/// `Owned|ManyOwned|None|Error|Break|Halt|Partial` set -- as every
+/// path-context evaluator function in this file produces -- into its output
+/// values plus an optional trailing escape. Shared by the key-materialization
+/// step in [`eval_index_expr_with_path_context`] and the bound-materialization
+/// step in [`eval_slice_bound_with_path_context`] (#2100), one definition
+/// instead of two independently hand-copied match blocks (CLAUDE.md:
+/// "duplicated predicates diverge silently", #106).
+///
+/// `Expr::Foreach`/`Expr::Reduce`'s own path-context arms still hand-roll
+/// this classification rather than calling here -- deliberately, for now:
+/// they diverge on the *bare* `Error`/`Break` variants, which they route
+/// through `suppress_or_raise`/`finish_fork` instead of folding into the
+/// escape slot, so converting them is a policy change rather than a
+/// cleanup. Tracked as #2216.
+fn drain_path_context_stream<W: Clone + AsRef<[u64]>>(
+    result: QueryResult<'_, W>,
+) -> (Vec<OwnedValue>, Option<Control>) {
+    match result {
+        QueryResult::Owned(v) => (vec![v], None),
+        QueryResult::ManyOwned(vs) => (vs, None),
+        QueryResult::None => (Vec::new(), None),
+        QueryResult::Error(e) => (Vec::new(), Some(Control::Error(e))),
+        QueryResult::Break(label) => (Vec::new(), Some(Control::Break(label))),
+        QueryResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
+        QueryResult::Partial(vs, control) => (vs, Some(control)),
+        QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => unreachable!(
+            "eval_expr_needing_path_context only ever produces \
+             Owned/ManyOwned/None/Error/Break/Halt/Partial"
+        ),
+    }
+}
+
+/// [`eval_index_expr`]'s path-context twin (#2100): reproduces its five
+/// documented properties (keys evaluated first at `optional: false`; target
+/// re-run fresh per key, #2032; `optional` reaching only `index_one_owned`;
+/// a later key's index error outranking an earlier key's `pending_halt`,
+/// #791/#400/#494/#1897) while additionally extending `current_path` by
+/// each resolved key before continuing `rest` -- the piece the plain
+/// evaluator has no notion of at all, which is what let `key`/`parent`/
+/// `file_index` silently stub or lose position across a computed bracket.
+///
+/// `key` is evaluated against `value`/`current_path` unchanged -- it's a
+/// sibling of `target`, not nested under it (`eval_index_expr`'s own doc
+/// comment, point 1). `target`'s own resolved *path* only needs computing
+/// when `rest` actually consumes it (`paired`, mirroring `Expr::Limit`'s own
+/// gate) -- probed via [`probe_stages`]/[`split_probe_pair`], the
+/// established idiom this file already uses for `Limit`/`FirstExpr`/
+/// `LastExpr`/`If`/`Try`/`Label`/`FuncDef`.
+///
+/// `bracket_optional` feeds only `index_one_owned`; `rest_optional` feeds
+/// only `rest`'s own continuation -- kept distinct so the `Expr::Optional`
+/// carve-out below can force the former to `true` without `rest` inheriting
+/// the bracket's own suppression (the unchanged rule #1410's own arm already
+/// established).
+#[allow(clippy::too_many_arguments)] // STYLE-0004: mirrors every path-context sibling in this file
+fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    target: &Expr,
+    key: &Expr,
+    rest: &[Expr],
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    bracket_optional: bool,
+    rest_optional: bool,
+) -> QueryResult<'a, W> {
+    // (1)/(3): keys first, at `optional: false`, against `value`'s own
+    // position -- current_path unchanged.
+    let key_result =
+        eval_expr_needing_path_context::<W, S>(key, value, root, file_origin, current_path, false);
+    let (keys, pending_halt): (Vec<OwnedValue>, Option<i32>) =
+        match drain_path_context_stream(key_result) {
+            (_, Some(Control::Error(e))) => return QueryResult::Error(e),
+            (_, Some(Control::Break(label))) => return QueryResult::Break(label),
+            // #791: keys already yielded before a halt still owe output.
+            (vs, Some(Control::Halt(code))) => (vs, Some(code)),
+            (vs, None) => (vs, None),
+        };
+    if keys.is_empty() {
+        // NOT `QueryResult::None`, the spelling `eval_index_expr` uses here.
+        // That function's own comment justifies the bare `None` with
+        // "`partial`'s invariant (a non-empty prefix by construction) means
+        // this is only reachable with `pending_halt` unset" -- true *there*,
+        // where a bare `QueryResult::Halt` returns from its own match arm
+        // before this check and only the `Partial(vs, Halt)` shape (whose
+        // `vs` is non-empty by construction) can set `pending_halt`. That
+        // invariant does not survive the port: `drain_path_context_stream`
+        // deliberately folds bare `Halt` and `Partial(_, Halt)` into one
+        // `(vs, Some(code))` arm, so an *empty* key stream can now arrive
+        // here carrying a live halt (`.[halt]`, `.[halt_error]`). Returning
+        // `None` swallowed it -- `[.a | .[halt_error] | key]` printed `[]`
+        // and exited 0 where the plain evaluator exits 5 with no stdout.
+        // `partial` collapses an empty prefix back to the bare
+        // `Halt`/`Error`/`Break`, which is exactly what the slice twin
+        // below already relies on for its own empty-bound short-circuits.
+        return match pending_halt {
+            Some(code) => partial(Vec::new(), Control::Halt(code)),
+            None => QueryResult::None,
+        };
+    }
+
+    let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+    let mut results: Vec<OwnedValue> = Vec::new();
+
+    for k in &keys {
+        // (2): target re-run fresh per key (#2032), always at `optional:
+        // false` regardless of `bracket_optional`.
+        let target_result = eval_stage_with_path_context::<W, S>(
+            target,
+            &probe_stages(paired),
+            value,
+            root,
+            file_origin,
+            current_path,
+            false,
+        );
+        let target_outputs = match target_result {
+            QueryResult::Owned(v) => vec![v],
+            QueryResult::ManyOwned(vs) => vs,
+            // Zero outputs for *this* key contributes nothing -- not every
+            // other key is empty too (#2032).
+            QueryResult::None => continue,
+            // Any target-level escape discards *this key's own* target
+            // output and escapes immediately with whatever earlier keys
+            // already accumulated -- matches `eval_index_expr`'s own
+            // `escape_with_prefix!` arms exactly.
+            QueryResult::Error(e) => {
+                return partial(core::mem::take(&mut results), Control::Error(e));
+            }
+            QueryResult::Break(label) => {
+                return partial(core::mem::take(&mut results), Control::Break(label));
+            }
+            QueryResult::Halt(code) => {
+                return partial(core::mem::take(&mut results), Control::Halt(code));
+            }
+            QueryResult::Partial(_, control) => {
+                return partial(core::mem::take(&mut results), control);
+            }
+            QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => unreachable!(
+                "eval_stage_with_path_context only ever produces \
+                 Owned/ManyOwned/None/Error/Break/Halt/Partial"
+            ),
+        };
+
+        for probed in target_outputs {
+            // `Some` exactly when `paired` -- so the probe split and the
+            // key push below are one branch, and the unpaired case borrows
+            // the ambient `current_path` instead of copying it. The copy it
+            // replaces was charged per (key, target output) and never read
+            // as anything but `current_path` itself.
+            let (target_path, t) = if paired {
+                let (path, value) = split_probe_pair(probed, current_path);
+                (Some(path), value)
+            } else {
+                (None, probed)
+            };
+            match index_one_owned(&t, k, bracket_optional) {
+                Ok(Some(v)) => {
+                    let new_path = target_path.map(|mut path| {
+                        path.push(k.clone());
+                        path
+                    });
+                    let step = eval_pipe_with_path_context_internal::<W, S>(
+                        rest,
+                        &v,
+                        root,
+                        file_origin,
+                        new_path.as_deref().unwrap_or(current_path),
+                        rest_optional,
+                    );
+                    if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                        return stop;
+                    }
+                }
+                Ok(None) => {}
+                // (4): a later key's index error outranks an earlier key's
+                // still-pending halt -- discard it, keeping the prefix
+                // accumulated across every earlier key/output.
+                Err(e) => return partial(core::mem::take(&mut results), Control::Error(e)),
+            }
+        }
+    }
+
+    match pending_halt {
+        // #1897: same fix the plain evaluator already applies here.
+        Some(code) => partial(results, Control::Halt(code)),
+        None => owned_vec_to_result(results),
+    }
+}
+
+/// One resolved slice bound: its raw value (as `key`/`parent` etc. would
+/// see it) paired with the rounded `i64` [`slice_owned_value_read`] actually
+/// indexes with. Distinct from [`ResolvedSliceBound`] (`(Option<i64>,
+/// Option<NumberKey>)`), the path-*mode* resolver's own already-classified
+/// pair -- this one keeps the pre-classification raw value instead, since
+/// `numeric_slice_bound_key` still needs to run on it here.
+type RawSliceBound = (OwnedValue, Option<i64>);
+
+/// [`eval_slice_bound`]'s path-context twin (#2100): resolves one slice
+/// bound (`start` or `end`) against `value`/`current_path` via
+/// [`eval_expr_needing_path_context`] instead of the plain evaluator, then
+/// reuses [`owned_bound_to_i64`] for the identical floor/ceil-and-classify
+/// step so the two can't independently drift on what counts as a valid
+/// bound (#106). Also keeps each resolved bound's *raw* value alongside its
+/// rounded `i64` -- needed by `numeric_slice_bound_key`/`slice_component_value`
+/// to build the resulting path component the same way `walk_path`/
+/// `navigation_element` already do for a *literal* slice (#1326's own
+/// representation).
+fn eval_slice_bound_with_path_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    bound: &Option<Box<Expr>>,
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    round: fn(f64) -> f64,
+) -> Result<(Vec<RawSliceBound>, Option<Control>), Control> {
+    let Some(expr) = bound else {
+        return Ok((vec![(OwnedValue::Null, None)], None));
+    };
+    let result =
+        eval_expr_needing_path_context::<W, S>(expr, value, root, file_origin, current_path, false);
+    let (raw, escape) = drain_path_context_stream(result);
+    let converted = raw
+        .into_iter()
+        .map(|v| {
+            owned_bound_to_i64(&v, round)
+                .map(|i| (v, i))
+                .map_err(Control::Error)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((converted, escape))
+}
+
+/// [`eval_slice_expr`]'s path-context twin (#2100): reproduces its actual
+/// coded shape exactly (`S` outer / `T` middle / `E`=target inner; target
+/// evaluated *once* for the whole `(s,e)` cross-product, not once per pair
+/// -- confirmed by reading `eval_slice_expr` itself, not its own doc
+/// comment's more aspirational "E inner" phrasing) with path threading
+/// added: each successful `(s, e, target-output)` triple extends
+/// `current_path` by a `{"start":s,"end":e}` component -- built via the
+/// same `slice_component_value`/`numeric_slice_bound_key` pair `walk_path`/
+/// `navigation_element` already use for the *literal* slice case (#1326) --
+/// before continuing `rest`.
+///
+/// **This arm has no literal-slice counterpart, and that asymmetry is
+/// visible.** `eval_pipe_with_path_context_internal` has arms for
+/// `Expr::Identity`/`Field`/`Index`/`Iterate` but none for a literal
+/// `Expr::Slice`, which still falls to the catch-all and leaves
+/// `current_path` unextended. Before #2100 both spellings agreed (both
+/// lost the component); now the computed one is right -- it matches the
+/// `{"start":..,"end":..}` component `walk_path`/`path(.a[0:3])` already
+/// produce -- and the literal one is the outlier, so which answer you get
+/// depends on whether the parser happened to fold the bounds:
+///
+/// ```text
+/// .a | .[0:3]         | path  =>  ["a"]                          (folded to Expr::Slice)
+/// .a | .[(0,1):(3)]   | path  =>  ["a",{"start":0,"end":3}], ...  (stays Expr::SliceExpr)
+/// .a | .[(1.7):(2.2)] | path  =>  ["a",{"start":1.7,"end":2.2}]   (floats don't fold)
+/// ```
+///
+/// Fixing the literal arm is the follow-up (#2215) rather than part of
+/// this change: it belongs next to `Field`/`Index` in the pipe evaluator,
+/// not here, and unlike them it has no owned-value navigation helper to
+/// reuse yet.
+///
+/// A mid-loop `Err` from [`slice_owned_value_read`] discards whatever this
+/// call already accumulated and returns the bare error immediately --
+/// matching `eval_slice_expr`'s own `return e.into()`/`return
+/// QueryResult::Error(e)` arms exactly. This is *not* symmetric with
+/// [`eval_index_expr_with_path_context`]'s own keep-the-prefix behavior on a
+/// mid-loop error; that asymmetry already exists between the two plain
+/// evaluators and this fix preserves it rather than papering over it.
+#[allow(clippy::too_many_arguments)]
+fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    target: &Expr,
+    start: &Option<Box<Expr>>,
+    end: &Option<Box<Expr>>,
+    rest: &[Expr],
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    bracket_optional: bool,
+    rest_optional: bool,
+) -> QueryResult<'a, W> {
+    let (starts, starts_escape) = match eval_slice_bound_with_path_context::<W, S>(
+        start,
+        value,
+        root,
+        file_origin,
+        current_path,
+        f64::floor,
+    ) {
+        Ok(v) => v,
+        Err(control) => return partial(Vec::new(), control),
+    };
+    if starts.is_empty() {
+        return match starts_escape {
+            None => QueryResult::None,
+            Some(control) => partial(Vec::new(), control),
+        };
+    }
+    let (ends, ends_escape) = match eval_slice_bound_with_path_context::<W, S>(
+        end,
+        value,
+        root,
+        file_origin,
+        current_path,
+        f64::ceil,
+    ) {
+        Ok(v) => v,
+        Err(control) => return partial(Vec::new(), control),
+    };
+    let ends_escaped = ends_escape.is_some();
+    let bounds_escape = ends_escape.or(starts_escape);
+    if ends.is_empty() {
+        return match bounds_escape {
+            None => QueryResult::None,
+            Some(control) => partial(Vec::new(), control),
+        };
+    }
+    let starts_len = if ends_escaped { 1 } else { starts.len() };
+    let starts = &starts[..starts_len];
+
+    let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
+    let target_result = eval_stage_with_path_context::<W, S>(
+        target,
+        &probe_stages(paired),
+        value,
+        root,
+        file_origin,
+        current_path,
+        false,
+    );
+    let target_outputs = match target_result {
+        QueryResult::Owned(v) => vec![v],
+        QueryResult::ManyOwned(vs) => vs,
+        QueryResult::None => return QueryResult::None,
+        QueryResult::Error(e) => return QueryResult::Error(e),
+        QueryResult::Break(label) => return QueryResult::Break(label),
+        QueryResult::Halt(code) => return QueryResult::Halt(code),
+        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
+        QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
+        QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
+        QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => unreachable!(
+            "eval_stage_with_path_context only ever produces \
+             Owned/ManyOwned/None/Error/Break/Halt/Partial"
+        ),
+    };
+    // `Some` exactly when `paired`, for the same reason
+    // [`eval_index_expr_with_path_context`] pairs its own target outputs
+    // that way: the unpaired case has no per-output path to carry, so it
+    // borrows the ambient `current_path` rather than copying it once per
+    // target output and then again per `(s, e, t)` triple below.
+    let target_pairs: Vec<(Option<Vec<OwnedValue>>, OwnedValue)> = target_outputs
+        .into_iter()
+        .map(|probed| {
+            if paired {
+                let (path, value) = split_probe_pair(probed, current_path);
+                (Some(path), value)
+            } else {
+                (None, probed)
+            }
+        })
+        .collect();
+
+    let mut results: Vec<OwnedValue> = Vec::new();
+    for (s_raw, s) in starts {
+        for (e_raw, e) in &ends {
+            for (target_path, t) in &target_pairs {
+                match slice_owned_value_read::<S>(t, *s, *e, bracket_optional) {
+                    Ok(Some(v)) => {
+                        // The clone is genuinely needed in the paired case
+                        // -- `target_pairs` is reused across every `(s, e)`
+                        // pair, so the component can't be pushed in place --
+                        // but it is now charged only where something reads
+                        // it, not to the whole `S x E x T` product.
+                        let new_path = target_path.as_ref().map(|path| {
+                            let mut path = path.clone();
+                            path.push(slice_component_value(
+                                *s,
+                                numeric_slice_bound_key(s_raw).as_ref(),
+                                *e,
+                                numeric_slice_bound_key(e_raw).as_ref(),
+                            ));
+                            path
+                        });
+                        let step = eval_pipe_with_path_context_internal::<W, S>(
+                            rest,
+                            &v,
+                            root,
+                            file_origin,
+                            new_path.as_deref().unwrap_or(current_path),
+                            rest_optional,
+                        );
+                        if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                            return stop;
+                        }
+                    }
+                    Ok(None) => {}
+                    // Matches `eval_slice_expr`'s own mid-loop `Err` arms:
+                    // discards whatever this call already accumulated,
+                    // rather than `eval_index_expr`'s keep-the-prefix rule
+                    // -- see this function's own doc comment.
+                    Err(e) => return QueryResult::Error(e),
+                }
+            }
+        }
+    }
+    match bounds_escape {
+        None => owned_vec_to_result(results),
+        Some(control) => partial(results, control),
+    }
+}
+
 /// Internal helper that also tracks the root value for parent navigation,
 /// and (for `--eval-all`, #715) an optional origin-file-index side table
 /// keyed by top-level array position, resolving `file_index`/`fileIndex`/`fi`.
@@ -31633,19 +32049,48 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // rather than being caught, matching `eval_index_expr`'s own
         // `QueryResult::Break(label) => return ...` and `eval_single`'s
         // carve-out, which never wraps this shape in `eval_try`.
+        //
+        // #2100: calling `eval_index_expr_with_path_context`/
+        // `eval_slice_expr_with_path_context` directly -- instead of the
+        // plain `eval_owned_input` + a separate `continue_rest_with_context`
+        // this arm used before -- is what threads path context through a
+        // *successful* `?`-guarded bracket too: `rest` now continues from
+        // each output's own resolved path, not one ambient, never-extended
+        // `current_path`. `bracket_optional: true` is this arm's own `?`
+        // (unchanged rule: covers only the final index/slice step);
+        // `rest_optional: optional` is the ambient value already in scope
+        // here, never the forced `true` above -- `rest` must not inherit
+        // this bracket's own suppression.
         Expr::Optional(inner)
             if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
         {
-            match eval_owned_input::<W, S>(inner, value, true) {
-                QueryResult::None => QueryResult::None,
-                result => continue_rest_with_context::<W, S>(
-                    result,
+            match &**inner {
+                Expr::IndexExpr { target, key } => eval_index_expr_with_path_context::<W, S>(
+                    target,
+                    key,
                     rest,
+                    value,
                     root,
                     file_origin,
                     current_path,
+                    true,
                     optional,
                 ),
+                Expr::SliceExpr { target, start, end } => {
+                    eval_slice_expr_with_path_context::<W, S>(
+                        target,
+                        start,
+                        end,
+                        rest,
+                        value,
+                        root,
+                        file_origin,
+                        current_path,
+                        true,
+                        optional,
+                    )
+                }
+                _ => unreachable!("matches! guard above restricts inner to IndexExpr|SliceExpr"),
             }
         }
         // This node *is* the `?`. Isolates `inner` with `optional` forced to
@@ -32089,6 +32534,42 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 optional,
             )
         }
+        // `.[K]`/`.[S:T]` (computed key/bounds), no `?` -- #2100. Unlike the
+        // literal `Expr::Index`/`Expr::Slice` arms, this must be
+        // unconditional: `needs_path_context(target)||needs_path_context(key)`
+        // can be `false` while a *sibling* `key`/`parent`/`file_index` in
+        // `rest` still routed the whole pipe here (`.a | .["" + "b"] | key`)
+        // -- what matters is whether `rest` needs the resulting path, not
+        // whether this bracket's own sub-expressions do.
+        // `eval_index_expr_with_path_context`'s/`eval_slice_expr_with_path_
+        // context`'s own internal `paired` gate (mirroring `Expr::Limit`'s)
+        // is what keeps a `rest`-doesn't-care case cheap. `bracket_optional`
+        // and `rest_optional` are both the same ambient `optional` here --
+        // there's no local `?` to separate them (see the `Expr::Optional`
+        // carve-out above for the case where there is one).
+        Expr::IndexExpr { target, key } => eval_index_expr_with_path_context::<W, S>(
+            target,
+            key,
+            rest,
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+            optional,
+        ),
+        Expr::SliceExpr { target, start, end } => eval_slice_expr_with_path_context::<W, S>(
+            target,
+            start,
+            end,
+            rest,
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+            optional,
+        ),
         // `[key]`/`[parent]`/`[file_index]` (#1302): the generic
         // `Expr::Array` arm below builds the array via `eval_owned_expr_opt`
         // -- the plain, context-less evaluator -- so a `key`/`parent`/

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8771,6 +8771,151 @@ fn test_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
     Ok(())
 }
 
+/// A computed bracket (`Expr::IndexExpr`/`Expr::SliceExpr`) must extend
+/// `current_path` the same way a literal `.foo`/`.[0]` does, so `key`/
+/// `parent`/`path` downstream (and inside the bracket's own key/bounds
+/// sub-expression) see the right position (#2100).
+///
+/// #1410 fixed a narrower bug in the same `Expr::Optional(IndexExpr|
+/// SliceExpr)` carve-out arm: an error inside the bracket's key/bounds must
+/// still escape through `?`. That fix left the arm calling the plain,
+/// path-context-blind evaluator and passing `current_path` through
+/// unchanged on a *successful* read -- the same gap the bare (no-`?`) case
+/// had, which fell to the generic `_ =>` catch-all's own documented
+/// "this loses path context for complex expressions" comment. No jq oracle
+/// exists for any of this -- every `needs_path_context` trigger but `path`
+/// is a succinctly extension -- so the plain evaluator's own semantics
+/// (`eval_index_expr`/`eval_slice_expr`) is the reference every case below
+/// is pinned against.
+#[test]
+fn test_computed_bracket_threads_path_context_2100() -> Result<()> {
+    // The issue's own headline repros: computed key, flipped from wrong to
+    // correct.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", r#".a | .["" + "b"] | key"#],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""b""#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[key]"], Some(r#"{"a":{"a":9}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "9");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", r#".a | .["b"] | parent"#],
+        Some(r#"{"a":{"b":{"c":1}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"b":{"c":1}}"#);
+
+    // The `?`-carve-out's *successful* path (not covered by #1410's own
+    // test, which only exercises the error-escaping half): `.a` is `1`, a
+    // non-container, so `.[key]?` (key resolves to `"a"`) suppresses to
+    // nothing and only the `1` branch survives.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[key]?, 1)"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1");
+
+    // Regression control: a bare computed key with no `key`/`parent`/`path`
+    // anywhere in the pipe never needs path context at all, so it must stay
+    // on today's cheap route and answer exactly as before.
+    let (stdout, _, code) = run_jq_full(&["-c", "--arg", "k", "a", ".[$k]"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1");
+
+    // Computed slice bounds (a genuine `Expr::SliceExpr`, not folded to a
+    // literal `Expr::Slice` at parse time since `(0,1)` is multi-valued):
+    // each `(s, e)` pair must extend the path with its own
+    // `{"start":s,"end":e}` component before `key` runs.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[(0,1):(3)] | key"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "{\"start\":0,\"end\":3}\n{\"start\":1,\"end\":3}"
+    );
+
+    // Escape-ordering (#791/#400/#494 extended to a `rest`-triggered
+    // escape, which the plain evaluator's value-only model never had to
+    // reason about): key "a" succeeds and must survive in the output
+    // prefix; key "b"'s own downstream `error` must outrank the still-
+    // pending `halt` a later key-stream attempt would have reached.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#".[("a","b",halt)] | if key=="b" then error("x") else . end"#,
+        ],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains('x'), "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "1");
+
+    // A halt reaching an *empty* key stream must still escape, not be
+    // swallowed into "no keys, no output" (code review). The plain
+    // evaluator's own `keys.is_empty()` short-circuit is only reachable
+    // with no pending halt (a bare `QueryResult::Halt` returns before it);
+    // the path-context twin folds bare and partial halts into one arm, so
+    // the same short-circuit had to learn about `pending_halt`. `halt_error`
+    // rather than `halt` because it is the shape whose escape is
+    // observable on both channels -- exit 5 and the payload on stderr --
+    // where a bare `halt` differs only by the `[]` a swallowed halt lets
+    // the enclosing array print.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[.a | .[halt_error] | key]"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout}, stderr: {stderr}");
+    assert_eq!(stdout.trim(), "");
+    assert_eq!(stderr.trim(), r#"{"b":1}"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[.a | .[halt] | key]"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Same through #1410's `?` carve-out, which shares the twin: `?` covers
+    // the indexing, never a halt (#791).
+    let (stdout, _, code) =
+        run_jq_full(&["-c", "[.a | .[halt]? | key]"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // The slice twin already routed its empty-bound short-circuit through
+    // `partial`, which collapses an empty prefix back to the bare halt --
+    // pinned here so the two brackets can't drift apart again.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[.a | .[(halt):(2)] | key]"],
+        Some(r#"{"a":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // The literal-slice arm is still missing from the path-context pipe
+    // evaluator (#2215), so a *folded* slice keeps naming its container's
+    // path while the computed spelling above names the slice component.
+    // Pinned as the current, deliberately-documented asymmetry rather than
+    // left to be discovered as a surprise by the next reader.
+    let (stdout, _, code) = run_jq_full(&["-c", "[.a | .[0:3] | key]"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a"]"#);
+
+    // Target re-evaluated fresh per key (#2032), preserved even when the
+    // per-key target is probed for its own path (`paired`, since `key`
+    // downstream needs it): `input` must be consumed exactly once per key,
+    // in order, not double-read or reordered by the probe.
+    let (stdout, _, code) = run_jq_full(
+        &["-n", "-c", r#"[(input)[("a","b")] | key]"#],
+        Some("{\"a\":1,\"z\":9}\n{\"b\":2,\"z\":9}\n"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a","b"]"#);
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8916,6 +8916,259 @@ fn test_computed_bracket_threads_path_context_2100() -> Result<()> {
     Ok(())
 }
 
+/// Coverage-gap follow-up to [`test_computed_bracket_threads_path_context_2100`]
+/// (identified by CI patch-coverage on #2218): every escape/empty/multi-value
+/// arm of `eval_index_expr_with_path_context`/`eval_slice_expr_with_path_context`
+/// and their shared `drain_path_context_stream` classifier, not just the
+/// headline repros the original test pinned.
+///
+/// A key/slice-bound expression must be something `fold_index_key`/
+/// `fold_slice_bound` (`src/jq/parser.rs`) can't reduce to a literal, or the
+/// parser folds the bracket to `Expr::Index`/`Expr::Slice` before this file
+/// ever sees it, silently testing the *old*, pre-#2100 code path instead
+/// (live-verified while writing this test: a plain `.[0:1]`-shaped bound
+/// took that fallback and printed a stale `null` for `key` rather than
+/// exercising either new function at all). `("a","b")`/`(0,1)`-style commas
+/// and non-integer floats (`0.5`) are both fold-proof; a single bare literal
+/// in parens is not enough on its own.
+#[test]
+fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
+    // `drain_path_context_stream`'s `None`/keys.is_empty() arms: a key
+    // stream with zero outputs and no pending escape.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[empty] | key"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // `drain_path_context_stream`'s `Break` arm, reached via the key
+    // expression's own evaluation -- caught by the enclosing `label`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | .a | .[break $out] | key"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Index twin's target-result match: `ManyOwned` (a multi-valued
+    // target re-run per key), `None` (this key's target evaluates to
+    // nothing, but the loop must still continue for later keys, #2032),
+    // `Error`/`Break`/`Halt`/`Partial` (every target-level escape, each
+    // discarding this key's own output and returning whatever earlier
+    // keys already accumulated). `if true then 0 else 1 end` keeps the key
+    // a runtime `0` without folding to a literal `Expr::Index`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "(.a,.b)[if true then 0 else 1 end] | key"],
+        Some(r#"{"a":[1,2],"b":[3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n0");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[empty[(\"a\",\"b\")] | key]"], Some(r"{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[(error(\"boom\"))[(\"a\",\"b\")] | key]"],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | [(break $out)[(\"a\",\"b\")] | key]"],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[(halt)[(\"a\",\"b\")] | key]"], Some(r"{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[((1,error(\"x\")))[(\"a\",\"b\")] | key]"],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert!(stderr.contains('x'), "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "");
+
+    // A later key's own index error (indexing an array with a string)
+    // outranks nothing pending, but still exercises the keep-the-prefix
+    // `Err` arm: the first key's `key` output survives on stdout.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ".arr | .[(0,\"a\")] | key"],
+        Some(r#"{"arr":[1,2,3]}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "0");
+
+    // Keys stream completes normally but carries a pending halt (#1897):
+    // both prior keys' outputs are printed before the process halts.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".[(\"a\",\"b\",halt)] | key"],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"a\"\n\"b\"");
+
+    // Slice twin's own bound resolver: an absent bound (`None`), and a
+    // conversion failure/empty stream on either side.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | .[(0,1):] | key"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "{\"start\":0,\"end\":null}\n{\"start\":1,\"end\":null}"
+    );
+
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | .[:(2,3)] | key"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "{\"start\":null,\"end\":2}\n{\"start\":null,\"end\":3}"
+    );
+
+    let (_, stderr, code) = run_jq_full(
+        &["-c", ".a | .[(\"x\"):(3)] | key"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("integers"), "stderr: {stderr}");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[(empty):(3)] | key"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    let (_, stderr, code) = run_jq_full(
+        &["-c", ".a | .[(0):(\"x\")] | key"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("integers"), "stderr: {stderr}");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[(0):(empty)] | key"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Slice twin's own target-result match -- same six escape/multi-value
+    // arms as the index twin above, but through `eval_slice_expr_with_
+    // path_context`'s independent copy. `(0.5):(1.5)` is fold-proof (a
+    // non-integer float bound never folds to `Expr::Slice`).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "(.a,.b)[(0.5):(1.5)] | key"],
+        Some(r#"{"a":[1,2],"b":[3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "{\"start\":0.5,\"end\":1.5}\n{\"start\":0.5,\"end\":1.5}"
+    );
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[empty[(0.5):(1.5)] | key]"], Some(r"{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
+
+    let (_, stderr, code) =
+        run_jq_full(&["-c", "(error(\"boom\"))[(0.5):(1.5)] | key"], Some(r"{}"))?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "label $out | [(break $out)[(0.5):(1.5)] | key]"],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "(halt)[(0.5):(1.5)] | key"], Some(r"{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Partial-target arms discard the target's own partial prefix
+    // entirely (asymmetric with the index twin's keep-the-prefix rule --
+    // this function's own doc comment) -- so a successful `[1,2]` ahead of
+    // the escape contributes nothing to stdout.
+    let (_, stderr, code) = run_jq_full(
+        &["-c", "(([1,2],error(\"x\")))[(0.5):(1.5)] | key"],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains('x'), "stderr: {stderr}");
+
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "label $out | [(([1,2],break $out))[(0.5):(1.5)] | key]",
+        ],
+        Some(r"{}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "(([1,2],halt))[(0.5):(1.5)] | key"], Some(r"{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Unpaired `target_pairs` (#2100's own charged-only-where-read
+    // optimization): the bracket's local `rest` is empty (nothing chains
+    // after it *within this branch*), even though a comma sibling (`key`)
+    // is what put the whole expression through path-context evaluation.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | (.[(0,1):(3)], key)"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[1,2,3]\n[2,3]\n\"a\"");
+
+    // `rest`'s own escape mid-loop over `(s, e, t)` triples: the first
+    // `(start, end)` combination's `key` output survives before `error`
+    // aborts the second.
+    let (_, stderr, code) = run_jq_full(
+        &["-c", ".a | .[(0,1):(3)] | key, error(\"x\")"],
+        Some(r#"{"a":[1,2,3,4]}"#),
+    )?;
+    assert_eq!(code, 5);
+    assert!(stderr.contains('x'), "stderr: {stderr}");
+
+    // `Ok(None)` from `slice_owned_value_read`: an optional (`?`) slice of
+    // a non-container target silently contributes nothing.
+    let (stdout, _, code) = run_jq_full(&["-c", ".[(0,1):(3)]? | key"], Some("1"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "");
+
+    // Mid-loop `Err` discards whatever this call already accumulated
+    // (unlike the index twin): the first target ([2,3], sliceable)
+    // succeeds, but the second (a bare number, not sliceable) errors, and
+    // neither's `key` output reaches stdout.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(([2,3],1))[(0.5):(1.5)] | key"], Some(r"{}"))?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "");
+
+    // Final `bounds_escape` arm: the loop over every `(s, e, t)` triple
+    // completes normally, but the start-bound stream itself carried a
+    // pending halt after two successful values.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[(0,1,halt):(3)] | key"],
+        Some(r#"{"a":[10,20,30,40]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        "{\"start\":0,\"end\":3}\n{\"start\":1,\"end\":3}"
+    );
+
+    Ok(())
+}
+
 /// `keys_unsorted` stays lazy through `length`/`.[]`/`.[n]`/`first`/`last`
 /// (#140), backed by a new `JqValue::LazyKeysArray` output writer in
 /// `print_json`. Uses `run_jq_full` (the pre-built binary) to exercise that

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8893,14 +8893,13 @@ fn test_computed_bracket_threads_path_context_2100() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "");
 
-    // The literal-slice arm is still missing from the path-context pipe
-    // evaluator (#2215), so a *folded* slice keeps naming its container's
-    // path while the computed spelling above names the slice component.
-    // Pinned as the current, deliberately-documented asymmetry rather than
-    // left to be discovered as a surprise by the next reader.
+    // #2215 added the literal-slice arm to the path-context pipe evaluator,
+    // so a *folded* slice now names the slice component the same way the
+    // computed spelling above does, instead of stopping at its container's
+    // path.
     let (stdout, _, code) = run_jq_full(&["-c", "[.a | .[0:3] | key]"], Some(r#"{"a":[1,2,3]}"#))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), r#"["a"]"#);
+    assert_eq!(stdout.trim(), r#"[{"start":0,"end":3}]"#);
 
     // Target re-evaluated fresh per key (#2032), preserved even when the
     // per-key target is probed for its own path (`paired`, since `key`
@@ -9092,10 +9091,12 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "");
 
-    // Partial-target arms discard the target's own partial prefix
-    // entirely (asymmetric with the index twin's keep-the-prefix rule --
-    // this function's own doc comment) -- so a successful `[1,2]` ahead of
-    // the escape contributes nothing to stdout.
+    // Partial-target arms discard the *target's own* partial prefix
+    // entirely, exactly like the index twin's identical rule -- so a
+    // successful `[1,2]` ahead of the escape contributes nothing to
+    // stdout. This is distinct from a mid-loop slice-*application* error,
+    // covered further below, which keeps whatever earlier `(s, e)` pairs
+    // already contributed.
     let (_, stderr, code) = run_jq_full(
         &["-c", "(([1,2],error(\"x\")))[(0.5):(1.5)] | key"],
         Some(r"{}"),
@@ -9117,7 +9118,7 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "");
 
-    // Unpaired `target_pairs` (#2100's own charged-only-where-read
+    // Unpaired target output (#2100's own charged-only-where-read
     // optimization): the bracket's local `rest` is empty (nothing chains
     // after it *within this branch*), even though a comma sibling (`key`)
     // is what put the whole expression through path-context evaluation.
@@ -9144,14 +9145,14 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "");
 
-    // Mid-loop `Err` discards whatever this call already accumulated
-    // (unlike the index twin): the first target ([2,3], sliceable)
-    // succeeds, but the second (a bare number, not sliceable) errors, and
-    // neither's `key` output reaches stdout.
+    // Mid-loop `Err` keeps whatever this call already accumulated, exactly
+    // like the index twin: the first target ([2,3], sliceable) succeeds and
+    // its `key` output survives, before the second (a bare number, not
+    // sliceable) errors.
     let (stdout, stderr, code) =
         run_jq_full(&["-c", "(([2,3],1))[(0.5):(1.5)] | key"], Some(r"{}"))?;
     assert_eq!(code, 5, "stderr: {stderr}");
-    assert_eq!(stdout.trim(), "");
+    assert_eq!(stdout.trim(), r#"{"start":0.5,"end":1.5}"#);
 
     // Final `bounds_escape` arm: the loop over every `(s, e, t)` triple
     // completes normally, but the start-bound stream itself carried a


### PR DESCRIPTION
## Summary

- `.[K]` and `.[S:T]` (computed index/slice) had no dedicated arm in the eager path-context evaluator (`eval_stage_with_path_context`), so they fell to the generic catch-all, which evaluates them with the plain, path-context-blind evaluator and leaves `current_path` unchanged — `key`/`parent`/`file_index`/`path` silently saw a stale or stubbed position, both inside the bracket's own key/bounds sub-expression and downstream of the bracket.
- The `#1410` `Expr::Optional(IndexExpr|SliceExpr)` carve-out had the identical bug on a *successful* `?`-guarded read (it only fixed error-escaping through `?`), fixed here too.
- Adds `eval_index_expr_with_path_context`/`eval_slice_expr_with_path_context`, path-context twins of `eval_index_expr`/`eval_slice_expr` that reproduce their documented semantics (key-outer/target-inner ordering, `optional` scoping, pending-halt/escape ordering) while extending `current_path` per resolved key or slice bound, reusing the existing `probe_stages`/`split_probe_pair` idiom to recover each target output's own path.
- One-evaluator fix: `eval_generic.rs` (the yq bridge) picks this up for free with no code changes, confirmed live.

Closes #2100.

## Test plan

- New `test_computed_bracket_threads_path_context_2100` in `tests/jq_cli_tests.rs`: the issue's own repros, the `?`-carve-out's successful path, a no-path-context regression control, computed-slice path threading, the halt/pending-halt escape-ordering interaction, and per-key target re-evaluation with side effects.
- Full `cargo test` green under default features, `--features cli,regex`, and `--no-default-features --features portable-popcount` (no_std).
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo doc --all-features` (with `RUSTDOCFLAGS=-D warnings`) both clean.
- Live-verified against the built binary (no jq oracle exists for these `key`/`parent`/`file_index` extensions — pinned against the plain evaluator's own semantics per the issue).