### PR TITLE
fix(jq): re-evaluate E[S:T]'s end bound once per start value

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16541,20 +16541,6 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Some(control) => partial(Vec::new(), control),
         };
     }
-    let (ends, ends_escape) = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
-        Ok(v) => v,
-        Err(control) => return partial(Vec::new(), control),
-    };
-    let ends_escaped = ends_escape.is_some();
-    let bounds_escape = ends_escape.or(starts_escape);
-    if ends.is_empty() {
-        return match bounds_escape {
-            None => QueryResult::None,
-            Some(control) => partial(Vec::new(), control),
-        };
-    }
-    let starts_len = if ends_escaped { 1 } else { starts.len() };
-    let starts = &starts[..starts_len];
 
     // Borrowed and owned targets are kept apart so the common (borrowed) case
     // never materializes the document — mirrors `eval_index_expr`.
@@ -16563,31 +16549,20 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Owned(Vec<OwnedValue>),
     }
 
-    // S outer, T middle, E inner (point 2 above), with E now genuinely
-    // re-evaluated once per (s, e) pair rather than once overall (#2143).
-    // The result is always owned: slicing constructs a new array/string
-    // (see `eval_single`'s `Expr::Slice` arm), so there is nothing to
-    // borrow except its rare whole-value fast paths, which `to_owned_lossy`
-    // below just copies out of.
+    // S outer, T middle, E inner (point 2 above), with E re-evaluated once
+    // per (s, e) pair (#2143) and T (`end`) now genuinely re-evaluated once
+    // per `s` rather than once overall (#2225) -- T sits inside S's own
+    // binding scope in jq's desugaring, so a fresh `s` gets a fresh `T`
+    // evaluation, the same nesting #2143 already established one level
+    // deeper for E relative to `(s, e)`.
     //
-    // `starts.len() * ends.len()` is still fully known before the loop --
-    // only the per-pair target count varies -- so `try_reserve_product`
-    // reserves that much upfront as a baseline (the common case is exactly
-    // one output per pair), recovering the single upfront allocation the
-    // pre-#2143 code made for that case instead of paying amortized-
-    // doubling reallocation/copy costs on every slice query; both `starts`
-    // and `ends` are already known non-empty here (the `is_empty` checks
-    // above), so this never takes the zero-factor fast-return arm. Reusing
-    // the existing helper -- rather than a bespoke `checked_mul` inline --
-    // keeps this refusal path covered by that function's own existing unit
-    // tests instead of adding new, practically-untestable ones of its own:
-    // constructing real `starts`/`ends` generator output long enough to
-    // organically overflow this product would first exhaust memory
-    // building the *inputs*, long before this reservation could ever run.
-    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
-        Ok(out) => out,
-        Err(e) => return QueryResult::Error(e),
-    };
+    // No upfront `starts.len() * ends.len()` reservation baseline anymore:
+    // `ends.len()` is no longer known until each `s` iteration evaluates T,
+    // so there is nothing fixed to reserve before the loop starts. The
+    // per-target `try_reserve` calls inside the loop still protect every
+    // real allocation; only the pre-#2225 upfront-baseline optimization is
+    // gone, not the overflow protection itself.
+    let mut out: Vec<OwnedValue> = Vec::new();
 
     // The shared exit every escape arm below funnels through, so folding
     // the running `out` in as a `Partial` prefix can't drift between arms
@@ -16601,7 +16576,21 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         };
     }
 
-    for s in starts {
+    for s in &starts {
+        // #2225: T (`end`) evaluated fresh for this `s`, not once overall.
+        // An empty T for this `s` contributes nothing and moves on to the
+        // next `s` (verified live: a `T` that's empty only for `s == 0`
+        // still lets `s == 1` run and contribute its own output -- not a
+        // whole-function short-circuit the way an entirely-empty `S` is).
+        // A `T` that produces some values before escaping processes those
+        // values first, then folds the running `out` in as the escape's
+        // prefix, same as every other per-iteration escape in this
+        // function (verified live: `.[0:(1,2,error("boom"))]` prints the
+        // slices for `1` and `2` before raising).
+        let (ends, ends_escape) = match eval_slice_bound::<W, S>(end, value.clone(), f64::ceil) {
+            Ok(v) => v,
+            Err(control) => escape!(control),
+        };
         for e in &ends {
             let targets = eval_single::<W, S>(target, value.clone(), false).materialize_cursor();
             let targets = match targets {
@@ -16706,11 +16695,23 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
             }
         }
+        // #2225: this `s`'s own T evaluation may have produced some values
+        // before escaping (a break/halt/error partway through T's own
+        // stream) -- fold the running `out` in as that escape's prefix,
+        // same as every other per-iteration escape above, rather than
+        // discarding it or deferring it past values a *later* `s` might
+        // still contribute (verified live: T escaping for a non-last `s`
+        // still reaches this point only after that `s`'s own successful
+        // `e` values have already been pushed).
+        if let Some(control) = ends_escape {
+            escape!(control);
+        }
     }
-    // #1528: the bound-escape info threaded through above still has to
-    // reach the final result -- a successful loop doesn't mean `start`/`end`
-    // themselves didn't escape after producing `out`'s own values.
-    match bounds_escape {
+    // #1528: `start`'s own trailing escape info still has to reach the
+    // final result -- a successful loop doesn't mean `start` itself didn't
+    // escape after producing `out`'s own values. `end`'s own escape is now
+    // handled per-`s` above (#2225), not here.
+    match starts_escape {
         None => owned_vec_to_result(out),
         Some(control) => partial(out, control),
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,8 +43,8 @@ use super::eval::{
     is_retryable_stop, literal_to_owned, needs_path_context, numeric_key_to_array_index,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
-    try_reserve_product, vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag,
-    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -8075,6 +8075,23 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
 /// folding them into `out`, not just discarding `prefix`; tracked
 /// separately (issue filed alongside this fix) since it's a pre-existing
 /// gap shared with `eval_index_expr`, not something #2143 introduces.
+///
+/// #2225: `T` (`end`) is *also* now re-evaluated fresh for every `s`, not
+/// once overall as an earlier revision of this doc comment claimed ("its
+/// own (prefix, escape) pair is identical on every notional re-run" — false
+/// whenever `T` involves a stateful generator like `input`, and jq's own
+/// desugaring puts `T` inside `S`'s binding scope for exactly this reason).
+/// Confirmed live against jq 1.7.1 with a stateful `T`
+/// (`input as $a | $a[(0,1):(input)]` fed two distinct bound values on
+/// stdin, one per `s`): each `s` gets its own fresh `T` result, not a
+/// shared one. An empty `T` for a given `s` contributes nothing for that
+/// `s` and moves on to the next one — not a whole-function short-circuit
+/// the way an entirely-empty `S` is (verified live: a `T` that's empty only
+/// for `s == 0` still lets `s == 1` run). A `T` that produces some values
+/// before escaping processes those first, then folds the running `out` in
+/// as the escape's prefix, same as every other per-iteration escape here
+/// (verified live: `.[0:(1,2,error("boom"))]` prints the slices for `1`
+/// and `2` before raising).
 fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -8083,24 +8100,12 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
-    // Bounds first: an empty start or end stream must not evaluate the
+    // Bounds first: an empty start stream must not evaluate `end` or the
     // target at all.
     //
     // #1528: keeps each bound generator's own partial prefix instead of
     // discarding it on escape (same fix #1517 applied to the path-mode
-    // resolver, re-derived here for value mode). jq compiles `E[S:T]` as
-    // `S as $s | T as $t | E | .[$s:$t]` -- `T` (end) is nested inside `S`
-    // (start)'s own iteration and re-run fresh for every `$s`, so a `T`
-    // escape fires before `S` ever gets a chance to expose its own
-    // (confirmed against jq 1.7.1: `.[(0,1):error("b")]` on `[10,20,30]`
-    // prints nothing before raising `b`). `ends_escape` therefore wins over
-    // `starts_escape` for what ultimately propagates, and `starts` truncates
-    // to its own first value whenever `ends` escaped -- `start`'s second
-    // value would only ever be tried after `end`'s *own* re-run for it
-    // completes, which never happens once `end` has already escaped once.
-    // `end` itself is computed once here (not re-run per `s`), which is
-    // still correct: it depends only on `value`, not `s`, so its own
-    // (prefix, escape) pair is identical on every notional re-run.
+    // resolver, re-derived here for value mode).
     let (starts, starts_escape) =
         match eval_slice_bound::<S, V>(start, value.clone(), cursor, f64::floor) {
             Ok(v) => v,
@@ -8112,21 +8117,6 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
             Some(control) => partial_generic(Vec::new(), control),
         };
     }
-    let (ends, ends_escape) = match eval_slice_bound::<S, V>(end, value.clone(), cursor, f64::ceil)
-    {
-        Ok(v) => v,
-        Err(control) => return partial_generic(Vec::new(), control),
-    };
-    let ends_escaped = ends_escape.is_some();
-    let bounds_escape = ends_escape.or(starts_escape);
-    if ends.is_empty() {
-        return match bounds_escape {
-            None => GenericResult::None,
-            Some(control) => partial_generic(Vec::new(), control),
-        };
-    }
-    let starts_len = if ends_escaped { 1 } else { starts.len() };
-    let starts = &starts[..starts_len];
 
     // Borrowed and owned targets are kept apart so the common (borrowed) case
     // never materializes the document — mirrors `eval_index_expr`.
@@ -8137,33 +8127,23 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
 
     // Start outer, end middle, target inner (#2143: target is now
     // re-evaluated once per (s, e) pair, so it is genuinely the innermost
-    // stage, not just looped as if it were). The result is always owned:
-    // slicing constructs a fresh array/string, same invariant as
-    // `eval::eval_slice_expr`. This is the actual dispatch path for an
-    // ordinary `.[$s:$e]` CLI read (see the comment on `Expr::SliceExpr`'s
-    // own match arm above), so this site -- not `eval::eval_slice_expr`'s
-    // sibling -- is what a real `succinctly jq`/`succinctly yq` invocation
-    // hits.
+    // stage, not just looped as if it were). `end` (#2225) is now
+    // re-evaluated once per `s`, so it is genuinely nested inside `start`'s
+    // own binding scope too, not looped as if it were. The result is
+    // always owned: slicing constructs a fresh array/string, same
+    // invariant as `eval::eval_slice_expr`. This is the actual dispatch
+    // path for an ordinary `.[$s:$e]` CLI read (see the comment on
+    // `Expr::SliceExpr`'s own match arm above), so this site -- not
+    // `eval::eval_slice_expr`'s sibling -- is what a real
+    // `succinctly jq`/`succinctly yq` invocation hits.
     //
-    // `starts.len() * ends.len()` is still fully known before the loop --
-    // only the per-pair target count varies -- so `try_reserve_product`
-    // reserves that much upfront as a baseline (the common case is exactly
-    // one output per pair), recovering the single upfront allocation the
-    // pre-#2143 code made for that case instead of paying amortized-
-    // doubling reallocation/copy costs on every slice query; both `starts`
-    // and `ends` are already known non-empty here (the `is_empty` checks
-    // above), so this never takes the zero-factor fast-return arm. See
-    // `eval::eval_slice_expr`'s identical comment for why this reuses the
-    // existing helper rather than a bespoke inline check: it keeps the
-    // refusal path covered by that function's own existing unit tests
-    // instead of adding new, practically-untestable ones (constructing
-    // real `starts`/`ends` generator output long enough to organically
-    // overflow this product would first exhaust memory building the
-    // *inputs*, long before this reservation could ever run).
-    let mut out: Vec<OwnedValue> = match try_reserve_product(&[starts.len(), ends.len()]) {
-        Ok(out) => out,
-        Err(e) => return GenericResult::Error(e),
-    };
+    // No upfront `starts.len() * ends.len()` reservation baseline anymore:
+    // `ends.len()` is no longer known until each `s` iteration evaluates
+    // `end`, so there is nothing fixed to reserve before the loop starts.
+    // The per-target `try_reserve` calls inside the loop still protect
+    // every real allocation; only the pre-#2225 upfront-baseline
+    // optimization is gone, not the overflow protection itself.
+    let mut out: Vec<OwnedValue> = Vec::new();
 
     // The shared exit every escape arm below funnels through, so folding
     // the running `out` in as a `Partial` prefix can't drift between arms
@@ -8177,7 +8157,13 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
         };
     }
 
-    for s in starts {
+    for s in &starts {
+        // #2225: `end` evaluated fresh for this `s`, not once overall.
+        let (ends, ends_escape) =
+            match eval_slice_bound::<S, V>(end, value.clone(), cursor, f64::ceil) {
+                Ok(v) => v,
+                Err(control) => escape!(control),
+            };
         for e in &ends {
             let targets = match eval_single::<S, V>(target, value.clone(), false, cursor) {
                 GenericResult::Error(e) => escape!(Control::Error(e)),
@@ -8257,11 +8243,21 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                 }
             }
         }
+        // #2225: this `s`'s own `end` evaluation may have produced some
+        // values before escaping (a break/halt/error partway through its
+        // own stream) -- fold the running `out` in as that escape's
+        // prefix, same as every other per-iteration escape above, rather
+        // than discarding it or deferring it past values a *later* `s`
+        // might still contribute.
+        if let Some(control) = ends_escape {
+            escape!(control);
+        }
     }
-    // #1528: the bound-escape info threaded through above still has to
-    // reach the final result -- a successful loop doesn't mean `start`/`end`
-    // themselves didn't escape after producing `out`'s own values.
-    match bounds_escape {
+    // #1528: `start`'s own trailing escape info still has to reach the
+    // final result -- a successful loop doesn't mean `start` itself didn't
+    // escape after producing `out`'s own values. `end`'s own escape is now
+    // handled per-`s` above (#2225), not here.
+    match starts_escape {
         // #1048: a zero-result collapse here (every (start, end) pair
         // optional-suppressed) must be `None`, not `ManyOwned(vec![])`.
         None => owned_vec_to_generic_result(out),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32210,6 +32210,80 @@ fn test_slice_expr_later_target_error_preserves_earlier_output_2143() -> Result<
     Ok(())
 }
 
+/// #2225: `E[S:T]` compiles as `S as $s | T as $t | E | .[$s:$t]` -- `T`
+/// (the end bound) sits inside `S`'s own binding scope, so it must be
+/// re-evaluated fresh once per `s` value, the same way #2143 already fixed
+/// `E` relative to `(s, e)` pairs one nesting level deeper. `succinctly`
+/// used to evaluate `T` once overall and reuse it across every `s`, firing
+/// a side effect in `T` once instead of once per `s`. Verified against jq
+/// 1.7.1: `stderr` fires twice, once per start value.
+#[test]
+fn test_slice_expr_end_bound_reevaluated_once_per_start_2225() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[(.)[(0,1):(stderr|2)]]"], Some("[10,20,30]"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[10,20],[20]]");
+    assert_eq!(stderr, "[10,20,30][10,20,30]");
+    Ok(())
+}
+
+/// #2225 sibling: an end bound that's genuinely empty for one `s` value
+/// must not short-circuit the *other* `s` values -- each `s`'s own `T`
+/// evaluation is now independent, unlike the old once-overall evaluation,
+/// where an empty `T` for any `s` made the whole slice look empty. `input`
+/// (an impure, stateful generator) is what makes `T` vary per
+/// re-evaluation here: for `s = 0` it reads `"skip"` and yields nothing;
+/// re-evaluating `input` for `s = 1` reads `3` and yields it, so `.[1:3]`
+/// still contributes `[20,30]`. Verified against jq 1.7.1 (identical
+/// output).
+#[test]
+fn test_slice_expr_one_empty_end_bound_does_not_short_circuit_others_2225() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-cn",
+            "input as $a | $a[(0,1):(if (input)==\"skip\" then empty else . end)]",
+        ],
+        Some("[10,20,30]\n\"skip\"\n3\n"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[20,30]");
+    Ok(())
+}
+
+/// #2225 (review finding, confirmed live against jq 1.7.1): a later `s`
+/// value's own end-bound error must not discard values already produced by
+/// an earlier `s`'s successful slice -- the same "later step's error
+/// outranks an earlier already-produced prefix, which still survives as
+/// `Partial`" rule #2143 already established for `E`'s own per-pair
+/// escape. `input` makes `T` differ per `s`: `s = 0` reads `3` and
+/// succeeds (`.[0:3]` = `[10,20,30]`), `s = 1` reads `"boom"` and raises.
+#[test]
+fn test_slice_expr_later_end_bound_error_preserves_earlier_output_2225() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-cn",
+            "input as $a | $a[(0,1):(if (input)==\"boom\" then error(\"boom\") else . end)]",
+        ],
+        Some("[10,20,30]\n3\n\"boom\"\n"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[10,20,30]");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// Regression guard: an ordinary, fully-independent cross product (every
+/// `(s, e)` pair a real value, no stateful generators involved) must be
+/// completely unaffected by moving the end bound's evaluation inside the
+/// start-value loop. Matches jq's own doc comment example verbatim.
+#[test]
+fn test_slice_expr_ordinary_cross_product_unaffected_2225() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "[.[(0,1):(3,4)]]"], Some("[1,2,3,4,5]"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[1,2,3],[1,2,3,4],[2,3],[2,3,4]]");
+    Ok(())
+}
+
 /// #2031's own primary repro: `SOURCE` (`.a`) is itself a genuine path
 /// expression, so real jq's single shared path register moves onto `.a`'s
 /// own position as a side effect of evaluating it -- and UPDATE's own

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32284,6 +32284,26 @@ fn test_slice_expr_ordinary_cross_product_unaffected_2225() -> Result<()> {
     Ok(())
 }
 
+/// #2225 (review): `-n`/`--null-input` routes through `eval::eval_slice_expr`
+/// (this file's other tests all hit `eval_generic::eval_slice_expr` via the
+/// ordinary stdin-fed cursor path) -- confirming the fix reaches *both*
+/// real dispatch paths, not just the one the rest of this cluster happens
+/// to exercise. `input as $a | ...` binds the array explicitly since `-n`
+/// leaves `.` as `null`; `stderr` proves re-evaluation the same way as the
+/// stdin-fed sibling test above. Verified against jq 1.7.1 (identical
+/// output).
+#[test]
+fn test_slice_expr_end_bound_reevaluated_under_null_input_2225() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-nc", "input as $a | $a[(0,1):(stderr|2)]"],
+        Some("[10,20,30]\n"),
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[10,20]\n[20]\n");
+    assert_eq!(stderr, "nullnull");
+    Ok(())
+}
+
 /// #2031's own primary repro: `SOURCE` (`.a`) is itself a genuine path
 /// expression, so real jq's single shared path register moves onto `.a`'s
 /// own position as a side effect of evaluating it -- and UPDATE's own

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1437,6 +1437,27 @@ fn test_yq_mode_zero_arity_wrong_arity_call_unaffected_by_2110() -> Result<()> {
     Ok(())
 }
 
+/// #2225 (review): the read-mode fix reaches yq mode too, not just jq mode
+/// -- `stderr` fires twice, once per start value, confirming `end` is
+/// re-evaluated fresh per `s` through `eval_generic::eval_slice_expr`
+/// regardless of which mode dispatches into it. Real yq's own grammar
+/// can't reproduce this repro's exact shape (its lexer rejects multi-
+/// valued slice bounds outright, and `input` needs `--jq-extensions`), so
+/// this is pinned against succinctly's own (already jq-oracle-verified via
+/// the sibling jq-mode tests) behavior, not a fresh oracle comparison.
+#[test]
+fn test_yq_mode_slice_expr_end_bound_reevaluated_once_per_start_2225() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
+        "[.a[(0,1):(stderr|2)]]",
+        "a: [10,20,30]\n",
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[[10,20],[20]]");
+    assert_eq!(stderr, "{\"a\":[10,20,30]}{\"a\":[10,20,30]}");
+    Ok(())
+}
+
 /// #1512/#1650/#1714: the CLI flag actually reaches the parser --
 /// `--jq-extensions` makes the same filters succeed end to end through the
 /// real `succinctly yq` binary, not just through the parser's own unit


### PR DESCRIPTION
## Summary

`E[S:T]` compiles as `S as $s | T as $t | E | .[$s:$t]` — jq's own desugaring puts `T`
inside `S`'s binding scope, so `T` must be re-evaluated fresh once per value `S`
produces, the same shape #2143 (PR #2223) already fixed for `E` relative to `(s, e)`
pairs one nesting level deeper. Both `eval_slice_expr` implementations
(`src/jq/eval.rs`, `src/jq/eval_generic.rs`) instead evaluated `end` exactly once,
before the loop over `starts` even began, and reused it across every `s`.

```console
$ echo '[10,20,30]' | jq -c '[(.)[(0,1):(stderr|2)]]'
[10,20,30][10,20,30][[10,20],[20]]
# stderr fires TWICE -- once per start value

$ echo '[10,20,30]' | succinctly jq -c '[(.)[(0,1):(stderr|2)]]'   # before this PR
[10,20,30][[10,20],[20]]
# stderr fires only ONCE
```

Confirmed pre-existing, not introduced by #2143/PR #2223 — both files reproduced
identically before that PR too.

## Designing the exact semantics

`T` structurally has no access to `$s` in jq's grammar, so proving/designing the exact
per-`s` behavior needed a stateful `T` (via `input`) to make it vary across
evaluations. Live-verified against jq 1.7.1 before implementing:

- An empty `T` for one particular `s` contributes nothing for that `s` and moves on to
  the next one — **not** a whole-function short-circuit the way an entirely-empty `S`
  is.
- A `T` that produces some values before escaping (error/break/halt) processes those
  values first, then folds the running accumulator in as the escape's `Partial`
  prefix, same as every other per-iteration escape already in these functions.
- A later `s`'s own end-bound error does not discard values an earlier `s` already
  contributed — they survive as the `Partial` prefix.

## Side effect: reservation optimization removed

Moving `end`'s evaluation inside the loop also removes the upfront
`starts.len() * ends.len()` product reservation both functions used as a baseline
allocation optimization (#2143): `ends.len()` is no longer known until each `s`
iteration evaluates `T`, so there's nothing fixed left to reserve before the loop
starts. The per-target `try_reserve` calls already inside the loop still protect every
real allocation — only the baseline optimization is gone, not the overflow protection
itself.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` (full suite, all 57 test binaries pass, including the full pre-existing #2143 cluster)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the two other CI feature-set legs)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (RUSTDOCFLAGS=-D warnings)
- [x] Live-verified against `/usr/bin/jq` (pinned 1.7.1) for every edge case above, both jq mode and yq mode

Added CLI-level regression tests mirroring the existing #2143 test cluster's own style
(re-evaluation count, one-empty-`s`-does-not-abort, later-`s`-error-preserves-earlier-
output, ordinary-cross-product regression guard). `eval.rs`'s own DOM-route copy
already had adequate value-correctness coverage via the pre-existing #2143 unit test
(still passing) — per that test's own doc comment, a side-effect/count-based check
isn't meaningful there since the harness has no `stderr`/`input`-equivalent to observe.

Fixes #2225
