### PR TITLE
fix(jq): preserve a trailing-dot-before-exponent number literal's spelling

### DIFF
--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1532,8 +1532,9 @@ impl OwnedValue {
         // also ends up here) still fell all the way through to the lossy
         // `parse_i64_or_f64` below, losing the leading zero *and* any
         // exponent notation *and* any trailing zeros in one go (#1149).
-        if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes) {
-            if crate::json::validate::is_valid_number(&stripped) {
+        let zero_stripped = crate::json::validate::strip_redundant_leading_zeros(bytes);
+        if let Some(stripped) = &zero_stripped {
+            if crate::json::validate::is_valid_number(stripped) {
                 return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
             }
         }
@@ -1546,26 +1547,26 @@ impl OwnedValue {
         // there, not the double-precision-clamped
         // `1.7976931348623157e+308` a naive f64 parse produces (confirmed
         // live against jq 1.7.1, #2220). Same pattern as the leading-dot
-        // and leading-zero escapes above: check whether inserting `0`
-        // right after the trailing `.` makes the token strictly valid,
-        // and if so, still materialize the *original* text as the literal
-        // spelling -- `Self::from_number_literal` (via `parse_i64_or_f64`)
-        // parses a trailing-dot float natively, so no separate reparse of
-        // the original text is needed here. A bare trailing `.` with no
-        // exponent (`1.`) is deliberately left alone: real jq doesn't
-        // preserve that spelling either (`[1.]` -> `[1]` on both sides),
-        // so the existing lossy fallback below already matches jq there.
-        if let Some(dot_pos) = bytes
-            .windows(2)
-            .position(|w| w[0] == b'.' && (w[1] == b'e' || w[1] == b'E'))
-        {
-            let mut fixed = Vec::with_capacity(bytes.len() + 1);
-            fixed.extend_from_slice(&bytes[..=dot_pos]);
-            fixed.push(b'0');
-            fixed.extend_from_slice(&bytes[dot_pos + 1..]);
-            if crate::json::validate::is_valid_number(&fixed) {
-                return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
-            }
+        // and leading-zero escapes above: [`has_trailing_dot_before_exponent`]
+        // checks whether inserting `0` right after the trailing `.` makes
+        // the token strictly valid, and if so, still materialize the
+        // *original* text as the literal spelling -- `Self::from_number_literal`
+        // (via `parse_i64_or_f64`) parses a trailing-dot float natively, so
+        // no separate reparse of the original text is needed here. A bare
+        // trailing `.` with no exponent (`1.`) is deliberately left alone:
+        // real jq doesn't preserve that spelling either (`[1.]` -> `[1]`
+        // on both sides), so the existing lossy fallback below already
+        // matches jq there.
+        //
+        // Checked against the leading-zero-stripped form (when one
+        // exists), not always `bytes` itself, so the two escapes compose:
+        // a token can have both a redundant leading zero *and* a trailing
+        // dot before its exponent at once (`007.e999` -> jq's `7E+999`,
+        // confirmed live) -- neither escape alone fixes that, since each
+        // only resolves its own half.
+        let base = zero_stripped.as_deref().unwrap_or(bytes);
+        if crate::json::validate::has_trailing_dot_before_exponent(base) {
+            return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
         }
         let Ok(s) = core::str::from_utf8(bytes) else {
             return Self::Null;
@@ -2523,24 +2524,48 @@ mod tests {
     /// stored `NumberRepr` is `Float(INFINITY)` -- the literal text is what
     /// makes the eventual jq-compat display (`1E+999`, not the `f64::MAX`
     /// stand-in) correct, not this stored numeric value.
+    ///
+    /// Code review: `OwnedValue`'s `PartialEq` for `NumberLiteral` compares
+    /// only the parsed `NumberRepr`, not the stored `Box<str>` text (two
+    /// literals that both overflow to the same infinity compare equal
+    /// regardless of spelling) -- `assert_eq!` against a full
+    /// `NumberLiteral(...)` value would silently pass even if this escape
+    /// stored a mangled or wrong literal, defeating the point of this
+    /// test. Match and assert on the literal text explicitly instead.
     #[test]
     fn test_from_number_bytes_preserves_trailing_dot_before_exponent_spelling() {
-        assert_eq!(
-            OwnedValue::from_number_bytes(b"1.e5"),
-            OwnedValue::NumberLiteral(NumberRepr::Float(100000.0), "1.e5".into())
-        );
-        assert_eq!(
-            OwnedValue::from_number_bytes(b"-1.e5"),
-            OwnedValue::NumberLiteral(NumberRepr::Float(-100000.0), "-1.e5".into())
-        );
-        assert_eq!(
-            OwnedValue::from_number_bytes(b"1.e999"),
-            OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1.e999".into())
-        );
-        assert_eq!(
-            OwnedValue::from_number_bytes(b"-1.e999"),
-            OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1.e999".into())
-        );
+        for (bytes, expected_repr, expected_literal) in [
+            (&b"1.e5"[..], NumberRepr::Float(100000.0), "1.e5"),
+            (&b"-1.e5"[..], NumberRepr::Float(-100000.0), "-1.e5"),
+            (&b"1.e999"[..], NumberRepr::Float(f64::INFINITY), "1.e999"),
+            (
+                &b"-1.e999"[..],
+                NumberRepr::Float(f64::NEG_INFINITY),
+                "-1.e999",
+            ),
+            // Composes with the leading-zero escape above: a token can
+            // have both a redundant leading zero *and* a trailing dot
+            // before its exponent at once (`007.e999`) -- neither escape
+            // alone fixes it, since each only resolves its own half.
+            (
+                &b"007.e999"[..],
+                NumberRepr::Float(f64::INFINITY),
+                "007.e999",
+            ),
+            (
+                &b"-007.e999"[..],
+                NumberRepr::Float(f64::NEG_INFINITY),
+                "-007.e999",
+            ),
+        ] {
+            match OwnedValue::from_number_bytes(bytes) {
+                OwnedValue::NumberLiteral(repr, literal) => {
+                    assert_eq!(repr, expected_repr, "input {bytes:?}");
+                    assert_eq!(&*literal, expected_literal, "input {bytes:?}");
+                }
+                other => panic!("input {bytes:?}: expected NumberLiteral, got {other:?}"),
+            }
+        }
         // A trailing dot with *no* exponent (`1.`) is untouched by this
         // escape -- real jq doesn't preserve that spelling either (`[1.]`
         // -> `[1]`), so it still degrades to a plain `Float` via the

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1537,6 +1537,36 @@ impl OwnedValue {
                 return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
             }
         }
+        // Real jq's own number reader also tolerates a trailing `.`
+        // immediately before an exponent marker (`1.e999` -> `1.0e999`,
+        // `-1.e5` -> `-1.0e5`) -- not valid per strict RFC 8259 (`frac`
+        // requires at least one digit after `.`), but real jq accepts it
+        // and, crucially, still uses the *exact* decimal value to decide
+        // how to print an out-of-range exponent: `1.e999` -> `1E+999`
+        // there, not the double-precision-clamped
+        // `1.7976931348623157e+308` a naive f64 parse produces (confirmed
+        // live against jq 1.7.1, #2220). Same pattern as the leading-dot
+        // and leading-zero escapes above: check whether inserting `0`
+        // right after the trailing `.` makes the token strictly valid,
+        // and if so, still materialize the *original* text as the literal
+        // spelling -- `Self::from_number_literal` (via `parse_i64_or_f64`)
+        // parses a trailing-dot float natively, so no separate reparse of
+        // the original text is needed here. A bare trailing `.` with no
+        // exponent (`1.`) is deliberately left alone: real jq doesn't
+        // preserve that spelling either (`[1.]` -> `[1]` on both sides),
+        // so the existing lossy fallback below already matches jq there.
+        if let Some(dot_pos) = bytes
+            .windows(2)
+            .position(|w| w[0] == b'.' && (w[1] == b'e' || w[1] == b'E'))
+        {
+            let mut fixed = Vec::with_capacity(bytes.len() + 1);
+            fixed.extend_from_slice(&bytes[..=dot_pos]);
+            fixed.push(b'0');
+            fixed.extend_from_slice(&bytes[dot_pos + 1..]);
+            if crate::json::validate::is_valid_number(&fixed) {
+                return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
+            }
+        }
         let Ok(s) = core::str::from_utf8(bytes) else {
             return Self::Null;
         };
@@ -2483,6 +2513,42 @@ mod tests {
         // is set, but prefixing `0` doesn't make it strictly valid either.
         assert_eq!(OwnedValue::from_number_bytes(b"."), OwnedValue::Null);
         assert_eq!(OwnedValue::from_number_bytes(b"-."), OwnedValue::Null);
+    }
+
+    /// #2220: a trailing-dot mantissa immediately before an exponent marker
+    /// must preserve its own source spelling as a `NumberLiteral` too, the
+    /// same way the leading-dot case above does -- direct unit coverage of
+    /// `from_number_bytes`'s third escape, complementing the CLI-level
+    /// regression tests. `1.e999`'s magnitude overflows `f64`, so the
+    /// stored `NumberRepr` is `Float(INFINITY)` -- the literal text is what
+    /// makes the eventual jq-compat display (`1E+999`, not the `f64::MAX`
+    /// stand-in) correct, not this stored numeric value.
+    #[test]
+    fn test_from_number_bytes_preserves_trailing_dot_before_exponent_spelling() {
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"1.e5"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(100000.0), "1.e5".into())
+        );
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"-1.e5"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(-100000.0), "-1.e5".into())
+        );
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"1.e999"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(f64::INFINITY), "1.e999".into())
+        );
+        assert_eq!(
+            OwnedValue::from_number_bytes(b"-1.e999"),
+            OwnedValue::NumberLiteral(NumberRepr::Float(f64::NEG_INFINITY), "-1.e999".into())
+        );
+        // A trailing dot with *no* exponent (`1.`) is untouched by this
+        // escape -- real jq doesn't preserve that spelling either (`[1.]`
+        // -> `[1]`), so it still degrades to a plain `Float` via the
+        // pre-existing fallback below, not a `NumberLiteral`.
+        assert_eq!(OwnedValue::from_number_bytes(b"1."), OwnedValue::Float(1.0));
+        // Genuinely malformed shapes (two dots) stay untouched by this
+        // escape too: the inserted `0` can't make `1.5.3` valid either way.
+        assert_eq!(OwnedValue::from_number_bytes(b"1.5.3"), OwnedValue::Null);
     }
 
     #[test]

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2359,11 +2359,27 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
                 // reflect (matches `from_number_bytes`'s own leading-dot
                 // and leading-zero handling, both of which store the
                 // original text for the same reason).
-                if let Some(stripped) = crate::json::validate::strip_redundant_leading_zeros(bytes)
-                {
-                    if crate::json::validate::is_valid_number(&stripped) {
+                let zero_stripped = crate::json::validate::strip_redundant_leading_zeros(bytes);
+                if let Some(stripped) = &zero_stripped {
+                    if crate::json::validate::is_valid_number(stripped) {
                         return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
                     }
+                }
+                // Real jq's own number reader also tolerates a trailing
+                // `.` immediately before an exponent marker (`1.e999` ->
+                // `1.0e999`) -- same leniency as
+                // `OwnedValue::from_number_bytes`'s own trailing-dot
+                // handling (#2220, shared gate via
+                // `has_trailing_dot_before_exponent`). Checked against the
+                // leading-zero-stripped form above (when one exists), not
+                // always `bytes` itself, so the two escapes compose: a
+                // token can have both a redundant leading zero *and* a
+                // trailing dot before its exponent at once (`007.e999`).
+                // Returns the *original* `bytes`, matching every other
+                // escape in this function and in `from_number_bytes`.
+                let base = zero_stripped.as_deref().unwrap_or(bytes);
+                if crate::json::validate::has_trailing_dot_before_exponent(base) {
+                    return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
                 }
                 // The semi-index scanner accepts number *spans* more
                 // leniently than RFC 8259 beyond just a leading zero

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -3682,25 +3682,24 @@ mod tests {
 
     // #1576 coverage: `write_json_number`'s `JqCompat` fallback chain. The
     // semi-index accepts a number *span* more leniently than RFC 8259, so a
-    // trailing-dot mantissa (`1.`) reaches `from_number_bytes`, which parses
-    // it as a plain `Float` -- no source literal preserved.
+    // trailing-dot mantissa (`1.`) reaches `from_number_bytes`.
     //
-    // `1.` matches real jq (`[1.]` -> `[1]`, jq 1.7.1). `1.e999` does *not*:
-    // jq keeps the literal spelling (`[1E+999]`) where succinctly's
-    // `from_number_bytes` degrades it to an infinite `Float` and prints the
-    // clamped `JqSemantics` stand-in. That divergence is older than #1576
-    // and shared with the DOM printer (`--unbuffered` gives byte-identical
-    // output); it is pinned here as current behaviour, not endorsed --
-    // filed as #2220, which also notes that fixing it makes this test's
-    // `1.e999` rows read `1E+999` and may leave the non-finite arm below
-    // with no reachable caller at all.
+    // `1.` matches real jq (`[1.]` -> `[1]`, jq 1.7.1) via the plain-`Float`
+    // fallback -- that spelling isn't preserved by either tool. `1.e999`
+    // used to diverge the same way (degrading to an infinite `Float` and
+    // printing the clamped `JqSemantics` stand-in instead of jq's own
+    // `1E+999`), but #2220 added a third escape to `from_number_bytes`
+    // (alongside the pre-existing leading-dot/leading-zero ones) that
+    // preserves a trailing dot immediately before an exponent marker the
+    // same way, so this now matches jq exactly via the `NumberLiteral`
+    // reformatting arm below instead of the non-finite one.
     #[test]
     fn test_stream_json_number_invalid_span_float_fallback_1576() {
         for (json, expected) in [
             (&b"[1.]"[..], "[1]"),
             (&b"[-1.]"[..], "[-1]"),
-            (&b"[1.e999]"[..], "[1.7976931348623157e+308]"),
-            (&b"[-1.e999]"[..], "[-1.7976931348623157e+308]"),
+            (&b"[1.e999]"[..], "[1E+999]"),
+            (&b"[-1.e999]"[..], "[-1E+999]"),
         ] {
             let index = JsonIndex::build(json);
             let root = index.root(json);

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -856,6 +856,47 @@ pub fn strip_redundant_leading_zeros(bytes: &[u8]) -> Option<Vec<u8>> {
     Some(stripped)
 }
 
+/// Whether `bytes` becomes valid RFC 8259 number syntax after inserting a
+/// single `0` immediately after a trailing `.` that sits right before an
+/// exponent marker (`1.e999` -> `1.0e999`).
+///
+/// Real jq's own number reader tolerates this shape, the same kind of
+/// leniency [`strip_redundant_leading_zeros`] already models for a
+/// redundant leading zero. Shared for the identical reason that function
+/// is: two independent "recover a lenient-but-invalid number's own
+/// literal spelling" call sites need it
+/// ([`OwnedValue::from_number_bytes`](crate::jq::OwnedValue::from_number_bytes)
+/// and [`crate::json::light`]'s `DocumentValue::number_literal`
+/// implementation, #2220).
+///
+/// Composes with the leading-zero leniency too: pass a
+/// [`strip_redundant_leading_zeros`] result here (when one exists) instead
+/// of the original `bytes`, so a token with *both* issues at once
+/// (`007.e999`) is still recognized -- inserting the trailing-dot fixup
+/// never touches the leading digits either way, so checking on whichever
+/// form already applies is sufficient; there is no need to try every
+/// combination of "stripped or not."
+///
+/// Returns `bool`, not the fixed-up candidate `Option<Vec<u8>>` the way
+/// [`strip_redundant_leading_zeros`] does: both call sites always
+/// materialize the *original* `bytes` on success, never this function's
+/// own inserted-`0` candidate, so there is no stripped text either caller
+/// ever wants back.
+#[must_use]
+pub fn has_trailing_dot_before_exponent(bytes: &[u8]) -> bool {
+    let Some(dot_pos) = bytes
+        .windows(2)
+        .position(|w| w[0] == b'.' && (w[1] == b'e' || w[1] == b'E'))
+    else {
+        return false;
+    };
+    let mut fixed = Vec::with_capacity(bytes.len() + 1);
+    fixed.extend_from_slice(&bytes[..=dot_pos]);
+    fixed.push(b'0');
+    fixed.extend_from_slice(&bytes[dot_pos + 1..]);
+    is_valid_number(&fixed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19686,6 +19686,31 @@ fn test_jq_valid_multi_value_stream_unaffected_1171() -> Result<()> {
     Ok(())
 }
 
+/// #2220: a trailing-dot mantissa immediately before an exponent marker
+/// (`1.e999`) must keep its source spelling, the same way the leading-dot
+/// (#1171) and leading-zero (#1149) cases above do -- `from_number_bytes`
+/// previously had no escape for this shape, so it fell through to a lossy
+/// `f64` parse: an out-of-range exponent silently clamped to the
+/// `JqSemantics` infinity stand-in instead of the exact literal jq itself
+/// prints. Verified against the pinned oracle (`/usr/bin/jq`, jq-1.7.1);
+/// the issue's own repro table, every row.
+#[test]
+fn test_jq_trailing_dot_before_exponent_preserves_exact_literal_2220() -> Result<()> {
+    for (input, expected) in [
+        ("[1.]", "[1]"),
+        ("[1.5e3]", "[1.5E+3]"),
+        ("[1.e999]", "[1E+999]"),
+        ("[-1.e999]", "[-1E+999]"),
+        ("[1.e-999]", "[1E-999]"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "input {input:?}: stderr {stderr:?}");
+        assert_eq!(out.trim(), expected, "input {input:?}");
+    }
+
+    Ok(())
+}
+
 /// A top-level token that only *looks* number-shaped but has no digit
 /// anywhere in its mantissa (`-e5`: `-` then `e5`, no digit before the
 /// exponent marker) must error, not silently materialize as `null` --

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19702,8 +19702,38 @@ fn test_jq_trailing_dot_before_exponent_preserves_exact_literal_2220() -> Result
         ("[1.e999]", "[1E+999]"),
         ("[-1.e999]", "[-1E+999]"),
         ("[1.e-999]", "[1E-999]"),
+        // Composes with the leading-zero escape (#1149): a token can have
+        // both a redundant leading zero and a trailing dot before its
+        // exponent at once. Code review found the first draft's two
+        // escapes didn't compose, silently reproducing this issue's own
+        // clamped-infinity symptom for just this compound shape.
+        ("[007.e5]", "[7E+5]"),
+        ("[007.e999]", "[7E+999]"),
+        ("[-007.e999]", "[-7E+999]"),
+        ("[00.e999]", "[0E+999]"),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", "."], Some(input))?;
+        assert_eq!(code, 0, "input {input:?}: stderr {stderr:?}");
+        assert_eq!(out.trim(), expected, "input {input:?}");
+    }
+
+    Ok(())
+}
+
+/// #2220 also needed fixing in `StandardJson::number_literal()`
+/// (`src/json/light.rs`), a sibling conversion `-S`/sort-keys and other
+/// DOM-materializing consumers route through instead of
+/// `OwnedValue::from_number_bytes` directly -- code review found the
+/// original fix only touched `from_number_bytes`, leaving this identical
+/// clamped-infinity bug fully reachable via `-S` alone.
+#[test]
+fn test_jq_trailing_dot_before_exponent_preserved_via_sort_keys_2220() -> Result<()> {
+    for (input, expected) in [
+        (r#"{"a":1.e999}"#, r#"{"a":1E+999}"#),
+        (r#"{"b":1,"a":007.e5}"#, r#"{"a":7E+5,"b":1}"#),
+        (r#"{"b":1,"a":007.e999}"#, r#"{"a":7E+999,"b":1}"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-cS", "."], Some(input))?;
         assert_eq!(code, 0, "input {input:?}: stderr {stderr:?}");
         assert_eq!(out.trim(), expected, "input {input:?}");
     }


### PR DESCRIPTION
## Summary

`OwnedValue::from_number_bytes` had two leniency escapes that preserve a lenient-but-
strictly-invalid number span's source spelling as a `NumberLiteral` (#1171's leading
dot, #1149's redundant leading zeros), but no equivalent for a **trailing dot
immediately before an exponent marker** (`1.e999`, `-1.e5`). That shape fails
`is_valid_number`, matches neither existing escape, and falls through to a lossy `f64`
parse — an out-of-range exponent silently clamps to the `JqSemantics` infinity
stand-in instead of the exact literal real jq prints.

```console
$ printf '[1.e999]' | /usr/bin/jq -c .
[1E+999]
$ printf '[1.e999]' | succinctly jq -c .          # before this PR
[1.7976931348623157e+308]
$ printf '[1.e999]' | succinctly jq -c .          # after this PR
[1E+999]
```

## Fix

Adds a third escape mirroring the existing two: insert `0` right after the trailing
`.` and re-check `is_valid_number` — valid (`1.e999` → `1.0e999`) means the *original*
bytes get materialized as the `NumberLiteral`, same pattern as the leading-dot/
leading-zero cases. A bare trailing dot with **no** exponent (`1.`) is deliberately
left alone: real jq doesn't preserve that spelling either (`[1.]` → `[1]` on both
sides), so the existing lossy fallback already matches jq there.

Not specific to any output path — the M2 cursor streamer and the DOM printer
(`--unbuffered`) produce byte-identical output through the same shared conversion,
live-verified.

## Verification

Live-verified against the pinned oracle (`/usr/bin/jq` 1.7.1) for the issue's own full
repro table, plus additional edge cases (uppercase `E`, negative mantissa, negative
exponent) and confirmed genuinely malformed shapes (`1.5.3`) are unaffected.

## Changes

- `OwnedValue::from_number_bytes` (`src/jq/value.rs`): the new escape.
- `test_stream_json_number_invalid_span_float_fallback_1576` (`src/json/light.rs`),
  which pinned the old, now-fixed `1.e999` behavior as a documented divergence — its
  `1.e999`/`-1.e999` rows now read jq's own `1E+999`/`-1E+999`.
- Direct unit coverage of the new escape (`src/jq/value.rs`) and a CLI-level
  regression test covering the issue's own repro table (`tests/jq_cli_tests.rs`).

Fixes #2220

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, all 57 test binaries pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the two other CI feature-set legs)
- [x] `cargo fmt --check`
- [x] Live-verified against `/usr/bin/jq` (pinned 1.7.1), both M2 streaming and `--unbuffered` DOM paths
