### PR TITLE
fix(jq): guard range()'s i64 stepping against overflow

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2817,7 +2817,247 @@ own repro table didn't happen to list, not new ones introduced by this fix.
 - `eval_range_values`'s integer stepping (`i += step`) has no overflow
   guard — pre-existing, reproduces identically before this fix too, and
   needs its own oracle verification before choosing a direction. Tracked as
-  [#2131](https://github.com/rust-works/succinctly/issues/2131).
+  [#2131](https://github.com/rust-works/succinctly/issues/2131). **Fixed**:
+  see the next section.
+
+### `range`'s `i64` fast path at extreme magnitude (#2131): overflow-checked in place, extending the same #2089 hang-avoidance divergence
+
+The gap the previous section left open: `eval_range_values` (the exact-`i64`
+fast path taken when `from`/`to`/`step` are all integers) computed
+`i += step` in plain `i64` arithmetic with no overflow guard. Near
+`i64::MIN`/`i64::MAX` this wrapped via two's-complement and streamed garbage
+instead of erroring or matching jq:
+
+```console
+$ echo null | succinctly jq 'range(-9223372036854775758; -9223372036854775808; -100)' | head -3   # before this fix
+-9223372036854775758
+9223372036854775758     # wrapped past i64::MIN
+9223372036854775658
+```
+
+Real jq represents every number as `f64`, so it has no `i64`-overflow concept
+at all — only precision loss: two integers close enough together at a large
+enough magnitude round to the *same* double, so a `range` between them is a
+zero-iteration loop by construction (`from > to` is false from the start).
+
+**First fix (superseded below):** `eval_range_values` only took the `i64`
+path when `from`, `to`, *and* `step` were all within `±2^53` (the magnitude
+where every `i64` round-trips through `f64` losslessly), routing anything
+outside that blanket cutoff to the pre-existing, `MAX_RANGE`-capped
+`eval_range_values_f64`. This was correct — it made overflow impossible by
+construction — but far more conservative than the actual overflow risk
+(`i64::MIN`/`i64::MAX`-adjacent, `~±9.2 * 10^18`, six orders of magnitude
+looser than `±2^53`), with a real, disclosed-but-understated side effect: an
+ordinary large-but-safe integer range — a nanosecond-epoch timestamp span, a
+large database ID range — got silently routed to `f64` purely on magnitude,
+where at that scale every value in a short range can round to the *same*
+double and the range degenerates to `[]`. For a realistic input, that is
+worse than the original overflow bug it replaced (wrong-looking wrapped
+output, at least visibly wrong; a silent empty result at exit 0 is not).
+
+**Current fix:** `eval_range_values` now uses `i.checked_add(step)` in place
+of the bare `i += step`, bailing out (`None`) the instant an addition would
+leave `i64`'s range; `each_range`'s `emit` closure reacts to `None` by
+discarding whatever that call already pushed and recomputing the *entire*
+range from scratch via `eval_range_values_f64`, exactly as the `±2^53` gate
+did for its own out-of-bound cases. The blanket magnitude cutoff and its
+`range_i64_fast_path_is_safe`/`I64_F64_EXACT_BOUND` gate are gone; there is
+no separate threshold to prove correct, because the check *is* the same
+arithmetic that would otherwise overflow, performed at the exact point it
+could occur. The safety property is now: **no possible sequence of
+`i += step`, starting at `from` and stopping at or before `to`, can ever
+overflow `i64`** — narrower than "agrees with `f64`", and (unlike the
+`±2^53` proof) not something that needs `from`/`to`/`step` bounded in
+advance, since `checked_add` detects the exact condition directly rather
+than a sufficient-but-loose approximation of it. Verified two ways: an
+analytical argument in `eval_range_values`'s own doc comment (`src/jq/eval.rs`),
+and `test_eval_range_values_matches_i128_reference_sweep_2131`, which
+differentially checks it against an independent `i128`-arithmetic
+reimplementation of the same loop across a magnitude-diverse grid anchored
+at `i64::MIN`/`i64::MAX`, `±2^53`, and the nanosecond-epoch scale.
+
+**Round-3 refinement, cap-boundary decoupling.** A review of the
+`checked_add`-based fix above found one more gap in *how* it was applied:
+the loop checked the cap (`values.len() < MAX_RANGE`) and attempted the
+advance in the same unconditional step, so on the iteration whose push
+reached the cap it still computed the next candidate the exact same way
+every other iteration does — including bailing the *whole call* via `?` if
+that candidate overflowed `i64`, discarding every already-correct value it
+had pushed for an `f64` recomputation none of them needed — confirmed live:
+`nth(250; range(0; 9223372036854775807; 92234642714974))` returned a wrong,
+`f64`-derived answer (`23058660678743610`) instead of the exact
+`250 * 92234642714974 = 23058660678743500`. The fix still computes that one
+lookahead at the cap boundary — there is no way to know whether one more
+value exists without it — but interprets its overflow *locally* rather than
+bailing: `to` is always representable in `i64`, so a candidate that
+overflows `i64` can never be less than `to` (greater than `to` on the
+descending arm) either, meaning it's provably not part of the range —
+indistinguishable from natural exhaustion. A cap-terminated exit therefore
+never *discards* on that overflow, only ever resolves its own `truncated`
+verdict to `false` in exactly the cases where that's providably correct
+(and still resolves to `true` when a cap-hit range's lookahead doesn't
+overflow and genuinely has more values, e.g. `range(0;100005;1)`).
+`reference_range_i64` shared the original revision's same unconditional
+structure (so the sweep above validated "matches an equally flawed model,"
+not the real property); it was corrected the same way, and the sweep's own
+`steps` grid gained a dedicated entry at this magnitude
+(`92234642714974`) so this class of bug is caught automatically rather
+than by inspection alone.
+
+This keeps the original repro fixed:
+
+```console
+$ echo null | succinctly jq 'range(-9223372036854775758; -9223372036854775808; -100)'
+$                                                                                     # empty, exit 0 -- matches jq 1.7.1
+```
+
+(`from` is only 50 above `i64::MIN` and `step` subtracts 100 more, so
+`checked_add` overflows on the very first application — the fallback engages
+before a single extra value is ever produced.) But it recovers the
+nanosecond-scale case the `±2^53` gate used to silently break:
+
+```console
+$ echo null | succinctly jq -c '[range(1700000000000000000; 1700000000000000010; 1)]'
+[1700000000000000000,1700000000000000001,1700000000000000002,1700000000000000003,1700000000000000004,1700000000000000005,1700000000000000006,1700000000000000007,1700000000000000008,1700000000000000009]
+```
+
+This range has no overflow risk whatsoever (a 10-step walk, nowhere near
+`i64::MAX`), so `checked_add` never trips and the exact `i64` answer comes
+back untouched — the fix this section documents.
+
+It also changes the confirmed-hangs-in-real-jq case from the previous
+section: once `i` reaches `2^53` with `step == 1`, `i + 1` rounds back to
+exactly `i` in `f64` arithmetic (the next representable double after `2^53`
+is `2^53 + 2`, not `2^53 + 1`), so real jq's own `while(. < $upto; . + $by)`
+never advances and never terminates — confirmed live and killed by hand
+while investigating this issue (`timeout 3 jq -c 'range(9007199254740990;
+9007199254740994; 1)'` hangs until killed, repeating `9007199254740992`
+forever). Under the `±2^53` gate this range (`to` exceeds the cutoff) was
+routed to `f64` same as any out-of-bound range, and the pre-existing
+`MAX_RANGE` cap (#2089) raised instead of looping forever — the same
+ADR-0018 rule 4c shape `repeat(f)`'s hang precedent documents above, reached
+through `range`'s dispatch rather than through `repeat`'s own round loop.
+Under the current fix this range has no `i64` overflow risk at all (`i64`
+has no precision-loss problem at this magnitude the way `f64` does: every
+integer here is exactly representable, and `i.checked_add(1)` always
+advances by exactly 1), so it now stays on the exact `i64` path and
+completes correctly and quickly, well under `MAX_RANGE`, rather than needing
+the cap to save it:
+
+```console
+$ echo null | succinctly jq -c '[range(9007199254740990; 9007199254740994; 1)]'
+[9007199254740990,9007199254740991,9007199254740992,9007199254740993]
+```
+
+A beneficial side effect of the narrower gate, not a new problem — `MAX_RANGE`
+still raises on any range that genuinely needs more than 100000 values,
+overflow or not.
+
+**Widened divergence from jq's own arithmetic, covering the *entire*
+`2^53`–`i64::MAX` range, not a narrow band near the top.** The divergence
+starts exactly at `2^53` (`9007199254740992`) — not "near `i64::MAX`" as an
+earlier revision of this section implied by leading with a single
+boundary-adjacent example. jq 1.7.1's actual number model above `2^53` is
+not plain `f64`: it preserves each literal as a `decNumber` (`src/jv.c`,
+`DEC_INIT_BASE`) and only rounds through a 17-significant-digit decimal
+intermediate when a value crosses into arithmetic (`. + $by` inside
+`while`'s definition), so its behavior differs from a bare `i64`-to-`f64`
+cast, and differs *again* depending on where in that ~3-order-of-magnitude
+range (`9007199254740992` to `9223372036854775807`) the values fall. A
+sweep from just above `2^53` through `i64::MAX` (all against the pinned jq
+1.7.1 oracle, every probe near this magnitude `timeout`-guarded — this has
+hung a live session twice in this issue's own history) found the divergence
+is close to universal across the whole range, not occasional, in two
+distinct shapes:
+
+- **Hang sub-band, `2^53` up to approximately `2^57`
+  (`144115188075855872`, `~1.441 * 10^17`):** real jq's own
+  `while(. < $upto; . + $by)` never advances and never terminates. Once `.`
+  rounds through `decNumber`-to-`double` conversion, `. + 1` rounds back to
+  exactly `.` (the increment is too small relative to the representable
+  gap at this magnitude to move to a different double), so the loop
+  condition never changes and jq spins forever, repeating the same value —
+  this is the mechanism the previous revision of this section documented
+  for the single literal `range(9007199254740990; 9007199254740994; 1)`,
+  but confirmed here to hold across a ~16x (roughly `2^4`) span of
+  magnitude, not one specific value: live-confirmed (`timeout`-killed) at
+  `9007199254740992`, `9007199254740993`, `10000000000000000`,
+  `20000000000000000`, `50000000000000000`, `80000000000000000`, several
+  points between `1.2 * 10^17` and `1.43 * 10^17`, and non-round
+  17-digit values (`12345678901234567`, `67891234567890123`).
+- **Truncate sub-band, approximately `2^57` up through `i64::MAX`:** real jq
+  terminates, but after emitting only its starting value — `. + $by` still
+  rounds through `decNumber`/`double` conversion, but now the rounded
+  increment is large enough to jump `.` past `$upto` in a single step
+  instead of rounding back to `.` itself, so the `while` loop exits after
+  exactly one iteration rather than spinning. Live-confirmed single-value
+  output (`[from]`, not the full walk) at `200000000000000000`,
+  `500000000000000000`, `800000000000000000`, `900000000000000000`,
+  `1000000000000000000`, `1230000000000000000`, `1700000000000000000`,
+  `4600000000000000000`, and this section's own pre-existing example,
+  `range(9223372036854775800; 9223372036854775807; 1)`.
+- **The boundary between the two sub-bands sits close to `2^57`,** not
+  precisely pinned to it: bisecting with a fixed `range(v; v+10; 1)` shape
+  found `144110000000000000` still hangs while `144115188075855871`
+  (`2^57 - 1`) already truncates to one value — a span of under
+  `10^10` around `2^57` itself. This is reported as *approximately* located
+  rather than an exact global constant because the true cutover is a
+  property of each specific value's bit pattern relative to its own
+  magnitude's rounding granularity (which doubles every power of two), not
+  a single sharp threshold that holds for every `from`/`to`/`step`
+  combination — a different span or step could shift exactly where a given
+  magnitude lands between the two shapes.
+
+**The nanosecond-epoch example from the fix above is itself an instance of
+this same divergence, not a case of matching jq.** `range(1700000000000000000;
+1700000000000000010; 1)` sits at `~1.7 * 10^18`, well inside the truncate
+sub-band just described. succinctly's overflow-free `i64` walk gives the
+exact 10-value enumeration documented above; real jq 1.7.1 gives a single
+value, `[1700000000000000000]`, live-confirmed. Presenting that example
+earlier as an unqualified fix would overstate it: succinctly did not
+*regain* parity with jq at this magnitude (jq never enumerated all 10
+values in the first place, both before and after this fix), it became
+*internally exact and consistent* where it previously produced a different
+wrong answer (silently empty, from the superseded `±2^53` gate). That is a
+real improvement — predictable, exact `i64` arithmetic beats silent `f64`
+rounding into an empty result — but it is not jq parity, and every other
+large-but-`i64`-safe integer range above `2^53` falls into the same
+category: succinctly now returns the mathematically exact enumeration,
+which is *usually not* what jq 1.7.1 itself would produce at that
+magnitude, whichever of the two sub-bands above it lands in.
+
+Two further shapes, both unaffected by this fix's own logic since they're
+both about *jq's* arithmetic or a separate, pre-existing part of
+succinctly's own dispatch rather than the exact-`i64`-path divergence just
+described:
+
+- **Both sides use `f64`** (a plain float literal, or an `i64` range where
+  `checked_add` genuinely detects overflow and falls back): reproducible via
+  `range(72057594037927936.0; 72057594037927944.0; 1)` — jq 1.7.1 gives one
+  value, `[72057594037927936.0]`, where succinctly's own (unchanged)
+  `eval_range_values_f64` gives `[]`. This is `eval_range_values_f64`'s own
+  pre-existing fidelity gap, exactly as recorded before this revision,
+  independent of the dispatch mechanism above it.
+- **succinctly stays on the exact `i64` path where jq's own arithmetic
+  would round, stall, or hang** — new to this revision's scope, since the
+  `±2^53` gate used to route every such case to `f64` too (matching jq's
+  *answer* incidentally, by sharing its precision loss, though not its
+  hang in the lower sub-band — the `MAX_RANGE` cap raised there instead,
+  the same ADR-0018 rule 4c trade-off `repeat(f)`'s hang precedent
+  documents elsewhere in this file). Whenever `eval_range_values` has no
+  overflow risk, its answer is the exact integer computation, which is
+  *always* what jq would compute too below `2^53`, but is no longer proven
+  to bit-match jq's own `f64`/`decNumber` arithmetic at any magnitude above
+  it — not just near the true overflow zone the way the `±2^53` gate's
+  property held. This is the redesign's own trade-off, stated directly in
+  the issue that requested it: the new safety criterion is "no `i64`
+  overflow", not "bit-identical to jq's own number model" — and is accepted
+  for the same reason the `2^53` hang case is accepted above (ADR-0018 rule
+  4c: not a case of succinctly emitting unreadable output, corrupting data,
+  or discarding a write, and the alternative — silently degrading
+  large-but-safe integers to `f64`, as the `±2^53` gate did, or reproducing
+  jq's own hang, as ADR-0018 does not require — is the worse failure mode
+  for the realistic inputs this magnitude range covers).
 
 ## Provenance
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4352,7 +4352,13 @@ fn each_range<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let mut emit = |from_val: RangeNum, to_val: RangeNum, step_val: RangeNum| -> Demand {
         let (one, truncated) = match (from_val, to_val, step_val) {
             (RangeNum::Int(f), RangeNum::Int(t), RangeNum::Int(st)) => {
-                eval_range_values::<W>(f, t, st)
+                // Try the exact-`i64` path first; it self-detects overflow
+                // (`None`) and only then do we pay for a from-scratch `f64`
+                // recomputation -- see `eval_range_values`'s own doc comment.
+                match eval_range_values::<W>(f, t, st) {
+                    Some(result) => result,
+                    None => eval_range_values_f64::<W>(f as f64, t as f64, st as f64),
+                }
             }
             (f, t, st) => eval_range_values_f64::<W>(f.as_f64(), t.as_f64(), st.as_f64()),
         };
@@ -29151,39 +29157,151 @@ fn range_max_exceeded_error() -> EvalError {
     EvalError::new("range: maximum iterations exceeded")
 }
 
-/// Helper to generate range values, capped at [`MAX_RANGE`] per call.
+/// Helper to generate range values, capped at [`MAX_RANGE`] per call --
+/// issue #2131's revised fix.
 ///
-/// Returns whether the cap actually cut the range short (`true`) or the
-/// range finished naturally within it (`false`) -- deliberately *not* an
+/// Returns `None` the instant `i64` arithmetic would overflow, signalling
+/// the caller ([`each_range`]'s `emit`) to discard whatever this call
+/// already pushed and recompute the *entire* range from scratch via
+/// [`eval_range_values_f64`] instead, matching jq's own `f64`-based model at
+/// that point. Otherwise returns `Some((result, truncated))`, `truncated`
+/// meaning the cap actually cut the range short (`true`) rather than the
+/// range finishing naturally within it (`false`) -- deliberately *not* an
 /// error here: this has no visibility into whether the caller's own sink
 /// would have stopped asking before the cap anyway (`first`/`limit`'s
 /// demand-driven early exit, #2089), only [`each_range`]'s `emit` does, so
 /// the truncation verdict is reported back rather than acted on locally.
+///
+/// # Safety criterion
+///
+/// The only way this loop can misbehave is the `i64` addition wrapping via
+/// two's-complement (#2131's original bug: plain `i +=`, no guard at all).
+/// [`i64::checked_add`] makes that impossible to miss -- the moment a
+/// partial sum would leave `i64`'s range, it returns `None` and this
+/// function bails immediately via `?`, before that value is ever observed or
+/// pushed. There is no separate bound to prove equivalent to this behavior
+/// (the earlier `±2^53` gate had to prove its threshold made `i64` and
+/// `f64` arithmetic agree bit-for-bit); overflow-freedom is checked exactly,
+/// by the same arithmetic that would otherwise overflow, at every step it
+/// could occur, however many magnitude combinations of `from`/`to`/`step`
+/// might trigger it.
+///
+/// # Cap-boundary decoupling (round 3)
+///
+/// An earlier revision of this loop checked the cap and attempted the
+/// advance in the same unconditional step (`while i < to && values.len() <
+/// MAX_RANGE { push; i = i.checked_add(step)?; }`): on the iteration whose
+/// push made `values.len()` reach [`MAX_RANGE`] -- the very last one the cap
+/// allows -- it still went on to compute `i.checked_add(step)` the exact
+/// same way every other iteration does, including the `?` that bails the
+/// *whole function* on overflow. If that lookahead candidate overflowed
+/// `i64` (astronomically large `step`s make this easy: the 100,001st
+/// candidate can leave `i64` range even when all 100,000 pushed values were
+/// perfectly valid), the caller discarded every already-correct pushed
+/// value for an `f64` recomputation none of them needed. Confirmed live:
+/// `nth(250; range(0; 9223372036854775807; 92234642714974))` returned the
+/// wrong, `f64`-derived answer instead of the exact `250 * 92234642714974`.
+///
+/// The loop above still computes that one lookahead at the cap boundary --
+/// there is no way to know whether one more value exists without it -- but
+/// interprets its result *locally* (`i.checked_add(step).is_some_and(|next|
+/// next < to)`) instead of bailing the whole function via `?` on failure.
+/// This is sound, not merely convenient: if `i.checked_add(step)` overflows
+/// here, the true mathematical next value exceeds `i64::MAX` (or, on the
+/// descending arm, is below `i64::MIN`), and `to` is always itself a valid
+/// `i64` (`<= i64::MAX` / `>= i64::MIN`) -- so an out-of-`i64`-range
+/// candidate can *never* satisfy `< to` (`> to` descending) either. That
+/// makes it indistinguishable from natural exhaustion: `truncated = false`
+/// is provably correct, not a guess, whenever this specific check overflows
+/// (see `test_eval_range_values_cap_hit_lookahead_overflow_does_not_bail_2131`,
+/// which confirms `range(0; i64::MAX; 92234642714974)` mathematically has
+/// *exactly* `MAX_RANGE` values -- `99999 * step < i64::MAX` but
+/// `100000 * step > i64::MAX` -- so this isn't even a close call once
+/// checked by hand). A cap-hit range whose lookahead does *not* overflow
+/// and genuinely has more values keeps reporting `truncated = true` exactly
+/// as before (`test_eval_range_values_cap_hit_genuine_truncation_still_flagged_2131`).
+///
+/// This cap-boundary lookahead is a fundamentally different call than the
+/// per-iteration advance on a *non*-cap-terminated loop: that one is still
+/// gated by `?`, because there the loop genuinely needs `i`'s next value to
+/// keep going, and an overflow there means the range ran off the edge of
+/// representable `i64` space while still short of the cap -- the
+/// genuine-overflow case the rest of this doc comment describes, where
+/// bailing to `eval_range_values_f64` is what makes near-`i64::MIN`/`MAX`
+/// ranges match jq's own boundary-adjacent rounding behavior (see the
+/// issue's own repro below). The cap-boundary lookahead has no such
+/// obligation: it exists purely to answer "does one more value exist" for
+/// a batch this call has *already* finished correctly computing, so there
+/// is nothing to discard either way. A natural exit (the `while` condition
+/// itself becoming false, cap never engaged) never sets `truncated`, so it
+/// stays at its `false` initial value -- no lookahead needed there at all.
+///
+/// This also *narrows* the previous gate correctly: a range with no
+/// overflow risk at all -- e.g. a nanosecond-epoch-scale
+/// `range(1_700_000_000_000_000_000; 1_700_000_000_000_000_010; 1)`, whose
+/// magnitude sits well past `2^53` but whose 10-step walk never comes close
+/// to `i64::MAX` -- now keeps its exact `i64` answer instead of being
+/// blanket-routed to `f64`, where at that magnitude every value in the
+/// range rounds to the *same* double and the whole range degenerates to
+/// empty. The previous `±2^53` gate was sufficient for correctness but far
+/// more conservative than the actual overflow risk (`i64::MIN`/`i64::MAX`
+/// adjacent, roughly `±9.2 * 10^18`) -- six orders of magnitude tighter than
+/// it needed to be, and this was that gate's own undisclosed regression.
+///
+/// A genuine `i64::MIN`/`i64::MAX`-adjacent case (the issue's own repro,
+/// `range(-9223372036854775758; -9223372036854775808; -100)`) still
+/// overflows on its very first `checked_add` (`from` is only 50 above
+/// `i64::MIN`, and `step` subtracts 100 more) and still correctly falls
+/// back to `f64` -- see `test_eval_range_values_overflow_detection_2131` and
+/// the rest of this module's `#2131`-tagged tests for the sign/step-width
+/// combinations swept to confirm this.
 fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
     from: i64,
     to: i64,
     step: i64,
-) -> (QueryResult<'a, W>, bool) {
+) -> Option<(QueryResult<'a, W>, bool)> {
     let mut values: Vec<OwnedValue> = Vec::new();
     let mut truncated = false;
 
     if step > 0 {
         let mut i = from;
-        while i < to && values.len() < MAX_RANGE {
+        while i < to {
             values.push(OwnedValue::Int(i));
-            i += step;
+            if values.len() >= MAX_RANGE {
+                // Cap hit on the push that just happened. Whether this is a
+                // *real* truncation depends on whether one more value would
+                // exist -- which still needs the next candidate, but this
+                // lookahead's overflow is handled locally (`is_some_and`
+                // rather than `?`) rather than bailing the whole function:
+                // if `i.checked_add(step)` overflows `i64`, the true
+                // mathematical next value exceeds `i64::MAX`, and since
+                // `to` is itself always a valid `i64` (<= `i64::MAX`), that
+                // hypothetical next value can never be `< to` either --
+                // it's provably not part of the range, exactly as if this
+                // were natural exhaustion. So an overflow here safely
+                // resolves to `false`, never to a bail: unlike the
+                // non-cap advance below, this call is answering "does a
+                // next value exist" for the *already-correct* batch this
+                // call already pushed, not "what is it", so there is
+                // nothing to discard either way (#2131 round 3).
+                truncated = i.checked_add(step).is_some_and(|next| next < to);
+                break;
+            }
+            i = i.checked_add(step)?;
         }
-        truncated = i < to;
     } else if step < 0 {
         let mut i = from;
-        while i > to && values.len() < MAX_RANGE {
+        while i > to {
             values.push(OwnedValue::Int(i));
-            i += step;
+            if values.len() >= MAX_RANGE {
+                truncated = i.checked_add(step).is_some_and(|next| next > to);
+                break;
+            }
+            i = i.checked_add(step)?;
         }
-        truncated = i > to;
     }
 
-    (owned_vec_to_result(values), truncated)
+    Some((owned_vec_to_result(values), truncated))
 }
 
 /// Helper to generate range values over floats, capped at [`MAX_RANGE`] per
@@ -42833,6 +42951,419 @@ mod tests {
                 lazy,
                 "eval_each diverged from eval_single for `{src}` on {}",
                 core::str::from_utf8(json).unwrap()
+            );
+        }
+    }
+
+    /// Shared by the `#2131` `eval_range_values` tests below: converts its
+    /// `Option<(QueryResult, bool)>` return into a plain `Option<(Vec<i64>,
+    /// bool)>` for equality comparison -- `QueryResult` doesn't derive
+    /// `PartialEq` (and doesn't need to for production code, only here).
+    /// Panics if a value comes back that isn't `Int`, since every input this
+    /// helper is used with is an all-integer `range` (the only case
+    /// [`eval_range_values`] is ever invoked for).
+    fn eval_range_values_i64(from: i64, to: i64, step: i64) -> Option<(Vec<i64>, bool)> {
+        eval_range_values::<Vec<u64>>(from, to, step).map(|(qr, truncated)| {
+            let values = match qr {
+                QueryResult::None => Vec::new(),
+                QueryResult::Owned(OwnedValue::Int(i)) => vec![i],
+                QueryResult::ManyOwned(items) => items
+                    .into_iter()
+                    .map(|v| match v {
+                        OwnedValue::Int(i) => i,
+                        other => panic!("expected Int, got {other:?}"),
+                    })
+                    .collect(),
+                other => panic!("expected an Int-only range result, got {other:?}"),
+            };
+            (values, truncated)
+        })
+    }
+
+    /// Independent reference for [`eval_range_values`]'s computation,
+    /// entirely in `i128` -- used only by the sweep test below to
+    /// cross-check its `checked_add`-based overflow detection over a wide
+    /// range of magnitudes, without relying on the same arithmetic it's
+    /// checking. `i128` has enormous headroom over anything a
+    /// `MAX_RANGE`-bounded `i64` walk can produce (at most `MAX_RANGE`
+    /// additions of an `i64`-magnitude step, nowhere near `i128::MAX`), so
+    /// this reference can never overflow itself; it instead explicitly
+    /// checks each candidate next value against `i64::MIN..=i64::MAX` right
+    /// where [`eval_range_values`]'s own `checked_add` would fail, in the
+    /// same push-then-add order (the current `i` is always already valid --
+    /// by induction from `from` itself, an `i64` -- so only the *next* value
+    /// needs checking, exactly mirroring what `checked_add` guards).
+    ///
+    /// Cap-checked *after* each push, mirroring [`eval_range_values`]'s own
+    /// round-3 decoupling (round 3, #2131): an earlier version of this
+    /// reference checked the cap and the lookahead together in one
+    /// `while`/`&&` condition, the same structural shape the real
+    /// `checked_add`-based fix originally shared and that let a
+    /// cap-terminated lookahead overflow wrongly discard an entire
+    /// already-correct answer via `return None`. That shared blind spot
+    /// meant this reference validated "matches an equally flawed model,"
+    /// not the real correctness property. This version still computes the
+    /// cap-boundary lookahead (there is no way to know whether one more
+    /// value exists without it) but, exactly like the real fix's
+    /// `i.checked_add(step).is_some_and(|next| next < to)`, treats an
+    /// out-of-`i64`-range candidate there as proof no further value exists
+    /// (`truncated = false`) rather than as a signal to bail -- `to` is
+    /// always representable in `i64`, so a candidate that isn't can never
+    /// satisfy the comparison against it either way. Only a lookahead
+    /// attempted on a *non*-cap-terminated iteration (the loop's own
+    /// advance, still needed to keep going) can trigger this reference's
+    /// `None`, mirroring `eval_range_values`'s own `?`. Decoupling it here
+    /// independently re-derives the same conclusion via `i128` arithmetic
+    /// instead of trusting the production code's own control flow.
+    fn reference_range_i64(from: i64, to: i64, step: i64) -> Option<(Vec<i64>, bool)> {
+        let to128 = to as i128;
+        let step128 = step as i128;
+        let mut i: i128 = from as i128;
+        let mut values = Vec::new();
+        let mut truncated = false;
+        let in_i64 = |v: i128| (i64::MIN as i128..=i64::MAX as i128).contains(&v);
+
+        if step > 0 {
+            while i < to128 {
+                values.push(i as i64);
+                if values.len() >= MAX_RANGE {
+                    let next = i + step128;
+                    truncated = in_i64(next) && next < to128;
+                    break;
+                }
+                let next = i + step128;
+                if !in_i64(next) {
+                    return None;
+                }
+                i = next;
+            }
+        } else if step < 0 {
+            while i > to128 {
+                values.push(i as i64);
+                if values.len() >= MAX_RANGE {
+                    let next = i + step128;
+                    truncated = in_i64(next) && next > to128;
+                    break;
+                }
+                let next = i + step128;
+                if !in_i64(next) {
+                    return None;
+                }
+                i = next;
+            }
+        }
+        Some((values, truncated))
+    }
+
+    /// #2131 (revised fix): pins the specific magnitudes the issue and its
+    /// review turned up, directly against [`eval_range_values`] -- the
+    /// near-`i64::MIN` original repro (must overflow on the very first
+    /// `checked_add`), the nanosecond-epoch-scale case the revised fix
+    /// exists to recover (must stay on the exact `i64` path -- the earlier
+    /// `±2^53` gate routed this to `f64`, where it silently degenerated to
+    /// `[]`), and the `2^53`-magnitude confirmed-hangs-in-real-jq shape
+    /// (also must now stay on the exact `i64` path: `i64` has no
+    /// precision-loss problem at that magnitude the way `f64` does, a
+    /// beneficial side effect of narrowing the gate, not a new bug).
+    #[test]
+    fn test_eval_range_values_overflow_detection_2131() {
+        // Ordinary small range: exact, no overflow.
+        assert_eq!(
+            eval_range_values_i64(0, 10, 1),
+            Some(((0..10).collect(), false))
+        );
+
+        // The regression this refinement fixes: a nanosecond-epoch-scale
+        // range whose magnitude is well past the old `2^53` gate but whose
+        // 10-step walk never comes close to `i64::MAX` -- must stay exact.
+        assert_eq!(
+            eval_range_values_i64(1_700_000_000_000_000_000, 1_700_000_000_000_000_010, 1),
+            Some((
+                (1_700_000_000_000_000_000..1_700_000_000_000_000_010).collect(),
+                false
+            ))
+        );
+
+        // The confirmed-hangs-in-real-jq shape: completes correctly and
+        // quickly on the `i64` path instead of needing `MAX_RANGE` to save
+        // it (`f64` can't advance past `2^53` by `1`; `i64` has no such
+        // problem).
+        let bound = 1i64 << 53;
+        assert_eq!(
+            eval_range_values_i64(bound - 2, bound + 2, 1),
+            Some(((bound - 2..bound + 2).collect(), false))
+        );
+
+        // The issue's own repro: `from` is 50 above `i64::MIN`, `step`
+        // subtracts 100 more -- overflows on the very first `checked_add`,
+        // before a single value beyond `from` is ever produced.
+        assert_eq!(
+            eval_range_values_i64(-9223372036854775758, -9223372036854775808, -100),
+            None
+        );
+
+        // Overflow near `i64::MAX` on the first add: the gap to `to` (10)
+        // is far smaller than `step` (1000), so the first push-then-add
+        // already overshoots.
+        assert_eq!(eval_range_values_i64(i64::MAX - 10, i64::MAX, 1000), None);
+
+        // Mirror at `i64::MIN`, negative step.
+        assert_eq!(eval_range_values_i64(i64::MIN + 10, i64::MIN, -1000), None);
+
+        // Overflow NOT on the first add: from 0, a step just past half of
+        // `i64::MAX` only overshoots on its *second* application.
+        let big_step = i64::MAX / 2 + 100;
+        assert_eq!(eval_range_values_i64(0, i64::MAX, big_step), None);
+
+        // Zero-iteration cases at the most extreme possible magnitudes: the
+        // `while` condition fails on entry, so no add is ever attempted
+        // regardless of how extreme `from`/`to` are.
+        assert_eq!(
+            eval_range_values_i64(i64::MAX, i64::MIN, 1),
+            Some((Vec::new(), false))
+        );
+        assert_eq!(
+            eval_range_values_i64(i64::MIN, i64::MAX, -1),
+            Some((Vec::new(), false))
+        );
+
+        // step == 0: always trivially empty (matches jq's `else empty end`
+        // arm), regardless of from/to magnitude -- no add is ever attempted.
+        assert_eq!(
+            eval_range_values_i64(i64::MIN, i64::MAX, 0),
+            Some((Vec::new(), false))
+        );
+    }
+
+    /// #2131 round 3: pins the exact live repro a review found in round 2's
+    /// `checked_add`-based fix -- `values.len() == MAX_RANGE` is reached on
+    /// the same push whose lookahead candidate (the 100,001st value, needed
+    /// only to answer "does one more value exist", never to be pushed
+    /// itself) overflows `i64`. Round 2's structure computed that lookahead
+    /// the same way it computed every other iteration's advance and bailed
+    /// the *whole function* via `?` when it overflowed, discarding all
+    /// 100,000 already-correct pushed values for an `f64` recomputation
+    /// none of them needed: `nth(250; range(0; 9223372036854775807;
+    /// 92234642714974))` returned `23058660678743610` (wrong, `f64`-derived)
+    /// instead of the exact `250 * 92234642714974 = 23058660678743500` --
+    /// confirmed live before this fix, both via `succinctly jq` directly and
+    /// via this test with round 2's code temporarily restored.
+    ///
+    /// The round-3 fix still computes that one lookahead at the cap
+    /// boundary (there is no way to know whether one more value exists
+    /// without it), but interprets its overflow *locally* instead of
+    /// bailing: `100000 * 92234642714974 = 9223464271497400000` exceeds
+    /// `i64::MAX`, and since `to` (`i64::MAX` here) is itself always a
+    /// valid `i64`, an out-of-`i64`-range candidate can never be `< to`
+    /// either -- it is provably not part of the range, exactly as if the
+    /// range had exhausted naturally. So this specific range, despite its
+    /// astronomically large step, mathematically has *exactly* `MAX_RANGE`
+    /// values (`99999 * step < to` but `100000 * step > to`, verified by
+    /// hand) -- hitting the cap here does not actually cut anything short,
+    /// so `truncated` must come back `false`, not `true`; what matters is
+    /// that this returns `Some` at all; instead of the round-2 bug's `None`,
+    /// discarding every already-correct pushed value.
+    #[test]
+    fn test_eval_range_values_cap_hit_lookahead_overflow_does_not_bail_2131() {
+        let step = 92234642714974i64;
+        let (values, truncated) =
+            eval_range_values_i64(0, i64::MAX, step).expect("cap-hit exit must not overflow-bail");
+        assert_eq!(values.len(), MAX_RANGE);
+        assert!(
+            !truncated,
+            "this range has exactly MAX_RANGE values (100000 * step already exceeds `to`), \
+             so hitting the cap here is natural exhaustion, not real truncation"
+        );
+        assert_eq!(values[250], 250 * step, "must be the exact i64 value");
+        assert_eq!(values[MAX_RANGE - 1], (MAX_RANGE as i64 - 1) * step);
+
+        // Mirror at the descending arm: `i64::MIN`-adjacent `to`, negative
+        // step, same magnitude -- same "exactly MAX_RANGE values" shape.
+        let (values, truncated) = eval_range_values_i64(0, i64::MIN, -step)
+            .expect("cap-hit exit must not overflow-bail (descending)");
+        assert_eq!(values.len(), MAX_RANGE);
+        assert!(!truncated);
+        assert_eq!(values[250], -250 * step);
+    }
+
+    /// #2131 round 3, contrast case: a cap-hit range whose lookahead does
+    /// *not* overflow and genuinely has more values beyond `MAX_RANGE`
+    /// (`to` is `MAX_RANGE + 5`, well within `i64`) -- `truncated` must
+    /// still come back `true` here. Exists alongside the overflow case
+    /// above to prove the round-3 fix didn't over-correct into always
+    /// reporting `false` at the cap boundary: the two cases share the same
+    /// code path (the `i.checked_add(step).is_some_and(...)` lookahead),
+    /// differing only in whether that lookahead overflows.
+    #[test]
+    fn test_eval_range_values_cap_hit_genuine_truncation_still_flagged_2131() {
+        let to = MAX_RANGE as i64 + 5;
+        let (values, truncated) =
+            eval_range_values_i64(0, to, 1).expect("small-step cap hit never overflows");
+        assert_eq!(values.len(), MAX_RANGE);
+        assert!(
+            truncated,
+            "5 more values ({MAX_RANGE}..{to}) genuinely exist beyond the cap"
+        );
+
+        let (values, truncated) =
+            eval_range_values_i64(0, -to, -1).expect("small-step cap hit never overflows");
+        assert_eq!(values.len(), MAX_RANGE);
+        assert!(truncated);
+    }
+
+    /// #2131 (revised fix): sweeps a magnitude-diverse, deterministic grid
+    /// of `(from, to, step)` triples -- anchored at and around
+    /// `i64::MIN`/`i64::MAX`, `±2^53`, the nanosecond-epoch scale, and
+    /// small/huge steps in both directions -- against
+    /// [`reference_range_i64`]'s independent `i128` computation. Every
+    /// combination must agree on both whether overflow occurs (`Some` vs.
+    /// `None`) and, when it doesn't, the exact pushed sequence and
+    /// truncation flag. Not a substitute for the analytical argument in
+    /// [`eval_range_values`]'s own doc comment, but the same kind of
+    /// adversarial sweep #2131's review already ran against the
+    /// now-replaced `±2^53` gate, scaled to this narrower criterion.
+    /// Deterministic (no RNG) and cheap: `to` is derived from `from` and
+    /// `step` with a small iteration-count target `k` for most
+    /// combinations, with only a few `k` values large enough to actually
+    /// engage the `MAX_RANGE` cap, keeping the whole grid well under a
+    /// second.
+    #[test]
+    fn test_eval_range_values_matches_i128_reference_sweep_2131() {
+        let bound = 1i64 << 53;
+        let from_anchors: &[i64] = &[
+            i64::MIN,
+            i64::MIN + 1,
+            i64::MIN / 2,
+            -bound - 2,
+            -bound,
+            -bound + 2,
+            -1_700_000_000_000_000_010,
+            -100,
+            -1,
+            0,
+            1,
+            100,
+            1_700_000_000_000_000_000,
+            bound - 2,
+            bound,
+            bound + 2,
+            i64::MAX / 2,
+            i64::MAX - 1,
+            i64::MAX,
+        ];
+        let steps: &[i64] = &[
+            1,
+            -1,
+            2,
+            -2,
+            100,
+            -100,
+            1_000_000_000_000_000,
+            -1_000_000_000_000_000,
+            // `i64::MAX / MAX_RANGE`-neighborhood: the live #2131-round-3
+            // repro's own step (`nth(250; range(0; 9223372036854775807;
+            // 92234642714974))`). Combined with `from = 0` and `k = 130_000`
+            // below, this is the specific "cap hit on the 100,000th push AND
+            // the never-pushed 100,001st lookahead candidate (needed only
+            // to answer whether one more value exists) overflows `i64`"
+            // shape the round-3 fix exists for -- neither of the wider
+            // `i64::MAX / 4`/`i64::MAX` steps below reproduces it, since
+            // those overflow long before the cap is ever reached.
+            92234642714974,
+            -92234642714974,
+            i64::MAX / 4,
+            -(i64::MAX / 4),
+            i64::MAX,
+            i64::MIN,
+        ];
+        // Small `k`s keep most combinations cheap (a handful of iterations);
+        // one `k` per (from, step) pair is pushed well past `MAX_RANGE` so
+        // the cap-interacts-with-overflow-detection path gets exercised too.
+        let ks: &[i128] = &[1, 3, 10, 130_000];
+
+        let mut combos = 0usize;
+        for &from in from_anchors {
+            for &step in steps {
+                for &k in ks {
+                    combos += 1;
+                    let to128 =
+                        (from as i128 + step as i128 * k).clamp(i64::MIN as i128, i64::MAX as i128);
+                    let to = to128 as i64;
+
+                    let expected = reference_range_i64(from, to, step);
+                    let actual = eval_range_values_i64(from, to, step);
+                    assert_eq!(
+                        actual, expected,
+                        "mismatch for from={from}, to={to}, step={step}"
+                    );
+                }
+            }
+        }
+        assert_eq!(combos, from_anchors.len() * steps.len() * ks.len());
+    }
+
+    /// #2131 (revised fix), end to end through the full `each_range`/`emit`
+    /// dispatch (not just [`eval_range_values`] directly): a range with no
+    /// overflow risk keeps its exact `Int` values regardless of how large
+    /// its magnitude is, while a range that genuinely cannot be computed in
+    /// `i64` without overflowing falls back to `Float` -- confirming the
+    /// routing decision in `each_range`'s `emit` closure (the `match` on
+    /// `eval_range_values`'s `Option`) actually reaches production code, not
+    /// just the unit-level tests above.
+    #[test]
+    fn test_range_dispatch_falls_back_to_f64_only_on_genuine_overflow_2131() {
+        fn range_values(src: &str) -> Vec<OwnedValue> {
+            let json: &[u8] = b"null";
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let expr = parse(src).unwrap();
+            let (values, tag) = normalize(eval::<Vec<u64>, JqSemantics>(&expr, cursor));
+            assert_eq!(tag, "ok", "`{src}` did not evaluate cleanly");
+            values
+        }
+
+        // Ordinary small range: every value is an exact Int.
+        for v in range_values("range(0;10;1)") {
+            assert!(matches!(v, OwnedValue::Int(_)), "expected Int, got {v:?}");
+        }
+
+        // The nanosecond-epoch-scale regression case: no overflow risk at
+        // all, so it must stay Int end to end, with the exact expected
+        // sequence (no precision loss, unlike the old `±2^53`-gated fix).
+        let ns = range_values("[range(1700000000000000000;1700000000000000010;1)]");
+        assert_eq!(ns.len(), 1, "expected a single array result");
+        match &ns[0] {
+            OwnedValue::Array(items) => {
+                let ints: Vec<i64> = items
+                    .iter()
+                    .map(|v| match v {
+                        OwnedValue::Int(i) => *i,
+                        other => panic!("expected Int, got {other:?}"),
+                    })
+                    .collect();
+                assert_eq!(
+                    ints,
+                    (1_700_000_000_000_000_000i64..1_700_000_000_000_000_010).collect::<Vec<_>>()
+                );
+            }
+            other => panic!("expected Array, got {other:?}"),
+        }
+
+        // The issue's own repro: overflows on the first `checked_add`,
+        // falls back to `f64`, and (matching real jq, whose `from`/`to`
+        // round to the same double at this magnitude) produces no values.
+        assert_eq!(
+            range_values("range(-9223372036854775758;-9223372036854775808;-100)"),
+            Vec::new()
+        );
+
+        // A genuine near-`i64::MAX` overflow: routed to the f64 path, so
+        // values come back as Float even though the source literals were
+        // plain integers.
+        for v in range_values("range(9223372036854774000;9223372036854775807;1000000000000000)") {
+            assert!(
+                matches!(v, OwnedValue::Float(_)),
+                "expected Float once a genuine i64 overflow is detected, got {v:?}"
             );
         }
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31745,3 +31745,193 @@ fn test_m2_lazyseq_halt_prints_nothing_1576() -> Result<()> {
     }
     Ok(())
 }
+
+// =============================================================================
+// range() i64 fast-path overflow at extreme magnitude (issue #2131)
+// =============================================================================
+//
+// `range`'s all-integer fast path (`eval_range_values`, `src/jq/eval.rs`) did
+// plain `i64` `i += step` with no overflow guard: near `i64::MIN`/`i64::MAX`
+// this wrapped via two's-complement and streamed garbage instead of erroring
+// or matching jq. Real jq represents every number as `f64`, so at these
+// magnitudes it has no "overflow" concept, only precision loss -- two
+// integers that round to the same `f64` compare equal, so a `range` between
+// them is a zero-iteration loop by construction.
+//
+// The fix (`eval_range_values`, `src/jq/eval.rs`) replaces the plain `+=`
+// with `i.checked_add(step)`, bailing out (`None`) the instant an addition
+// would leave `i64`'s range; `each_range`'s `emit` closure then falls back to
+// the pre-existing, `MAX_RANGE`-capped `eval_range_values_f64`, matching jq's
+// own `f64`-based model, for that one `(from, to, step)` combination.
+//
+// An earlier version of this fix gated the `i64` path behind a blanket
+// `±2^53` magnitude cutoff (the threshold where every integer round-trips
+// through `f64` losslessly) -- correct, but far more conservative than the
+// actual overflow risk (`i64::MIN`/`i64::MAX`-adjacent, ~`±9.2 * 10^18`, six
+// orders of magnitude tighter than it needed to be). That blanket cutoff
+// silently degraded ordinary large-but-safe integers (nanosecond-epoch
+// timestamps, large database IDs) to `f64`, where at that magnitude they can
+// round to the same double and the whole range collapses to empty. The
+// `checked_add`-based fix below only ever falls back when an overflow is
+// genuinely about to happen, so it keeps the exact `i64` answer for every
+// range that doesn't actually risk one, however large its magnitude.
+
+/// The issue's own repro: two `i64` literals only 50 apart at `~2^63`
+/// magnitude round to the *same* `f64` once parsed, so real jq's
+/// `while(. > $upto; . + $by)` never even emits its own starting value --
+/// confirmed live against the pinned jq 1.7.1 oracle (empty output, exit 0).
+/// Before this fix, succinctly's unconditional `i64` fast path instead wrapped
+/// `from + step` past `i64::MIN` via two's-complement and streamed garbage.
+/// `from` is only 50 above `i64::MIN` and `step` subtracts 100 more, so the
+/// revised fix's `checked_add` overflows on the very first application,
+/// falling back to `f64` before a single value is ever produced.
+#[test]
+fn test_range_i64_overflow_original_repro_matches_jq_2131() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-nc",
+            "range(-9223372036854775758; -9223372036854775808; -100)",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "", "expected no output, matching real jq");
+    Ok(())
+}
+
+/// A range straddling `2^53` -- the top of jq's own exact-`f64` zone, and
+/// where the earlier, now-replaced `±2^53`-gated fix drew its line -- has no
+/// `i64` overflow risk at all (nowhere near `i64::MIN`/`i64::MAX`), so it
+/// still takes the exact `i64` fast path: verified against the pinned jq
+/// 1.7.1 oracle, byte-for-byte identical output.
+#[test]
+fn test_range_near_boundary_still_uses_i64_fast_path_2131() -> Result<()> {
+    let (stdout, code) = run_jq_null("[range(9007199254740982;9007199254740992;1)]", &["-c"])?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(
+        stdout.trim(),
+        "[9007199254740982,9007199254740983,9007199254740984,9007199254740985,\
+9007199254740986,9007199254740987,9007199254740988,9007199254740989,\
+9007199254740990,9007199254740991]"
+    );
+    Ok(())
+}
+
+/// A range whose `to` bound is close to `i64::MAX` (`i64::MAX - ~1.8e15`,
+/// still a valid `i64`) with a `step` (`1e15`) large enough to overshoot it
+/// in one add must route to the `f64` path rather than the exact `i64`
+/// one -- before this fix, `eval_range_values` computed this directly in
+/// `i64` and (depending on the exact combination) either produced an answer
+/// jq itself would not, or -- as this exact case does when misrouted --
+/// panics on `attempt to add with overflow` in a debug build (confirmed
+/// while developing this fix); the revised fix's `checked_add` catches this
+/// on the very first addition. The chosen step is large relative to the
+/// span so real jq also terminates quickly rather than stalling near this
+/// magnitude; verified against the pinned jq 1.7.1 oracle (timeout-guarded
+/// during development -- this specific combination returns instantly).
+#[test]
+fn test_range_beyond_boundary_routes_to_f64_path_2131() -> Result<()> {
+    let (stdout, code) = run_jq_null(
+        "[range(9223372036854774000;9223372036854775807;1000000000000000)]",
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim(), "[9223372036854774000]");
+    Ok(())
+}
+
+/// The confirmed-hangs-in-real-jq shape from the issue's own investigation:
+/// once `i` reaches `2^53` with `step == 1`, `i + 1` rounds back to exactly
+/// `i` in `f64` arithmetic (the next representable double after `2^53` is
+/// `2^53 + 2`, not `2^53 + 1`), so real jq's `while` loop never advances and
+/// never terminates -- reproduced live and killed by hand while
+/// investigating this issue; NOT re-run here against the real oracle (would
+/// hang the test suite). Per ADR-0018's host-process-endangering exception,
+/// succinctly is not obligated to reproduce that hang.
+///
+/// Under the earlier, now-replaced `±2^53`-gated fix, this range (`to`
+/// exceeds the gate) was routed to `f64` same as any out-of-bound range, and
+/// the pre-existing `MAX_RANGE` cap (#2089) raised instead of looping
+/// forever. The revised, `checked_add`-based fix changes this: `i64` has no
+/// precision-loss problem at `2^53`'s magnitude the way `f64` does (every
+/// integer here is exactly representable and `i += 1` always advances by
+/// exactly 1), and this walk is nowhere near `i64::MIN`/`i64::MAX`, so
+/// `checked_add` never trips -- the range now stays on the exact `i64` path
+/// and completes correctly, well under `MAX_RANGE`, instead of needing the
+/// cap to save it. A nice side effect of narrowing the gate, not a
+/// regression: this asserts succinctly's own behavior completes (not a
+/// hang) with the exact correct answer.
+#[test]
+fn test_range_2_53_magnitude_completes_via_i64_not_hang_or_cap_2131() -> Result<()> {
+    let (stdout, code) = run_jq_null("[range(9007199254740990; 9007199254740994; 1)]", &["-c"])?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(
+        stdout.trim(),
+        "[9007199254740990,9007199254740991,9007199254740992,9007199254740993]"
+    );
+    Ok(())
+}
+
+/// #2131's own regression that this refinement fixes: a nanosecond-epoch-
+/// scale integer range with no `i64` overflow risk at all -- its magnitude
+/// (`~1.7e18`) sits well past the earlier, now-replaced `±2^53` gate, but
+/// its 10-step walk never comes remotely close to `i64::MAX`
+/// (`~9.2e18`). The earlier gate routed this to `f64` purely on magnitude,
+/// where every one of these 10 integers rounds to the *same* double and the
+/// range silently degenerates to empty -- worse than the original overflow
+/// bug for a realistic input (nanosecond timestamps, large database IDs),
+/// since it fails silently at exit 0 rather than producing wrong data loudly.
+/// The revised fix keeps this on the exact `i64` path, matching what an
+/// unpatched, pre-#2131 build already produced for this specific range (this
+/// magnitude has no overflow risk, so the original bug never affected it) --
+/// not a claim about matching real jq here, which has its own separate
+/// `decNumber`-vs-`double` quirk at this magnitude (out of this issue's
+/// scope; see `docs/compliance/jq/limitations.md`).
+#[test]
+fn test_range_nanosecond_epoch_scale_stays_exact_i64_2131() -> Result<()> {
+    let (stdout, code) = run_jq_null(
+        "[range(1700000000000000000;1700000000000000010;1)]",
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(
+        stdout.trim(),
+        "[1700000000000000000,1700000000000000001,1700000000000000002,\
+1700000000000000003,1700000000000000004,1700000000000000005,\
+1700000000000000006,1700000000000000007,1700000000000000008,\
+1700000000000000009]"
+    );
+    Ok(())
+}
+
+/// #2131 round 3: pins the exact live repro a review found in round 2's
+/// `checked_add`-based fix. `eval_range_values`'s loop hit `MAX_RANGE`
+/// (100000 pushed values) on the same push whose lookahead candidate --
+/// the 100,001st value, needed only to answer "does one more value exist",
+/// never pushed itself -- overflows `i64` (`100000 * 92234642714974`
+/// exceeds `i64::MAX`). Round 2's structure computed that lookahead the
+/// same way it computed every other iteration's advance and bailed the
+/// *entire* function on its overflow, discarding all 100000 already-correct
+/// pushed values for an `f64` recomputation none of them needed:
+///
+/// ```console
+/// $ succinctly jq -nc 'nth(250; range(0;9223372036854775807;92234642714974))'
+/// 23058660678743610     # wrong, f64-derived (before this fix)
+/// ```
+///
+/// The round-3 fix still computes that one lookahead at the cap boundary,
+/// but interprets its overflow *locally* (as proof no further value could
+/// exist -- `to` is always representable in `i64`, so an out-of-range
+/// candidate could never be less than it anyway) instead of bailing the
+/// whole function on it: `nth(250; ...)` must come back with the exact
+/// `i64` value `250 * 92234642714974`, matching the same step used with a
+/// `to` small enough that the cap is never engaged
+/// (`range(0;92234642714974000;92234642714974)`, verified separately as a
+/// control while developing this fix and confirmed to already agree).
+#[test]
+fn test_range_cap_hit_lookahead_overflow_keeps_exact_i64_answer_2131() -> Result<()> {
+    let (stdout, code) = run_jq_null("nth(250; range(0;9223372036854775807;92234642714974))", &[])?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim(), (250i64 * 92234642714974).to_string());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- \`eval_range_values\`'s \`i += step\` had no overflow guard -- near \`i64::MIN\`/\`i64::MAX\` it wraps via two's-complement and silently streams garbage instead of the empty/short answer real jq's own double-based arithmetic gives at that magnitude.
- Detects overflow exactly where it can occur via \`checked_add\` rather than a conservative magnitude bound -- an earlier draft gated the whole \`i64\` fast path behind \`|value| <= 2^53\` (the largest magnitude where \`f64\` stays exact), but that silently degraded realistic large-but-safe integer ranges (nanosecond-epoch timestamps, ~1.7e18, nowhere near \`i64::MAX\`) from an exact enumeration to an empty answer.
- The \`MAX_RANGE\` cap-boundary's own lookahead (computing the next candidate purely to decide whether to keep looping) resolves an overflowing lookahead *locally* instead of bailing the whole function: since \`to\` is always a valid \`i64\`, an overflowing candidate can never satisfy the loop's own continuation condition, so it's provably indistinguishable from natural exhaustion -- an earlier draft discarded an entire \`MAX_RANGE\`-sized batch of already-correct values over this unused lookahead value overflowing.
- Documents the resulting divergence class in \`docs/compliance/jq/limitations.md\`: above \`2^53\`, real jq's own number model (decNumber-backed, not pure \`f64\`) diverges from succinctly's now-internally-exact \`i64\` answer in two distinct ways depending on magnitude -- it hangs forever from \`2^53\` to roughly \`2^57\` (confirmed to span this whole band via live bisection, not just the single already-documented \`2^53\` literal case), and gives a truncated answer from there through \`i64::MAX\`. Per ADR-0018, matching jq's own hang isn't required (the "would take the host process down" exception); the existing \`MAX_RANGE\` cap already gives a safe, bounded answer there instead.
- A narrower residual gap -- the ordinary per-iteration advance (not the cap boundary) can still discard already-correct values on overflow within roughly one step's width of \`i64::MIN\`/\`MAX\` -- is deliberately deferred to #2219: generalizing the cap-boundary's local-resolution treatment there would also change this fix's own original repro's answer (from an empty match with jq's f64-collision coincidence to a non-empty, jq-diverging one), a real design decision rather than a mechanical port.

This went through 3 implementation rounds and 3 adversarial code reviews before landing here -- each prior round shipped something that looked complete but a careful review found a real gap (round 1: the \`2^53\` gate regressed realistic large integers; round 2: the cap-boundary lookahead itself could discard correct results on overflow). This round's fix and its test suite were built specifically to close those two gaps, verified via live oracle checks (all timeout-guarded near the precision/overflow boundaries -- both prior review rounds genuinely hung a session when probing unguarded) and a 912+-case differential sweep against an independent \`i128\`-based reference implementation.

## Test plan
- [x] Original repro (\`range(-9223372036854775758; -9223372036854775808; -100)\`) produces nothing, exit 0, matching real jq.
- [x] Cap-boundary lookahead-overflow repro (\`nth(250; range(0;9223372036854775807;92234642714974))\`) now gives the exact value \`23058660678743500\` (\`250 * step\`), not a silently-wrong \`f64\`-derived answer.
- [x] Nanosecond-epoch-scale ranges (\`range(1700000000000000000; 1700000000000000010; 1)\`) stay on the exact \`i64\` path -- 10 values, not silently empty.
- [x] A range landing exactly on \`MAX_RANGE\` (\`range(100000)\`) does not spuriously raise.
- [x] A range that hits \`MAX_RANGE\` with a small, safe step still correctly raises \`"range: maximum iterations exceeded"\`.
- [x] The confirmed-hang case (\`range(9007199254740990; 9007199254740994; 1)\`, timeout-guarded) now completes instantly via the exact \`i64\` path with the correct answer, rather than needing the \`MAX_RANGE\` cap to avoid hanging.
- [x] Both ascending and descending arms verified independently, including at the extreme \`to = i64::MIN\`/\`i64::MAX\` ends.
- [x] The 912+-case \`i128\` differential sweep's own reference implementation was itself found (round 2 review) to share the cap-boundary blind spot with the code under test, and was restructured to be genuinely independent -- verified via mutation testing (reverting just the fix's cap-boundary logic makes the sweep fail, confirming it's not vacuous).
- [x] \`docs/compliance/jq/limitations.md\`'s new divergence-class numbers (the \`2^53\`/\`2^57\` boundaries, the hang-vs-truncate sub-bands) were live-verified against \`/usr/bin/jq\` 1.7.1 at multiple points in each band, all timeout-guarded.
- [x] Full test suite: \`cargo test --features cli,simd,regex,serde --no-fail-fast\` -- 0 failures.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo clippy --all-targets --features std,simd,broadword-yaml,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\` -- clean.
- [x] \`cargo fmt --check\` -- clean.

Fixes #2131