### PR TITLE
fix(jq): make modulemeta error like real jq instead of always returning null

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -28,14 +28,14 @@ For jq *feature* coverage rather than error wording, see
 
 ## Summary
 
-Measured against jq-1.7.1 over the 221 probes in
+Measured against jq-1.7.1 over the 223 probes in
 [`tests/data/jq-error-probes.tsv`](../../../tests/data/jq-error-probes.tsv), through
 **both** evaluators — the full one (`src/jq/eval.rs`) and the generic one
 (`src/jq/eval_generic.rs`, which the CLI uses):
 
 | Dimension                                    | Result              | Meaning                                                |
 |----------------------------------------------|---------------------|--------------------------------------------------------|
-| **Message text** (both evaluators, verbatim) | **219/221 = 99.1%** | Byte-identical to jq                                   |
+| **Message text** (both evaluators, verbatim) | **221/223 = 99.1%** | Byte-identical to jq                                   |
 | **Wording divergences**                      | **2**               | Both evaluators raise, but word it differently from jq |
 | **Behaviour / parser gaps**                  | **0**               | succinctly does not raise the error at all             |
 
@@ -2762,33 +2762,6 @@ still array-collapses `n` to `[1,2]`, then errors on the wrong type -- a
 narrower, lower-traffic case than the three arms fixed above, not attempted
 here). Full fan-out for it, if ever needed, remains out of scope per
 #1522's design doc.
-
-### `modulemeta` never errors, unlike real jq -- no carve-out; tracked in #2111
-
-Real jq's `modulemeta` is not a pure no-op: it reads `.` as a module name and always
-errors, since there is no module for it to actually find in ordinary use --
-non-string input gets a type error, any string gets "not found":
-
-```console
-$ echo 'null' | jq 'modulemeta'
-jq: error (at <stdin>:1): modulemeta input module name must be a string   # exit 5
-$ echo '"foo"' | jq 'modulemeta'
-jq: error (at <stdin>:1): module not found: foo                          # exit 5
-$ echo 'null' | succinctly jq 'modulemeta'
-null                                                                      # exit 0
-$ echo '"foo"' | succinctly jq 'modulemeta'
-null                                                                      # exit 0
-```
-
-`builtin_modulemeta` (`src/jq/eval.rs`) unconditionally returns `null` and ignores its
-input entirely -- a stub comment ("we don't support modules") that predates
-[#2035](https://github.com/rust-works/succinctly/issues/2035), which fixed only the
-builtin's *arity* (the parser previously demanded `modulemeta(name)`, inverted from
-jq's actual `modulemeta/0`) and did not touch this runtime behavior. None of ADR-0018's
-four permitted conditions cover it -- matching jq's error here would corrupt nothing,
-discard no write, and cannot crash the process -- so per rule 4 it is recorded here as a
-still-open gap rather than an accepted-forever divergence. Tracked in
-[#2111](https://github.com/rust-works/succinctly/issues/2111).
 
 ### `range`'s own accumulation cap (#2089): a resource-exhaustion guard, now raising instead of silently truncating
 

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -208,7 +208,7 @@ below and [ADR-0019](../adrs/adr-0019.md).
 - [x] `recurse` / `recurse(f)` / `recurse(f; cond)`
 - [x] `walk(f)`
 - [x] `isvalid(expr)`
-- [x] `modulemeta` (stub, arity 0 like real jq's — #2035)
+- [x] `modulemeta` (arity 0 like real jq's — #2035; errors the same way real jq's does — #2111)
 - [x] `tojsonstream` / `fromjsonstream`
 - [x] `tostream` / `fromstream(f)` / `truncate_stream(f)` — jq's standard streaming
   builtins (#396). Distinct from `tojsonstream`/`fromjsonstream` above, which predate

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40544,16 +40544,32 @@ fn bsearch_one_target<W: Clone + AsRef<[u64]>>(
 // Object functions
 
 /// Builtin: modulemeta - get module metadata for the input module name.
-/// Arity 0, matching real jq (#2035) -- but the stub below always returns
-/// `null` rather than erroring the way real jq's `modulemeta` always does;
-/// that runtime-behavior gap is pre-existing, recorded in
-/// docs/compliance/jq/limitations.md, and tracked in #2111.
+/// Arity 0, matching real jq (#2035). succinctly has no real module system to
+/// describe, and real jq's `modulemeta` is not a no-op even so -- it always
+/// errors: a type-check error if `.` isn't a string, otherwise a
+/// module-not-found error citing the name, since there is never a module to
+/// actually resolve in this repo's single-file CLI/library context.
+/// Verified live against jq 1.7.1: every input type errors, exit 5 --
+/// `null`/`123`/`true`/`[]`/`{}` all give "modulemeta input module name must
+/// be a string", any string (including `""`) gives "module not found: <name
+/// verbatim>". Both arms are ordinary `error(...)`-shaped and suppressible by
+/// `?`, unlike a decode failure (#1620) -- confirmed live,
+/// `("foo","null") | modulemeta?` produces no output, exit 0 (#2111).
 fn builtin_modulemeta<W: Clone + AsRef<[u64]>>(
-    _value: StandardJson<'_, W>,
-    _optional: bool,
+    value: StandardJson<'_, W>,
+    optional: bool,
 ) -> QueryResult<'_, W> {
-    // Return null as we don't support modules
-    QueryResult::Owned(OwnedValue::Null)
+    match &value {
+        StandardJson::String(s) => match s.as_str() {
+            Ok(_) if optional => QueryResult::None,
+            Ok(name) => QueryResult::Error(EvalError::new(format!("module not found: {name}"))),
+            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+        },
+        _ if optional => QueryResult::None,
+        _ => QueryResult::Error(EvalError::new(
+            "modulemeta input module name must be a string",
+        )),
+    }
 }
 
 /// Builtin: pick(keys) - select only specified keys from object/array (yq)
@@ -61105,9 +61121,32 @@ mod tests {
     }
 
     #[test]
-    fn test_modulemeta() {
-        // modulemeta is arity 0 in real jq (#2035); returns null (stub).
-        query!(b"null", "modulemeta", QueryResult::Owned(OwnedValue::Null) => {});
+    fn test_modulemeta_2111() {
+        // modulemeta is arity 0 in real jq (#2035). Real jq's modulemeta is
+        // not a no-op: a non-string `.` is a type-check error, verified live
+        // against jq 1.7.1.
+        query!(b"null", "modulemeta", QueryResult::Error(e) => {
+            assert_eq!(e.message, "modulemeta input module name must be a string");
+        });
+        query!(b"123", "modulemeta", QueryResult::Error(e) => {
+            assert_eq!(e.message, "modulemeta input module name must be a string");
+        });
+        // A string `.` always errors "module not found" -- there is never a
+        // real module to resolve in this repo's CLI/library context.
+        query!(br#""foo""#, "modulemeta", QueryResult::Error(e) => {
+            assert_eq!(e.message, "module not found: foo");
+        });
+        // Empty string still hits the module-not-found arm, not the
+        // type-check one -- verified live (`"" | jq modulemeta` -> "module
+        // not found: ", not a type error).
+        query!(br#""""#, "modulemeta", QueryResult::Error(e) => {
+            assert_eq!(e.message, "module not found: ");
+        });
+        // Both error shapes are ordinary, `?`-suppressible errors, unlike a
+        // decode failure (#1620) -- verified live, `modulemeta?` on either
+        // input produces no output rather than propagating.
+        query!(b"null", "modulemeta?", QueryResult::None => {});
+        query!(br#""foo""#, "modulemeta?", QueryResult::None => {});
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -40555,21 +40555,23 @@ fn bsearch_one_target<W: Clone + AsRef<[u64]>>(
 /// verbatim>". Both arms are ordinary `error(...)`-shaped and suppressible by
 /// `?`, unlike a decode failure (#1620) -- confirmed live,
 /// `("foo","null") | modulemeta?` produces no output, exit 0 (#2111).
+///
+/// Routed through `scalar_fallback` (#1907 item 5) rather than a hand-rolled
+/// decode-failure/optional/type-error triplet: its `err` closure inspects the
+/// captured `value` to pick the message, the same idiom `flatten`'s own
+/// `scalar_fallback` calls already use to build a value-dependent error.
 fn builtin_modulemeta<W: Clone + AsRef<[u64]>>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
-    match &value {
-        StandardJson::String(s) => match s.as_str() {
-            Ok(_) if optional => QueryResult::None,
-            Ok(name) => QueryResult::Error(EvalError::new(format!("module not found: {name}"))),
-            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
-        },
-        _ if optional => QueryResult::None,
-        _ => QueryResult::Error(EvalError::new(
-            "modulemeta input module name must be a string",
+    scalar_fallback(&value, optional, || match &value {
+        StandardJson::String(s) => EvalError::new(format!(
+            "module not found: {}",
+            s.as_str()
+                .expect("scalar_fallback already returned on a decode failure")
         )),
-    }
+        _ => EvalError::new("modulemeta input module name must be a string"),
+    })
 }
 
 /// Builtin: pick(keys) - select only specified keys from object/array (yq)
@@ -61147,6 +61149,26 @@ mod tests {
         // input produces no output rather than propagating.
         query!(b"null", "modulemeta?", QueryResult::None => {});
         query!(br#""foo""#, "modulemeta?", QueryResult::None => {});
+    }
+
+    /// #2111: a genuine decode failure on `.` must still survive `optional`,
+    /// the same #1620 rule `test_builtin_upper_in_decode_failure_survives_optional_2015`
+    /// pins for `IN(s)` -- `scalar_fallback`'s own decode-failure check runs
+    /// before `optional` is ever consulted, so this must never reach the
+    /// `err` closure's `s.as_str().expect(...)` at all.
+    #[test]
+    fn test_modulemeta_decode_failure_survives_optional_2111() {
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let index = JsonIndex::build(decode_failure_bytes);
+        let cursor = index.root(decode_failure_bytes);
+        match builtin_modulemeta::<Vec<u64>>(cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "{}", e.message),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+        match builtin_modulemeta::<Vec<u64>>(cursor.value(), false) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "{}", e.message),
+            other => panic!("expected a decode failure, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1177,8 +1177,10 @@ pub enum Builtin {
     BSearch(Box<Expr>),
 
     // Phase 10: Object functions
-    /// `modulemeta` - get module metadata for the input module name (stub
-    /// for compatibility). Real jq's builtin is arity 0, not arity 1 (#2035).
+    /// `modulemeta` - get module metadata for the input module name. Real
+    /// jq's builtin is arity 0, not arity 1 (#2035), and always errors --
+    /// succinctly has no real module system to describe, and matches that
+    /// behavior rather than stubbing it out (#2111).
     ModuleMeta,
     /// `pick(keys)` - select only specified keys from object/array (yq)
     Pick(Box<Expr>),

--- a/tests/data/jq-error-messages.tsv
+++ b/tests/data/jq-error-messages.tsv
@@ -223,3 +223,5 @@ infinite_preview	scan(infinite)	"x"	number (1.797693134...) is not a string
 neg_infinite_preview	scan(-infinite)	"x"	number (-1.79769313...) is not a string
 nan_preview	scan(nan)	"x"	number (null) is not a string
 arithmetic_overflow_preview	scan(1e300*1e300)	"x"	number (1.797693134...) is not a string
+modulemeta_non_string	modulemeta	null	modulemeta input module name must be a string
+modulemeta_not_found	modulemeta	"foo"	module not found: foo

--- a/tests/data/jq-error-probes.tsv
+++ b/tests/data/jq-error-probes.tsv
@@ -363,3 +363,7 @@ infinite_preview	scan(infinite)	"x"
 neg_infinite_preview	scan(-infinite)	"x"
 nan_preview	scan(nan)	"x"
 arithmetic_overflow_preview	scan(1e300*1e300)	"x"
+
+# ── modulemeta always errors: type-check or module-not-found (#2111) ───────
+modulemeta_non_string	modulemeta	null
+modulemeta_not_found	modulemeta	"foo"

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29799,11 +29799,7 @@ fn test_unimplemented_jq_builtin_still_errors_when_reached_1473() -> Result<()> 
 /// a paren'd argument) -- succinctly's parser previously demanded
 /// `modulemeta(...)`, inverted from jq's actual grammar. The arity/parse
 /// dimension below is confirmed against the pinned oracle (`/usr/bin/jq`,
-/// jq-1.7.1) (#2035). The second assertion pins succinctly's current stub
-/// behavior (always `null`), not oracle-matched output -- real jq's
-/// `modulemeta` always errors instead (see
-/// docs/compliance/jq/limitations.md and #2111, which tracks closing that
-/// separate, pre-existing gap).
+/// jq-1.7.1) (#2035).
 #[test]
 fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
     // Bare `modulemeta`, no parens, must parse -- matching `if false then
@@ -29814,11 +29810,38 @@ fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "1");
 
-    // Reached, bare `modulemeta` does not error -- succinctly's stub
-    // (#2111, not real jq's own behavior, which always errors).
-    let (stdout, stderr, code) = run_jq_full(&["-nc", "modulemeta"], None)?;
+    Ok(())
+}
+
+/// Real jq's `modulemeta` is not a pure no-op: it always errors, since there
+/// is never a real module to resolve in this repo's single-file CLI/library
+/// context -- a type-check error for non-string `.`, otherwise "module not
+/// found" citing the name. `builtin_modulemeta` (`src/jq/eval.rs`) used to
+/// unconditionally return `null`, ignoring `.` entirely; both cases now
+/// raise, matching the pinned oracle (`/usr/bin/jq`, jq-1.7.1) byte for byte
+/// (#2111).
+#[test]
+fn test_modulemeta_always_errors_like_jq_2111() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta"], Some("null"))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("modulemeta input module name must be a string"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5);
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta"], Some(r#""foo""#))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("module not found: foo"),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5);
+
+    // `?` suppresses both -- ordinary errors, not decode failures (#1620).
+    let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta?"], Some("null"))?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
     assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(stdout.trim_end(), "null");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29823,25 +29823,36 @@ fn test_modulemeta_is_arity_zero_2035() -> Result<()> {
 #[test]
 fn test_modulemeta_always_errors_like_jq_2111() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta"], Some("null"))?;
-    assert_eq!(stdout, "", "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("modulemeta input module name must be a string"),
-        "stderr: {stderr:?}"
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr,
+        "jq: error (at <stdin>:0): modulemeta input module name must be a string\n"
     );
     assert_eq!(code, 5);
 
     let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta"], Some(r#""foo""#))?;
-    assert_eq!(stdout, "", "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("module not found: foo"),
-        "stderr: {stderr:?}"
-    );
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "jq: error (at <stdin>:0): module not found: foo\n");
     assert_eq!(code, 5);
 
     // `?` suppresses both -- ordinary errors, not decode failures (#1620).
     let (stdout, stderr, code) = run_jq_full(&["-c", "modulemeta?"], Some("null"))?;
     assert_eq!(stdout, "", "stderr: {stderr:?}");
     assert_eq!(code, 0, "stderr: {stderr:?}");
+
+    // `-n` (null-input) is a genuinely separate dispatch path -- it bypasses
+    // stdin/JsonIndex construction entirely rather than merely feeding `.` a
+    // literal `null`. The old (pre-#2111) version of this test reached
+    // `modulemeta` this way; keep that path covered too, not just stdin-fed
+    // evaluation above. `-n` has no stdin source, so jq's own location tag
+    // is `<unknown>`, not `<stdin>`.
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "modulemeta"], None)?;
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr,
+        "jq: error (at <unknown>): modulemeta input module name must be a string\n"
+    );
+    assert_eq!(code, 5);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`builtin_modulemeta` unconditionally returned `null`, ignoring both its input and
`optional` — a stub predating #2035, which only fixed the builtin's *arity* (parser
grammar demanded `modulemeta(name)`, inverted from jq's real `modulemeta/0`), not this
separate runtime-behavior gap.

Real jq's `modulemeta` is not a no-op: it reads `.` as a module name and always errors,
since there's never a real module to resolve in this repo's single-file CLI/library
context — a type-check error for non-string input, otherwise "module not found: <name>".

## Verification against the pinned oracle

```console
$ echo 'null' | /usr/bin/jq 'modulemeta'
jq: error (at <stdin>:1): modulemeta input module name must be a string   # exit 5
$ echo '"foo"' | /usr/bin/jq 'modulemeta'
jq: error (at <stdin>:1): module not found: foo                          # exit 5
$ echo '""' | /usr/bin/jq 'modulemeta'
jq: error (at <stdin>:1): module not found:                              # exit 5 (still module-not-found, not a type error)
```

Confirmed live across `null`/`123`/`true`/`[]`/`{}` (all give the type-check message)
and both both error shapes are ordinary, `?`-suppressible errors, unlike a decode
failure (#1620) — `modulemeta?` on either input produces no output, exit 0.

## Changes

- `builtin_modulemeta` (`src/jq/eval.rs`): raises the two error shapes above instead of
  returning `null`.
- Added two probes (`modulemeta_non_string`, `modulemeta_not_found`) to the
  error-message parity corpus (#356) and regenerated the golden table via
  `./scripts/sync-jq-error-messages.sh` — both now match jq byte for byte (221/223
  probes passing, up from 219/221; the 2 pre-existing wording divergences are
  unaffected).
- Updated the two now-stale existing tests that pinned the old always-`null` stub
  (`test_modulemeta` in `src/jq/eval.rs`, `test_modulemeta_is_arity_zero_2035` in
  `tests/jq_cli_tests.rs`) and added direct regression coverage
  (`test_modulemeta_2111`, `test_modulemeta_always_errors_like_jq_2111`) for both error
  shapes plus `?` suppression.
- Removed the now-resolved `docs/compliance/jq/limitations.md` entry and updated the
  page's own probe-count summary.

Fixes #2111

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, all 57 test binaries pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the two other CI feature-set legs)
- [x] `cargo fmt --check`
- [x] `./scripts/sync-jq-error-messages.sh --check` passes (table matches pinned oracle)
- [x] Live-verified against `/usr/bin/jq` (pinned 1.7.1) across all input types
