### PR TITLE
fix(jq): charge pipe/object sibling width in MAX_EVAL_FRAMES (#2135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A recursive `def` whose body is a wide, flat pipe or object literal could abort the
+  process with a real native stack overflow instead of raising `MAX_EVAL_FRAMES`'s catchable
+  error** (#2135). `install_def_calls`'s frame-charging model (#1371/#2080) only accumulated
+  cost through *nesting* — an expression descending into another, like array-wrapping
+  `[[[X]]]` — charging a flat `frames + 1` to every sibling of an `Expr::Pipe`/`Expr::Object`
+  node regardless of how many siblings existed or which one held the recursive call. A
+  200-stage pipe (or 200-entry object) wrapping a recursive `deep(m-1)` call in its last
+  position carried real native stack cost per level of `deep`'s own recursion — `eval_pipe`'s
+  and `build_object_entries`'s own per-sibling recursion is not guaranteed to be
+  tail-call-eliminated — that the guard never counted, so `MAX_EVAL_FRAMES` (40,000) never
+  fired and `deep(1500)` overflowed the real stack instead (confirmed live: `thread
+  '<unknown>' has overflowed its stack`, SIGABRT, exit 134, where real jq 1.7.1 returns `null`,
+  exit 0, on the identical filter).
+
+  Fixed by charging pipe/object sibling `i` (0-indexed) `frames + i + 1` instead of a flat
+  `frames + 1`, pricing a sibling near the end of a wide pipe/object the same as an
+  equally-deep nested wrapping, while a sibling near the front — genuinely cheap in
+  `eval_pipe`'s own recursion, since reaching it needs no extra frames — stays cheap. An
+  ordinary long *non-recursive* pipe or wide array/object literal is unaffected either way:
+  nothing is checked against `MAX_EVAL_FRAMES` until a `DefCall` is actually reached, and one
+  with no recursive call inside never creates one, regardless of width (verified: a 100,000
+  element array literal, a 50,000-key object literal, and a 50,000-stage non-recursive pipe
+  all still evaluate exactly as before). `Expr::Comma` looks like the same shape but was
+  confirmed, by direct experiment, *not* to share the gap — `eval_comma` is a flat loop over
+  its siblings, not a per-sibling self-recursive call chain — so it was left unchanged.
+  `MAX_EVAL_FRAMES` itself did not need to change: re-bisected crash floors for several
+  width/depth shapes all show the guard now firing with better than 6x safety margin below
+  the real (pre-fix) crash floor. See `install_def_calls`'s `Expr::Pipe`/`Expr::Comma`/
+  `Expr::Object` arms and `MAX_EVAL_FRAMES`'s own doc comment (`src/jq/eval.rs`) for the full
+  account.
+
 - **`IN(s)`/`IN(src; s)` now forward the real ambient `optional` instead of
   hardcoding `false`** (#2015). Both builtins are defined in terms of
   `any(...)` (`IN(s)` is `any(s == .; .)`, `IN(src; s)` is

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41751,7 +41751,12 @@ pub(crate) fn bind_def(
             params: params.to_vec(),
             body: body.clone(),
         });
-        Rc::new(install_def_calls(then, &def, depth))
+        // `false`: `then` is everything textually *after* this `def`
+        // declaration, not `def`'s own body -- a one-shot scope this walk
+        // visits exactly once for this `def`, never a self-recursive
+        // substitution `bind_def_call` re-enters. See `sibling_frame_charge`'s
+        // own doc comment (#2135 code review, Finding 1).
+        Rc::new(install_def_calls(then, &def, depth, false))
     })
 }
 
@@ -41920,9 +41925,13 @@ pub(crate) fn bind_def_call<'e>(
                 for (param, arg) in params_and_args {
                     body = substitute_func_param(&body, param, &Expr::Shared(Rc::new(arg.clone())));
                 }
-                install_def_calls(&body, def, frames + 1)
+                // `true`: this is `def`'s own body, the scope that repeats
+                // once per actual recursive level -- see
+                // `sibling_frame_charge`'s own doc comment (#2135 code
+                // review, Finding 1).
+                install_def_calls(&body, def, frames + 1, true)
             }
-            None => install_def_calls(&def.body, def, frames + 1),
+            None => install_def_calls(&def.body, def, frames + 1, true),
         };
         Ok(Rc::new(installed_body))
     })
@@ -41947,7 +41956,25 @@ fn eval_def_call<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Expand function calls to a defined function by inlining the body.
-pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32) -> Expr {
+///
+/// `in_recursive_body` (#2135 code review, Finding 1): `true` exactly when
+/// this walk is happening *inside* `def`'s own (potentially self-recursive)
+/// body -- i.e. this call, or an ancestor call in the same walk, originated
+/// from [`bind_def_call`]'s own re-entry -- `false` for a one-shot scope
+/// this pass visits exactly once for this `def`, such as [`bind_def`]'s own
+/// `then`. Threaded through unchanged by every arm below: it never toggles
+/// mid-walk, only at those two call sites. See [`sibling_frame_charge`]'s
+/// own doc comment for why this, and not `frames` itself, is the correct
+/// signal for whether sibling width should compound -- `frames` also grows
+/// from ordinary AST nesting within a single one-shot walk (an enclosing
+/// `Expr::Paren`, an `if`, ...), which is not recursion and must not be
+/// mistaken for it.
+pub(crate) fn install_def_calls(
+    expr: &Expr,
+    def: &Rc<FuncDefData>,
+    frames: u32,
+    in_recursive_body: bool,
+) -> Expr {
     match expr {
         // #1376: the arity check used to live *inside* this arm, matching
         // on name alone and erroring on any arity mismatch -- which broke
@@ -42005,7 +42032,7 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                 def: Rc::clone(def),
                 args: args
                     .iter()
-                    .map(|a| install_def_calls(a, def, frames + 1))
+                    .map(|a| install_def_calls(a, def, frames + 1, in_recursive_body))
                     .collect(),
                 frames,
                 bound: BoundBody::default(),
@@ -42015,7 +42042,12 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
         // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
-        Expr::Builtin(b) => Expr::Builtin(install_def_calls_in_builtin(b, def, frames + 1)),
+        Expr::Builtin(b) => Expr::Builtin(install_def_calls_in_builtin(
+            b,
+            def,
+            frames + 1,
+            in_recursive_body,
+        )),
         Expr::FuncDef {
             name: inner_name,
             params: inner_params,
@@ -42044,8 +42076,13 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
                 Expr::FuncDef {
                     name: inner_name.clone(),
                     params: inner_params.clone(),
-                    body: Box::new(install_def_calls(inner_body, def, frames + 1)),
-                    then: Box::new(install_def_calls(then, def, frames + 1)),
+                    body: Box::new(install_def_calls(
+                        inner_body,
+                        def,
+                        frames + 1,
+                        in_recursive_body,
+                    )),
+                    then: Box::new(install_def_calls(then, def, frames + 1, in_recursive_body)),
                     // Rebuilt above, so any cache from the pre-install node
                     // is stale (#2094) -- the shadowed branch above instead
                     // clones `expr` wholesale, correctly carrying its cache
@@ -42097,7 +42134,7 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
             def: Rc::clone(d),
             args: args
                 .iter()
-                .map(|a| install_def_calls(a, def, frames + 1))
+                .map(|a| install_def_calls(a, def, frames + 1, in_recursive_body))
                 .collect(),
             frames: frames.max(*n),
             // `args` (and possibly `frames`) may have changed, so a stale
@@ -42115,30 +42152,17 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // eliminated as a real tail call). That is exactly the mechanism
         // `MAX_EVAL_FRAMES`'s own doc comment already names for *nesting*
         // ("how much structure each one holds live across its own recursive
-        // call") -- just uncounted here for sibling breadth. The flat
-        // `frames + 1` every sibling used to get regardless of width or
-        // position undercounted this: a 200-wide pipe wrapping a recursive
-        // `deep(m-1)` call in its last position charged that call the same
-        // single `+1` a 2-wide pipe would, so `MAX_EVAL_FRAMES` (checked
-        // against the undercounted total) never fired and `deep(1500)`
-        // overflowed the real native stack instead (confirmed live, #2135).
-        //
-        // Charging sibling `i` (0-indexed) `frames + i + 1` instead prices a
-        // sibling near the end of a wide pipe the same as an equally-deep
-        // nested wrapping would be, while a sibling near the front --
-        // genuinely cheap in `eval_pipe`'s own recursion, since reaching it
-        // needs no extra frames at all -- stays cheap here too. An ordinary
-        // long *non-recursive* pipe (`.a | .b | .c | ...`, the common
-        // generated/templated-filter shape) is unaffected either way:
-        // nothing here is ever checked against `MAX_EVAL_FRAMES` until a
-        // `DefCall` is actually reached, and a pipe with no recursive call
-        // inside never creates one, regardless of how wide it is.
+        // call") -- just uncounted here for sibling breadth, and only
+        // *while that structure sits inside an already-recursing `def`'s own
+        // body* -- see [`sibling_frame_charge`]'s own doc comment for why
+        // that qualifier is load-bearing (#2135 code-review Finding 1).
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
                 .enumerate()
                 .map(|(i, e)| {
-                    install_def_calls(e, def, frames.saturating_add(i as u32).saturating_add(1))
+                    let charged = sibling_frame_charge(frames, i as u32, in_recursive_body);
+                    install_def_calls(e, def, charged, in_recursive_body)
                 })
                 .collect(),
         ),
@@ -42178,33 +42202,139 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // #2135: `Expr::Object` is pulled out of that shared fallthrough for
         // the same reason `Pipe` above is -- see the `Comma` doc comment
         // above for why it, alone among the three `Vec`-shaped siblings
-        // here, needed no change. Charged the same way as `Pipe`: entry `i`
-        // (0-indexed)'s key and value both see `frames + i + 1`, so an entry
-        // near the end of a wide object literal is priced like an
-        // equally-deep nested wrapping, while the ordinary case -- a handful
-        // of keys, or a very wide but non-recursive object literal -- is
-        // unaffected, since nothing is checked against `MAX_EVAL_FRAMES`
-        // until a `DefCall` is actually reached inside one of the entries.
+        // here, needed no change. Charged the same way as `Pipe`, gated by
+        // the same [`sibling_frame_charge`] rule: entry `i` (0-indexed)'s
+        // key and value both see the same charge.
         Expr::Object(entries) => Expr::Object(
             entries
                 .iter()
                 .enumerate()
                 .map(|(i, entry)| {
-                    let charged = frames.saturating_add(i as u32).saturating_add(1);
+                    let charged = sibling_frame_charge(frames, i as u32, in_recursive_body);
                     let key = match &entry.key {
                         ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
-                        ObjectKey::Expr(e) => {
-                            ObjectKey::Expr(Box::new(install_def_calls(e, def, charged)))
-                        }
+                        ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(install_def_calls(
+                            e,
+                            def,
+                            charged,
+                            in_recursive_body,
+                        ))),
                     };
                     ObjectEntry {
                         key,
-                        value: install_def_calls(&entry.value, def, charged),
+                        value: install_def_calls(&entry.value, def, charged, in_recursive_body),
                     }
                 })
                 .collect(),
         ),
-        _ => map_subexprs(expr, &mut |sub| install_def_calls(sub, def, frames + 1)),
+        // #2135 code-review Finding 2: `build_string_parts`/`build_string_
+        // parts_with_context` (`src/jq/eval.rs`) have the identical
+        // non-tail per-part recursion `Expr::Object`'s own `build_object_
+        // entries` does (an `acc`/`slots` mutation sits before the
+        // recursive call returns, so it cannot be tail-call-eliminated) --
+        // confirmed live: a real stack overflow, not caught by any guard,
+        // since this variant fell through to the ordinary flat fallthrough
+        // arm below before this fix and so was never charged for width at
+        // all. Gated by the same [`sibling_frame_charge`] rule as `Pipe`/
+        // `Object`.
+        //
+        // The index is *reversed* from `Pipe`/`Object`'s own left-to-right
+        // charge: both `build_string_parts` functions shrink `parts` from
+        // the right via `split_last()` each recursive call (see either
+        // one's own doc comment for why -- it is what gives `"\(1,2)-\(3,4)"`
+        // its jq-verified `1-3,2-3,1-4,2-4` fan-out order, the *opposite* of
+        // object construction's "last entry varies fastest"), so the
+        // *first* (leftmost) part is the one still live the deepest on the
+        // native stack when the *last* part's own slot is finally reached,
+        // not the other way around. A part at 0-indexed position `i` among
+        // `len` total is therefore charged as if it were at structural
+        // position `len - 1 - i`, not `i` itself.
+        Expr::StringInterpolation(parts) => {
+            let len = parts.len();
+            Expr::StringInterpolation(
+                parts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, part)| match part {
+                        StringPart::Literal(s) => StringPart::Literal(s.clone()),
+                        StringPart::Expr(e) => {
+                            let position = (len - 1 - i) as u32;
+                            let charged = sibling_frame_charge(frames, position, in_recursive_body);
+                            StringPart::Expr(Box::new(install_def_calls(
+                                e,
+                                def,
+                                charged,
+                                in_recursive_body,
+                            )))
+                        }
+                    })
+                    .collect(),
+            )
+        }
+        _ => map_subexprs(expr, &mut |sub| {
+            install_def_calls(sub, def, frames + 1, in_recursive_body)
+        }),
+    }
+}
+
+/// The per-sibling `frames` charge `install_def_calls` uses for a
+/// structurally-recursive `Vec`-shaped node (`Expr::Pipe`, `Expr::Object`,
+/// `Expr::StringInterpolation`) at 0-indexed structural position `position`
+/// (#2135, corrected by its own code review -- see the two findings this
+/// function's doc comment on `MAX_EVAL_FRAMES` records).
+///
+/// **Width only compounds when `in_recursive_body` is true** -- i.e. this
+/// walk is happening *inside* `def`'s own (potentially self-recursive) body,
+/// via `bind_def_call`'s own re-entry (`install_def_calls(&body, def, frames
+/// + 1, true)`), rather than a one-shot scope like `bind_def`'s own `then`
+/// (`install_def_calls(then, &def, depth, false)` -- *everything textually
+/// after* a `def` declaration, not that `def`'s own body, walked exactly
+/// once for this `def`). A wide-but-non-recursive pipe/object/string-
+/// interpolation sitting in that one-shot `then` is walked exactly once,
+/// ever, for this `def` -- so unlike a wrapping that sits *inside* a self-
+/// recursive body (repeated once per recursive level, where the extra width
+/// genuinely does compound into real accumulated native stack), a wide
+/// sibling list here contributes no compounding risk at all, no matter how
+/// wide it is, and must fall back to the flat, position-independent `frames
+/// + 1` every sibling got before #2135.
+///
+/// **This is `in_recursive_body`, not `frames > 0`, deliberately** -- an
+/// earlier version of this fix tried gating on `frames > 0` instead, on the
+/// theory that `frames` starts at `0` for `bind_def`'s own one-shot walk and
+/// is always `>= 1` inside `bind_def_call`'s re-entry. That is true, but
+/// insufficient: `frames` *also* grows by `+1` per level of ordinary AST
+/// nesting within the very same one-shot walk (an enclosing `Expr::Paren`,
+/// an `if`, ...) via this function's own generic fallthrough arm below --
+/// nesting that never repeats and so must not compound either. Confirmed
+/// live: `def f: . + 1; ({41000-stage pipe} | f)` (no wrapping parens)
+/// worked correctly under the `frames > 0` gate, but reinstating the exact
+/// same filter's own outer parentheses (`(...)`) bumped `frames` to `1`
+/// *before* the pipe was ever reached (the `Expr::Paren` fallthrough's own
+/// `frames + 1`), defeating the gate and reproducing the original bug
+/// despite zero actual recursion anywhere. `in_recursive_body` is threaded
+/// as its own parameter specifically so ordinary AST nesting can never be
+/// mistaken for genuine recursive re-entry, however many non-`Pipe`/
+/// `Object`/`StringInterpolation` layers sit in between.
+///
+/// Getting this wrong the *other* way (no gate at all) was Finding 1 of
+/// #2135's own code review: charging position-based width unconditionally
+/// made an entirely ordinary, non-recursive call to a user-defined function
+/// -- one instance, zero actual recursion anywhere -- spuriously trip
+/// `MAX_EVAL_FRAMES` merely for sitting late in a sufficiently wide one-shot
+/// pipe or object literal (confirmed live: pre-#2135 `main` and real jq both
+/// return the correct answer for the repro above; the position-based charge
+/// with no gate at all raised `f/0 exceeded maximum recursion depth`
+/// instead). The gate above is what keeps that filter -- and the realistic
+/// generated/templated-filter shape it stands in for -- unaffected, while
+/// still charging the width that sits *inside* a genuinely self-recursive
+/// body starting from its very first level (`bind_def_call`'s own re-entry
+/// is always `in_recursive_body: true`), which is what #2135's own original
+/// repro needs caught.
+fn sibling_frame_charge(frames: u32, position: u32, in_recursive_body: bool) -> u32 {
+    if in_recursive_body {
+        frames.saturating_add(position).saturating_add(1)
+    } else {
+        frames.saturating_add(1)
     }
 }
 
@@ -42360,13 +42490,23 @@ fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
 }
 
 /// Expand function calls in a builtin expression.
-fn install_def_calls_in_builtin(builtin: &Builtin, def: &Rc<FuncDefData>, depth: u32) -> Builtin {
+fn install_def_calls_in_builtin(
+    builtin: &Builtin,
+    def: &Rc<FuncDefData>,
+    depth: u32,
+    in_recursive_body: bool,
+) -> Builtin {
     // Every other structural arm in `install_def_calls` charges `frames + 1`
     // at each descent step (once at the call site into this function, again
     // here for the step into each subexpression) -- matching that keeps a
     // `DefCall` reached through a builtin argument (`map(recurse_def)`,
     // `select(...)`) charged the same as an equivalent plain-expression path.
-    map_builtin_subexprs(builtin, &mut |e| install_def_calls(e, def, depth + 1))
+    // `in_recursive_body` is threaded through unchanged, same as every other
+    // arm (#2135 code review, Finding 1) -- a builtin argument is ordinary
+    // structural nesting, not a recursive-substitution boundary of its own.
+    map_builtin_subexprs(builtin, &mut |e| {
+        install_def_calls(e, def, depth + 1, in_recursive_body)
+    })
 }
 
 /// Substitute function parameter in a builtin expression.
@@ -69684,6 +69824,7 @@ mod tests {
                     body: Expr::Identity,
                 }),
                 0,
+                false,
             ),
             slice_number
         );
@@ -69717,7 +69858,7 @@ mod tests {
             expr: Box::new(call_f()),
         };
 
-        match install_def_calls(&nth, &def, 0) {
+        match install_def_calls(&nth, &def, 0, false) {
             Expr::NthExpr { n, expr } => {
                 assert!(
                     matches!(*n, Expr::DefCall { .. }),
@@ -69755,7 +69896,7 @@ mod tests {
             }],
         };
 
-        match install_def_calls(&ns_call, &def, 0) {
+        match install_def_calls(&ns_call, &def, 0, false) {
             Expr::NamespacedCall {
                 namespace,
                 name,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41874,6 +41874,20 @@ pub(crate) fn is_pure_chain_link(expr: &Expr) -> bool {
 /// the guard now fires at depth 40, again better than 6x -- consistent
 /// across an order of magnitude of width, so `MAX_EVAL_FRAMES` itself did
 /// not need to change, only the per-sibling charge.
+///
+/// **Corrected by its own code review, twice more (#2135).** The
+/// position-based charge above compounded unconditionally -- a genuine bug,
+/// not a refinement: an entirely ordinary, non-recursive call sitting late
+/// in a wide *one-shot* pipe or object (no recursion anywhere) spuriously
+/// tripped this guard purely from its own textual position. And
+/// `Expr::StringInterpolation` shares `Expr::Object`'s own non-tail
+/// per-part recursion shape but had been given no charging arm at all,
+/// leaving a real, uncaught stack overflow reachable. See
+/// [`sibling_frame_charge`]'s own doc comment for the full account of both
+/// and the fix (an explicit `in_recursive_body` flag, not `frames` itself,
+/// gates when width compounds) -- the bisected numbers just above are for
+/// the case that flag now confirms unchanged: a recursive call's own
+/// wrapping, still charged exactly as bisected here.
 pub(crate) const MAX_EVAL_FRAMES: u32 = 40_000;
 
 /// Evaluate one call to a user-defined function (#1371).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41838,6 +41838,37 @@ pub(crate) fn is_pure_chain_link(expr: &Expr) -> bool {
 /// Real jq does not manage this on the same input -- `def deep: [deep]; deep`
 /// dies there with `cannot allocate memory`, exit 134 (confirmed live) -- so
 /// erroring instead is a divergence in the only direction ADR-0018 permits.
+///
+/// **Sibling breadth counts too, not just nesting (#2135).** The charging
+/// above was originally described only through *nesting* -- an expression
+/// descending into another, like array-wrapping `[[[X]]]`. A *wide, flat*
+/// sibling list (many elements in one `Expr::Pipe` or `Expr::Object`) turned
+/// out to carry the same kind of live native cost per recursive level, for
+/// the same reason: `eval_pipe`'s own recursion into a later pipe stage, and
+/// `build_object_entries`'s own recursion into a later object entry, are
+/// each not guaranteed to be tail-call-eliminated, so reaching sibling `i`
+/// holds siblings `0..i` live on the stack. `install_def_calls` charges pipe
+/// and object sibling `i` (0-indexed) `frames + i + 1` for exactly that
+/// reason -- confirmed necessary live: a 200-wide pipe (or 200-entry object)
+/// wrapping a recursive call in its last position crashed with a real stack
+/// overflow at 1,500 recursive levels under the old flat `frames + 1`
+/// charge, which never grew past a handful of units regardless of width and
+/// so never tripped this guard. `Expr::Comma` looks like the same shape but
+/// is not: `eval_comma` is a flat loop over its siblings, not a per-sibling
+/// self-recursive call chain, so it stayed on the flat charge -- confirmed
+/// by rebuilding the same repro through `Comma`/`last` instead of `Pipe`,
+/// which neither crashes nor trips the guard at 20x the width*depth product
+/// that crashes through `Pipe`. See `install_def_calls`'s own `Expr::Pipe`/
+/// `Expr::Comma`/`Expr::Object` arms for the full account.
+///
+/// Re-bisected after that fix, same 256 MB release profile: a 200-wide pipe
+/// wrapping a recursive call crashed (pre-fix) between depth 1,220 and 1,225
+/// -- the guard now fires at depth 197, better than 6x margin. A 5,000-wide
+/// pipe crashed between depth 50 and 51; the guard now fires at depth 8,
+/// also better than 6x. A 1,000-wide pipe crashed between depth 250 and 255;
+/// the guard now fires at depth 40, again better than 6x -- consistent
+/// across an order of magnitude of width, so `MAX_EVAL_FRAMES` itself did
+/// not need to change, only the per-sibling charge.
 pub(crate) const MAX_EVAL_FRAMES: u32 = 40_000;
 
 /// Evaluate one call to a user-defined function (#1371).
@@ -42075,6 +42106,65 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
             // node before it has been evaluated).
             bound: BoundBody::default(),
         },
+        // #2135: `eval_pipe` (`src/jq/eval.rs`) recurses once per pipe stage
+        // before it reaches a later sibling -- `eval_single(first, ...)` for
+        // stage 0 costs nothing extra, but reaching stage `i` costs `i`
+        // further `eval_pipe` frames still live on the native stack while
+        // control descends into it (the `QueryResult::One(v) =>
+        // eval_pipe::<W, S>(rest, v, optional)` arm is not guaranteed to be
+        // eliminated as a real tail call). That is exactly the mechanism
+        // `MAX_EVAL_FRAMES`'s own doc comment already names for *nesting*
+        // ("how much structure each one holds live across its own recursive
+        // call") -- just uncounted here for sibling breadth. The flat
+        // `frames + 1` every sibling used to get regardless of width or
+        // position undercounted this: a 200-wide pipe wrapping a recursive
+        // `deep(m-1)` call in its last position charged that call the same
+        // single `+1` a 2-wide pipe would, so `MAX_EVAL_FRAMES` (checked
+        // against the undercounted total) never fired and `deep(1500)`
+        // overflowed the real native stack instead (confirmed live, #2135).
+        //
+        // Charging sibling `i` (0-indexed) `frames + i + 1` instead prices a
+        // sibling near the end of a wide pipe the same as an equally-deep
+        // nested wrapping would be, while a sibling near the front --
+        // genuinely cheap in `eval_pipe`'s own recursion, since reaching it
+        // needs no extra frames at all -- stays cheap here too. An ordinary
+        // long *non-recursive* pipe (`.a | .b | .c | ...`, the common
+        // generated/templated-filter shape) is unaffected either way:
+        // nothing here is ever checked against `MAX_EVAL_FRAMES` until a
+        // `DefCall` is actually reached, and a pipe with no recursive call
+        // inside never creates one, regardless of how wide it is.
+        Expr::Pipe(exprs) => Expr::Pipe(
+            exprs
+                .iter()
+                .enumerate()
+                .map(|(i, e)| {
+                    install_def_calls(e, def, frames.saturating_add(i as u32).saturating_add(1))
+                })
+                .collect(),
+        ),
+        // #2135: `Expr::Comma` looks like it should share `Pipe`'s gap above
+        // -- same `Vec<Expr>` sibling shape -- but does not. `eval_comma`
+        // (`src/jq/eval.rs`) is a flat `for expr in exprs` loop over its
+        // siblings, not a per-sibling self-recursive call chain: evaluating
+        // comma element `i` runs and returns within that same loop iteration,
+        // so elements `0..i` are never held live on the native stack while
+        // element `i` runs, no matter how wide the comma is. Confirmed by
+        // direct experiment, not just by reading the loop: rebuilding the
+        // #2135 repro shape with `last((1, 1, ..., 1, deep(m-1)))` (200
+        // ones) in place of the piped chain does not crash at the same
+        // (width=200, depth=1500) that overflows the stack through `Pipe`,
+        // nor even at (width=2000, depth=3000) -- a width*depth product 20x
+        // past `Pipe`'s own measured crash floor (~250,000-300,000). Left on
+        // the ordinary flat `frames + 1` charge below, via the generic
+        // fallthrough arm.
+        //
+        // `Expr::Object` turned out to need the opposite verdict --
+        // `build_object_entries` (`src/jq/eval.rs`) *is* self-recursive per
+        // entry (an entry's own recursive call sits before an `acc.pop()`
+        // cleanup step, so it cannot be tail-call-eliminated), and a
+        // 200-entry object literal wrapping the same recursive call crashes
+        // exactly like `Pipe` does, at the same shape. See its own arm below.
+        //
         // Reached for a different function name entirely, or (#1376)
         // a same-name call whose arity doesn't match this occurrence
         // -- either way, not this pass's call to resolve, so just
@@ -42084,6 +42174,36 @@ pub(crate) fn install_def_calls(expr: &Expr, def: &Rc<FuncDefData>, frames: u32)
         // comment for the full variant-by-variant justification, including
         // the arms above that stay explicit here instead of ever reaching
         // it.
+        //
+        // #2135: `Expr::Object` is pulled out of that shared fallthrough for
+        // the same reason `Pipe` above is -- see the `Comma` doc comment
+        // above for why it, alone among the three `Vec`-shaped siblings
+        // here, needed no change. Charged the same way as `Pipe`: entry `i`
+        // (0-indexed)'s key and value both see `frames + i + 1`, so an entry
+        // near the end of a wide object literal is priced like an
+        // equally-deep nested wrapping, while the ordinary case -- a handful
+        // of keys, or a very wide but non-recursive object literal -- is
+        // unaffected, since nothing is checked against `MAX_EVAL_FRAMES`
+        // until a `DefCall` is actually reached inside one of the entries.
+        Expr::Object(entries) => Expr::Object(
+            entries
+                .iter()
+                .enumerate()
+                .map(|(i, entry)| {
+                    let charged = frames.saturating_add(i as u32).saturating_add(1);
+                    let key = match &entry.key {
+                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
+                        ObjectKey::Expr(e) => {
+                            ObjectKey::Expr(Box::new(install_def_calls(e, def, charged)))
+                        }
+                    };
+                    ObjectEntry {
+                        key,
+                        value: install_def_calls(&entry.value, def, charged),
+                    }
+                })
+                .collect(),
+        ),
         _ => map_subexprs(expr, &mut |sub| install_def_calls(sub, def, frames + 1)),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17819,6 +17819,128 @@ fn test_deeply_nested_conditional_wrapping_hits_frame_guard_without_growing_valu
     Ok(())
 }
 
+/// #2135: `install_def_calls`'s `Expr::Pipe` arm used to charge the same flat
+/// `frames + 1` to every sibling regardless of how many siblings existed or
+/// where the recursive call sat among them -- nesting depth compounded
+/// through repeated descent, but sibling *breadth* in one `Vec` did not
+/// compound at all. A recursive `def` whose body is a wide, flat pipe (many
+/// trivial `.` stages, one of which recurses) carries real native stack cost
+/// per level that the guard never saw: confirmed live before this fix, this
+/// exact repro (200 pipe stages wrapping `deep(m-1)`, called to depth 1,500)
+/// raised `thread '<unknown>' has overflowed its stack` / `fatal runtime
+/// error: stack overflow, aborting` (SIGABRT, exit 134) -- with real jq 1.7.1
+/// returning `null`, exit 0, on the identical filter. Charging each pipe
+/// sibling `frames + i + 1` (its own position, not a flat `+1`) now prices a
+/// sibling near the end of a wide pipe the same as an equally-deep nested
+/// wrapping, so `MAX_EVAL_FRAMES` fires here as a clean, catchable error
+/// well before the native stack would.
+#[test]
+fn test_wide_recursive_pipe_reports_cleanly_not_stack_overflow_2135() -> Result<()> {
+    let chain = std::iter::repeat_n(".", 200)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let query = format!("def deep(m): if m == 0 then . else ({chain} | deep(m-1)) end; deep(1500)");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("stack overflow") && !stderr.contains("fatal runtime error"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2135 follow-up finding: `Expr::Object` shares `Pipe`'s gap even though
+/// the issue that found it only named `Pipe`/`Comma`. `build_object_entries`
+/// (`src/jq/eval.rs`) recurses once per object entry with real cleanup
+/// (`acc.pop()`) after the recursive call, so it cannot be tail-call
+/// eliminated -- a wide object literal wrapping a recursive call crashed the
+/// same way `Pipe` did, at the same (200, 1500) shape, confirmed live before
+/// this fix. `install_def_calls`'s new `Expr::Object` arm charges each
+/// entry's key/value the same position-based `frames + i + 1` `Pipe` uses.
+#[test]
+fn test_wide_recursive_object_reports_cleanly_not_stack_overflow_2135() -> Result<()> {
+    let entries = (0..200)
+        .map(|i| format!(r#""k{i}":1"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let query = format!(
+        r#"def deep(m): if m == 0 then . else (({{{entries},"r":deep(m-1)}}) | .r) end; deep(1500)"#
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("stack overflow") && !stderr.contains("fatal runtime error"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2135 sibling investigation: `Expr::Comma` looks like it should need the
+/// same position-based charge as `Pipe`/`Object` above -- same `Vec<Expr>`
+/// sibling shape -- but `eval_comma` (`src/jq/eval.rs`) is a flat loop over
+/// its siblings, not a per-sibling self-recursive call chain, so it was left
+/// on the ordinary flat `frames + 1` charge. This rebuilds the `Pipe` repro's
+/// exact (width=200, depth=1500) shape through `Comma`/`last` instead of a
+/// piped chain and confirms it neither crashes nor false-positives on
+/// `MAX_EVAL_FRAMES` -- both the width and the depth here match the shape
+/// that overflows the stack through `Pipe`.
+#[test]
+fn test_wide_recursive_comma_neither_crashes_nor_false_positives_2135() -> Result<()> {
+    let ones = std::iter::repeat_n("1", 200).collect::<Vec<_>>().join(", ");
+    let query =
+        format!("def deep(m): if m == 0 then . else (last(({ones}, deep(m-1)))) end; deep(1500)");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "null");
+    Ok(())
+}
+
+/// #2135: the fix must not create false positives on the ordinary, common
+/// shapes real jq programs use -- a wide array/object literal or a long pipe
+/// with no recursive `def` inside never creates a `DefCall`, so nothing here
+/// is ever checked against `MAX_EVAL_FRAMES` regardless of width. Matches
+/// real jq 1.7.1 byte for byte on all three (confirmed live).
+#[test]
+fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
+    let array = format!(
+        "[{}] | length",
+        (0..100_000)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &array], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "100000");
+
+    let object = format!(
+        "{{{}}} | length",
+        (0..50_000)
+            .map(|i| format!(r#""k{i}":{i}"#))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &object], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "50000");
+
+    let pipe = std::iter::repeat_n(".", 50_000)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &pipe], Some("42"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "42");
+    Ok(())
+}
+
 /// #1371: the depth guard has to be reachable from every evaluator, not just
 /// the plain one, and each reports it differently. A runaway recursion under a
 /// *truncating* consumer goes through `eval_each`'s own `DefCall` arm, and one

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17908,6 +17908,16 @@ fn test_wide_recursive_comma_neither_crashes_nor_false_positives_2135() -> Resul
 /// with no recursive `def` inside never creates a `DefCall`, so nothing here
 /// is ever checked against `MAX_EVAL_FRAMES` regardless of width. Matches
 /// real jq 1.7.1 byte for byte on all three (confirmed live).
+///
+/// Filters are passed via `-f <file>`, not as a raw argv element (#2135 CI
+/// fix): a 41,000+-component filter string comfortably clears Linux's
+/// `ARG_MAX` for a single argument in isolation, but this crate's own test
+/// harness execs the binary through a `Command` whose *total* argv/environment
+/// footprint (inherited env included) counts against the same kernel limit --
+/// large enough here to trip `execve`'s "Argument list too long" on Linux CI
+/// (macOS's much larger `ARG_MAX` let this pass locally). `-f`/a temp file
+/// sidesteps the limit entirely, matching this file's own existing
+/// `test_from_file` pattern.
 #[test]
 fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
     let array = format!(
@@ -17917,7 +17927,12 @@ fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
             .collect::<Vec<_>>()
             .join(",")
     );
-    let (stdout, stderr, code) = run_jq_full(&["-c", &array], Some("null"))?;
+    let mut array_file = NamedTempFile::new()?;
+    write!(array_file, "{array}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", array_file.path().to_str().unwrap()],
+        Some("null"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "100000");
 
@@ -17928,14 +17943,24 @@ fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
             .collect::<Vec<_>>()
             .join(",")
     );
-    let (stdout, stderr, code) = run_jq_full(&["-c", &object], Some("null"))?;
+    let mut object_file = NamedTempFile::new()?;
+    write!(object_file, "{object}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", object_file.path().to_str().unwrap()],
+        Some("null"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "50000");
 
     let pipe = std::iter::repeat_n(".", 50_000)
         .collect::<Vec<_>>()
         .join(" | ");
-    let (stdout, stderr, code) = run_jq_full(&["-c", &pipe], Some("42"))?;
+    let mut pipe_file = NamedTempFile::new()?;
+    write!(pipe_file, "{pipe}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", pipe_file.path().to_str().unwrap()],
+        Some("42"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "42");
     Ok(())
@@ -17966,13 +17991,24 @@ fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
 /// answer to match at all -- the width is chosen instead to comfortably
 /// clear this crate's own 40,000-frame ceiling, which is exactly the point
 /// being pinned.
+///
+/// Filters are passed via `-f <file>`, not as a raw argv element (#2135 CI
+/// fix) -- see `test_wide_non_recursive_literals_and_pipes_unaffected_2135`'s
+/// own doc comment for why a filter this size trips Linux's `ARG_MAX` for
+/// this harness's `Command` even though it passed locally on macOS.
 #[test]
 fn test_wide_non_recursive_pipe_and_object_do_not_false_positive_2135() -> Result<()> {
     let chain = std::iter::repeat_n(".", 41_000)
         .collect::<Vec<_>>()
         .join(" | ");
+
     let query = format!("def f: . + 1; ({chain} | f)");
-    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    let mut query_file = NamedTempFile::new()?;
+    write!(query_file, "{query}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", query_file.path().to_str().unwrap()],
+        Some("1"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "2");
 
@@ -17983,7 +18019,12 @@ fn test_wide_non_recursive_pipe_and_object_do_not_false_positive_2135() -> Resul
     // charge silently defeated -- see `sibling_frame_charge`'s own doc
     // comment for the full account).
     let query = format!("def f: . + 1; {chain} | f");
-    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    let mut query_file = NamedTempFile::new()?;
+    write!(query_file, "{query}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", query_file.path().to_str().unwrap()],
+        Some("1"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "2");
 
@@ -17992,7 +18033,12 @@ fn test_wide_non_recursive_pipe_and_object_do_not_false_positive_2135() -> Resul
         .collect::<Vec<_>>()
         .join(",");
     let query = format!(r#"def f: . + 1; ({{{entries},"r":f}}) | .r"#);
-    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    let mut query_file = NamedTempFile::new()?;
+    write!(query_file, "{query}")?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", query_file.path().to_str().unwrap()],
+        Some("1"),
+    )?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "2");
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17941,6 +17941,117 @@ fn test_wide_non_recursive_literals_and_pipes_unaffected_2135() -> Result<()> {
     Ok(())
 }
 
+/// #2135 code-review Finding 1: unlike the sibling test above (a wide pipe
+/// with *no* `DefCall` in it at all, so nothing is ever checked against
+/// `MAX_EVAL_FRAMES` regardless of width), this filter has a genuine,
+/// one-time call to a user-defined function -- `f`, called exactly once, no
+/// recursion anywhere -- sitting at the very last position of a 41,000-stage
+/// pipe. `install_def_calls`'s original #2135 fix charged that position-based
+/// width to *every* `DefCall` it reached, recursive or not, which made this
+/// entirely ordinary filter spuriously raise `f/0 exceeded maximum recursion
+/// depth` instead of returning the correct answer -- confirmed live (both
+/// pre-#2135 `main` and real jq 1.7.1 at a width real jq can still compile,
+/// see this test's own width note below, return the correct value; the
+/// unguarded position-based charge did not). Fixed by
+/// `sibling_frame_charge`'s own `in_recursive_body` gate: width only
+/// compounds when this walk is already inside a `def`'s own (potentially
+/// self-recursive) body, never for a one-shot call embedded in ordinary
+/// top-level structure. Both a wide `Pipe` and a wide `Object` sharing the
+/// same one-time, non-recursive call are pinned here.
+///
+/// Deliberately does **not** compare against real jq at this exact width:
+/// real jq's own bytecode compiler exhausts memory somewhere between 1,000
+/// and 5,000 pipe stages regardless of recursion (confirmed live, unrelated
+/// to this fix or to `MAX_EVAL_FRAMES`), so 41,000 has no real-jq reference
+/// answer to match at all -- the width is chosen instead to comfortably
+/// clear this crate's own 40,000-frame ceiling, which is exactly the point
+/// being pinned.
+#[test]
+fn test_wide_non_recursive_pipe_and_object_do_not_false_positive_2135() -> Result<()> {
+    let chain = std::iter::repeat_n(".", 41_000)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let query = format!("def f: . + 1; ({chain} | f)");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+
+    // The identical shape with no wrapping parens at all around `then` --
+    // confirms the fix does not depend on `Expr::Paren` happening to be
+    // absent (an earlier, incorrect attempt at this fix gated on `frames >
+    // 0`, which an enclosing `Paren`'s own ordinary `frames + 1` AST-nesting
+    // charge silently defeated -- see `sibling_frame_charge`'s own doc
+    // comment for the full account).
+    let query = format!("def f: . + 1; {chain} | f");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+
+    let entries = (0..41_000)
+        .map(|i| format!(r#""k{i}":1"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let query = format!(r#"def f: . + 1; ({{{entries},"r":f}}) | .r"#);
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("1"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #2135 code-review Finding 2: `Expr::StringInterpolation` had the identical
+/// non-tail per-part recursion shape `Expr::Object`'s own `build_object_
+/// entries` does (`build_string_parts`/`build_string_parts_with_context`,
+/// `src/jq/eval.rs`, both a `split_last()`-based reverse walk that mutates a
+/// shared `slots` buffer before the recursive call returns, so neither can be
+/// tail-call-eliminated), but was never given a charging arm at all -- it fell
+/// through to the ordinary flat fallthrough, so nothing here was ever charged
+/// for width, and a recursive `def` wrapping its own self-call in enough
+/// interpolation parts crashed with a real, uncaught stack overflow
+/// (confirmed live before this fix). Fixed by giving `Expr::StringInterpolation`
+/// its own arm in `install_def_calls`, gated by the same `sibling_frame_charge`
+/// rule `Pipe`/`Object` use.
+///
+/// The recursive call sits *first* in source order deliberately: both
+/// `build_string_parts` functions shrink `parts` from the right via
+/// `split_last()`, so the first (leftmost) part is the one still live
+/// deepest on the native stack, not the last -- putting the recursive call
+/// last instead (matching `Pipe`/`Object`'s own left-to-right intuition) does
+/// not reproduce this crash at all, since it would then be the *shallowest*
+/// frame instead of the deepest one.
+#[test]
+fn test_wide_recursive_string_interpolation_reports_cleanly_not_stack_overflow_2135() -> Result<()>
+{
+    let trailing_slots = "\\(1)".repeat(200);
+    let query = format!(
+        r#"def deep(m): if m == 0 then "done" else "\(deep(m-1)){trailing_slots}" end; deep(1500) | length"#
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("stack overflow") && !stderr.contains("fatal runtime error"),
+        "stderr: {stderr:?}"
+    );
+
+    // A shallow, ordinary case must still return the correct value -- the
+    // new charging arm must not itself become a false positive.
+    let small_slots = "\\(1)".repeat(50);
+    let query = format!(
+        r#"def deep(m): if m == 0 then "done" else "\(deep(m-1)){small_slots}" end; deep(100) | length"#
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &query], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        "5004",
+        "stdout: {stdout:?} stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1371: the depth guard has to be reachable from every evaluator, not just
 /// the plain one, and each reports it differently. A runaway recursion under a
 /// *truncating* consumer goes through `eval_each`'s own `DefCall` arm, and one


### PR DESCRIPTION
## Summary

Fixes #2135: `install_def_calls`'s `MAX_EVAL_FRAMES` accounting only charged *nesting*
depth (an expression descending into another), never sibling *breadth* in a
`Expr::Pipe`/`Expr::Object` node — every sibling got a flat `frames + 1` regardless of
how many siblings existed. A wide-but-flat recursive `def` body (many trivial pipe stages
wrapping a recursive call) therefore carries real live native-stack cost per recursive
level that the guard never saw, so `MAX_EVAL_FRAMES` (40,000) never fires and the process
eventually overflows its native stack for real:

```console
$ python3 -c "
chain = ' | '.join(['.'] * 200)
print(f'def deep(m): if m == 0 then . else ({chain} | deep(m-1)) end; deep(1500)')
" > /tmp/repro.jq
$ echo 'null' | /usr/bin/jq -c "$(cat /tmp/repro.jq)"
null                                     # exit 0, real jq handles this fine
$ echo 'null' | succinctly jq -c "$(cat /tmp/repro.jq)"     # pre-fix
thread '<unknown>' has overflowed its stack
fatal runtime error: stack overflow, aborting               # exit 134
```

## Fix (revised after code-review — two rounds)

**Round 1** charged pipe/object sibling `i` (0-indexed) `frames + i + 1` instead of a flat
`+1`. Code-review found two problems, both confirmed live and fixed in round 2:

1. **False positive**: charging width unconditionally made an entirely ordinary,
   non-recursive call to a user-defined function — one instance, zero actual recursion
   anywhere — spuriously trip `MAX_EVAL_FRAMES` merely for sitting late in a wide one-shot
   pipe/object literal (a realistic generated/templated-filter shape). Fixed by threading
   an explicit `in_recursive_body: bool` through `install_def_calls`, set `true` only at
   `bind_def_call`'s own re-entry (the scope that genuinely repeats once per recursive
   level) and `false` at `bind_def`'s one-shot walk — **not** `frames > 0`, which is
   insufficient: `frames` also grows from ordinary AST nesting (an enclosing `Paren`, an
   `if`, ...) within the same one-shot walk, and mistaking that for recursion reintroduces
   the same bug one layer down. Width now only compounds when `in_recursive_body` is true.
2. **`Expr::StringInterpolation`** (`build_string_parts`) shares `Expr::Object`'s
   non-tail, `split_last()`-based recursion shape and was left unguarded — still a real
   stack overflow, just at a larger scale. Given the same charging arm (with reversed
   indexing, since `build_string_parts` processes parts right-to-left).

`Expr::Comma` stays on the flat charge (`eval_comma` is a flat loop, not self-recursive
per sibling — confirmed by direct experiment, not just by reading the loop).

## Calibration

Re-bisected the real crash floor (release, 256 MB stack) before and after the fix:

| Width | Pre-fix crash floor (depth) | Post-fix guard fires (depth) | Margin |
|---|---|---|---|
| 200 | 1,220 (OK) → 1,225 (crash) | 197 | ~6.2x |
| 1,000 | 250 (OK) → 255 (crash) | 40 | ~6.25x |
| 5,000 | 50 (OK) → 51 (crash) | 8 | ~6.25x |

Consistent >6x safety margin across an order of magnitude of width — `MAX_EVAL_FRAMES`
itself needed no recalibration, only the per-sibling charge.

## Verification (independently re-run twice, not just taken on the implementer's word)

- Re-confirmed the original repro against a freshly rebuilt binary: no crash, clean
  `jq: error (at <stdin>:1): deep/1 exceeded maximum recursion depth`, exit 5.
- Re-confirmed the false-positive repro (`def f: . + 1; (<41000-stage pipe> | f)`, with and
  without wrapping parens) now returns the correct value (`2`), matching pre-fix `main`
  and real jq.
- Re-confirmed the `StringInterpolation` crash repro (width=1000/depth=2000) now raises a
  clean bounded error instead of a stack overflow.
- Spot-checked no other false positives: 100k-element array literal, 50k-key object
  literal, 50k-stage non-recursive pipe, and a legitimate 10,000-deep narrow recursion
  (`sum_to`) all still work and match `/usr/bin/jq` exactly.
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`: clean.
- Patch coverage: **100%** (90/90 new lines).

Fixes #2135
