### PR TITLE
fix(jq): recognise stderr/debug as identity passthroughs in path context

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22183,21 +22183,39 @@ fn resolve_node<'a, S: EvalSemantics>(
         // and raised jq's own `#530` "Invalid path expression" unconditionally
         // -- even on a bare `path(. | stderr)`, which real jq answers `[]`
         // (confirmed live against jq 1.7.1). Perform each builtin's own side
-        // effect here, matching its value-mode counterpart exactly, then
-        // delegate the actual path-tracking to bare `Expr::Identity` -- this
-        // inherits every one of Identity's existing rules (the untracked
-        // bare-`.` passthrough, the four-primitives `is_primitive` branch)
-        // instead of re-deriving them for a fifth and sixth call site.
+        // effect here (via the shared `write_stderr_value`/`write_debug_line`
+        // helpers their value-mode counterparts also call, so the formatting
+        // rule can't drift between the two), then hand back the same
+        // zero-copy passthrough branch `Select`/the type-filter family above
+        // already use for "navigates nothing, inherits whatever trackability
+        // was already ambient" -- review: an earlier draft delegated to
+        // `resolve_leaf(&Expr::Identity, ...)` instead, which for a
+        // *trackable* branch routes through that function's `is_primitive`
+        // arm and deep-clones `value` via `eval_each_owned`'s own
+        // `Expr::Identity` fast path (`input.clone()`) -- real allocation
+        // this call has no use for, since there is nothing left to decode
+        // that `value` doesn't already hold. Both constructions are provably
+        // equivalent for the `!trackable` case too: `resolve_leaf`'s own
+        // early bare-`.` exemption builds this identical
+        // `PathBranch::passthrough(root, Cow::Borrowed(value), false,
+        // snapshot)` shape.
         Expr::Builtin(Builtin::Stderr) => {
-            match value {
-                OwnedValue::String(s) => write_stderr(s),
-                other => write_stderr(&owned_value_to_json::<S>(other)),
-            }
-            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+            write_stderr_value::<S>(value);
+            Ok(vec![PathBranch::passthrough(
+                PathPrefix::root(),
+                Cow::Borrowed(value),
+                trackable,
+                snapshot,
+            )])
         }
         Expr::Builtin(Builtin::Debug) => {
             write_debug_line::<S>(value);
-            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+            Ok(vec![PathBranch::passthrough(
+                PathPrefix::root(),
+                Cow::Borrowed(value),
+                trackable,
+                snapshot,
+            )])
         }
         // `debug(msg)`'s own definition is `(msg|debug|empty), .` -- `msg`'s
         // generator runs for its side effects only, in true per-item order
@@ -22219,7 +22237,12 @@ fn resolve_node<'a, S: EvalSemantics>(
             if let Flow::Escaped(control) = flow {
                 return Err((Vec::new(), EvalEscape::from(control)));
             }
-            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+            Ok(vec![PathBranch::passthrough(
+                PathPrefix::root(),
+                Cow::Borrowed(value),
+                trackable,
+                snapshot,
+            )])
         }
 
         other => resolve_leaf::<S>(other, value, trackable, snapshot, keep),
@@ -40192,11 +40215,23 @@ fn builtin_stderr<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(v) => v,
         Err(e) => return QueryResult::Error(e),
     };
-    match &owned {
+    write_stderr_value::<S>(&owned);
+    QueryResult::Owned(owned)
+}
+
+/// The write half of [`builtin_stderr`] -- raw content for a string, compact
+/// JSON otherwise -- factored out so `resolve_node`'s own `Builtin::Stderr`
+/// arm (#2234, path context) can perform the identical side effect without
+/// hand-copying the match (review: an earlier draft of that arm did exactly
+/// that, the kind of duplicated formatting rule CLAUDE.md's own optimization
+/// notes warn drifts silently -- `Builtin::Debug`'s sibling arm already
+/// reuses [`write_debug_line`] this same way, so this brings `Stderr` to the
+/// same standard rather than being the one call site left copying it by hand).
+fn write_stderr_value<S: EvalSemantics>(value: &OwnedValue) {
+    match value {
         OwnedValue::String(s) => write_stderr(s),
         other => write_stderr(&owned_value_to_json::<S>(other)),
     }
-    QueryResult::Owned(owned)
 }
 
 /// Builtin: halt_error / halt_error(exit_code) - print input to stderr and

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22174,6 +22174,54 @@ fn resolve_node<'a, S: EvalSemantics>(
             resolve_leaf::<S>(expr, value, trackable, snapshot, keep)
         }
 
+        // #2234: `stderr`/`debug`/`debug(msg)` are true identity passthroughs
+        // in jq -- their value-mode implementations (`builtin_stderr`/
+        // `builtin_debug`/`builtin_debug_msg` below) all decode-then-return
+        // `value` completely unchanged, side effect aside. Before this arm,
+        // none of the three were recognised here, so they fell through to
+        // `resolve_leaf`'s generic "not one of the four primitives" rejection
+        // and raised jq's own `#530` "Invalid path expression" unconditionally
+        // -- even on a bare `path(. | stderr)`, which real jq answers `[]`
+        // (confirmed live against jq 1.7.1). Perform each builtin's own side
+        // effect here, matching its value-mode counterpart exactly, then
+        // delegate the actual path-tracking to bare `Expr::Identity` -- this
+        // inherits every one of Identity's existing rules (the untracked
+        // bare-`.` passthrough, the four-primitives `is_primitive` branch)
+        // instead of re-deriving them for a fifth and sixth call site.
+        Expr::Builtin(Builtin::Stderr) => {
+            match value {
+                OwnedValue::String(s) => write_stderr(s),
+                other => write_stderr(&owned_value_to_json::<S>(other)),
+            }
+            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+        }
+        Expr::Builtin(Builtin::Debug) => {
+            write_debug_line::<S>(value);
+            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+        }
+        // `debug(msg)`'s own definition is `(msg|debug|empty), .` -- `msg`'s
+        // generator runs for its side effects only, in true per-item order
+        // (mirrors `builtin_debug_msg`'s own doc comment on why an eager
+        // collect would get ordering and partial-output-before-escape both
+        // wrong); the trailing `.` is only reached once `msg` is fully
+        // exhausted without escaping, which is exactly what an `Ok` `Flow`
+        // means here. An escape from `msg` propagates with an empty prefix --
+        // `debug(msg)` itself never produces a real value in that case, so
+        // there is nothing about `expr`'s own passthrough to have resolved
+        // yet (mirrors the identical "nothing built yet, so no prefix to
+        // keep" reasoning `resolve_index_expr`'s own key/target evaluation
+        // escapes already document).
+        Expr::Builtin(Builtin::DebugMsg(msg)) => {
+            let flow = eval_each_owned::<S>(msg, value, false, &mut |msg_value| {
+                write_debug_line::<S>(&msg_value);
+                Demand::Continue
+            });
+            if let Flow::Escaped(control) = flow {
+                return Err((Vec::new(), EvalEscape::from(control)));
+            }
+            resolve_leaf::<S>(&Expr::Identity, value, trackable, snapshot, keep)
+        }
+
         other => resolve_leaf::<S>(other, value, trackable, snapshot, keep),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -17020,8 +17020,11 @@ fn test_resolve_node_alternative_falsy_left_no_catch_needed_845() -> Result<()> 
 /// The shipped fix only special-cases a bare literal (whose value needs no
 /// evaluation at all), so a non-literal falsy-*valued* left like `stderr`
 /// still takes the original, single-evaluation code path -- this pins
-/// "exactly one write", not jq-matching output (that query still diverges
-/// from jq for an unrelated, pre-existing reason, tracked as #986).
+/// "exactly one write". Used to also pin a real jq-mismatch here (`stderr`
+/// wasn't path-trackable at all, an unrelated pre-existing gap tracked as
+/// #986) -- #2234 fixed that: `path(stderr // .b)` now matches jq byte for
+/// byte (`{"a":10}[]`, exit 0), so this test's own write-count check is the
+/// only thing left worth pinning.
 #[test]
 fn test_resolve_node_alternative_does_not_double_evaluate_non_literal_left_845() -> Result<()> {
     let (_stdout, stderr, _code) = run_jq_full(&["-c", "path(stderr // .b)"], Some(r#"{"a":10}"#))?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -31400,16 +31400,50 @@ fn fold_source_side_effect_fires_once_per_output_1872() -> Result<()> {
             "123",
             "one write per output, in order",
         ),
-        (
-            "[1,2,3]",
-            ". as $x | path(foreach (.[] | stderr) as $i (0; $x))",
-            "123",
-            "foreach pulls the same single evaluation",
-        ),
     ] {
         let (_stdout, stderr, _code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(stderr, want, "{why}");
     }
+    Ok(())
+}
+
+/// #1872 sibling, `foreach` rather than `reduce`: real jq's own disposition
+/// for this exact shape genuinely differs between the two -- `reduce` (above)
+/// answers `[]` (its UPDATE, `$x`, stays trackable), but `foreach` raises
+/// `Invalid path expression` on its *first* step instead (jq 1.7.1: `. as $x
+/// | path(foreach (.[] | stderr) as $i (0; $x))` on `[1,2,3]` writes `1` to
+/// stderr, once, then raises -- #2031's "source navigation clobbers the
+/// shared path register" rule makes `$x` untrackable inside a `foreach` step
+/// where it stays trackable inside `reduce`'s single terminal step).
+///
+/// succinctly matches that disposition (raises, no stdout) since #2234 fixed
+/// `stderr`'s own path-trackability -- before that fix, this raised nowhere
+/// at all and instead answered wrongly with `[]` three times, exit 0.
+///
+/// The one remaining divergence from jq is `stderr`'s own write *count*:
+/// `resolve_fold_source`'s `Keep::AtMost(usize::MAX)` (#1467) pulls the whole
+/// navigating source upfront, so all three writes happen before the fold
+/// loop ever inspects the first step's own UPDATE result -- jq's true
+/// demand-driven generator stops pulling the source the moment that first
+/// step fails to track, writing only once. Tracked separately (not #2234's
+/// own scope, which is specifically about stderr/debug's trackability, not
+/// fold-source pull laziness) -- filed as a follow-up.
+#[test]
+fn fold_source_foreach_diverges_from_reduce_on_this_shape_1872() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", ". as $x | path(foreach (.[] | stderr) as $i (0; $x))"],
+        Some("[1,2,3]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.starts_with("123"),
+        "known divergence from jq's own single write -- see this test's doc comment; stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Invalid path expression with result"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 
@@ -32522,5 +32556,72 @@ fn test_range_cap_hit_lookahead_overflow_keeps_exact_i64_answer_2131() -> Result
     let (stdout, code) = run_jq_null("nth(250; range(0;9223372036854775807;92234642714974))", &[])?;
     assert_eq!(code, 0, "stdout: {stdout:?}");
     assert_eq!(stdout.trim(), (250i64 * 92234642714974).to_string());
+    Ok(())
+}
+
+/// #2234: `stderr`/`debug`/`debug(msg)` are true identity passthroughs in
+/// jq -- `path()` should treat `EXPR | stderr` (etc.) exactly like `EXPR`
+/// itself. Before this fix, all three fell through to `resolve_leaf`'s
+/// generic "not one of the four primitives" rejection and raised jq's own
+/// `Invalid path expression`, even on a bare `path(. | stderr)` where real
+/// jq answers `[]`. Verified against jq 1.7.1.
+#[test]
+fn test_path_stderr_debug_are_identity_passthroughs_2234() -> Result<()> {
+    for (filter, want_stdout, why) in [
+        (
+            "path(. | stderr)",
+            "[]\n",
+            "bare stderr passthrough on the root",
+        ),
+        (
+            "path(. | debug)",
+            "[]\n",
+            "bare debug passthrough on the root",
+        ),
+        (
+            r#"path(. | debug("msg"))"#,
+            "[]\n",
+            "debug(msg) passthrough on the root",
+        ),
+        (
+            "path(.a | stderr)",
+            "[\"a\"]\n",
+            "stderr passthrough after real navigation",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_eq!(code, 0, "{why} -- stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, want_stdout, "{why}");
+    }
+    Ok(())
+}
+
+/// #2234 sibling: `debug(msg)`'s own definition is `(msg|debug|empty), .`
+/// -- when `msg` itself errors, the whole `debug(msg)` expression never
+/// reaches its trailing `.`, so `path()` sees no branch at all (an empty
+/// prefix, matching every other bare-escape site in this file). Verified
+/// against jq 1.7.1: both raise the same error, no path output.
+#[test]
+fn test_path_debug_msg_propagates_msg_escape_2234() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(. | debug(error("boom")))"#], Some("[1,2]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2234 sibling: the fix has to work through the write side too
+/// (`resolve_node` backs `path()`/`=`/`|=`/`del()` alike), not just
+/// `path()` itself -- `stderr` inside an update-assignment target used to
+/// raise the same spurious "Invalid path expression" this issue fixes.
+/// Verified against jq 1.7.1.
+#[test]
+fn test_stderr_in_update_assignment_target_2234() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(.a | stderr) |= . + 1"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"a\":2}\n");
+    assert_eq!(stderr, "1");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28052,3 +28052,23 @@ fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
 
     Ok(())
 }
+
+/// #2234: `resolve_node`'s new `Builtin::Stderr` arm is generic over
+/// `S: EvalSemantics` and shared verbatim by jq and yq -- this pins that the
+/// fix reaches yq mode too, not just jq's own CLI dispatch. `stderr` isn't
+/// actually a real yq builtin (`stderr`/`stderr` alone both lex-reject
+/// against real yq v4.53.3: `Error: 1:1: lexer: invalid input text
+/// "stderr"`), so this is confirming succinctly's own dual-mode consistency
+/// -- there is no real yq oracle output to match here, unlike the project's
+/// usual convention. `stderr` parses unconditionally in succinctly's own yq
+/// mode (unlike `debug`, which needs `--jq-extensions`) -- a pre-existing
+/// parser-gating gap, not introduced or addressed by this fix.
+#[test]
+fn test_stderr_path_passthrough_reaches_yq_mode_2234() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("(.a | stderr) |= . + 1", "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(stderr, "1");
+    assert_eq!(out.trim(), "{\n  \"a\": 2\n}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `stderr`/`debug`/`debug(msg)` are true identity passthroughs in jq — they return their input unchanged, purely as a diagnostic side channel. `resolve_node` (the shared dispatch backing `path()`/`=`/`|=`/`del()`) had no case for any of the three, so they fell through to `resolve_leaf`'s generic "not one of the four primitives" rejection and raised jq's own `#530` "Invalid path expression" — even for a bare `path(. | stderr)`, where real jq answers `[]`. Any real-world use of `stderr`/`debug` inside a path-tracked expression (`.foo |= (debug | . + 1)`, a common debugging idiom) was broken.
- Fix: perform each builtin's own side effect (via the shared `write_stderr_value`/`write_debug_line` helpers their value-mode counterparts also call), then hand back the same zero-copy `PathBranch::passthrough` construction `Select`/the type-filter family already use for the "navigates nothing, inherits ambient trackability" shape.
- Fixing this exposed that `resolve_fold_source` (the `foreach`/`reduce` source resolver) also routes a navigating source through `resolve_node` — `stderr`'s newly-correct trackability changes a `foreach`-with-`stderr`-source's *disposition* to correctly match jq's own raise, where it previously (incorrectly) succeeded silently with wrong output. Updated the one existing test this affects, and filed #2235 for the one remaining divergence (write *count*, not disposition) that surfaced once the spurious error stopped masking it — confirmed that gap also affects `debug`/`debug(msg)`, not just `stderr`.

## Code review (6-agent multi-pass)

Confirmed correct, no functional bugs. Two real improvements applied in a follow-up commit:
- Replaced a delegate-to-`resolve_leaf(&Expr::Identity, ...)` design (which deep-clones `value` for every trackable branch) with the same zero-copy `PathBranch::passthrough` construction the sibling `Select`/type-filter arms already use.
- Factored `Stderr`'s formatting match (previously a verbatim copy of `builtin_stderr`'s own) into a shared `write_stderr_value` helper, matching how `Debug` already reuses `write_debug_line`.
- Added yq-mode regression coverage (confirmed `stderr` isn't gated behind `--jq-extensions` in succinctly's own yq parser, a pre-existing, unrelated gap — and confirmed live that `stderr` isn't a real yq builtin at all, so this test pins succinctly's own dual-mode consistency, not oracle parity).

Two apparent regressions review flagged were investigated and ruled out as pre-existing:
- A claim that `debug` now fires 3× instead of once behind `range()` bisects to already-filed #2178 (from #2050's own review) — reproduces identically on a `main` build from before this PR even branched.
- A stale doc comment in an unrelated pre-existing test claimed a `path(stderr // .b)` divergence (#986) that this fix actually closes — updated the comment to say so.

## Test plan

- [x] Live-verified against pinned oracle jq 1.7.1: `path(. | stderr)`, `path(. | debug)`, `path(. | debug("msg"))` all now answer `[]` matching jq exactly (previously raised).
- [x] Live-verified `path(.a | stderr)`, `debug(msg)` error propagation, write-path usage (`(.a | stderr) |= . + 1`, `del(.a | stderr)`), and the `!trackable` passthrough case — all match jq exactly.
- [x] Added 4 new tests: 3 in `tests/jq_cli_tests.rs` (identity-passthrough coverage, `debug(msg)` escape propagation, write-path usage), 1 in `tests/yq_cli_tests.rs` (dual-mode consistency).
- [x] Found and fixed a genuine regression during full-suite verification: `fold_source_side_effect_fires_once_per_output_1872`'s `foreach` case — this fix correctly changes that query's disposition to match jq (raise, not silently succeed); split into its own test documenting the new, closer-to-jq behavior.
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite): 3346 lib + 1296 jq_cli + 1368 yq_cli (+4 net), 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (avoids the `scalar-yaml` blind spot)
- [x] `cargo build --no-default-features` / `cargo test --no-default-features` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo fmt --check`

Fixes #2234