### PR TITLE
docs(jq): correct #2032 test comment's eval::eval_index_expr reachability claim (#2153)

### DIFF
--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31320,10 +31320,20 @@ fn test_index_expr_one_empty_key_does_not_short_circuit_others_2032() -> Result<
 /// CLI-unreachable in general, though -- `succinctly yq` reaches it via
 /// `yq_runner.rs`'s `evaluate_input` (`jq::eval::<Vec<u64>,
 /// YqSemantics>(expr, cursor)`, at least 8 call sites, triggered by e.g.
-/// `-n`/`-R`/`--slurp`), so its sibling fix is covered there both by that
-/// live yq-mode path and by `eval.rs`'s own in-process `#[cfg(test)]` unit
-/// tests on pure targets, e.g.
-/// `test_computed_index_ordinary_cross_product_unaffected_1634`.
+/// `-n`/`-R`/`--slurp`). That path can't extend regression coverage to
+/// *this* stateful-target mechanism specifically, though: `input`/`inputs`
+/// are rejected at parse time in yq mode (`parser.rs`'s
+/// `reject_in_yq_mode("input")`, live-verified: `succinctly yq -n
+/// '[(input)[("a","b")]]'` -> "input is not supported in yq mode"), so the
+/// yq-mode path only proves `eval::eval_index_expr` is CLI-reachable on
+/// *pure* targets -- the same category `eval.rs`'s own in-process
+/// `#[cfg(test)]` unit tests already cover (e.g.
+/// `test_computed_index_ordinary_cross_product_unaffected_1634`), not a
+/// second, independent source of coverage for the stateful re-evaluation
+/// bug this test itself pins. That bug's only coverage remains this test
+/// (via `eval_generic::eval_index_expr`, live over `succinctly jq`) plus
+/// `eval.rs`'s own in-process unit tests -- unchanged from before this
+/// comment was corrected.
 /// Verified against jq 1.7.1: both emit `[1,4]` (key `"a"` re-reads `input`
 /// to get `{"a":1,"b":2}` -> `.a` = 1; key `"b"` re-reads `input` again to
 /// get `{"a":3,"b":4}` -> `.b` = 4).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31313,14 +31313,17 @@ fn test_index_expr_one_empty_key_does_not_short_circuit_others_2032() -> Result<
 /// cases above, this time via `input` (a stateful generator that consumes
 /// from the CLI's document stream) rather than a side-channel write --
 /// `.[$keys]`'s target must be *re-read* from the stream once per key, not
-/// read once and reused. `run_jq_full` execs the real CLI subprocess, which
-/// always dispatches through `eval_generic::eval_index_expr`
-/// (`eval::eval_index_expr` has no CLI-reachable path at all -- it's a
-/// separate, pure-in-process library entry point with no `input`/`inputs`
-/// builtin and no observable side-effect mechanism in its own unit tests,
-/// so its sibling fix is covered there only by reachability/regression
+/// read once and reused. `run_jq_full` execs the real CLI subprocess in
+/// `succinctly jq` mode, which always dispatches through
+/// `eval_generic::eval_index_expr` -- `jq_runner.rs` never calls
+/// `eval::eval_index_expr` at all. #2153: `eval::eval_index_expr` is *not*
+/// CLI-unreachable in general, though -- `succinctly yq` reaches it via
+/// `yq_runner.rs`'s `evaluate_input` (`jq::eval::<Vec<u64>,
+/// YqSemantics>(expr, cursor)`, at least 8 call sites, triggered by e.g.
+/// `-n`/`-R`/`--slurp`), so its sibling fix is covered there both by that
+/// live yq-mode path and by `eval.rs`'s own in-process `#[cfg(test)]` unit
 /// tests on pure targets, e.g.
-/// `test_computed_index_ordinary_cross_product_unaffected_1634`).
+/// `test_computed_index_ordinary_cross_product_unaffected_1634`.
 /// Verified against jq 1.7.1: both emit `[1,4]` (key `"a"` re-reads `input`
 /// to get `{"a":1,"b":2}` -> `.a` = 1; key `"b"` re-reads `input` again to
 /// get `{"a":3,"b":4}` -> `.b` = 4).


### PR DESCRIPTION
## Summary
- `test_index_expr_eval_rs_dispatch_target_reevaluated_per_key_2032`'s doc comment (added by #2142, fixing #2032) claimed `eval::eval_index_expr` "has no CLI-reachable path at all". True for `succinctly jq` (`jq_runner.rs` dispatches exclusively through `eval_generic.rs`), but false for `succinctly yq`: `yq_runner.rs`'s `evaluate_input` calls `jq::eval::<Vec<u64>, YqSemantics>(expr, cursor)` directly (at least 8 call sites, triggered by e.g. `-n`/`-R`/`--slurp`).
- The shipped #2032 fix itself is correct and unaffected — this is a comment-accuracy-only correction (Trivial severity per the issue).
- Live-verified the yq-mode reachability claim's boundary: `input`/`inputs` are not supported at all in yq mode (`succinctly yq -n --input-format json '[(input)[("a","b")]]'` → `parse error: input is not supported in yq mode`), so the issue's own suggested optional yq-mode regression test for this exact repro shape (target re-evaluated per key via a stateful generator) isn't straightforward to construct — `evaluate_input` doesn't have an equivalent stateful-stream-read primitive to reuse the jq-mode test's shape with. Left for a follow-up if someone wants to pursue a differently-shaped yq-mode repro; not adding it here to avoid scope creep on what the issue itself marks Trivial.

## Test plan
- [x] Comment-only change (no behavior/assertion modification) — existing test re-run and confirmed still passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean build)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde` (0 failed)
- [x] `cargo test --no-default-features --verbose` (no_std, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

Fixes #2153