### PR TITLE
fix(jq): report zero-arity builtins called with args as a name/arity error

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1397,18 +1397,25 @@ impl<'a> Parser<'a> {
 
             // Keywords: null, true, false, not, if, try, error, reduce, foreach, etc.
             Some(c) if c.is_alphabetic() => {
+                let keyword_start = self.pos;
                 if self.matches_keyword("null") {
                     self.consume_keyword("null");
-                    Ok(Expr::Literal(Literal::Null))
+                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Literal(Literal::Null))
                 } else if self.matches_keyword("true") {
                     self.consume_keyword("true");
-                    Ok(Expr::Literal(Literal::Bool(true)))
+                    self.zero_arity_or_wrong_arity_call(
+                        keyword_start,
+                        Expr::Literal(Literal::Bool(true)),
+                    )
                 } else if self.matches_keyword("false") {
                     self.consume_keyword("false");
-                    Ok(Expr::Literal(Literal::Bool(false)))
+                    self.zero_arity_or_wrong_arity_call(
+                        keyword_start,
+                        Expr::Literal(Literal::Bool(false)),
+                    )
                 } else if self.matches_keyword("not") {
                     self.consume_keyword("not");
-                    Ok(Expr::Not)
+                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Not)
                 } else if self.matches_keyword("if") {
                     self.parse_if_expr()
                 } else if self.matches_keyword("try") {
@@ -1443,8 +1450,14 @@ impl<'a> Parser<'a> {
                 } else if self.matches_keyword("break") {
                     self.parse_break_expr()
                 } else if let Some(builtin) = self.try_parse_builtin()? {
-                    // Allow postfix operations after builtins (e.g., env.PATH, keys[0])
-                    self.parse_postfix(Expr::Builtin(builtin))
+                    // #2110: a following `(` means this was actually a
+                    // wrong-arity call, not a bare builtin reference --
+                    // `zero_arity_or_wrong_arity_call` rewinds and re-parses
+                    // it as one instead of falling into `parse_postfix`,
+                    // which would just reject the `(` as a stray token.
+                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Builtin(builtin))
+                        // Allow postfix operations after builtins (e.g., env.PATH, keys[0])
+                        .and_then(|expr| self.parse_postfix(expr))
                 } else {
                     // Phase 9: Try to parse as function call
                     self.parse_func_call_or_error()
@@ -2261,6 +2274,41 @@ impl<'a> Parser<'a> {
         };
 
         Ok(Expr::Format(format_type))
+    }
+
+    /// A zero-arity keyword (`null`/`true`/`false`/`not`, or anything
+    /// [`try_parse_builtin`] recognizes) immediately followed by `(` is a
+    /// wrong-arity call, not a stray token -- real jq resolves it at compile
+    /// time via name/arity resolution ("`length/1 is not defined`", the same
+    /// class #1473/#2037 already give a genuinely-undefined name), not as a
+    /// raw parser rejection of the `(` (#2110). Whitespace before `(` is
+    /// allowed too, matching real jq (`length (1)` errors identically to
+    /// `length(1)`).
+    ///
+    /// `start_pos` must be the position *before* the keyword was consumed:
+    /// on a hit, this rewinds there and re-parses the same text through
+    /// [`Self::parse_func_call_or_error`], which treats it as an ordinary
+    /// (name, args) call for the resolver to reject by arity -- exactly as
+    /// if the keyword recognizer had never matched at all. `if`-style syntax
+    /// keywords are not `Expr::FuncCall`-shaped in real jq either (`if(1)`
+    /// is a genuine syntax error there, not `if/1 is not defined`), so only
+    /// call this from a site that already recognized a true zero-arity
+    /// *builtin* or literal (`null`/`true`/`false`/`not`, or anything
+    /// [`try_parse_builtin`] recognizes) -- never from `if`/`try`/`reduce`/
+    /// `def`/etc.
+    ///
+    /// [`try_parse_builtin`]: Self::try_parse_builtin
+    fn zero_arity_or_wrong_arity_call(
+        &mut self,
+        start_pos: usize,
+        parsed: Expr,
+    ) -> Result<Expr, ParseError> {
+        self.skip_ws();
+        if self.peek() == Some('(') {
+            self.pos = start_pos;
+            return self.parse_func_call_or_error();
+        }
+        Ok(parsed)
     }
 
     /// Try to parse a builtin function.

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1450,14 +1450,14 @@ impl<'a> Parser<'a> {
                 } else if self.matches_keyword("break") {
                     self.parse_break_expr()
                 } else if let Some(builtin) = self.try_parse_builtin()? {
-                    // #2110: a following `(` means this was actually a
-                    // wrong-arity call, not a bare builtin reference --
+                    // #2110: a following `(<args>)` means this was actually
+                    // a wrong-arity call, not a bare builtin reference --
                     // `zero_arity_or_wrong_arity_call` rewinds and re-parses
-                    // it as one instead of falling into `parse_postfix`,
-                    // which would just reject the `(` as a stray token.
+                    // it as one instead of falling into postfix parsing,
+                    // which would just reject the `(` as a stray token; it
+                    // also applies postfix itself (e.g. `env.PATH`,
+                    // `keys[0]`) on whichever `Expr` it ends up returning.
                     self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Builtin(builtin))
-                        // Allow postfix operations after builtins (e.g., env.PATH, keys[0])
-                        .and_then(|expr| self.parse_postfix(expr))
                 } else {
                     // Phase 9: Try to parse as function call
                     self.parse_func_call_or_error()
@@ -2277,13 +2277,39 @@ impl<'a> Parser<'a> {
     }
 
     /// A zero-arity keyword (`null`/`true`/`false`/`not`, or anything
-    /// [`try_parse_builtin`] recognizes) immediately followed by `(` is a
-    /// wrong-arity call, not a stray token -- real jq resolves it at compile
-    /// time via name/arity resolution ("`length/1 is not defined`", the same
-    /// class #1473/#2037 already give a genuinely-undefined name), not as a
-    /// raw parser rejection of the `(` (#2110). Whitespace before `(` is
-    /// allowed too, matching real jq (`length (1)` errors identically to
-    /// `length(1)`).
+    /// [`try_parse_builtin`] recognizes) immediately followed by `(<args>)`
+    /// (at least one argument), **in jq mode**, is a wrong-arity call, not a
+    /// stray token -- real jq resolves it at compile time via name/arity
+    /// resolution ("`length/1 is not defined`", the same class #1473/#2037
+    /// already give a genuinely-undefined name), not as a raw parser
+    /// rejection of the `(` (#2110). Whitespace before `(` is allowed too,
+    /// matching real jq (`length (1)` errors identically to `length(1)`).
+    ///
+    /// yq mode never rewinds, regardless of argument count: real yq (v4.53.3)
+    /// has no name/arity resolution vocabulary at all -- confirmed live,
+    /// `null(1)` and `length(1)` both give the identical generic "bad
+    /// expression, please check expression syntax" -- so jq's "X/N is not
+    /// defined" wording would be a *new*, jq-flavored divergence in yq mode,
+    /// not a fix. yq mode keeps the pre-#2110 generic parse-error rejection
+    /// unchanged.
+    ///
+    /// An *empty* `()` is deliberately excluded from the rewind: real jq's
+    /// grammar has no zero-argument parenthesized call shape at all, for
+    /// any name -- confirmed live, `def f: 1; f()` is a syntax error
+    /// ("unexpected ')'") in real jq exactly like `length()`/
+    /// `undefinedname()` are, not a name/arity resolution error. Rewinding
+    /// `length()` the same way as `length(1)` would ask
+    /// [`Self::parse_func_call_or_error`] to answer a question it isn't --
+    /// that function's own empty-arg-list leniency (`FuncCall { args: [] }`)
+    /// exists for the ordinary "just call `foo`" case, not this one, and for
+    /// any name [`resolve.rs`]'s builtin roster tracks at arity 0 for an
+    /// unrelated reason (a real jq builtin succinctly doesn't implement,
+    /// e.g. `cbrt`) it would let compile-time resolution wrongly accept the
+    /// call, deferring the failure to a confusing runtime "undefined
+    /// function" error instead. Leaving `()` alone here restores exactly
+    /// the pre-#2110 behavior (a raw parser rejection of the stray `(`) --
+    /// not a match for jq's own wording, but not a new divergence either,
+    /// and never worse than what `main` already did.
     ///
     /// `start_pos` must be the position *before* the keyword was consumed:
     /// on a hit, this rewinds there and re-parses the same text through
@@ -2297,18 +2323,48 @@ impl<'a> Parser<'a> {
     /// [`try_parse_builtin`] recognizes) -- never from `if`/`try`/`reduce`/
     /// `def`/etc.
     ///
+    /// Postfix (`.field`, `[idx]`) is applied uniformly to whichever `Expr`
+    /// this returns, matching the sibling call site inside
+    /// [`Self::parse_primary_inner`] that already needed it for a bare
+    /// builtin (`env.PATH`) -- earlier revisions of this fix only wrapped
+    /// that one site, which left a wrong-arity `null`/`true`/`false`/`not`
+    /// call followed by postfix syntax (`null(1).foo`) with the *same* raw
+    /// parser rejection this whole function exists to replace, and, worse,
+    /// broke postfix chaining after a legitimately name/arity-*resolved*
+    /// call too (`def null(x): {foo:x}; null(1).foo` must parse -- real jq
+    /// accepts it and returns `1` -- not just fail cleanly).
+    ///
     /// [`try_parse_builtin`]: Self::try_parse_builtin
+    /// [`resolve.rs`]: super::resolve
     fn zero_arity_or_wrong_arity_call(
         &mut self,
         start_pos: usize,
         parsed: Expr,
     ) -> Result<Expr, ParseError> {
+        let after_keyword = self.pos;
         self.skip_ws();
         if self.peek() == Some('(') {
-            self.pos = start_pos;
-            return self.parse_func_call_or_error();
+            let paren_pos = self.pos;
+            self.next();
+            self.skip_ws();
+            let has_arg = self.peek() != Some(')');
+            self.pos = paren_pos;
+            // yq mode: real yq has no name/arity resolution vocabulary at
+            // all -- confirmed live (yq v4.53.3), `null(1)` and `length(1)`
+            // both give the identical generic "bad expression, please
+            // check expression syntax" regardless of name or arity. Real
+            // jq's own "X/N is not defined" wording this rewind produces
+            // would be a *new*, jq-flavored divergence in yq mode, not a
+            // fix -- so only jq mode rewinds; yq mode falls through to the
+            // pre-#2110 generic parse-error rejection below, unchanged.
+            if has_arg && self.mode == ParserMode::Jq {
+                self.pos = start_pos;
+                let call = self.parse_func_call_or_error()?;
+                return self.parse_postfix(call);
+            }
         }
-        Ok(parsed)
+        self.pos = after_keyword;
+        self.parse_postfix(parsed)
     }
 
     /// Try to parse a builtin function.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18397,6 +18397,59 @@ fn test_func_call_arity_mismatch_reports_clean_error_1016() -> Result<()> {
     Ok(())
 }
 
+/// A zero-arity builtin/literal keyword (`length`, `not`, `null`, `true`,
+/// `false`, ...) immediately followed by `(` is a wrong-arity call, not a
+/// stray token -- real jq resolves it the same way #1473/#2037 already
+/// resolve a genuinely-undefined name: a compile-time "X/1 is not defined"
+/// error (exit 3), not a raw parser rejection of the `(`. Before this fix,
+/// succinctly's zero-arity keyword recognizers returned their node the
+/// instant they matched, so the parser choked on the following `(` as an
+/// unexpected character instead. Verified against the pinned oracle
+/// (`/usr/bin/jq`, jq-1.7.1); whitespace before `(` is accepted too,
+/// matching real jq (#2110).
+#[test]
+fn test_zero_arity_builtin_called_with_args_reports_not_defined_2110() -> Result<()> {
+    for (filter, name) in [
+        ("length(1)", "length/1"),
+        ("length (1)", "length/1"),
+        ("not(1)", "not/1"),
+        ("null(1)", "null/1"),
+        ("true(1)", "true/1"),
+        ("false(1)", "false/1"),
+        ("modulemeta(\"x\")", "modulemeta/1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert!(
+            stderr.contains("jq: 1 compile error"),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// `if(1)`-shaped input must stay a genuine *syntax* error (jq's own `if`
+/// grammar, not a resolvable name) -- confirmed live against the pinned
+/// oracle that real jq gives a syntax error here too (different wording,
+/// "unexpected end of file", since `(1)` is consumed as `if`'s own
+/// condition and then no `then` follows), never "if/1 is not defined". Only
+/// a genuine zero-arity *builtin* routes through
+/// `zero_arity_or_wrong_arity_call` (#2110); `if`/`try`/`reduce`/etc. never
+/// do, and this pins that they still don't.
+#[test]
+fn test_if_called_with_args_stays_a_syntax_error_not_arity_error_2110() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "if(1)"], None)?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(!stderr.contains("is not defined"), "stderr: {stderr:?}");
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18450,6 +18450,73 @@ fn test_if_called_with_args_stays_a_syntax_error_not_arity_error_2110() -> Resul
     Ok(())
 }
 
+/// Round-2 review finding: `null`/`true`/`false`/`not`'s own call sites
+/// initially didn't apply postfix parsing to `zero_arity_or_wrong_arity_call`'s
+/// result the way the sibling builtin call site did, so a wrong-arity call
+/// to one of these four followed by `.field`/`[idx]` regressed to the same
+/// raw "unexpected character" parse error #2110 exists to replace. Verified
+/// against the pinned oracle (`/usr/bin/jq`, jq-1.7.1).
+#[test]
+fn test_zero_arity_wrong_arity_call_still_reports_not_defined_with_postfix_2110() -> Result<()> {
+    for (filter, name) in [
+        ("null(1).foo", "null/1"),
+        ("not(1)[0]", "not/1"),
+        ("true(1).foo", "true/1"),
+        ("false(1)[0]", "false/1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// The same missing-postfix gap the test above pins was not just a wrong
+/// error message but a genuine correctness regression: once `null` is
+/// legitimately redefined at arity 1, `null(1).foo` is a valid call, not a
+/// wrong-arity one -- real jq accepts it and returns the field. Before
+/// `zero_arity_or_wrong_arity_call` applied postfix uniformly, succinctly
+/// failed to parse this at all. Verified against the pinned oracle.
+#[test]
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_shadowed_zero_arity_keyword_with_postfix_still_parses_2110() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def null(x): {foo:x}; null(1).foo"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// Round-2 review finding: an explicit, *empty* `()` on a zero-arity
+/// builtin real jq itself already implements (`length`, `not`, `keys`,
+/// ...) must not rewind into a `FuncCall` -- `resolve.rs`'s builtin roster
+/// lists these names at arity 0 for the unrelated `#1473` "builtins jq has
+/// that succinctly doesn't implement" purpose, so a rewound `length()`
+/// would pass compile-time resolution and only fail later with a confusing
+/// runtime "undefined function" error (exit 5) instead of staying the
+/// exit-3 compile-time rejection every other malformed-arity shape in this
+/// file gets. Real jq's own grammar has no zero-argument parenthesized
+/// call shape at all (`def f: 1; f()` is *also* a syntax error there, not
+/// `f/0 is not defined` -- verified live), so this specific shape is left
+/// exactly as the pre-#2110 parser already treated it: a raw parse
+/// rejection, not a name/arity resolution error.
+#[test]
+fn test_zero_arity_builtin_empty_parens_stays_compile_error_2110() -> Result<()> {
+    for filter in ["length()", "not()", "keys()", "null()"] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            !stderr.contains("undefined function"),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1412,6 +1412,31 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
     Ok(())
 }
 
+/// #2110's jq-mode fix (a zero-arity builtin/literal called with the wrong
+/// arity reports jq's own "X/N is not defined" instead of a raw parser
+/// rejection) must not leak into yq mode: real yq (v4.53.3) has no
+/// name/arity resolution vocabulary at all -- `null(1)` and `length(1)`
+/// both give the identical generic "bad expression, please check
+/// expression syntax" there, verified live. `zero_arity_or_wrong_arity_call`
+/// (`src/jq/parser.rs`) only rewinds in jq mode for exactly this reason, so
+/// yq mode keeps its own pre-#2110 generic parse-error rejection unchanged
+/// -- pinned here against succinctly's own wording (a pre-existing,
+/// separate divergence from real yq's wording, out of scope for #2110).
+#[test]
+fn test_yq_mode_zero_arity_wrong_arity_call_unaffected_by_2110() -> Result<()> {
+    for (filter, position) in [("null(1)", 4), ("length(1)", 6), ("not(1)", 3)] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert!(
+            stderr.contains(&format!(
+                "parse error: parse error at position {position}: unexpected character '('"
+            )),
+            "filter {filter:?} stderr: {stderr}"
+        );
+        assert_eq!(code, 1, "filter {filter:?} stderr: {stderr}");
+    }
+    Ok(())
+}
+
 /// #1512/#1650/#1714: the CLI flag actually reaches the parser --
 /// `--jq-extensions` makes the same filters succeed end to end through the
 /// real `succinctly yq` binary, not just through the parser's own unit


### PR DESCRIPTION
## Summary

Real jq resolves `length(1)`, `not(1)`, `null(1)` etc. (a zero-arity builtin/literal
called with the wrong arity) as a compile-time name/arity resolution error
(`length/1 is not defined`, exit 3) — the same class #1473/#2037 already give a
genuinely-undefined name. succinctly's zero-arity keyword recognizers instead returned
their AST node the instant they matched, so a following `(` reached the surrounding
grammar as a raw parser rejection.

```console
$ /usr/bin/jq -n 'length(1)'
jq: error: length/1 is not defined at <top-level>, line 1:
length(1)
jq: 1 compile error

$ succinctly jq -n 'length(1)'          # before this PR
jq: compile error: parse error at position 6: unexpected character '('

$ succinctly jq -n 'length(1)'          # after this PR
jq: error: length/1 is not defined at <top-level>, line 1:
length(1)
jq: 1 compile error
```

## Fix

Rather than touching all ~126 individual `matches_keyword`/`consume_keyword` branches
in `try_parse_builtin`, this adds one helper (`zero_arity_or_wrong_arity_call`) called
from the small number of actual call sites (`null`/`true`/`false`/`not`, and
`try_parse_builtin`'s single call site): peek past optional whitespace for a following
`(`, and if present, rewind to before the keyword was consumed and re-parse through
`parse_func_call_or_error` — the same path a genuinely-undefined name already takes, so
the existing #1473 resolver machinery reports the "X/N is not defined" error without any
new logic there.

`if`/`try`/`reduce`/etc. are unaffected — they're syntax keywords, not
`Expr::FuncCall`-shaped in real jq either (`if(1)` is a genuine syntax error there too,
verified live: "unexpected end of file", not "if/1 is not defined") — so they don't
route through the new helper.

## Verification

Live-verified against the pinned oracle (`/usr/bin/jq` 1.7.1) for `length`, `not`,
`null`, `true`, `false`, `modulemeta`, plus whitespace-before-paren (`length (1)`), and
that `if(1)` correctly stays a syntax error. Confirmed ordinary usage (no parens),
postfix chaining after a bare builtin (`keys[0]`), and builtin-shadowing (`def length:
99; length`, a separate already-tracked #2036 gap) are all unaffected.

Fixes #2110

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, all 57 test binaries pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the two other CI feature-set legs)
- [x] `cargo fmt --check`
- [x] Live-verified against `/usr/bin/jq` (pinned 1.7.1)
