### PR TITLE
fix(jq): thread path context through a literal slice (#2215)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20696,11 +20696,9 @@ pub(crate) fn index_component_value(idx: i64, key: Option<&NumberKey>) -> OwnedV
 
 /// The `OwnedValue` a static slice component's `{"start":s,"end":e}` path
 /// descriptor is reported as, one bound at a time -- the slice-bound sibling
-/// of [`index_component_value`] (#1326), shared by [`walk_path`] and
-/// [`navigation_element`]. `eval_pipe_with_path_context_internal` has no
-/// `Expr::Slice` arm at all -- a slice there falls
-/// through to that function's generic, path-context-losing fallback, a
-/// pre-existing gap #1326 doesn't touch.
+/// of [`index_component_value`] (#1326), shared by [`walk_path`],
+/// [`navigation_element`], and `eval_stage_with_path_context`'s own
+/// `Expr::Slice` arm (#2215).
 ///
 /// Each bound converts independently via [`index_component_value`] itself
 /// (an absent/integer-spelled bound and a float-spelled one are exactly the
@@ -31412,6 +31410,44 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     owned_type_name(value),
                     "number",
                 ))
+            }
+        }
+        Expr::Slice {
+            start,
+            end,
+            start_key,
+            end_key,
+        } => {
+            // Extend path with the slice's own `{start,end}` descriptor, as
+            // written rather than as resolved (#1326) -- see
+            // `slice_component_value`, the shared per-bound rule this and
+            // `walk_path`'s own `Expr::Slice` arm both call rather than
+            // hand-deriving a third copy (CLAUDE.md's "duplicated
+            // predicates diverge silently", #106).
+            let mut new_path = current_path.to_vec();
+            new_path.push(slice_component_value(
+                *start,
+                start_key.as_ref(),
+                *end,
+                end_key.as_ref(),
+            ));
+
+            // Read via the same owned-value helper `eval_slice_expr`'s
+            // `Targets::Owned` loop uses, so bound/type/optional semantics
+            // (open bounds, negatives, strings, yq's object-slicing rule)
+            // can't drift from the ordinary (non-path-context) evaluator's
+            // own answer for the identical slice.
+            match slice_owned_value_read::<S>(value, *start, *end, optional) {
+                Ok(Some(sliced)) => continue_rest_with_borrowed_value::<W, S>(
+                    &sliced,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                ),
+                Ok(None) => QueryResult::None,
+                Err(err) => QueryResult::Error(err),
             }
         }
         Expr::Iterate => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34082,6 +34082,39 @@ fn get_value_at_path(value: &OwnedValue, path: &[OwnedValue]) -> Option<OwnedVal
             arr.get(index)
                 .and_then(|v| get_value_at_path(v, &path[1..]))
         }
+        // A slice path component, `{"start":s,"end":e}` (#2215) -- re-slices
+        // the container the same way `builtin_getpath`'s own Array/String/
+        // yq-Object arms do, via the same shared `SliceBounds` this file
+        // already uses everywhere else a runtime descriptor is resolved, so
+        // ancestor re-derivation can't disagree with what was actually
+        // sliced. Without this, `parent`/`parent(n)` landed on a path that
+        // passed through a slice fabricated an empty object instead of
+        // re-deriving the real ancestor.
+        //
+        // The yq-Object arm below isn't gated on `S::TAG == EvalTag::Yq`
+        // the way `builtin_getpath`'s own is: this function has no `S`
+        // parameter, and doesn't need one here -- in jq mode a slice can
+        // never successfully read an *object* target in the first place
+        // (`slice_owned_value_read` errors there), so no path this function
+        // is ever called with can pair a slice-descriptor component with an
+        // object-shaped value unless that slice really was taken in yq
+        // mode.
+        (OwnedValue::Object(desc), OwnedValue::Array(arr)) => {
+            let bounds = SliceBounds::from_descriptor(desc).ok()?;
+            let sliced = OwnedValue::Array(arr[bounds.resolve(arr.len())].to_vec());
+            get_value_at_path(&sliced, &path[1..])
+        }
+        (OwnedValue::Object(desc), OwnedValue::String(s)) => {
+            let bounds = SliceBounds::from_descriptor(desc).ok()?;
+            let range = bounds.resolve(s.chars().count());
+            let sliced = OwnedValue::String(slice::slice_str(s, range));
+            get_value_at_path(&sliced, &path[1..])
+        }
+        (OwnedValue::Object(desc), OwnedValue::Object(map)) => {
+            let bounds = SliceBounds::from_descriptor(desc).ok()?;
+            let sliced = slice_object_children_at(map, bounds.resolve_object_children(map.len()));
+            get_value_at_path(&sliced, &path[1..])
+        }
         _ => None,
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7545,6 +7545,82 @@ fn test_first_last_expr_path_context_resolves_2074() -> Result<()> {
     Ok(())
 }
 
+/// #2215: a literal `Expr::Slice` (`.[0:3]`, both bounds constant) had no
+/// arm in `eval_stage_with_path_context`, so it fell to the generic
+/// catch-all and left `current_path` unextended -- `key`/`path` named the
+/// *container*, not the slice. `path(.a[0:3])` (routed through `walk_path`
+/// instead) already got this right, so that's the reference matched here,
+/// same as every assertion below cross-checks against it directly.
+#[test]
+fn test_literal_slice_path_context_resolves_2215() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[0:3] | path"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":0,"end":3}]"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", "path(.a[0:3])"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":0,"end":3}]"#);
+
+    // `key` is the last path component, same as `path` less the wrapping
+    // array -- exercises the same arm through a different downstream
+    // consumer.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[0:3] | key"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"start":0,"end":3}"#);
+
+    // Open bounds: `start`/`end` each independently `null` in the
+    // descriptor when omitted, matching `slice_component_value`'s own
+    // `Null`-for-absent rule.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[1:] | path"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":1,"end":null}]"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[:2] | path"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":null,"end":2}]"#);
+
+    // `rest` continues from the sliced value itself, not the container --
+    // `continue_rest_with_borrowed_value` threading the freshly-sliced
+    // owned value through, same as the `Expr::Field`/`Expr::Index` arms.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[0:3] | .[0]"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1");
+
+    let (stdout, _, code) =
+        run_jq_full(&["-c", ".a | .[0:3] | length"], Some(r#"{"a":[1,2,3,4]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "3");
+
+    // String targets slice by character, not byte -- same
+    // `slice_owned_value_read` the plain (non-path-context) evaluator uses,
+    // so this can't drift from `.a | .[1:3]`'s own already-correct answer.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[1:3] | path"], Some(r#"{"a":"hello"}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":1,"end":3}]"#);
+
+    // `null` slices to `null` (jq's own rule) -- still names the slice
+    // component, not just the container.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[0:3] | path"], Some(r#"{"a":null}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["a",{"start":0,"end":3}]"#);
+
+    // A non-sliceable type errors exactly like the plain evaluator and the
+    // `path(...)` reference both already do -- the new arm's error path
+    // isn't a divergence of its own.
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".a | .[0:3] | path"], Some(r#"{"a":5}"#))?;
+    assert_eq!(code, 5);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("Cannot index number with object"));
+
+    // `?` on the slice itself suppresses that error into no output, not a
+    // stubbed path.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | .[0:3]? | path"], Some(r#"{"a":5}"#))?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    Ok(())
+}
+
 /// #1964 (found in review of the `Expr::Limit` path-context fix above, then
 /// fixed by #1964 itself): `eval_pipe_with_path_context_internal`'s
 /// `Expr::Comma` arm routes every branch through this same evaluator,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7621,6 +7621,53 @@ fn test_literal_slice_path_context_resolves_2215() -> Result<()> {
     Ok(())
 }
 
+/// #2215 (found in review of the fix above): `get_value_at_path` -- what
+/// `parent`/`parent(n)` re-derives an ancestor value through -- only
+/// pattern-matched a plain field/index path component, so once the new
+/// `Expr::Slice` arm above started making a slice's `{"start":s,"end":e}`
+/// descriptor a genuinely reachable path component, landing `parent` on one
+/// fell through `get_value_at_path`'s catch-all and fabricated an empty
+/// object instead of re-deriving the real ancestor. `getpath` (which
+/// already understood this descriptor shape before this fix) is the
+/// reference every assertion below cross-checks against.
+#[test]
+fn test_literal_slice_parent_ancestor_resolves_2215() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[0:3] | .[0] | parent"],
+        Some(r#"{"a":["FIRST","SECOND","THIRD","FOURTH"]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["FIRST","SECOND","THIRD"]"#);
+
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[0:3] | .[0] | parent(1)"],
+        Some(r#"{"a":["FIRST","SECOND","THIRD","FOURTH"]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["FIRST","SECOND","THIRD"]"#);
+
+    // Cross-checked directly against `getpath` on the identical path `path`
+    // already reports for this exact query (the two must never drift, per
+    // CLAUDE.md's "duplicated predicates diverge silently").
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "getpath([\"a\",{\"start\":0,\"end\":3}])"],
+        Some(r#"{"a":["FIRST","SECOND","THIRD","FOURTH"]}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["FIRST","SECOND","THIRD"]"#);
+
+    // String targets slice by character, same as the plain (non-ancestor)
+    // read.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | .[1:5] | .[0:1] | parent"],
+        Some(r#"{"a":"hello world"}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#""ello""#);
+
+    Ok(())
+}
+
 /// #1964 (found in review of the `Expr::Limit` path-context fix above, then
 /// fixed by #1964 itself): `eval_pipe_with_path_context_internal`'s
 /// `Expr::Comma` arm routes every branch through this same evaluator,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12135,6 +12135,27 @@ fn test_literal_slice_path_context_resolves_yq_2215() -> Result<()> {
 }
 
 /// yq-mode counterpart to `jq_cli_tests.rs`'s
+/// `test_literal_slice_parent_ancestor_resolves_2215` -- `get_value_at_path`
+/// (what `parent` re-derives an ancestor through) lives on the shared,
+/// mode-blind evaluator, so this covers yq's own object-slicing rule
+/// (#1102) specifically: slicing a mapping produces a descriptor over the
+/// object's AST child-node layout, a shape `get_value_at_path` has no
+/// `S: EvalSemantics` parameter to gate on -- see the fix's own comment for
+/// why that's still sound.
+#[test]
+fn test_literal_slice_parent_ancestor_resolves_yq_2215() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".a | .[0:2] | .[0] | parent",
+        "a:\n  x: 1\n  y: 2\n  z: 3\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["x",1]"#);
+
+    Ok(())
+}
+
+/// yq-mode counterpart to `jq_cli_tests.rs`'s
 /// `test_string_interpolation_path_context_builtins_1334`/
 /// `test_func_def_path_context_builtins_1306` -- both new
 /// `needs_path_context`/`eval_pipe_with_path_context_internal` arms

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12100,6 +12100,41 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 }
 
 /// yq-mode counterpart to `jq_cli_tests.rs`'s
+/// `test_literal_slice_path_context_resolves_2215` -- the new
+/// `eval_stage_with_path_context` `Expr::Slice` arm lives on the shared
+/// `<S: EvalSemantics>` evaluator, so this file needs its own dedicated
+/// check rather than relying on the jq-mode coverage alone (a jq-scoped fix
+/// to shared evaluator code can silently regress yq without one).
+#[test]
+fn test_literal_slice_path_context_resolves_yq_2215() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".a | .[0:3] | path",
+        "a: [1, 2, 3, 4]\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a",{"start":0,"end":3}]"#);
+
+    let (output, code) = run_yq_stdin(
+        ".a | .[0:3] | key",
+        "a: [1, 2, 3, 4]\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"start":0,"end":3}"#);
+
+    let (output, code) = run_yq_stdin(
+        ".a | .[0:3] | .[0]",
+        "a: [1, 2, 3, 4]\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1");
+
+    Ok(())
+}
+
+/// yq-mode counterpart to `jq_cli_tests.rs`'s
 /// `test_string_interpolation_path_context_builtins_1334`/
 /// `test_func_def_path_context_builtins_1306` -- both new
 /// `needs_path_context`/`eval_pipe_with_path_context_internal` arms


### PR DESCRIPTION
## Summary

`eval_stage_with_path_context` had navigation arms for `Expr::Identity`, `Expr::Field`, `Expr::Index`, and `Expr::Iterate`, but none for a literal `Expr::Slice` (`.a[0:3]`, both bounds constant). That fell through the generic catch-all, which uses the plain evaluator and leaves `current_path` unchanged — `.a | .[0:3] | path` answered `["a"]` (the container), not `["a",{"start":0,"end":3}]`, while `path(.a[0:3])` (routed through `walk_path` instead) already got it right.

Fixes it the way the issue's own fix direction lays out:
1. Push `slice_component_value(*start, start_key.as_ref(), *end, end_key.as_ref())` onto `current_path` — the identical call `walk_path`'s own `Expr::Slice` arm already makes, not a third hand-derived copy.
2. Read the slice via `slice_owned_value_read::<S>`, the owned-value helper `eval_slice_expr`'s own `Targets::Owned` loop already uses, so bound/type/optional semantics (open bounds, negatives, strings, yq's object-slicing rule) can't drift from the ordinary evaluator's answer for the same slice.
3. Continue `rest` from the sliced value via `continue_rest_with_borrowed_value`, same as `Field`/`Index`.

No jq/yq oracle exists for this (`path`/`key` on a piped chain are succinctly's own extensions), so `walk_path`'s own `Expr::Slice` arm is the reference matched throughout, both in the fix and in the new tests.

Shared by both CLI modes: `eval_generic`'s `path_context_is_cursor_walkable` never lists `Expr::Slice`, so a slice under path context always falls to this owned-value routine regardless of `jq`/`yq` mode — verified live in both.

## Test plan
- [x] New `test_literal_slice_path_context_resolves_2215` (jq mode): `path`/`key` naming the slice component, open bounds, `rest` continuation (`.[0]`, `length`), string targets, `null` targets, non-sliceable-type error message matches the plain evaluator and `path(...)` reference, `?` suppression.
- [x] New `test_literal_slice_path_context_resolves_yq_2215` (yq mode): same shape via the shared `<S: EvalSemantics>` evaluator.
- [x] `cargo test --features cli` — full suite green (57/57 binaries).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo build --no-default-features` (no_std) — builds.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` — clean.
- [x] `cargo fmt --check` — clean.

Fixes #2215