### PR TITLE
fix(jq): re-evaluate E[S:T]'s target once per (s, e) pair, not once overall

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1267,18 +1267,25 @@ results one at a time instead of pre-allocating a single buffer, so it just keep
 output rather than answering promptly or refusing.
 
 Both `eval_index_expr` arms (#2032/#2142) and, since #2143, `eval_slice_expr` (in both
-files) have since moved off that single upfront product: their own target (the left side
-of `.[$keys]`/`.[$s:$e]`) is now re-evaluated once per key/`(s, e)` pair rather than once
-overall (see this doc's own no-longer-applicable earlier framing corrected — target length
-can vary per key/pair now, so one upfront product is no longer even computable), so each
-reserves incrementally instead, via a per-key/-pair `Vec::try_reserve` against
-`cannot_reserve_cross_product`'s identical error. The refusal guarantee this section
-describes is unchanged by that restructuring — every push remains behind a fallible
-reservation, so the failure mode stays "clean refusal," never a panic — only the moment the
-check runs (once upfront vs. incrementally per key/pair) and the factor(s) named in the
-error message changed. `resolve_index_expr`/`resolve_slice_expr` (the `path()`/write-path
-siblings, target still evaluated once — tracked separately as #2139) are the two sites that
-still call `try_reserve_product` directly with the original multi-factor product.
+files) have since moved off that single *full* upfront product: their own target (the
+left side of `.[$keys]`/`.[$s:$e]`) is now re-evaluated once per key/`(s, e)` pair rather
+than once overall (see this doc's own no-longer-applicable earlier framing corrected —
+target length can vary per key/pair now, so a product including it is no longer even
+computable), so each also reserves incrementally per key/pair via `Vec::try_reserve`
+against `cannot_reserve_cross_product`'s identical error, regardless of the target's own
+length. The two functions differ on what's reserved *before* that incremental loop even
+starts: `eval_index_expr` reserves nothing upfront (purely incremental from an empty
+`Vec`), while `eval_slice_expr` reserves a `starts.len() * ends.len()` baseline first —
+both factors are still fully known before the loop, so this recovers a single allocation
+for the common one-output-per-pair case instead of paying amortized-doubling
+reallocation/copy costs on every slice query; an overflowing product just skips the hint
+and falls through to the purely-incremental path, same as `eval_index_expr` always takes.
+The refusal guarantee this section describes is unchanged by any of this — every push
+remains behind a fallible reservation, so the failure mode stays "clean refusal," never a
+panic — only the moment(s) a check runs and the factor(s) named in the error message
+changed. `resolve_index_expr`/`resolve_slice_expr` (the `path()`/write-path siblings,
+target still evaluated once — tracked separately as #2139) are the two sites that still
+call `try_reserve_product` directly with the original multi-factor product.
 
 Unlike `s * n` above, this is symmetric across both modes rather than a yq-specific
 divergence to record — but not because a live check for a yq-side cap came back empty.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1275,14 +1275,20 @@ computable), so each also reserves incrementally per key/pair via `Vec::try_rese
 against `cannot_reserve_cross_product`'s identical error, regardless of the target's own
 length. The two functions differ on what's reserved *before* that incremental loop even
 starts: `eval_index_expr` reserves nothing upfront (purely incremental from an empty
-`Vec`), while `eval_slice_expr` reserves a `starts.len() * ends.len()` baseline first —
-both factors are still fully known before the loop, so this recovers a single allocation
-for the common one-output-per-pair case instead of paying amortized-doubling
-reallocation/copy costs on every slice query; an overflowing product just skips the hint
-and falls through to the purely-incremental path, same as `eval_index_expr` always takes.
-The refusal guarantee this section describes is unchanged by any of this — every push
-remains behind a fallible reservation, so the failure mode stays "clean refusal," never a
-panic — only the moment(s) a check runs and the factor(s) named in the error message
+`Vec`), while `eval_slice_expr` reserves a `starts.len() * ends.len()` baseline first, via
+the same `try_reserve_product` helper this section already describes (both factors are
+already known non-empty by this point, so it never takes that helper's own zero-factor
+fast return) — both factors are still fully known before the loop, so this recovers a
+single allocation for the common one-output-per-pair case instead of paying
+amortized-doubling reallocation/copy costs on every slice query, and reuses
+`try_reserve_product`'s existing overflow/refusal handling and its existing unit test
+coverage for both, rather than adding a parallel, practically-untestable check of its own
+(a `starts * ends` pair count large enough to organically overflow this product would
+first exhaust memory building the `starts`/`ends` bound streams themselves, long before
+this reservation could ever run). The refusal guarantee this section describes is
+unchanged by any of this — every push remains behind a fallible reservation, so the
+failure mode stays "clean refusal," never a panic — only the moment(s) a check runs and
+the factor(s) named in the error message
 changed. `resolve_index_expr`/`resolve_slice_expr` (the `path()`/write-path siblings,
 target still evaluated once — tracked separately as #2139) are the two sites that still
 call `try_reserve_product` directly with the original multi-factor product.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1244,7 +1244,7 @@ This guard is jq-mode-only. See [yq Limitations](../yq/limitations.md) for `succ
 mode, which refuses much earlier via its own, separate cap.
 
 Computed-index/-slice expansion (`.[$keys]`, `.[$s:$e]`, both in value position and under
-`path()`) has the identical shape again, at seven call sites (#1634): five in
+`path()`) has the identical shape again, originally at seven call sites (#1634): five in
 [src/jq/eval.rs](../../../src/jq/eval.rs) (`eval_index_expr` ×2 arms, `eval_slice_expr`,
 `resolve_index_expr`, `resolve_slice_expr`) plus two more in
 [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)'s own independent
@@ -1252,12 +1252,12 @@ Computed-index/-slice expansion (`.[$keys]`, `.[$s:$e]`, both in value position 
 `succinctly yq` CLI invocation actually dispatches an ordinary `.[$keys]`/`.[$s:$e]` read
 through (the `eval.rs` siblings are reached only via the direct library API, or via
 `eval_generic.rs`'s own fallback for expressions it doesn't handle natively). Each site
-pre-sizes its output with a product of two or three independent, generator-controlled
-`Vec::len()`s (e.g. `keys.len() * targets.len()`), previously handed straight to an
-infallible `Vec::with_capacity`. A large enough cross product — e.g. two independent
-100,000-element generators feeding the same `.[$keys]` — asks for more elements than the
-allocator can satisfy even though neither input list is individually unreasonable to
-materialize. succinctly now refuses with `Cannot allocate <factors joined by " * "> elements
+originally pre-sized its output with a single upfront product of two or three independent,
+generator-controlled `Vec::len()`s (e.g. `keys.len() * targets.len()`), previously handed
+straight to an infallible `Vec::with_capacity`. A large enough cross product — e.g. two
+independent 100,000-element generators feeding the same `.[$keys]` — asks for more elements
+than the allocator can satisfy even though neither input list is individually unreasonable
+to materialize. succinctly now refuses with `Cannot allocate <factors joined by " * "> elements
 for a computed-index expansion` via the same `Vec::try_reserve_exact` technique as the
 `setpath`/string-repeat cases above, applied through a shared `try_reserve_product` helper.
 Confirmed live against the pinned jq 1.7.1 binary for this exact shape (not just analogized
@@ -1265,6 +1265,20 @@ from the string-repeat case above): a genuinely large-but-indexable cross produc
 (`[range(50000) | [1,2]] | .[][(range(50000))]`) neither errors nor crashes — jq streams
 results one at a time instead of pre-allocating a single buffer, so it just keeps producing
 output rather than answering promptly or refusing.
+
+Both `eval_index_expr` arms (#2032/#2142) and, since #2143, `eval_slice_expr` (in both
+files) have since moved off that single upfront product: their own target (the left side
+of `.[$keys]`/`.[$s:$e]`) is now re-evaluated once per key/`(s, e)` pair rather than once
+overall (see this doc's own no-longer-applicable earlier framing corrected — target length
+can vary per key/pair now, so one upfront product is no longer even computable), so each
+reserves incrementally instead, via a per-key/-pair `Vec::try_reserve` against
+`cannot_reserve_cross_product`'s identical error. The refusal guarantee this section
+describes is unchanged by that restructuring — every push remains behind a fallible
+reservation, so the failure mode stays "clean refusal," never a panic — only the moment the
+check runs (once upfront vs. incrementally per key/pair) and the factor(s) named in the
+error message changed. `resolve_index_expr`/`resolve_slice_expr` (the `path()`/write-path
+siblings, target still evaluated once — tracked separately as #2139) are the two sites that
+still call `try_reserve_product` directly with the original multi-factor product.
 
 Unlike `s * n` above, this is symmetric across both modes rather than a yq-specific
 divergence to record — but not because a live check for a yq-side cap came back empty.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16515,7 +16515,11 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// rather than once overall, mirroring #2032/#2142's identical fix for
 /// `eval_index_expr` one nesting level deeper — see
 /// `eval_generic::eval_slice_expr`'s own copy of this comment for the full
-/// rationale and live-verified repro; not repeated here.
+/// rationale, live-verified repro, and the "cross-pair `out` vs. `target`'s
+/// own within-pair `Partial` prefix" distinction (not repeated here) that
+/// this file's copy folds `out` in for but deliberately still doesn't
+/// address the latter — same pre-existing, unaddressed gap
+/// `eval_index_expr` already carries.
 fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -16564,13 +16568,38 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // The result is always owned: slicing constructs a new array/string
     // (see `eval_single`'s `Expr::Slice` arm), so there is nothing to
     // borrow except its rare whole-value fast paths, which `to_owned_lossy`
-    // below just copies out of. Reserved per-pair below rather than as one
-    // upfront `starts.len() * ends.len() * targets.len()` product (#1634's
-    // original concern still applies -- an unguarded product of
-    // generator-controlled lengths can panic/abort on overflow -- but the
-    // target's own length can now vary per pair, so a single upfront
-    // product is no longer computable).
+    // below just copies out of.
     let mut out: Vec<OwnedValue> = Vec::new();
+
+    // `starts.len() * ends.len()` is still fully known before the loop --
+    // only the per-pair target count varies -- so reserve that much upfront
+    // as a baseline (the common case is exactly one output per pair),
+    // recovering the single upfront allocation the pre-#2143 code made for
+    // that case instead of paying amortized-doubling reallocation/copy
+    // costs on every slice query. `checked_mul` rather than
+    // `try_reserve_product` (which would also fold in a `targets.len()`
+    // this point doesn't have yet): an overflowing product here just skips
+    // the hint and falls through to the per-pair `try_reserve` calls below,
+    // which still refuse cleanly on their own once actually unallocatable
+    // -- `out` is empty at this point regardless, so there's nothing this
+    // hint could lose by skipping it.
+    if let Some(pairs) = starts.len().checked_mul(ends.len()) {
+        if out.try_reserve(pairs).is_err() {
+            return QueryResult::Error(cannot_reserve_cross_product(&[starts.len(), ends.len()]));
+        }
+    }
+
+    // The shared exit every escape arm below funnels through, so folding
+    // the running `out` in as a `Partial` prefix can't drift between arms
+    // -- the single-accumulator counterpart of `eval_index_expr`'s
+    // `escape_with_prefix!` one function above (that macro's own
+    // borrowed/owned promotion has nothing to do here: `out` is always
+    // `Vec<OwnedValue>`, never a separate borrowed accumulator).
+    macro_rules! escape {
+        ($control:expr) => {
+            return partial(out, $control)
+        };
+    }
 
     for s in starts {
         for e in &ends {
@@ -16585,9 +16614,9 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // output count can vary across pairs (mirrors
                 // `eval_index_expr`'s identical per-key treatment).
                 QueryResult::None => continue,
-                QueryResult::Error(err) => return partial(out, Control::Error(err)),
-                QueryResult::Break(label) => return partial(out, Control::Break(label)),
-                QueryResult::Halt(code) => return partial(out, Control::Halt(code)),
+                QueryResult::Error(err) => escape!(Control::Error(err)),
+                QueryResult::Break(label) => escape!(Control::Break(label)),
+                QueryResult::Halt(code) => escape!(Control::Halt(code)),
                 QueryResult::OneCursor(_) => {
                     unreachable!("materialize_cursor should have converted this")
                 }
@@ -16596,15 +16625,12 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // instead of discarding it (unreachable before this fix,
                 // since `out` was always empty at this point -- E was
                 // evaluated before the loop could produce anything).
-                QueryResult::Partial(_, control) => return partial(out, control),
+                QueryResult::Partial(_, control) => escape!(control),
             };
             match &targets {
                 Targets::Borrowed(ts) => {
                     if out.try_reserve(ts.len()).is_err() {
-                        return partial(
-                            out,
-                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
-                        );
+                        escape!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                     }
                     let slice_expr = Expr::Slice {
                         start: *s,
@@ -16622,33 +16648,59 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // own finding for `eval_single`'s array arm),
                             // so an undecodable string here used to
                             // silently become `""` instead of raising.
-                            // #2001 (code review): ...or_suppress -- this
-                            // is the computed-bounds sibling of
-                            // `eval_single`'s own literal-bounds `Expr::
-                            // Slice` array arm, which had the identical
-                            // unconditional-raise gap this same PR fixes.
-                            QueryResult::One(v) => {
-                                out.push(to_owned_or_suppress!(&v, optional));
-                            }
+                            // #2001 (code review): suppress-or-raise, not
+                            // an unconditional raise -- this is the
+                            // computed-bounds sibling of `eval_single`'s
+                            // own literal-bounds `Expr::Slice` array arm,
+                            // which had the identical unconditional-raise
+                            // gap this same PR fixed. Not the
+                            // `to_owned_or_suppress!` macro (#2143,
+                            // review): its bare `return` would discard
+                            // `out`'s already-accumulated prefix from
+                            // earlier (s, e) pairs/targets -- inlined here
+                            // so the raise arm can fold `out` in via
+                            // `escape!` instead, same as
+                            // `suppress_or_raise`'s own logic.
+                            QueryResult::One(v) => match to_owned(&v) {
+                                Ok(v) => out.push(v),
+                                Err(err) if suppresses(&err, optional) => {}
+                                Err(err) => escape!(Control::Error(err)),
+                            },
                             QueryResult::Owned(v) => out.push(v),
                             QueryResult::None => {}
-                            QueryResult::Error(e) => return QueryResult::Error(e),
+                            // #2143 (review): a later (s, e) pair's/target's
+                            // slice-application error must not discard the
+                            // values already produced by earlier ones --
+                            // same "later step's error outranks an earlier
+                            // already-produced prefix, which still survives
+                            // as Partial" rule this function's own
+                            // target-evaluation escape above follows,
+                            // mirroring `eval_index_expr`'s identical
+                            // treatment of a later key's index error.
+                            // Pre-existing gap (predates #2143, confirmed
+                            // live against jq 1.7.1: `[1,2,3,4] |
+                            // (.,5)[(1-1):(1+1)]` prints `[1,2]` before
+                            // raising "Cannot index number with object";
+                            // this arm used to discard it), fixed here now
+                            // that it sits directly beneath the
+                            // target-evaluation fix above making the same
+                            // claim.
+                            QueryResult::Error(e) => escape!(Control::Error(e)),
                             _ => unreachable!("Expr::Slice yields only One/Owned/None/Error"),
                         }
                     }
                 }
                 Targets::Owned(ts) => {
                     if out.try_reserve(ts.len()).is_err() {
-                        return partial(
-                            out,
-                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
-                        );
+                        escape!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                     }
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
-                            Err(e) => return e.into(),
+                            // #2143 (review): same fix as the Borrowed arm
+                            // above.
+                            Err(e) => escape!(Control::Error(e)),
                         }
                     }
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16569,25 +16569,25 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (see `eval_single`'s `Expr::Slice` arm), so there is nothing to
     // borrow except its rare whole-value fast paths, which `to_owned_lossy`
     // below just copies out of.
-    let mut out: Vec<OwnedValue> = Vec::new();
-
+    //
     // `starts.len() * ends.len()` is still fully known before the loop --
-    // only the per-pair target count varies -- so reserve that much upfront
-    // as a baseline (the common case is exactly one output per pair),
-    // recovering the single upfront allocation the pre-#2143 code made for
-    // that case instead of paying amortized-doubling reallocation/copy
-    // costs on every slice query. `checked_mul` rather than
-    // `try_reserve_product` (which would also fold in a `targets.len()`
-    // this point doesn't have yet): an overflowing product here just skips
-    // the hint and falls through to the per-pair `try_reserve` calls below,
-    // which still refuse cleanly on their own once actually unallocatable
-    // -- `out` is empty at this point regardless, so there's nothing this
-    // hint could lose by skipping it.
-    if let Some(pairs) = starts.len().checked_mul(ends.len()) {
-        if out.try_reserve(pairs).is_err() {
-            return QueryResult::Error(cannot_reserve_cross_product(&[starts.len(), ends.len()]));
-        }
-    }
+    // only the per-pair target count varies -- so `try_reserve_product`
+    // reserves that much upfront as a baseline (the common case is exactly
+    // one output per pair), recovering the single upfront allocation the
+    // pre-#2143 code made for that case instead of paying amortized-
+    // doubling reallocation/copy costs on every slice query; both `starts`
+    // and `ends` are already known non-empty here (the `is_empty` checks
+    // above), so this never takes the zero-factor fast-return arm. Reusing
+    // the existing helper -- rather than a bespoke `checked_mul` inline --
+    // keeps this refusal path covered by that function's own existing unit
+    // tests instead of adding new, practically-untestable ones of its own:
+    // constructing real `starts`/`ends` generator output long enough to
+    // organically overflow this product would first exhaust memory
+    // building the *inputs*, long before this reservation could ever run.
+    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
+        Ok(out) => out,
+        Err(e) => return QueryResult::Error(e),
+    };
 
     // The shared exit every escape arm below funnels through, so folding
     // the running `out` in as a `Partial` prefix can't drift between arms

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16510,6 +16510,12 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `null | .[("x"):2]?` both still raise, matching a literal computed key
 /// (`.[.k]?` still raises on a string target) rather than
 /// `key_to_path_component`'s optional-gated type check.
+///
+/// #2143: `target` (`E`) is re-evaluated fresh for every `(s, e)` pair
+/// rather than once overall, mirroring #2032/#2142's identical fix for
+/// `eval_index_expr` one nesting level deeper — see
+/// `eval_generic::eval_slice_expr`'s own copy of this comment for the full
+/// rationale and live-verified repro; not repeated here.
 fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -16546,57 +16552,60 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let starts_len = if ends_escaped { 1 } else { starts.len() };
     let starts = &starts[..starts_len];
 
-    let targets = eval_single::<W, S>(target, value, false).materialize_cursor();
-
     // Borrowed and owned targets are kept apart so the common (borrowed) case
     // never materializes the document — mirrors `eval_index_expr`.
     enum Targets<'a, W> {
         Borrowed(Vec<StandardJson<'a, W>>),
         Owned(Vec<OwnedValue>),
     }
-    impl<W> Targets<'_, W> {
-        fn len(&self) -> usize {
-            match self {
-                Self::Borrowed(ts) => ts.len(),
-                Self::Owned(ts) => ts.len(),
-            }
-        }
-    }
-    let targets = match targets {
-        QueryResult::One(v) => Targets::Borrowed(vec![v]),
-        QueryResult::Many(vs) => Targets::Borrowed(vs),
-        QueryResult::Owned(v) => Targets::Owned(vec![v]),
-        QueryResult::ManyOwned(vs) => Targets::Owned(vs),
-        QueryResult::None => return QueryResult::None,
-        QueryResult::Error(e) => return QueryResult::Error(e),
-        QueryResult::Break(label) => return QueryResult::Break(label),
-        QueryResult::Halt(code) => return QueryResult::Halt(code),
-        QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
-        QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
-        QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
-        QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
-    };
 
-    // S outer, T middle, E inner (point 2 above). The result is always
-    // owned: slicing constructs a new array/string (see `eval_single`'s
-    // `Expr::Slice` arm), so there is nothing to borrow except its rare
-    // whole-value fast paths, which `to_owned_lossy` below just copies out of.
-    //
-    // All three factors, not just `starts.len() * ends.len()`: the loop
-    // below is genuinely S outer / T middle / E inner, so the true upper
-    // bound includes the target count too (#1634 review) -- an
-    // under-reservation here wouldn't overflow on its own, but it would
-    // leave the eventual `Vec::push` growth past this capacity unguarded
-    // for exactly the same crash class this function exists to close.
-    let mut out: Vec<OwnedValue> =
-        match try_reserve_product(&[starts.len(), ends.len(), targets.len()]) {
-            Ok(out) => out,
-            Err(e) => return QueryResult::Error(e),
-        };
-    match &targets {
-        Targets::Borrowed(ts) => {
-            for s in starts {
-                for e in &ends {
+    // S outer, T middle, E inner (point 2 above), with E now genuinely
+    // re-evaluated once per (s, e) pair rather than once overall (#2143).
+    // The result is always owned: slicing constructs a new array/string
+    // (see `eval_single`'s `Expr::Slice` arm), so there is nothing to
+    // borrow except its rare whole-value fast paths, which `to_owned_lossy`
+    // below just copies out of. Reserved per-pair below rather than as one
+    // upfront `starts.len() * ends.len() * targets.len()` product (#1634's
+    // original concern still applies -- an unguarded product of
+    // generator-controlled lengths can panic/abort on overflow -- but the
+    // target's own length can now vary per pair, so a single upfront
+    // product is no longer computable).
+    let mut out: Vec<OwnedValue> = Vec::new();
+
+    for s in starts {
+        for e in &ends {
+            let targets = eval_single::<W, S>(target, value.clone(), false).materialize_cursor();
+            let targets = match targets {
+                QueryResult::One(v) => Targets::Borrowed(vec![v]),
+                QueryResult::Many(vs) => Targets::Borrowed(vs),
+                QueryResult::Owned(v) => Targets::Owned(vec![v]),
+                QueryResult::ManyOwned(vs) => Targets::Owned(vs),
+                // Zero outputs for *this* (s, e) pair contributes nothing to
+                // it -- not a whole-function short-circuit, now that E's own
+                // output count can vary across pairs (mirrors
+                // `eval_index_expr`'s identical per-key treatment).
+                QueryResult::None => continue,
+                QueryResult::Error(err) => return partial(out, Control::Error(err)),
+                QueryResult::Break(label) => return partial(out, Control::Break(label)),
+                QueryResult::Halt(code) => return partial(out, Control::Halt(code)),
+                QueryResult::OneCursor(_) => {
+                    unreachable!("materialize_cursor should have converted this")
+                }
+                // Same conservative Error/Break/Halt-only handling as
+                // before, now folding the running `out` in as the prefix
+                // instead of discarding it (unreachable before this fix,
+                // since `out` was always empty at this point -- E was
+                // evaluated before the loop could produce anything).
+                QueryResult::Partial(_, control) => return partial(out, control),
+            };
+            match &targets {
+                Targets::Borrowed(ts) => {
+                    if out.try_reserve(ts.len()).is_err() {
+                        return partial(
+                            out,
+                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
+                        );
+                    }
                     let slice_expr = Expr::Slice {
                         start: *s,
                         end: *e,
@@ -16628,11 +16637,13 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         }
                     }
                 }
-            }
-        }
-        Targets::Owned(ts) => {
-            for s in starts {
-                for e in &ends {
+                Targets::Owned(ts) => {
+                    if out.try_reserve(ts.len()).is_err() {
+                        return partial(
+                            out,
+                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
+                        );
+                    }
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
@@ -49483,18 +49494,51 @@ mod tests {
     /// so each arm does a per-key `Vec::try_reserve` against
     /// `cannot_reserve_cross_product`'s own error instead of one upfront
     /// product reservation; see that fix's own comments on each arm for the
-    /// current mechanism. `eval_slice_expr`/`resolve_index_expr`/
-    /// `resolve_slice_expr` (target evaluated once, unaffected by #2032)
-    /// still call `try_reserve_product` directly and are covered by the
-    /// direct unit tests above and the CLI-level path/slice tests elsewhere
-    /// in this file, e.g. `test_path_...`/`test_slice_...` cases exercising
-    /// `.[$s:$e]` and `path(...)`.
+    /// current mechanism. `eval_slice_expr` moved to the identical per-pair
+    /// `Vec::try_reserve` scheme in #2143, for the same reason (the target's
+    /// length can now vary per `(s, e)` pair). `resolve_index_expr`/
+    /// `resolve_slice_expr` (the `path()`/write-path siblings, target still
+    /// evaluated once -- out of scope for both #2032 and #2143, tracked
+    /// separately as #2139) still call `try_reserve_product` directly and
+    /// are covered by the direct unit tests above and the CLI-level
+    /// path/slice tests elsewhere in this file, e.g.
+    /// `test_path_...`/`test_slice_...` cases exercising `.[$s:$e]` and
+    /// `path(...)`.
     #[test]
     fn test_computed_index_ordinary_cross_product_unaffected_1634() {
         query!(br#"{"a":1,"b":2}"#, r#".[("a","b")]"#,
             QueryResult::Many(vs) => {
                 let values: Vec<OwnedValue> = vs.iter().map(to_owned_lossy).collect();
                 assert_eq!(values, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+    }
+
+    /// #2143: `eval::eval_slice_expr` (the DOM route reached through the
+    /// public `succinctly::jq::eval` library API -- see this file's
+    /// `eval_index_expr`/#2032 test group above for why the CLI itself
+    /// dispatches through `eval_generic.rs`'s sibling instead) still
+    /// produces the exact same *values* after being restructured to
+    /// re-evaluate its target once per `(s, e)` pair -- this function has
+    /// no side-effecting builtin reachable through this harness, so value
+    /// agreement is what's left to pin here; the CLI-level
+    /// `test_slice_expr_target_reevaluated_once_per_pair_2143` (in
+    /// `tests/jq_cli_tests.rs`) covers the actual re-evaluation-count fix
+    /// via `stderr`. Doubles as this function's own #1634-style
+    /// cross-product regression check, now that a single upfront
+    /// `starts.len() * ends.len() * targets.len()` reservation no longer
+    /// exists to test. Verified against jq 1.7.1 (see this function's own
+    /// doc comment, point 2, for the identical worked example).
+    #[test]
+    fn test_computed_slice_ordinary_cross_product_unaffected_2143() {
+        query!(br"[1,2,3,4,5]", r".[(0,1):(3,4)]",
+            QueryResult::ManyOwned(vs) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3), OwnedValue::Int(4)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3), OwnedValue::Int(4)]),
+                ]);
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,8 +43,8 @@ use super::eval::{
     is_retryable_stop, literal_to_owned, needs_path_context, numeric_key_to_array_index,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
-    try_reserve_product, vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag,
-    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -8048,6 +8048,20 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
 /// immediately above — `start`/`end` are evaluated first (outermost) against
 /// the original value/cursor, not the target's output, and an empty bound
 /// stream short-circuits before the target is evaluated at all. See #615.
+///
+/// #2143: `target` (`E`) is now re-evaluated fresh for every `(s, e)` pair
+/// rather than once overall, mirroring #2032/#2142's identical fix for
+/// `eval_index_expr` one nesting level deeper — jq's own
+/// `S as $s | T as $t | E | .[$s:$t]` desugaring puts `E` inside both
+/// bindings, so a side effect in `E` (`stderr`, `input`) must fire once per
+/// `(s, e)` pair, not once total (verified against jq 1.7.1: `[10,20,30] |
+/// [(stderr)[(0,1):(2,3)]]` writes `[10,20,30]` to stderr four times, once
+/// per pair). `target`'s own escape (`Error`/`Break`/`Halt`/`Partial`) can
+/// now fire after earlier pairs already contributed real output, so it
+/// folds the running `out` in as a `Partial` prefix instead of discarding
+/// it — the "target's own `Partial` arm discards its prefix, unreachable in
+/// practice" note this comment used to carry no longer applies now that the
+/// arm runs inside the loop.
 fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -8074,13 +8088,6 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     // `end` itself is computed once here (not re-run per `s`), which is
     // still correct: it depends only on `value`, not `s`, so its own
     // (prefix, escape) pair is identical on every notional re-run.
-    //
-    // Not addressed here (pre-existing, separate from this fix): `target`'s
-    // own `Partial` arm below still discards its prefix outright rather than
-    // threading it through with the same truncation `target_escape` would
-    // need against `ends`, mirroring `resolve_slice_expr`'s own 3-way rule
-    // -- unreachable in practice today, since that arm already returns
-    // before the loop below can run at all.
     let (starts, starts_escape) =
         match eval_slice_bound::<S, V>(start, value.clone(), cursor, f64::floor) {
             Ok(v) => v,
@@ -8114,65 +8121,64 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         Borrowed(Vec<V>),
         Owned(Vec<OwnedValue>),
     }
-    impl<V> Targets<V> {
-        fn len(&self) -> usize {
-            match self {
-                Self::Borrowed(ts) => ts.len(),
-                Self::Owned(ts) => ts.len(),
-            }
-        }
-    }
-    let targets = match eval_single::<S, V>(target, value, false, cursor) {
-        GenericResult::Error(e) => return GenericResult::Error(e),
-        GenericResult::Break(label) => return GenericResult::Break(label),
-        // Same reasoning as `eval_index_expr`'s target match: kept out of
-        // the `owned @ (...)` group below so a halted target stream isn't
-        // quietly swallowed into an empty `Vec` by `collect_owned()`.
-        GenericResult::Halt(code) => return GenericResult::Halt(code),
-        GenericResult::None => return GenericResult::None,
-        // Same conservative Error/Break-only handling as `eval_index_expr`'s
-        // target Partial arm above.
-        GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
-        GenericResult::Partial(_, Control::Break(label)) => return GenericResult::Break(label),
-        GenericResult::Partial(_, Control::Halt(code)) => return GenericResult::Halt(code),
-        GenericResult::One(v) => Targets::Borrowed(vec![v]),
-        GenericResult::Many(vs) => Targets::Borrowed(vs),
-        GenericResult::OneCursor(c) => Targets::Borrowed(vec![c.value()]),
-        GenericResult::ManyCursor(cs) => {
-            Targets::Borrowed(cs.iter().map(DocumentCursor::value).collect())
-        }
-        // See `eval_index_expr`'s identical arm for the accepted, pre-existing
-        // error-swallowing note that also applies to `LazySeq` here.
-        owned @ (GenericResult::Owned(_)
-        | GenericResult::ManyOwned(_)
-        | GenericResult::LazyKeys { .. }
-        | GenericResult::LazyIndexRange(_)
-        | GenericResult::LazySeq(_)) => Targets::Owned(owned_or_err!(owned.collect_owned())),
-    };
 
-    // Start outer, end middle, target inner. The result is always owned:
+    // Start outer, end middle, target inner (#2143: target is now
+    // re-evaluated once per (s, e) pair, so it is genuinely the innermost
+    // stage, not just looped as if it were). The result is always owned:
     // slicing constructs a fresh array/string, same invariant as
-    // `eval::eval_slice_expr`.
-    //
-    // All three factors (#1634 review): the loop below is genuinely S
-    // outer / E middle / T inner, so `starts.len() * ends.len()` alone
-    // under-reserves whenever the target itself has more than one output
-    // -- an unguarded `Vec::with_capacity` product of two or three such
-    // generator-controlled lengths can also panic/abort the process on
-    // overflow or a genuine allocation failure. This is the actual
-    // dispatch path for an ordinary `.[$s:$e]` CLI read (see the comment
-    // on `Expr::SliceExpr`'s own match arm above), so this site -- not
+    // `eval::eval_slice_expr`. Reserved per-pair below rather than as one
+    // upfront `starts.len() * ends.len() * targets.len()` product (#1634's
+    // original concern still applies -- an unguarded product of
+    // generator-controlled lengths can panic/abort on overflow -- but the
+    // target's own length can now vary per pair, so a single upfront
+    // product is no longer computable). This is the actual dispatch path
+    // for an ordinary `.[$s:$e]` CLI read (see the comment on
+    // `Expr::SliceExpr`'s own match arm above), so this site -- not
     // `eval::eval_slice_expr`'s sibling -- is what a real `succinctly
     // jq`/`succinctly yq` invocation hits.
-    let mut out: Vec<OwnedValue> = owned_or_err!(try_reserve_product(&[
-        starts.len(),
-        ends.len(),
-        targets.len()
-    ]));
-    match &targets {
-        Targets::Borrowed(ts) => {
-            for s in starts {
-                for e in &ends {
+    let mut out: Vec<OwnedValue> = Vec::new();
+
+    for s in starts {
+        for e in &ends {
+            let targets = match eval_single::<S, V>(target, value.clone(), false, cursor) {
+                GenericResult::Error(e) => return partial_generic(out, Control::Error(e)),
+                GenericResult::Break(label) => return partial_generic(out, Control::Break(label)),
+                GenericResult::Halt(code) => return partial_generic(out, Control::Halt(code)),
+                // Zero outputs for *this* (s, e) pair contributes nothing to
+                // it -- not a whole-function short-circuit, now that E's own
+                // output count can vary across pairs (mirrors
+                // `eval_index_expr`'s identical per-key treatment).
+                GenericResult::None => continue,
+                // Same conservative Error/Break/Halt-only handling as
+                // `eval_index_expr`'s target `Partial` arm, now folding the
+                // running `out` in as the prefix instead of discarding it.
+                GenericResult::Partial(_, control) => return partial_generic(out, control),
+                GenericResult::One(v) => Targets::Borrowed(vec![v]),
+                GenericResult::Many(vs) => Targets::Borrowed(vs),
+                GenericResult::OneCursor(c) => Targets::Borrowed(vec![c.value()]),
+                GenericResult::ManyCursor(cs) => {
+                    Targets::Borrowed(cs.iter().map(DocumentCursor::value).collect())
+                }
+                // See `eval_index_expr`'s identical arm for the accepted,
+                // pre-existing error-swallowing note that also applies to
+                // `LazySeq` here.
+                owned @ (GenericResult::Owned(_)
+                | GenericResult::ManyOwned(_)
+                | GenericResult::LazyKeys { .. }
+                | GenericResult::LazyIndexRange(_)
+                | GenericResult::LazySeq(_)) => match owned.collect_owned() {
+                    Ok(vs) => Targets::Owned(vs),
+                    Err(err) => return partial_generic(out, Control::Error(err)),
+                },
+            };
+            match &targets {
+                Targets::Borrowed(ts) => {
+                    if out.try_reserve(ts.len()).is_err() {
+                        return partial_generic(
+                            out,
+                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
+                        );
+                    }
                     for t in ts {
                         match slice_one_generic::<S, V>(t.clone(), *s, *e, optional) {
                             GenericResult::Owned(v) => out.push(v),
@@ -8182,11 +8188,13 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                         }
                     }
                 }
-            }
-        }
-        Targets::Owned(ts) => {
-            for s in starts {
-                for e in &ends {
+                Targets::Owned(ts) => {
+                    if out.try_reserve(ts.len()).is_err() {
+                        return partial_generic(
+                            out,
+                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
+                        );
+                    }
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8057,11 +8057,24 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
 /// `(s, e)` pair, not once total (verified against jq 1.7.1: `[10,20,30] |
 /// [(stderr)[(0,1):(2,3)]]` writes `[10,20,30]` to stderr four times, once
 /// per pair). `target`'s own escape (`Error`/`Break`/`Halt`/`Partial`) can
-/// now fire after earlier pairs already contributed real output, so it
-/// folds the running `out` in as a `Partial` prefix instead of discarding
-/// it — the "target's own `Partial` arm discards its prefix, unreachable in
-/// practice" note this comment used to carry no longer applies now that the
-/// arm runs inside the loop.
+/// now fire after *earlier pairs* already contributed real output to `out`,
+/// so it folds `out` in as a `Partial` prefix instead of discarding it —
+/// this cross-pair prefix was provably always empty before this fix (`E`
+/// used to be evaluated once, before the loop could produce anything), so
+/// there was nothing to lose by discarding it there; now there can be. The
+/// per-target slice-application escape one level in got the identical
+/// cross-pair fix for the identical reason (review). Left deliberately
+/// unaddressed, matching `eval_index_expr`'s own identical, pre-existing
+/// gap (confirmed live on `main`, not introduced or worsened by this fix):
+/// a `Partial(prefix, control)` result still discards `prefix` itself —
+/// the values `E`'s *own* generator produced before erroring *within* one
+/// (s, e) pair (as opposed to the cross-pair `out` this fix does thread
+/// through) — e.g. `E = ([1,2],[3,4],error("x"))` loses the `[1]`/`[3]`
+/// slices it should still emit before raising `x`. Real fix needs applying
+/// the pair's own slice/index operation to each of `prefix`'s values before
+/// folding them into `out`, not just discarding `prefix`; tracked
+/// separately (issue filed alongside this fix) since it's a pre-existing
+/// gap shared with `eval_index_expr`, not something #2143 introduces.
 fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -8126,24 +8139,47 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     // re-evaluated once per (s, e) pair, so it is genuinely the innermost
     // stage, not just looped as if it were). The result is always owned:
     // slicing constructs a fresh array/string, same invariant as
-    // `eval::eval_slice_expr`. Reserved per-pair below rather than as one
-    // upfront `starts.len() * ends.len() * targets.len()` product (#1634's
-    // original concern still applies -- an unguarded product of
-    // generator-controlled lengths can panic/abort on overflow -- but the
-    // target's own length can now vary per pair, so a single upfront
-    // product is no longer computable). This is the actual dispatch path
-    // for an ordinary `.[$s:$e]` CLI read (see the comment on
-    // `Expr::SliceExpr`'s own match arm above), so this site -- not
-    // `eval::eval_slice_expr`'s sibling -- is what a real `succinctly
-    // jq`/`succinctly yq` invocation hits.
+    // `eval::eval_slice_expr`. This is the actual dispatch path for an
+    // ordinary `.[$s:$e]` CLI read (see the comment on `Expr::SliceExpr`'s
+    // own match arm above), so this site -- not `eval::eval_slice_expr`'s
+    // sibling -- is what a real `succinctly jq`/`succinctly yq` invocation
+    // hits.
     let mut out: Vec<OwnedValue> = Vec::new();
+
+    // `starts.len() * ends.len()` is still fully known before the loop --
+    // only the per-pair target count varies -- so reserve that much upfront
+    // as a baseline (the common case is exactly one output per pair),
+    // recovering the single upfront allocation the pre-#2143 code made for
+    // that case instead of paying amortized-doubling reallocation/copy
+    // costs on every slice query. An overflowing product just skips the
+    // hint and falls through to the per-pair `try_reserve` calls below,
+    // which still refuse cleanly on their own once actually unallocatable
+    // -- `out` is empty at this point regardless, so there's nothing this
+    // hint could lose by skipping it.
+    if let Some(pairs) = starts.len().checked_mul(ends.len()) {
+        if out.try_reserve(pairs).is_err() {
+            return GenericResult::Error(cannot_reserve_cross_product(&[starts.len(), ends.len()]));
+        }
+    }
+
+    // The shared exit every escape arm below funnels through, so folding
+    // the running `out` in as a `Partial` prefix can't drift between arms
+    // -- the single-accumulator counterpart of `eval_index_expr`'s
+    // `escape_generic!` above (that macro's own cursor/owned promotion has
+    // nothing to do here: `out` is always `Vec<OwnedValue>`, never a
+    // separate cursor accumulator).
+    macro_rules! escape {
+        ($control:expr) => {
+            return partial_generic(out, $control)
+        };
+    }
 
     for s in starts {
         for e in &ends {
             let targets = match eval_single::<S, V>(target, value.clone(), false, cursor) {
-                GenericResult::Error(e) => return partial_generic(out, Control::Error(e)),
-                GenericResult::Break(label) => return partial_generic(out, Control::Break(label)),
-                GenericResult::Halt(code) => return partial_generic(out, Control::Halt(code)),
+                GenericResult::Error(e) => escape!(Control::Error(e)),
+                GenericResult::Break(label) => escape!(Control::Break(label)),
+                GenericResult::Halt(code) => escape!(Control::Halt(code)),
                 // Zero outputs for *this* (s, e) pair contributes nothing to
                 // it -- not a whole-function short-circuit, now that E's own
                 // output count can vary across pairs (mirrors
@@ -8152,7 +8188,7 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                 // Same conservative Error/Break/Halt-only handling as
                 // `eval_index_expr`'s target `Partial` arm, now folding the
                 // running `out` in as the prefix instead of discarding it.
-                GenericResult::Partial(_, control) => return partial_generic(out, control),
+                GenericResult::Partial(_, control) => escape!(control),
                 GenericResult::One(v) => Targets::Borrowed(vec![v]),
                 GenericResult::Many(vs) => Targets::Borrowed(vs),
                 GenericResult::OneCursor(c) => Targets::Borrowed(vec![c.value()]),
@@ -8168,38 +8204,51 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                 | GenericResult::LazyIndexRange(_)
                 | GenericResult::LazySeq(_)) => match owned.collect_owned() {
                     Ok(vs) => Targets::Owned(vs),
-                    Err(err) => return partial_generic(out, Control::Error(err)),
+                    Err(err) => escape!(Control::Error(err)),
                 },
             };
             match &targets {
                 Targets::Borrowed(ts) => {
                     if out.try_reserve(ts.len()).is_err() {
-                        return partial_generic(
-                            out,
-                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
-                        );
+                        escape!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                     }
                     for t in ts {
                         match slice_one_generic::<S, V>(t.clone(), *s, *e, optional) {
                             GenericResult::Owned(v) => out.push(v),
                             GenericResult::None => {}
-                            GenericResult::Error(e) => return GenericResult::Error(e),
+                            // #2143 (review): a later (s, e) pair's/target's
+                            // slice-application error must not discard the
+                            // values already produced by earlier ones --
+                            // same "later step's error outranks an earlier
+                            // already-produced prefix, which still survives
+                            // as Partial" rule this function's own
+                            // target-evaluation escape above follows,
+                            // mirroring `eval_index_expr`'s identical
+                            // treatment of a later key's index error.
+                            // Pre-existing gap (predates #2143, confirmed
+                            // live against jq 1.7.1: `[1,2,3,4] |
+                            // (.,5)[(1-1):(1+1)]` prints `[1,2]` before
+                            // raising "Cannot index number with object";
+                            // this arm used to discard it), fixed here now
+                            // that it sits directly beneath the
+                            // target-evaluation fix above making the same
+                            // claim.
+                            GenericResult::Error(e) => escape!(Control::Error(e)),
                             _ => unreachable!("slice_one_generic yields Owned/None/Error"),
                         }
                     }
                 }
                 Targets::Owned(ts) => {
                     if out.try_reserve(ts.len()).is_err() {
-                        return partial_generic(
-                            out,
-                            Control::Error(cannot_reserve_cross_product(&[ts.len()])),
-                        );
+                        escape!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                     }
                     for t in ts {
                         match slice_owned_value_read::<S>(t, *s, *e, optional) {
                             Ok(Some(v)) => out.push(v),
                             Ok(None) => {}
-                            Err(e) => return GenericResult::Error(e),
+                            // #2143 (review): same fix as the Borrowed arm
+                            // above.
+                            Err(e) => escape!(Control::Error(e)),
                         }
                     }
                 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,8 +43,8 @@ use super::eval::{
     is_retryable_stop, literal_to_owned, needs_path_context, numeric_key_to_array_index,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
-    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
-    LimitN, PathTrail, QueryResult, YqSemantics,
+    try_reserve_product, vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag,
+    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -8144,23 +8144,26 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     // own match arm above), so this site -- not `eval::eval_slice_expr`'s
     // sibling -- is what a real `succinctly jq`/`succinctly yq` invocation
     // hits.
-    let mut out: Vec<OwnedValue> = Vec::new();
-
+    //
     // `starts.len() * ends.len()` is still fully known before the loop --
-    // only the per-pair target count varies -- so reserve that much upfront
-    // as a baseline (the common case is exactly one output per pair),
-    // recovering the single upfront allocation the pre-#2143 code made for
-    // that case instead of paying amortized-doubling reallocation/copy
-    // costs on every slice query. An overflowing product just skips the
-    // hint and falls through to the per-pair `try_reserve` calls below,
-    // which still refuse cleanly on their own once actually unallocatable
-    // -- `out` is empty at this point regardless, so there's nothing this
-    // hint could lose by skipping it.
-    if let Some(pairs) = starts.len().checked_mul(ends.len()) {
-        if out.try_reserve(pairs).is_err() {
-            return GenericResult::Error(cannot_reserve_cross_product(&[starts.len(), ends.len()]));
-        }
-    }
+    // only the per-pair target count varies -- so `try_reserve_product`
+    // reserves that much upfront as a baseline (the common case is exactly
+    // one output per pair), recovering the single upfront allocation the
+    // pre-#2143 code made for that case instead of paying amortized-
+    // doubling reallocation/copy costs on every slice query; both `starts`
+    // and `ends` are already known non-empty here (the `is_empty` checks
+    // above), so this never takes the zero-factor fast-return arm. See
+    // `eval::eval_slice_expr`'s identical comment for why this reuses the
+    // existing helper rather than a bespoke inline check: it keeps the
+    // refusal path covered by that function's own existing unit tests
+    // instead of adding new, practically-untestable ones (constructing
+    // real `starts`/`ends` generator output long enough to organically
+    // overflow this product would first exhaust memory building the
+    // *inputs*, long before this reservation could ever run).
+    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
+        Ok(out) => out,
+        Err(e) => return GenericResult::Error(e),
+    };
 
     // The shared exit every escape arm below funnels through, so folding
     // the running `out` in as a `Partial` prefix can't drift between arms

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31358,6 +31358,95 @@ fn test_index_expr_native_to_owned_flip_mid_key_reserves_2032() -> Result<()> {
     Ok(())
 }
 
+/// #2143: `E[S:T]` compiles as `S as $s | T as $t | E | .[$s:$t]` -- `E` is
+/// re-evaluated once per `(s, t)` pair the bound generators produce, not
+/// once total. `succinctly` used to cache `E`'s result and loop the
+/// `(s, t)` pairs over it, firing a side effect in `E` once overall instead
+/// of once per pair. Counted by occurrence, not by line (`stderr` writes no
+/// trailing newline). Verified against jq 1.7.1.
+///
+/// This is `eval_generic::eval_slice_expr`'s own fix -- the function an
+/// ordinary CLI `.[$s:$t]` read actually reaches (confirmed empirically,
+/// same as #2032's sibling: `eval::eval_slice_expr`'s identical fix is
+/// reached only through certain fallback shapes, not this file's own
+/// stdin-fed queries).
+#[test]
+fn test_slice_expr_target_reevaluated_once_per_pair_2143() -> Result<()> {
+    for (input, filter, want_stderr, why) in [
+        (
+            "[[10,20],[30,40]]",
+            "[(.[] | stderr)[(0,1):(1,2)]]",
+            "[10,20][30,40][10,20][30,40][10,20][30,40][10,20][30,40]",
+            "the issue's own repro: two starts x two ends = four pairs, \
+             target re-runs once per pair",
+        ),
+        (
+            "[10,20,30]",
+            "[(. | stderr)[0:(1,2,3)]]",
+            "[10,20,30][10,20,30][10,20,30]",
+            "a single start bound still re-runs the target once per end \
+             value, not just once overall",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stderr, want_stderr, "{why}");
+    }
+    Ok(())
+}
+
+/// #2143 sibling: a pair whose target evaluation is genuinely empty must
+/// not short-circuit the *remaining* pairs -- each pair's target is now
+/// independent, unlike the old once-overall evaluation, where an empty
+/// target for any one pair made every pair look empty. `inputs` (an impure,
+/// stateful generator) is what makes the target vary per re-evaluation
+/// here: for pair `(0,1)` it drains the one remaining stdin line
+/// (`[10,20]`) and yields it, so `.[0:1]` produces `[10]`; re-evaluating
+/// `inputs` for pair `(1,2)` finds the stream already exhausted and yields
+/// nothing at all (not an error -- a target that legitimately produces zero
+/// values for that pair), so that pair contributes nothing to the output.
+/// Verified against jq 1.7.1 (`jq -n 'inputs[(0,1):(1,2)]'` also emits only
+/// `[10]`).
+#[test]
+fn test_slice_expr_one_empty_pair_does_not_short_circuit_others_2143() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "-n", "inputs[(0,1):(1,2)]"], Some("[10,20]\n"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10]\n");
+    Ok(())
+}
+
+/// #2143 sibling: a second impure-target regression alongside the `stderr`
+/// cases above, this time via `input` (a stateful generator that consumes
+/// from the CLI's document stream) rather than a side-channel write --
+/// `.[$s:$t]`'s target must be *re-read* from the stream once per pair, not
+/// read once and reused. `run_jq_full` execs the real CLI subprocess, which
+/// always dispatches through `eval_generic::eval_slice_expr`
+/// (`eval::eval_slice_expr` has no CLI-reachable path at all -- it's a
+/// separate, pure-in-process library entry point with no `input`/`inputs`
+/// builtin and no observable side-effect mechanism in its own unit tests,
+/// so its sibling fix is covered there only by reachability/regression
+/// tests on pure targets, e.g.
+/// `test_computed_slice_ordinary_cross_product_unaffected_2143` in
+/// `src/jq/eval.rs`).
+///
+/// Verified against jq 1.7.1: emits `[1,2]` then `[4,5,6]` (pair `(0,2)`
+/// re-reads `input` to get `[1,2,3]` -> `.[0:2]` = `[1,2]`; pair `(0,3)`
+/// re-reads `input` again to get `[4,5,6]` -> `.[0:3]` = `[4,5,6]`), then a
+/// third `input` read past the two provided lines raises, and the prior
+/// two successfully-produced values still print first (real jq streams
+/// top-level output progressively; succinctly matches via `Partial`).
+#[test]
+fn test_slice_expr_eval_rs_dispatch_target_reevaluated_per_pair_2143() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-n", "(input)[(0,1):(2,3)]"],
+        Some("[1,2,3]\n[4,5,6]\n"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2]\n[4,5,6]\n");
+    Ok(())
+}
+
 /// #2031's own primary repro: `SOURCE` (`.a`) is itself a genuine path
 /// expression, so real jq's single shared path register moves onto `.a`'s
 /// own position as a side effect of evaluating it -- and UPDATE's own

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31447,6 +31447,60 @@ fn test_slice_expr_eval_rs_dispatch_target_reevaluated_per_pair_2143() -> Result
     Ok(())
 }
 
+/// #2143 (review finding, confirmed live against jq 1.7.1): a per-target
+/// slice-application error one level inside the `(s, e)` loop must not
+/// discard values already produced by earlier pairs/targets, the same
+/// "later step's error outranks an earlier already-produced prefix, which
+/// still survives as `Partial`" rule the target-evaluation escape just
+/// above it already follows. Pre-existing gap (present on `main` before
+/// #2143 too, in the sense that a *single* pair's own multi-target list
+/// could already lose an earlier target's output to a later one's error --
+/// #2143's fix to re-evaluate the target per pair is what newly makes an
+/// earlier *pair's* output reachable at this point too), closed as part of
+/// this fix since the new per-pair escape sits directly above it making the
+/// identical claim.
+///
+/// Covers both `Targets` arms: the generator here (`[10,20,30,40,50], 99`)
+/// resolves to `GenericResult::ManyOwned` (a computed, non-navigational
+/// left side), reaching the `Owned` arm; `Borrowed` is covered by
+/// `test_slice_expr_eval_rs_dispatch_target_reevaluated_per_pair_2143`
+/// above, whose `(input)` target reaches it via a document-borrowed value.
+#[test]
+fn test_slice_expr_later_target_error_preserves_earlier_output_2143() -> Result<()> {
+    for (filter, why) in [
+        (
+            "(.[])[(0,1):(2,3)]",
+            "single pair, two targets from `.[]` -- second target (a bare \
+             number) fails to slice after the first (an array) already \
+             succeeded",
+        ),
+        (
+            "0 as $z | ([10,20,30,40,50], 99)[$z:2]",
+            "literal comma-generator target, same shape via a different \
+             AST path",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(
+            &["-c", filter],
+            Some(if filter.starts_with("(.[])") {
+                "[[9,9,9,9],1]"
+            } else {
+                "null"
+            }),
+        )?;
+        assert_eq!(code, 5, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("Cannot index"),
+            "{why} -- stderr: {stderr:?}"
+        );
+        assert!(
+            !stdout.is_empty(),
+            "{why} -- lost the already-produced prefix, stdout: {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2031's own primary repro: `SOURCE` (`.a`) is itself a genuine path
 /// expression, so real jq's single shared path register moves onto `.a`'s
 /// own position as a side effect of evaluating it -- and UPDATE's own


### PR DESCRIPTION
## Summary

- `E[S:T]` compiles as `S as $s | T as $t | E | .[$s:$t]` — jq re-runs `E` fresh for every `(s, e)` pair the bound generators produce. `eval_slice_expr` (both `src/jq/eval.rs` and its `eval_generic.rs` CLI-dispatch sibling) evaluated `E` once upfront and reused it across every pair instead, so a side effect in `E` (`stderr`, `input`) fired once total rather than once per pair.
- Mirrors #2032/#2142's identical, already-shipped fix for `eval_index_expr`, one nesting level deeper (`S` outer, `T` middle, `E` inner). Restructures both `eval_slice_expr` implementations to evaluate the target inside the `(s, e)` loop.
- `resolve_slice_expr` (the `path()`/write-path sibling, target still evaluated once) stays out of scope, per the issue's own scoping note — tracked separately as #2139.

**Code review** (10-agent multi-pass, independently cross-verified against the pinned jq 1.7.1 oracle) found and this PR now also fixes:
- A later `(s, e)` pair's/target's own slice-application error was discarding the `out` accumulated from *earlier* pairs — newly reachable because of this PR's own restructuring (before it, `out` was provably always empty at that point). Fixed by folding `out` through every escape path, mirroring `eval_index_expr`'s identical treatment.
- Reinstated a `starts.len() * ends.len()` upfront reservation hint (both factors are still statically known before the loop) by reusing the existing `try_reserve_product` helper, recovering the single-allocation fast path for the common one-output-per-pair case instead of paying amortized-doubling reallocation costs on every slice query.
- Factored the repeated "reserve or escape with `out` folded in" shape into a small local `escape!` macro in each function, mirroring `eval_index_expr`'s own `escape_with_prefix!`/`escape_generic!` macros.

Two **separate, pre-existing** gaps surfaced during review (confirmed live on `main`, unrelated to this PR's own scope) were filed as follow-ups rather than bundled in:
- #2225 — the `end` bound (T) isn't re-evaluated per start value (S), unlike jq's own desugaring.
- #2226 — `E`'s own within-generator partial output is discarded on its own mid-stream error, identically present in the already-merged `eval_index_expr`.

## Test plan

- [x] Live-verified against pinned oracle jq 1.7.1 (`/usr/bin/jq`): issue's own `stderr`-count repro now matches exactly (8 writes, was 2).
- [x] Live-verified partial-output preservation on a later-pair target error (`(input)[(0,1):(2,3)]` with only 2 stdin lines) and on a later-pair/target slice-application error (`(.[])[(0,1):(2,3)]` on `[[9,9,9,9],1]`, `([1,2],5)[(0,1):(1,2)]`) — succinctly now matches jq's exact stdout/stderr/exit-code triple in both cases.
- [x] Live-verified an empty-for-one-pair generator target (`inputs[(0,1):(1,2)]`) does not short-circuit other pairs, matching jq.
- [x] Added 5 new tests: 4 CLI-level (`tests/jq_cli_tests.rs`, exercising the actual `eval_generic.rs` dispatch path) covering re-evaluation count, no-short-circuit-on-empty-pair, later-pair-error output preservation (both `Targets` arms), and the `eval.rs`-dispatch-only `input` reachability note; 1 direct-library unit test (`src/jq/eval.rs`) pinning `eval::eval_slice_expr`'s value-correctness post-refactor.
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite): 3329 lib + 1283 jq_cli (+5 new) + 1367 yq_cli, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (avoids the `scalar-yaml` blind spot)
- [x] `cargo build --no-default-features` / `cargo test --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`
- [x] Spot-checked `succinctly yq` mode too (shared evaluator) — same per-pair re-evaluation behavior, no regressions.
- [x] Patch coverage: **91.43%** (64/70 new lines). The 6 remaining uncovered lines are all reservation-failure/invariant-assertion arms requiring either astronomical-scale generator output (which would exhaust memory constructing the *inputs* long before the check could run — the same class `try_reserve_product`'s own unit tests bypass by calling it directly rather than through real generators) or a provably-unreachable `unreachable!()` invariant, matching the coverage profile the existing `eval_index_expr` precedent (#2032/#2142) already accepts for the identical shape.
- [x] All 30 CI checks green.

Fixes #2143